### PR TITLE
Fix site asset paths for custom domain root

### DIFF
--- a/.github/scripts/publish-pages.sh
+++ b/.github/scripts/publish-pages.sh
@@ -56,11 +56,21 @@ else
   git -C "$work" checkout --orphan "$PAGES_BRANCH" 2>/dev/null || git -C "$work" checkout -B "$PAGES_BRANCH"
 fi
 
+# Keep existing custom-domain CNAME across publishes unless the build provides one.
+preserved_cname=""
+if [[ -f "$work/CNAME" && ! -f "$src/CNAME" ]]; then
+  preserved_cname="$(cat "$work/CNAME")"
+fi
+
 # Replace tree contents but keep .git
 find "$work" -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
 cp -a "$src"/. "$work"/
 
-# Project Pages under /approving-pages/ must not be processed by Jekyll.
+if [[ -n "$preserved_cname" && ! -f "$work/CNAME" ]]; then
+  printf '%s\n' "$preserved_cname" >"$work/CNAME"
+fi
+
+# Avoid Jekyll processing on GitHub Pages.
 if [[ ! -f "$work/.nojekyll" ]]; then
   : >"$work/.nojekyll"
 fi

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ web/dist/
 docs/node_modules/
 docs/public/
 docs/.deploy_git/
+# local Pages deploy key material (never commit)
+/approving-pages-deploy
+/approving-pages-deploy.pub
 node_modules/
 web/test-results/
 web/playwright-report/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ when Secret `PAGES_DEPLOY_KEY` is configured.
    **Allow write access**.
 5. On `cocofhu/approving`, add the **private** key as Secret `PAGES_DEPLOY_KEY`.
 6. Optional: set the Approving repo Homepage to
