### PR TITLE
feat(web): unify boolean controls as square AppSwitch

### DIFF
--- a/web/e2e/agent-studio-mobile-data.spec.ts
+++ b/web/e2e/agent-studio-mobile-data.spec.ts
@@ -187,8 +187,8 @@ test.describe('Agent Studio 窄屏数据 Tab', () => {
     await expect(page.getByTestId('agent-cron-mobile-cards').getByRole('button', { name: /新建/ })).toHaveCount(0)
 
     const deliver = page.getByTestId('agent-cron-deliver')
-    await deliver.check()
-    await expect(deliver).toBeChecked()
+    await deliver.click()
+    await expect(deliver).toHaveAttribute('aria-checked', 'true')
 
     await page.getByRole('button', { name: /^MCP/ }).click()
     await expect(page.getByText('请在桌面端完成')).toBeVisible()

--- a/web/src/components/agent/AgentDataPanel.test.ts
+++ b/web/src/components/agent/AgentDataPanel.test.ts
@@ -176,14 +176,16 @@ describe('AgentDataPanel', () => {
     const enabled = w.get('[data-testid="agent-cron-enabled"]')
     const deliver = w.get('[data-testid="agent-cron-deliver"]')
     const del = w.get('[data-testid="agent-cron-delete"]')
-    expect((enabled.element as HTMLInputElement).disabled).toBe(false)
-    expect((deliver.element as HTMLInputElement).disabled).toBe(false)
+    expect((enabled.element as HTMLButtonElement).disabled).toBe(false)
+    expect((deliver.element as HTMLButtonElement).disabled).toBe(false)
     expect((del.element as HTMLButtonElement).disabled).toBe(false)
+    expect(enabled.attributes('role')).toBe('switch')
+    expect(deliver.attributes('role')).toBe('switch')
     expect(enabled.attributes('title')).toBeUndefined()
     expect(deliver.attributes('title')).toBeUndefined()
     expect(del.attributes('title')).toBeUndefined()
 
-    await enabled.setValue(false)
+    await enabled.trigger('click')
     await flushPromises()
     expect(apiMocks.patchAgentCronJob).toHaveBeenCalledWith('demo-agent', 'cron-1', { enabled: false })
 
@@ -224,8 +226,8 @@ describe('AgentDataPanel', () => {
     expect(apiMocks.listAgentCronJobs).toHaveBeenCalledWith('demo-agent')
     expect(w.text()).toContain('查看与管理')
     const enabled = w.get('[data-testid="agent-cron-enabled"]')
-    expect((enabled.element as HTMLInputElement).disabled).toBe(false)
-    await enabled.setValue(false)
+    expect((enabled.element as HTMLButtonElement).disabled).toBe(false)
+    await enabled.trigger('click')
     await flushPromises()
     expect(apiMocks.patchAgentCronJob).toHaveBeenCalledWith('demo-agent', 'cron-1', { enabled: false })
   })
@@ -273,7 +275,7 @@ describe('AgentDataPanel', () => {
     expect(w.findAll('button').some((b) => /^新建/.test(b.text()))).toBe(false)
 
     const deliver = w.get('[data-testid="agent-cron-deliver"]')
-    await deliver.setValue(true)
+    await deliver.trigger('click')
     await flushPromises()
     expect(apiMocks.patchAgentCronJob).toHaveBeenCalledWith('demo-agent', 'cron-1', {
       deliverToChannel: true,
@@ -282,7 +284,7 @@ describe('AgentDataPanel', () => {
 
     const enabled = w.get('[data-testid="agent-cron-enabled"]')
     apiMocks.patchAgentCronJob.mockResolvedValueOnce({ ...SAMPLE_JOB, enabled: false })
-    await enabled.setValue(false)
+    await enabled.trigger('click')
     await flushPromises()
     expect(apiMocks.patchAgentCronJob).toHaveBeenCalledWith('demo-agent', 'cron-1', { enabled: false })
 

--- a/web/src/components/agent/AgentDataPanel.vue
+++ b/web/src/components/agent/AgentDataPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import AppSwitch from '@/components/ui/AppSwitch.vue'
 import Icon from '@/components/ui/Icon.vue'
 import { api } from '@/lib/api'
 import type { ProjectMemoryItem, ChatThread, ChatMessage, AgentCronJob } from '@/lib/types'
@@ -366,24 +367,22 @@ onMounted(() => reload())
             <div class="mt-3 space-y-2">
               <label class="flex min-h-11 items-center justify-between gap-3 text-[12px] text-txt2">
                 <span>{{ t('pages.agentStudio.data.jobs.colEnabled') }}</span>
-                <input
-                  type="checkbox"
-                  class="h-5 w-5"
+                <AppSwitch
                   data-testid="agent-cron-enabled"
-                  :checked="job.enabled"
+                  :model-value="job.enabled"
                   :disabled="jobBusy === job.id"
-                  @change="patchJob(job, { enabled: ($event.target as HTMLInputElement).checked })"
+                  :aria-label="t('pages.agentStudio.data.jobs.colEnabled')"
+                  @update:model-value="patchJob(job, { enabled: $event })"
                 />
               </label>
               <label class="flex min-h-11 items-center justify-between gap-3 text-[12px] text-txt2">
                 <span>{{ t('pages.agentStudio.data.jobs.colDeliver') }}</span>
-                <input
-                  type="checkbox"
-                  class="h-5 w-5"
+                <AppSwitch
                   data-testid="agent-cron-deliver"
-                  :checked="job.deliverToChannel"
+                  :model-value="job.deliverToChannel"
                   :disabled="jobBusy === job.id"
-                  @change="patchJob(job, { deliverToChannel: ($event.target as HTMLInputElement).checked })"
+                  :aria-label="t('pages.agentStudio.data.jobs.colDeliver')"
+                  @update:model-value="patchJob(job, { deliverToChannel: $event })"
                 />
               </label>
               <button
@@ -415,21 +414,21 @@ onMounted(() => reload())
               <td class="px-2 py-2">{{ job.name }}</td>
               <td class="px-2 py-2 text-txt2">{{ job.scheduleKind }}: {{ job.scheduleExpr }}</td>
               <td class="px-2 py-2">
-                <input
-                  type="checkbox"
+                <AppSwitch
                   data-testid="agent-cron-enabled"
-                  :checked="job.enabled"
+                  :model-value="job.enabled"
                   :disabled="jobBusy === job.id"
-                  @change="patchJob(job, { enabled: ($event.target as HTMLInputElement).checked })"
+                  :aria-label="t('pages.agentStudio.data.jobs.colEnabled')"
+                  @update:model-value="patchJob(job, { enabled: $event })"
                 />
               </td>
               <td class="px-2 py-2">
-                <input
-                  type="checkbox"
+                <AppSwitch
                   data-testid="agent-cron-deliver"
-                  :checked="job.deliverToChannel"
+                  :model-value="job.deliverToChannel"
                   :disabled="jobBusy === job.id"
-                  @change="patchJob(job, { deliverToChannel: ($event.target as HTMLInputElement).checked })"
+                  :aria-label="t('pages.agentStudio.data.jobs.colDeliver')"
+                  @update:model-value="patchJob(job, { deliverToChannel: $event })"
                 />
               </td>
               <td class="px-2 py-2 text-right">

--- a/web/src/components/canvas/NodeInspector.vue
+++ b/web/src/components/canvas/NodeInspector.vue
@@ -3,6 +3,7 @@ import { computed, ref, onMounted, onUnmounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Icon from '../ui/Icon.vue'
 import AppButton from '../ui/AppButton.vue'
+import AppSwitch from '../ui/AppSwitch.vue'
 import { nodeColorHex, syncHumanGateFormDefaults } from '@/data/nodeRegistry'
 import { useNodeDefs } from '@/lib/useNodeDefs'
 import { buildOutputSourceOptions } from '@/lib/outputSourceOptions'
@@ -406,16 +407,17 @@ function addAssignment() {
 
         <p v-if="f.help" class="mt-1 text-[11px] leading-4 text-txt3">{{ f.help }}</p>
 
-        <button
+        <div
           v-else-if="f.type === 'switch'"
           class="flex items-center gap-2"
-          @click="node.config[f.key] = !node.config[f.key]"
         >
-          <span class="relative h-5 w-9 rounded-full transition" :class="node.config[f.key] ? 'bg-accent' : 'bg-line-strong'">
-            <span class="absolute top-0.5 h-4 w-4 rounded-full bg-white transition-all" :class="node.config[f.key] ? 'left-[18px]' : 'left-0.5'" />
-          </span>
+          <AppSwitch
+            :model-value="!!node.config[f.key]"
+            :aria-label="f.label || f.key"
+            @update:model-value="node.config[f.key] = $event"
+          />
           <span class="text-xs text-txt2">{{ node.config[f.key] ? t('common.switchOn') : t('common.switchOff') }}</span>
-        </button>
+        </div>
 
         <template v-else-if="f.type === 'textarea' || f.type === 'prompt'">
           <textarea v-model="node.config[f.key]" class="input min-h-[96px] font-mono text-[12px] leading-relaxed" :placeholder="f.placeholder" />

--- a/web/src/components/canvas/OutputSourcesEditor.vue
+++ b/web/src/components/canvas/OutputSourcesEditor.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import AppSwitch from '@/components/ui/AppSwitch.vue'
 import { buildOutputSourceOptions, labelForOutputTemplate } from '@/lib/outputSourceOptions'
 import { useToast } from '@/lib/useToast'
 import type { WFEdge, WFNode } from '@/lib/types'
@@ -100,7 +101,11 @@ function onDrop(target: string) {
         >
           <span class="cursor-grab text-[12px] text-txt3">⠿</span>
           <span class="min-w-[18px] bg-accent-dim px-1.5 py-0.5 text-center text-[10px] text-accent-2">{{ i + 1 }}</span>
-          <input type="checkbox" checked class="accent-accent-2" @change="remove(template)" />
+          <AppSwitch
+            :model-value="true"
+            :aria-label="labelFor(template)"
+            @update:model-value="(on) => { if (!on) remove(template) }"
+          />
           <div class="min-w-0 flex-1">
             <div class="truncate text-[12px] text-txt">{{ labelFor(template) }}</div>
             <div class="truncate font-mono text-[10px] text-txt3">{{ template }}</div>

--- a/web/src/components/pm/PmCronJobsPanel.test.ts
+++ b/web/src/components/pm/PmCronJobsPanel.test.ts
@@ -89,11 +89,12 @@ describe('PmCronJobsPanel', () => {
     const w = mountPanel()
     await flushPromises()
     const toggle = w.get('[data-testid="cron-deliver-toggle"]')
-    expect((toggle.element as HTMLInputElement).disabled).toBe(false)
+    expect((toggle.element as HTMLButtonElement).disabled).toBe(false)
+    expect(toggle.attributes('role')).toBe('switch')
     expect(w.text()).toContain('任意已登录用户')
     expect(w.text()).not.toMatch(/修改需平台管理员|但不能修改渠道推送/)
     expect(w.find('.bg-amber-500\\/10').exists()).toBe(false)
-    await toggle.setValue(true)
+    await toggle.trigger('click')
     await flushPromises()
     expect(apiMocks.patchProjectCronJob).toHaveBeenCalledWith('proj-1', 'cron-1', {
       deliverToChannel: true,
@@ -105,8 +106,8 @@ describe('PmCronJobsPanel', () => {
     const w = mountPanel()
     await flushPromises()
     const toggle = w.get('[data-testid="cron-deliver-toggle"]')
-    expect((toggle.element as HTMLInputElement).disabled).toBe(false)
-    await toggle.setValue(true)
+    expect((toggle.element as HTMLButtonElement).disabled).toBe(false)
+    await toggle.trigger('click')
     await flushPromises()
     expect(apiMocks.patchProjectCronJob).toHaveBeenCalledWith('proj-1', 'cron-1', {
       deliverToChannel: true,

--- a/web/src/components/pm/PmCronJobsPanel.vue
+++ b/web/src/components/pm/PmCronJobsPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import AppSwitch from '@/components/ui/AppSwitch.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import StatusPill from '@/components/ui/StatusPill.vue'
 import { api } from '@/lib/api'
@@ -122,13 +123,12 @@ onMounted(() => void load())
                   class="inline-flex items-center gap-2"
                   :title="t('pages.projectDetail.cron.deliverHint')"
                 >
-                  <input
-                    type="checkbox"
-                    class="h-4 w-4"
+                  <AppSwitch
                     data-testid="cron-deliver-toggle"
-                    :checked="job.deliverToChannel"
+                    :model-value="job.deliverToChannel"
                     :disabled="togglingId === job.id || deletingId === job.id"
-                    @change="onDeliverToggle(job, ($event.target as HTMLInputElement).checked)"
+                    :aria-label="t('pages.projectDetail.cron.deliverLabel')"
+                    @update:model-value="onDeliverToggle(job, $event)"
                   />
                   <span class="text-xs text-txt3">{{ t('pages.projectDetail.cron.deliverLabel') }}</span>
                 </label>

--- a/web/src/components/pm/PmSettingsPanel.test.ts
+++ b/web/src/components/pm/PmSettingsPanel.test.ts
@@ -90,8 +90,22 @@ async function mountPanel(
   return w
 }
 
-function cronDeliverCheckbox(w: Awaited<ReturnType<typeof mountPanel>>) {
+function cronDeliverSwitch(w: Awaited<ReturnType<typeof mountPanel>>) {
   return w.find('[data-testid="cron-deliver-enable"]')
+}
+
+async function setSwitch(
+  el: ReturnType<Awaited<ReturnType<typeof mountPanel>>['find']>,
+  on: boolean,
+) {
+  const checked = el.attributes('aria-checked') === 'true'
+  if (checked !== on) await el.trigger('click')
+}
+
+function mcpSwitches(w: Awaited<ReturnType<typeof mountPanel>>) {
+  return ['pm-progress', 'pm-workflow-read', 'pm-workflow-write'].map((id) =>
+    w.get(`[aria-label="${id}"]`),
+  )
 }
 
 describe('PmSettingsPanel enabledMcps', () => {
@@ -108,15 +122,14 @@ describe('PmSettingsPanel enabledMcps', () => {
     const mcpCodes = w.findAll('code').map((c) => c.text())
     expect(mcpCodes).toEqual(['pm-progress', 'pm-workflow-read', 'pm-workflow-write'])
 
-    // The first three checkboxes are the PM MCP toggles; the channel section
-    // renders additional checkboxes after them.
-    const boxes = w.findAll('input[type="checkbox"]')
-    expect(boxes.length).toBeGreaterThanOrEqual(3)
-    expect((boxes[0].element as HTMLInputElement).checked).toBe(true)
-    expect((boxes[1].element as HTMLInputElement).checked).toBe(false)
-    expect((boxes[2].element as HTMLInputElement).checked).toBe(false)
+    // PM MCP toggles are AppSwitch (role=switch); channel section has more switches after them.
+    const boxes = mcpSwitches(w)
+    expect(boxes).toHaveLength(3)
+    expect(boxes[0].attributes('aria-checked')).toBe('true')
+    expect(boxes[1].attributes('aria-checked')).toBe('false')
+    expect(boxes[2].attributes('aria-checked')).toBe('false')
 
-    await boxes[1].trigger('change')
+    await boxes[1].trigger('click')
     const saveBtn = w.find('[data-testid="pm-leader-save"]')
     expect(saveBtn).toBeTruthy()
     await saveBtn!.trigger('click')
@@ -129,20 +142,20 @@ describe('PmSettingsPanel enabledMcps', () => {
   it('defaults all PM mcps when binding omits enabledMcps', async () => {
     const { enabledMcps: _drop, ...rest } = BINDING
     const w = await mountPanel(rest as PmLeaderBinding)
-    const boxes = w.findAll('input[type="checkbox"]')
-    expect((boxes[0].element as HTMLInputElement).checked).toBe(true)
-    expect((boxes[1].element as HTMLInputElement).checked).toBe(true)
-    expect((boxes[2].element as HTMLInputElement).checked).toBe(true)
+    const boxes = mcpSwitches(w)
+    expect(boxes[0].attributes('aria-checked')).toBe('true')
+    expect(boxes[1].attributes('aria-checked')).toBe('true')
+    expect(boxes[2].attributes('aria-checked')).toBe('true')
   })
 
   it('can toggle off a PM mcp and persist only the remaining ids', async () => {
     const w = await mountPanel()
-    const boxes = w.findAll('input[type="checkbox"]')
-    expect((boxes[0].element as HTMLInputElement).checked).toBe(true)
-    expect((boxes[1].element as HTMLInputElement).checked).toBe(true)
-    expect((boxes[2].element as HTMLInputElement).checked).toBe(true)
+    const boxes = mcpSwitches(w)
+    expect(boxes[0].attributes('aria-checked')).toBe('true')
+    expect(boxes[1].attributes('aria-checked')).toBe('true')
+    expect(boxes[2].attributes('aria-checked')).toBe('true')
 
-    await boxes[0].trigger('change') // uncheck pm-progress
+    await boxes[0].trigger('click') // uncheck pm-progress
     const saveBtn = w.find('[data-testid="pm-leader-save"]')
     await saveBtn!.trigger('click')
     await flushPromises()
@@ -156,10 +169,10 @@ describe('PmSettingsPanel enabledMcps', () => {
       ...BINDING,
       enabledMcps: [],
     })
-    const boxes = w.findAll('input[type="checkbox"]')
-    expect((boxes[0].element as HTMLInputElement).checked).toBe(false)
-    expect((boxes[1].element as HTMLInputElement).checked).toBe(false)
-    expect((boxes[2].element as HTMLInputElement).checked).toBe(false)
+    const boxes = mcpSwitches(w)
+    expect(boxes[0].attributes('aria-checked')).toBe('false')
+    expect(boxes[1].attributes('aria-checked')).toBe('false')
+    expect(boxes[2].attributes('aria-checked')).toBe('false')
 
     const saveBtn = w.find('[data-testid="pm-leader-save"]')
     await saveBtn!.trigger('click')
@@ -284,10 +297,10 @@ describe('PmSettingsPanel session capabilities', () => {
     expect(w.text()).toContain('风险提示')
     const mem = w.find('[data-testid="channel-allow-memory-write"]')
     const sch = w.find('[data-testid="channel-allow-scheduler-write"]')
-    expect((mem.element as HTMLInputElement).checked).toBe(false)
-    expect((sch.element as HTMLInputElement).checked).toBe(false)
+    expect(mem.attributes('aria-checked')).toBe('false')
+    expect(sch.attributes('aria-checked')).toBe('false')
 
-    await mem.setValue(true)
+    await setSwitch(mem, true)
     const saveBtns = w.findAll('button').filter((b) => b.text().includes('保存渠道配置'))
     await saveBtns[0].trigger('click')
     await flushPromises()
@@ -300,8 +313,8 @@ describe('PmSettingsPanel session capabilities', () => {
       allowMemoryWrite: true,
       allowSchedulerWrite: false,
     })
-    expect((mem.element as HTMLInputElement).checked).toBe(true)
-    expect((sch.element as HTMLInputElement).checked).toBe(false)
+    expect(mem.attributes('aria-checked')).toBe('true')
+    expect(sch.attributes('aria-checked')).toBe('false')
   })
 
   it('loads saved session caps and keeps sandbox when toggling scheduler write', async () => {
@@ -338,10 +351,10 @@ describe('PmSettingsPanel session capabilities', () => {
 
     const mem = w.find('[data-testid="channel-allow-memory-write"]')
     const sch = w.find('[data-testid="channel-allow-scheduler-write"]')
-    expect((mem.element as HTMLInputElement).checked).toBe(true)
-    expect((sch.element as HTMLInputElement).checked).toBe(false)
+    expect(mem.attributes('aria-checked')).toBe('true')
+    expect(sch.attributes('aria-checked')).toBe('false')
 
-    await sch.setValue(true)
+    await setSwitch(sch, true)
     const saveBtns = w.findAll('button').filter((b) => b.text().includes('保存渠道配置'))
     await saveBtns[0].trigger('click')
     await flushPromises()
@@ -391,7 +404,7 @@ describe('PmSettingsPanel cron deliver target Combobox', () => {
         },
       ],
     })
-    await cronDeliverCheckbox(w).setValue(true)
+    await setSwitch(cronDeliverSwitch(w), true)
     await flushPromises()
     expect(apiMocks.listPmThreads).toHaveBeenCalledTimes(1)
 
@@ -411,9 +424,9 @@ describe('PmSettingsPanel cron deliver target Combobox', () => {
     await flushPromises()
     expect(apiMocks.listPmThreads).toHaveBeenCalledTimes(1)
 
-    await cronDeliverCheckbox(w).setValue(false)
+    await setSwitch(cronDeliverSwitch(w), false)
     await flushPromises()
-    await cronDeliverCheckbox(w).setValue(true)
+    await setSwitch(cronDeliverSwitch(w), true)
     await flushPromises()
     expect(apiMocks.listPmThreads).toHaveBeenCalledTimes(2)
   })
@@ -446,7 +459,7 @@ describe('PmSettingsPanel cron deliver target Combobox', () => {
         },
       ],
     })
-    await cronDeliverCheckbox(w).setValue(true)
+    await setSwitch(cronDeliverSwitch(w), true)
     await flushPromises()
     await w.find('[data-testid="cron-deliver-target-toggle"]').trigger('click')
     await flushPromises()
@@ -514,7 +527,7 @@ describe('PmSettingsPanel cron deliver target Combobox', () => {
     })
     const w = await mountPanel()
     apiMocks.listPmThreads.mockRejectedValue(new Error('network down'))
-    await cronDeliverCheckbox(w).setValue(true)
+    await setSwitch(cronDeliverSwitch(w), true)
     await flushPromises()
     expect(toastMocks.error).toHaveBeenCalled()
     const toastMsg = String(toastMocks.error.mock.calls[0]?.[0] ?? '')
@@ -543,7 +556,7 @@ describe('PmSettingsPanel cron deliver target Combobox', () => {
         },
       ],
     })
-    await cronDeliverCheckbox(w).setValue(true)
+    await setSwitch(cronDeliverSwitch(w), true)
     await flushPromises()
     const input = w.find('[data-testid="cron-deliver-target-input"]')
     const toggle = w.find('[data-testid="cron-deliver-target-toggle"]')

--- a/web/src/components/pm/PmSettingsPanel.vue
+++ b/web/src/components/pm/PmSettingsPanel.vue
@@ -2,6 +2,7 @@
 import { computed, ref, onMounted, onUnmounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import AppButton from '@/components/ui/AppButton.vue'
+import AppSwitch from '@/components/ui/AppSwitch.vue'
 import Icon from '@/components/ui/Icon.vue'
 import { api } from '@/lib/api'
 import {
@@ -205,18 +206,6 @@ const agentOptions = computed((): { name: string; stale: boolean }[] => {
 const aclText = computed(
   () => binding.value?.aclNote || t('pages.projectDetail.pm.aclMemoryNote'),
 )
-
-function toggleEnabled() {
-  if (controlsDisabled.value) return
-  enabled.value = !enabled.value
-}
-
-function onEnableKeydown(e: KeyboardEvent) {
-  if (e.key === 'Enter' || e.key === ' ') {
-    e.preventDefault()
-    toggleEnabled()
-  }
-}
 
 function toggleMcp(id: string) {
   if (controlsDisabled.value) return
@@ -455,28 +444,12 @@ onUnmounted(() => {
               {{ t('pages.projectDetail.pm.enablePermissionHint') }}
             </p>
           </div>
-          <button
-            type="button"
-            role="switch"
-            class="relative h-[22px] w-10 shrink-0 border transition max-sm:self-end disabled:cursor-not-allowed disabled:opacity-45"
-            :class="
-              enabled
-                ? 'border-accent bg-accent'
-                : 'border-line-strong bg-base'
-            "
-            :aria-checked="enabled"
-            :aria-disabled="controlsDisabled ? 'true' : undefined"
-            :aria-label="t('pages.projectDetail.pm.enable')"
+          <AppSwitch
+            v-model="enabled"
+            class="max-sm:self-end"
             :disabled="controlsDisabled"
-            :tabindex="controlsDisabled ? -1 : 0"
-            @click="toggleEnabled"
-            @keydown="onEnableKeydown"
-          >
-            <span
-              class="absolute top-0.5 h-4 w-4 transition-all"
-              :class="enabled ? 'left-[18px] bg-white' : 'left-0.5 bg-txt2'"
-            />
-          </button>
+            :aria-label="t('pages.projectDetail.pm.enable')"
+          />
         </div>
 
         <div>
@@ -523,12 +496,12 @@ onUnmounted(() => {
               class="flex cursor-pointer items-start gap-2.5 text-[13px] text-txt"
               :class="controlsDisabled ? 'cursor-not-allowed opacity-55' : ''"
             >
-              <input
-                type="checkbox"
+              <AppSwitch
                 class="mt-0.5"
-                :checked="enabledMcps.includes(opt.id)"
+                :model-value="enabledMcps.includes(opt.id)"
                 :disabled="controlsDisabled"
-                @change="toggleMcp(opt.id)"
+                :aria-label="opt.id"
+                @update:model-value="toggleMcp(opt.id)"
               />
               <span>
                 <code class="font-mono text-[12px] text-accent-2">{{ opt.id }}</code>
@@ -549,7 +522,10 @@ onUnmounted(() => {
           </div>
 
           <label class="mt-3 flex cursor-pointer items-center gap-2.5 text-[13px] text-txt">
-            <input v-model="chEnabled" type="checkbox" />
+            <AppSwitch
+              v-model="chEnabled"
+              :aria-label="t('pages.projectDetail.pm.channel.enable')"
+            />
             <span>{{ t('pages.projectDetail.pm.channel.enable') }}</span>
           </label>
 
@@ -594,16 +570,19 @@ onUnmounted(() => {
           </div>
 
           <label class="mt-3 flex cursor-pointer items-center gap-2.5 text-[13px] text-txt">
-            <input v-model="chSandbox" type="checkbox" />
+            <AppSwitch
+              v-model="chSandbox"
+              :aria-label="t('pages.projectDetail.pm.channel.sandbox')"
+            />
             <span>{{ t('pages.projectDetail.pm.channel.sandbox') }}</span>
           </label>
 
           <div class="mt-3 border border-line p-3">
             <label class="flex cursor-pointer items-center gap-2.5 text-[13px] text-txt">
-              <input
+              <AppSwitch
                 v-model="chCronDeliver"
-                type="checkbox"
                 data-testid="cron-deliver-enable"
+                :aria-label="t('pages.projectDetail.pm.channel.cronDeliver')"
               />
               <span>{{ t('pages.projectDetail.pm.channel.cronDeliver') }}</span>
             </label>
@@ -700,11 +679,11 @@ onUnmounted(() => {
             <label
               class="mt-2.5 flex cursor-pointer items-start gap-2.5 text-[13px] text-txt select-none"
             >
-              <input
+              <AppSwitch
                 v-model="chAllowMemoryWrite"
-                type="checkbox"
                 class="mt-0.5"
                 data-testid="channel-allow-memory-write"
+                :aria-label="t('pages.projectDetail.pm.channel.allowMemoryWrite')"
               />
               <span>
                 <span class="block text-[13px] text-txt">
@@ -719,11 +698,11 @@ onUnmounted(() => {
             <label
               class="mt-2.5 flex cursor-pointer items-start gap-2.5 text-[13px] text-txt select-none"
             >
-              <input
+              <AppSwitch
                 v-model="chAllowSchedulerWrite"
-                type="checkbox"
                 class="mt-0.5"
                 data-testid="channel-allow-scheduler-write"
+                :aria-label="t('pages.projectDetail.pm.channel.allowSchedulerWrite')"
               />
               <span>
                 <span class="block text-[13px] text-txt">

--- a/web/src/components/ui/AppSwitch.test.ts
+++ b/web/src/components/ui/AppSwitch.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment happy-dom
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import AppSwitch from './AppSwitch.vue'
+
+describe('AppSwitch', () => {
+  it('renders square accent track when on', () => {
+    const w = mount(AppSwitch, { props: { modelValue: true } })
+    const btn = w.get('button[role="switch"]')
+    expect(btn.attributes('aria-checked')).toBe('true')
+    expect(btn.classes().join(' ')).toContain('bg-accent')
+    expect(btn.classes().join(' ')).not.toContain('rounded-full')
+    w.unmount()
+  })
+
+  it('renders off-state track when false', () => {
+    const w = mount(AppSwitch, { props: { modelValue: false } })
+    const btn = w.get('button[role="switch"]')
+    expect(btn.attributes('aria-checked')).toBe('false')
+    expect(btn.classes().join(' ')).toContain('bg-base')
+    w.unmount()
+  })
+
+  it('emits update:modelValue on click and Space/Enter', async () => {
+    const w = mount(AppSwitch, { props: { modelValue: false } })
+    await w.get('button[role="switch"]').trigger('click')
+    expect(w.emitted('update:modelValue')?.[0]).toEqual([true])
+
+    await w.get('button[role="switch"]').trigger('keydown', { key: ' ' })
+    expect(w.emitted('update:modelValue')?.[1]).toEqual([true])
+
+    await w.get('button[role="switch"]').trigger('keydown', { key: 'Enter' })
+    expect(w.emitted('update:modelValue')?.[2]).toEqual([true])
+    w.unmount()
+  })
+
+  it('does not toggle when disabled', async () => {
+    const w = mount(AppSwitch, { props: { modelValue: false, disabled: true } })
+    const btn = w.get('button[role="switch"]')
+    expect(btn.attributes('disabled')).toBeDefined()
+    await btn.trigger('click')
+    expect(w.emitted('update:modelValue')).toBeUndefined()
+    w.unmount()
+  })
+})

--- a/web/src/components/ui/AppSwitch.test.ts
+++ b/web/src/components/ui/AppSwitch.test.ts
@@ -5,10 +5,15 @@ import AppSwitch from './AppSwitch.vue'
 
 describe('AppSwitch', () => {
   it('renders square accent track when on', () => {
-    const w = mount(AppSwitch, { props: { modelValue: true } })
+    const w = mount(AppSwitch, {
+      props: { modelValue: true },
+      attrs: { 'aria-label': 'Enable feature' },
+    })
     const btn = w.get('button[role="switch"]')
     expect(btn.attributes('aria-checked')).toBe('true')
+    expect(btn.attributes('aria-label')).toBe('Enable feature')
     expect(btn.classes().join(' ')).toContain('bg-accent')
+    expect(btn.classes().join(' ')).toContain('rounded-none')
     expect(btn.classes().join(' ')).not.toContain('rounded-full')
     w.unmount()
   })

--- a/web/src/components/ui/AppSwitch.vue
+++ b/web/src/components/ui/AppSwitch.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+/**
+ * Square accent switch (role=switch) — shared boolean control.
+ * On: bg-accent track + white square thumb on the right (attachment style).
+ * Off: border-line-strong / bg-base + thumb on the left (Pm enable semantics).
+ */
+const props = withDefaults(
+  defineProps<{
+    modelValue?: boolean
+    disabled?: boolean
+  }>(),
+  { modelValue: false, disabled: false },
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+}>()
+
+function toggle() {
+  if (props.disabled) return
+  emit('update:modelValue', !props.modelValue)
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault()
+    toggle()
+  }
+}
+</script>
+
+<template>
+  <button
+    type="button"
+    role="switch"
+    class="relative h-[22px] w-10 shrink-0 border transition disabled:cursor-not-allowed disabled:opacity-45"
+    :class="modelValue ? 'border-accent bg-accent' : 'border-line-strong bg-base'"
+    :aria-checked="modelValue"
+    :aria-disabled="disabled ? 'true' : undefined"
+    :disabled="disabled"
+    :tabindex="disabled ? -1 : 0"
+    @click="toggle"
+    @keydown="onKeydown"
+  >
+    <span
+      class="pointer-events-none absolute top-0.5 h-4 w-4 transition-all"
+      :class="modelValue ? 'left-[18px] bg-white' : 'left-0.5 bg-txt2'"
+    />
+  </button>
+</template>

--- a/web/src/components/ui/AppSwitch.vue
+++ b/web/src/components/ui/AppSwitch.vue
@@ -3,6 +3,7 @@
  * Square accent switch (role=switch) — shared boolean control.
  * On: bg-accent track + white square thumb on the right (attachment style).
  * Off: border-line-strong / bg-base + thumb on the left (Pm enable semantics).
+ * Callers pass aria-label / class / data-testid via attribute fallthrough.
  */
 const props = withDefaults(
   defineProps<{
@@ -33,7 +34,7 @@ function onKeydown(e: KeyboardEvent) {
   <button
     type="button"
     role="switch"
-    class="relative h-[22px] w-10 shrink-0 border transition disabled:cursor-not-allowed disabled:opacity-45"
+    class="relative h-[22px] w-10 shrink-0 rounded-none border transition disabled:cursor-not-allowed disabled:opacity-45"
     :class="modelValue ? 'border-accent bg-accent' : 'border-line-strong bg-base'"
     :aria-checked="modelValue"
     :aria-disabled="disabled ? 'true' : undefined"
@@ -43,7 +44,7 @@ function onKeydown(e: KeyboardEvent) {
     @keydown="onKeydown"
   >
     <span
-      class="pointer-events-none absolute top-0.5 h-4 w-4 transition-all"
+      class="pointer-events-none absolute top-0.5 h-4 w-4 rounded-none transition-all"
       :class="modelValue ? 'left-[18px] bg-white' : 'left-0.5 bg-txt2'"
     />
   </button>

--- a/web/src/components/workflow/RunLaunchModal.vue
+++ b/web/src/components/workflow/RunLaunchModal.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import Icon from '@/components/ui/Icon.vue'
 import AppButton from '@/components/ui/AppButton.vue'
 import AppModal from '@/components/ui/AppModal.vue'
+import AppSwitch from '@/components/ui/AppSwitch.vue'
 import ParagraphInput from '@/components/ui/ParagraphInput.vue'
 import ArtifactLoadingPane from '@/components/run/ArtifactLoadingPane.vue'
 import ReposEditor, { type RepoRow } from '@/components/ReposEditor.vue'
@@ -215,17 +216,9 @@ function boolDisplayValue(key: string): 'true' | 'false' {
   return boolIsOn(key) ? 'true' : 'false'
 }
 
-function toggleBoolField(f: InputField) {
+function setBoolField(f: InputField, on: boolean) {
   if (f.editable === false) return
-  props.runInputs[f.key] = boolIsOn(f.key) ? 'false' : 'true'
-}
-
-function onBoolKeydown(e: KeyboardEvent, f: InputField) {
-  if (f.editable === false) return
-  if (e.key === ' ' || e.key === 'Enter') {
-    e.preventDefault()
-    toggleBoolField(f)
-  }
+  props.runInputs[f.key] = on ? 'true' : 'false'
 }
 
 async function startRun() {
@@ -326,24 +319,15 @@ async function startRun() {
           </select>
           <div
             v-else-if="f.type === 'bool'"
-            role="switch"
-            :aria-checked="boolIsOn(f.key)"
-            :aria-disabled="f.editable === false ? 'true' : undefined"
-            :tabindex="f.editable === false ? undefined : 0"
-            class="flex w-fit cursor-pointer select-none items-center gap-2.5"
-            :class="{ 'pointer-events-none opacity-60': f.editable === false }"
-            @click="toggleBoolField(f)"
-            @keydown="onBoolKeydown($event, f)"
+            class="flex w-fit select-none items-center gap-2.5"
+            :class="{ 'opacity-60': f.editable === false }"
           >
-            <span
-              class="relative h-5 w-9 shrink-0 transition"
-              :class="boolIsOn(f.key) ? 'bg-accent' : 'bg-line-strong'"
-            >
-              <span
-                class="absolute top-0.5 h-4 w-4 bg-white transition-all"
-                :class="boolIsOn(f.key) ? 'left-[18px]' : 'left-0.5'"
-              />
-            </span>
+            <AppSwitch
+              :model-value="boolIsOn(f.key)"
+              :disabled="f.editable === false"
+              :aria-label="f.desc || f.key"
+              @update:model-value="setBoolField(f, $event)"
+            />
             <span class="font-mono text-[12px] text-txt2">{{ boolDisplayValue(f.key) }}</span>
           </div>
           <input


### PR DESCRIPTION
## Summary
- Add shared square `AppSwitch` (right-angle track, accent on-state, white square thumb) and replace in-scope boolean checkboxes/rounded switches across approving/web.
- Keep existing business behavior (including OutputSourcesEditor remove-on-off) and a11y (`role=switch`, keyboard, aria-checked).
- Sync affected unit/E2E tests; merge `origin/main` into the feature branch before open.

## Test plan
- [x] vitest: AppSwitch + affected panels (48 passed)
- [x] playwright: agent-studio-mobile-data (4 passed)
- [x] Confirm no `input[type=checkbox]` boolean controls remain under `web/src`
- [ ] Smoke UI: open/close AppSwitch on Pm/Agent settings and OutputSourcesEditor