### PR TITLE
feat(web): add run list delete and three-state ops column

### DIFF
--- a/web/e2e/delete-run-list.spec.ts
+++ b/web/e2e/delete-run-list.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * Acceptance E2E for DeleteRun UI on RunListView (mocked API).
+ * Harness: run-list.html → RunListView at /runs.
+ */
+import { expect, test, type Page } from '@playwright/test'
+
+type RunStatus = 'queued' | 'running' | 'waiting_human' | 'completed' | 'failed' | 'cancelled'
+
+function buildRun(id: string, status: RunStatus, name: string) {
+  return {
+    id,
+    workflowId: 'wf-list-delete',
+    workflowName: name,
+    workflowVersion: 1,
+    title: name,
+    status,
+    trigger: 'manual',
+    startedAt: '2026-07-24T12:00:00Z',
+    createdAt: '2026-07-24T11:59:00Z',
+    durationSec: 42,
+    progress: status === 'completed' || status === 'failed' ? 1 : 0.4,
+    priority: 'normal',
+    currentNodeLabel: status === 'running' || status === 'waiting_human' ? '执行中' : undefined,
+  }
+}
+
+async function openRunList(
+  page: Page,
+  opts?: {
+    width?: number
+    height?: number
+    runs?: ReturnType<typeof buildRun>[]
+    onDelete?: (id: string) => void
+    deleteFailStatus?: number
+  },
+) {
+  const width = opts?.width ?? 1280
+  const height = opts?.height ?? 900
+  await page.setViewportSize({ width, height })
+
+  let runs =
+    opts?.runs ??
+    [
+      buildRun('run-completed', 'completed', '已结束流水线'),
+      buildRun('run-failed', 'failed', '失败流水线'),
+      buildRun('run-running', 'running', '运行中流水线'),
+      buildRun('run-cancelled', 'cancelled', '已取消流水线'),
+    ]
+
+  await page.route('**/api/**', async (route) => {
+    const req = route.request()
+    const url = new URL(req.url())
+    const path = url.pathname
+    const method = req.method()
+
+    if (method === 'DELETE' && path.startsWith('/api/runs/')) {
+      const id = path.slice('/api/runs/'.length)
+      if (opts?.deleteFailStatus) {
+        await route.fulfill({
+          status: opts.deleteFailStatus,
+          json: { error: opts.deleteFailStatus === 409 ? 'cannot delete run' : 'not found' },
+        })
+        return
+      }
+      opts?.onDelete?.(id)
+      runs = runs.filter((r) => r.id !== id)
+      await route.fulfill({ json: { status: 'deleted' } })
+      return
+    }
+
+    if (path === '/api/runs' || (path.startsWith('/api/runs') && method === 'GET' && !path.slice('/api/runs'.length).includes('/'))) {
+      await route.fulfill({ json: { items: runs, total: runs.length } })
+      return
+    }
+    if (path === '/api/workflows') {
+      await route.fulfill({ json: [] })
+      return
+    }
+    if (path === '/api/projects') {
+      await route.fulfill({ json: [] })
+      return
+    }
+    await route.fulfill({ status: 404, json: { error: 'not mocked' } })
+  })
+
+  await page.goto('/run-list.html')
+  await expect(page.getByRole('heading', { name: '运行' })).toBeVisible({ timeout: 15_000 })
+  await expect(page.getByText('所有工作流的运行记录')).toBeVisible()
+}
+
+test.describe('RunListView delete run acceptance', () => {
+  test('completed: delete confirm mentions not WorkflowDef, success stays on list', async ({ page }) => {
+    let deletedId = ''
+    await openRunList(page, {
+      onDelete: (id) => {
+        deletedId = id
+      },
+    })
+
+    const completedRow = page.locator('tr', { hasText: '已结束流水线' })
+    await expect(completedRow.getByTestId('delete-run-btn')).toBeVisible()
+    await expect(completedRow.getByTestId('cancel-run-btn')).toHaveCount(0)
+
+    await completedRow.getByTestId('delete-run-btn').click()
+    await expect(page.getByText('确认删除该次运行？')).toBeVisible()
+    await expect(page.getByText(/不会删除工作流定义/)).toBeVisible()
+    await expect(page.getByText(/删除成功后列表将刷新/)).toBeVisible()
+
+    // Dismiss without deleting (modal footer ghost cancel, not list cancel-run-btn)
+    await page
+      .locator('.fixed.inset-0')
+      .filter({ hasText: '确认删除该次运行？' })
+      .getByRole('button', { name: '取消' })
+      .click()
+    await expect(page.getByText('确认删除该次运行？')).toHaveCount(0)
+    await expect(page.getByText('已结束流水线', { exact: true })).toBeVisible()
+
+    await completedRow.getByTestId('delete-run-btn').click()
+    await page.getByTestId('confirm-delete-run-btn').click()
+    await expect.poll(() => deletedId).toBe('run-completed')
+    await expect(page.getByText('已结束流水线', { exact: true })).toHaveCount(0)
+    await expect(page.getByRole('heading', { name: '运行' })).toBeVisible()
+    await expect(page.getByText(/已删除运行/)).toBeVisible()
+    await expect(page.getByTestId('run-detail-page')).toHaveCount(0)
+  })
+
+  test('running: only cancel; cancelled: dash placeholder; no delete entry', async ({ page }) => {
+    await openRunList(page)
+
+    const runningRow = page.locator('tr', { hasText: '运行中流水线' })
+    await expect(runningRow.getByTestId('cancel-run-btn')).toBeVisible()
+    await expect(runningRow.getByTestId('delete-run-btn')).toHaveCount(0)
+
+    const cancelledRow = page.locator('tr', { hasText: '已取消流水线' })
+    await expect(cancelledRow.getByTestId('run-ops-placeholder')).toBeVisible()
+    await expect(cancelledRow.getByTestId('delete-run-btn')).toHaveCount(0)
+    await expect(cancelledRow.getByTestId('cancel-run-btn')).toHaveCount(0)
+
+    // Placeholder click must not navigate to detail
+    await cancelledRow.getByTestId('run-ops-placeholder').click()
+    await expect(page.getByTestId('run-detail-page')).toHaveCount(0)
+  })
+
+  test('delete failure keeps row and shows error', async ({ page }) => {
+    await openRunList(page, { deleteFailStatus: 409 })
+    const failedRow = page.locator('tr', { hasText: '失败流水线' })
+    await failedRow.getByTestId('delete-run-btn').click()
+    await page.getByTestId('confirm-delete-run-btn').click()
+    await expect(page.getByText('当前状态不可删除')).toBeVisible()
+    await expect(page.getByText('失败流水线', { exact: true })).toBeVisible()
+  })
+
+  test('mobile cards: delete / cancel / dash parity', async ({ page }) => {
+    await openRunList(page, { width: 390, height: 844 })
+    await expect(page.locator('table')).toHaveCount(0)
+
+    const completedCard = page.locator('[role="button"]', { hasText: '已结束流水线' })
+    await expect(completedCard.getByTestId('delete-run-btn')).toBeVisible()
+    await expect(completedCard.getByTestId('cancel-run-btn')).toHaveCount(0)
+
+    const runningCard = page.locator('[role="button"]', { hasText: '运行中流水线' })
+    await expect(runningCard.getByTestId('cancel-run-btn')).toBeVisible()
+    await expect(runningCard.getByTestId('delete-run-btn')).toHaveCount(0)
+
+    const cancelledCard = page.locator('[role="button"]', { hasText: '已取消流水线' })
+    await expect(cancelledCard.getByTestId('run-ops-placeholder')).toBeVisible()
+
+    await completedCard.getByTestId('delete-run-btn').click()
+    await expect(page.getByText('确认删除该次运行？')).toBeVisible()
+    await expect(page.getByTestId('run-detail-page')).toHaveCount(0)
+  })
+})

