### PR TITLE
fix(docs): Approve Demo 框选左上→右下与 NW 指针

### DIFF
--- a/docs/site/css/home.css
+++ b/docs/site/css/home.css
@@ -1565,7 +1565,7 @@
 .demo-marquee {
   position: absolute;
   left: 52%;
-  bottom: 12%;
+  top: 70%; /* ≈ 100% − 12% − 18%: grow top-left → bottom-right (was bottom:12%) */
   width: 0;
   height: 0;
   border: 2px solid #ef4444;
@@ -2012,8 +2012,8 @@ html:lang(en) .demo-marquee::after {
 
 .demo-cursor {
   position: absolute;
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 20px;
   left: 0;
   top: 0;
   z-index: 9;
@@ -2022,18 +2022,21 @@ html:lang(en) .demo-marquee::after {
   transition: left 0.5s cubic-bezier(0.22, 0.8, 0.28, 1), top 0.5s cubic-bezier(0.22, 0.8, 0.28, 1), opacity 0.2s ease;
 }
 
+/* Standard OS-style NW arrow (hotspot = tip at left/top); pure CSS, no extra DOM */
 .demo-cursor::before {
   content: "";
   position: absolute;
-  border-style: solid;
-  border-width: 0 0 16px 12px;
-  border-color: transparent transparent transparent currentColor;
-  color: #18181b;
+  left: 0;
+  top: 0;
+  width: 16px;
+  height: 20px;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 20'%3E%3Cpath d='M1 1 L1 16 L5.2 12.4 L8.2 19 L10.4 18 L7.4 11.4 L13 11.4 Z' fill='%23111' stroke='%23fff' stroke-width='1.2' stroke-linejoin='round'/%3E%3C/svg%3E") no-repeat 0 0 / 16px 20px;
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
 }
 
+/* Dark panels: light fill + dark stroke for contrast */
 .panel:not(.panel--light) .demo-cursor::before {
-  color: #ededf0;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 20'%3E%3Cpath d='M1 1 L1 16 L5.2 12.4 L8.2 19 L10.4 18 L7.4 11.4 L13 11.4 Z' fill='%23ededf0' stroke='%23181b1f' stroke-width='1.2' stroke-linejoin='round'/%3E%3C/svg%3E");
 }
 
 .demo-cursor.is-visible { opacity: 1; }

--- a/docs/site/js/home.js
+++ b/docs/site/js/home.js
@@ -304,6 +304,51 @@
     cursor.classList.add("is-visible");
   }
 
+  function placeCursorAt(stage, cursor, x, y) {
+    if (!cursor || !stage) return;
+    cursor.style.left = `${x}px`;
+    cursor.style.top = `${y}px`;
+    cursor.classList.add("is-visible");
+  }
+
+  /** Marquee final box in stage coords: left 52% / top 70% / w 42% / h 18% of .demo-ui */
+  function marqueeBoxInStage(stage, ui) {
+    const sr = stage.getBoundingClientRect();
+    const ur = ui.getBoundingClientRect();
+    const left = ur.left - sr.left;
+    const top = ur.top - sr.top;
+    return {
+      x0: left + ur.width * 0.52,
+      y0: top + ur.height * 0.7,
+      x1: left + ur.width * (0.52 + 0.42),
+      y1: top + ur.height * (0.7 + 0.18),
+    };
+  }
+
+  function animateCursorTo(cursor, x1, y1, duration) {
+    return new Promise((resolve) => {
+      const x0 = parseFloat(cursor.style.left) || 0;
+      const y0 = parseFloat(cursor.style.top) || 0;
+      const prev = cursor.style.transition;
+      cursor.style.transition = "none";
+      let start = null;
+      function frame(t) {
+        if (start === null) start = t;
+        const p = Math.min(1, (t - start) / duration);
+        const e = 1 - Math.pow(1 - p, 3);
+        cursor.style.left = `${x0 + (x1 - x0) * e}px`;
+        cursor.style.top = `${y0 + (y1 - y0) * e}px`;
+        if (p < 1) {
+          requestAnimationFrame(frame);
+        } else {
+          cursor.style.transition = prev;
+          resolve();
+        }
+      }
+      requestAnimationFrame(frame);
+    });
+  }
+
   function hideCursor(cursor) {
     cursor?.classList.remove("is-visible", "is-click");
   }
@@ -665,14 +710,22 @@
 
       if (caption) caption.textContent = COPY.capApproveAnnotate;
       const target = within(root, "[data-annotate-target]");
-      if (target && cursor && stage) {
-        moveCursor(stage, cursor, target);
-        await sleep(450);
+      const demoUi = target?.closest(".demo-ui") || within(root, '[data-demo-case="reject"]');
+      if (target && cursor && stage && demoUi) {
+        /* Frame-select path: NW tip at marquee top-left → drag to bottom-right with is-show (no is-click) */
+        const box = marqueeBoxInStage(stage, demoUi);
+        const prevTransition = cursor.style.transition;
+        cursor.style.transition = "none";
+        placeCursorAt(stage, cursor, box.x0 - 28, box.y0 - 24);
+        void cursor.offsetWidth;
+        cursor.style.transition = prevTransition;
+        await animateCursorTo(cursor, box.x0, box.y0, 380);
+        await sleep(120);
         if (signal.aborted) break;
         marquee?.classList.add("is-show");
-        cursor.classList.add("is-click");
-        await sleep(180);
-        cursor.classList.remove("is-click");
+        await animateCursorTo(cursor, box.x1, box.y1, 550);
+        await sleep(280);
+        if (signal.aborted) break;
         hideCursor(cursor);
       } else {
         marquee?.classList.add("is-show");


### PR DESCRIPTION
## Summary
- `.demo-marquee` 锚定由 `bottom:12%` 改为 `top:70%`（+ `left:52%`），宽高过渡自左上→右下展开，终态几何与现网等价；保留中文「问题」/英文 `Issue` 徽章。
- `playApprove` 标注段改为对角拖拽同步（≈550ms），全程不加 `is-click`；`clickEl` / parallel / reduced-motion 路径不变。
- 全部 showcase 的 `.demo-cursor` 用纯 CSS data-URI SVG 重绘为标准 NW 箭头（黑底白描边，热点左上）。

## Test plan
- [ ] 桌面打开中文首页 Approve showcase：选框明显左上→右下展开，光标从左上拖到右下同步，无点击涟漪；徽章为「问题」
- [ ] 英文 `/en/`：同上，徽章为 Issue
- [ ] 窄屏（≤860px）重复上述框选观感正常
- [ ] Parallel showcase：指针为 NW，点击仍有 is-click 涟漪
- [ ] `prefers-reduced-motion`：Approve 直接静态终态，不播框选
- [ ] ci-docs 绿灯；diff 仅 `docs/site/css/home.css` 与 `docs/site/js/home.js`


Made with [Cursor](https://cursor.com)