### PR TITLE
feat(ci): add coverage-server and coverage-gateway README badges

### DIFF
--- a/.github/workflows/ci-gateway.yml
+++ b/.github/workflows/ci-gateway.yml
@@ -7,17 +7,26 @@ on:
   push:
     paths:
       - "sandbox-gateway/gateway/**"
+      - "sandbox-gateway/scripts/cover-check.sh"
       - ".github/workflows/ci-gateway.yml"
+      - ".github/scripts/coverage-badge-color.sh"
+      - ".github/scripts/publish-coverage-badge.sh"
       - ".golangci.yml"
   pull_request:
     paths:
       - "sandbox-gateway/gateway/**"
+      - "sandbox-gateway/scripts/cover-check.sh"
       - ".github/workflows/ci-gateway.yml"
+      - ".github/scripts/coverage-badge-color.sh"
+      - ".github/scripts/publish-coverage-badge.sh"
       - ".golangci.yml"
 
 jobs:
   gateway:
     runs-on: ubuntu-latest
+    # contents:write only used to update the orphan coverage-badges branch endpoint.
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: sandbox-gateway/gateway
@@ -37,5 +46,25 @@ jobs:
           args: --config=${{ github.workspace }}/.golangci.yml
       - run: go vet ./...
       - name: Gateway Go coverage gate
+        id: cover
         working-directory: sandbox-gateway
         run: ./scripts/cover-check.sh gateway 90
+      - name: Publish coverage-gateway badge
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && success()
+        continue-on-error: true
+        working-directory: .
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          pct="${{ steps.cover.outputs.coverage_pct }}"
+          if [[ -z "$pct" ]]; then
+            echo "no coverage_pct from cover-check; skip badge publish"
+            exit 0
+          fi
+          color="$(./.github/scripts/coverage-badge-color.sh "$pct")"
+          ./.github/scripts/publish-coverage-badge.sh \
+            coverage-gateway.json \
+            coverage-gateway \
+            "$pct" \
+            "$color"

--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -2,13 +2,26 @@ name: ci-server
 
 on:
   push:
-    paths: ["server/**", ".github/workflows/ci-server.yml", ".golangci.yml"]
+    paths:
+      - "server/**"
+      - ".github/workflows/ci-server.yml"
+      - ".github/scripts/coverage-badge-color.sh"
+      - ".github/scripts/publish-coverage-badge.sh"
+      - ".golangci.yml"
   pull_request:
-    paths: ["server/**", ".github/workflows/ci-server.yml", ".golangci.yml"]
+    paths:
+      - "server/**"
+      - ".github/workflows/ci-server.yml"
+      - ".github/scripts/coverage-badge-color.sh"
+      - ".github/scripts/publish-coverage-badge.sh"
+      - ".golangci.yml"
 
 jobs:
   server:
     runs-on: ubuntu-latest
+    # contents:write only used to update the orphan coverage-badges branch endpoint.
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: server
@@ -30,6 +43,26 @@ jobs:
       - run: go run ./cmd/gen-configdoc -out CONFIGURATION.md -check
       - run: go test ./...
       - name: Server Go coverage gate
+        id: cover
         run: ./scripts/cover-check-server.sh 90
+      - name: Publish coverage-server badge
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && success()
+        continue-on-error: true
+        working-directory: .
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          pct="${{ steps.cover.outputs.coverage_pct }}"
+          if [[ -z "$pct" ]]; then
+            echo "no coverage_pct from cover-check; skip badge publish"
+            exit 0
+          fi
+          color="$(./.github/scripts/coverage-badge-color.sh "$pct")"
+          ./.github/scripts/publish-coverage-badge.sh \
+            coverage-server.json \
+            coverage-server \
+            "$pct" \
+            "$color"
       - name: e2e fake runtime
         run: go test ./internal/runtime/ -count=1 -run 'TestRunAgent|TestReact'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,16 +148,17 @@ Dev-only local sandbox image:
 
 ## Coverage badges
 
-README shows `coverage-web` / `coverage-sandbox` Lines% via shields.io Endpoint
-Badges. Endpoint JSON lives on the orphan `coverage-badges` branch and is
-updated only when the corresponding workflow succeeds on the default branch
-(`ci-web` / `ci-sandbox`). Failed or skipped coverage runs do not overwrite the
-last successful value. Color bands: ≥85% green, 70–84% yellow, below 70% orange;
+README shows `coverage-web` / `coverage-sandbox` / `coverage-server` /
+`coverage-gateway` via shields.io Endpoint Badges. Endpoint JSON lives on the
+orphan `coverage-badges` branch and is updated only when the corresponding
+workflow succeeds on the default branch (`ci-web` / `ci-sandbox` / `ci-server` /
+`ci-gateway`). Failed or skipped coverage runs do not overwrite the last
+successful value. Color bands: ≥85% green, 70–84% yellow, below 70% orange;
 cold start is `n/a` / lightgrey.
 
 Because those workflows are path-filtered, a module badge stays at its last
 successful percent until that module’s paths change again — expected lag, not a
