### PR TITLE
fix(web): pending inbox post-approve UI race / Run # - shell

### DIFF
--- a/web/src/lib/usePendingGates.test.ts
+++ b/web/src/lib/usePendingGates.test.ts
@@ -176,4 +176,71 @@ describe('usePendingGates', () => {
     resolve(paged([gate('1')], 1))
     await Promise.all([first, second])
   })
+
+  it('force/submit during in-flight peek does not join peek or get stolen by setPending', async () => {
+    vi.mocked(api.listGates).mockResolvedValueOnce(paged([gate('1'), gate('2')], 2))
+    const pg = usePendingGates()
+    await pg.refresh({ mode: 'force' })
+    expect(pg.displayedItems.value).toHaveLength(2)
+    expect(pg.totalCount.value).toBe(2)
+
+    let resolvePeek!: (value: ReturnType<typeof paged>) => void
+    const peekPending = new Promise<ReturnType<typeof paged>>((r) => {
+      resolvePeek = r
+    })
+    vi.mocked(api.listGates).mockClear()
+    vi.mocked(api.listGates).mockReturnValueOnce(peekPending)
+
+    const peekFlight = pg.peek({ source: 'sidebar-poll' })
+    expect(api.listGates).toHaveBeenCalledTimes(1)
+
+    // Submit force must start its own request — never await the peek promise.
+    vi.mocked(api.listGates).mockResolvedValueOnce(paged([gate('2')], 1))
+    const forceFlight = pg.refresh({ source: 'submit', mode: 'force' })
+    expect(api.listGates).toHaveBeenCalledTimes(2)
+
+    await forceFlight
+    expect(pg.displayedItems.value.map((it) => it.nodeId)).toEqual(['node-2'])
+    expect(pg.totalCount.value).toBe(1)
+    expect(pg.hasPendingUpdate.value).toBe(false)
+    expect(pg.lastRefreshSource.value).toBe('submit')
+
+    // Stale peek resolves with the pre-approve snapshot — must not overwrite force.
+    resolvePeek(paged([gate('1'), gate('2')], 2))
+    await peekFlight
+    expect(pg.displayedItems.value.map((it) => it.nodeId)).toEqual(['node-2'])
+    expect(pg.totalCount.value).toBe(1)
+    expect(pg.hasPendingUpdate.value).toBe(false)
+  })
+
+  it('removeItemLocally drops displayed/remote and decrements totalCount', async () => {
+    vi.mocked(api.listGates).mockResolvedValueOnce(paged([gate('1'), gate('2')], 2))
+    const pg = usePendingGates()
+    await pg.refresh({ mode: 'force' })
+
+    pg.removeItemLocally('run-1:node-1')
+    expect(pg.displayedItems.value).toHaveLength(1)
+    expect(pg.remoteItems.value).toHaveLength(1)
+    expect(pg.totalCount.value).toBe(1)
+    expect(pg.displayedItems.value[0].nodeId).toBe('node-2')
+  })
+
+  it('peek awaits in-flight force instead of starting a parallel peek', async () => {
+    let resolveForce!: (value: ReturnType<typeof paged>) => void
+    const forcePending = new Promise<ReturnType<typeof paged>>((r) => {
+      resolveForce = r
+    })
+    vi.mocked(api.listGates).mockReturnValueOnce(forcePending)
+    vi.mocked(api.listGates).mockClear()
+
+    const pg = usePendingGates()
+    const forceFlight = pg.refresh({ mode: 'force' })
+    const peekFlight = pg.peek({ source: 'focus' })
+    expect(api.listGates).toHaveBeenCalledTimes(1)
+
+    resolveForce(paged([gate('1')], 1))
+    await Promise.all([forceFlight, peekFlight])
+    expect(pg.displayedItems.value).toHaveLength(1)
+    expect(pg.totalCount.value).toBe(1)
+  })
 })

