### PR TITLE
feat: show web/sandbox Lines coverage badges on README

### DIFF
--- a/.github/coverage-badges/README.md
+++ b/.github/coverage-badges/README.md
@@ -1,0 +1,31 @@
+# Coverage badge endpoint templates
+
+Cold-start shields.io endpoint JSON for README coverage badges.
+
+Live endpoints are published on the orphan `coverage-badges` branch
+(`coverage-web.json`, `coverage-sandbox.json`) by `ci-web` / `ci-sandbox`
+on default-branch success only.
+
+Schema (shields Endpoint Badge):
+
+```json
+{
+  "schemaVersion": 1,
+  "label": "coverage-web",
+  "message": "n/a",
+  "color": "lightgrey"
+}
+```
+
+Color bands (see `.github/scripts/coverage-badge-color.sh`):
+
+| Lines % | Color  | Band |
+|--------:|--------|------|
+| ≥ 85    | green  | high |
+| 70–84   | yellow | mid  |
+| < 70    | orange | low  |
+| n/a     | lightgrey | cold start |
+
+Auth: workflows use the job `GITHUB_TOKEN` with `contents: write` to update
+only the `coverage-badges` branch. No coverage SaaS and no `contents: write`
+to `main`. A dedicated `GIST_TOKEN` is not required for this carrier.

--- a/.github/coverage-badges/coverage-sandbox.json
+++ b/.github/coverage-badges/coverage-sandbox.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "coverage-sandbox",
+  "message": "n/a",
+  "color": "lightgrey"
+}

--- a/.github/coverage-badges/coverage-web.json
+++ b/.github/coverage-badges/coverage-web.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "coverage-web",
+  "message": "n/a",
+  "color": "lightgrey"
+}

--- a/.github/scripts/coverage-badge-color.sh
+++ b/.github/scripts/coverage-badge-color.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Map Lines coverage percent → shields.io endpoint color (discrete bands).
+# Bands (aligned with Demo high/mid readability):
+#   >=85  → green  (high)
+#   70–84 → yellow (mid)
+#   <70   → orange (low)
+set -euo pipefail
+pct="${1:?usage: coverage-badge-color.sh <percent>}"
+# Accept integers or decimals; compare numerically.
+if awk -v p="$pct" 'BEGIN{exit !(p+0 >= 85)}'; then
+  echo green
+elif awk -v p="$pct" 'BEGIN{exit !(p+0 >= 70)}'; then
+  echo yellow
+else
+  echo orange
+fi

--- a/.github/scripts/publish-coverage-badge.sh
+++ b/.github/scripts/publish-coverage-badge.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Publish one shields endpoint JSON file to the coverage-badges branch.
+# Only call on default-branch success paths. Failure/skip should not invoke this
+# script, so the previous successful endpoint snapshot is retained.
+#
+# Usage: publish-coverage-badge.sh <filename> <label> <percent> <color>
+# Example: publish-coverage-badge.sh coverage-web.json coverage-web 82 green
+set -euo pipefail
+
+filename="${1:?filename}"
+label="${2:?label}"
+percent="${3:?percent}"
+color="${4:?color}"
+
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+# Normalize message to integer percent with % suffix (e.g. 82%).
+message="$(awk -v p="$percent" 'BEGIN{printf "%.0f%%", p+0}')"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Clone only the endpoint branch (orphan; no product source).
+git clone --depth 1 --branch coverage-badges \
+  "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+  "$work"
+
+python3 - "$work/$filename" "$label" "$message" "$color" <<'PY'
+import json, pathlib, sys
+path, label, message, color = sys.argv[1:5]
+payload = {
+    "schemaVersion": 1,
+    "label": label,
+    "message": message,
+    "color": color,
+}
+pathlib.Path(path).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+
+cd "$work"
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git add "$filename"
+if git diff --cached --quiet; then
+  echo "coverage badge unchanged: ${filename} (${message})"
+  exit 0
+fi
+git commit -m "chore: update ${label} badge to ${message}"
+git push origin HEAD:coverage-badges
+echo "published ${filename}: ${label}=${message} color=${color}"

--- a/.github/workflows/ci-sandbox.yml
+++ b/.github/workflows/ci-sandbox.yml
@@ -9,11 +9,15 @@ on:
       - "sandbox-gateway/sandbox/**"
       - "sandbox-gateway/scripts/**"
       - ".github/workflows/ci-sandbox.yml"
