### PR TITLE
fix(web): Token 统计 / 项目详情 Tab 窄屏布局修复

### DIFF
--- a/web/src/components/board/token-stats/TokenCharts.test.ts
+++ b/web/src/components/board/token-stats/TokenCharts.test.ts
@@ -84,6 +84,20 @@ describe('Token charts (g2.3/g2.4)', () => {
     wrapper.unmount()
   })
 
+  it('trend wrap uses min-w-0 + overflow-x-clip to prevent Chart.js flex overflow (g3.1)', () => {
+    const wrapper = mount(TokenTrendChart, {
+      props: {
+        bucketWidth: 'day',
+        trend: sampleTrend(7),
+      },
+      global: { plugins: [i18n()] },
+    })
+    const wrap = wrapper.find('[data-testid="token-trend-wrap"]')
+    expect(wrap.classes()).toEqual(expect.arrayContaining(['min-w-0', 'overflow-x-clip', 'w-full']))
+    expect((wrap.element as HTMLElement).style.height).toBe('200px')
+    wrapper.unmount()
+  })
+
   it('maps 30-day labels with tick thinning options (maxTicksLimit≈8) (g2.2)', () => {
     const wrapper = mount(TokenTrendChart, {
       props: {
@@ -127,6 +141,28 @@ describe('Token charts (g2.3/g2.4)', () => {
     expect(wrapper.find('[data-testid="token-donut-svg"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="token-donut-legend"]').text()).toContain('input')
     expect(wrapper.text()).toContain('总量')
+    wrapper.unmount()
+  })
+
+  it('narrow donut stacks ring above legend and shrinks ring (~120px) (g4.1/g4.2)', () => {
+    const wrapper = mount(TokenDonutChart, {
+      props: {
+        composition: {
+          inputTokens: 70,
+          outputTokens: 55,
+          cacheReadTokens: 35,
+          cacheWriteTokens: 20,
+          total: 180,
+        },
+      },
+      global: { plugins: [i18n()] },
+    })
+    const row = wrapper.find('[data-testid="token-donut-row"]')
+    expect(row.classes()).toEqual(expect.arrayContaining(['flex-col', 'sm:flex-row']))
+    const svg = wrapper.find('[data-testid="token-donut-svg"]')
+    expect(svg.classes()).toEqual(expect.arrayContaining(['h-[120px]', 'w-[120px]', 'sm:h-[150px]', 'sm:w-[150px]']))
+    const legend = wrapper.find('[data-testid="token-donut-legend"]')
+    expect(legend.classes()).toEqual(expect.arrayContaining(['w-full']))
     wrapper.unmount()
   })
 

--- a/web/src/components/board/token-stats/TokenDonutChart.vue
+++ b/web/src/components/board/token-stats/TokenDonutChart.vue
@@ -113,10 +113,13 @@ const tipPart = computed(() => parts.value.find((p) => p.key === tip.value.key) 
 </script>
 
 <template>
-  <div data-testid="token-donut-row" class="token-donut-row relative flex min-h-[180px] items-center gap-4">
+  <div
+    data-testid="token-donut-row"
+    class="token-donut-row relative flex min-h-[180px] flex-col items-center gap-4 sm:flex-row sm:items-center"
+  >
     <svg
       data-testid="token-donut-svg"
-      class="h-[150px] w-[150px] shrink-0"
+      class="h-[120px] w-[120px] shrink-0 sm:h-[150px] sm:w-[150px]"
       viewBox="0 0 120 120"
       role="img"
       :aria-label="t('pages.board.tokenStats.compositionTitle')"
@@ -140,7 +143,7 @@ const tipPart = computed(() => parts.value.find((p) => p.key === tip.value.key) 
         {{ fmtCompactTokenCount(composition.total) }}
       </text>
     </svg>
-    <ul data-testid="token-donut-legend" class="m-0 grid min-w-0 flex-1 list-none gap-2 p-0">
+    <ul data-testid="token-donut-legend" class="m-0 grid w-full min-w-0 list-none gap-2 p-0 sm:flex-1">
       <li
         v-for="p in parts"
         :key="p.key"

--- a/web/src/components/board/token-stats/TokenStatsPanel.test.ts
+++ b/web/src/components/board/token-stats/TokenStatsPanel.test.ts
@@ -99,6 +99,34 @@ describe('TokenStatsPanel', () => {
     wrapper.unmount()
   })
 
+  it('narrow layout: head stacks, windows ~44px touch, panel clips overflow (g2.1/g2.2/g3.2)', async () => {
+    getProjectTokenStats.mockResolvedValue(sampleStats())
+    const wrapper = mountPanel()
+    await flushPromises()
+
+    const panel = wrapper.find('[data-testid="token-stats-panel"]')
+    expect(panel.classes()).toEqual(expect.arrayContaining(['min-w-0', 'overflow-x-clip']))
+
+    const head = wrapper.find('[data-testid="token-stats-head"]')
+    expect(head.classes()).toEqual(expect.arrayContaining(['flex-col']))
+    expect(head.classes()).toEqual(expect.arrayContaining(['md:flex-row']))
+
+    const winBtn = wrapper.find('[data-testid="token-stats-window-7d"]')
+    expect(winBtn.classes()).toEqual(expect.arrayContaining(['min-h-11']))
+
+    const trendCard = wrapper.find('[data-testid="token-stats-trend-card"]')
+    expect(trendCard.classes()).toEqual(expect.arrayContaining(['min-w-0', 'overflow-x-clip']))
+
+    // Stack order: trend → composition → rank (g4.2)
+    const trendEl = trendCard.element as HTMLElement
+    const compEl = wrapper.find('[data-testid="token-stats-comp-card"]').element as HTMLElement
+    const rankEl = wrapper.find('[data-testid="token-stats-rank-card"]').element as HTMLElement
+    expect(trendEl.compareDocumentPosition(compEl) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(compEl.compareDocumentPosition(rankEl) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+
+    wrapper.unmount()
+  })
+
   it('shows empty state when API reports empty (g2.5 null≠0)', async () => {
     getProjectTokenStats.mockResolvedValue(sampleStats({ empty: true, trend: [], workflows: [] }))
     const wrapper = mountPanel()

--- a/web/src/components/board/token-stats/TokenStatsPanel.vue
+++ b/web/src/components/board/token-stats/TokenStatsPanel.vue
@@ -100,10 +100,13 @@ onUnmounted(() => {
 <template>
   <section
     data-testid="token-stats-panel"
-    class="token-stats-panel mb-4"
+    class="token-stats-panel mb-4 min-w-0 overflow-x-clip"
     aria-labelledby="token-stats-heading"
   >
-    <div class="mb-3 flex flex-wrap items-center justify-between gap-3">
+    <div
+      data-testid="token-stats-head"
+      class="mb-3 flex flex-col items-stretch gap-3 md:flex-row md:flex-wrap md:items-center md:justify-between"
+    >
       <h3 id="token-stats-heading" class="m-0 flex items-center gap-2 text-sm font-semibold text-txt">
         {{ t('pages.board.tokenStats.title') }}
         <span
@@ -114,7 +117,7 @@ onUnmounted(() => {
         </span>
       </h3>
       <div
-        class="flex flex-wrap gap-1.5 rounded-[10px] bg-elevated p-0.5"
+        class="flex flex-wrap gap-2 rounded-[10px] bg-elevated p-0.5"
         role="tablist"
         :aria-label="t('pages.board.tokenStats.windowAria')"
         data-testid="token-stats-windows"
@@ -124,7 +127,7 @@ onUnmounted(() => {
           :key="w"
           type="button"
           role="tab"
-          class="rounded-lg border-0 px-2.5 py-1.5 text-xs transition"
+          class="min-h-11 rounded-lg border-0 px-3 py-2.5 text-sm transition md:min-h-0 md:px-2.5 md:py-1.5 md:text-xs"
           :class="
             windowSel === w
               ? 'bg-surface font-semibold text-txt shadow-sm'
@@ -171,7 +174,7 @@ onUnmounted(() => {
       data-testid="token-stats-empty"
       class="grid gap-3"
     >
-      <div class="relative min-h-[200px] rounded-xl border border-line bg-surface p-3.5">
+      <div class="relative min-h-[200px] min-w-0 overflow-x-clip rounded-xl border border-line bg-surface p-3.5">
         <div class="mb-2 flex items-baseline justify-between gap-2">
           <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.board.tokenStats.trendTitle') }}</h4>
           <span class="text-[11px] text-txt3">{{ grainLabel }}</span>
@@ -181,8 +184,8 @@ onUnmounted(() => {
           <span class="max-w-[28ch] text-xs text-txt3">{{ t('pages.board.tokenStats.emptyTrendHint') }}</span>
         </div>
       </div>
-      <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
-        <div class="relative min-h-[200px] rounded-xl border border-line bg-surface p-3.5">
+      <div class="grid min-w-0 grid-cols-1 gap-3 md:grid-cols-2">
+        <div class="relative min-h-[200px] min-w-0 rounded-xl border border-line bg-surface p-3.5">
           <div class="mb-2 flex items-baseline justify-between gap-2">
             <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.board.tokenStats.compositionTitle') }}</h4>
           </div>
@@ -191,7 +194,7 @@ onUnmounted(() => {
             <span class="max-w-[28ch] text-xs text-txt3">{{ t('pages.board.tokenStats.emptyCompHint') }}</span>
           </div>
         </div>
-        <div class="relative min-h-[200px] rounded-xl border border-line bg-surface p-3.5">
+        <div class="relative min-h-[200px] min-w-0 rounded-xl border border-line bg-surface p-3.5">
           <div class="mb-2 flex items-baseline justify-between gap-2">
             <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.board.tokenStats.rankTitle') }}</h4>
             <span class="text-[11px] text-txt3">{{ t('pages.board.tokenStats.rankSub') }}</span>
@@ -206,15 +209,18 @@ onUnmounted(() => {
 
     <!-- Ready charts -->
     <div v-else-if="data" data-testid="token-stats-charts" class="grid gap-3">
-      <div class="rounded-xl border border-line bg-surface p-3.5" data-testid="token-stats-trend-card">
+      <div
+        class="min-w-0 overflow-x-clip rounded-xl border border-line bg-surface p-3.5"
+        data-testid="token-stats-trend-card"
+      >
         <div class="mb-2 flex items-baseline justify-between gap-2">
           <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.board.tokenStats.trendTitle') }}</h4>
           <span class="text-[11px] text-txt3">{{ grainLabel }}</span>
         </div>
         <TokenTrendChart :trend="data.trend" :bucket-width="data.bucketWidth" />
       </div>
-      <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
-        <div class="rounded-xl border border-line bg-surface p-3.5" data-testid="token-stats-comp-card">
+      <div class="grid min-w-0 grid-cols-1 gap-3 md:grid-cols-2">
+        <div class="min-w-0 rounded-xl border border-line bg-surface p-3.5" data-testid="token-stats-comp-card">
           <div class="mb-2 flex items-baseline justify-between gap-2">
             <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.board.tokenStats.compositionTitle') }}</h4>
             <span class="text-[11px] text-txt3">
@@ -223,7 +229,7 @@ onUnmounted(() => {
           </div>
           <TokenDonutChart :composition="data.composition" />
         </div>
-        <div class="rounded-xl border border-line bg-surface p-3.5" data-testid="token-stats-rank-card">
+        <div class="min-w-0 rounded-xl border border-line bg-surface p-3.5" data-testid="token-stats-rank-card">
           <div class="mb-2 flex items-baseline justify-between gap-2">
             <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.board.tokenStats.rankTitle') }}</h4>
             <span class="text-[11px] text-txt3">{{ t('pages.board.tokenStats.rankSub') }}</span>

--- a/web/src/components/board/token-stats/TokenTrendChart.vue
+++ b/web/src/components/board/token-stats/TokenTrendChart.vue
@@ -151,7 +151,7 @@ defineExpose({ chartOptions, chartData })
 <template>
   <div
     data-testid="token-trend-wrap"
-    class="token-trend-wrap relative w-full"
+    class="token-trend-wrap relative w-full min-w-0 overflow-x-clip"
     :style="{ height: `${CHART_HEIGHT_PX}px` }"
     role="img"
     :aria-label="t('pages.board.tokenStats.trendTitle')"

--- a/web/src/views/BoardView.vue
+++ b/web/src/views/BoardView.vue
@@ -120,7 +120,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div data-testid="board-view">
+  <div data-testid="board-view" class="min-w-0">
     <div v-if="!embedded" class="mb-5 flex flex-wrap items-start justify-between gap-4">
       <div>
         <h2 class="text-lg font-semibold text-txt">{{ t('pages.board.title') }}</h2>

--- a/web/src/views/ProjectDetailView.pmSettings.test.ts
+++ b/web/src/views/ProjectDetailView.pmSettings.test.ts
@@ -148,6 +148,24 @@ describe('ProjectDetailView PM Leader settings inline', () => {
     vi.clearAllMocks()
   })
 
+  it('tabs use single-row horizontal scroll with ~44px touch targets (g1.1/g1.2/g1.3)', async () => {
+    const { wrapper } = await mountDetail('board')
+    const tabs = wrapper.find('[data-testid="project-detail-tabs"]')
+    expect(tabs.exists()).toBe(true)
+    expect(tabs.classes()).toEqual(
+      expect.arrayContaining(['flex-nowrap', 'overflow-x-auto', 'overflow-y-hidden']),
+    )
+    expect(tabs.classes()).not.toContain('flex-wrap')
+
+    const boardTab = wrapper.find('[data-testid="project-tab-board"]')
+    expect(boardTab.classes()).toEqual(
+      expect.arrayContaining(['min-h-11', 'shrink-0', 'whitespace-nowrap', 'border-b-2']),
+    )
+    // Desktop selected underline style preserved
+    expect(boardTab.classes()).toEqual(expect.arrayContaining(['border-accent']))
+    expect(wrapper.find('[data-testid="project-board-panel"]').classes()).toContain('min-w-0')
+  })
+
   it('hides top-bar pmSettings and pmMemory tabs while keeping cron', async () => {
     const { wrapper } = await mountDetail('pmLeader')
     const tabIds = wrapper

--- a/web/src/views/ProjectDetailView.vue
+++ b/web/src/views/ProjectDetailView.vue
@@ -695,12 +695,15 @@ onUnmounted(() => {
     </div>
 
     <template v-if="project">
-      <div class="mb-4 flex shrink-0 flex-wrap gap-1 border-b border-line" data-testid="project-detail-tabs">
+      <div
+        class="scroll-area mb-4 flex shrink-0 flex-nowrap gap-1 overflow-x-auto overflow-y-hidden border-b border-line [-webkit-overflow-scrolling:touch]"
+        data-testid="project-detail-tabs"
+      >
         <button
           v-for="tb in tabs"
           :key="tb.id"
           type="button"
-          class="border-b-2 px-3 py-2 text-sm transition"
+          class="min-h-11 shrink-0 whitespace-nowrap border-b-2 px-3 py-2.5 text-sm transition"
           :class="
             tab === tb.id
               ? 'border-accent text-accent-2'
@@ -737,7 +740,7 @@ onUnmounted(() => {
         </div>
       </div>
 
-      <div v-if="tab === 'board'" data-testid="project-board-panel">
+      <div v-if="tab === 'board'" class="min-w-0" data-testid="project-board-panel">
         <BoardView :project-id="projectId" embedded />
       </div>
 


### PR DESCRIPTION
## Summary
- ProjectDetailView 顶栏 Tab 改为单行横滑（`flex-nowrap` + `overflow-x-auto`）并加大至 `min-h-11`，保留 `border-b-2` 选中态
- TokenStatsPanel：标题与时间窗窄屏分行、窗口按钮 `min-h-11`；Panel/Trend 补 `min-w-0` + `overflow-x-clip` 防止 Chart.js 横撑
- TokenDonutChart：窄屏环上图例下、环径约 120px；md 双列与桌面横向布局不回退
- vitest 锁定 Tab/时间窗/Trend/Donut 布局类（plan g1–g5）

## Test plan
- [x] `npx vitest run` TokenStatsPanel / TokenCharts / ProjectDetailView.pmSettings
- [ ] 约 390px：项目详情 → 看板，确认无页面横撑、趋势无内部横滚
- [ ] 窄屏横滑可访问全部 Tab；时间窗四档可点
- [ ] 三图顺序趋势 → 构成 → Top10；构成环上图例下
- [ ] 桌面 Tab 下划线与 md 双列观感不回退


Made with [Cursor](https://cursor.com)