### PR TITLE
feat(sandbox-gateway): K8s driver support for sandbox logs

### DIFF
--- a/GATEWAY.md
+++ b/GATEWAY.md
@@ -39,7 +39,7 @@ build `universal-sandbox-cursor:local` from `sandbox-gateway/sandbox` on first r
 | Get | `GET /api/v1/sandboxes/{id}` returns status and endpoints (session/ide/ssh/cdp/novnc) |
 | List | `GET /api/v1/sandboxes?label=key:value` (AND) |
 | Delete | `DELETE /api/v1/sandboxes/{id}` returns 2xx |
-| Logs | `GET /api/v1/sandboxes/{id}/logs?tail=` returns `{content}` (PID1 stdout/stderr, non-follow). Docker required; kubernetes → `501` |
+| Logs | `GET /api/v1/sandboxes/{id}/logs?tail=` returns `{content}` (PID1 stdout/stderr, non-follow). Docker (`docker logs --tail`) and kubernetes (pod `sandbox` container via client-go GetLogs) both supported. Cluster RBAC must allow `pods/log` (ops prerequisite). Drivers that still omit Logs → `501` |
 | Ready | status `running` with a `session` endpoint |
 | Images | per Agent `acpBackend`: `universal-sandbox-{cursor\|claude_code\|codebuddy\|trae}` |
 | Data plane | SSH / session / cdp / novnc connect to endpoints directly |

--- a/sandbox-gateway/gateway/docs/API.md
+++ b/sandbox-gateway/gateway/docs/API.md
@@ -214,11 +214,20 @@ for the agent execution event log.
 
 | Query | Default | Notes |
 |-------|---------|-------|
-| `tail` | `5000` | Lines from the end of the log stream (`docker logs --tail`) |
+| `tail` | `5000` | Lines from the end of the log stream |
 
-- **Docker driver**: implemented via `docker logs --tail` (stdout+stderr).
-- **Kubernetes driver**: returns `501` (`sandbox logs not supported by this driver`).
-- Missing sandbox → `404`. Driver / docker CLI failure → `500` with `error`.
+- **Docker driver**: `docker logs --tail` (combined stdout+stderr).
+- **Kubernetes driver**: client-go `Pods.GetLogs` on the sandbox pod's
+  `sandbox` container (combined stdout+stderr, non-follow). Pods are located by
+  labels `sandbox-gateway.io/id` + `app.kubernetes.io/managed-by=sandbox-gateway`;
+  when multiple pods match, prefer `Running`, else the newest by creation time.
+- Missing sandbox (store / no matching workload) → `404` or driver not-found
+  mapped by handlers. Driver / API / CLI failure → `500` with `error`.
+- Drivers that do not implement Logs still return `501`
+  (`sandbox logs not supported by this driver`).
+- **Ops prerequisite**: the gateway ServiceAccount needs `pods/log` (or
+  equivalent) in the sandbox namespace. This release does not ship RBAC
+  manifests; missing permission surfaces as a non-2xx error (not empty success).
 
 ## What the gateway does NOT do
 
@@ -227,6 +236,6 @@ for the agent execution event log.
 - No reverse proxy for code-server, session, or preview. Clients connect to the
   returned endpoint addresses directly.
 - No streaming / follow logs (`?follow=1` / SSE). Clients re-fetch on demand.
-- No kubernetes log retrieval in this release (explicit `501`).
+- No previous-container / multi-container log fan-out (single `sandbox` container).
 - code-flow's former `/api/changes` is gone from the image; compute "changes"
   by running `git` over a direct SSH/exec connection.

--- a/sandbox-gateway/gateway/internal/driver/driver.go
+++ b/sandbox-gateway/gateway/internal/driver/driver.go
@@ -7,7 +7,8 @@ import (
 )
 
 // ErrLogsUnsupported is returned by drivers that do not implement container
-// log retrieval (e.g. kubernetes in this release).
+// log retrieval. Handlers map it to HTTP 501. Docker and kubernetes implement Logs;
+// other/future drivers may still return this error.
 var ErrLogsUnsupported = errors.New("sandbox logs not supported by this driver")
 
 // Sandbox lifecycle statuses reported by drivers.

