### PR TITLE
fix(web): sandbox copy works on HTTP/intranet

### DIFF
--- a/web/src/lib/copyToClipboard.test.ts
+++ b/web/src/lib/copyToClipboard.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { copyToClipboard } from './copyToClipboard'
+
+describe('copyToClipboard', () => {
+  let originalIsSecureContext: PropertyDescriptor | undefined
+  let originalClipboard: PropertyDescriptor | undefined
+  let execCommand: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    originalIsSecureContext = Object.getOwnPropertyDescriptor(window, 'isSecureContext')
+    originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+    execCommand = vi.fn().mockReturnValue(true)
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      writable: true,
+      value: execCommand,
+    })
+  })
+
+  afterEach(() => {
+    if (originalIsSecureContext) {
+      Object.defineProperty(window, 'isSecureContext', originalIsSecureContext)
+    }
+    if (originalClipboard) {
+      Object.defineProperty(navigator, 'clipboard', originalClipboard)
+    } else {
+      // @ts-expect-error restore undefined clipboard in happy-dom
+      delete navigator.clipboard
+    }
+    vi.restoreAllMocks()
+  })
+
+  function stubSecureContext(value: boolean) {
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      get: () => value,
+    })
+  }
+
+  function stubClipboard(writeText: ((text: string) => Promise<void>) | undefined) {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: writeText ? { writeText } : undefined,
+    })
+  }
+
+  it('secure context: writeText resolves → true and does not call execCommand', async () => {
+    stubSecureContext(true)
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    stubClipboard(writeText)
+
+    await expect(copyToClipboard('hello')).resolves.toBe(true)
+    expect(writeText).toHaveBeenCalledWith('hello')
+    expect(execCommand).not.toHaveBeenCalled()
+  })
+
+  it('non-secure context: skips API and uses legacy copy', async () => {
+    stubSecureContext(false)
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    stubClipboard(writeText)
+    execCommand.mockReturnValue(true)
+
+    await expect(copyToClipboard('192.168.2.182:8765')).resolves.toBe(true)
+    expect(writeText).not.toHaveBeenCalled()
+    expect(execCommand).toHaveBeenCalledWith('copy')
+  })
+
+  it('missing clipboard: falls back to execCommand', async () => {
+    stubSecureContext(true)
+    stubClipboard(undefined)
+    execCommand.mockReturnValue(true)
+
+    await expect(copyToClipboard('/sandbox/proxy/80/')).resolves.toBe(true)
+    expect(execCommand).toHaveBeenCalledWith('copy')
+  })
+
+  it('secure context: writeText rejects then legacy succeeds → true', async () => {
+    stubSecureContext(true)
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    stubClipboard(writeText)
+    execCommand.mockReturnValue(true)
+
+    await expect(copyToClipboard('fallback-ok')).resolves.toBe(true)
+    expect(writeText).toHaveBeenCalled()
+    expect(execCommand).toHaveBeenCalledWith('copy')
+  })
+
+  it('both paths fail → false', async () => {
+    stubSecureContext(true)
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    stubClipboard(writeText)
+    execCommand.mockReturnValue(false)
+
+    await expect(copyToClipboard('nope')).resolves.toBe(false)
+    expect(writeText).toHaveBeenCalled()
+    expect(execCommand).toHaveBeenCalledWith('copy')
+  })
+
+  it('non-secure context and execCommand fails → false', async () => {
+    stubSecureContext(false)
+    stubClipboard(undefined)
+    execCommand.mockReturnValue(false)
+
+    await expect(copyToClipboard('nope')).resolves.toBe(false)
+    expect(execCommand).toHaveBeenCalledWith('copy')
+  })
+})

--- a/web/src/lib/copyToClipboard.ts
+++ b/web/src/lib/copyToClipboard.ts
@@ -1,0 +1,51 @@
+/**
+ * Copy text to the system clipboard.
+ *
+ * - Secure context (HTTPS / localhost): prefer Clipboard API; on failure, fall back.
+ * - Non-secure context (e.g. http://intranet-IP): skip the API and use legacy
+ *   textarea + execCommand('copy') in the same user-gesture stack.
+ *
+ * Returns true on success, false when both paths fail. Never throws to the UI.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  const value = String(text ?? '')
+
+  if (typeof window !== 'undefined' && window.isSecureContext) {
+    const writeText = navigator.clipboard?.writeText
+    if (typeof writeText === 'function') {
+      try {
+        await writeText.call(navigator.clipboard, value)
+        return true
+      } catch {
+        // fall through to legacy
+      }
+    }
+  }
+
+  return legacyCopy(value)
+}
+
+function legacyCopy(text: string): boolean {
+  if (typeof document === 'undefined') return false
+  try {
+    const ta = document.createElement('textarea')
+    ta.value = text
+    ta.setAttribute('readonly', '')
+    ta.style.cssText = 'position:fixed;left:-9999px;top:0;opacity:0;'
+    document.body.appendChild(ta)
+    ta.focus()
+    ta.select()
+    ta.setSelectionRange(0, text.length)
+    let ok = false
+    try {
+      ok = document.execCommand('copy')
+    } catch {
+      ok = false
+    } finally {
+      ta.remove()
+    }
+    return !!ok
+  } catch {
+    return false
+  }
+}

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -162,6 +162,7 @@
       "copied": "Copied as \"{name}\"",
       "pathCopied": "Path copied: {path}",
       "copyPathFailed": "Copy failed",
+      "copyFailed": "Copy failed",
       "importedFiles": "Imported {count} file(s) into {dir}"
     },
     "action": "Action",

--- a/web/src/locales/zh-CN/common.json
+++ b/web/src/locales/zh-CN/common.json
@@ -162,6 +162,7 @@
       "copied": "已复制为「{name}」",
       "pathCopied": "已复制路径：{path}",
       "copyPathFailed": "复制失败",
+      "copyFailed": "复制失败",
       "importedFiles": "已从文件夹导入 {count} 个文件到 {dir}"
     },
     "action": "动作",

--- a/web/src/views/SandboxConsoleView.vue
+++ b/web/src/views/SandboxConsoleView.vue
@@ -8,10 +8,13 @@ import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import '@xterm/xterm/css/xterm.css'
 import { api, type SandboxView } from '@/lib/api'
+import { copyToClipboard } from '@/lib/copyToClipboard'
+import { useToast } from '@/lib/useToast'
 
 const route = useRoute()
 const router = useRouter()
 const { t } = useI18n()
+const toast = useToast()
 const id = Number(route.params.id)
 
 const CONSOLE_TABS = ['terminal', 'ide', 'acp', 'novnc', 'log'] as const
@@ -51,13 +54,13 @@ const passwordCopied = ref(false)
 async function copyPassword() {
   const pw = sandbox.value?.password
   if (!pw) return
-  try {
-    await navigator.clipboard.writeText(pw)
-    passwordCopied.value = true
-    window.setTimeout(() => { passwordCopied.value = false }, 1500)
-  } catch {
-    /* ignore */
+  const ok = await copyToClipboard(pw)
+  if (!ok) {
+    toast.error(t('common.toast.copyFailed'))
+    return
   }
