### PR TITLE
fix: run failure observability for early node failures

### DIFF
--- a/server/internal/engine/dispatcher.go
+++ b/server/internal/engine/dispatcher.go
@@ -97,7 +97,7 @@ func (e *Engine) claimNextQueued() (runID, fromNodeID string, ok bool) {
 	if !hasFrom {
 		start := run.Graph.StartNode()
 		if start == nil {
-			e.finish(run.ID, "failed")
+			e.failRun(run.ID, "工作流没有可执行节点")
 			return "", "", false
 		}
 		fromNodeID = start.ID

--- a/server/internal/engine/engine.go
+++ b/server/internal/engine/engine.go
@@ -477,7 +477,7 @@ func (e *Engine) startRun(def models.WorkflowDef, graph models.Graph, inputs map
 
 	start := graph.StartNode()
 	if start == nil {
-		e.finish(runID, "failed")
+		e.failRun(runID, "工作流没有可执行节点")
 		return &run, fmt.Errorf("workflow has no nodes")
 	}
 	log.Info().Str("run_id", runID).Str("node_id", start.ID).Int("priority", priority).Msg("run queued")
@@ -851,14 +851,14 @@ func (e *Engine) execute(runID, fromNodeID string) {
 		if r := recover(); r != nil {
 			log.Error().Str("run_id", runID).Interface("panic", r).
 				Bytes("stack", debug.Stack()).Msg("execute goroutine panicked; marking run failed")
-			e.finish(runID, "failed")
+			e.failRun(runID, fmt.Sprintf("执行协程异常: %v", r))
 		}
 	}()
 
 	c, err := e.loadCtx(runID)
 	if err != nil {
 		log.Error().Str("run_id", runID).Err(err).Msg("load run context failed")
-		e.finish(runID, "failed")
+		e.failRun(runID, "加载运行上下文失败: "+err.Error())
 		return
 	}
 	c.execGen = gen
@@ -882,7 +882,7 @@ func (e *Engine) execute(runID, fromNodeID string) {
 		node := c.graph.FindNode(cur)
 		if node == nil {
 			e.appendTrace(c, models.TraceEntry{NodeID: cur, Event: "exit", Detail: "node not found"})
-			e.finish(runID, "failed")
+			e.failRun(runID, "节点不存在: "+cur)
 			return
 		}
 		// Snapshot variables on entering a checkpoint, for rollback restore.
@@ -1254,6 +1254,17 @@ func (e *Engine) pauseStillPending(runID string, node *models.Node) bool {
 	}
 }
 
+// failRun records a human-readable reason (vars.last_error) then finishes the
+// run as failed. Used by early-exit paths (loadCtx / node-not-found / panic /
+// empty graph) that never wrote StateRun.error, so AggregateRunFailure still
+// has a non-empty source before the default fallback.
+func (e *Engine) failRun(runID, reason string) {
+	if strings.TrimSpace(reason) != "" {
+		e.persistVar(runID, "last_error", reason)
+	}
+	e.finish(runID, "failed")
+}
+
 func (e *Engine) finish(runID, status string) {
 	updates := map[string]any{"status": status}
 	if status == "completed" {
@@ -1303,20 +1314,43 @@ func (e *Engine) finish(runID, status string) {
 		e.supersedePendingGates(runID, status)
 	}
 	if status == "completed" || status == "failed" || status == "cancelled" {
-		e.host.UnregisterRun(runID)
 		// Release any live react session (and its sandbox) still held for this
 		// run. For completed runs the session is already closed, so this is a
 		// no-op; for cancel/fail while paused at a react node it prevents the
-		// sandbox from lingering forever as "busy".
+		// sandbox from lingering forever as "busy". Abort before writing
+		// run_error.json so archived sandbox logs (if any) are available.
 		if ab, ok := e.provider.(runtime.RunAborter); ok {
 			ab.AbortRun(runID)
 		}
+		if status == "failed" {
+			e.persistRunErrorArtifact(runID)
+		}
+		e.host.UnregisterRun(runID)
 		e.mu.Lock()
 		delete(e.tokens, runID)
 		e.mu.Unlock()
 	}
 	msg, _ := json.Marshal(map[string]any{"type": "status", "runId": runID, "status": status})
 	e.broker.Publish(runID, msg)
+}
+
+// persistRunErrorArtifact writes run_error.json via the artifact store so empty
+// product failures remain queryable. Best-effort: store failures are logged and
+// do not change finish control flow.
+func (e *Engine) persistRunErrorArtifact(runID string) {
+	if e.store == nil {
+		return
+	}
+	info := services.NewRunService(e.db).AggregateRunFailure(runID)
+	body, err := services.MarshalRunErrorJSON(info)
+	if err != nil {
+		log.Warn().Str("run_id", runID).Err(err).Msg("marshal run_error.json failed")
+		return
+	}
+	nodeID := info.FailedNode
+	if _, err := e.store.Save(runID, nodeID, services.RunErrorArtifactName, "json", body); err != nil {
+		log.Warn().Str("run_id", runID).Err(err).Msg("save run_error.json failed")
+	}
 }
 
 // logDB records a GORM write error on an engine best-effort persistence path.

--- a/server/internal/engine/run_failure_observability_test.go
+++ b/server/internal/engine/run_failure_observability_test.go
@@ -1,0 +1,261 @@
+package engine
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/pmmcp"
+	"github.com/cocofhu/approving/internal/services"
+)
+
+// extractMCPToolText pulls the first text content blob from a tools/call RPC response.
+func extractMCPToolText(t *testing.T, resp []byte) string {
+	t.Helper()
+	var envelope struct {
+		Result struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+			IsError bool `json:"isError"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(resp, &envelope); err != nil {
+		t.Fatalf("unmarshal mcp resp: %v\n%s", err, resp)
+	}
+	if envelope.Result.IsError || len(envelope.Result.Content) == 0 {
+		t.Fatalf("mcp tool error: %s", resp)
+	}
+	return envelope.Result.Content[0].Text
+}
+
+func researchEarlyFailGraph() models.Graph {
+	return models.Graph{
+		Nodes: []models.Node{
+			{ID: "input", Type: "input"},
+			{ID: "research", Type: "research", Label: "代码调研", Config: map[string]any{"prompt": "调研"}},
+			{ID: "output", Type: "output"},
+		},
+		Edges: []models.Edge{
+			{ID: "e1", Source: "input", Target: "research"},
+			{ID: "e2", Source: "research", Target: "output"},
+		},
+	}
+}
+
+// TestResearchEarlyFailureThreeChannelsNonEmpty locks the clarified acceptance:
+// first-node (research) Agent/sandbox-style failure must expose a non-empty
+// reason via run_error.json, AggregateRunFailure (DTO/API), and PM MCP.
+func TestResearchEarlyFailureThreeChannelsNonEmpty(t *testing.T) {
+	eng, db, fp := setupEngineGraphP(t, researchEarlyFailGraph())
+	fp.mu.Lock()
+	fp.failLeft = map[string]int{"research": 1}
+	fp.reason = "sandbox setup failed: create sandbox: timeout after retries"
+	fp.mu.Unlock()
+
+	run, err := eng.StartRun("wf", map[string]any{}, "test")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitRunStatus(t, db, run.ID, "failed")
+	waitNodeStatus(t, db, run.ID, "research", "failed")
+
+	// (a) Aggregated Run-level reason (runDetailDTO / V1GetRun source)
+	rs := services.NewRunService(db)
+	info := rs.AggregateRunFailure(run.ID)
+	if info.DisplayReason() == "" {
+		t.Fatal("AggregateRunFailure display reason empty")
+	}
+	if info.FailedNode != "research" {
+		t.Fatalf("failedNode=%q", info.FailedNode)
+	}
+	if !strings.Contains(info.Reason, "sandbox setup failed") {
+		t.Fatalf("reason=%q", info.Reason)
+	}
+	// No archived sandbox logs in the fake provider path.
+	if !info.NoSandboxLog {
+		t.Fatal("expected noSandboxLog for fake early failure")
+	}
+	if !strings.Contains(info.DisplayReason(), services.NoSandboxLogMarker) {
+		t.Fatalf("display missing no-log marker: %q", info.DisplayReason())
+	}
+
+	// (b) run_error.json product
+	arts := services.NewArtifactService(db)
+	body, ok := arts.Get(run.ID, services.RunErrorArtifactName)
+	if !ok || body == "" {
+		t.Fatal("expected run_error.json artifact")
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("parse run_error.json: %v\n%s", err, body)
+	}
+	reason, _ := parsed["reason"].(string)
+	if reason == "" {
+		t.Fatalf("run_error.json reason empty: %s", body)
+	}
+	if parsed["failedNode"] != "research" {
+		t.Fatalf("run_error failedNode=%v", parsed["failedNode"])
+	}
+	// Must not synthesize node_complete.json for infrastructure failure.
+	if _, has := arts.Get(run.ID, "node_complete.json"); has {
+		t.Fatal("must not synthesize node_complete.json on infra failure")
+	}
+
+	// (c) ArtifactSummary + pm_list_runs
+	ps := services.NewProjectService(db)
+	proj, err := ps.Create("ObsFail", "", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Model(&models.WorkflowDef{}).Where("id = ?", "wf").Update("project_id", proj.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	pm := services.NewPmService(db, nil)
+	en := true
+	agent := "agent-a"
+	if _, err := pm.UpdateBinding(proj.ID, &en, &agent, []string{pmmcp.MCPProgress, pmmcp.MCPWorkflowRead}); err != nil {
+		t.Fatal(err)
+	}
+	progress := services.NewPmProgress(pm, rs, arts)
+	summary := progress.ArtifactSummary(proj.ID, run.ID, 10)
+	sumErr, _ := summary["error"].(string)
+	if sumErr == "" {
+		t.Fatalf("ArtifactSummary missing error: %+v", summary)
+	}
+	// After finish, run_error.json should appear in the product list.
+	if summary["empty"] == true {
+		t.Fatalf("expected run_error.json in artifacts: %+v", summary)
+	}
+
+	host := pmmcp.NewHost(pm, progress, services.NewWorkflowService(db), rs, eng)
+	tok := host.Register(proj.ID, "thr-obs", "tester", "agent-a")
+	req, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{
+			"name": "pm_list_runs",
+			"arguments": map[string]any{"workflowId": "wf", "limit": 5},
+		},
+	})
+	st, resp := host.ServeRPC(proj.ID, pmmcp.MCPWorkflowRead, tok, req)
+	if st != 200 {
+		t.Fatalf("pm_list_runs status=%d body=%s", st, resp)
+	}
+	text := extractMCPToolText(t, resp)
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(text), &payload); err != nil {
+		t.Fatalf("payload: %v\n%s", err, text)
+	}
+	found := false
+	switch rows := payload["runs"].(type) {
+	case []any:
+		for _, row := range rows {
+			m, _ := row.(map[string]any)
+			if m["id"] == run.ID {
+				found = true
+				if errStr, _ := m["error"].(string); errStr == "" {
+					t.Fatalf("pm_list_runs row missing error: %+v", m)
+				}
+			}
+		}
+	case []map[string]any:
+		for _, m := range rows {
+			if m["id"] == run.ID {
+				found = true
+				if errStr, _ := m["error"].(string); errStr == "" {
+					t.Fatalf("pm_list_runs row missing error: %+v", m)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("run not in pm_list_runs: %s", text)
+	}
+}
+
+// TestResearchEarlyFailureNoSandboxLogBoundary ensures missing docker logs never
+// blank the outward reason and always mark 「无可用沙箱日志」.
+func TestResearchEarlyFailureNoSandboxLogBoundary(t *testing.T) {
+	eng, db, fp := setupEngineGraphP(t, researchEarlyFailGraph())
+	fp.mu.Lock()
+	fp.failLeft = map[string]int{"research": 1}
+	fp.reason = "Agent 启动失败: exit code 1"
+	fp.mu.Unlock()
+
+	run, err := eng.StartRun("wf", map[string]any{}, "test")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitRunStatus(t, db, run.ID, "failed")
+
+	info := services.NewRunService(db).AggregateRunFailure(run.ID)
+	if info.DisplayReason() == "" {
+		t.Fatal("reason empty")
+	}
+	if !info.NoSandboxLog {
+		t.Fatal("expected NoSandboxLog")
+	}
+	if !strings.Contains(info.DisplayReason(), services.NoSandboxLogMarker) {
+		t.Fatalf("display=%q", info.DisplayReason())
+	}
+	body, ok := services.NewArtifactService(db).Get(run.ID, services.RunErrorArtifactName)
+	if !ok {
+		t.Fatal("missing run_error.json")
+	}
+	if !strings.Contains(body, services.NoSandboxLogMarker) && !strings.Contains(body, `"noSandboxLog": true`) {
+		t.Fatalf("run_error.json missing no-log signal: %s", body)
+	}
+}
+
+// TestSuccessfulRunSkipsRunErrorArtifact keeps the happy path free of
+// misleading failure products / fields.
+func TestSuccessfulRunSkipsRunErrorArtifact(t *testing.T) {
+	g := models.Graph{
+		Nodes: []models.Node{
+			{ID: "input", Type: "input"},
+			{ID: "research", Type: "research", Config: map[string]any{"prompt": "调研"}},
+			{ID: "output", Type: "output"},
+		},
+		Edges: []models.Edge{
+			{ID: "e1", Source: "input", Target: "research"},
+			{ID: "e2", Source: "research", Target: "output"},
+		},
+	}
+	eng, db := setupEngineGraph(t, g)
+	run, err := eng.StartRun("wf", map[string]any{}, "test")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitRunStatus(t, db, run.ID, "completed")
+
+	if _, ok := services.NewArtifactService(db).Get(run.ID, services.RunErrorArtifactName); ok {
+		t.Fatal("completed run must not write run_error.json")
+	}
+	info := services.NewRunService(db).AggregateRunFailure(run.ID)
+	// Aggregate may still invent a fallback if called wrongly; DTO only lifts
+	// on status==failed. Ensure the completed run has no failed StateRun.error.
+	var failed int64
+	db.Model(&models.StateRun{}).Where("run_id = ? AND status = ?", run.ID, "failed").Count(&failed)
+	if failed != 0 {
+		t.Fatalf("unexpected failed state runs: %d (info=%+v)", failed, info)
+	}
+}
+
+// TestFailRunEarlyExitPersistsReason covers loadCtx-style early finish via
+// failRun so aggregation is never an empty string.
+func TestFailRunEarlyExitPersistsReason(t *testing.T) {
+	eng, db := setupEngineGraph(t, researchEarlyFailGraph())
+	stubID := "run-early-fail"
+	db.Create(&models.Run{ID: stubID, WorkflowID: "wf", Status: "running", Graph: researchEarlyFailGraph()})
+	eng.failRun(stubID, "加载运行上下文失败: simulated")
+	waitRunStatus(t, db, stubID, "failed")
+
+	info := services.NewRunService(db).AggregateRunFailure(stubID)
+	if !strings.Contains(info.DisplayReason(), "加载运行上下文失败") {
+		t.Fatalf("display=%q", info.DisplayReason())
+	}
+	if _, ok := services.NewArtifactService(db).Get(stubID, services.RunErrorArtifactName); !ok {
+		t.Fatal("expected run_error.json from failRun")
+	}
+}

--- a/server/internal/handlers/dto.go
+++ b/server/internal/handlers/dto.go
@@ -197,6 +197,24 @@ func (h *Handlers) runDetailDTO(r models.Run) gin.H {
 		clarifyByNode[conv.NodeID] = gin.H{"nodeId": conv.NodeID, "iteration": conv.Iteration, "turns": conv.Messages, "done": conv.Done}
 	}
 	out["clarifyByNode"] = clarifyByNode
+	// Lift a Run-level failure reason for any failed run so the Web detail banner
+	// (and clients) can read a human message without opening a node. Successful
+	// runs omit these fields entirely.
+	if r.Status == "failed" && h.Runs != nil {
+		info := h.Runs.AggregateRunFailure(r.ID)
+		reason := info.DisplayReason()
+		out["error"] = reason
+		out["failedReason"] = reason
+		if info.FailedNode != "" {
+			out["failedNode"] = info.FailedNode
+		}
+		if info.NoSandboxLog {
+			out["noSandboxLog"] = true
+		}
+		if info.LogSummaryOrRef != "" {
+			out["logSummaryOrRef"] = info.LogSummaryOrRef
+		}
+	}
 	h.hydrateNodeExecutions(nodeExecutions, r.ID)
 	return out
 }

--- a/server/internal/handlers/handlers_test.go
+++ b/server/internal/handlers/handlers_test.go
@@ -1319,6 +1319,41 @@ func TestRunDetailRichBranches(t *testing.T) {
 	}
 }
 
+// TestRunDetailFailedExposesRunLevelError ensures failed runs lift a human
+// reason to the detail DTO (banner / API) without requiring a node click.
+func TestRunDetailFailedExposesRunLevelError(t *testing.T) {
+	h := newHarness(t)
+	h.db.Create(&models.Run{ID: "rd-fail", Status: "failed", StartedAt: time.Now().Add(-time.Minute), Graph: models.Graph{
+		Nodes: []models.Node{{ID: "research", Type: "research"}, {ID: "out", Type: "output"}},
+	}})
+	h.db.Create(&models.StateRun{RunID: "rd-fail", NodeID: "research", Iteration: 1, Status: "failed",
+		Error: "sandbox setup failed: create timeout"})
+
+	w := h.do("GET", "/api/runs/rd-fail", nil)
+	if w.Code != 200 {
+		t.Fatalf("get run: %d %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, want := range []string{`"error"`, `"failedReason"`, "sandbox setup failed", `"failedNode":"research"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("failed run detail missing %q in %s", want, body)
+		}
+	}
+
+	// Completed runs must not carry misleading failure fields.
+	h.db.Create(&models.Run{ID: "rd-ok", Status: "completed", Progress: 1, StartedAt: time.Now().Add(-time.Minute), Graph: models.Graph{
+		Nodes: []models.Node{{ID: "out", Type: "output"}},
+	}})
+	w = h.do("GET", "/api/runs/rd-ok", nil)
+	if w.Code != 200 {
+		t.Fatalf("get ok run: %d", w.Code)
+	}
+	okBody := w.Body.String()
+	if strings.Contains(okBody, `"failedReason"`) || strings.Contains(okBody, `"noSandboxLog"`) {
+		t.Fatalf("completed run must omit failure fields: %s", okBody)
+	}
+}
+
 // TestSandboxLogFoundBranches drives the "found" path of the sandbox log
 // endpoints by seeding an archived log alongside a stopped sandbox row.
 func TestSandboxLogFoundBranches(t *testing.T) {

--- a/server/internal/handlers/v1_handlers.go
+++ b/server/internal/handlers/v1_handlers.go
@@ -122,7 +122,9 @@ func (h *Handlers) V1GetRun(c *gin.Context) {
 	nodeIDs := h.Runs.CurrentNodeIDs([]models.Run{run})
 	var errMsg string
 	if run.Status == "failed" {
-		errMsg = h.Runs.RunFailedError(run.ID)
+		// Prefer the aggregated display reason (covers early-exit fallbacks
+		// where StateRun.error was never written).
+		errMsg = h.Runs.AggregateRunFailure(run.ID).DisplayReason()
 	}
 	c.JSON(http.StatusOK, v1RunDTO(run, nodeIDs[run.ID], errMsg))
 }

--- a/server/internal/pmmcp/host.go
+++ b/server/internal/pmmcp/host.go
@@ -386,11 +386,18 @@ func (h *Host) callWorkflowRead(projectID, name string, args map[string]any) (an
 		}
 		rows := make([]map[string]any, 0, len(runs))
 		for _, r := range runs {
-			rows = append(rows, map[string]any{
+			row := map[string]any{
 				"id": r.ID, "status": r.Status, "progress": r.Progress,
 				"title": r.Title, "startedAt": r.StartedAt, "durationSec": r.DurationSec,
 				"attempt": r.Attempt, "workflowVersion": r.WorkflowVersion,
-			})
+			}
+			if r.Status == "failed" {
+				info := h.runs.AggregateRunFailure(r.ID)
+				if short := info.ShortDisplayReason(200); short != "" {
+					row["error"] = short
+				}
+			}
+			rows = append(rows, row)
 		}
 		return map[string]any{"workflowId": wfID, "runs": rows, "count": len(rows)}, false
 	case "pm_list_pending_gates":

--- a/server/internal/services/pm_progress.go
+++ b/server/internal/services/pm_progress.go
@@ -158,12 +158,14 @@ func (p *PmProgress) ArtifactSummary(projectID, runID string, limit int) map[str
 		items, _ = p.arts.AllPage("", projectID, 1, limit, "")
 	}
 	if len(items) == 0 {
-		return map[string]any{"empty": true, "message": "暂无产物"}
+		out := map[string]any{"empty": true, "message": "暂无产物"}
+		p.attachRunFailure(out, runID)
+		return out
 	}
 	if len(items) > limit {
 		items = items[:limit]
 	}
-	out := make([]map[string]any, 0, len(items))
+	arts := make([]map[string]any, 0, len(items))
 	for _, a := range items {
 		entry := map[string]any{
 			"id": a.ID, "name": a.Name, "kind": a.Kind, "runId": a.RunID,
@@ -173,9 +175,32 @@ func (p *PmProgress) ArtifactSummary(projectID, runID string, limit int) map[str
 		if content, ok := p.arts.Get(a.RunID, a.Name); ok && content != "" {
 			entry["preview"] = truncateStr(content, 800)
 		}
-		out = append(out, entry)
+		arts = append(arts, entry)
 	}
-	return map[string]any{"empty": false, "artifacts": out, "count": len(out)}
+	out := map[string]any{"empty": false, "artifacts": arts, "count": len(arts)}
+	p.attachRunFailure(out, runID)
+	return out
+}
+
+// attachRunFailure adds a human-readable error when the scoped run failed, so
+// empty-product failures are not reduced to "暂无产物" alone.
+func (p *PmProgress) attachRunFailure(out map[string]any, runID string) {
+	if out == nil || runID == "" || p.runs == nil {
+		return
+	}
+	r, ok := p.runs.Get(runID)
+	if !ok || r.Status != "failed" {
+		return
+	}
+	info := p.runs.AggregateRunFailure(runID)
+	out["status"] = "failed"
+	out["error"] = info.DisplayReason()
+	if info.FailedNode != "" {
+		out["failedNode"] = info.FailedNode
+	}
+	if info.NoSandboxLog {
+		out["noSandboxLog"] = true
+	}
 }
 
 // RiskTrends scans recent runs for failures, repeated waiting, stagnation.

--- a/server/internal/services/run_failure.go
+++ b/server/internal/services/run_failure.go
@@ -1,0 +1,173 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/cocofhu/approving/internal/models"
+)
+
+// RunErrorArtifactName is the unified failure product written when a run ends
+// as failed. Infrastructure failures must not synthesize node_complete.json.
+const RunErrorArtifactName = "run_error.json"
+
+// Human-readable fallbacks for early-exit paths that never wrote StateRun.error.
+const (
+	DefaultRunFailureReason = "运行失败，未记录具体错误原因"
+	NoSandboxLogMarker      = "无可用沙箱日志"
+)
+
+// Log summary caps for run_error.json (tail of archived sandbox logs).
+const (
+	maxLogSummaryLines = 40
+	maxLogSummaryBytes = 8 * 1024
+)
+
+// RunFailureInfo is the single aggregated failure view distributed to Run detail
+// DTO/API, run_error.json, and PM/MCP.
+type RunFailureInfo struct {
+	Reason          string `json:"reason"`
+	FailedNode      string `json:"failedNode,omitempty"`
+	LogSummaryOrRef string `json:"logSummaryOrRef,omitempty"`
+	NoSandboxLog    bool   `json:"noSandboxLog,omitempty"`
+}
+
+// AggregateRunFailure builds RunFailureInfo from the latest non-empty failed
+// StateRun.error, vars.last_error, and archived sandbox logs. Reason is never
+// empty: early-exit / panic paths without StateRun.error fall back to a
+// human-readable default. Call after finalizeActiveStateRuns when possible so
+// in-flight nodes that were force-failed contribute their error text.
+func (s *RunService) AggregateRunFailure(runID string) RunFailureInfo {
+	info := RunFailureInfo{}
+	if runID == "" || s == nil || s.db == nil {
+		info.Reason = DefaultRunFailureReason
+		info.NoSandboxLog = true
+		return info
+	}
+
+	var sr models.StateRun
+	if err := s.db.Where("run_id = ? AND status = ? AND error != ''", runID, "failed").
+		Order("id desc").First(&sr).Error; err == nil {
+		info.Reason = strings.TrimSpace(sr.Error)
+		info.FailedNode = sr.NodeID
+	} else if err := s.db.Where("run_id = ? AND status = ?", runID, "failed").
+		Order("id desc").First(&sr).Error; err == nil {
+		info.FailedNode = sr.NodeID
+		info.Reason = strings.TrimSpace(sr.Error)
+	}
+
+	if info.Reason == "" {
+		if le := s.runVarString(runID, "last_error"); le != "" {
+			info.Reason = le
+		}
+	}
+	if info.Reason == "" {
+		info.Reason = DefaultRunFailureReason
+	}
+
+	logContent := s.sandboxLogContent(runID, info.FailedNode)
+	if logContent != "" {
+		info.LogSummaryOrRef = TruncateLogSummary(logContent)
+		info.NoSandboxLog = false
+	} else {
+		info.NoSandboxLog = true
+	}
+	return info
+}
+
+// DisplayReason returns a one-line human-readable failure reason suitable for
+// UI banners and MCP short fields (includes failed node and no-log marker).
+func (info RunFailureInfo) DisplayReason() string {
+	reason := strings.TrimSpace(info.Reason)
+	if reason == "" {
+		reason = DefaultRunFailureReason
+	}
+	if info.FailedNode != "" && !strings.Contains(reason, info.FailedNode) {
+		reason = fmt.Sprintf("%s（节点 %s）", reason, info.FailedNode)
+	}
+	if info.NoSandboxLog && !strings.Contains(reason, NoSandboxLogMarker) {
+		reason = reason + " · " + NoSandboxLogMarker
+	}
+	return reason
+}
+
+// ShortDisplayReason truncates DisplayReason for list rows.
+func (info RunFailureInfo) ShortDisplayReason(max int) string {
+	return truncateStr(info.DisplayReason(), max)
+}
+
+// MarshalRunErrorJSON serializes RunFailureInfo for ArtifactService.Save.
+// The reason field uses DisplayReason so empty-product consumers see the same
+// human text as the Web banner.
+func MarshalRunErrorJSON(info RunFailureInfo) (string, error) {
+	payload := map[string]any{
+		"reason":       info.DisplayReason(),
+		"noSandboxLog": info.NoSandboxLog,
+	}
+	if info.FailedNode != "" {
+		payload["failedNode"] = info.FailedNode
+	}
+	if info.LogSummaryOrRef != "" {
+		payload["logSummaryOrRef"] = info.LogSummaryOrRef
+	}
+	b, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// TruncateLogSummary keeps the last N lines within a byte budget.
+func TruncateLogSummary(content string) string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.TrimRight(content, "\n")
+	if content == "" {
+		return ""
+	}
+	lines := strings.Split(content, "\n")
+	if len(lines) > maxLogSummaryLines {
+		lines = lines[len(lines)-maxLogSummaryLines:]
+	}
+	out := strings.Join(lines, "\n")
+	if len(out) > maxLogSummaryBytes {
+		out = out[len(out)-maxLogSummaryBytes:]
+		if i := strings.IndexByte(out, '\n'); i >= 0 && i+1 < len(out) {
+			out = out[i+1:]
+		}
+	}
+	return out
+}
+
+func (s *RunService) runVarString(runID, name string) string {
+	var rv models.RunVariable
+	if err := s.db.Where("run_id = ? AND name = ?", runID, name).First(&rv).Error; err != nil {
+		return ""
+	}
+	switch v := rv.Value.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case nil:
+		return ""
+	default:
+		return strings.TrimSpace(fmt.Sprint(v))
+	}
+}
+
+func (s *RunService) sandboxLogContent(runID, nodeID string) string {
+	var rec models.SandboxLog
+	q := s.db.Where("run_id = ?", runID)
+	if nodeID != "" {
+		q = q.Where("node_id = ?", nodeID)
+	}
+	if err := q.Order("updated_at desc").First(&rec).Error; err == nil && strings.TrimSpace(rec.Content) != "" {
+		return rec.Content
+	}
+	// Fall back to any archived log for the run (node id may be empty on early fail).
+	if nodeID != "" {
+		if err := s.db.Where("run_id = ?", runID).Order("updated_at desc").First(&rec).Error; err == nil {
+			return rec.Content
+		}
+	}
+	return ""
+}

--- a/server/internal/services/run_failure_test.go
+++ b/server/internal/services/run_failure_test.go
@@ -1,0 +1,159 @@
+package services
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+)
+
+func TestAggregateRunFailureFromStateRun(t *testing.T) {
+	db := newTestDB(t)
+	s := NewRunService(db)
+	db.Create(&models.Run{ID: "rf1", Status: "failed"})
+	db.Create(&models.StateRun{RunID: "rf1", NodeID: "research", Status: "failed", Error: "sandbox setup failed: create timeout"})
+
+	info := s.AggregateRunFailure("rf1")
+	if info.Reason == "" || !strings.Contains(info.Reason, "sandbox setup failed") {
+		t.Fatalf("reason=%q", info.Reason)
+	}
+	if info.FailedNode != "research" {
+		t.Fatalf("failedNode=%q", info.FailedNode)
+	}
+	if !info.NoSandboxLog {
+		t.Fatal("expected noSandboxLog when no archived logs")
+	}
+	display := info.DisplayReason()
+	if !strings.Contains(display, "research") || !strings.Contains(display, NoSandboxLogMarker) {
+		t.Fatalf("display=%q", display)
+	}
+}
+
+func TestAggregateRunFailureLastErrorFallback(t *testing.T) {
+	db := newTestDB(t)
+	s := NewRunService(db)
+	db.Create(&models.Run{ID: "rf2", Status: "failed"})
+	db.Create(&models.RunVariable{RunID: "rf2", Name: "last_error", Type: "string", Value: "加载运行上下文失败: not found"})
+
+	info := s.AggregateRunFailure("rf2")
+	if info.Reason != "加载运行上下文失败: not found" {
+		t.Fatalf("reason=%q", info.Reason)
+	}
+	if info.DisplayReason() == "" {
+		t.Fatal("display empty")
+	}
+}
+
+func TestAggregateRunFailureDefaultFallback(t *testing.T) {
+	db := newTestDB(t)
+	s := NewRunService(db)
+	db.Create(&models.Run{ID: "rf3", Status: "failed"})
+	info := s.AggregateRunFailure("rf3")
+	if info.Reason != DefaultRunFailureReason {
+		t.Fatalf("reason=%q", info.Reason)
+	}
+	if info.DisplayReason() == "" {
+		t.Fatal("display empty")
+	}
+}
+
+func TestAggregateRunFailureWithSandboxLog(t *testing.T) {
+	db := newTestDB(t)
+	s := NewRunService(db)
+	db.Create(&models.Run{ID: "rf4", Status: "failed"})
+	db.Create(&models.StateRun{RunID: "rf4", NodeID: "research", Status: "failed", Error: "agent exit 1"})
+	lines := make([]string, 50)
+	for i := range lines {
+		lines[i] = "log-line-" + string(rune('A'+i%26))
+	}
+	db.Create(&models.SandboxLog{
+		Name: "sbx-rf4", RunID: "rf4", NodeID: "research",
+		Content: strings.Join(lines, "\n") + "\nTAIL_MARKER",
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+
+	info := s.AggregateRunFailure("rf4")
+	if info.NoSandboxLog {
+		t.Fatal("expected sandbox log present")
+	}
+	if !strings.Contains(info.LogSummaryOrRef, "TAIL_MARKER") {
+		t.Fatalf("log summary missing tail: %q", info.LogSummaryOrRef)
+	}
+	if strings.Contains(info.DisplayReason(), NoSandboxLogMarker) {
+		t.Fatalf("display should not claim no log: %q", info.DisplayReason())
+	}
+}
+
+func TestMarshalRunErrorJSON(t *testing.T) {
+	body, err := MarshalRunErrorJSON(RunFailureInfo{
+		Reason: "boom", FailedNode: "research", NoSandboxLog: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed["failedNode"] != "research" {
+		t.Fatalf("parsed=%v", parsed)
+	}
+	reason, _ := parsed["reason"].(string)
+	if reason == "" || !strings.Contains(reason, "boom") {
+		t.Fatalf("reason=%q", reason)
+	}
+	if parsed["noSandboxLog"] != true {
+		t.Fatalf("noSandboxLog=%v", parsed["noSandboxLog"])
+	}
+}
+
+func TestTruncateLogSummary(t *testing.T) {
+	if TruncateLogSummary("") != "" {
+		t.Fatal("empty")
+	}
+	var b strings.Builder
+	for i := 0; i < 100; i++ {
+		b.WriteString("line\n")
+	}
+	out := TruncateLogSummary(b.String())
+	if strings.Count(out, "\n")+1 > maxLogSummaryLines {
+		t.Fatalf("too many lines: %d", strings.Count(out, "\n")+1)
+	}
+}
+
+func TestArtifactSummaryFailedEmptyStillReturnsError(t *testing.T) {
+	p, db, pid, wfID := setupPmProgressFixtures(t)
+	db.Create(&models.Run{
+		ID: "run-empty-fail", WorkflowID: wfID, WorkflowName: "Pipeline",
+		Status: "failed", Progress: 0.05, Title: "Early fail", StartedAt: time.Now(),
+	})
+	db.Create(&models.StateRun{
+		RunID: "run-empty-fail", NodeID: "research", Status: "failed",
+		Error: "sandbox setup failed: create timeout",
+	})
+
+	got := p.ArtifactSummary(pid, "run-empty-fail", 5)
+	if got["empty"] != true {
+		t.Fatalf("expected empty artifacts: %+v", got)
+	}
+	errMsg, _ := got["error"].(string)
+	if errMsg == "" {
+		t.Fatalf("expected non-empty error on empty failed run: %+v", got)
+	}
+	if !strings.Contains(errMsg, "sandbox setup failed") {
+		t.Fatalf("error=%q", errMsg)
+	}
+}
+
+func TestArtifactSummarySuccessOmitsFailureFields(t *testing.T) {
+	p, _, pid, _ := setupPmProgressFixtures(t)
+	got := p.ArtifactSummary(pid, "run-a", 5)
+	if got["empty"] != false {
+		t.Fatalf("artifacts: %+v", got)
+	}
+	if _, ok := got["error"]; ok {
+		t.Fatalf("success run must not expose error: %+v", got)
+	}
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -506,4 +506,11 @@ export interface Run {
   git?: { pushed: boolean; pushedSha?: string; branch?: string; mrUrl?: string } | null
   trace?: StateTraceEntry[]
   vars?: RunVar[]
+  /** Run-level human failure reason (failed runs only). */
+  error?: string
+  /** Alias of error for API consumers expecting failedReason. */
+  failedReason?: string
+  failedNode?: string
+  noSandboxLog?: boolean
+  logSummaryOrRef?: string
 }

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -526,6 +526,9 @@
       "executionN": "Run {n}",
       "historicalReadonly": "Historical (read-only)",
       "nodeFailed": "This node failed",
+      "failureBanner": {
+        "title": "Failure reason"
+      },
       "gateError": "Submit failed; try again",
       "resumeError": "Resume failed; try again",
       "priorityTitle": "Change priority",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -526,6 +526,9 @@
       "executionN": "第{n}次",
       "historicalReadonly": "历史执行(只读)",
       "nodeFailed": "该节点执行失败",
+      "failureBanner": {
+        "title": "失败原因"
+      },
       "gateError": "提交失败,请重试",
       "resumeError": "续跑失败,请重试",
       "priorityTitle": "修改优先级",

--- a/web/src/views/RunDetailView.vue
+++ b/web/src/views/RunDetailView.vue
@@ -1086,6 +1086,12 @@ const clarifyInputActive = computed(
 const clarifySandboxFailed = computed(
   () => selNode.value?.type === 'react' && selStatus.value === 'failed' && !!selRun.value?.error,
 )
+// Run-level failure banner for any failed run (research/agent early fails included).
+const runFailureReason = computed(() => {
+  if (run.value.status !== 'failed') return ''
+  return (run.value.error || run.value.failedReason || '').trim()
+})
+const showRunFailureBanner = computed(() => !!runFailureReason.value)
 const { draft: clarifyDraft, attachments: clarifyAttachments, annotations: clarifyAnnotations } = useClarifyDraft(() => runId.value, () => selected.value)
 // Every sandbox-backed node (all "Agent" category types: agent/react/plan/
 // implement/research/test/review/proposal/submit_mr/visual) runs the in-container
@@ -1415,6 +1421,17 @@ function selectExecution(nodeId: string, idx: number) {
             <div class="h-full rounded-full bg-gradient-to-r from-accent to-accent-2 transition-all" :style="{ width: progressFrac * 100 + '%' }" />
           </div>
           <span class="text-[11px] text-txt3">{{ Math.round(progressFrac * 100) }}%</span>
+        </div>
+        <div
+          v-if="showRunFailureBanner"
+          data-testid="run-failure-banner"
+          class="mt-3 ml-11 mr-0 rounded-md border border-err/35 bg-err/8 px-3.5 py-2.5 text-[13px] leading-relaxed text-err"
+          role="alert"
+        >
+          <strong class="mb-0.5 block text-[11px] font-semibold uppercase tracking-wide text-err/90">
+            {{ t('pages.runDetail.failureBanner.title') }}
+          </strong>
+          <p class="m-0 whitespace-pre-wrap break-words text-txt">{{ runFailureReason }}</p>
         </div>
       </template>
     </header>


### PR DESCRIPTION
## Summary
- Aggregate a non-empty human failure reason at `finish(failed)` (StateRun.error / last_error / fallback) and write `run_error.json` with failedNode + sandbox log tail or「无可用沙箱日志」.
- Lift Run-level `error`/`failedReason` in run detail DTO and show a top banner for any failed run (not only react+sandbox).
- PM MCP: `ArtifactSummary` returns `error` even when products were empty; `pm_list_runs` rows include a short `error` for failed runs.
- Regression: research early failure asserts three channels non-empty; covers no-sandbox-log boundary and successful path (no `run_error.json`).

## Test plan
- [x] `go test ./internal/services/ -run 'TestAggregate|TestMarshal|TestTruncate|TestArtifactSummaryFailed|TestArtifactSummarySuccess'`
- [x] `go test ./internal/engine/ -run 'TestResearchEarly|TestSuccessfulRunSkips|TestFailRunEarly|TestPlanSandbox|TestReactSandbox'`
- [x] `go test ./internal/handlers/ -run 'TestRunDetailFailedExposes|TestRunDetailRich'`
- [ ] Manually open a failed early research run in Web and confirm top banner + `run_error.json` in artifacts
- [ ] Call `pm_get_artifact_summary` / `pm_list_runs` on that run and confirm non-empty `error`


Made with [Cursor](https://cursor.com)