+      - ".github/scripts/coverage-badge-color.sh"
+      - ".github/scripts/publish-coverage-badge.sh"
   pull_request:
     paths:
       - "sandbox-gateway/sandbox/**"
       - "sandbox-gateway/scripts/**"
       - ".github/workflows/ci-sandbox.yml"
+      - ".github/scripts/coverage-badge-color.sh"
+      - ".github/scripts/publish-coverage-badge.sh"
 
 jobs:
   scripts:
@@ -32,6 +36,8 @@ jobs:
           bash -n scripts/test-inject.sh
           bash -n scripts/test-git-auth.sh
           bash -n scripts/cover-check-sandbox.sh
+          bash -n ../.github/scripts/coverage-badge-color.sh
+          bash -n ../.github/scripts/publish-coverage-badge.sh
       - name: SANDBOX_INJECT smoke
         run: ./scripts/test-inject.sh
       - name: Git auth (gh/glab) smoke
@@ -39,6 +45,9 @@ jobs:
 
   sandbox-go:
     runs-on: ubuntu-latest
+    # contents:write only used to update the orphan coverage-badges branch endpoint.
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: sandbox-gateway
@@ -51,7 +60,27 @@ jobs:
           go-version: "1.25.x"
           cache-dependency-path: sandbox-gateway/sandbox/go.sum
       - name: Sandbox Go coverage gate
+        id: cover
         run: ./scripts/cover-check-sandbox.sh 90
+      - name: Publish coverage-sandbox badge
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && success()
+        continue-on-error: true
+        working-directory: .
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          pct="${{ steps.cover.outputs.coverage_pct }}"
+          if [[ -z "$pct" ]]; then
+            echo "no coverage_pct from cover-check; skip badge publish"
+            exit 0
+          fi
+          color="$(./.github/scripts/coverage-badge-color.sh "$pct")"
+          ./.github/scripts/publish-coverage-badge.sh \
+            coverage-sandbox.json \
+            coverage-sandbox \
+            "$pct" \
+            "$color"
 
   cli-tools:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -2,13 +2,16 @@ name: ci-web
 
 on:
   push:
-    paths: ["web/**", ".github/workflows/ci-web.yml"]
+    paths: ["web/**", ".github/workflows/ci-web.yml", ".github/scripts/coverage-badge-color.sh", ".github/scripts/publish-coverage-badge.sh"]
   pull_request:
-    paths: ["web/**", ".github/workflows/ci-web.yml"]
+    paths: ["web/**", ".github/workflows/ci-web.yml", ".github/scripts/coverage-badge-color.sh", ".github/scripts/publish-coverage-badge.sh"]
 
 jobs:
   web:
     runs-on: ubuntu-latest
+    # contents:write only used to update the orphan coverage-badges branch endpoint.
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: web
@@ -23,3 +26,37 @@ jobs:
       - run: npx vue-tsc --noEmit
       - run: npm test -- --coverage
       - run: npm run build