+  passwordCopied.value = true
+  window.setTimeout(() => { passwordCopied.value = false }, 1500)
 }
 
 // Raw container logs (docker logs): live while running, else archived snapshot.

--- a/web/src/views/SandboxListView.vue
+++ b/web/src/views/SandboxListView.vue
@@ -6,7 +6,9 @@ import Icon from '@/components/ui/Icon.vue'
 import AppButton from '@/components/ui/AppButton.vue'
 import AppModal from '@/components/ui/AppModal.vue'
 import { api, type SandboxView } from '@/lib/api'
+import { copyToClipboard } from '@/lib/copyToClipboard'
 import { useBreakpoint } from '@/lib/useBreakpoint'
+import { useToast } from '@/lib/useToast'
 
 const SKELETON_ROWS = 6
 const SKELETON_CARDS = 4
@@ -17,6 +19,7 @@ let hasInitialLoaded = false
 
 const router = useRouter()
 const { t } = useI18n()
+const toast = useToast()
 const { isMobile } = useBreakpoint()
 const rows = ref<SandboxView[]>([])
 const loading = ref(false)
@@ -205,29 +208,29 @@ function closeDetail() {
 }
 
 async function copyText(key: string, text: string) {
-  try {
-    await navigator.clipboard.writeText(text)
-    copiedKey.value = key
-    if (detailCopiedTimer) window.clearTimeout(detailCopiedTimer)
-    detailCopiedTimer = window.setTimeout(() => {
-      if (copiedKey.value === key) copiedKey.value = ''
-    }, 1200)
-  } catch {
-    /* clipboard unavailable */
+  const ok = await copyToClipboard(text)
+  if (!ok) {
+    toast.error(t('common.toast.copyFailed'))
+    return
   }
+  copiedKey.value = key
+  if (detailCopiedTimer) window.clearTimeout(detailCopiedTimer)
+  detailCopiedTimer = window.setTimeout(() => {
+    if (copiedKey.value === key) copiedKey.value = ''
+  }, 1200)
 }
 
 async function copySandboxId(s: SandboxView) {
-  try {
-    await navigator.clipboard.writeText(String(s.id))
-    copiedId.value = s.id
-    if (copiedTimer) window.clearTimeout(copiedTimer)
-    copiedTimer = window.setTimeout(() => {
-      if (copiedId.value === s.id) copiedId.value = null
-    }, 1500)
-  } catch {
-    /* clipboard unavailable */
+  const ok = await copyToClipboard(String(s.id))
+  if (!ok) {
+    toast.error(t('common.toast.copyFailed'))
+    return
   }
+  copiedId.value = s.id
+  if (copiedTimer) window.clearTimeout(copiedTimer)
+  copiedTimer = window.setTimeout(() => {
+    if (copiedId.value === s.id) copiedId.value = null
+  }, 1500)
 }
 
 async function stop(s: SandboxView) {


### PR DESCRIPTION
## Summary
- Add reusable `copyToClipboard` helper: secure context prefers Clipboard API; non-secure (HTTP/intranet) skips API and uses textarea + `execCommand('copy')` in the same gesture stack; returns `Promise<boolean>` without throwing.
- Wire `SandboxListView` (detail proxy URL / ENDPOINTS / copy ID) and `SandboxConsoleView` (copy password) to the helper: success keeps inline「已复制」; failure shows Toast `common.toast.copyFailed`（复制失败 / Copy failed）— no silent catch.
- Colocated vitest covers secure success (no fallback), non-secure / API reject → fallback success, and dual failure → false.

**Coverage (this PR only):** `SandboxListView` + `SandboxConsoleView`. Out of scope (unchanged): `ArtifactPreview`, `PmLeaderChat`, `WorkflowApiTab`, `AgentStudioView`.

## Test plan
- [x] `npm test -- --run src/lib/copyToClipboard.test.ts` (6 cases green)
- [ ] Manual: open sandboxes over `http://内网IP`, click detail「复制」on proxy path and `host:port` — clipboard gets text, button shows「已复制」
- [ ] Manual: HTTPS/localhost — Clipboard API path succeeds without unnecessary fallback
- [ ] Force dual failure (if possible) — Toast「复制失败」/「Copy failed」, button does not enter「已复制」
- [ ] Console copy password: success inline; failure Toast does not leak password plaintext


Made with [Cursor](https://cursor.com)