### PR TITLE
fix(agent-studio): hide reportsTo subtitle in org tree leaves

### DIFF
--- a/web/src/components/agent/AgentOrgSidebar.test.ts
+++ b/web/src/components/agent/AgentOrgSidebar.test.ts
@@ -362,7 +362,7 @@ describe('AgentOrgSidebar agent name text color', () => {
     expect(unselectedName).not.toContain('text-txt3')
   })
 
-  it('分组名保持 text-txt2，有 parentAgent 时 reportsTo 保持 text-txt3', () => {
+  it('分组名保持 text-txt2，有 parentAgent 时树内不渲染 reportsTo', () => {
     const wrapper = mountSidebar()
 
     const group = wrapper
@@ -374,10 +374,10 @@ describe('AgentOrgSidebar agent name text color', () => {
     expect(groupName.classes()).not.toContain('text-txt')
 
     const bob = findAgentRow(wrapper, 'bob')!
+    expect(bob.text()).not.toMatch(/上级|reportsTo|Reports to/i)
     const reportsTo = bob
       .findAll('span')
       .find((s) => s.classes().includes('text-txt3') && s.text().includes('alice'))
-    expect(reportsTo).toBeTruthy()
-    expect(reportsTo!.classes()).toContain('text-txt3')
+    expect(reportsTo).toBeFalsy()
   })
 })

--- a/web/src/components/agent/AgentOrgSidebar.vue
+++ b/web/src/components/agent/AgentOrgSidebar.vue
@@ -364,10 +364,6 @@ function onDrop(e: DragEvent, row: OrgTreeRow) {
                     class="shrink-0 border border-accent-2/35 bg-accent/15 px-1 text-[9px] font-bold uppercase tracking-wide text-accent-2"
                   >{{ t('pages.agentStudio.org.multiGroup') }}</span>
                 </span>
-                <span
-                  v-if="row.parentAgent"
-                  class="mt-0.5 block truncate text-[10.5px] leading-tight text-txt3"
-                >{{ t('pages.agentStudio.org.reportsTo', { name: row.parentAgent }) }}</span>
               </span>
             </button>
           </div>

--- a/web/src/views/AgentStudioView.vue
+++ b/web/src/views/AgentStudioView.vue
@@ -2891,10 +2891,6 @@ onBeforeUnmount(() => {
                         class="shrink-0 border border-accent-2/35 bg-accent/15 px-1 text-[9px] font-bold uppercase tracking-wide text-accent-2"
                       >{{ t('pages.agentStudio.org.multiGroup') }}</span>
                     </span>
-                    <span
-                      v-if="row.parentAgent"
-                      class="mt-0.5 block truncate text-[10.5px] leading-tight text-txt3"
-                    >{{ t('pages.agentStudio.org.reportsTo', { name: row.parentAgent }) }}</span>
                   </span>
                 </button>
               </template>


### PR DESCRIPTION
Remove the parentAgent second line from desktop sidebar and mobile org
sheet so agent rows stay single-line, matching the approved Demo.
Keep parent editing in the detail panel and flip the locked test.

Co-authored-by: Cursor <cursoragent@cursor.com>
