### PR TITLE
ci: add path-filtered ci-gateway suite for gateway module

### DIFF
--- a/.github/workflows/ci-gateway.yml
+++ b/.github/workflows/ci-gateway.yml
@@ -1,0 +1,33 @@
+name: ci-gateway
+
+# Path-filtered suite for sandbox-gateway/gateway (control plane).
+# Keeps PR CI light: go vet + unit tests with a 90% coverage gate.
+# Image publish remains in publish-gateway (v* tags); not merged into ci-sandbox.
+on:
+  push:
+    paths:
+      - "sandbox-gateway/gateway/**"
+      - ".github/workflows/ci-gateway.yml"
+  pull_request:
+    paths:
+      - "sandbox-gateway/gateway/**"
+      - ".github/workflows/ci-gateway.yml"
+
+jobs:
+  gateway:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sandbox-gateway/gateway
+    env:
+      GOPROXY: https://proxy.golang.org,direct
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: "1.25.x"
+          cache-dependency-path: sandbox-gateway/gateway/go.sum
+      - run: go vet ./...
+      - name: Gateway Go coverage gate
+        working-directory: sandbox-gateway
+        run: ./scripts/cover-check.sh gateway 90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: ci
 
 # Always-on gate for branch protection. Path-filtered suites (ci-server /
-# ci-web / ci-sandbox) still run only when their trees change; this job always
-# reports.
+# ci-web / ci-sandbox / ci-gateway) still run only when their trees change;
+# this job always reports.
 on:
   push:
     branches: [main]
@@ -16,4 +16,4 @@ jobs:
       - name: Gate
         run: |
           echo "Branch protection gate OK."
-          echo "server/ → ci-server; web/ → ci-web; sandbox-gateway/sandbox|scripts → ci-sandbox."
+          echo "server/ → ci-server; web/ → ci-web; sandbox-gateway/sandbox|scripts → ci-sandbox; sandbox-gateway/gateway → ci-gateway."

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Build rollback-capable, human-gated, observable workflows — agents run in real
 [![CI Server](https://github.com/cocofhu/approving/actions/workflows/ci-server.yml/badge.svg)](https://github.com/cocofhu/approving/actions/workflows/ci-server.yml)
 [![CI Web](https://github.com/cocofhu/approving/actions/workflows/ci-web.yml/badge.svg)](https://github.com/cocofhu/approving/actions/workflows/ci-web.yml)
 [![CI Sandbox](https://github.com/cocofhu/approving/actions/workflows/ci-sandbox.yml/badge.svg)](https://github.com/cocofhu/approving/actions/workflows/ci-sandbox.yml)
+[![CI Gateway](https://github.com/cocofhu/approving/actions/workflows/ci-gateway.yml/badge.svg)](https://github.com/cocofhu/approving/actions/workflows/ci-gateway.yml)
 
 [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Support](SUPPORT.md) · [Configuration](server/CONFIGURATION.md) · [Gateway](GATEWAY.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,6 +8,7 @@
 [![CI Server](https://github.com/cocofhu/approving/actions/workflows/ci-server.yml/badge.svg)](https://github.com/cocofhu/approving/actions/workflows/ci-server.yml)
 [![CI Web](https://github.com/cocofhu/approving/actions/workflows/ci-web.yml/badge.svg)](https://github.com/cocofhu/approving/actions/workflows/ci-web.yml)
 [![CI Sandbox](https://github.com/cocofhu/approving/actions/workflows/ci-sandbox.yml/badge.svg)](https://github.com/cocofhu/approving/actions/workflows/ci-sandbox.yml)
+[![CI Gateway](https://github.com/cocofhu/approving/actions/workflows/ci-gateway.yml/badge.svg)](https://github.com/cocofhu/approving/actions/workflows/ci-gateway.yml)
 
 [贡献指南](CONTRIBUTING.md) · [安全](SECURITY.md) · [支持](SUPPORT.md) · [配置](server/CONFIGURATION.md) · [网关](GATEWAY.md)
 


### PR DESCRIPTION
Run go vet and cover-check (90%) when sandbox-gateway/gateway changes, and surface the suite via README badges and the always-on ci.yml path map.

Co-authored-by: Cursor <cursoragent@cursor.com>
