### PR TITLE
fix(board): replace TokenTrendChart SVG stretch with Chart.js

### DIFF
--- a/web/e2e/board-token-stats.spec.ts
+++ b/web/e2e/board-token-stats.spec.ts
@@ -205,7 +205,12 @@ test.describe('看板 Token 统计图', () => {
     await expect(page.getByTestId('token-stats-trend-card')).toBeVisible()
     await expect(page.getByTestId('token-stats-comp-card')).toBeVisible()
     await expect(page.getByTestId('token-stats-rank-card')).toBeVisible()
-    await expect(page.getByTestId('token-trend-svg')).toBeVisible()
+    await expect(page.getByTestId('token-trend-wrap')).toBeVisible()
+    await expect(page.getByTestId('token-trend-chart')).toBeVisible()
+    await expect(page.getByTestId('token-trend-chart').locator('canvas')).toBeVisible()
+    // Regression: no non-uniform SVG stretch path for the trend chart
+    await expect(page.getByTestId('token-trend-svg')).toHaveCount(0)
+    await expect(page.locator('[data-testid="token-trend-wrap"] svg[preserveAspectRatio="none"]')).toHaveCount(0)
     await expect(page.getByTestId('token-donut-svg')).toBeVisible()
     await expect(page.getByTestId('token-donut-legend')).toContainText('input')
     await expect(panel).toContainText('approve-main')
@@ -243,6 +248,13 @@ test.describe('看板 Token 统计图', () => {
     await expect(page.getByTestId('token-stats-charts')).toBeVisible({ timeout: 10_000 })
     await expect(page.getByTestId('token-stats-window-badge')).toContainText('近 7 天')
     await expect(page.getByTestId('token-stats-window-7d')).toHaveAttribute('aria-selected', 'true')
+    // After window switch: Chart.js canvas still hosts trend; no SVG none stretch
+    await expect(page.getByTestId('token-trend-chart').locator('canvas')).toBeVisible()
+    await expect(page.locator('[data-testid="token-trend-wrap"] svg[preserveAspectRatio="none"]')).toHaveCount(0)
+    const wrapBox = await page.getByTestId('token-trend-wrap').boundingBox()
+    expect(wrapBox).toBeTruthy()
+    expect(wrapBox!.height).toBeGreaterThanOrEqual(180)
+    expect(wrapBox!.height).toBeLessThanOrEqual(240)
 
     // Failure + retry
     failNext = true
@@ -289,6 +301,7 @@ test.describe('看板 Token 统计图', () => {
     await expect(page.getByTestId('token-stats-panel')).toBeVisible({ timeout: 15_000 })
     await expect(page.getByTestId('token-stats-empty')).toBeVisible()
     await expect(page.getByTestId('token-stats-charts')).toHaveCount(0)
+    await expect(page.getByTestId('token-trend-chart')).toHaveCount(0)
     await expect(page.getByTestId('token-trend-svg')).toHaveCount(0)
     await expect(page.getByTestId('token-donut-svg')).toHaveCount(0)
     await expect(page.getByTestId('token-stats-empty')).toContainText('未上报不会显示为 0')

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,11 +16,13 @@
         "@vue-flow/minimap": "^1.5.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
+        "chart.js": "^4.5.1",
         "dompurify": "^3.2.3",
         "marked": "^15.0.6",
         "monaco-editor": "^0.52.2",
         "pinia": "^2.3.0",
         "vue": "^3.5.13",
+        "vue-chartjs": "^5.3.4",
         "vue-i18n": "^10.0.7",
         "vue-router": "^4.5.0"
       },
@@ -875,6 +877,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmmirror.com/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2521,6 +2529,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmmirror.com/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/check-error": {
@@ -5495,6 +5516,16 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-chartjs": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmmirror.com/vue-chartjs/-/vue-chartjs-5.3.4.tgz",
+      "integrity": "sha512-x3Fqob8RQvrTdssfi9ecsCzEkFOd8JPmNwSkSQzdfKj/uBsRJs/Y88cZcZIEcPsTVfMGwMo4MOoihoDG2DoE/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "vue": "^3.0.0-0 || ^2.7.0"
       }
     },
     "node_modules/vue-component-type-helpers": {

--- a/web/package.json
+++ b/web/package.json
@@ -24,11 +24,13 @@
     "@vue-flow/minimap": "^1.5.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
+    "chart.js": "^4.5.1",
     "dompurify": "^3.2.3",
     "marked": "^15.0.6",
     "monaco-editor": "^0.52.2",
     "pinia": "^2.3.0",
     "vue": "^3.5.13",
+    "vue-chartjs": "^5.3.4",
     "vue-i18n": "^10.0.7",
     "vue-router": "^4.5.0"
   },

--- a/web/src/components/board/token-stats/TokenCharts.test.ts
+++ b/web/src/components/board/token-stats/TokenCharts.test.ts
@@ -15,8 +15,22 @@ const i18n = () =>
     messages: { 'zh-CN': { ...common, ...pages } },
   })
 
+function sampleTrend(n: number) {
+  return Array.from({ length: n }, (_, i) => {
+    const day = String(i + 1).padStart(2, '0')
+    return {
+      bucket: `2026-07-${day}`,
+      total: i === n - 1 ? 1_500_000 : i * 100,
+      inputTokens: 40,
+      outputTokens: 30,
+      cacheReadTokens: 20,
+      cacheWriteTokens: 10,
+    }
+  })
+}
+
 describe('Token charts (g2.3/g2.4)', () => {
-  it('renders trend svg from buckets including a zero day', () => {
+  it('renders trend chart.js canvas from buckets including a zero day (g2.1)', () => {
     const wrapper = mount(TokenTrendChart, {
       props: {
         bucketWidth: 'day',
@@ -41,8 +55,59 @@ describe('Token charts (g2.3/g2.4)', () => {
       },
       global: { plugins: [i18n()] },
     })
-    expect(wrapper.find('[data-testid="token-trend-svg"]').exists()).toBe(true)
-    expect(wrapper.findAll('circle').length).toBe(2)
+    expect(wrapper.find('[data-testid="token-trend-wrap"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="token-trend-chart"]').exists()).toBe(true)
+    expect(wrapper.find('canvas').exists()).toBe(true)
+    // Chart.js Canvas path — no legacy non-uniform SVG stretch host
+    expect(wrapper.find('[data-testid="token-trend-svg"]').exists()).toBe(false)
+    expect(wrapper.html()).not.toMatch(/preserveAspectRatio\s*=\s*["']none["']/)
+    wrapper.unmount()
+  })
+
+  it('keeps ~200px wrap height and rejects preserveAspectRatio=none stretch (g2.2)', () => {
+    const wrapper = mount(TokenTrendChart, {
+      props: {
+        bucketWidth: 'day',
+        trend: sampleTrend(30),
+      },
+      global: { plugins: [i18n()] },
+      attachTo: document.body,
+    })
+    const wrap = wrapper.find('[data-testid="token-trend-wrap"]')
+    expect(wrap.exists()).toBe(true)
+    expect((wrap.element as HTMLElement).style.height).toBe('200px')
+    expect(wrapper.find('svg[preserveAspectRatio="none"]').exists()).toBe(false)
+    expect(wrapper.html()).not.toContain('preserveAspectRatio="none"')
+    // Wide container must still host canvas (aspect handled by Chart.js, not SVG none)
+    ;(wrap.element as HTMLElement).style.width = '1280px'
+    expect(wrapper.find('[data-testid="token-trend-chart"] canvas').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('maps 30-day labels with tick thinning options (maxTicksLimit≈8) (g2.2)', () => {
+    const wrapper = mount(TokenTrendChart, {
+      props: {
+        bucketWidth: 'day',
+        trend: sampleTrend(30),
+      },
+      global: { plugins: [i18n()] },
+    })
+    const exposed = wrapper.vm as unknown as {
+      chartOptions: {
+        maintainAspectRatio?: boolean
+        scales?: { x?: { ticks?: { maxTicksLimit?: number; autoSkip?: boolean } } }
+        plugins?: { tooltip?: { enabled?: boolean; external?: unknown } }
+      }
+      chartData: { labels: string[]; datasets: { data: number[] }[] }
+    }
+    const opts = exposed.chartOptions
+    expect(opts.maintainAspectRatio).toBe(false)
+    expect(opts.scales?.x?.ticks?.maxTicksLimit).toBe(8)
+    expect(opts.scales?.x?.ticks?.autoSkip).toBe(true)
+    expect(opts.plugins?.tooltip?.enabled).toBe(false)
+    expect(typeof opts.plugins?.tooltip?.external).toBe('function')
+    expect(exposed.chartData.labels).toHaveLength(30)
+    expect(exposed.chartData.datasets[0]?.data).toHaveLength(30)
     wrapper.unmount()
   })
 

--- a/web/src/components/board/token-stats/TokenTrendChart.vue
+++ b/web/src/components/board/token-stats/TokenTrendChart.vue
@@ -1,9 +1,24 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Filler,
+  Tooltip,
+  type ChartOptions,
+  type TooltipModel,
+  type Chart,
+} from 'chart.js'
+import { Line } from 'vue-chartjs'
 import type { TokenStatsBucket } from '@/lib/types'
 import { fmtTokenCount } from '@/lib/tokenUsage'
 import { TOKEN_PART_COLORS, TOKEN_PART_KEYS, formatBucketLabel } from './tokenStatsShared'
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Filler, Tooltip)
 
 const props = defineProps<{
   trend: TokenStatsBucket[]
@@ -12,67 +27,11 @@ const props = defineProps<{
 
 const { t } = useI18n()
 
-const W = 640
-const H = 200
-const PAD = { t: 16, r: 12, b: 28, l: 44 }
+const LINE_COLOR = '#6d5cff'
+const CHART_HEIGHT_PX = 200
 
-const activeIdx = ref<number | null>(null)
 const tip = ref({ show: false, x: 0, y: 0, idx: -1 })
-
-const maxTotal = computed(() => {
-  const m = Math.max(0, ...props.trend.map((b) => b.total || 0))
-  return m > 0 ? m : 1
-})
-
-const points = computed(() => {
-  const n = props.trend.length
-  if (n === 0) return [] as { x: number; y: number; i: number }[]
-  const innerW = W - PAD.l - PAD.r
-  const innerH = H - PAD.t - PAD.b
-  return props.trend.map((b, i) => {
-    const x = PAD.l + (n === 1 ? innerW / 2 : (i / (n - 1)) * innerW)
-    const y = PAD.t + innerH * (1 - (b.total || 0) / maxTotal.value)
-    return { x, y, i }
-  })
-})
-
-const linePath = computed(() => {
-  if (points.value.length === 0) return ''
-  return points.value.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x.toFixed(1)} ${p.y.toFixed(1)}`).join(' ')
-})
-
-const areaPath = computed(() => {
-  if (points.value.length === 0) return ''
-  const first = points.value[0]!
-  const last = points.value[points.value.length - 1]!
-  const baseY = H - PAD.b
-  return `${linePath.value} L ${last.x.toFixed(1)} ${baseY} L ${first.x.toFixed(1)} ${baseY} Z`
-})
-
-const xLabels = computed(() => {
-  const n = props.trend.length
-  if (n === 0) return [] as { x: number; label: string }[]
-  const step = n <= 8 ? 1 : n <= 16 ? 2 : Math.ceil(n / 8)
-  const out: { x: number; label: string }[] = []
-  for (let i = 0; i < n; i += step) {
-    const p = points.value[i]
-    if (!p) continue
-    out.push({
-      x: p.x,
-      label: formatBucketLabel(props.trend[i]!.bucket, props.bucketWidth),
-    })
-  }
-  return out
-})
-
-const yTicks = computed(() => {
-  const innerH = H - PAD.t - PAD.b
-  const ticks = [0, 0.5, 1]
-  return ticks.map((f) => ({
-    y: PAD.t + innerH * (1 - f),
-    label: fmtCompact(Math.round(maxTotal.value * f)),
-  }))
-})
+const tipBucket = computed(() => (tip.value.idx >= 0 ? props.trend[tip.value.idx] : null))
 
 function fmtCompact(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
@@ -80,101 +39,126 @@ function fmtCompact(n: number): string {
   return String(n)
 }
 
-function showTip(i: number, ev: MouseEvent) {
-  activeIdx.value = i
-  const wrap = (ev.currentTarget as SVGElement).closest('[data-testid="token-trend-wrap"]') as HTMLElement | null
-  if (!wrap) return
-  const rect = wrap.getBoundingClientRect()
-  tip.value = {
-    show: true,
-    x: Math.min(Math.max(ev.clientX - rect.left, 8), rect.width - 160),
-    y: Math.max(ev.clientY - rect.top - 8, 8),
-    idx: i,
-  }
+function partValue(bucket: TokenStatsBucket, key: (typeof TOKEN_PART_KEYS)[number]): number {
+  if (key === 'input') return bucket.inputTokens
+  if (key === 'output') return bucket.outputTokens
+  if (key === 'cacheRead') return bucket.cacheReadTokens
+  return bucket.cacheWriteTokens
 }
 
 function hideTip() {
-  activeIdx.value = null
-  tip.value = { ...tip.value, show: false }
+  tip.value = { ...tip.value, show: false, idx: -1 }
 }
 
-const tipBucket = computed(() => (tip.value.idx >= 0 ? props.trend[tip.value.idx] : null))
+function externalTooltip(context: { chart: Chart; tooltip: TooltipModel<'line'> }) {
+  const { chart, tooltip } = context
+  const wrap = chart.canvas.closest('[data-testid="token-trend-wrap"]') as HTMLElement | null
+  if (!wrap) return
+
+  if (tooltip.opacity === 0 || !tooltip.dataPoints?.length) {
+    hideTip()
+    return
+  }
+
+  const idx = tooltip.dataPoints[0]!.dataIndex
+  const rect = wrap.getBoundingClientRect()
+  const canvasRect = chart.canvas.getBoundingClientRect()
+  const caretX = canvasRect.left - rect.left + tooltip.caretX
+  const caretY = canvasRect.top - rect.top + tooltip.caretY
+
+  tip.value = {
+    show: true,
+    x: Math.min(Math.max(caretX, 8), rect.width - 160),
+    y: Math.max(caretY - 8, 8),
+    idx,
+  }
+}
+
+const chartData = computed(() => {
+  const labels = props.trend.map((b) => formatBucketLabel(b.bucket, props.bucketWidth))
+  const totals = props.trend.map((b) => b.total || 0)
+  return {
+    labels,
+    datasets: [
+      {
+        label: t('pages.board.tokenStats.trendTitle'),
+        data: totals,
+        borderColor: LINE_COLOR,
+        backgroundColor: 'rgba(109, 92, 255, 0.18)',
+        borderWidth: 2.2,
+        fill: true,
+        tension: 0.15,
+        pointRadius: 3.5,
+        pointHoverRadius: 5,
+        pointBackgroundColor: '#fff',
+        pointBorderColor: LINE_COLOR,
+        pointBorderWidth: 2,
+        pointHoverBackgroundColor: '#fff',
+        pointHoverBorderColor: LINE_COLOR,
+        pointHoverBorderWidth: 2,
+      },
+    ],
+  }
+})
+
+const chartOptions = computed<ChartOptions<'line'>>(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  interaction: { mode: 'index', intersect: false },
+  plugins: {
+    legend: { display: false },
+    tooltip: {
+      enabled: false,
+      external: externalTooltip,
+    },
+  },
+  scales: {
+    x: {
+      grid: { display: false },
+      ticks: {
+        maxTicksLimit: 8,
+        autoSkip: true,
+        maxRotation: 0,
+        minRotation: 0,
+        color: '#9aa1ad',
+        font: { size: 10 },
+      },
+      border: { display: false },
+    },
+    y: {
+      beginAtZero: true,
+      grid: { color: '#eef0f3' },
+      ticks: {
+        maxTicksLimit: 4,
+        color: '#9aa1ad',
+        font: { size: 10 },
+        callback: (value) => fmtCompact(Number(value)),
+      },
+      border: { display: false },
+    },
+  },
+}))
+
+watch(
+  () => props.trend,
+  () => hideTip(),
+)
+
+/** Exposed for unit tests: option mapping (tick thinning / aspect / tooltip). */
+defineExpose({ chartOptions, chartData })
 </script>
 
 <template>
-  <div data-testid="token-trend-wrap" class="token-trend-wrap relative h-[200px] w-full">
-    <svg
-      data-testid="token-trend-svg"
-      viewBox="0 0 640 200"
-      preserveAspectRatio="none"
-      class="h-full w-full"
-      role="img"
-      :aria-label="t('pages.board.tokenStats.trendTitle')"
-    >
-      <defs>
-        <linearGradient id="tokenTrendArea" x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stop-color="#6d5cff" stop-opacity="0.22" />
-          <stop offset="100%" stop-color="#6d5cff" stop-opacity="0.02" />
-        </linearGradient>
-      </defs>
-      <line
-        v-for="(tk, i) in yTicks"
-        :key="'g' + i"
-        :x1="PAD.l"
-        :x2="W - PAD.r"
-        :y1="tk.y"
-        :y2="tk.y"
-        stroke="#eef0f3"
-        stroke-width="1"
-      />
-      <text
-        v-for="(tk, i) in yTicks"
-        :key="'yl' + i"
-        :x="PAD.l - 6"
-        :y="tk.y + 3"
-        text-anchor="end"
-        fill="#9aa1ad"
-        font-size="10"
-      >
-        {{ tk.label }}
-      </text>
-      <path v-if="areaPath" :d="areaPath" fill="url(#tokenTrendArea)" />
-      <path
-        v-if="linePath"
-        :d="linePath"
-        fill="none"
-        stroke="#6d5cff"
-        stroke-width="2.2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-      />
-      <g v-for="p in points" :key="p.i">
-        <circle
-          :cx="p.x"
-          :cy="p.y"
-          :r="activeIdx === p.i ? 5 : 3.5"
-          fill="#fff"
-          stroke="#6d5cff"
-          stroke-width="2"
-          class="cursor-pointer"
-          @mouseenter="showTip(p.i, $event)"
-          @mousemove="showTip(p.i, $event)"
-          @mouseleave="hideTip"
-          @click="showTip(p.i, $event)"
-        />
-      </g>
-      <text
-        v-for="(xl, i) in xLabels"
-        :key="'xl' + i"
-        :x="xl.x"
-        :y="H - 8"
-        text-anchor="middle"
-        fill="#9aa1ad"
-        font-size="10"
-      >
-        {{ xl.label }}
-      </text>
-    </svg>
+  <div
+    data-testid="token-trend-wrap"
+    class="token-trend-wrap relative w-full"
+    :style="{ height: `${CHART_HEIGHT_PX}px` }"
+    role="img"
+    :aria-label="t('pages.board.tokenStats.trendTitle')"
+  >
+    <div data-testid="token-trend-chart" class="h-full w-full">
+      <Line :data="chartData" :options="chartOptions" />
+    </div>
     <div
       v-if="tip.show && tipBucket"
       data-testid="token-trend-tooltip"
@@ -194,17 +178,7 @@ const tipBucket = computed(() => (tip.value.idx >= 0 ? props.trend[tip.value.idx
           <i class="inline-block h-2 w-2 rounded-sm" :style="{ background: TOKEN_PART_COLORS[key] }" />
           {{ key }}
         </span>
-        <b class="font-normal tabular-nums text-white">{{
-          fmtTokenCount(
-            key === 'input'
-              ? tipBucket.inputTokens
-              : key === 'output'
-                ? tipBucket.outputTokens
-                : key === 'cacheRead'
-                  ? tipBucket.cacheReadTokens
-                  : tipBucket.cacheWriteTokens,
-          )
-        }}</b>
+        <b class="font-normal tabular-nums text-white">{{ fmtTokenCount(partValue(tipBucket, key)) }}</b>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Self-drawn SVG used preserveAspectRatio=none, which squashed points and
axis labels on wide viewports. Render the consumption trend via Chart.js
+ vue-chartjs with fixed ~200px height, tick thinning, and part tooltips.

Co-authored-by: Cursor <cursoragent@cursor.com>
