### PR TITLE
chore: upgrade GitHub Actions to node24 majors

### DIFF
--- a/.github/workflows/ci-sandbox.yml
+++ b/.github/workflows/ci-sandbox.yml
@@ -22,7 +22,7 @@ jobs:
       run:
         working-directory: sandbox-gateway
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Shell syntax
         run: |
           bash -n sandbox/scripts/startup.sh
@@ -45,8 +45,8 @@ jobs:
     env:
       GOPROXY: https://proxy.golang.org,direct
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.25.x"
           cache-dependency-path: sandbox-gateway/sandbox/go.sum
@@ -57,10 +57,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v4
       - name: Build Dockerfile --target cli-tools
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./sandbox-gateway/sandbox
           file: ./sandbox-gateway/sandbox/Dockerfile

--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -15,8 +15,8 @@ jobs:
     env:
       GOPROXY: https://proxy.golang.org,direct
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.25.x"
           cache-dependency-path: server/go.sum

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -13,8 +13,8 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   gate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Gate
         run: |
           echo "Branch protection gate OK."

--- a/.github/workflows/publish-gateway.yml
+++ b/.github/workflows/publish-gateway.yml
@@ -14,16 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/cocofhu/sandbox-gateway
           tags: |
@@ -31,7 +31,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref_name, '-') }}
             type=sha
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./sandbox-gateway
           file: ./sandbox-gateway/Dockerfile

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -14,16 +14,16 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/cocofhu/approving
           tags: |
@@ -31,7 +31,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref_name, '-') }}
             type=sha
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: server/Dockerfile

--- a/.github/workflows/publish-sandbox.yml
+++ b/.github/workflows/publish-sandbox.yml
@@ -18,16 +18,16 @@ jobs:
       matrix:
         provider: [cursor, claude_code, codebuddy, trae]
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/cocofhu/universal-sandbox-${{ matrix.provider }}
           tags: |
@@ -35,7 +35,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref_name, '-') }}
             type=sha
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./sandbox-gateway/sandbox
           file: ./sandbox-gateway/sandbox/Dockerfile

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -9,7 +9,7 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Require digest-pinned images
         env:
           APPROVING_IMAGE: ${{ secrets.APPROVING_IMAGE }}
@@ -21,7 +21,7 @@ jobs:
           test -n "$SANDBOX_IMAGE"
           export APPROVING_IMAGE SANDBOX_GATEWAY_IMAGE SANDBOX_IMAGE
           ./release-smoke.sh
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: release-evidence


### PR DESCRIPTION
## Summary
- Upgrade all third-party Action `uses` in 8 workflows to latest stable node24 majors (`checkout@v7`, `setup-node@v7`, `setup-go@v7`, `upload-artifact@v7`, `setup-buildx@v4`, `login@v4`, `metadata@v6`, `build-push@v7`).
- Clear Checks Annotations for Node.js 20 deprecated Warnings while keeping existing CI job success.
- Sync publish/release workflow sources; no business code changes.

## Test plan
- [ ] `ci` / `ci-web` / `ci-server` / `ci-sandbox` jobs succeed
- [ ] Related job Annotations show 0 Node.js 20 deprecated Warnings


Made with [Cursor](https://cursor.com)