### PR TITLE
feat(docs): English /en mirror and locale switcher

### DIFF
--- a/docs/content/en/guide/concepts.md
+++ b/docs/content/en/guide/concepts.md
@@ -1,0 +1,40 @@
+---
+title: Core concepts
+description: FSM orchestration, human gates, sandboxed execution, and artifact contracts.
+---
+
+## FSM orchestration
+
+Approving turns coding agents into steps in a workflow. You orchestrate on a finite state machine:
+
+- **Nodes** are states (agent / react / gate / …)
+- **Edges** are transitions, with configurable success, failure, and rollback paths
+- Use `when` guards and checkpoints to make risky steps explicit
+
+This is not a one-shot, irreversible agent run: design the path first, then gate the critical steps.
+
+## Human gates
+
+When a step needs a human decision, the run stops at a **gate** until someone approves or rejects.
+
+Approval moments are first-class — not an afterthought. Approving bets that agents can be fast while people still own the critical decisions.
+
+## Real Docker sandboxes
+
+Agents are not black-box prompts on a laptop. They execute in Docker containers through the in-repo [sandbox-gateway](https://github.com/cocofhu/approving/tree/main/sandbox-gateway), talking over ACP.
+
+Supported backends: **Cursor**, **Claude Code**, **CodeBuddy**, and **Trae**. Configure `acpBackend` per agent; keep secrets in agent meta env.
+
+## Artifact contract and MCP
+
+Each run has an isolated artifact MCP. Agents call tools such as:
+
+- `write_artifact`
+- `set_*`
+- `node_complete`
+
+Isolation is by run token, leaving an inspectable paper trail.
+
+## Single-repo self-hosting
+
+`sandbox-gateway` and the generic sandbox image sources live in this repository. One clone is enough to self-host.

--- a/docs/content/en/guide/quick-start.md
+++ b/docs/content/en/guide/quick-start.md
@@ -1,0 +1,50 @@
+---
+title: Quick start
+description: Bring up Approving on a Linux host with Docker Compose.
+---
+
+## Prerequisites
+
+- A Linux host
+- Git, Docker, and Docker Compose installed
+
+## Clone the repository
+
+```bash
+git clone https://github.com/cocofhu/approving.git
+cd approving
+```
+
+## Start
+
+By default this pulls published images from GHCR (no local image build required):
+
+```bash
+./start.sh -d
+```
+
+Then open:
+
+- UI / API: http://localhost:8080
+- API health: http://localhost:8080/api/health
+- Gateway health: http://localhost:8899/healthz
+- Default login: `admin` / `demo1234` (local-demo)
+
+`./start.sh` also pulls the **sandbox runtime** image from GHCR (large). Until that finishes, sandbox chats may stay on “starting sandbox…”.
+
+## Common commands
+
+```bash
+./start.sh logs
+./start.sh down
+./start.sh pull          # refresh GHCR images
+./start.sh dev -d        # source stack: go run + Vite HMR
+```
+
+Image tags / digests can be overridden in `.env` — see [`.env.example`](https://github.com/cocofhu/approving/blob/main/.env.example) at the repo root. Publish and smoke checks are covered in [Contributing](https://github.com/cocofhu/approving/blob/main/CONTRIBUTING.md).
+
+## Next steps
+
+- [Core concepts](../concepts/) — FSM, gates, sandbox, artifacts
+- [Configuration summary](../../help/configuration/) — points to full `CONFIGURATION.md`
+- [Gateway summary](../../help/gateway/) — points to `GATEWAY.md`

--- a/docs/content/en/help/configuration.md
+++ b/docs/content/en/help/configuration.md
@@ -1,0 +1,28 @@
+---
+title: Configuration
+description: Configuration highlights; full details live in source CONFIGURATION.md.
+---
+
+Approving server configuration is primarily YAML / environment variables (local examples: `server/config.example.yaml` and the root `.env.example`).
+
+## Full documentation
+
+Treat the in-repo docs as authoritative (avoids drift between this site and source):
+
+- [server/CONFIGURATION.md](https://github.com/cocofhu/approving/blob/main/server/CONFIGURATION.md)
+
+That document is generated/checked by `go run ./cmd/gen-configdoc`; CI runs `-check`.
+
+## Local quick path
+
+```bash
+./start.sh -d          # published image stack
+./start.sh dev -d      # source + HMR
+```
+
+Image tags / digests, gateway, and sandbox-related variables are in `.env.example`. Agent API keys, `GITHUB_*` / `GITLAB_*` / SSH, and similar belong in agent meta env (values may reference `${vars.<name>}`).
+
+## Related
+
+- [Gateway](../gateway/)
+- [Contributing](../contributing/)

--- a/docs/content/en/help/contributing.md
+++ b/docs/content/en/help/contributing.md
@@ -1,0 +1,34 @@
+---
+title: Contributing
+description: How to contribute to Approving; points to the repository contributing guide.
+---
+
+Contributions are welcome. Please read:
+
+- [CODE_OF_CONDUCT.md](https://github.com/cocofhu/approving/blob/main/CODE_OF_CONDUCT.md)
+- [SECURITY.md](https://github.com/cocofhu/approving/blob/main/SECURITY.md)
+- [CONTRIBUTING.md](https://github.com/cocofhu/approving/blob/main/CONTRIBUTING.md)
+
+Short rules for agents / contributors (path→commands, gates, do-not-touch lists):
+
+- [AGENTS.md](https://github.com/cocofhu/approving/blob/main/AGENTS.md)
+
+## Local build for this site (`docs/`)
+
+```bash
+cd docs
+npm ci --no-audit --no-fund
+npm run build
+```
+
+Preview:
+
+```bash
+BASE_PATH=/ npm run server
+```
+
+Output lands in `docs/public/`. When changes under `docs/**` land on `main`, `ci-docs` builds and deploys to the separate Pages repo `cocofhu/approving-pages` (requires Secret `PAGES_DEPLOY_KEY`).
+
+## Related module gates
+
+When you change `server/`, `web/`, or `sandbox-gateway/`, run the matching local suites from `AGENTS.md` — do not rely only on the always-on `ci` gate.

--- a/docs/content/en/help/gateway.md
+++ b/docs/content/en/help/gateway.md
@@ -1,0 +1,25 @@
+---
+title: Gateway
+description: sandbox-gateway contract summary; full details in GATEWAY.md.
+---
+
+Approving schedules the generic sandbox image through the vendored **sandbox-gateway** control plane. The Web UI talks to the Approving API; agent / react nodes execute in containers via the gateway.
+
+## Full documentation
+
+- [GATEWAY.md](https://github.com/cocofhu/approving/blob/main/GATEWAY.md)
+
+## Health checks (default local stack)
+
+- Gateway: http://localhost:8899/healthz
+- Approving API: http://localhost:8080/api/health
+
+## Source locations
+
+- Control plane: `sandbox-gateway/gateway/`
+- Sandbox image and scripts: `sandbox-gateway/sandbox/`, `sandbox-gateway/scripts/`
+
+## Related
+
+- [Configuration](../configuration/)
+- [Core concepts](../../guide/concepts/)

--- a/docs/scripts/build.mjs
+++ b/docs/scripts/build.mjs
@@ -4,6 +4,7 @@
  * - copy site/ to public/
  * - convert content markdown files to public/<path>/index.html
  *
+ * Locale: zh-CN at site root; English under en/ (content/en/** → public/en/**).
  * BASE_PATH defaults to / for the custom domain (www.approving-ai.com).
  * Legacy CI may set BASE_PATH=/approving-pages; that is remapped to / unless
  * FORCE_PROJECT_PAGES=1 (project Pages fallback).
@@ -20,6 +21,8 @@ const siteDir = path.join(root, "site");
 const contentDir = path.join(root, "content");
 const outDir = path.join(root, "public");
 
+const SITE_CANONICAL = "https://www.approving-ai.com";
+
 // Custom domain is served from /. Legacy ci-docs set BASE_PATH=/approving-pages;
 // remap that so CI builds root-relative assets (workflow env update needs workflow scope).
 const envBase = process.env.BASE_PATH;
@@ -29,6 +32,35 @@ const basePath = normalizeBase(
   useLegacyProjectPages ? envBase : (envBase === "/approving-pages" ? "/" : (envBase ?? "/")),
 );
 const md = new MarkdownIt({ html: false, linkify: true, typographer: true });
+
+const SHELL = {
+  "zh-CN": {
+    htmlLang: "zh-CN",
+    navAria: "主导航",
+    docs: "文档",
+    concepts: "概念",
+    eyebrow: "文档",
+    footerAria: "页脚",
+    quickStart: "快速开始",
+    configuration: "配置",
+    gateway: "网关",
+    source: "源码",
+    langAria: "语言",
+  },
+  en: {
+    htmlLang: "en",
+    navAria: "Main navigation",
+    docs: "Docs",
+    concepts: "Concepts",
+    eyebrow: "Docs",
+    footerAria: "Footer",
+    quickStart: "Quick start",
+    configuration: "Configuration",
+    gateway: "Gateway",
+    source: "Source",
+    langAria: "Language",
+  },
+};
 
 function normalizeBase(raw) {
   let b = String(raw || "/").trim();
@@ -43,6 +75,41 @@ function withBase(p) {
   const cleaned = p.startsWith("/") ? p : `/${p}`;
   if (basePath === "/") return cleaned;
   return `${basePath}${cleaned}`;
+}
+
+function localeFromSlug(slug) {
+  return slug === "en" || slug.startsWith("en/") ? "en" : "zh-CN";
+}
+
+/** @returns {{ zh: string, en: string }} site-absolute paths ending with / */
+function dualPaths(slug) {
+  const isEn = slug === "en" || slug.startsWith("en/");
+  const bare = isEn ? (slug === "en" ? "" : slug.slice(3)) : slug;
+  const zh = bare ? `/${bare}/` : "/";
+  const en = bare ? `/en/${bare}/` : "/en/";
+  return { zh, en };
+}
+
+function canonicalHref(sitePath) {
+  return `${SITE_CANONICAL}${sitePath}`;
+}
+
+function langSwitcherHtml(locale, dual) {
+  const zhCurrent = locale === "zh-CN" ? " is-current" : "";
+  const enCurrent = locale === "en" ? " is-current" : "";
+  const zhAria = locale === "zh-CN" ? ' aria-current="page"' : "";
+  const enAria = locale === "en" ? ' aria-current="page"' : "";
+  return `<nav class="lang-switch" aria-label="${escapeHtml(SHELL[locale].langAria)}">
+        <a class="lang-switch__link${zhCurrent}" href="${withBase(dual.zh)}" data-locale-set="zh-CN"${zhAria}>中文</a>
+        <span class="lang-switch__sep" aria-hidden="true">|</span>
+        <a class="lang-switch__link${enCurrent}" href="${withBase(dual.en)}" data-locale-set="en"${enAria}>English</a>
+      </nav>`;
+}
+
+function hreflangLinks(dual) {
+  return `  <link rel="alternate" hreflang="zh-CN" href="${canonicalHref(dual.zh)}">
+  <link rel="alternate" hreflang="en" href="${canonicalHref(dual.en)}">
+  <link rel="alternate" hreflang="x-default" href="${canonicalHref(dual.zh)}">`;
 }
 
 async function rmrf(dir) {
@@ -79,37 +146,52 @@ function rewriteBasePlaceholders(text) {
 }
 
 function docTemplate({ title, description, bodyHtml, relPath }) {
+  const locale = localeFromSlug(relPath);
+  const t = SHELL[locale];
+  const dual = dualPaths(relPath);
+  const prefix = locale === "en" ? "/en" : "";
+  const homeHref = withBase(locale === "en" ? "/en/" : "/");
+  const docsHref = withBase(`${prefix}/guide/quick-start/`);
+  const conceptsHref = withBase(`${prefix}/guide/concepts/`);
+  const quickStartHref = withBase(`${prefix}/guide/quick-start/`);
+  const configHref = withBase(`${prefix}/help/configuration/`);
+  const gatewayHref = withBase(`${prefix}/help/gateway/`);
+  const dataBase = basePath === "/" ? "" : basePath;
   const pageTitle = title ? `${title} · Approving` : "Approving";
-  const desc = description || "Approving help documentation";
+  const desc = description || (locale === "en" ? "Approving help documentation" : "Approving 帮助文档");
+
   return `<!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="${t.htmlLang}" data-base="${escapeHtml(dataBase)}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>${escapeHtml(pageTitle)}</title>
   <meta name="description" content="${escapeHtml(desc)}">
+${hreflangLinks(dual)}
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+SC:wght@400;500;600;700&family=Noto+Serif+SC:wght@500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="${withBase("/css/tokens.css")}">
   <link rel="stylesheet" href="${withBase("/css/site.css")}">
   <link rel="stylesheet" href="${withBase("/css/page.css")}">
+  <script src="${withBase("/js/locale.js")}"></script>
 </head>
 <body class="page-doc">
   <header class="site-header">
     <div class="site-header__inner">
-      <a class="site-header__brand" href="${withBase("/")}">Approving</a>
-      <nav class="site-header__nav" aria-label="主导航">
-        <a class="site-header__link" href="${withBase("/guide/quick-start/")}">文档</a>
-        <a class="site-header__link" href="${withBase("/guide/concepts/")}">概念</a>
+      <a class="site-header__brand" href="${homeHref}">Approving</a>
+      <nav class="site-header__nav" aria-label="${escapeHtml(t.navAria)}">
+        <a class="site-header__link" href="${docsHref}">${escapeHtml(t.docs)}</a>
+        <a class="site-header__link" href="${conceptsHref}">${escapeHtml(t.concepts)}</a>
         <a class="site-header__link" href="https://github.com/cocofhu/approving" rel="noopener noreferrer" target="_blank">GitHub</a>
+        ${langSwitcherHtml(locale, dual)}
       </nav>
     </div>
   </header>
   <main id="main">
     <article class="doc">
       <header class="doc__header">
-        <p class="doc__eyebrow">文档</p>
+        <p class="doc__eyebrow">${escapeHtml(t.eyebrow)}</p>
         <h1 class="doc__title">${escapeHtml(title || relPath)}</h1>
         ${description ? `<p class="doc__lead">${escapeHtml(description)}</p>` : ""}
       </header>
@@ -121,11 +203,11 @@ function docTemplate({ title, description, bodyHtml, relPath }) {
   <footer class="site-footer">
     <div class="site-footer__inner">
       <p class="site-footer__brand">Approving</p>
-      <nav class="site-footer__nav" aria-label="页脚">
-        <a href="${withBase("/guide/quick-start/")}">快速开始</a>
-        <a href="${withBase("/help/configuration/")}">配置</a>
-        <a href="${withBase("/help/gateway/")}">网关</a>
-        <a href="https://github.com/cocofhu/approving" rel="noopener noreferrer" target="_blank">源码</a>
+      <nav class="site-footer__nav" aria-label="${escapeHtml(t.footerAria)}">
+        <a href="${quickStartHref}">${escapeHtml(t.quickStart)}</a>
+        <a href="${configHref}">${escapeHtml(t.configuration)}</a>
+        <a href="${gatewayHref}">${escapeHtml(t.gateway)}</a>
+        <a href="https://github.com/cocofhu/approving" rel="noopener noreferrer" target="_blank">${escapeHtml(t.source)}</a>
       </nav>
       <p class="site-footer__meta">MIT · <a href="https://github.com/cocofhu/approving" rel="noopener noreferrer" target="_blank">cocofhu/approving</a></p>
     </div>

--- a/docs/site/css/site.css
+++ b/docs/site/css/site.css
@@ -83,6 +83,37 @@ img {
   color: var(--ink);
 }
 
+.lang-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-left: 0.25rem;
+  font-size: 0.875rem;
+}
+
+.lang-switch__sep {
+  color: var(--muted);
+  opacity: 0.55;
+  user-select: none;
+}
+
+.lang-switch__link {
+  color: var(--muted);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.lang-switch__link:hover {
+  color: var(--ink);
+}
+
+.lang-switch__link.is-current {
+  color: var(--ink);
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
 .site-footer {
   border-top: 1px solid var(--line);
   background: var(--panel);

--- a/docs/site/en/index.html
+++ b/docs/site/en/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="zh-CN" data-home-entry="1" data-base="{{BASE}}">
+<html lang="en" data-home-entry="1" data-base="{{BASE}}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Approving</title>
-  <meta name="description" content="Agent 工作流与人类协同推进，开启多Agent协作新范式 — Approving。">
+  <meta name="description" content="Agent workflows with human collaboration — a new multi-agent paradigm. Approving.">
   <link rel="alternate" hreflang="zh-CN" href="https://www.approving-ai.com/">
   <link rel="alternate" hreflang="en" href="https://www.approving-ai.com/en/">
   <link rel="alternate" hreflang="x-default" href="https://www.approving-ai.com/">
@@ -19,37 +19,37 @@
 <body class="page-home">
   <header class="site-header">
     <div class="site-header__inner">
-      <a class="site-header__brand" href="{{BASE_SLASH}}">Approving</a>
-      <nav class="site-header__nav" aria-label="主导航">
-        <a class="site-header__link" href="{{BASE}}/guide/quick-start/">文档</a>
+      <a class="site-header__brand" href="{{BASE}}/en/">Approving</a>
+      <nav class="site-header__nav" aria-label="Main navigation">
+        <a class="site-header__link" href="{{BASE}}/en/guide/quick-start/">Docs</a>
         <a class="site-header__link" href="https://github.com/cocofhu/approving" rel="noopener noreferrer" target="_blank">GitHub</a>
-        <nav class="lang-switch" aria-label="语言">
-          <a class="lang-switch__link is-current" href="{{BASE_SLASH}}" data-locale-set="zh-CN" aria-current="page">中文</a>
+        <nav class="lang-switch" aria-label="Language">
+          <a class="lang-switch__link" href="{{BASE_SLASH}}" data-locale-set="zh-CN">中文</a>
           <span class="lang-switch__sep" aria-hidden="true">|</span>
-          <a class="lang-switch__link" href="{{BASE}}/en/" data-locale-set="en">English</a>
+          <a class="lang-switch__link is-current" href="{{BASE}}/en/" data-locale-set="en" aria-current="page">English</a>
         </nav>
       </nav>
     </div>
   </header>
 
   <main id="main">
-    <section class="hero" aria-label="Approving 首页">
+    <section class="hero" aria-label="Approving home">
       <div class="hero__atmosphere" aria-hidden="true"></div>
       <div class="hero__shell">
         <div class="hero__content">
           <p class="hero__brand" data-reveal>Approving</p>
           <h1 class="hero__headline" data-reveal>
-            <span>Agent 工作流与人类协同推进，</span>
-            <span>开启多Agent协作新范式。</span>
+            <span>Agent workflows with human collaboration —</span>
+            <span>a new multi-agent paradigm.</span>
           </h1>
-          <p class="hero__support" data-reveal>Approving 把 coding agent 编成可信任的工作流：可视化编排、沙箱执行，关键节点由人 Approve 后再继续。</p>
+          <p class="hero__support" data-reveal>Approving turns coding agents into trusted workflows: visual orchestration, sandboxed execution, and human Approve gates at critical steps.</p>
           <div class="hero__cta" data-reveal>
-            <a class="btn btn--primary" href="https://github.com/cocofhu/approving" rel="noopener noreferrer" target="_blank">项目仓库</a>
-            <a class="btn btn--ghost" href="{{BASE}}/guide/quick-start/">快速开始</a>
-            <span class="hero__cta-note">此项目由该工作流构建</span>
+            <a class="btn btn--primary" href="https://github.com/cocofhu/approving" rel="noopener noreferrer" target="_blank">Repository</a>
+            <a class="btn btn--ghost" href="{{BASE}}/en/guide/quick-start/">Quick start</a>
+            <span class="hero__cta-note">This site was built by this workflow</span>
           </div>
-          <div class="hero__backends" data-reveal aria-label="支持的 Agent 后端">
-            <span class="hero__backends-label">支持</span>
+          <div class="hero__backends" data-reveal aria-label="Supported agent backends">
+            <span class="hero__backends-label">Supports</span>
             <ul class="hero__backends-list">
               <li>Cursor</li>
               <li>Claude Code</li>
@@ -61,37 +61,37 @@
         <aside class="hero__visual" data-reveal aria-hidden="true">
           <div class="hero-flow" data-hero-flow>
             <div class="hero-flow__chrome">
-              <span class="hero-flow__chip" data-hero-title>需求交付 · 编排</span>
+              <span class="hero-flow__chip" data-hero-title>Delivery · Orchestration</span>
               <span class="hero-flow__chip hero-flow__chip--live" data-hero-live>● idle</span>
             </div>
             <div class="hf-board">
               <div class="hf-chain">
                 <div class="hf-node" data-hf="research" data-kind="research">
                   <span class="hf-node__stripe"></span>
-                  <span class="hf-node__icon">研</span>
+                  <span class="hf-node__icon">R</span>
                   <span class="hf-node__body">
-                    <span class="hf-node__name">代码调研</span>
-                    <span class="hf-node__meta">调研</span>
+                    <span class="hf-node__name">Code research</span>
+                    <span class="hf-node__meta">Research</span>
                   </span>
                   <span class="hf-node__badge"></span>
                 </div>
                 <span class="hf-link" data-hf-e="e1"><i></i></span>
                 <div class="hf-node" data-hf="clarify" data-kind="react">
                   <span class="hf-node__stripe"></span>
-                  <span class="hf-node__icon">澄</span>
+                  <span class="hf-node__icon">C</span>
                   <span class="hf-node__body">
-                    <span class="hf-node__name">需求澄清</span>
-                    <span class="hf-node__meta">需求澄清</span>
+                    <span class="hf-node__name">Clarify requirements</span>
+                    <span class="hf-node__meta">Clarify requirements</span>
                   </span>
                   <span class="hf-node__badge"></span>
                 </div>
                 <span class="hf-link" data-hf-e="e2"><i></i></span>
                 <div class="hf-node" data-hf="visual" data-kind="visual">
                   <span class="hf-node__stripe"></span>
-                  <span class="hf-node__icon">视</span>
+                  <span class="hf-node__icon">V</span>
                   <span class="hf-node__body">
-                    <span class="hf-node__name">视觉网页</span>
-                    <span class="hf-node__meta">视觉网页</span>
+                    <span class="hf-node__name">Visual page</span>
+                    <span class="hf-node__meta">Visual page</span>
                   </span>
                   <span class="hf-node__badge"></span>
                 </div>
@@ -99,32 +99,32 @@
                 <div class="hf-node hf-node--gate" data-hf="gate" data-kind="gate">
                   <span class="hf-node__stripe"></span>
                   <div class="hf-node__main">
-                    <span class="hf-node__icon">审</span>
+                    <span class="hf-node__icon">G</span>
                     <span class="hf-node__body">
-                      <span class="hf-node__name">人工确认</span>
-                      <span class="hf-node__meta">人工门禁</span>
+                      <span class="hf-node__name">Human confirm</span>
+                      <span class="hf-node__meta">Human gate</span>
                     </span>
                     <span class="hf-node__badge"></span>
                   </div>
                   <div class="hf-node__actions">
-                    <span class="hf-action" data-hf-action="approve"><em>动作</em>批准</span>
-                    <span class="hf-action" data-hf-action="revise"><em>动作</em>退回修改</span>
+                    <span class="hf-action" data-hf-action="approve"><em>Action</em>Approve</span>
+                    <span class="hf-action" data-hf-action="revise"><em>Action</em>Request changes</span>
                   </div>
                 </div>
                 <span class="hf-link" data-hf-e="e4"><i></i></span>
                 <div class="hf-node" data-hf="plan" data-kind="plan">
                   <span class="hf-node__stripe"></span>
-                  <span class="hf-node__icon">方</span>
+                  <span class="hf-node__icon">P</span>
                   <span class="hf-node__body">
-                    <span class="hf-node__name">制定方案</span>
-                    <span class="hf-node__meta">方案</span>
+                    <span class="hf-node__name">Draft plan</span>
+                    <span class="hf-node__meta">Plan</span>
                   </span>
                   <span class="hf-node__badge"></span>
                 </div>
               </div>
               <div class="hf-loop" data-hf-loop aria-hidden="true">
                 <span class="hf-loop__line"></span>
-                <span class="hf-loop__label">退回修改</span>
+                <span class="hf-loop__label">Request changes</span>
               </div>
             </div>
           </div>
@@ -133,30 +133,30 @@
     </section>
 
     <!-- Big page 1: Approve -->
-    <section class="showcase showcase--alt" id="showcase-approve" data-showcase="approve" aria-label="Approve 演示">
+    <section class="showcase showcase--alt" id="showcase-approve" data-showcase="approve" aria-label="Approve demo">
       <div class="showcase__inner showcase__inner--wide">
         <header class="showcase__intro">
-          <h2 class="showcase__title">人机协作 从未如此简单</h2>
-          <p class="showcase__lead showcase__lead--single">多 Agent 协作最大瓶颈就是审核，我们做了大量的视觉展示审批，审批变得所见即所得。</p>
+          <h2 class="showcase__title">Human–agent collaboration, made simple</h2>
+          <p class="showcase__lead showcase__lead--single">Review is the bottleneck in multi-agent work. Visual, interactive approvals make gates what-you-see-is-what-you-get.</p>
         </header>
         <div class="showcase__stage" data-stage="approve">
           <div class="panel panel--light">
             <div class="panel__chrome panel__chrome--light">
               <span class="panel__dot"></span><span class="panel__dot"></span><span class="panel__dot"></span>
-              <span class="panel__title">Gates · 待审批</span>
+              <span class="panel__title">Gates · Pending</span>
             </div>
             <div class="panel__body panel__body--approve">
               <aside class="approve-rail">
-                <p class="approve-rail__label">待审批</p>
-                <div class="approve-rail__item is-active" data-approve-rail="reject">人工评审 · 登录鉴权</div>
-                <div class="approve-rail__item" data-approve-rail="pass">人工评审 · 会话续期</div>
+                <p class="approve-rail__label">Pending</p>
+                <div class="approve-rail__item is-active" data-approve-rail="reject">Human review · Sign-in</div>
+                <div class="approve-rail__item" data-approve-rail="pass">Human review · Session renew</div>
               </aside>
               <div class="approve-stage">
                 <div class="approve-window" data-approve-window>
                   <header class="approve-window__head">
                     <div>
                       <p class="approve-window__eyebrow">human_gate · waiting_human</p>
-                      <h3 class="approve-window__title" data-approve-title>登录鉴权 · UI DEMO</h3>
+                      <h3 class="approve-window__title" data-approve-title>Sign-in · UI DEMO</h3>
                     </div>
                     <span class="approve-window__pill" data-approve-pill>pending</span>
                   </header>
@@ -168,42 +168,42 @@
                           <span class="preview-chip">ui-demo</span>
                           <span class="preview-chip preview-chip--ok">interactive</span>
                         </div>
-                        <p class="preview-board__desc" data-approve-desc>审阅可交互 Demo — 框选问题区域后可拒绝或批准。</p>
+                        <p class="preview-board__desc" data-approve-desc>Review an interactive demo — annotate issues, then reject or approve.</p>
                         <div class="demo-stage" data-demo-stage>
                           <div class="demo-ui" data-demo-case="reject">
                             <div class="demo-ui__brand">Approving</div>
-                            <h4 class="demo-ui__title">欢迎回来</h4>
-                            <p class="demo-ui__hint">使用企业账号继续</p>
+                            <h4 class="demo-ui__title">Welcome back</h4>
+                            <p class="demo-ui__hint">Continue with your work account</p>
                             <div class="demo-ui__field"><span></span></div>
                             <div class="demo-ui__field"><span></span></div>
                             <div class="demo-ui__actions">
-                              <span class="demo-ui__btn">取消</span>
-                              <span class="demo-ui__btn is-bad" data-annotate-target>删除账号</span>
+                              <span class="demo-ui__btn">Cancel</span>
+                              <span class="demo-ui__btn is-bad" data-annotate-target>Delete account</span>
                             </div>
                             <div class="demo-marquee" data-marquee aria-hidden="true"></div>
                           </div>
                           <div class="demo-ui is-pass" data-demo-case="pass" hidden>
                             <div class="demo-ui__brand">Approving</div>
-                            <h4 class="demo-ui__title">会话续期</h4>
-                            <p class="demo-ui__hint">保持登录，安全确认</p>
+                            <h4 class="demo-ui__title">Renew session</h4>
+                            <p class="demo-ui__hint">Stay signed in — confirm securely</p>
                             <div class="demo-ui__card">
                               <div class="demo-ui__avatar"></div>
                               <div class="demo-ui__meta"><i></i><i></i></div>
                             </div>
                             <div class="demo-ui__actions">
-                              <span class="demo-ui__btn">稍后</span>
-                              <span class="demo-ui__btn is-primary">确认续期</span>
+                              <span class="demo-ui__btn">Later</span>
+                              <span class="demo-ui__btn is-primary">Confirm renew</span>
                             </div>
                           </div>
                         </div>
                       </div>
                     </div>
                     <aside class="approve-window__aside">
-                      <p class="approve-aside__label">审批意见</p>
+                      <p class="approve-aside__label">Review comment</p>
                       <div class="approve-aside__comment" data-approve-comment></div>
                       <div class="approve-aside__actions">
-                        <button type="button" class="approve-btn approve-btn--reject" data-reject-btn tabindex="-1">拒绝</button>
-                        <button type="button" class="approve-btn" data-approve-btn tabindex="-1">批准</button>
+                        <button type="button" class="approve-btn approve-btn--reject" data-reject-btn tabindex="-1">Reject</button>
+                        <button type="button" class="approve-btn" data-approve-btn tabindex="-1">Approve</button>
                       </div>
                     </aside>
                   </div>
@@ -211,18 +211,18 @@
                 <div class="demo-cursor" data-cursor="approve"></div>
               </div>
             </div>
-            <p class="panel__caption panel__caption--light" data-caption="approve">打开审批窗口…</p>
+            <p class="panel__caption panel__caption--light" data-caption="approve">Open the approval window…</p>
           </div>
         </div>
       </div>
     </section>
 
     <!-- Big page 2: PM — IM manage workflows via ApprovingPM -->
-    <section class="showcase" id="showcase-pm" data-showcase="pm" aria-label="PM 演示">
+    <section class="showcase" id="showcase-pm" data-showcase="pm" aria-label="PM demo">
       <div class="showcase__inner showcase__inner--wide">
         <header class="showcase__intro">
-          <h2 class="showcase__title">项目管理正在被重新定义</h2>
-          <p class="showcase__lead">我们为每一个项目定义了一位 PM，你可以接入自己常用的 IM，在手机上管理你的项目、下发任务。<br>未来，我们将支持总监、总经理等更复杂的组织架构——OPC 这一次是真的。</p>
+          <h2 class="showcase__title">Project management, redefined</h2>
+          <p class="showcase__lead">Every project gets a PM. Connect your usual IM and manage work from your phone.<br>Next: richer org roles — director, GM, and beyond. OPC, for real.</p>
         </header>
         <div class="showcase__stage" data-stage="pm">
           <div class="panel panel--light">
@@ -237,7 +237,7 @@
                     <span class="pm-im__avatar">PM</span>
                     <div>
                       <p class="pm-im__channel">ApprovingPM</p>
-                      <p class="pm-im__sub">工作流项目经理 · 对话即编排</p>
+                      <p class="pm-im__sub">Workflow PM · chat is orchestration</p>
                     </div>
                   </div>
                   <div class="pm-im__stats">
@@ -247,51 +247,51 @@
                 </header>
                 <div class="pm-im__thread" data-pm-thread>
                   <div class="pm-msg pm-msg--you" data-pm-msg="1">
-                    <span class="pm-msg__who">你</span>
-                    <div class="pm-msg__bubble" data-pm-text="有什么办法可以保证质量？调研一下业界的 harness 和软件工程经验，看看怎么保证这个开源项目的质量。"><span data-pm-typeout></span></div>
+                    <span class="pm-msg__who">You</span>
+                    <div class="pm-msg__bubble" data-pm-text="How do we guarantee quality? Research industry harness practices and software engineering experience for this open-source project."><span data-pm-typeout></span></div>
                   </div>
                   <div class="pm-msg" data-pm-msg="2">
                     <span class="pm-msg__who">ApprovingPM</span>
-                    <div class="pm-msg__bubble" data-pm-text="收到。我先调研 agent harness 实践，再对照经典软件工程质量门禁，整理成可落地的方案给你确认。"><span data-pm-typeout></span></div>
+                    <div class="pm-msg__bubble" data-pm-text="Got it. I will research agent harness practices, map them to classic software quality gates, and propose a concrete plan for your confirmation."><span data-pm-typeout></span></div>
                   </div>
                   <div class="pm-msg" data-pm-msg="3">
                     <span class="pm-msg__who">ApprovingPM</span>
-                    <div class="pm-msg__bubble" data-pm-text="调研结论 → 建议方案：">
+                    <div class="pm-msg__bubble" data-pm-text="Research takeaways → proposed plan:">
                       <span data-pm-typeout></span>
                       <ul class="pm-progress" data-pm-extra hidden>
-                        <li data-pm-step="1"><span class="pm-dot"></span>Harness：评测集 + 回归门槛 <b data-pm-step-tag="1">proposed</b></li>
-                        <li data-pm-step="2"><span class="pm-dot"></span>工程：覆盖率 / lint / 安全扫描入 CI <b data-pm-step-tag="2">proposed</b></li>
-                        <li data-pm-step="3"><span class="pm-dot"></span>门禁：关键路径人工 Approve <b data-pm-step-tag="3">proposed</b></li>
+                        <li data-pm-step="1"><span class="pm-dot"></span>Harness: eval suite + regression bar <b data-pm-step-tag="1">proposed</b></li>
+                        <li data-pm-step="2"><span class="pm-dot"></span>Engineering: coverage / lint / security in CI <b data-pm-step-tag="2">proposed</b></li>
+                        <li data-pm-step="3"><span class="pm-dot"></span>Gates: human Approve on critical paths <b data-pm-step-tag="3">proposed</b></li>
                       </ul>
                     </div>
                   </div>
                   <div class="pm-msg is-gate" data-pm-msg="4">
                     <span class="pm-msg__who">ApprovingPM</span>
-                    <div class="pm-msg__bubble" data-pm-text="方案已就绪。确认后我启动「质量保障」工作流：调研落地 → CI 加固 → 门禁接线。"><span data-pm-typeout></span></div>
+                    <div class="pm-msg__bubble" data-pm-text="Plan ready. On confirm I will start the Quality Assurance workflow: land research → harden CI → wire gates."><span data-pm-typeout></span></div>
                   </div>
                   <div class="pm-msg pm-msg--you" data-pm-msg="5">
-                    <span class="pm-msg__who">你</span>
-                    <div class="pm-msg__bubble" data-pm-text="确认，按这个方案启动工作流。"><span data-pm-typeout></span></div>
+                    <span class="pm-msg__who">You</span>
+                    <div class="pm-msg__bubble" data-pm-text="Confirmed — start the workflow with this plan."><span data-pm-typeout></span></div>
                   </div>
                   <div class="pm-msg" data-pm-msg="6">
                     <span class="pm-msg__who">ApprovingPM</span>
-                    <div class="pm-msg__bubble" data-pm-text="已启动。预计今晚 22:30 前给出第一轮 PR，我会持续跟进执行进度。">
+                    <div class="pm-msg__bubble" data-pm-text="Started. Expect the first PR wave before 22:30 tonight; I will keep tracking progress.">
                       <span data-pm-typeout></span>
                       <ul class="pm-progress" data-pm-extra hidden>
-                        <li data-pm-step="4"><span class="pm-dot"></span>Harness 评测脚手架 <b data-pm-step-tag="4">queued</b></li>
-                        <li data-pm-step="5"><span class="pm-dot"></span>CI 质量门禁 <b data-pm-step-tag="5">queued</b></li>
-                        <li data-pm-step="6"><span class="pm-dot"></span>人工 Approve 接线 <b data-pm-step-tag="6">queued</b></li>
+                        <li data-pm-step="4"><span class="pm-dot"></span>Harness eval scaffolding <b data-pm-step-tag="4">queued</b></li>
+                        <li data-pm-step="5"><span class="pm-dot"></span>CI quality gates <b data-pm-step-tag="5">queued</b></li>
+                        <li data-pm-step="6"><span class="pm-dot"></span>Wire human Approve <b data-pm-step-tag="6">queued</b></li>
                       </ul>
                     </div>
                   </div>
                   <div class="pm-msg" data-pm-msg="7">
                     <span class="pm-msg__who">ApprovingPM</span>
-                    <div class="pm-msg__bubble" data-pm-text="执行中：Harness 脚手架已开 PR；CI 扫描跑到 60%；Approve 门禁待合入。有阻塞我再找你。"><span data-pm-typeout></span></div>
+                    <div class="pm-msg__bubble" data-pm-text="In progress: harness scaffold PR opened; CI scans at 60%; Approve gate pending merge. I will ping you on blockers."><span data-pm-typeout></span></div>
                   </div>
                 </div>
                 <div class="pm-im__composer">
-                  <span class="pm-im__input" data-pm-composer data-placeholder="跟 ApprovingPM 说下一句…"></span>
-                  <span class="pm-im__send" aria-hidden="true">发送</span>
+                  <span class="pm-im__input" data-pm-composer data-placeholder="Say the next thing to ApprovingPM…"></span>
+                  <span class="pm-im__send" aria-hidden="true">Send</span>
                 </div>
               </div>
             </div>
@@ -301,11 +301,11 @@
     </section>
 
     <!-- Big page 3: Parallel (stacked) -->
-    <section class="showcase" id="showcase-parallel" data-showcase="parallel" aria-label="并行演示">
+    <section class="showcase" id="showcase-parallel" data-showcase="parallel" aria-label="Parallel demo">
       <div class="showcase__inner showcase__inner--wide">
         <header class="showcase__intro">
-          <h2 class="showcase__title">并行调度，加速迭代</h2>
-          <p class="showcase__lead">所有 Agent 在沙箱执行，由 PM 统一管理，迭代速度更进一步。</p>
+          <h2 class="showcase__title">Parallel scheduling, faster iteration</h2>
+          <p class="showcase__lead">Agents run in sandboxes, coordinated by the PM — iteration gets another gear.</p>
         </header>
         <div class="showcase__stage" data-stage="parallel">
           <div class="panel">
@@ -327,22 +327,22 @@
                     <span class="launch-im__avatar">PM</span>
                     <div>
                       <p class="launch-im__title">ApprovingPM</p>
-                      <p class="launch-im__sub">IM · 对话启动工作流</p>
+                      <p class="launch-im__sub">IM · start workflows by chat</p>
                     </div>
                   </header>
                   <div class="launch-im__thread" data-par-thread>
                     <div class="pm-msg pm-msg--you" data-par-msg="1">
-                      <span class="pm-msg__who">你</span>
-                      <div class="pm-msg__bubble" data-par-text="并行推进登录鉴权、计费结算、消息通知这三个需求，现在启动。"><span data-par-typeout></span></div>
+                      <span class="pm-msg__who">You</span>
+                      <div class="pm-msg__bubble" data-par-text="Run sign-in, billing, and notifications in parallel — start now."><span data-par-typeout></span></div>
                     </div>
                     <div class="pm-msg" data-par-msg="2">
                       <span class="pm-msg__who">ApprovingPM</span>
-                      <div class="pm-msg__bubble" data-par-text="收到。已按三条需求拉起并行工作流，开始执行。"><span data-par-typeout></span></div>
+                      <div class="pm-msg__bubble" data-par-text="Got it. Parallel workflows for the three requirements are up and running."><span data-par-typeout></span></div>
                     </div>
                   </div>
                   <div class="launch-im__composer">
-                    <span class="pm-im__input" data-par-composer data-placeholder="跟 ApprovingPM 说下一句…"></span>
-                    <span class="pm-im__send" aria-hidden="true">发送</span>
+                    <span class="pm-im__input" data-par-composer data-placeholder="Say the next thing to ApprovingPM…"></span>
+                    <span class="pm-im__send" aria-hidden="true">Send</span>
                   </div>
                 </div>
               </div>
@@ -353,7 +353,7 @@
                     <div class="demo-lane__head">
                       <div>
                         <span class="demo-lane__id">REQ-12</span>
-                        <span class="demo-lane__label">登录鉴权</span>
+                        <span class="demo-lane__label">Sign-in</span>
                       </div>
                       <span class="demo-lane__pill" data-lane-pill="auth">queued</span>
                     </div>
@@ -363,7 +363,7 @@
                         <span class="vf-node__icon">R</span>
                         <span class="vf-node__text">
                           <span class="vf-node__name">research</span>
-                          <span class="vf-node__type">Agent · OAuth 方案</span>
+                          <span class="vf-node__type">Agent · OAuth plan</span>
                         </span>
                         <span class="vf-node__badge"></span>
                         <span class="vf-node__meta">artifact · brief</span>
@@ -411,7 +411,7 @@
                     <div class="demo-lane__head">
                       <div>
                         <span class="demo-lane__id">REQ-18</span>
-                        <span class="demo-lane__label">计费结算</span>
+                        <span class="demo-lane__label">Billing</span>
                       </div>
                       <span class="demo-lane__pill" data-lane-pill="billing">queued</span>
                     </div>
@@ -421,7 +421,7 @@
                         <span class="vf-node__icon">P</span>
                         <span class="vf-node__text">
                           <span class="vf-node__name">plan</span>
-                          <span class="vf-node__type">Agent · 计费模型</span>
+                          <span class="vf-node__type">Agent · billing model</span>
                         </span>
                         <span class="vf-node__badge"></span>
                         <span class="vf-node__meta">artifact · plan</span>
@@ -445,7 +445,7 @@
                         <span class="vf-node__icon">G</span>
                         <span class="vf-node__text">
                           <span class="vf-node__name">human gate</span>
-                          <span class="vf-node__type">Gate · 方案对照</span>
+                          <span class="vf-node__type">Gate · plan check</span>
                         </span>
                         <span class="vf-node__badge"></span>
                         <span class="vf-node__meta">waiting human</span>
@@ -468,7 +468,7 @@
                     <div class="demo-lane__head">
                       <div>
                         <span class="demo-lane__id">REQ-21</span>
-                        <span class="demo-lane__label">消息通知</span>
+                        <span class="demo-lane__label">Notifications</span>
                       </div>
                       <span class="demo-lane__pill" data-lane-pill="notify">queued</span>
                     </div>
@@ -478,7 +478,7 @@
                         <span class="vf-node__icon">R</span>
                         <span class="vf-node__text">
                           <span class="vf-node__name">research</span>
-                          <span class="vf-node__type">Agent · 通道选型</span>
+                          <span class="vf-node__type">Agent · channel pick</span>
                         </span>
                         <span class="vf-node__badge"></span>
                         <span class="vf-node__meta">artifact · brief</span>
@@ -523,7 +523,7 @@
                   </div>
                 </div>
 
-                <aside class="side-peek" aria-label="执行环境与门禁">
+                <aside class="side-peek" aria-label="Runtimes and gates">
                   <div class="sb-peek">
                     <p class="sb-peek__title">Runtime</p>
                                         <div class="sb-card" data-sb="auth">
@@ -532,7 +532,7 @@
                         <i>ctr-auth</i>
                       </div>
                       <div class="sb-card__top">
-                        <strong>登录鉴权</strong>
+                        <strong>Sign-in</strong>
                         <span class="sb-card__status" data-sb-status>idle</span>
                       </div>
                       <div class="sb-term" data-sb-term aria-hidden="true">
@@ -540,7 +540,7 @@
                         <span data-sb-line></span>
                         <span data-sb-line></span>
                       </div>
-                      <span class="sb-card__meta" data-sb-meta>待机</span>
+                      <span class="sb-card__meta" data-sb-meta>Idle</span>
                     </div>
                     <div class="sb-card" data-sb="billing">
                       <div class="sb-card__chrome" aria-hidden="true">
@@ -548,7 +548,7 @@
                         <i>ctr-billing</i>
                       </div>
                       <div class="sb-card__top">
-                        <strong>计费结算</strong>
+                        <strong>Billing</strong>
                         <span class="sb-card__status" data-sb-status>idle</span>
                       </div>
                       <div class="sb-term" data-sb-term aria-hidden="true">
@@ -556,7 +556,7 @@
                         <span data-sb-line></span>
                         <span data-sb-line></span>
                       </div>
-                      <span class="sb-card__meta" data-sb-meta>待机</span>
+                      <span class="sb-card__meta" data-sb-meta>Idle</span>
                     </div>
                     <div class="sb-card" data-sb="notify">
                       <div class="sb-card__chrome" aria-hidden="true">
@@ -564,7 +564,7 @@
                         <i>ctr-notify</i>
                       </div>
                       <div class="sb-card__top">
-                        <strong>消息通知</strong>
+                        <strong>Notifications</strong>
                         <span class="sb-card__status" data-sb-status>idle</span>
                       </div>
                       <div class="sb-term" data-sb-term aria-hidden="true">
@@ -572,15 +572,15 @@
                         <span data-sb-line></span>
                         <span data-sb-line></span>
                       </div>
-                      <span class="sb-card__meta" data-sb-meta>待机</span>
+                      <span class="sb-card__meta" data-sb-meta>Idle</span>
                     </div>
                   </div>
                   <div class="gates-peek" data-gates-peek>
                     <p class="gates-peek__title">Gates Inbox</p>
-                    <p class="gates-peek__empty" data-gates-empty>暂无待审批</p>
+                    <p class="gates-peek__empty" data-gates-empty>No pending approvals</p>
                     <div class="gates-peek__item" data-gates-item>
                       <span class="gates-peek__kind">human_gate</span>
-                      <strong>计费结算 · 方案对照</strong>
+                      <strong>Billing · plan check</strong>
                       <span class="gates-peek__meta">REQ-18 · waiting_human</span>
                     </div>
                     <div class="gates-peek__foot">
@@ -591,7 +591,7 @@
                 </aside>
               </div>
             </div>
-            <p class="panel__caption" data-caption="parallel">IM 确认启动，并行推进中…</p>
+            <p class="panel__caption" data-caption="parallel">IM confirmed — running in parallel…</p>
           </div>
         </div>
       </div>
@@ -599,31 +599,31 @@
 
     <section class="section capabilities" id="capabilities">
       <div class="section__inner">
-        <h2 class="section__title">能力</h2>
+        <h2 class="section__title">Capabilities</h2>
         <ul class="capabilities__list">
           <li class="capabilities__item">
-            <strong class="capabilities__name">可视化编排</strong>
-            <span class="capabilities__body">画布 FSM、运行态高亮；多需求并行泳道，门禁 Inbox 收口审批。</span>
+            <strong class="capabilities__name">Visual orchestration</strong>
+            <span class="capabilities__body">Canvas FSM with live states; parallel requirement lanes and a Gates Inbox.</span>
           </li>
           <li class="capabilities__item">
-            <strong class="capabilities__name">真实 Docker 沙箱</strong>
-            <span class="capabilities__body">经 ACP 与 sandbox-gateway 在容器中执行，Web UI 走 API。</span>
+            <strong class="capabilities__name">Real Docker sandboxes</strong>
+            <span class="capabilities__body">Execute in containers via ACP and sandbox-gateway; the Web UI uses the API.</span>
           </li>
           <li class="capabilities__item">
-            <strong class="capabilities__name">多 Agent 后端</strong>
-            <span class="capabilities__body">Cursor、Claude Code、CodeBuddy、Trae；按 Agent 选择 acpBackend。</span>
+            <strong class="capabilities__name">Multi-agent backends</strong>
+            <span class="capabilities__body">Cursor, Claude Code, CodeBuddy, Trae — pick acpBackend per agent.</span>
           </li>
           <li class="capabilities__item">
-            <strong class="capabilities__name">产物契约 + MCP</strong>
-            <span class="capabilities__body">write_artifact / set_* / node_complete；按 run token 隔离。</span>
+            <strong class="capabilities__name">Artifact contract + MCP</strong>
+            <span class="capabilities__body">write_artifact / set_* / node_complete — isolated by run token.</span>
           </li>
           <li class="capabilities__item">
-            <strong class="capabilities__name">沙箱内 Git 凭证</strong>
-            <span class="capabilities__body">GITHUB_* / GITLAB_* / SSH；GitLab auto-MR 与 GitHub gh 可用。</span>
+            <strong class="capabilities__name">Git credentials in sandbox</strong>
+            <span class="capabilities__body">GITHUB_* / GITLAB_* / SSH; GitLab auto-MR and GitHub gh supported.</span>
           </li>
           <li class="capabilities__item">
-            <strong class="capabilities__name">单仓自托管</strong>
-            <span class="capabilities__body">sandbox-gateway 与沙箱镜像源码在本仓库，一次克隆即可。</span>
+            <strong class="capabilities__name">Single-repo self-host</strong>
+            <span class="capabilities__body">sandbox-gateway and sandbox image sources live in this repo — one clone to self-host.</span>
           </li>
         </ul>
       </div>
@@ -633,11 +633,11 @@
   <footer class="site-footer">
     <div class="site-footer__inner">
       <p class="site-footer__brand">Approving</p>
-      <nav class="site-footer__nav" aria-label="页脚">
-        <a href="{{BASE}}/guide/quick-start/">快速开始</a>
-        <a href="{{BASE}}/help/configuration/">配置</a>
-        <a href="{{BASE}}/help/gateway/">网关</a>
-        <a href="https://github.com/cocofhu/approving" rel="noopener noreferrer" target="_blank">源码</a>
+      <nav class="site-footer__nav" aria-label="Footer">
+        <a href="{{BASE}}/en/guide/quick-start/">Quick start</a>
+        <a href="{{BASE}}/en/help/configuration/">Configuration</a>
+        <a href="{{BASE}}/en/help/gateway/">Gateway</a>
+        <a href="https://github.com/cocofhu/approving" rel="noopener noreferrer" target="_blank">Source</a>
       </nav>
       <p class="site-footer__meta">MIT · <a href="https://github.com/cocofhu/approving" rel="noopener noreferrer" target="_blank">cocofhu/approving</a></p>
     </div>

--- a/docs/site/js/home.js
+++ b/docs/site/js/home.js
@@ -1,6 +1,83 @@
 (() => {
   const hero = document.querySelector(".hero");
   const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  const pageLang = (document.documentElement.lang || "zh-CN").toLowerCase();
+  const isEn = pageLang === "en" || pageLang.startsWith("en-");
+
+  const COPY = isEn
+    ? {
+        heroTitles: ["Self-improve · Orchestration", "Delivery · Orchestration", "Visual review · Orchestration"],
+        heroTitleIdle: "Delivery · Orchestration",
+        parAsk: "Run sign-in, billing, and notifications in parallel — start now.",
+        parReply: "Got it. Parallel workflows for the three requirements are up and running.",
+        pmPlaceholder: "Say the next thing to ApprovingPM…",
+        idleMeta: "Idle",
+        bootingMeta: "Booting",
+        readyMeta: "Ready",
+        busyMeta: "Running",
+        waitingGateMeta: "Waiting on gate",
+        doneMeta: "Done",
+        capParStart: "IM confirmed — running in parallel…",
+        capParBoot: "Confirmed — spinning up parallel runtimes",
+        capParRun: "Three requirements running in parallel — research / plan",
+        capParImpl: "Implement writing code in parallel — no interference",
+        capParTest: "Tests keep running; billing waits at a gate — parallel, not blocked",
+        capParShip: "Two MRs submitted; billing still awaiting approval",
+        capParGate: "Gate cleared — billing submits its MR",
+        capParDone: "IM start → parallel run → closed out",
+        approveTitleReject: "Sign-in · UI DEMO",
+        approveDescReject: "Review an interactive demo — annotate issues, then reject or approve.",
+        approveTitlePass: "Session renew · UI DEMO",
+        approveDescPass: "Issues fixed. Review the demo again — approve if it looks good.",
+        capApproveOpen: "Open the approval window — reviewing a UI demo",
+        capApproveAnnotate: "Annotate the issue: primary button label is wrong",
+        approveRejectComment:
+          'Reject: primary button should not be "Delete account" — change it back to "Sign in / Continue".',
+        capApproveReject: "Reject case — send back with annotation feedback",
+        capApproveNext: "Next item: session renew demo — approve if clean",
+        approvePassComment: "LGTM — demo flow and copy match. Approved.",
+        capApproveJust: "Just Approve",
+        capApproveDone: "Annotate reject / demo approve — both paths covered",
+        pmAsk:
+          "How do we guarantee quality? Research industry harness practices and software engineering experience for this open-source project.",
+        pmConfirm: "Confirmed — start the workflow with this plan.",
+      }
+    : {
+        heroTitles: ["自我迭代 · 编排", "需求交付 · 编排", "视觉评审 · 编排"],
+        heroTitleIdle: "需求交付 · 编排",
+        parAsk: "并行推进登录鉴权、计费结算、消息通知这三个需求，现在启动。",
+        parReply: "收到。已按三条需求拉起并行工作流，开始执行。",
+        pmPlaceholder: "跟 ApprovingPM 说下一句…",
+        idleMeta: "待机",
+        bootingMeta: "拉起中",
+        readyMeta: "就绪",
+        busyMeta: "执行中",
+        waitingGateMeta: "等待门禁",
+        doneMeta: "完成",
+        capParStart: "IM 确认启动，并行推进中…",
+        capParBoot: "已确认启动 — 拉起并行执行环境",
+        capParRun: "三条需求并行开跑 — research / plan",
+        capParImpl: "Implement 并行写代码 — 互不干扰",
+        capParTest: "测试继续跑；计费停在门禁 — 并行不互相堵",
+        capParShip: "两条已提交 MR；计费仍等批准",
+        capParGate: "门禁通过 — 计费补交 MR",
+        capParDone: "IM 启动 → 并行执行 → 收口完成",
+        approveTitleReject: "登录鉴权 · UI DEMO",
+        approveDescReject: "审阅可交互 Demo — 框选问题区域后可拒绝或批准。",
+        approveTitlePass: "会话续期 · UI DEMO",
+        approveDescPass: "问题已修。再看一遍 Demo，没问题即可批准。",
+        capApproveOpen: "打开审批窗口 — 审的是 UI Demo",
+        capApproveAnnotate: "框选问题区域：主按钮文案不对",
+        approveRejectComment: "拒绝：主按钮不应是「删除账号」，请改回「登录 / 继续」。",
+        capApproveReject: "拒绝 Case — 带着框选反馈打回",
+        capApproveNext: "下一单：会话续期 Demo — 无问题可批准",
+        approvePassComment: "LGTM — Demo 流程与文案一致，批准。",
+        capApproveJust: "Just Approve",
+        capApproveDone: "框选拒绝 / Demo 批准 — 两种路径都走通",
+        pmAsk:
+          "有什么办法可以保证质量？调研一下业界的 harness 和软件工程经验，看看怎么保证这个开源项目的质量。",
+        pmConfirm: "确认，按这个方案启动工作流。",
+      };
 
   if (hero) {
     requestAnimationFrame(() => {
@@ -11,7 +88,7 @@
   const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
   const lanes = ["auth", "billing", "notify"];
 
-  const heroTitles = ["自我迭代 · 编排", "需求交付 · 编排", "视觉评审 · 编排"];
+  const heroTitles = COPY.heroTitles;
   const pick = (arr) => arr[Math.floor(Math.random() * arr.length)];
   const jitter = (base, spread = 0.35) => Math.round(base * (1 - spread + Math.random() * spread * 2));
 
@@ -157,7 +234,7 @@
   } else if (heroFlow && reduceMotion) {
     const titleEl = within(heroFlow, "[data-hero-title]");
     const liveEl = within(heroFlow, "[data-hero-live]");
-    if (titleEl) titleEl.textContent = "需求交付 · 编排";
+    if (titleEl) titleEl.textContent = COPY.heroTitleIdle;
     if (liveEl) liveEl.textContent = "● done";
     ["research", "clarify", "visual", "gate", "plan"].forEach((id) => {
       within(heroFlow, `[data-hf="${id}"]`)?.classList.add("is-done");
@@ -264,8 +341,8 @@
     notify: ["notify-research", "notify-impl", "notify-test", "notify-ship"],
   };
 
-  const PAR_ASK = "并行推进登录鉴权、计费结算、消息通知这三个需求，现在启动。";
-  const PAR_REPLY = "收到。已按三条需求拉起并行工作流，开始执行。";
+  const PAR_ASK = COPY.parAsk;
+  const PAR_REPLY = COPY.parReply;
   const TERM_LINES = {
     auth: ["$ boot runtime", "$ mount workspace", "$ agent research …"],
     billing: ["$ boot runtime", "$ mount workspace", "$ agent plan …"],
@@ -305,7 +382,7 @@
 
   function resetSandboxes(root) {
     for (const id of lanes) {
-      setSandbox(root, id, "", "idle", "待机", ["", "", ""]);
+      setSandbox(root, id, "", "idle", COPY.idleMeta, ["", "", ""]);
     }
     setSbChip(root, 0);
   }
@@ -326,7 +403,7 @@
     if (!composer) return;
     composer.classList.remove("is-typing");
     composer.textContent = "";
-    composer.setAttribute("data-placeholder", "跟 ApprovingPM 说下一句…");
+    composer.setAttribute("data-placeholder", COPY.pmPlaceholder);
   }
 
   async function typeParComposer(root, text, signal) {
@@ -376,7 +453,7 @@
 
     while (!signal.aborted) {
       resetParallel(root);
-      if (caption) caption.textContent = "IM 确认启动，并行推进中…";
+      if (caption) caption.textContent = COPY.capParStart;
       await sleep(300);
       if (signal.aborted) break;
 
@@ -390,12 +467,12 @@
 
       await typeParMsg(root, 2, signal);
       setLiveChip(root, "● starting");
-      if (caption) caption.textContent = "已确认启动 — 拉起并行执行环境";
+      if (caption) caption.textContent = COPY.capParBoot;
       await sleep(500);
       if (signal.aborted) break;
 
       for (const id of lanes) {
-        setSandbox(root, id, "creating", "booting", "拉起中", [
+        setSandbox(root, id, "creating", "booting", COPY.bootingMeta, [
           "$ init runtime",
           "$ allocate cpu/mem",
           "…",
@@ -408,9 +485,9 @@
       sheet?.classList.remove("is-open");
       setLiveChip(root, "● live run");
       for (const id of lanes) {
-        setSandbox(root, id, "running", "ready", "就绪", TERM_LINES[id]);
+        setSandbox(root, id, "running", "ready", COPY.readyMeta, TERM_LINES[id]);
       }
-      if (caption) caption.textContent = "三条需求并行开跑 — research / plan";
+      if (caption) caption.textContent = COPY.capParRun;
       await sleep(400);
       if (signal.aborted) break;
 
@@ -423,9 +500,9 @@
       setLanePill(root, "auth", "running", "running");
       setLanePill(root, "billing", "running", "running");
       setLanePill(root, "notify", "running", "running");
-      setSandbox(root, "auth", "busy", "busy", "执行中", ["$ agent research", "writing brief…", "ok"]);
-      setSandbox(root, "billing", "busy", "busy", "执行中", ["$ agent plan", "draft model…", "ok"]);
-      setSandbox(root, "notify", "busy", "busy", "执行中", ["$ agent research", "channel pick…", "ok"]);
+      setSandbox(root, "auth", "busy", "busy", COPY.busyMeta, ["$ agent research", "writing brief…", "ok"]);
+      setSandbox(root, "billing", "busy", "busy", COPY.busyMeta, ["$ agent plan", "draft model…", "ok"]);
+      setSandbox(root, "notify", "busy", "busy", COPY.busyMeta, ["$ agent research", "channel pick…", "ok"]);
       await sleep(900);
       if (signal.aborted) break;
 
@@ -441,10 +518,10 @@
       setEdge(root, "auth-2", "active");
       setEdge(root, "billing-2", "active");
       setEdge(root, "notify-2", "active");
-      setSandbox(root, "auth", "busy", "busy", "执行中", ["$ implement", "edit middleware…", "tests…"]);
-      setSandbox(root, "billing", "busy", "busy", "执行中", ["$ implement", "edit ledger…", "tests…"]);
-      setSandbox(root, "notify", "busy", "busy", "执行中", ["$ implement", "edit webhook…", "tests…"]);
-      if (caption) caption.textContent = "Implement 并行写代码 — 互不干扰";
+      setSandbox(root, "auth", "busy", "busy", COPY.busyMeta, ["$ implement", "edit middleware…", "tests…"]);
+      setSandbox(root, "billing", "busy", "busy", COPY.busyMeta, ["$ implement", "edit ledger…", "tests…"]);
+      setSandbox(root, "notify", "busy", "busy", COPY.busyMeta, ["$ implement", "edit webhook…", "tests…"]);
+      if (caption) caption.textContent = COPY.capParImpl;
       await sleep(1000);
       if (signal.aborted) break;
 
@@ -463,10 +540,10 @@
       setEdge(root, "billing-3", "wait");
       setLanePill(root, "billing", "waiting", "waiting human");
       setGates(root, 1);
-      setSandbox(root, "auth", "busy", "busy", "执行中", ["$ e2e", "playwright…", "green"]);
-      setSandbox(root, "billing", "running", "paused", "等待门禁", ["$ gate", "waiting human…", ""]);
-      setSandbox(root, "notify", "busy", "busy", "执行中", ["$ contract test", "retries…", "ok"]);
-      if (caption) caption.textContent = "测试继续跑；计费停在门禁 — 并行不互相堵";
+      setSandbox(root, "auth", "busy", "busy", COPY.busyMeta, ["$ e2e", "playwright…", "green"]);
+      setSandbox(root, "billing", "running", "paused", COPY.waitingGateMeta, ["$ gate", "waiting human…", ""]);
+      setSandbox(root, "notify", "busy", "busy", COPY.busyMeta, ["$ contract test", "retries…", "ok"]);
+      if (caption) caption.textContent = COPY.capParTest;
       await sleep(1100);
       if (signal.aborted) break;
 
@@ -477,9 +554,9 @@
       setNode(root, "auth-ship", "running");
       setNode(root, "notify-ship", "running");
       setShipStat(root, 2);
-      setSandbox(root, "auth", "busy", "busy", "执行中", ["$ submit MR", "!482", "done"]);
-      setSandbox(root, "notify", "busy", "busy", "执行中", ["$ submit MR", "!491", "done"]);
-      if (caption) caption.textContent = "两条已提交 MR；计费仍等批准";
+      setSandbox(root, "auth", "busy", "busy", COPY.busyMeta, ["$ submit MR", "!482", "done"]);
+      setSandbox(root, "notify", "busy", "busy", COPY.busyMeta, ["$ submit MR", "!491", "done"]);
+      if (caption) caption.textContent = COPY.capParShip;
       await sleep(900);
       if (signal.aborted) break;
 
@@ -487,23 +564,23 @@
       setNode(root, "notify-ship", "done");
       setLanePill(root, "auth", "done", "shipped");
       setLanePill(root, "notify", "done", "shipped");
-      setSandbox(root, "auth", "done", "done", "完成", ["$ idle", "", ""]);
-      setSandbox(root, "notify", "done", "done", "完成", ["$ idle", "", ""]);
+      setSandbox(root, "auth", "done", "done", COPY.doneMeta, ["$ idle", "", ""]);
+      setSandbox(root, "notify", "done", "done", COPY.doneMeta, ["$ idle", "", ""]);
       setNode(root, "billing-gate", "done");
       setEdge(root, "billing-3", "done");
       setGates(root, 0);
       setNode(root, "billing-ship", "running");
       setLanePill(root, "billing", "running", "shipping");
-      setSandbox(root, "billing", "busy", "busy", "执行中", ["$ submit MR", "push…", "done"]);
+      setSandbox(root, "billing", "busy", "busy", COPY.busyMeta, ["$ submit MR", "push…", "done"]);
       setShipStat(root, 3);
-      if (caption) caption.textContent = "门禁通过 — 计费补交 MR";
+      if (caption) caption.textContent = COPY.capParGate;
       await sleep(700);
       if (signal.aborted) break;
 
       setNode(root, "billing-ship", "done");
       setLanePill(root, "billing", "done", "shipped");
-      setSandbox(root, "billing", "done", "done", "完成", ["$ idle", "", ""]);
-      if (caption) caption.textContent = "IM 启动 → 并行执行 → 收口完成";
+      setSandbox(root, "billing", "done", "done", COPY.doneMeta, ["$ idle", "", ""]);
+      if (caption) caption.textContent = COPY.capParDone;
       await sleep(1500);
     }
   }
@@ -537,8 +614,8 @@
     if (which === "reject") {
       if (rejectUi) rejectUi.hidden = false;
       if (passUi) passUi.hidden = true;
-      if (title) title.textContent = "登录鉴权 · UI DEMO";
-      if (desc) desc.textContent = "审阅可交互 Demo — 框选问题区域后可拒绝或批准。";
+      if (title) title.textContent = COPY.approveTitleReject;
+      if (desc) desc.textContent = COPY.approveDescReject;
       if (pill) {
         pill.textContent = "pending";
         pill.classList.remove("is-rejected", "is-approved");
@@ -549,8 +626,8 @@
     } else {
       if (rejectUi) rejectUi.hidden = true;
       if (passUi) passUi.hidden = false;
-      if (title) title.textContent = "会话续期 · UI DEMO";
-      if (desc) desc.textContent = "问题已修。再看一遍 Demo，没问题即可批准。";
+      if (title) title.textContent = COPY.approveTitlePass;
+      if (desc) desc.textContent = COPY.approveDescPass;
       if (pill) {
         pill.textContent = "pending";
         pill.classList.remove("is-rejected", "is-approved");
@@ -578,7 +655,7 @@
       win?.classList.remove("is-open");
       setApproveCase(root, "reject");
       if (comment) comment.textContent = "";
-      if (caption) caption.textContent = "打开审批窗口 — 审的是 UI Demo";
+      if (caption) caption.textContent = COPY.capApproveOpen;
       await sleep(350);
       if (signal.aborted) break;
 
@@ -586,7 +663,7 @@
       await sleep(reduceMotion ? 300 : 700);
       if (signal.aborted) break;
 
-      if (caption) caption.textContent = "框选问题区域：主按钮文案不对";
+      if (caption) caption.textContent = COPY.capApproveAnnotate;
       const target = within(root, "[data-annotate-target]");
       if (target && cursor && stage) {
         moveCursor(stage, cursor, target);
@@ -603,12 +680,12 @@
       await sleep(400);
       if (signal.aborted) break;
 
-      await typeComment(comment, "拒绝：主按钮不应是「删除账号」，请改回「登录 / 继续」。", signal);
+      await typeComment(comment, COPY.approveRejectComment, signal);
       if (signal.aborted) break;
       await sleep(250);
       if (signal.aborted) break;
 
-      if (caption) caption.textContent = "拒绝 Case — 带着框选反馈打回";
+      if (caption) caption.textContent = COPY.capApproveReject;
       await clickEl(stage, cursor, rejectBtn);
       if (signal.aborted) break;
       if (pill) {
@@ -620,16 +697,16 @@
 
       setApproveCase(root, "pass");
       if (comment) comment.textContent = "";
-      if (caption) caption.textContent = "下一单：会话续期 Demo — 无问题可批准";
+      if (caption) caption.textContent = COPY.capApproveNext;
       await sleep(550);
       if (signal.aborted) break;
 
-      await typeComment(comment, "LGTM — Demo 流程与文案一致，批准。", signal);
+      await typeComment(comment, COPY.approvePassComment, signal);
       if (signal.aborted) break;
       await sleep(250);
       if (signal.aborted) break;
 
-      if (caption) caption.textContent = "Just Approve";
+      if (caption) caption.textContent = COPY.capApproveJust;
       await clickEl(stage, cursor, approveBtn);
       if (signal.aborted) break;
       if (pill) {
@@ -638,13 +715,13 @@
         pill.classList.add("is-approved");
       }
       railPass?.classList.add("is-done");
-      if (caption) caption.textContent = "框选拒绝 / Demo 批准 — 两种路径都走通";
+      if (caption) caption.textContent = COPY.capApproveDone;
       await sleep(1400);
     }
   }
 
   /* PM showcase — typewriter IM, no bottom caption */
-  const PM_PLACEHOLDER = "跟 ApprovingPM 说下一句…";
+  const PM_PLACEHOLDER = COPY.pmPlaceholder;
 
   function scrollPmThread(root, behavior = "smooth") {
     const thread = within(root, "[data-pm-thread]");
@@ -730,9 +807,8 @@
   }
 
   async function playPm(root, signal) {
-    const ask =
-      "有什么办法可以保证质量？调研一下业界的 harness 和软件工程经验，看看怎么保证这个开源项目的质量。";
-    const confirm = "确认，按这个方案启动工作流。";
+    const ask = COPY.pmAsk;
+    const confirm = COPY.pmConfirm;
 
     while (!signal.aborted) {
       hideAllMsgs(root);
@@ -815,7 +891,7 @@
         for (const lane of lanes) {
           for (let i = 1; i <= 3; i += 1) setEdge(el, `${lane}-${i}`, "done");
           setLanePill(el, lane, "done", "shipped");
-          setSandbox(el, lane, "done", "done", "完成", ["$ idle", "", ""]);
+          setSandbox(el, lane, "done", "done", COPY.doneMeta, ["$ idle", "", ""]);
         }
         setShipStat(el, 3);
         setSbChip(el, 3);
@@ -824,7 +900,7 @@
         within(el, "[data-approve-window]")?.classList.add("is-open");
         setApproveCase(el, "pass");
         const c = within(el, "[data-approve-comment]");
-        if (c) c.textContent = "LGTM — Demo 流程与文案一致，批准。";
+        if (c) c.textContent = COPY.approvePassComment;
         const pill = within(el, "[data-approve-pill]");
         if (pill) {
           pill.textContent = "approved";

--- a/docs/site/js/locale.js
+++ b/docs/site/js/locale.js
@@ -6,18 +6,6 @@
 (() => {
   const STORAGE_KEY = "approving-locale";
 
-  function readBase() {
-    const raw = document.documentElement.getAttribute("data-base");
-    if (raw == null || raw === "") return "";
-    return raw.endsWith("/") ? raw.slice(0, -1) : raw;
-  }
-
-  function withBase(path) {
-    const base = readBase();
-    const cleaned = path.startsWith("/") ? path : `/${path}`;
-    return `${base}${cleaned}`;
-  }
-
   function getSaved() {
     try {
       const v = localStorage.getItem(STORAGE_KEY);
@@ -65,19 +53,28 @@
    * - saved zh-CN on /en/ → /
    * - no saved: en* on / → /en/; zh* or other stay on /
    * - no saved on /en/: stay (do not bounce zh* away)
+   *
+   * Use string-literal destinations only (not DOM-derived data-base).
+   * Avoids CodeQL "DOM text reinterpreted as HTML" on location.replace;
+   * custom-domain docs are served at site root (BASE=/).
    */
   function maybeRedirectHome() {
     if (document.documentElement.getAttribute("data-home-entry") !== "1") return;
 
     const page = pageLocale();
     const saved = getSaved();
-    let dest = null;
 
-    if (saved === "en" && page === "zh-CN") dest = withBase("/en/");
-    else if (saved === "zh-CN" && page === "en") dest = withBase("/");
-    else if (!saved && page === "zh-CN" && fromNavigator() === "en") dest = withBase("/en/");
-
-    if (dest) location.replace(dest);
+    if (saved === "en" && page === "zh-CN") {
+      location.replace("/en/");
+      return;
+    }
+    if (saved === "zh-CN" && page === "en") {
+      location.replace("/");
+      return;
+    }
+    if (!saved && page === "zh-CN" && fromNavigator() === "en") {
+      location.replace("/en/");
+    }
   }
 
   // Script loads in <head>; bind switcher after [data-locale-set] exists in body.

--- a/docs/site/js/locale.js
+++ b/docs/site/js/locale.js
@@ -1,0 +1,85 @@
+/**
+ * Docs/site locale: approving-locale (zh-CN | en).
+ * Priority: localStorage > navigator (zh*→zh-CN, en*→en, else zh-CN).
+ * Home entry (/ and /en/) may redirect once; deep links never auto-rewrite.
+ */
+(() => {
+  const STORAGE_KEY = "approving-locale";
+
+  function readBase() {
+    const raw = document.documentElement.getAttribute("data-base");
+    if (raw == null || raw === "") return "";
+    return raw.endsWith("/") ? raw.slice(0, -1) : raw;
+  }
+
+  function withBase(path) {
+    const base = readBase();
+    const cleaned = path.startsWith("/") ? path : `/${path}`;
+    return `${base}${cleaned}`;
+  }
+
+  function getSaved() {
+    try {
+      const v = localStorage.getItem(STORAGE_KEY);
+      if (v === "zh-CN" || v === "en") return v;
+    } catch {
+      /* private mode / opaque origin */
+    }
+    return null;
+  }
+
+  function setSaved(loc) {
+    if (loc !== "zh-CN" && loc !== "en") return;
+    try {
+      localStorage.setItem(STORAGE_KEY, loc);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function fromNavigator() {
+    const lang = (navigator.language || "zh-CN").toLowerCase();
+    if (lang.startsWith("zh")) return "zh-CN";
+    if (lang.startsWith("en")) return "en";
+    return "zh-CN";
+  }
+
+  function pageLocale() {
+    const lang = (document.documentElement.lang || "zh-CN").toLowerCase();
+    if (lang === "en" || lang.startsWith("en-")) return "en";
+    return "zh-CN";
+  }
+
+  function wireSwitcher() {
+    document.querySelectorAll("[data-locale-set]").forEach((el) => {
+      el.addEventListener("click", () => {
+        const loc = el.getAttribute("data-locale-set");
+        if (loc === "zh-CN" || loc === "en") setSaved(loc);
+      });
+    });
+  }
+
+  /**
+   * Home entry matrix (at most one redirect):
+   * - saved en on / → /en/
+   * - saved zh-CN on /en/ → /
+   * - no saved: en* on / → /en/; zh*/other stay on /
+   * - no saved on /en/: stay (do not bounce zh* away)
+   */
+  function maybeRedirectHome() {
+    if (document.documentElement.getAttribute("data-home-entry") !== "1") return;
+
+    const page = pageLocale();
+    const saved = getSaved();
+    let dest = null;
+
+    if (saved === "en" && page === "zh-CN") dest = withBase("/en/");
+    else if (saved === "zh-CN" && page === "en") dest = withBase("/");
+    else if (!saved && page === "zh-CN" && fromNavigator() === "en") dest = withBase("/en/");
+
+    if (dest) location.replace(dest);
+  }
+
+  wireSwitcher();
+  maybeRedirectHome();
+})();

--- a/docs/site/js/locale.js
+++ b/docs/site/js/locale.js
@@ -1,6 +1,6 @@
 /**
  * Docs/site locale: approving-locale (zh-CN | en).
- * Priority: localStorage > navigator (zh*→zh-CN, en*→en, else zh-CN).
+ * Priority: localStorage > navigator (zh* → zh-CN, en* → en, else zh-CN).
  * Home entry (/ and /en/) may redirect once; deep links never auto-rewrite.
  */
 (() => {
@@ -63,7 +63,7 @@
    * Home entry matrix (at most one redirect):
    * - saved en on / → /en/
    * - saved zh-CN on /en/ → /
-   * - no saved: en* on / → /en/; zh*/other stay on /
+   * - no saved: en* on / → /en/; zh* or other stay on /
    * - no saved on /en/: stay (do not bounce zh* away)
    */
   function maybeRedirectHome() {
@@ -80,6 +80,11 @@
     if (dest) location.replace(dest);
   }
 
-  wireSwitcher();
+  // Script loads in <head>; bind switcher after [data-locale-set] exists in body.
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", wireSwitcher);
+  } else {
+    wireSwitcher();
+  }
   maybeRedirectHome();
 })();


### PR DESCRIPTION
## Summary
- Add English homepage (`/en/`) and five English docs under `content/en/**`, keeping Chinese root URLs unchanged.
- Locale-aware `build.mjs` shell (nav/footer/eyebrow), page-header「中文 | English」switcher, and absolute `hreflang` + `x-default` → Chinese.
- Client `approving-locale` preference (localStorage > navigator); home entry redirect matrix; deep links never hijacked; `home.js` copy branches by `html lang`.

## Test plan
- [ ] `cd docs && npm ci && npm run build` — public contains `/`, `/en/`, and five zh/en doc pairs
- [ ] Open `/` and `/en/` — header switcher jumps to dual URL and sets `localStorage.approving-locale`
- [ ] Clear preference + `en` browser language on `/` → lands on `/en/`; zh stays on `/`
- [ ] Preference `en` + open Chinese deep doc URL → stays Chinese (no auto-redirect)
- [ ] Verify `hreflang`/`x-default` on home and a doc page; Chinese content not regressed
- [ ] ci-docs green on this PR


Made with [Cursor](https://cursor.com)