### PR TITLE
ci(web): add critical-path Playwright e2e to ci-web

### DIFF
--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -61,3 +61,36 @@ jobs:
             coverage-web \
             "${{ steps.coverage.outputs.pct }}" \
             "${{ steps.coverage.outputs.color }}"
+
+  # Critical-path Playwright subset (mock vite.e2e harness; no real backend).
+  # Parallel with `web`. Minimal permissions (no coverage-badge write).
+  # Follow-up: add this job to main required checks for hard merge blocking.
+  web-e2e:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci --no-audit --no-fund
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Run critical-path e2e
+        run: npm run test:e2e:ci
+      - name: Upload Playwright failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-e2e-failure
+          path: |
+            web/playwright-report/
+            web/test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Before contributing, read [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) and
 
 - Backend: `cd server && go test ./...`
 - Web: `cd web && npm ci && npm test && npx vue-tsc --noEmit`
+- Web critical e2e (same subset as CI `web-e2e`): see [Critical-path Playwright e2e](#critical-path-playwright-e2e)
 - Configuration doc: `cd server && go run ./cmd/gen-configdoc -check`
 - Full local development stack: `./start.sh dev -d` (source/HMR; gateway
   sources live in `sandbox-gateway/`). Default `./start.sh -d` pulls published
@@ -41,7 +42,30 @@ Matching workflows: `ci-server`, `ci-gateway`, `ci-sandbox` (sandbox-go job).
 cd web && npm ci && npm run lint && npx vue-tsc --noEmit
 ```
 
-Matching workflow: `ci-web`.
+Matching workflow: `ci-web` (`web` job).
+
+### Critical-path Playwright e2e
+
+PR `ci-web` also runs a parallel `web-e2e` job for a fixed critical-path subset
+(local vite.e2e mock harness; no real backend). Specs:
+
+- `gate-mobile-fill.spec.ts` — gate mobile approve / reject
+- `clarify-inbox-product.spec.ts` — clarify inbox product surface
+- `delete-run-list.spec.ts` — run list delete / cancel / placeholders
+- `cancel-run.spec.ts` — cancel run across statuses
+
+Reproduce locally (same entry as CI):
+
+```bash
+cd web && npm ci && npx playwright install chromium && npm run test:e2e:ci
+```
+
+Full suite remains `npm run test:e2e` (not run in PR CI). On `web-e2e`
+failure, Actions uploads `playwright-report/` and `test-results/` artifacts.
+
+**Follow-up:** add the `web-e2e` check to main branch protection required
+checks so a red job hard-blocks merge. Until then, failure is a visible red
+signal only.
 
 Later tightening (more Go linters, stricter ESLint rules, optional type-aware
 ESLint) can ratchet without changing this layout; not required for this pass.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Publish the pipeline if needed, then start a run. Watch sandbox execution, artif
 
 ## Development
 
-For contributors working on the Approving codebase, see the [Contributing Guide](CONTRIBUTING.md).
+For contributors working on the Approving codebase, see the [Contributing Guide](CONTRIBUTING.md). Critical-path Playwright e2e (CI `web-e2e`): see [CONTRIBUTING — Critical-path Playwright e2e](CONTRIBUTING.md#critical-path-playwright-e2e).
 
 **Prerequisites:** Go, Node.js, Docker Compose (Linux host for sandboxes)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -124,7 +124,7 @@ Approving 覆盖完整 Agent 工作流：从图设计到沙箱执行，再到产
 
 ## 开发
 
-参与 Approving 代码贡献，请看 [贡献指南](CONTRIBUTING.md)。
+参与 Approving 代码贡献，请看 [贡献指南](CONTRIBUTING.md)。关键路径 Playwright e2e（CI `web-e2e`）见 [贡献指南 — Critical-path Playwright e2e](CONTRIBUTING.md#critical-path-playwright-e2e)。
 
 **前置要求：** Go、Node.js、Docker Compose（沙箱需 Linux 宿主）
 

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
+    "test:e2e:ci": "playwright test e2e/gate-mobile-fill.spec.ts e2e/clarify-inbox-product.spec.ts e2e/delete-run-list.spec.ts e2e/cancel-run.spec.ts",
     "lint": "eslint .",
     "assert:novnc-http": "node scripts/assert-no-novnc-secure-context.mjs",
     "measure:lcp": "node scripts/measure-lcp.mjs",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -8,9 +8,12 @@ export default defineConfig({
   // Shared vite.e2e mock state (vncConnectCount / delay/fail flags) is process-global.
   workers: 1,
   fullyParallel: false,
+  // CI uploads html report + traces on failure (see ci-web web-e2e job).
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
   use: {
     headless: true,
     locale: 'zh-CN',
+    trace: 'retain-on-failure',
   },
   webServer: {
     command: 'npx vite --config vite.e2e.config.ts',


### PR DESCRIPTION
## Summary
- Add parallel `web-e2e` job in `ci-web.yml` (contents:read) that installs Chromium and runs a fixed critical-path Playwright subset via `npm run test:e2e:ci`.
- Specs: `gate-mobile-fill`, `clarify-inbox-product`, `delete-run-list`, `cancel-run` (12 cases; vite.e2e mock, no real backend).
- On failure, upload `playwright-report/` + `test-results/` (`actions/upload-artifact@v7`); enable CI html reporter and `trace: retain-on-failure`.
- Document local reproduction in CONTRIBUTING; note follow-up to add `web-e2e` to main required checks for hard merge blocking.

## Test plan
- [x] Local: `cd web && npm ci && npx playwright install chromium && CI=true npm run test:e2e:ci` → 12 passed
- [x] Local: deliberately break cancel-run assertion → exit 1, report/trace under `playwright-report/` + `test-results/`; restore → 12 passed
- [ ] CI: confirm `web` and `web-e2e` both green on this PR
- [ ] Follow-up (maintainer): add `web-e2e` to main branch protection required checks


Made with [Cursor](https://cursor.com)