+      - name: Export web Lines coverage
+        id: coverage
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        working-directory: web
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          summary="coverage/coverage-summary.json"
+          if [[ ! -f "$summary" ]]; then
+            echo "missing $summary; skip badge publish"
+            exit 1
+          fi
+          pct="$(jq -r '.total.lines.pct' "$summary")"
+          if [[ -z "$pct" || "$pct" == "null" ]]; then
+            echo "could not parse total.lines.pct; skip badge publish"
+            exit 1
+          fi
+          color="$(../.github/scripts/coverage-badge-color.sh "$pct")"
+          echo "pct=$pct" >>"$GITHUB_OUTPUT"
+          echo "color=$color" >>"$GITHUB_OUTPUT"
+          echo "ok=true" >>"$GITHUB_OUTPUT"
+          echo "web Lines coverage=${pct}% color=${color}"
+      - name: Publish coverage-web badge
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.coverage.outputs.ok == 'true'
+        continue-on-error: true
+        working-directory: .
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./.github/scripts/publish-coverage-badge.sh \
+            coverage-web.json \
+            coverage-web \
+            "${{ steps.coverage.outputs.pct }}" \
+            "${{ steps.coverage.outputs.color }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,19 @@ Dev-only local sandbox image:
 ./start.sh sandbox       # build universal-sandbox-cursor:local
 ```
 
+## Coverage badges
+
+README shows `coverage-web` / `coverage-sandbox` Lines% via shields.io Endpoint
+Badges. Endpoint JSON lives on the orphan `coverage-badges` branch and is
+updated only when the corresponding workflow succeeds on the default branch
+(`ci-web` / `ci-sandbox`). Failed or skipped coverage runs do not overwrite the
+last successful value. Color bands: ≥85% green, 70–84% yellow, below 70% orange;
+cold start is `n/a` / lightgrey.
+
+Because those workflows are path-filtered, a module badge stays at its last
+successful percent until that module’s paths change again — expected lag, not a
+badge outage. There is no `coverage-server` badge and no coverage SaaS.
+
 ## Changes and pull requests
 
 1. Create a focused branch from the current default branch.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Build rollback-capable, human-gated, observable workflows — agents run in real
 [![CI Web](https://github.com/cocofhu/approving/actions/workflows/ci-web.yml/badge.svg)](https://github.com/cocofhu/approving/actions/workflows/ci-web.yml)
 [![CI Sandbox](https://github.com/cocofhu/approving/actions/workflows/ci-sandbox.yml/badge.svg)](https://github.com/cocofhu/approving/actions/workflows/ci-sandbox.yml)
 
+[![coverage-web](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcocofhu%2Fapproving%2Fcoverage-badges%2Fcoverage-web.json)](https://github.com/cocofhu/approving/actions/workflows/ci-web.yml)
+[![coverage-sandbox](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcocofhu%2Fapproving%2Fcoverage-badges%2Fcoverage-sandbox.json)](https://github.com/cocofhu/approving/actions/workflows/ci-sandbox.yml)
+
 [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Support](SUPPORT.md) · [Configuration](server/CONFIGURATION.md) · [Gateway](GATEWAY.md)
 
 **English | [简体中文](README.zh-CN.md)**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,6 +9,9 @@
 [![CI Web](https://github.com/cocofhu/approving/actions/workflows/ci-web.yml/badge.svg)](https://github.com/cocofhu/approving/actions/workflows/ci-web.yml)
 [![CI Sandbox](https://github.com/cocofhu/approving/actions/workflows/ci-sandbox.yml/badge.svg)](https://github.com/cocofhu/approving/actions/workflows/ci-sandbox.yml)
 
+[![coverage-web](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcocofhu%2Fapproving%2Fcoverage-badges%2Fcoverage-web.json)](https://github.com/cocofhu/approving/actions/workflows/ci-web.yml)
+[![coverage-sandbox](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcocofhu%2Fapproving%2Fcoverage-badges%2Fcoverage-sandbox.json)](https://github.com/cocofhu/approving/actions/workflows/ci-sandbox.yml)
+
 [贡献指南](CONTRIBUTING.md) · [安全](SECURITY.md) · [支持](SUPPORT.md) · [配置](server/CONFIGURATION.md) · [网关](GATEWAY.md)
 
 **[English](README.md) | 简体中文**

--- a/sandbox-gateway/scripts/cover-check-sandbox.sh
+++ b/sandbox-gateway/scripts/cover-check-sandbox.sh
@@ -11,4 +11,11 @@ LIST="$(go list "${PKGS[@]}" | paste -sd, -)"
 go test "${PKGS[@]}" -count=1 -coverpkg="$LIST" -coverprofile="$COVER"
 TOTAL="$(go tool cover -func="$COVER" | awk '/^total:/{gsub(/%/,"",$NF); print $NF}')"
 echo "sandbox-core coverage=${TOTAL}% (min=${MIN}%)"
+# Export for CI badge publishing (does not affect the gate below).
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "coverage_pct=${TOTAL}" >>"$GITHUB_OUTPUT"
+fi
+if [[ -n "${COVER_CHECK_OUT:-}" ]]; then
+  printf '%s\n' "$TOTAL" >"$COVER_CHECK_OUT"
+fi
 awk -v t="$TOTAL" -v m="$MIN" 'BEGIN{ if ((t+0)<(m+0)) { print "FAIL"; exit 1 } print "OK" }'

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig(({ command }) => {
       include: ['src/**/*.test.ts'],
       coverage: {
         provider: 'v8',
-        reporter: ['text', 'text-summary', 'cobertura'],
+        reporter: ['text', 'text-summary', 'cobertura', 'json-summary'],
         reportsDirectory: './coverage',
         // 收窄分母：计入可测业务代码（含全部 components），排除 views/router/e2e/构建样式配置。
         // CI/MR 的 Lines 正则与 web:coverage-gate 均依赖此口径。


### PR DESCRIPTION
Publish shields endpoint JSON on the coverage-badges branch from
ci-web/ci-sandbox default-branch success paths so visitors see live
coverage without a coverage SaaS or gate changes.

Co-authored-by: Cursor <cursoragent@cursor.com>
