### PR TITLE
feat(workflow-editor): allow editing description in toolbar

### DIFF
--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -330,3 +330,28 @@ describe('api req helpers', () => {
     await expect(api.deleteArtifact('x')).rejects.toThrow('gone')
   })
 })
+
+describe('api.saveWorkflow description payload', () => {
+  it('includes description in PUT/POST body (including empty string)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: 'w1', name: 'n', description: 'list subtitle' }))
+    await api.saveWorkflow({ id: 'w1', name: 'n', description: 'list subtitle' })
+    const putCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]
+    expect(String(putCall?.[0])).toMatch(/\/workflows\/w1$/)
+    expect(putCall?.[1]).toMatchObject({ method: 'PUT' })
+    expect(JSON.parse(String(putCall?.[1]?.body))).toMatchObject({
+      id: 'w1',
+      name: 'n',
+      description: 'list subtitle',
+    })
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: 'w2', name: 'n', description: '' }))
+    await api.saveWorkflow({ name: 'n', description: '' })
+    const postCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]
+    expect(String(postCall?.[0])).toMatch(/\/workflows$/)
+    expect(postCall?.[1]).toMatchObject({ method: 'POST' })
+    expect(JSON.parse(String(postCall?.[1]?.body))).toMatchObject({
+      name: 'n',
+      description: '',
+    })
+  })
+})

--- a/web/src/lib/workflowEditorDirty.test.ts
+++ b/web/src/lib/workflowEditorDirty.test.ts
@@ -58,6 +58,16 @@ describe('workflowEditorDirty snapshots', () => {
     expect(isMetaDirty(graphOnly, base)).toBe(false)
   })
 
+  it('changing only description marks meta dirty (not graph dirty)', () => {
+    const live = wf({ description: '' })
+    const metaBase = snapshotMeta(live)
+    const graphBase = snapshotGraph(live)
+    live.description = 'list subtitle'
+    expect(isMetaDirty(live, metaBase)).toBe(true)
+    expect(isGraphDirty(live, graphBase)).toBe(false)
+    expect(saveDraftBranch(false, true)).toBe('meta')
+  })
+
   it('baseline is a deep clone (mutating live wf does not rewrite baseline)', () => {
     const live = wf()
     const base = snapshotGraph(live)

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -336,6 +336,8 @@
     },
     "workflowEditor": {
       "unnamedWorkflow": "Untitled workflow",
+      "descLabel": "Description (optional)",
+      "descPlaceholder": "List subtitle / brief description",
       "projectRequired": "Pick a project before creating a pipeline",
       "loadFailed": "Failed to load workflow; backend may be offline",
       "publishFailed": "Publish failed:",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -336,6 +336,8 @@
     },
     "workflowEditor": {
       "unnamedWorkflow": "未命名工作流",
+      "descLabel": "描述（可选）",
+      "descPlaceholder": "列表副文案 / 简要说明",
       "projectRequired": "请先选择所属项目后再新建流水线",
       "loadFailed": "加载工作流失败,后端可能未连接",
       "publishFailed": "发布失败:",

--- a/web/src/views/WorkflowEditorView.vue
+++ b/web/src/views/WorkflowEditorView.vue
@@ -460,12 +460,24 @@ function deleteEdge() {
 <template>
   <div class="flex h-full flex-col bg-base">
     <!-- toolbar -->
-    <header class="flex h-14 shrink-0 items-center gap-3 border-b border-line bg-surface px-4">
-      <button class="flex h-8 w-8 items-center justify-center rounded-md text-txt2 hover:bg-elevated hover:text-txt" @click="router.push(wf.projectId ? '/projects/' + wf.projectId : '/projects')">
+    <header class="flex min-h-14 shrink-0 items-center gap-3 border-b border-line bg-surface px-4 py-2">
+      <button class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-txt2 hover:bg-elevated hover:text-txt" @click="router.push(wf.projectId ? '/projects/' + wf.projectId : '/projects')">
         <Icon name="arrow-left" :size="18" />
       </button>
-      <Icon name="workflow" :size="18" class="text-accent-2" />
-      <input v-model="wf.name" class="rounded-md bg-transparent px-1.5 py-1 text-[15px] font-semibold text-txt outline-none hover:bg-elevated focus:bg-elevated" />
+      <Icon name="workflow" :size="18" class="shrink-0 text-accent-2" />
+      <div class="flex min-w-0 max-w-md flex-col gap-0.5">
+        <input
+          v-model="wf.name"
+          class="min-w-0 rounded-md bg-transparent px-1.5 py-1 text-[15px] font-semibold text-txt outline-none hover:bg-elevated focus:bg-elevated"
+        />
+        <textarea
+          v-model="wf.description"
+          rows="2"
+          class="max-h-16 w-full resize-none rounded-md bg-transparent px-1.5 py-0.5 text-[12px] leading-snug text-txt2 outline-none hover:bg-elevated focus:bg-elevated"
+          :aria-label="t('pages.workflowEditor.descLabel')"
+          :placeholder="t('pages.workflowEditor.descPlaceholder')"
+        />
+      </div>
       <StatusPill :status="wf.status" size="sm" />
       <span class="chip">v{{ wf.version }}</span>
       <span v-if="graphDirty" class="text-[11px] text-warn">{{ t('common.saved.unsaved') }}</span>


### PR DESCRIPTION
Expose wf.description under the name field so list subtitles can be
edited and saved via the existing draft Save path.

Co-authored-by: Cursor <cursoragent@cursor.com>