--- a/sandbox-gateway/gateway/internal/driver/kubernetes/kubernetes.go
+++ b/sandbox-gateway/gateway/internal/driver/kubernetes/kubernetes.go
@@ -90,6 +90,11 @@ func (d *Driver) defaultGetPodLogs(ctx context.Context, namespace, podName strin
 	if err != nil {
 		return "", err
 	}
+	return drainLogStream(stream)
+}
+
+// drainLogStream reads a pod log stream to completion and closes it.
+func drainLogStream(stream io.ReadCloser) (string, error) {
 	defer stream.Close()
 	b, err := io.ReadAll(stream)
 	if err != nil {

--- a/sandbox-gateway/gateway/internal/driver/kubernetes/kubernetes.go
+++ b/sandbox-gateway/gateway/internal/driver/kubernetes/kubernetes.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,39 +18,49 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-const managedByLabel = "sandbox-gateway"
+const (
+	managedByLabel   = "sandbox-gateway"
+	sandboxContainer = "sandbox"
+	defaultLogsTail  = 5000
+)
+
+// podLogReader reads a pod container log stream (overridable in unit tests).
+// The default implementation uses client-go GetLogs().Stream.
+type podLogReader func(ctx context.Context, namespace, podName string, opts *corev1.PodLogOptions) (string, error)
 
 // Options configures the kubernetes driver.
 type Options struct {
-	InCluster            bool
-	Kubeconfig           string
-	Namespace            string
-	NamePrefix           string
-	StorageClass         string
-	DataDiskGi           int64 // default PVC size fallback
-	PVCAnnotations       map[string]string
-	ImagePullSecret      string
-	ImagePullPolicy      string
-	EnableLoadBalancer   bool
-	CPUCores             float64 // default CPU limit fallback
-	MemoryMB             int64   // default memory limit fallback
-	CPURequestCores      float64 // fixed request; >0 preferred over ratio
-	MemoryRequestMB      int64
-	CPURequestRatio      float64
-	MemoryRequestRatio   float64
+	InCluster          bool
+	Kubeconfig         string
+	Namespace          string
+	NamePrefix         string
+	StorageClass       string
+	DataDiskGi         int64 // default PVC size fallback
+	PVCAnnotations     map[string]string
+	ImagePullSecret    string
+	ImagePullPolicy    string
+	EnableLoadBalancer bool
+	CPUCores           float64 // default CPU limit fallback
+	MemoryMB           int64   // default memory limit fallback
+	CPURequestCores    float64 // fixed request; >0 preferred over ratio
+	MemoryRequestMB    int64
+	CPURequestRatio    float64
+	MemoryRequestRatio float64
 }
 
 // Driver provisions sandboxes as Deployments in Kubernetes and exposes them via
 // a MetalLB LoadBalancer Service so clients connect directly to the LB IP.
 type Driver struct {
-	cs   kubernetes.Interface
-	opts Options
+	cs         kubernetes.Interface
+	opts       Options
+	getPodLogs podLogReader
 }
 
 // New builds a kubernetes driver from a kubeconfig or in-cluster config.
@@ -69,7 +80,22 @@ func New(o Options) (*Driver, error) {
 // NewFromClient builds a Driver over an existing client (used by unit tests
 // with client-go's fake clientset).
 func NewFromClient(cs kubernetes.Interface, o Options) *Driver {
-	return &Driver{cs: cs, opts: withDefaults(o)}
+	d := &Driver{cs: cs, opts: withDefaults(o)}
+	d.getPodLogs = d.defaultGetPodLogs
+	return d
+}
+
+func (d *Driver) defaultGetPodLogs(ctx context.Context, namespace, podName string, opts *corev1.PodLogOptions) (string, error) {
+	stream, err := d.cs.CoreV1().Pods(namespace).GetLogs(podName, opts).Stream(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer stream.Close()
+	b, err := io.ReadAll(stream)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }
 
 func withDefaults(o Options) Options {
@@ -762,9 +788,64 @@ func (d *Driver) Endpoints(ctx context.Context, id string) (map[int]string, erro
 	return out, nil
 }
 
-// Logs is unsupported for the kubernetes driver in this release (OOS).
-func (d *Driver) Logs(_ context.Context, _ string, _ int) (string, error) {
-	return "", driver.ErrLogsUnsupported
+// Logs returns combined sandbox-container stdout/stderr via client-go GetLogs
+// (non-follow). Semantics align with the docker driver: merge streams, honor
+// tail (≤0 → 5000), empty success vs not-found/API failure are distinguishable.
+func (d *Driver) Logs(ctx context.Context, id string, tail int) (string, error) {
+	if tail <= 0 {
+		tail = defaultLogsTail
+	}
+	ns := d.opts.Namespace
+	list, err := d.cs.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.Set(d.selector(id)).String(),
+	})
+	if err != nil {
+		return "", fmt.Errorf("list pods for sandbox %s: %w", id, err)
+	}
+	pod := pickPodForLogs(list.Items)
+	if pod == nil {
+		return "", fmt.Errorf("sandbox %s not found", id)
+	}
+	tailLines := int64(tail)
+	opts := &corev1.PodLogOptions{
+		Container: sandboxContainer,
+		Follow:    false,
+		TailLines: &tailLines,
+	}
+	out, err := d.getPodLogs(ctx, ns, pod.Name, opts)
+	if err != nil {
+		return "", fmt.Errorf("kubernetes logs: %w", err)
+	}
+	return out, nil
+}
+
+// pickPodForLogs prefers a Running pod; otherwise picks the newest by
+// CreationTimestamp. Returns nil when the list is empty.
+func pickPodForLogs(pods []corev1.Pod) *corev1.Pod {
+	if len(pods) == 0 {
+		return nil
+	}
+	var best *corev1.Pod
+	for i := range pods {
+		p := &pods[i]
+		if p.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		if best == nil || p.CreationTimestamp.After(best.CreationTimestamp.Time) {
+			best = p
+		}
+	}
+	if best != nil {
+		return best
+	}
+	best = &pods[0]
+	for i := 1; i < len(pods); i++ {
+		p := &pods[i]
+		if p.CreationTimestamp.After(best.CreationTimestamp.Time) {
+			best = p
+		}
+	}
+	return best
 }
 
 // WaitLoadBalancerIP polls the LB Service until an ingress IP is assigned.

--- a/sandbox-gateway/gateway/internal/driver/kubernetes/kubernetes_test.go
+++ b/sandbox-gateway/gateway/internal/driver/kubernetes/kubernetes_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -96,11 +97,109 @@ func TestNameAndHelpers(t *testing.T) {
 	}
 }
 
-func TestLogsUnsupported(t *testing.T) {
+func seedSandboxPod(t *testing.T, d *Driver, id, name string, phase corev1.PodPhase, created time.Time) {
+	t.Helper()
+	_, err := d.cs.CoreV1().Pods(d.opts.Namespace).Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         d.opts.Namespace,
+			Labels:            d.selector(id),
+			CreationTimestamp: metav1.NewTime(created),
+		},
+		Status: corev1.PodStatus{Phase: phase},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("seed pod: %v", err)
+	}
+}
+
+func TestLogsContent(t *testing.T) {
 	d := testDriver(t, true)
-	_, err := d.Logs(context.Background(), "any", 100)
-	if err == nil || err != driver.ErrLogsUnsupported {
-		t.Fatalf("Logs want ErrLogsUnsupported, got %v", err)
+	id := "log1"
+	seedSandboxPod(t, d, id, "sbx-log1-pod", corev1.PodRunning, time.Now())
+	want := "[boot] sandbox container started\nhello\n"
+	var gotOpts *corev1.PodLogOptions
+	d.getPodLogs = func(_ context.Context, ns, pod string, opts *corev1.PodLogOptions) (string, error) {
+		if ns != "sandboxes" || pod != "sbx-log1-pod" {
+			t.Fatalf("getPodLogs ns/pod=%s/%s", ns, pod)
+		}
+		gotOpts = opts
+		return want, nil
+	}
+	out, err := d.Logs(context.Background(), id, 100)
+	if err != nil {
+		t.Fatalf("Logs: %v", err)
+	}
+	if out != want {
+		t.Fatalf("content=%q want %q", out, want)
+	}
+	if gotOpts == nil || gotOpts.Container != sandboxContainer || gotOpts.Follow {
+		t.Fatalf("opts=%+v", gotOpts)
+	}
+	if gotOpts.TailLines == nil || *gotOpts.TailLines != 100 {
+		t.Fatalf("TailLines=%v", gotOpts.TailLines)
+	}
+}
+
+func TestLogsEmptySuccess(t *testing.T) {
+	d := testDriver(t, true)
+	id := "empty"
+	seedSandboxPod(t, d, id, "sbx-empty-pod", corev1.PodRunning, time.Now())
+	d.getPodLogs = func(_ context.Context, _, _ string, opts *corev1.PodLogOptions) (string, error) {
+		if opts.TailLines == nil || *opts.TailLines != defaultLogsTail {
+			t.Fatalf("default tail: %v", opts.TailLines)
+		}
+		return "", nil
+	}
+	out, err := d.Logs(context.Background(), id, 0)
+	if err != nil {
+		t.Fatalf("Logs empty success: %v", err)
+	}
+	if out != "" {
+		t.Fatalf("want empty content, got %q", out)
+	}
+}
+
+func TestLogsNotFound(t *testing.T) {
+	d := testDriver(t, true)
+	d.getPodLogs = func(context.Context, string, string, *corev1.PodLogOptions) (string, error) {
+		t.Fatal("getPodLogs must not be called when no pods match")
+		return "", nil
+	}
+	_, err := d.Logs(context.Background(), "missing", 10)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("want not-found error, got %v", err)
+	}
+}
+
+func TestPickPodForLogsPrefersRunning(t *testing.T) {
+	older := time.Now().Add(-time.Hour)
+	newer := time.Now()
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pending-new", CreationTimestamp: metav1.NewTime(newer)},
+			Status:     corev1.PodStatus{Phase: corev1.PodPending},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "running-old", CreationTimestamp: metav1.NewTime(older)},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "succeeded", CreationTimestamp: metav1.NewTime(newer)},
+			Status:     corev1.PodStatus{Phase: corev1.PodSucceeded},
+		},
+	}
+	got := pickPodForLogs(pods)
+	if got == nil || got.Name != "running-old" {
+		t.Fatalf("pick=%v want running-old", got)
+	}
+	if pickPodForLogs(nil) != nil {
+		t.Fatal("empty list must return nil")
+	}
+	onlyPending := []corev1.Pod{pods[0], pods[2]}
+	got = pickPodForLogs(onlyPending)
+	if got == nil || got.Name != "pending-new" {
+		t.Fatalf("fallback newest=%v want pending-new", got)
 	}
 }
 

