### PR TITLE
ci(server): add core-package coverage gate at 90%

### DIFF
--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -23,5 +23,7 @@ jobs:
       - run: go vet ./...
       - run: go run ./cmd/gen-configdoc -out CONFIGURATION.md -check
       - run: go test ./...
+      - name: Server Go coverage gate
+        run: ./scripts/cover-check-server.sh 90
       - name: e2e fake runtime
         run: go test ./internal/runtime/ -count=1 -run 'TestRunAgent|TestReact'

--- a/server/scripts/cover-check-server.sh
+++ b/server/scripts/cover-check-server.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Server coverage gate: core unit-testable packages
+# (auth/apikey / config / crypto / textutil / logging / nodereg / models / shutdown / router / mcp).
+# Excludes handlers/services/engine/sandbox/runtime/database/browser/channels/cmd
+# (integration/IO surfaces covered via go test ./... and e2e subsets).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MIN="${1:-90}"
+cd "$ROOT"
+COVER="$(mktemp)"; trap 'rm -f "$COVER"' EXIT
+PKGS=(
+  ./internal/auth/...
+  ./internal/config
+  ./internal/crypto
+  ./internal/textutil
+  ./internal/logging
+  ./internal/nodereg
+  ./internal/models/...
+  ./internal/shutdown
+  ./internal/router
+  ./internal/mcp/...
+)
+LIST="$(go list "${PKGS[@]}" | paste -sd, -)"
+go test "${PKGS[@]}" -count=1 -timeout 20m -coverpkg="$LIST" -coverprofile="$COVER"
+TOTAL="$(go tool cover -func="$COVER" | awk '/^total:/{gsub(/%/,"",$NF); print $NF}')"
+if [[ -z "${TOTAL}" ]]; then
+  echo "FAIL: unable to parse total coverage from go tool cover" >&2
+  exit 1
+fi
+echo "server-core coverage=${TOTAL}% (min=${MIN}%)"
+awk -v t="$TOTAL" -v m="$MIN" 'BEGIN{ if ((t+0)<(m+0)) { print "FAIL"; exit 1 } print "OK" }'


### PR DESCRIPTION
Mirror sandbox cover-check script for server CI so PRs fail when
auth/config/crypto/mcp and related core packages drop below the threshold,
without replacing the existing full go test ./... suite.

Co-authored-by: Cursor <cursoragent@cursor.com>