-   `https://cocofhu.github.io/approving-pages/`.
+   `https://www.approving-ai.com/`.
 
 ## Release images and smoke
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Build rollback-capable, human-gated, observable workflows — agents run in real
 
 Security scans (CodeQL, web npm audit, gitleaks) run via the [security](https://github.com/cocofhu/approving/actions/workflows/security.yml) workflow on push/PR. View CodeQL under Security → Code scanning (or PR Checks); npm audit and gitleaks results are in the corresponding Actions job logs.
 
-[Site](https://cocofhu.github.io/approving-pages/) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Support](SUPPORT.md) · [Configuration](server/CONFIGURATION.md) · [Gateway](GATEWAY.md)
+[Site](https://www.approving-ai.com/) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Support](SUPPORT.md) · [Configuration](server/CONFIGURATION.md) · [Gateway](GATEWAY.md)
 
 **English | [简体中文](README.zh-CN.md)**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,7 +13,7 @@
 [![coverage-web](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcocofhu%2Fapproving%2Fcoverage-badges%2Fcoverage-web.json)](https://github.com/cocofhu/approving/actions/workflows/ci-web.yml)
 [![coverage-sandbox](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcocofhu%2Fapproving%2Fcoverage-badges%2Fcoverage-sandbox.json)](https://github.com/cocofhu/approving/actions/workflows/ci-sandbox.yml)
 
-[项目站](https://cocofhu.github.io/approving-pages/) · [贡献指南](CONTRIBUTING.md) · [安全](SECURITY.md) · [支持](SUPPORT.md) · [配置](server/CONFIGURATION.md) · [网关](GATEWAY.md)
+[项目站](https://www.approving-ai.com/) · [贡献指南](CONTRIBUTING.md) · [安全](SECURITY.md) · [支持](SUPPORT.md) · [配置](server/CONFIGURATION.md) · [网关](GATEWAY.md)
 
 **[English](README.md) | 简体中文**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Static HTML homepage + Markdown help, built to `public/` and published by
 `ci-docs` to [`cocofhu/approving-pages`](https://github.com/cocofhu/approving-pages)
-(`https://cocofhu.github.io/approving-pages/`).
+(`https://www.approving-ai.com/`).
 
 ## Layout
 
@@ -18,7 +18,7 @@ Static HTML homepage + Markdown help, built to `public/` and published by
 ```bash
 cd docs
 npm ci --no-audit --no-fund
-npm run build                 # BASE_PATH=/approving-pages (Pages URL)
+npm run build                 # BASE_PATH=/ (custom domain root)
 BASE_PATH=/ npm run server    # local preview at http://localhost:4000
 ```
 

--- a/docs/content/help/contributing.md
+++ b/docs/content/help/contributing.md
@@ -27,7 +27,7 @@ npm run build
 BASE_PATH=/ npm run server
 ```
 
-产物在 `docs/public/`。推送到 `main` 且改动 `docs/**` 时，`ci-docs` 会构建并部署到独立 Pages 仓库 `cocofhu/approving-pages`（需配置 Secret `PAGES_DEPLOY_TOKEN`）。
+产物在 `docs/public/`。推送到 `main` 且改动 `docs/**` 时，`ci-docs` 会构建并部署到独立 Pages 仓库 `cocofhu/approving-pages`（需配置 Secret `PAGES_DEPLOY_KEY`）。
 
 ## 相关模块门禁
 

--- a/docs/scripts/build.mjs
+++ b/docs/scripts/build.mjs
@@ -5,7 +5,8 @@
  * - convert content markdown files to public/<path>/index.html
  *
  * BASE_PATH defaults to / for the custom domain (www.approving-ai.com).
- * Project Pages fallback: BASE_PATH=/approving-pages npm run build
+ * Legacy CI may set BASE_PATH=/approving-pages; that is remapped to / unless
+ * FORCE_PROJECT_PAGES=1 (project Pages fallback).
  */
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -20,10 +21,12 @@ const contentDir = path.join(root, "content");
 const outDir = path.join(root, "public");
 
 // Custom domain is served from /. Legacy ci-docs set BASE_PATH=/approving-pages;
-// remap that so CI builds root-relative assets until the workflow env is updated.
+// remap that so CI builds root-relative assets (workflow env update needs workflow scope).
 const envBase = process.env.BASE_PATH;
+const useLegacyProjectPages =
+  envBase === "/approving-pages" && process.env.FORCE_PROJECT_PAGES === "1";
 const basePath = normalizeBase(
-  envBase === "/approving-pages" ? "/" : (envBase ?? "/"),
+  useLegacyProjectPages ? envBase : (envBase === "/approving-pages" ? "/" : (envBase ?? "/")),
 );
 const md = new MarkdownIt({ html: false, linkify: true, typographer: true });
 

--- a/docs/scripts/build.mjs
+++ b/docs/scripts/build.mjs
@@ -19,7 +19,12 @@ const siteDir = path.join(root, "site");
 const contentDir = path.join(root, "content");
 const outDir = path.join(root, "public");
 
-const basePath = normalizeBase(process.env.BASE_PATH ?? "/");
+// Custom domain is served from /. Legacy ci-docs set BASE_PATH=/approving-pages;
+// remap that so CI builds root-relative assets until the workflow env is updated.
+const envBase = process.env.BASE_PATH;
+const basePath = normalizeBase(
+  envBase === "/approving-pages" ? "/" : (envBase ?? "/"),
+);
 const md = new MarkdownIt({ html: false, linkify: true, typographer: true });
 
 function normalizeBase(raw) {

--- a/docs/scripts/build.mjs
+++ b/docs/scripts/build.mjs
@@ -4,8 +4,8 @@
  * - copy site/ to public/
  * - convert content markdown files to public/<path>/index.html
  *
- * BASE_PATH defaults to /approving-pages for GitHub project Pages.
- * Local preview: BASE_PATH=/ npm run build && npx serve public
+ * BASE_PATH defaults to / for the custom domain (www.approving-ai.com).
+ * Project Pages fallback: BASE_PATH=/approving-pages npm run build
  */
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -19,7 +19,7 @@ const siteDir = path.join(root, "site");
 const contentDir = path.join(root, "content");
 const outDir = path.join(root, "public");
 
-const basePath = normalizeBase(process.env.BASE_PATH ?? "/approving-pages");
+const basePath = normalizeBase(process.env.BASE_PATH ?? "/");
 const md = new MarkdownIt({ html: false, linkify: true, typographer: true });
 
 function normalizeBase(raw) {

--- a/docs/site/CNAME
+++ b/docs/site/CNAME
@@ -1,0 +1,1 @@
+www.approving-ai.com


### PR DESCRIPTION
## Summary
- Build with root-relative asset paths for the custom domain (`https://www.approving-ai.com/`): `docs/scripts/build.mjs` defaults to `BASE_PATH=/` and remaps legacy CI `BASE_PATH=/approving-pages` to `/` (override with `FORCE_PROJECT_PAGES=1` for project Pages).
- Add `docs/site/CNAME` (`www.approving-ai.com`) and preserve an existing CNAME across `publish-pages.sh` wipe/copy publishes.
- Point README / docs / CONTRIBUTING site links at `https://www.approving-ai.com/`; document `PAGES_DEPLOY_KEY`; gitignore local deploy key files.

### Follow-up (blocked by token scope)
Updating `.github/workflows/ci-docs.yml` to set `BASE_PATH: /` (with a custom-domain comment) could not be pushed: the available `GH_TOKEN` has `repo` only, not `workflow`. Please apply that one-line workflow env change (or re-push with a token that includes the `workflow` scope). Until then, the build.mjs remap keeps CI assets correct.

## Test plan
- [ ] `cd docs && npm ci && BASE_PATH=/approving-pages npm run build` — asset URLs are root-relative (`/…`, not `/approving-pages/…`)
- [ ] Confirm `docs/public/CNAME` is `www.approving-ai.com`
- [ ] After merge, site loads at https://www.approving-ai.com/ with CSS/JS intact
- [ ] (Maintainer) Land `ci-docs.yml` `BASE_PATH: /` when a `workflow`-scoped token is available


Made with [Cursor](https://cursor.com)