--- a/web/src/lib/usePendingGates.ts
+++ b/web/src/lib/usePendingGates.ts
@@ -129,7 +129,9 @@ async function peek(opts?: PeekOptions): Promise<void> {
   if (peekPromise) return peekPromise
 
   const gen = ++refreshGeneration
-  const flight = (async () => {
+  // Holder avoids TS2454: const flight = (async () => flight)() is "used before assigned".
+  const holder: { flight: Promise<void> | null } = { flight: null }
+  holder.flight = (async () => {
     try {
       const { items: remote, total } = await fetchPeek()
       // Discard if a newer peek/force superseded this request.
@@ -140,11 +142,11 @@ async function peek(opts?: PeekOptions): Promise<void> {
     } catch {
       /* keep last known items on transient errors */
     } finally {
-      if (peekPromise === flight) peekPromise = null
+      if (peekPromise === holder.flight) peekPromise = null
     }
   })()
-  peekPromise = flight
-  return flight
+  peekPromise = holder.flight
+  return holder.flight
 }
 
 function applyPending(): void {
@@ -175,7 +177,9 @@ async function refresh(opts?: RefreshOptions): Promise<void> {
 
   // Invalidate any in-flight peek writeback (setPending) before we apply.
   const gen = ++refreshGeneration
-  const flight = (async () => {
+  // Holder avoids TS2454 on self-referential flight cleanup.
+  const holder: { flight: Promise<void> | null } = { flight: null }
+  holder.flight = (async () => {
     try {
       const { items: remote, total } = await fetchPeek()
       if (gen !== refreshGeneration) return
@@ -184,11 +188,11 @@ async function refresh(opts?: RefreshOptions): Promise<void> {
     } catch {
       /* keep last known items on transient errors */
     } finally {
-      if (forcePromise === flight) forcePromise = null
+      if (forcePromise === holder.flight) forcePromise = null
     }
   })()
-  forcePromise = flight
-  return flight
+  forcePromise = holder.flight
+  return holder.flight
 }
 
 export function usePendingGates() {

--- a/web/src/lib/usePendingGates.ts
+++ b/web/src/lib/usePendingGates.ts
@@ -56,7 +56,14 @@ const lastPeekAt = ref(0)
 const items = displayedItems
 const count = computed(() => totalCount.value)
 
-let refreshPromise: Promise<void> | null = null
+/** Separate flight slots so force/submit never joins an in-flight peek. */
+let peekPromise: Promise<void> | null = null
+let forcePromise: Promise<void> | null = null
+/**
+ * Monotonic generation: bumping invalidates in-flight peek/force writebacks.
+ * Force always bumps so a slower peek cannot overwrite with setPending.
+ */
+let refreshGeneration = 0
 
 async function fetchPeek(): Promise<{ items: InboxItem[]; total: number }> {
   const data = await api.listGates({ page: 1, pageSize: 20 })
@@ -87,23 +94,57 @@ function applyRemoteToDisplayed(remote: InboxItem[], total: number) {
   pendingMeta.value = null
 }
 
-async function peek(opts?: PeekOptions): Promise<void> {
-  if (refreshPromise) return refreshPromise
+function syncPendingMetaFromDiff() {
+  const meta = diffKeys(displayedItems.value, remoteItems.value)
+  if (meta.added > 0 || meta.removed > 0) {
+    hasPendingUpdate.value = true
+    pendingMeta.value = meta
+  } else {
+    hasPendingUpdate.value = false
+    pendingMeta.value = null
+  }
+}
 
-  refreshPromise = (async () => {
+/**
+ * Optimistic local removal after approve/reject/clarify-force succeeds.
+ * Keeps sidebar totalCount/displayedItems aligned even when force refresh fails
+ * or a stale peek would otherwise linger.
+ */
+function removeItemLocally(key: string): void {
+  const inDisplayed = displayedItems.value.some((it) => itemKey(it) === key)
+  const inRemote = remoteItems.value.some((it) => itemKey(it) === key)
+  if (!inDisplayed && !inRemote) return
+
+  displayedItems.value = displayedItems.value.filter((it) => itemKey(it) !== key)
+  remoteItems.value = remoteItems.value.filter((it) => itemKey(it) !== key)
+  if (inDisplayed || inRemote) {
+    totalCount.value = Math.max(0, totalCount.value - 1)
+  }
+  syncPendingMetaFromDiff()
+}
+
+async function peek(opts?: PeekOptions): Promise<void> {
+  // Prefer awaiting in-flight force: it applies to displayed and is fresher.
+  if (forcePromise) return forcePromise
+  if (peekPromise) return peekPromise
+
+  const gen = ++refreshGeneration
+  const flight = (async () => {
     try {
       const { items: remote, total } = await fetchPeek()
+      // Discard if a newer peek/force superseded this request.
+      if (gen !== refreshGeneration) return
       lastRefreshSource.value = opts?.source ?? null
       setPending(remote, total)
       lastPeekAt.value = Date.now()
     } catch {
       /* keep last known items on transient errors */
     } finally {
-      refreshPromise = null
+      if (peekPromise === flight) peekPromise = null
     }
   })()
-
-  return refreshPromise
+  peekPromise = flight
+  return flight
 }
 
 function applyPending(): void {
@@ -129,21 +170,25 @@ async function refresh(opts?: RefreshOptions): Promise<void> {
     return peek({ source: opts?.source })
   }
 
-  if (refreshPromise) return refreshPromise
+  // Deduplicate concurrent force calls, but never join an in-flight peek.
+  if (forcePromise) return forcePromise
 
-  refreshPromise = (async () => {
+  // Invalidate any in-flight peek writeback (setPending) before we apply.
+  const gen = ++refreshGeneration
+  const flight = (async () => {
     try {
       const { items: remote, total } = await fetchPeek()
+      if (gen !== refreshGeneration) return
       lastRefreshSource.value = opts?.source ?? null
       applyRemoteToDisplayed(remote, total)
     } catch {
       /* keep last known items on transient errors */
     } finally {
-      refreshPromise = null
+      if (forcePromise === flight) forcePromise = null
     }
   })()
-
-  return refreshPromise
+  forcePromise = flight
+  return flight
 }
 
 export function usePendingGates() {
@@ -160,6 +205,7 @@ export function usePendingGates() {
     refresh,
     peek,
     applyPending,
+    removeItemLocally,
     itemKey,
   }
 }

--- a/web/src/views/GatesInboxView.inboxLifecycle.test.ts
+++ b/web/src/views/GatesInboxView.inboxLifecycle.test.ts
@@ -12,7 +12,6 @@ const mocks = vi.hoisted(() => ({
   inboxContext: vi.fn(),
   resumeGate: vi.fn(),
   reactReply: vi.fn(),
-  refresh: vi.fn(async () => undefined),
   runEventsWsUrl: vi.fn((id: string) => `ws://test/runs/${id}/events`),
   toastError: vi.fn(),
   toastSuccess: vi.fn(),
@@ -53,18 +52,25 @@ vi.mock('@/lib/useToast', () => ({
   }),
 }))
 
+const filterState = vi.hoisted(() => ({
+  pipelineSelected: null as { value: string } | null,
+  projectSelected: null as { value: string } | null,
+}))
+
 vi.mock('@/lib/usePipelineFilter', async () => {
   const { ref } = await import('vue')
+  filterState.pipelineSelected = ref('')
   return {
-    usePipelineFilter: () => ({ selected: ref('') }),
+    usePipelineFilter: () => ({ selected: filterState.pipelineSelected! }),
   }
 })
 
 vi.mock('@/lib/useProjectContext', async () => {
   const { ref } = await import('vue')
+  filterState.projectSelected = ref('')
   return {
     useProjectContext: () => ({
-      selected: ref(''),
+      selected: filterState.projectSelected!,
       ensureHydrated: vi.fn(),
     }),
   }
@@ -81,27 +87,11 @@ vi.mock('@/lib/useClarifyDraft', async () => {
   }
 })
 
-vi.mock('@/lib/usePendingGates', async () => {
-  const { ref } = await import('vue')
-  const actual = await vi.importActual<typeof import('@/lib/usePendingGates')>('@/lib/usePendingGates')
-  return {
-    ...actual,
-    usePendingGates: () => ({
-      displayedItems: ref([]),
-      remoteItems: ref([]),
-      totalCount: ref(0),
-      refresh: mocks.refresh,
-      peek: vi.fn(async () => undefined),
-      applyPending: vi.fn(),
-      hasPendingUpdate: ref(false),
-      pendingMeta: ref(null),
-      lastPeekAt: ref(0),
-      itemKey: actual.itemKey,
-    }),
-  }
-})
+// Use the real usePendingGates singleton (api.listGates is mocked) so peek/force
+// races and sidebar totalCount stay covered — do not stub the composable away.
 
 import GatesInboxView from './GatesInboxView.vue'
+import { usePendingGates } from '@/lib/usePendingGates'
 
 function paged(items: InboxItem[]) {
   return { items, total: items.length, page: 1, pageSize: 20 }
@@ -218,13 +208,17 @@ function inboxCallsFor(runId: string, nodeId: string, iteration = 1) {
   )
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.clearAllMocks()
   FakeWebSocket.instances = []
   vi.stubGlobal('WebSocket', FakeWebSocket as unknown as typeof WebSocket)
   mocks.resumeGate.mockResolvedValue({ status: 'ok' })
   mocks.reactReply.mockResolvedValue({ status: 'ok' })
-  mocks.refresh.mockResolvedValue(undefined)
+  if (filterState.pipelineSelected) filterState.pipelineSelected.value = ''
+  if (filterState.projectSelected) filterState.projectSelected.value = ''
+  // Reset singleton so each test starts from an empty pending badge/list.
+  mocks.listGates.mockResolvedValue(paged([]))
+  await usePendingGates().refresh({ mode: 'force' })
   mocks.inboxContext.mockImplementation(async (runId: string, nodeId: string) => {
     if (nodeId.startsWith('clarify-')) {
       return {
@@ -745,27 +739,31 @@ describe('GatesInboxView inbox-context lifecycle', () => {
     const b = gateItem('b')
     let list = [a, b]
     mocks.listGates.mockImplementation(async () => paged(list))
-    mocks.refresh.mockRejectedValueOnce(new Error('refresh blew up'))
 
     const wrapper = mountInbox()
     await flushPromises()
     await nextTick()
 
+    // Force refresh + loadList both fail after resume — local converge must still win.
     list = [b]
+    mocks.listGates.mockRejectedValueOnce(new Error('refresh blew up'))
+    mocks.listGates.mockRejectedValueOnce(new Error('loadList blew up'))
     await wrapper.get('[data-testid="resolve-btn"]').trigger('click')
     await flushPromises()
     await nextTick()
     await flushPromises()
 
-    // Local converge + unlock must happen even when submit refresh throws.
+    // Local converge + unlock must happen even when submit refresh soft-fails.
     expect(wrapper.text()).not.toContain('Gate a')
     expect(wrapper.text()).toContain('Gate b')
     expect(inboxCallsFor('run-b', 'gate-b', 1).length).toBeGreaterThan(0)
+    expect(usePendingGates().totalCount.value).toBe(1)
 
     // Lock released: user can select another (re-select b after converge is fine;
     // add a third via list to prove selectItem is not ignored).
     const c = gateItem('c')
     list = [b, c]
+    mocks.listGates.mockImplementation(async () => paged(list))
     const refreshBtn = wrapper.findAll('button').find((btn) => btn.text().includes('刷新'))
     expect(refreshBtn).toBeTruthy()
     await refreshBtn!.trigger('click')
@@ -785,13 +783,14 @@ describe('GatesInboxView inbox-context lifecycle', () => {
     const b = clarifyItem('b')
     let list = [a, b]
     mocks.listGates.mockImplementation(async () => paged(list))
-    mocks.refresh.mockRejectedValueOnce(new Error('refresh blew up'))
 
     const wrapper = mountInbox()
     await flushPromises()
     await nextTick()
 
     list = [b]
+    mocks.listGates.mockRejectedValueOnce(new Error('refresh blew up'))
+    mocks.listGates.mockRejectedValueOnce(new Error('loadList blew up'))
     await wrapper.get('[data-testid="clarify-send"]').trigger('click')
     await flushPromises()
     await nextTick()
@@ -802,9 +801,11 @@ describe('GatesInboxView inbox-context lifecycle', () => {
     expect(wrapper.text()).toContain('Clarify b')
     expect(inboxCallsFor('run-b', 'clarify-b', 1).length).toBeGreaterThan(0)
     expect(mocks.toastSuccess).toHaveBeenCalled()
+    expect(usePendingGates().totalCount.value).toBe(1)
 
     const c = clarifyItem('c')
     list = [b, c]
+    mocks.listGates.mockImplementation(async () => paged(list))
     const refreshBtn = wrapper.findAll('button').find((btn) => btn.text().includes('刷新'))
     expect(refreshBtn).toBeTruthy()
     expect(refreshBtn!.attributes('disabled')).toBeUndefined()
@@ -845,11 +846,11 @@ describe('GatesInboxView inbox-context lifecycle', () => {
     expect(refreshBtn).toBeTruthy()
     expect(refreshBtn!.attributes('disabled')).toBeDefined()
 
-    const refreshCallsBefore = mocks.refresh.mock.calls.length
+    const listCallsBefore = mocks.listGates.mock.calls.length
     // Even if a click is synthesized, processingLock short-circuits onManualRefresh.
     await refreshBtn!.trigger('click')
     await flushPromises()
-    expect(mocks.refresh.mock.calls.length).toBe(refreshCallsBefore)
+    expect(mocks.listGates.mock.calls.length).toBe(listCallsBefore)
 
     // Selection must stay on a while locked.
     expect(wrapper.find('[data-testid="resolve-btn"]').exists()).toBe(true)
@@ -865,6 +866,77 @@ describe('GatesInboxView inbox-context lifecycle', () => {
     expect(wrapper.text()).toContain('Gate b')
     const refreshAfter = wrapper.findAll('button').find((btn) => btn.text().includes('刷新'))
     expect(refreshAfter?.attributes('disabled')).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  it('approve success: list removes item, detail is not Run # - shell, counts sync', async () => {
+    const a = gateItem('a')
+    const b = gateItem('b')
+    let list: InboxItem[] = [a, b]
+    mocks.listGates.mockImplementation(async () => paged(list))
+
+    const wrapper = mountInbox()
+    await flushPromises()
+    await nextTick()
+
+    list = [b]
+    await wrapper.get('[data-testid="resolve-btn"]').trigger('click')
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('Gate a')
+    expect(wrapper.text()).toContain('Gate b')
+    expect(wrapper.text()).not.toMatch(/Run #\s*-/)
+    expect(wrapper.text()).toContain('Run #b')
+    expect(usePendingGates().totalCount.value).toBe(1)
+    expect(usePendingGates().displayedItems.value.map((it) => it.nodeId)).toEqual(['gate-b'])
+    wrapper.unmount()
+  })
+
+  it('late overlapping listGates after unlock does not restore ghost or Run # - shell', async () => {
+    const only = gateItem('solo')
+    let list: InboxItem[] = [only]
+    mocks.listGates.mockImplementation(async () => paged(list))
+
+    const wrapper = mountInbox()
+    await flushPromises()
+    await nextTick()
+    expect(wrapper.text()).toContain('Gate solo')
+    expect(wrapper.text()).toContain('Run #solo')
+
+    // Start a background loadList via filter watch; keep its snapshot pending.
+    let releaseStale!: (value: ReturnType<typeof paged>) => void
+    mocks.listGates.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseStale = resolve
+        }),
+    )
+    filterState.pipelineSelected!.value = 'wf-stale'
+    await flushPromises()
+
+    // Approve while the stale listGates is still in flight.
+    list = []
+    mocks.listGates.mockImplementation(async () => paged(list))
+    await wrapper.get('[data-testid="resolve-btn"]').trigger('click')
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+
+    // Converged empty inbox — no Run # - shell, no ghost card.
+    expect(wrapper.text()).not.toContain('Gate solo')
+    expect(wrapper.text()).not.toMatch(/Run #\s*-/)
+    expect(wrapper.find('[data-testid="resolve-btn"]').exists()).toBe(false)
+    expect(usePendingGates().totalCount.value).toBe(0)
+
+    // Stale snapshot arrives with the approved item — must be discarded.
+    releaseStale(paged([only]))
+    await flushPromises()
+    await nextTick()
+    expect(wrapper.text()).not.toContain('Gate solo')
+    expect(wrapper.text()).not.toMatch(/Run #\s*-/)
+    expect(usePendingGates().totalCount.value).toBe(0)
     wrapper.unmount()
   })
 })

--- a/web/src/views/GatesInboxView.vue
+++ b/web/src/views/GatesInboxView.vue
@@ -52,6 +52,7 @@ const {
   refresh,
   peek,
   applyPending,
+  removeItemLocally,
   hasPendingUpdate,
   pendingMeta,
   lastPeekAt,
@@ -64,6 +65,8 @@ let listSnapshotForNeighbor: InboxItem[] = []
 const listTotal = ref(0)
 const listPage = ref(1)
 const listLoading = ref(false)
+/** Monotonic generation: stale listGates responses must not overwrite local converge. */
+let listLoadGeneration = 0
 const { isMobile } = useBreakpoint()
 const active = ref<InboxItem | null>(null)
 const mobileView = ref<'list' | 'detail'>('list')
@@ -184,12 +187,38 @@ function shouldFetchActiveInboxContext() {
   return true
 }
 
+/** Invalidate in-flight loadList writebacks (e.g. after local approve converge). */
+function invalidateListLoads() {
+  listLoadGeneration++
+}
+
 /** Drop a lagging list row so users cannot re-select a processed ghost. */
 function removeListItemLocally(removedKey: string) {
+  // Any older listGates still in flight must not restore this row after unlock.
+  invalidateListLoads()
   const before = listItems.value.length
   listItems.value = listItems.value.filter((row) => itemKey(row) !== removedKey)
   const removed = before - listItems.value.length
   if (removed > 0) listTotal.value = Math.max(0, listTotal.value - removed)
+  // Keep sidebar badge / singleton in lockstep with the page list.
+  removeItemLocally(removedKey)
+}
+
+/**
+ * List non-empty + invalid/missing active → pick first valid item.
+ * Empty list → clear active (full empty inbox). Never leave a Run # - shell.
+ */
+function ensureValidActive() {
+  if (processingLock.value) return
+  const list = listItems.value
+  if (!list.length) {
+    if (active.value) active.value = null
+    return
+  }
+  if (active.value && list.some((it) => itemKey(it) === itemKey(active.value!))) {
+    return
+  }
+  active.value = list[0]
 }
 
 /**
@@ -235,6 +264,7 @@ function handleLeftInboxContext(it: InboxItem) {
 }
 
 async function loadList({ showLoading = false }: { showLoading?: boolean } = {}) {
+  const gen = ++listLoadGeneration
   if (showLoading) listLoading.value = true
   try {
     const data = await api.listGates({
@@ -243,6 +273,8 @@ async function loadList({ showLoading = false }: { showLoading?: boolean } = {})
       wf: selected.value || undefined,
       projectId: selectedProject.value || undefined,
     })
+    // Discard overdue snapshots so they cannot resurrect a just-removed gate.
+    if (gen !== listLoadGeneration) return
     listSnapshotForNeighbor = listItems.value.slice()
     if (isPaginated(data)) {
       listItems.value = data.items
@@ -252,10 +284,12 @@ async function loadList({ showLoading = false }: { showLoading?: boolean } = {})
       listTotal.value = data.length
     }
     reconcileProcessedWithList(listItems.value)
+    // Independent loadList success path: repair invalid selection (no Run # - shell).
+    if (!processingLock.value) ensureValidActive()
   } catch {
     /* keep previous list on transient failure */
   } finally {
-    listLoading.value = false
+    if (gen === listLoadGeneration) listLoading.value = false
   }
 }
 
@@ -1124,18 +1158,18 @@ function badgeLabel(it: InboxItem) {
         <Pagination v-if="listTotal > PAGE_SIZE" v-model:page="listPage" :page-size="PAGE_SIZE" :total="listTotal" />
       </div>
 
-      <div class="flex h-full max-h-full min-h-0 min-w-0 flex-col">
+      <div v-if="active" class="flex h-full max-h-full min-h-0 min-w-0 flex-col">
         <div class="card flex max-h-full w-full min-h-0 flex-col overflow-hidden">
           <div class="flex shrink-0 items-center justify-between border-b border-line px-4 py-2.5">
-            <span class="text-xs text-txt3">Run #{{ active?.runId.replace('run-', '') }} · {{ active?.nodeId }}</span>
-            <button class="text-xs text-accent-2 hover:underline" @click="router.push('/runs/' + active?.runId)">
+            <span class="text-xs text-txt3">Run #{{ active.runId.replace('run-', '') }} · {{ active.nodeId }}</span>
+            <button class="text-xs text-accent-2 hover:underline" @click="router.push('/runs/' + active.runId)">
               {{ t('common.buttons.openRunDetail') }}
             </button>
           </div>
           <div class="flex min-h-0 flex-1 flex-col overflow-hidden">
             <ArtifactLoadingPane v-if="activeRunLoading" message-key="pages.gatesInbox.loadingRun" />
             <GateApproval
-              v-else-if="active?.type === 'gate'"
+              v-else-if="active.type === 'gate'"
               ref="gateApprovalRef"
               :key="active.runId + active.nodeId"
               :gate="activeGate!"
@@ -1145,7 +1179,7 @@ function badgeLabel(it: InboxItem) {
               @react-revised="onReactRevised"
             />
             <ReviewShell
-              v-else-if="active?.type === 'clarify' && activeClarify"
+              v-else-if="active.type === 'clarify' && activeClarify"
               :key="active.runId + active.nodeId"
               class="min-h-0 flex-1"
               :sidebar-width="400"
@@ -1183,7 +1217,7 @@ function badgeLabel(it: InboxItem) {
               </template>
             </ReviewShell>
             <ClarifyProductStage
-              v-else-if="active?.type === 'clarify'"
+              v-else-if="active.type === 'clarify'"
               :product-nodes="[]"
               :selected-product-id="null"
               stage-kind="loadFailed"


### PR DESCRIPTION
## Summary
- Separate `usePendingGates` peek vs force/submit flights with generation discard so in-flight sidebar peek cannot steal force semantics or restore stale `totalCount`.
- Add `loadList` generation + invalidate on local remove so overdue `listGates` cannot resurrect approved gates; sync singleton via `removeItemLocally`.
- Guard desktop detail: only render Run header/body when `active` is valid; auto-repair invalid selection after list apply.
- Extend unit tests for peek↔force race, approve→list/detail/count consistency, and late overlapping `listGates`.

## Test plan
- [x] `npx vitest run src/lib/usePendingGates.test.ts src/views/GatesInboxView.inboxLifecycle.test.ts src/lib/inboxActiveSelection.test.ts src/views/GatesInboxView.mobileFill.test.ts`
- [ ] Manually: approve/reject/clarify-force several items; confirm no `Run # -`, no ghost cards, Approving counts (list / filter / sidebar) stay in sync
- [ ] Manually: sole-item approve → full empty inbox; backend pending=0 → UI counts 0


Made with [Cursor](https://cursor.com)