-badge outage. There is no `coverage-server` badge and no coverage SaaS.
+badge outage. There is no coverage SaaS.
 
 ## Changes and pull requests
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Build rollback-capable, human-gated, observable workflows — agents run in real
 
 [![coverage-web](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcocofhu%2Fapproving%2Fcoverage-badges%2Fcoverage-web.json)](https://github.com/cocofhu/approving/actions/workflows/ci-web.yml)
 [![coverage-sandbox](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcocofhu%2Fapproving%2Fcoverage-badges%2Fcoverage-sandbox.json)](https://github.com/cocofhu/approving/actions/workflows/ci-sandbox.yml)
+[![coverage-server](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcocofhu%2Fapproving%2Fcoverage-badges%2Fcoverage-server.json)](https://github.com/cocofhu/approving/actions/workflows/ci-server.yml)
+[![coverage-gateway](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcocofhu%2Fapproving%2Fcoverage-badges%2Fcoverage-gateway.json)](https://github.com/cocofhu/approving/actions/workflows/ci-gateway.yml)
 
 Security scans (CodeQL, web npm audit, gitleaks) run via the [security](https://github.com/cocofhu/approving/actions/workflows/security.yml) workflow on push/PR. View CodeQL under Security → Code scanning (or PR Checks); npm audit and gitleaks results are in the corresponding Actions job logs.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,6 +12,8 @@
 
 [![coverage-web](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcocofhu%2Fapproving%2Fcoverage-badges%2Fcoverage-web.json)](https://github.com/cocofhu/approving/actions/workflows/ci-web.yml)
 [![coverage-sandbox](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcocofhu%2Fapproving%2Fcoverage-badges%2Fcoverage-sandbox.json)](https://github.com/cocofhu/approving/actions/workflows/ci-sandbox.yml)
+[![coverage-server](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcocofhu%2Fapproving%2Fcoverage-badges%2Fcoverage-server.json)](https://github.com/cocofhu/approving/actions/workflows/ci-server.yml)
+[![coverage-gateway](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcocofhu%2Fapproving%2Fcoverage-badges%2Fcoverage-gateway.json)](https://github.com/cocofhu/approving/actions/workflows/ci-gateway.yml)
 
 [项目站](https://www.approving-ai.com/) · [贡献指南](CONTRIBUTING.md) · [安全](SECURITY.md) · [支持](SUPPORT.md) · [配置](server/CONFIGURATION.md) · [网关](GATEWAY.md)
 

--- a/sandbox-gateway/scripts/cover-check.sh
+++ b/sandbox-gateway/scripts/cover-check.sh
@@ -14,4 +14,11 @@ go test ./... -count=1 -coverprofile="$COVER"
 { head -1 "$COVER"; grep -vE "$EXCLUDE" "$COVER" | grep -v '^mode:' || true; } >"$GATE"
 TOTAL="$(go tool cover -func="$GATE" | awk '/^total:/{gsub(/%/,"",$NF); print $NF}')"
 echo "coverage=${TOTAL}% (gate min=${MIN}%, exclude=${EXCLUDE})"
+# Export for CI badge publishing (does not affect the gate below).
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "coverage_pct=${TOTAL}" >>"$GITHUB_OUTPUT"
+fi
+if [[ -n "${COVER_CHECK_OUT:-}" ]]; then
+  printf '%s\n' "$TOTAL" >"$COVER_CHECK_OUT"
+fi
 awk -v t="$TOTAL" -v m="$MIN" 'BEGIN{ if ((t+0) < (m+0)) { print "FAIL: coverage below threshold"; exit 1 } print "OK: coverage meets threshold" }'

--- a/server/scripts/cover-check-server.sh
+++ b/server/scripts/cover-check-server.sh
@@ -28,4 +28,11 @@ if [[ -z "${TOTAL}" ]]; then
   exit 1
 fi
 echo "server-core coverage=${TOTAL}% (min=${MIN}%)"
+# Export for CI badge publishing (does not affect the gate below).
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "coverage_pct=${TOTAL}" >>"$GITHUB_OUTPUT"
+fi
+if [[ -n "${COVER_CHECK_OUT:-}" ]]; then
+  printf '%s\n' "$TOTAL" >"$COVER_CHECK_OUT"
+fi
 awk -v t="$TOTAL" -v m="$MIN" 'BEGIN{ if ((t+0)<(m+0)) { print "FAIL"; exit 1 } print "OK" }'


### PR DESCRIPTION
## Summary
- Publish `coverage-server` / `coverage-gateway` shields endpoint JSON from `ci-server` / `ci-gateway` on successful `main` pushes (same orphan `coverage-badges` flow as web/sandbox).
- Export `coverage_pct` from server/gateway cover-check scripts for badge publishing.
- Show both badges on `README.md` / `README.zh-CN.md` and update `CONTRIBUTING.md`.
- Seeded initial endpoint JSON on `coverage-badges` from latest main CI (server ≈92%, gateway 90%) so README is not broken before the next module push.

## Test plan
- [x] `bash -n` on cover-check + badge helper scripts
- [ ] PR CI: path-filtered `ci-server` / `ci-gateway` still green
- [ ] After merge + next successful main run of each workflow, badges refresh on `coverage-badges`
- [ ] README badges render: coverage-server / coverage-gateway


Made with [Cursor](https://cursor.com)