### PR TITLE
feat(pm): allow deleting project cron jobs from detail page

### DIFF
--- a/server/internal/handlers/pm.go
+++ b/server/internal/handlers/pm.go
@@ -986,6 +986,24 @@ func (h *Handlers) PatchProjectCronJob(c *gin.Context) {
 	c.JSON(http.StatusOK, job)
 }
 
+// DeleteProjectCronJob handles DELETE /api/projects/:id/cron-jobs/:jobId.
+// Any authenticated user may delete (aligned with PatchProjectCronJob / sessionUser).
+// Cross-project jobId returns 404. Cleanup matches Agent/MCP delete (runs + thread).
+func (h *Handlers) DeleteProjectCronJob(c *gin.Context) {
+	if h.Pm == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "pm unavailable"})
+		return
+	}
+	if _, ok := h.sessionUser(c); !ok {
+		return
+	}
+	if err := h.Pm.DeleteCronJob(c.Param("id"), c.Param("jobId")); err != nil {
+		writePmErr(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "deleted"})
+}
+
 func writePmErr(c *gin.Context, err error) {
 	switch {
 	case errors.Is(err, services.ErrProjectNotFound),

--- a/server/internal/handlers/pm_test.go
+++ b/server/internal/handlers/pm_test.go
@@ -666,6 +666,175 @@ func TestProjectCronJobsPatchAllowedForNonAdmin(t *testing.T) {
 	}
 }
 
+func TestProjectCronJobsDeleteCleansRunsAndThread(t *testing.T) {
+	hn := newHarness(t)
+	enableAdmin(t)
+
+	pm := services.NewPmService(hn.db, hn.h.Skill)
+	hn.h.Pm = pm
+
+	w := hn.do(http.MethodPost, "/api/projects", map[string]any{"name": "CronDelA"})
+	if w.Code != 200 {
+		t.Fatalf("create a: %d %s", w.Code, w.Body.String())
+	}
+	var projA map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &projA)
+	pidA := projA["id"].(string)
+
+	w = hn.do(http.MethodPost, "/api/projects", map[string]any{"name": "CronDelB"})
+	if w.Code != 200 {
+		t.Fatalf("create b: %d", w.Code)
+	}
+	var projB map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &projB)
+	pidB := projB["id"].(string)
+
+	now := time.Now().UTC()
+	thread := models.ChatThread{
+		ID: "th-del-1", ProjectID: pidA, UserID: "system", AgentName: "agent-a",
+		Kind: "cron", Title: "cron thread", CreatedAt: now, UpdatedAt: now,
+	}
+	if err := hn.db.Create(&thread).Error; err != nil {
+		t.Fatalf("seed thread: %v", err)
+	}
+	msg := models.ChatMessage{
+		ID: "msg-del-1", ThreadID: thread.ID, Role: "user", Content: "hello", CreatedAt: now,
+	}
+	if err := hn.db.Create(&msg).Error; err != nil {
+		t.Fatalf("seed message: %v", err)
+	}
+	draft := models.ChatTurnDraft{
+		ID: "draft-del-1", ThreadID: thread.ID, Status: "done", CreatedAt: now, UpdatedAt: now,
+	}
+	if err := hn.db.Create(&draft).Error; err != nil {
+		t.Fatalf("seed draft: %v", err)
+	}
+	job := models.AgentCronJob{
+		ID: "cron-del-1", AgentName: "agent-a", ProjectID: pidA, ThreadID: thread.ID,
+		Name: "待删任务", Prompt: "p", ScheduleKind: "every", ScheduleExpr: "1h",
+		Enabled: true, DeliverToChannel: false, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := hn.db.Create(&job).Error; err != nil {
+		t.Fatalf("seed job: %v", err)
+	}
+	run := models.AgentCronRun{
+		ID: "run-del-1", JobID: job.ID, Status: "ok", StartedAt: now,
+	}
+	if err := hn.db.Create(&run).Error; err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	other := models.AgentCronJob{
+		ID: "cron-del-other", AgentName: "agent-a", ProjectID: pidB, ThreadID: "th-other",
+		Name: "其他项目", Prompt: "x", ScheduleKind: "every", ScheduleExpr: "1h",
+		Enabled: true, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := hn.db.Create(&other).Error; err != nil {
+		t.Fatalf("seed other: %v", err)
+	}
+
+	w = hn.do(http.MethodDelete, "/api/projects/"+pidA+"/cron-jobs/cron-del-other", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("cross-project delete want 404 got %d %s", w.Code, w.Body.String())
+	}
+	var stillOther models.AgentCronJob
+	if err := hn.db.Where("id = ?", "cron-del-other").First(&stillOther).Error; err != nil {
+		t.Fatalf("cross-project delete must not remove other job: %v", err)
+	}
+
+	w = hn.do(http.MethodDelete, "/api/projects/"+pidA+"/cron-jobs/cron-del-1", nil)
+	if w.Code != 200 {
+		t.Fatalf("delete: %d %s", w.Code, w.Body.String())
+	}
+	var delResp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &delResp)
+	if delResp["status"] != "deleted" {
+		t.Fatalf("want status deleted, got %+v", delResp)
+	}
+
+	if err := hn.db.Where("id = ?", "cron-del-1").First(&models.AgentCronJob{}).Error; err == nil {
+		t.Fatal("job should be deleted")
+	}
+	var runCount int64
+	if err := hn.db.Model(&models.AgentCronRun{}).Where("job_id = ?", "cron-del-1").Count(&runCount).Error; err != nil {
+		t.Fatalf("count runs: %v", err)
+	}
+	if runCount != 0 {
+		t.Fatalf("want runs cleaned, got %d", runCount)
+	}
+	if err := hn.db.Where("id = ?", thread.ID).First(&models.ChatThread{}).Error; err == nil {
+		t.Fatal("thread should be deleted")
+	}
+	var msgCount int64
+	if err := hn.db.Model(&models.ChatMessage{}).Where("thread_id = ?", thread.ID).Count(&msgCount).Error; err != nil {
+		t.Fatalf("count messages: %v", err)
+	}
+	if msgCount != 0 {
+		t.Fatalf("want messages cleaned, got %d", msgCount)
+	}
+	var draftCount int64
+	if err := hn.db.Model(&models.ChatTurnDraft{}).Where("thread_id = ?", thread.ID).Count(&draftCount).Error; err != nil {
+		t.Fatalf("count drafts: %v", err)
+	}
+	if draftCount != 0 {
+		t.Fatalf("want drafts cleaned, got %d", draftCount)
+	}
+
+	w = hn.do(http.MethodGet, "/api/projects/"+pidA+"/cron-jobs", nil)
+	if w.Code != 200 {
+		t.Fatalf("list after delete: %d", w.Code)
+	}
+	var list struct {
+		Items []models.AgentCronJob `json:"items"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &list)
+	if len(list.Items) != 0 {
+		t.Fatalf("want empty list after delete, got %+v", list.Items)
+	}
+}
+
+func TestProjectCronJobsDeleteAllowedForNonAdmin(t *testing.T) {
+	hn := newHarness(t)
+	enableAdmin(t)
+
+	pm := services.NewPmService(hn.db, hn.h.Skill)
+	hn.h.Pm = pm
+
+	w := hn.do(http.MethodPost, "/api/projects", map[string]any{"name": "CronDelNoAdmin"})
+	if w.Code != 200 {
+		t.Fatalf("create: %d", w.Code)
+	}
+	var proj map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &proj)
+	pid := proj["id"].(string)
+
+	now := time.Now().UTC()
+	job := models.AgentCronJob{
+		ID: "cron-del-na1", AgentName: "agent-a", ProjectID: pid, ThreadID: "",
+		Name: "任务", Prompt: "p", ScheduleKind: "every", ScheduleExpr: "1h",
+		Enabled: true, DeliverToChannel: false, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := hn.db.Create(&job).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	cfg := config.GetConfig()
+	users := make([]config.AuthUser, len(cfg.Auth.Users))
+	copy(users, cfg.Auth.Users)
+	for i := range users {
+		users[i].IsAdmin = false
+	}
+	cfg.Auth.Users = users
+	config.StoreConfig(cfg)
+
+	w = hn.do(http.MethodDelete, "/api/projects/"+pid+"/cron-jobs/cron-del-na1", nil)
+	if w.Code != 200 {
+		t.Fatalf("non-admin delete want 200 got %d %s", w.Code, w.Body.String())
+	}
+	if err := hn.db.Where("id = ?", "cron-del-na1").First(&models.AgentCronJob{}).Error; err == nil {
+		t.Fatal("job should be deleted for non-admin")
+	}
+}
+
 func setupPmEnabledHarness(t *testing.T) (*harness, string, string) {
 	t.Helper()
 	hn := newHarness(t)

--- a/server/internal/router/router.go
+++ b/server/internal/router/router.go
@@ -76,6 +76,7 @@ func New(h *handlers.Handlers) *gin.Engine {
 		api.PUT("/projects/:id/pm-leader", h.UpdatePmLeader)
 		api.GET("/projects/:id/cron-jobs", h.ListProjectCronJobs)
 		api.PATCH("/projects/:id/cron-jobs/:jobId", h.PatchProjectCronJob)
+		api.DELETE("/projects/:id/cron-jobs/:jobId", h.DeleteProjectCronJob)
 		api.GET("/projects/:id/channel", h.GetProjectChannel)
 		api.PUT("/projects/:id/channel", h.PutProjectChannel)
 		api.DELETE("/projects/:id/channel", h.DeleteProjectChannel)

--- a/server/internal/services/pm.go
+++ b/server/internal/services/pm.go
@@ -1046,6 +1046,22 @@ func (s *PmService) PatchCronJobDeliver(projectID, jobID string, deliver bool) (
 	return job, nil
 }
 
+// DeleteCronJob removes a project-scoped cron job with the same cleanup as
+// DeleteCronJobForAgent (runs, job, and exclusive cron thread/messages/drafts).
+func (s *PmService) DeleteCronJob(projectID, jobID string) error {
+	if _, ok := s.project(projectID); !ok {
+		return ErrProjectNotFound
+	}
+	var job models.AgentCronJob
+	if err := s.db.Where("id = ? AND project_id = ?", jobID, projectID).First(&job).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrPmCronJobNotFound
+		}
+		return err
+	}
+	return s.DeleteCronJobForAgent(projectID, job.AgentName, jobID)
+}
+
 // GetThreadForAgent returns one thread when it belongs to project+agent.
 func (s *PmService) GetThreadForAgent(projectID, agentName, threadID string) (models.ChatThread, error) {
 	agentName = strings.TrimSpace(agentName)

--- a/web/src/components/pm/PmCronJobsPanel.test.ts
+++ b/web/src/components/pm/PmCronJobsPanel.test.ts
@@ -7,9 +7,13 @@ import pages from '@/locales/zh-CN/pages.json'
 import { useAuth } from '@/lib/useAuth'
 import PmCronJobsPanel from './PmCronJobsPanel.vue'
 
+const toastSuccess = vi.fn()
+const toastError = vi.fn()
+
 const apiMocks = vi.hoisted(() => ({
   listProjectCronJobs: vi.fn(),
   patchProjectCronJob: vi.fn(),
+  deleteProjectCronJob: vi.fn(),
 }))
 
 vi.mock('@/lib/api', async () => {
@@ -20,12 +24,13 @@ vi.mock('@/lib/api', async () => {
       ...actual.api,
       listProjectCronJobs: apiMocks.listProjectCronJobs,
       patchProjectCronJob: apiMocks.patchProjectCronJob,
+      deleteProjectCronJob: apiMocks.deleteProjectCronJob,
     },
   }
 })
 
 vi.mock('@/lib/useToast', () => ({
-  useToast: () => ({ success: vi.fn(), error: vi.fn() }),
+  useToast: () => ({ success: toastSuccess, error: toastError }),
 }))
 
 const SAMPLE_JOB = {
@@ -64,6 +69,7 @@ describe('PmCronJobsPanel', () => {
     const job = { ...SAMPLE_JOB, deliverToChannel: false }
     apiMocks.listProjectCronJobs.mockResolvedValue({ items: [job] })
     apiMocks.patchProjectCronJob.mockResolvedValue({ ...job, deliverToChannel: true })
+    apiMocks.deleteProjectCronJob.mockResolvedValue({ status: 'deleted' })
     useAuth().clearUser()
   })
 
@@ -75,6 +81,7 @@ describe('PmCronJobsPanel', () => {
     expect(w.text()).toContain('每日汇报')
     expect(w.text()).toContain('agent-a')
     expect(w.text()).toContain('cron: 0 9 * * *')
+    expect(w.text()).toMatch(/可查看与删除/)
   })
 
   it('allows deliver toggle for non-admin without readonly banner', async () => {
@@ -104,5 +111,36 @@ describe('PmCronJobsPanel', () => {
     expect(apiMocks.patchProjectCronJob).toHaveBeenCalledWith('proj-1', 'cron-1', {
       deliverToChannel: true,
     })
+  })
+
+  it('cancel confirm does not call delete API', async () => {
+    useAuth().setUser({ username: 'u', expiresAt: 't', isAdmin: false })
+    const w = mountPanel()
+    await flushPromises()
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    await w.get('[data-testid="project-cron-delete"]').trigger('click')
+    await flushPromises()
+    expect(apiMocks.deleteProjectCronJob).not.toHaveBeenCalled()
+    expect(w.text()).toContain('每日汇报')
+  })
+
+  it('confirm delete calls API, refreshes list, and toasts success', async () => {
+    useAuth().setUser({ username: 'u', expiresAt: 't', isAdmin: false })
+    apiMocks.listProjectCronJobs
+      .mockResolvedValueOnce({ items: [{ ...SAMPLE_JOB }] })
+      .mockResolvedValueOnce({ items: [] })
+    const w = mountPanel()
+    await flushPromises()
+    expect(w.text()).toContain('每日汇报')
+
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    await w.get('[data-testid="project-cron-delete"]').trigger('click')
+    await flushPromises()
+
+    expect(apiMocks.deleteProjectCronJob).toHaveBeenCalledWith('proj-1', 'cron-1')
+    expect(apiMocks.listProjectCronJobs).toHaveBeenCalledTimes(2)
+    expect(toastSuccess).toHaveBeenCalled()
+    expect(toastError).not.toHaveBeenCalled()
+    expect(w.text()).not.toContain('每日汇报')
   })
 })

--- a/web/src/components/pm/PmCronJobsPanel.vue
+++ b/web/src/components/pm/PmCronJobsPanel.vue
@@ -15,6 +15,7 @@ const toast = useToast()
 const items = ref<AgentCronJob[]>([])
 const loading = ref(true)
 const togglingId = ref<string | null>(null)
+const deletingId = ref<string | null>(null)
 
 async function load() {
   loading.value = true
@@ -54,6 +55,20 @@ async function onDeliverToggle(job: AgentCronJob, checked: boolean) {
   }
 }
 
+async function removeJob(id: string) {
+  if (!confirm(t('pages.projectDetail.cron.deleteConfirm'))) return
+  deletingId.value = id
+  try {
+    await api.deleteProjectCronJob(props.projectId, id)
+    await load()
+    toast.success(t('pages.projectDetail.cron.deleted'))
+  } catch (e: any) {
+    toast.error(String(e?.message || e))
+  } finally {
+    deletingId.value = null
+  }
+}
+
 watch(
   () => props.projectId,
   () => void load(),
@@ -87,6 +102,7 @@ onMounted(() => void load())
               <th class="px-3 py-2 font-medium">{{ t('pages.projectDetail.cron.colNextRun') }}</th>
               <th class="px-3 py-2 font-medium">{{ t('pages.projectDetail.cron.colLastRun') }}</th>
               <th class="px-3 py-2 font-medium">{{ t('pages.projectDetail.cron.colStatus') }}</th>
+              <th class="px-3 py-2 font-medium">{{ t('pages.projectDetail.cron.colActions') }}</th>
             </tr>
           </thead>
           <tbody>
@@ -111,7 +127,7 @@ onMounted(() => void load())
                     class="h-4 w-4"
                     data-testid="cron-deliver-toggle"
                     :checked="job.deliverToChannel"
-                    :disabled="togglingId === job.id"
+                    :disabled="togglingId === job.id || deletingId === job.id"
                     @change="onDeliverToggle(job, ($event.target as HTMLInputElement).checked)"
                   />
                   <span class="text-xs text-txt3">{{ t('pages.projectDetail.cron.deliverLabel') }}</span>
@@ -122,6 +138,17 @@ onMounted(() => void load())
               <td class="px-3 py-2.5">
                 <StatusPill v-if="job.lastStatus" :status="job.lastStatus" size="sm" />
                 <span v-else class="text-txt3">—</span>
+              </td>
+              <td class="px-3 py-2.5 text-right">
+                <button
+                  type="button"
+                  class="text-[11px] text-err disabled:cursor-not-allowed disabled:opacity-40"
+                  data-testid="project-cron-delete"
+                  :disabled="deletingId === job.id || togglingId === job.id"
+                  @click="removeJob(job.id)"
+                >
+                  {{ t('common.buttons.delete') }}
+                </button>
               </td>
             </tr>
           </tbody>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -342,6 +342,8 @@ export const api = {
       method: 'PATCH',
       body: JSON.stringify(body),
     }),
+  deleteProjectCronJob: (projectId: string, jobId: string) =>
+    req<{ status: string }>(`/projects/${projectId}/cron-jobs/${jobId}`, { method: 'DELETE' }),
   listPmMemories: (projectId: string) =>
     req<{ items: ProjectMemoryItem[] }>(`/projects/${projectId}/pm/memories`),
   upsertPmMemory: (projectId: string, body: { title: string; content: string }) =>

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -133,7 +133,7 @@
       "tabMeta": "Project info",
       "cron": {
         "title": "Scheduled tasks",
-        "hint": "All Agent cron jobs in this project. Create and edit schedules via task-scheduler in PM Leader consult; here you can review them, and any authenticated user can toggle channel delivery.",
+        "hint": "All Agent cron jobs in this project. Create and edit schedules via task-scheduler in PM Leader consult; here you can review and delete them, and any authenticated user can toggle channel delivery.",
         "emptyTitle": "No scheduled tasks yet",
         "emptyDesc": "Jobs created in PM Leader consult will appear in this list.",
         "colName": "Name",
@@ -144,10 +144,13 @@
         "colNextRun": "Next run",
         "colLastRun": "Last run",
         "colStatus": "Status",
+        "colActions": "Actions",
         "enabledYes": "Yes",
         "enabledNo": "No",
         "deliverLabel": "Deliver",
-        "deliverHint": "When on, results push to the project channel marked for cron delivery. Configure the delivery target in channel settings first."
+        "deliverHint": "When on, results push to the project channel marked for cron delivery. Configure the delivery target in channel settings first.",
+        "deleteConfirm": "Delete this cron job?",
+        "deleted": "Job deleted"
       },
       "pm": {
         "settingsTitle": "PM Leader settings",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -133,7 +133,7 @@
       "tabMeta": "项目信息",
       "cron": {
         "title": "定时任务",
-        "hint": "本项目下全部 Agent 的定时任务。创建与调度编辑请在 PM Leader 咨询中通过 task-scheduler 完成；此处可查看，并由任意已登录用户开关是否推送到项目绑定渠道。",
+        "hint": "本项目下全部 Agent 的定时任务。创建与调度编辑请在 PM Leader 咨询中通过 task-scheduler 完成；此处可查看与删除，并由任意已登录用户开关是否推送到项目绑定渠道。",
         "emptyTitle": "暂无定时任务",
         "emptyDesc": "在 PM Leader 咨询中创建任务后，将显示在此列表。",
         "colName": "名称",
@@ -144,10 +144,13 @@
         "colNextRun": "下次执行",
         "colLastRun": "上次执行",
         "colStatus": "状态",
+        "colActions": "操作",
         "enabledYes": "是",
         "enabledNo": "否",
         "deliverLabel": "推送",
-        "deliverHint": "开启后，任务结果会推送到项目渠道中标记为定时任务推送的目标。需先在渠道设置中配置推送目标。"
+        "deliverHint": "开启后，任务结果会推送到项目渠道中标记为定时任务推送的目标。需先在渠道设置中配置推送目标。",
+        "deleteConfirm": "确认删除该定时任务？",
+        "deleted": "已删除定时任务"
       },
       "pm": {
         "settingsTitle": "PM Leader 设置",


### PR DESCRIPTION
Add project-scoped DELETE with the same run/thread cleanup as Agent delete, plus confirm-and-refresh UI so users can remove jobs without leaving project detail.

Co-authored-by: Cursor <cursoragent@cursor.com>
