### PR TITLE
chore: add minimal security scan CI (CodeQL, npm audit, gitleaks)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,89 @@
+# Minimal security scan baseline (bypass path — does not modify ci-*).
+# CodeQL: results in Security → Code scanning / PR Checks (not branch-protection required).
+# npm audit: high+ logged; continue-on-error so known web highs do not fail the job.
+# gitleaks: fail-on-leak after .gitleaks.toml allowlist for documented placeholders.
+name: security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "17 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  codeql:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: autobuild
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        if: matrix.language == 'go'
+        with:
+          go-version: "1.25.x"
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+      - name: Manual Go build (fallback when autobuild is skipped)
+        if: matrix.build-mode == 'manual'
+        env:
+          GOPROXY: https://proxy.golang.org,direct
+        run: |
+          set -euo pipefail
+          (cd server && go build ./...)
+          (cd sandbox-gateway/gateway && go build ./...)
+          (cd sandbox-gateway/sandbox && go build ./...)
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  npm-audit:
+    name: npm audit (web)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - name: npm audit (high+, warn-only)
+        # First baseline: log highs but do not fail the job on known web findings.
+        # Use the official registry (mirror audit APIs are often unimplemented).
+        continue-on-error: true
+        env:
+          npm_config_registry: https://registry.npmjs.org
+        run: npm audit --audit-level=high
+
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,14 @@
+# Minimal allowlist for confirmed documentation false positives only.
+# Do not broaden into a global disable of secret scanning.
+# Target: web/src/components/workflow/WorkflowApiTab.vue curl-auth-header
+# examples that use the placeholder YOUR_API_KEY (lines ~109/111/113/115/117).
+title = "approving gitleaks"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "WorkflowApiTab API docs: curl Authorization examples use placeholder YOUR_API_KEY"
+regexes = [
+  '''YOUR_API_KEY''',
+]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Build rollback-capable, human-gated, observable workflows — agents run in real
 [![coverage-web](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcocofhu%2Fapproving%2Fcoverage-badges%2Fcoverage-web.json)](https://github.com/cocofhu/approving/actions/workflows/ci-web.yml)
 [![coverage-sandbox](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcocofhu%2Fapproving%2Fcoverage-badges%2Fcoverage-sandbox.json)](https://github.com/cocofhu/approving/actions/workflows/ci-sandbox.yml)
 
+Security scans (CodeQL, web npm audit, gitleaks) run via the [security](https://github.com/cocofhu/approving/actions/workflows/security.yml) workflow on push/PR. View CodeQL under Security → Code scanning (or PR Checks); npm audit and gitleaks results are in the corresponding Actions job logs.
+
 [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Support](SUPPORT.md) · [Configuration](server/CONFIGURATION.md) · [Gateway](GATEWAY.md)
 
 **English | [简体中文](README.zh-CN.md)**


### PR DESCRIPTION
## Summary
- Add independent `.github/workflows/security.yml` with three jobs: CodeQL (`go` + `javascript-typescript`), web `npm audit --audit-level=high` (warn via `continue-on-error`), and gitleaks (fail-on-leak).
- Add minimal `.gitleaks.toml` allowlist for the documented `YOUR_API_KEY` placeholder false positives in `WorkflowApiTab.vue`.
- Document in English README (1–2 sentences) how to view CodeQL / audit / gitleaks results.
- Does **not** modify `ci-server` / `ci-web` / `ci-sandbox` / `ci-gateway` / `ci.yml`.

## Gate semantics (baseline)
- CodeQL: results visible in Code scanning / PR Checks; not configured as required.
- npm audit: highs are logged; job stays green (warn) so known web highs do not block merge.
- gitleaks: passes with only the allowlisted docs placeholder; real/new leaks outside allowlist fail.

## Test plan
- [ ] PR runs `security` workflow; existing `ci-*` unchanged and still green when their paths change
- [ ] CodeQL jobs upload/analyze for Go and JS/TS
- [ ] `npm audit (web)` logs findings and completes as success (warned) despite existing highs
- [ ] `gitleaks` passes on this baseline
- [ ] Introducing a non-allowlisted secret causes only gitleaks to fail


Made with [Cursor](https://cursor.com)