### PR TITLE
fix(sandbox-gateway): ship incremental pods/log RBAC for K8s logs

### DIFF
--- a/GATEWAY.md
+++ b/GATEWAY.md
@@ -39,7 +39,7 @@ build `universal-sandbox-cursor:local` from `sandbox-gateway/sandbox` on first r
 | Get | `GET /api/v1/sandboxes/{id}` returns status and endpoints (session/ide/ssh/cdp/novnc) |
 | List | `GET /api/v1/sandboxes?label=key:value` (AND) |
 | Delete | `DELETE /api/v1/sandboxes/{id}` returns 2xx |
-| Logs | `GET /api/v1/sandboxes/{id}/logs?tail=` returns `{content}` (PID1 stdout/stderr, non-follow). Docker (`docker logs --tail`) and kubernetes (pod `sandbox` container via client-go GetLogs) both supported. Cluster RBAC must allow `pods/log` (ops prerequisite). Drivers that still omit Logs → `501` |
+| Logs | `GET /api/v1/sandboxes/{id}/logs?tail=` returns `{content}` (PID1 stdout/stderr, non-follow). Docker (`docker logs --tail`) and kubernetes (pod `sandbox` container via client-go GetLogs) both supported. Cluster RBAC must allow `get` on `pods/log` in the sandbox namespace; the incremental Role+RoleBinding is shipped in `sandbox-gateway/deploy/k8s/` (apply alongside existing Roles — do not replace a full production Role). Drivers that still omit Logs → `501` |
 | Ready | status `running` with a `session` endpoint |
 | Images | per Agent `acpBackend`: `universal-sandbox-{cursor\|claude_code\|codebuddy\|trae}` |
 | Data plane | SSH / session / cdp / novnc connect to endpoints directly |

--- a/sandbox-gateway/deploy/k8s/role-pods-log.yaml
+++ b/sandbox-gateway/deploy/k8s/role-pods-log.yaml
@@ -1,0 +1,17 @@
+# Incremental RBAC: grant get on pods/log only.
+# Apply alongside existing Roles; do NOT kubectl replace a full production Role
+# with this file — that would drop Deployment/PVC/etc. permissions.
+#
+# Namespace MUST match the sandbox workload namespace (SBGW_K8S_NAMESPACE /
+# kubernetes.namespace). Default below matches the live error namespace
+# "sandbox-gateway"; adjust before apply if your cluster uses another ns
+# (e.g. config.example.yaml default "sandboxes").
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sandbox-gateway-pods-log
+  namespace: sandbox-gateway
+rules:
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]

--- a/sandbox-gateway/deploy/k8s/rolebinding-pods-log.yaml
+++ b/sandbox-gateway/deploy/k8s/rolebinding-pods-log.yaml
@@ -1,0 +1,19 @@
+# Binds incremental Role sandbox-gateway-pods-log to ServiceAccount
+# sandbox-gateway. Permissions accumulate with any other Roles already bound
+# to the same SA — safe to apply without replacing the existing RBAC matrix.
+#
+# Namespace MUST match role-pods-log.yaml and the sandbox workload namespace
+# (SBGW_K8S_NAMESPACE / kubernetes.namespace).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sandbox-gateway-pods-log
+  namespace: sandbox-gateway
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sandbox-gateway-pods-log
+subjects:
+  - kind: ServiceAccount
+    name: sandbox-gateway
+    namespace: sandbox-gateway

--- a/sandbox-gateway/gateway/docs/API.md
+++ b/sandbox-gateway/gateway/docs/API.md
@@ -225,9 +225,12 @@ for the agent execution event log.
   mapped by handlers. Driver / API / CLI failure → `500` with `error`.
 - Drivers that do not implement Logs still return `501`
   (`sandbox logs not supported by this driver`).
-- **Ops prerequisite**: the gateway ServiceAccount needs `pods/log` (or
-  equivalent) in the sandbox namespace. This release does not ship RBAC
-  manifests; missing permission surfaces as a non-2xx error (not empty success).
+- **Required RBAC (shipped)**: the gateway ServiceAccount needs `get` on
+  `pods/log` in the sandbox namespace. Incremental manifests are provided at
+  `sandbox-gateway/deploy/k8s/` (`role-pods-log.yaml` +
+  `rolebinding-pods-log.yaml`); apply them alongside existing Roles (do not
+  replace a full production Role). Missing permission surfaces as a non-2xx
+  error (not empty success).
 
 ## What the gateway does NOT do
 


### PR DESCRIPTION
## Summary
- Add incremental `Role` + `RoleBinding` under `sandbox-gateway/deploy/k8s/` granting `get` on `pods/log` to ServiceAccount `sandbox-gateway` (default ns `sandbox-gateway`).
- Align `GATEWAY.md` and `sandbox-gateway/gateway/docs/API.md`: pods/log is required and **shipped in-tree** (no longer “ops prerequisite / does not ship RBAC manifests”).
- No Logs / Docker driver code changes — RBAC-only fix for the post–PR #44 forbidden → 500 path.

## Ops note
After merge, apply the incremental manifests (do **not** replace a full production Role):

```bash
kubectl apply -f sandbox-gateway/deploy/k8s/role-pods-log.yaml
kubectl apply -f sandbox-gateway/deploy/k8s/rolebinding-pods-log.yaml
```

Ensure `metadata.namespace` matches `SBGW_K8S_NAMESPACE` / sandbox Pod namespace before apply. Then `GET /api/v1/sandboxes/{id}/logs?tail=5000` should no longer fail with pods/log forbidden.

## Test plan
- [x] Confirm YAML only contains `pods/log` + `get` (no extra resources/verbs)
- [x] Confirm RoleBinding subjects → SA `sandbox-gateway`, roleRef → new Role
- [x] Docs point at `sandbox-gateway/deploy/k8s/` and no longer say RBAC is not shipped
- [x] Diff has no Go / Docker driver changes
- [x] Related CI stays green (manifest + docs only)
- [ ] After cluster apply: logs API returns content or empty success (not forbidden 500)