### PR TITLE
Move project delete from header into meta footer.

### DIFF
--- a/web/e2e/project-detail.spec.ts
+++ b/web/e2e/project-detail.spec.ts
@@ -282,10 +282,13 @@ async function gotoProjectDetailWithProject(
 }
 
 test.describe('ProjectDetailView 沙箱/工作流变量面板布局', () => {
-  test('页头无「合并规则」且保留删除', async ({ page }) => {
+  test('页头无「合并规则」且无项目删除', async ({ page }) => {
     await gotoProjectDetailWithProject(page, MOCK_PROJECT)
 
-    await expect(page.getByRole('button', { name: '删除' }).first()).toBeVisible()
+    // 页头右区仅保留 Token；项目级「删除」已迁入「项目信息」底栏（g1.1 / g3.1）
+    const headerActions = page.getByTestId('project-detail-header-actions')
+    await expect(headerActions.getByTestId('project-token-stat')).toBeVisible()
+    await expect(headerActions.getByRole('button', { name: '删除' })).toHaveCount(0)
     // 页头不应再有「合并规则」按钮；Tab hint 旁的「查看合并规则」链接在进入对应 Tab 后才出现
     await expect(page.getByRole('button', { name: '合并规则' })).toHaveCount(0)
   })
@@ -387,7 +390,7 @@ test.describe('ProjectDetailView 沙箱/工作流变量面板布局', () => {
 })
 
 test.describe('ProjectDetailView 项目信息面板', () => {
-  test('进入 Tab：近全宽壳 + 壳内顶栏 + primary 保存', async ({ page }) => {
+  test('进入 Tab：近全宽壳 + 壳内顶栏 + 左删右存 + 删除确认可取消', async ({ page }) => {
     await gotoProjectDetailWithProject(page, MOCK_PROJECT)
     await page.getByRole('button', { name: '项目信息' }).click()
 
@@ -402,10 +405,28 @@ test.describe('ProjectDetailView 项目信息面板', () => {
     const box = await panel.boundingBox()
     expect(box?.width).toBeGreaterThan(900)
 
-    const saveBtn = panel.getByRole('button', { name: '保存' })
+    const footer = panel.getByTestId('project-meta-footer')
+    const deleteBtn = footer.getByTestId('project-meta-delete')
+    const saveBtn = footer.getByRole('button', { name: '保存' })
+    await expect(deleteBtn).toBeVisible()
+    await expect(deleteBtn).toHaveClass(/text-err/)
     await expect(saveBtn).toBeVisible()
     await expect(saveBtn).toHaveClass(/bg-accent/)
-    await expect(panel.getByRole('button', { name: '删除' })).toHaveCount(0)
+
+    // 左删右存：删除在保存左侧（g2.1 / g3.2）
+    const deleteBox = await deleteBtn.boundingBox()
+    const saveBox = await saveBtn.boundingBox()
+    expect(deleteBox && saveBox).toBeTruthy()
+    expect(deleteBox!.x).toBeLessThan(saveBox!.x)
+
+    // 点击删除 → 既有确认弹窗 → 取消后仍停留详情且项目未删
+    await deleteBtn.click()
+    await expect(page.getByText('删除项目 · Demo Project')).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText('仅当项目下已无流水线时可删除')).toBeVisible()
+    await page.getByRole('button', { name: '取消' }).click()
+    await expect(page.getByText('删除项目 · Demo Project')).toHaveCount(0)
+    await expect(page.getByRole('heading', { name: 'Demo Project' })).toBeVisible()
+    await expect(panel.getByTestId('project-meta-delete')).toBeVisible()
   })
 })
 

--- a/web/src/views/ProjectDetailView.vue
+++ b/web/src/views/ProjectDetailView.vue
@@ -655,7 +655,7 @@ onUnmounted(() => {
             <h2 class="text-lg font-semibold text-txt">{{ project.name }}</h2>
             <p v-if="project.description" class="mt-0.5 text-sm text-txt3">{{ project.description }}</p>
           </div>
-          <div class="flex flex-wrap items-start gap-2">
+          <div class="flex flex-wrap items-start gap-2" data-testid="project-detail-header-actions">
             <div
               class="min-w-[132px] rounded-[10px] border border-accent/35 bg-gradient-to-b from-accent-dim/90 to-surface px-3 py-2 text-left md:text-right"
               data-testid="project-token-stat"
@@ -674,9 +674,6 @@ onUnmounted(() => {
                 {{ t('pages.projectDetail.tokenUsageHint') }}
               </div>
             </div>
-            <AppButton variant="outline" size="sm" class="text-err" @click="showDelete = true">
-              {{ t('common.buttons.delete') }}
-            </AppButton>
           </div>
         </div>
       </template>
@@ -1302,7 +1299,19 @@ onUnmounted(() => {
             </div>
           </div>
 
-          <div class="flex flex-wrap justify-end gap-2 border-t border-line bg-surface p-3">
+          <div
+            class="flex flex-wrap items-center justify-between gap-2 border-t border-line bg-surface p-3"
+            data-testid="project-meta-footer"
+          >
+            <AppButton
+              variant="outline"
+              size="sm"
+              class="text-err"
+              data-testid="project-meta-delete"
+              @click="showDelete = true"
+            >
+              {{ t('common.buttons.delete') }}
+            </AppButton>
             <AppButton variant="primary" :disabled="savingMeta" @click="saveMeta">
               {{ t('common.buttons.save') }}
             </AppButton>


### PR DESCRIPTION
Keep the header for Token stats only and place outline delete beside save in project info, reusing the existing confirm flow; update e2e for the new layout.

Co-authored-by: Cursor <cursoragent@cursor.com>