--- a/sandbox-gateway/gateway/internal/driver/kubernetes/kubernetes_test.go
+++ b/sandbox-gateway/gateway/internal/driver/kubernetes/kubernetes_test.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -169,6 +170,84 @@ func TestLogsNotFound(t *testing.T) {
 	_, err := d.Logs(context.Background(), "missing", 10)
 	if err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Fatalf("want not-found error, got %v", err)
+	}
+}
+
+// TestDefaultGetPodLogsViaFakeClient exercises the real defaultGetPodLogs path
+// (no mock). client-go's fake Pods.GetLogs streams "fake logs".
+func TestDefaultGetPodLogsViaFakeClient(t *testing.T) {
+	d := testDriver(t, true)
+	id := "deflogs"
+	seedSandboxPod(t, d, id, "sbx-deflogs-pod", corev1.PodRunning, time.Now())
+	out, err := d.Logs(context.Background(), id, 50)
+	if err != nil {
+		t.Fatalf("Logs via defaultGetPodLogs: %v", err)
+	}
+	if out != "fake logs" {
+		t.Fatalf("content=%q want %q from fake GetLogs", out, "fake logs")
+	}
+}
+
+func TestDefaultGetPodLogsDirect(t *testing.T) {
+	d := testDriver(t, true)
+	tail := int64(10)
+	out, err := d.defaultGetPodLogs(context.Background(), "sandboxes", "any-pod", &corev1.PodLogOptions{
+		Container: sandboxContainer,
+		Follow:    false,
+		TailLines: &tail,
+	})
+	if err != nil {
+		t.Fatalf("defaultGetPodLogs: %v", err)
+	}
+	if out != "fake logs" {
+		t.Fatalf("content=%q want fake logs", out)
+	}
+}
+
+type errReadCloser struct {
+	err error
+}
+
+func (e errReadCloser) Read([]byte) (int, error) { return 0, e.err }
+func (e errReadCloser) Close() error             { return nil }
+
+func TestDrainLogStream(t *testing.T) {
+	out, err := drainLogStream(io.NopCloser(strings.NewReader("hello\n")))
+	if err != nil || out != "hello\n" {
+		t.Fatalf("drain success: %q err=%v", out, err)
+	}
+	out, err = drainLogStream(io.NopCloser(strings.NewReader("")))
+	if err != nil || out != "" {
+		t.Fatalf("drain empty: %q err=%v", out, err)
+	}
+	_, err = drainLogStream(errReadCloser{err: fmt.Errorf("read boom")})
+	if err == nil || !strings.Contains(err.Error(), "read boom") {
+		t.Fatalf("want read error, got %v", err)
+	}
+}
+
+func TestLogsGetPodLogsError(t *testing.T) {
+	d := testDriver(t, true)
+	id := "logerr"
+	seedSandboxPod(t, d, id, "sbx-logerr-pod", corev1.PodRunning, time.Now())
+	d.getPodLogs = func(context.Context, string, string, *corev1.PodLogOptions) (string, error) {
+		return "", fmt.Errorf("stream refused")
+	}
+	_, err := d.Logs(context.Background(), id, 10)
+	if err == nil || !strings.Contains(err.Error(), "kubernetes logs") || !strings.Contains(err.Error(), "stream refused") {
+		t.Fatalf("want wrapped stream error, got %v", err)
+	}
+}
+
+func TestLogsListPodsError(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	cs.PrependReactor("list", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("list apiserver down")
+	})
+	d := NewFromClient(cs, Options{Namespace: "sandboxes", NamePrefix: "sbx-"})
+	_, err := d.Logs(context.Background(), "x", 10)
+	if err == nil || !strings.Contains(err.Error(), "list pods") {
+		t.Fatalf("want list pods error, got %v", err)
 	}
 }
 

