### PR TITLE
fix(docs): show Issue badge on English Approve annotate marquee

### DIFF
--- a/docs/site/css/home.css
+++ b/docs/site/css/home.css
@@ -1595,6 +1595,11 @@
   padding: 0.05rem 0.3rem;
 }
 
+/* English docs homepage: Approve annotate badge must not leak Chinese */
+html:lang(en) .demo-marquee::after {
+  content: "Issue";
+}
+
 .approve-aside__label {
   margin: 0;
   font-size: 0.7rem;


### PR DESCRIPTION
## Summary
- English `/en/` Approve demo annotate marquee shared hardcoded Chinese 「问题」 via `.demo-marquee::after`.
- Override with `html:lang(en)` so annotate shows **Issue**, keeping zh-CN 「问题」.

## Test plan
- [ ] Open `/en/`, wait for Approve annotate/框选: badge reads Issue (no Chinese)
- [ ] Open `/`, same stage: badge still 「问题」
- [ ] Locale switcher unchanged; styles/animation unchanged


Made with [Cursor](https://cursor.com)