--- a/web/e2e/run-list-main.ts
+++ b/web/e2e/run-list-main.ts
@@ -1,0 +1,43 @@
+import '../src/styles/global.css'
+import { createApp, h, defineComponent } from 'vue'
+import { createMemoryHistory, createRouter, RouterView } from 'vue-router'
+import { i18n } from '../src/lib/i18n'
+import { initLocale, setLocale } from '../src/lib/locale'
+import { installIdleScrollbar } from '../src/lib/idleScrollbar'
+import ToastHost from '../src/components/ui/ToastHost.vue'
+import RunListView from '../src/views/RunListView.vue'
+
+installIdleScrollbar()
+
+async function bootstrap() {
+  await initLocale()
+  await setLocale('zh-CN')
+
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/runs', component: RunListView },
+      {
+        path: '/runs/:id',
+        component: {
+          render: () => h('div', { 'data-testid': 'run-detail-page' }, 'run detail'),
+        },
+      },
+    ],
+  })
+  await router.push('/runs')
+
+  const Root = defineComponent({
+    setup() {
+      return () =>
+        h('div', [
+          h(RouterView),
+          h(ToastHost),
+        ])
+    },
+  })
+
+  createApp(Root).use(i18n).use(router).mount('#app')
+}
+
+void bootstrap()