--- a/sandbox-gateway/gateway/internal/service/service.go
+++ b/sandbox-gateway/gateway/internal/service/service.go
@@ -25,7 +25,8 @@ const destroyDriverTimeout = 2 * time.Minute
 var ErrEndpointNotFound = errors.New("no endpoint for port")
 
 // ErrLogsUnsupported is returned when the configured driver cannot retrieve
-// container logs (currently kubernetes). Handlers map it to 501.
+// container logs. Handlers map it to 501. Docker and kubernetes implement Logs;
+// the mapping remains for any driver that still returns driver.ErrLogsUnsupported.
 var ErrLogsUnsupported = driver.ErrLogsUnsupported
 
 // lbWaiter is optionally implemented by drivers that expose LoadBalancer-backed


### PR DESCRIPTION
## Summary
- Implement `kubernetes.Driver.Logs` with injectable `getPodLogs`, label-based pod pick (prefer Running, else newest), and `PodLogOptions{Container:\"sandbox\", TailLines, Follow:false}` so GET `/api/v1/sandboxes/:id/logs` no longer returns 501 on K8s.
- Replace `TestLogsUnsupported` with content / empty-success / not-found cases (plus Running-prefer pick helper); keep `ErrLogsUnsupported`→501 for other drivers.
- Update `GATEWAY.md` and `gateway/docs/API.md`; document `pods/log` as an ops RBAC prerequisite.

## Test plan
- [x] `go test ./internal/driver/kubernetes/ -run 'TestLogs|TestPickPod'`
- [x] `go test ./internal/driver/docker/ -run 'TestLogs'` (no Docker regression)
- [ ] CI `ci-gateway` green
- [ ] After deploy: sample K8s sandbox GET `.../logs` is not 501; UI sandbox-log shows live / empty / error (not unsupported)


Made with [Cursor](https://cursor.com)