--- a/web/e2e/run-list.html
+++ b/web/e2e/run-list.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Run List E2E</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./run-list-main.ts"></script>
+  </body>
+</html>

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -495,6 +495,8 @@
       "subtitle": "Run history for all workflows",
       "queued": "queued",
       "cancelConfirm": "Only this run is stopped; the list row status will refresh after success.",
+      "deleteConfirm": "Only this run is removed; the list will refresh after success.",
+      "deleteSuccess": "Run deleted; list refreshed",
       "loadFailedTitle": "Failed to load runs",
       "loadFailedDesc": "Could not fetch run history. Background polling will retry automatically. Filters and pagination remain available."
     },

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -495,6 +495,8 @@
       "subtitle": "所有工作流的运行记录",
       "queued": "入队",
       "cancelConfirm": "仅停止这一次 Run；取消成功后列表将刷新该行状态。",
+      "deleteConfirm": "仅清理这一次 Run；删除成功后列表将刷新。",
+      "deleteSuccess": "已删除运行，列表已刷新",
       "loadFailedTitle": "加载失败",
       "loadFailedDesc": "无法加载运行记录，后台轮询将自动重试。筛选与翻页仍可使用。"
     },

--- a/web/src/views/RunListView.test.ts
+++ b/web/src/views/RunListView.test.ts
@@ -26,7 +26,7 @@ describe('RunListView cancel run', () => {
     expect(openFn).not.toContain('api.cancelRun')
 
     const confirmStart = src.indexOf('async function confirmCancelRun()')
-    const confirmEnd = src.indexOf('\nfunction runIdShort(', confirmStart)
+    const confirmEnd = src.indexOf('\nfunction openDeleteConfirm(', confirmStart)
     const confirmFn = src.slice(confirmStart, confirmEnd > 0 ? confirmEnd : undefined)
     expect(confirmFn).toContain('api.cancelRun(target.id)')
     expect(confirmFn).toContain("toast.success(t('pages.runDetail.cancelSuccess'))")
@@ -38,5 +38,78 @@ describe('RunListView cancel run', () => {
     expect(src).toMatch(/pages\.runList\.cancelConfirm/)
     expect(src).toMatch(/role="button"/)
     expect(src).toMatch(/@click\.stop @keydown\.stop/)
+  })
+})
+
+describe('RunListView delete run and ops column', () => {
+  it('adds canDeleteRun mutually exclusive with canCancelRun', () => {
+    expect(src).toMatch(/function canDeleteRun\(/)
+    expect(src).toMatch(/r\.status === 'completed' \|\| r\.status === 'failed'/)
+    expect(src).toMatch(/v-else-if="canDeleteRun\(r\)"/)
+    expect(src).toMatch(/data-testid="delete-run-btn"/)
+    expect(src).toMatch(/data-testid="run-ops-placeholder"/)
+    // cancel and delete sets must not overlap in predicates
+    const cancelFn = src.slice(
+      src.indexOf('function canCancelRun(r: Run)'),
+      src.indexOf('function canDeleteRun(r: Run)'),
+    )
+    const deleteFn = src.slice(
+      src.indexOf('function canDeleteRun(r: Run)'),
+      src.indexOf('function openRun(r: Run)'),
+    )
+    expect(cancelFn).not.toMatch(/completed|failed/)
+    expect(deleteFn).not.toMatch(/queued|running|waiting_human/)
+  })
+
+  it('renders text danger buttons without icons and grey dash placeholder', () => {
+    // List ops cancel/delete must be text-only; confirm modals may still use icons.
+    const cancelBtnBlocks = [...src.matchAll(/data-testid="cancel-run-btn"[\s\S]*?<\/AppButton>/g)].map((m) => m[0])
+    const deleteBtnBlocks = [...src.matchAll(/data-testid="delete-run-btn"[\s\S]*?<\/AppButton>/g)].map((m) => m[0])
+    expect(cancelBtnBlocks.length).toBeGreaterThanOrEqual(2)
+    expect(deleteBtnBlocks.length).toBeGreaterThanOrEqual(2)
+    for (const block of [...cancelBtnBlocks, ...deleteBtnBlocks]) {
+      expect(block).not.toMatch(/\bicon=/)
+    }
+    expect(src).toMatch(/data-testid="run-ops-placeholder"/)
+    expect(src).toContain('—')
+    expect(src).toMatch(/common\.buttons\.delete/)
+  })
+
+  it('opens delete confirm before DELETE and stays on list after success', () => {
+    expect(src).toMatch(/openDeleteConfirm\(r\)/)
+    expect(src).toMatch(/data-testid="confirm-delete-run-btn"/)
+    expect(src).toMatch(/pages\.runDetail\.deleteWarning/)
+    expect(src).toMatch(/pages\.runList\.deleteConfirm/)
+    expect(src).toMatch(/pages\.runList\.deleteSuccess/)
+
+    const openStart = src.indexOf('function openDeleteConfirm(r: Run)')
+    const openEnd = src.indexOf('\nfunction closeDeleteConfirm(', openStart)
+    const openFn = src.slice(openStart, openEnd)
+    expect(openFn).toContain('deleteTarget.value = r')
+    expect(openFn).not.toContain('api.deleteRun')
+
+    const confirmStart = src.indexOf('async function confirmDeleteRun()')
+    const confirmEnd = src.indexOf('\nwatch(statusFilterOpen', confirmStart)
+    const confirmFn = src.slice(confirmStart, confirmEnd > 0 ? confirmEnd : undefined)
+    expect(confirmFn).toContain('api.deleteRun(target.id)')
+    expect(confirmFn).toContain("toast.success(t('pages.runList.deleteSuccess'))")
+    expect(confirmFn).toContain('await load()')
+    expect(confirmFn).not.toContain('router.push')
+    expect(confirmFn).toContain('deletingRun.value = true')
+    expect(confirmFn).toContain('mapDeleteRunError')
+  })
+
+  it('stops propagation on ops area and placeholder so row does not open detail', () => {
+    expect(src).toMatch(/data-testid="run-ops"/)
+    expect(src).toMatch(/data-testid="run-ops-placeholder"/)
+    // desktop ops cell and mobile ops wrapper both stop click
+    expect(src.match(/data-testid="run-ops"[^>]*@click\.stop/g)?.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('keeps cancel confirm flow and does not drop cancel modal', () => {
+    expect(src).toMatch(/openCancelConfirm\(r\)/)
+    expect(src).toMatch(/confirmCancelRun/)
+    expect(src).toMatch(/data-testid="confirm-cancel-run-btn"/)
+    expect(src).toMatch(/pages\.runDetail\.cancelTitle/)
   })
 })

--- a/web/src/views/RunListView.vue
+++ b/web/src/views/RunListView.vue
@@ -55,9 +55,16 @@ const pipelineFilterOpen = ref(false)
 const cancelTarget = ref<Run | null>(null)
 const cancellingRun = ref(false)
 const cancelRunError = ref('')
+const deleteTarget = ref<Run | null>(null)
+const deletingRun = ref(false)
+const deleteRunError = ref('')
 
 function canCancelRun(r: Run) {
   return r.status === 'queued' || r.status === 'running' || r.status === 'waiting_human'
+}
+
+function canDeleteRun(r: Run) {
+  return r.status === 'completed' || r.status === 'failed'
 }
 
 function openRun(r: Run) {
@@ -65,7 +72,7 @@ function openRun(r: Run) {
 }
 
 function openCancelConfirm(r: Run) {
-  if (!canCancelRun(r) || cancellingRun.value) return
+  if (!canCancelRun(r) || cancellingRun.value || deletingRun.value) return
   cancelRunError.value = ''
   cancelTarget.value = r
 }
@@ -100,6 +107,43 @@ async function confirmCancelRun() {
     cancelRunError.value = mapCancelRunError(e)
   } finally {
     cancellingRun.value = false
+  }
+}
+
+function openDeleteConfirm(r: Run) {
+  if (!canDeleteRun(r) || deletingRun.value || cancellingRun.value) return
+  deleteRunError.value = ''
+  deleteTarget.value = r
+}
+
+function closeDeleteConfirm() {
+  if (deletingRun.value) return
+  deleteTarget.value = null
+  deleteRunError.value = ''
+}
+
+function mapDeleteRunError(e: unknown): string {
+  const status = (e as { status?: number })?.status
+  const msg = e instanceof Error ? e.message : String(e || '')
+  if (status === 404 || /not found/i.test(msg)) return t('pages.runDetail.deleteErrorNotFound')
+  if (status === 409 || /cannot delete run/i.test(msg)) return t('pages.runDetail.deleteErrorNotDeletable')
+  return msg || t('pages.runDetail.deleteErrorGeneric')
+}
+
+async function confirmDeleteRun() {
+  const target = deleteTarget.value
+  if (!target || !canDeleteRun(target) || deletingRun.value) return
+  deletingRun.value = true
+  deleteRunError.value = ''
+  try {
+    await api.deleteRun(target.id)
+    deleteTarget.value = null
+    toast.success(t('pages.runList.deleteSuccess'))
+    await load()
+  } catch (e) {
+    deleteRunError.value = mapDeleteRunError(e)
+  } finally {
+    deletingRun.value = false
   }
 }
 
@@ -352,15 +396,29 @@ onUnmounted(() => {
               <span class="truncate">{{ r.workflowName }}</span>
               <span v-if="r.workflowVersion" class="chip shrink-0">v{{ r.workflowVersion }}</span>
             </div>
-            <div v-if="canCancelRun(r)" class="shrink-0" @click.stop @keydown.stop>
+            <div class="shrink-0" data-testid="run-ops" @click.stop @keydown.stop>
               <AppButton
+                v-if="canCancelRun(r)"
                 data-testid="cancel-run-btn"
                 variant="danger"
                 size="sm"
-                icon="close"
                 :disabled="cancellingRun && cancelTarget?.id === r.id"
                 @click="openCancelConfirm(r)"
               >{{ t('common.buttons.cancel') }}</AppButton>
+              <AppButton
+                v-else-if="canDeleteRun(r)"
+                data-testid="delete-run-btn"
+                variant="danger"
+                size="sm"
+                :disabled="deletingRun && deleteTarget?.id === r.id"
+                @click="openDeleteConfirm(r)"
+              >{{ t('common.buttons.delete') }}</AppButton>
+              <span
+                v-else
+                data-testid="run-ops-placeholder"
+                class="select-none px-1 text-sm text-txt3/50"
+                aria-hidden="true"
+              >—</span>
             </div>
           </div>
         </div>
@@ -481,16 +539,29 @@ onUnmounted(() => {
               </td>
               <td class="px-5 py-3"><StatusPill :status="r.status" size="sm" /></td>
               <td class="px-5 py-3"><PriorityBadge :priority="r.priority" /></td>
-              <td class="px-5 py-3 text-right" @click.stop>
+              <td class="px-5 py-3 text-right" data-testid="run-ops" @click.stop>
                 <AppButton
                   v-if="canCancelRun(r)"
                   data-testid="cancel-run-btn"
                   variant="danger"
                   size="sm"
-                  icon="close"
                   :disabled="cancellingRun && cancelTarget?.id === r.id"
                   @click="openCancelConfirm(r)"
                 >{{ t('common.buttons.cancel') }}</AppButton>
+                <AppButton
+                  v-else-if="canDeleteRun(r)"
+                  data-testid="delete-run-btn"
+                  variant="danger"
+                  size="sm"
+                  :disabled="deletingRun && deleteTarget?.id === r.id"
+                  @click="openDeleteConfirm(r)"
+                >{{ t('common.buttons.delete') }}</AppButton>
+                <span
+                  v-else
+                  data-testid="run-ops-placeholder"
+                  class="select-none px-1 text-sm text-txt3/50"
+                  aria-hidden="true"
+                >—</span>
               </td>
             </tr>
           </template>
@@ -530,6 +601,41 @@ onUnmounted(() => {
           @click="confirmCancelRun"
         >
           {{ cancellingRun ? t('common.buttons.cancelling') : t('common.buttons.confirmCancelRun') }}
+        </AppButton>
+      </template>
+    </AppModal>
+
+    <AppModal
+      :open="!!deleteTarget"
+      :title="t('pages.runDetail.deleteTitle')"
+      :width="440"
+      @close="closeDeleteConfirm"
+    >
+      <div class="space-y-3 text-sm text-txt2">
+        <div class="flex items-start gap-2 rounded-md border border-err/30 bg-err/10 px-3 py-2 text-[12px] text-err">
+          <Icon name="alert" :size="14" class="mt-0.5 shrink-0" />
+          {{ t('pages.runDetail.deleteWarning') }}
+        </div>
+        <p>{{ t('pages.runList.deleteConfirm') }}</p>
+        <div
+          v-if="deleteRunError"
+          class="flex items-start gap-2 rounded-md border border-err/30 bg-err/10 px-3 py-2 text-[12px] text-err"
+        >
+          <Icon name="alert" :size="14" class="mt-0.5" />{{ deleteRunError }}
+        </div>
+      </div>
+      <template #footer>
+        <AppButton variant="ghost" :disabled="deletingRun" @click="closeDeleteConfirm">
+          {{ t('common.buttons.cancel') }}
+        </AppButton>
+        <AppButton
+          data-testid="confirm-delete-run-btn"
+          variant="danger"
+          icon="trash"
+          :disabled="deletingRun"
+          @click="confirmDeleteRun"
+        >
+          {{ deletingRun ? t('common.buttons.deleting') : t('common.buttons.confirmDelete') }}
         </AppButton>
       </template>
     </AppModal>


### PR DESCRIPTION
Allow deleting completed/failed runs from the runs list with confirm dialog,
and show mutually exclusive cancel/delete/dash actions on desktop and mobile.

Co-authored-by: Cursor <cursoragent@cursor.com>
