### PR TITLE
fix(web): eliminate poor INP on P0 interaction paths

### DIFF
--- a/web/src/components/canvas/WorkflowCanvas.vue
+++ b/web/src/components/canvas/WorkflowCanvas.vue
@@ -10,6 +10,12 @@ import ConditionEdge from './ConditionEdge.vue'
 import { getEdgeStroke, type EdgeTone } from './edgeColors'
 import { nodeColorHex } from '@/data/nodeRegistry'
 import { computeSessionLayout, isInvalidPosition } from '@/lib/canvasLayout'
+import {
+  flowFingerprint,
+  pruneFlowCache,
+  reuseFlowElement,
+  type FlowNodeCacheEntry,
+} from '@/lib/workflowCanvasFlow'
 import { theme } from '@/lib/theme'
 import type { WFNode, WFEdge, NodeType, NodeRunStatus } from '@/lib/types'
 
@@ -137,24 +143,61 @@ function structuredExitHandles(n: WFNode) {
   return []
 }
 
-const flowNodes = computed(() =>
-  props.nodes.map((n) => ({
-    id: n.id,
-    type: 'custom',
-    position: resolvePosition(n),
-    draggable: props.mode !== 'run',
-    selected: props.selectedNode === n.id,
-    data: {
-      type: n.type as NodeType,
+// Cache flow node objects so a selection-only change rebuilds only the
+// previously/newly selected nodes — Vue Flow skips reconcile for stable refs.
+type FlowNodeObj = {
+  id: string
+  type: string
+  position: { x: number; y: number }
+  draggable: boolean
+  selected: boolean
+  data: Record<string, unknown>
+}
+const flowNodeCache = new Map<string, FlowNodeCacheEntry<FlowNodeObj>>()
+
+const flowNodes = computed(() => {
+  const selectedId = props.selectedNode
+  const modeRun = props.mode === 'run'
+  const out = props.nodes.map((n) => {
+    const position = resolvePosition(n)
+    const status = props.statusMap?.[n.id]
+    const branches = n.type === 'branch' ? branchHandles(n) : undefined
+    const gateActions =
+      n.type === 'human_gate' || n.type === 'app_preview' ? actionHandles(n) : undefined
+    const structuredExits =
+      n.type === 'test' || n.type === 'review' ? structuredExitHandles(n) : undefined
+    const selected = selectedId === n.id
+    const fingerprint = flowFingerprint({
+      type: n.type,
       label: n.label,
-      status: props.statusMap?.[n.id],
+      status,
       checkpoint: n.checkpoint,
-      branches: n.type === 'branch' ? branchHandles(n) : undefined,
-      gateActions: n.type === 'human_gate' || n.type === 'app_preview' ? actionHandles(n) : undefined,
-      structuredExits: n.type === 'test' || n.type === 'review' ? structuredExitHandles(n) : undefined,
-    },
-  }))
-)
+      position,
+      draggable: !modeRun,
+      branches,
+      gateActions,
+      structuredExits,
+    })
+    return reuseFlowElement(flowNodeCache, n.id, fingerprint, selected, () => ({
+      id: n.id,
+      type: 'custom',
+      position,
+      draggable: !modeRun,
+      selected,
+      data: {
+        type: n.type as NodeType,
+        label: n.label,
+        status,
+        checkpoint: n.checkpoint,
+        branches,
+        gateActions,
+        structuredExits,
+      },
+    }))
+  })
+  pruneFlowCache(flowNodeCache, props.nodes.map((n) => n.id))
+  return out
+})
 
 const BRANCH_COLOR = '#E879F9'
 
@@ -317,16 +360,31 @@ const structuredGateEdges = computed(() => {
   return out
 })
 
+type FlowEdgeObj = {
+  id: string
+  source: string
+  target: string
+  type: string
+  animated: boolean
+  selected: boolean
+  data: Record<string, unknown>
+  markerEnd: any
+  style: Record<string, unknown>
+  sourceHandle?: string
+  selectable?: boolean
+}
+const flowEdgeCache = new Map<string, FlowNodeCacheEntry<FlowEdgeObj>>()
+
 const flowEdges = computed(() => {
   const nodeById = new Map(props.nodes.map((n) => [n.id, n]))
-  return [
-  ...props.edges.map((e) => {
+  const selectedEdge = props.selectedEdge
+  const strokes = edgeStrokes.value
+  const realEdges = props.edges.map((e) => {
     const kind = e.kind || 'success'
-    const active = props.activePath?.includes(e.id)
+    const active = !!props.activePath?.includes(e.id)
     const sourceNode = nodeById.get(e.source)
     const isStructuredGate = isStructuredGateNode(sourceNode)
     const tone = inferEdgeTone(e, sourceNode)
-    const strokes = edgeStrokes.value
     const stroke = active
       ? '#7B61FF'
       : isStructuredGate && (tone === 'ok' || tone === 'err') && kind === 'success'
@@ -336,13 +394,28 @@ const flowEdges = computed(() => {
           : kind === 'rollback'
             ? strokes.warn
             : undefined
-    return {
+    const selected = selectedEdge === e.id
+    const fingerprint = flowFingerprint({
+      source: e.source,
+      target: e.target,
+      kind,
+      label: e.label,
+      carry: e.carry,
+      tone,
+      active,
+      stroke,
+      strokeWidth: kind !== 'success' ? 1.6 : undefined,
+      dash: kind === 'rollback' ? '6 4' : undefined,
+      edgeType: e.label || kind !== 'success' ? 'condition' : 'default',
+      animated: active || kind === 'rollback',
+    })
+    return reuseFlowElement(flowEdgeCache, e.id, fingerprint, selected, () => ({
       id: e.id,
       source: e.source,
       target: e.target,
       type: e.label || kind !== 'success' ? 'condition' : 'default',
       animated: !!active || kind === 'rollback',
-      selected: props.selectedEdge === e.id,
+      selected,
       data: { label: e.label, tone, kind, carry: e.carry },
       markerEnd: MarkerType.ArrowClosed,
       style: {
@@ -350,12 +423,16 @@ const flowEdges = computed(() => {
         strokeWidth: kind !== 'success' ? 1.6 : undefined,
         strokeDasharray: kind === 'rollback' ? '6 4' : undefined,
       },
-    }
-  }),
-  ...branchEdges.value,
-  ...gateEdges.value,
-  ...structuredGateEdges.value,
-]
+    }))
+  })
+  // Derived edges (branch/gate/structured) are rebuild-cheap and not selection-driven;
+  // keep them as-is. Only real edges participate in selected-edge identity reuse.
+  const derived = [...branchEdges.value, ...gateEdges.value, ...structuredGateEdges.value]
+  pruneFlowCache(
+    flowEdgeCache,
+    props.edges.map((e) => e.id),
+  )
+  return [...realEdges, ...derived]
 })
 
 function onNodeClick(e: any) {

--- a/web/src/components/pm/PmLeaderChat.vue
+++ b/web/src/components/pm/PmLeaderChat.vue
@@ -8,6 +8,7 @@ import ArtifactLoadingPane from '@/components/run/ArtifactLoadingPane.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import { relTime } from '@/lib/format'
 import { renderMarkdown } from '@/lib/markdown'
+import { createStreamMarkdownPreview } from '@/lib/streamMarkdownPreview'
 import { api } from '@/lib/api'
 import { imgSrc } from '@/lib/compositeText'
 import { useImageAttachments } from '@/lib/useImageAttachments'
@@ -50,6 +51,27 @@ const finalizing = ref(false)
 const sending = ref(false)
 const streaming = ref(false)
 const streamText = ref('')
+/** HTML for the live bubble — updated at most once per animation frame. */
+const streamHtml = ref('')
+const streamPreview = createStreamMarkdownPreview({ render: renderMarkdown })
+const unsubStreamHtml = streamPreview.subscribe((html) => {
+  streamHtml.value = html
+})
+function syncStreamText(next: string) {
+  streamText.value = next
+  streamPreview.setText(next)
+  // Absolute snapshots (resume / seed) paint immediately; deltas stay rAF-batched.
+  streamPreview.flush()
+}
+function appendStreamText(delta: string) {
+  streamText.value += delta
+  streamPreview.append(delta)
+}
+function clearStreamText() {
+  streamText.value = ''
+  streamPreview.reset()
+  streamHtml.value = ''
+}
 const resuming = ref(false)
 const lastEventSeq = ref(-1)
 const scroller = ref<HTMLElement | null>(null)
@@ -552,7 +574,7 @@ async function beginResume(tid: string, partial: string, afterSeq: number, userM
   sending.value = true
   streaming.value = true
   resuming.value = true
-  streamText.value = partial
+  syncStreamText(partial)
   lastEventSeq.value = afterSeq
   startTurnDeadline(gen)
   readyAbort = new AbortController()
@@ -682,7 +704,7 @@ function resetTurnLocal() {
     readyAbort.abort()
     readyAbort = null
   }
-  streamText.value = ''
+  clearStreamText()
   streaming.value = false
   sending.value = false
   resuming.value = false
@@ -735,7 +757,7 @@ async function failTurn(kind: FailKind) {
     readyAbort.abort()
     readyAbort = null
   }
-  streamText.value = ''
+  clearStreamText()
   streaming.value = false
   sending.value = false
   resuming.value = false
@@ -834,7 +856,7 @@ async function openWs(_id: number) {
     } else if (msg.type === 'resume_hint') {
       // Absolute snapshot from server draft — never append onto stale streamText.
       if (typeof msg.partialText === 'string') {
-        streamText.value = msg.partialText
+        syncStreamText(msg.partialText)
       }
       if (typeof msg.eventSeq === 'number') {
         lastEventSeq.value = msg.eventSeq
@@ -864,14 +886,14 @@ function handleAcp(raw: any) {
   if (streamCancelled) return
   const delta = extractAgentMessageDelta(raw)
   if (!delta?.text) return
-  streamText.value += delta.text
+  appendStreamText(delta.text)
   void nextTick().then(() => scrollBottom())
 }
 
 function clearFinalizingStream() {
   finalizing.value = false
   finalizingRefetchFailed.value = false
-  streamText.value = ''
+  clearStreamText()
   activeUserMessageId.value = ''
   resuming.value = false
 }
@@ -914,7 +936,7 @@ async function refetchAfterTurnDone() {
  */
 async function onTurnDone() {
   if (streamCancelled || turnClosed) {
-    streamText.value = ''
+    clearStreamText()
     streaming.value = false
     sending.value = false
     resuming.value = false
@@ -928,6 +950,7 @@ async function onTurnDone() {
   streaming.value = false
   sending.value = false
   resuming.value = false
+      streamPreview.flush()
   finalizing.value = true
   if (!activeId.value) {
     clearFinalizingStream()
@@ -942,7 +965,7 @@ async function onTurnError(kind: FailKind, detail: string) {
   turnClosed = true
   streamCancelled = true
   clearTurnDeadline()
-  streamText.value = ''
+  clearStreamText()
   streaming.value = false
   sending.value = false
   resuming.value = false
@@ -1000,7 +1023,7 @@ async function runTurn(
   activeUserMessageId.value = userMsg.id
   sending.value = true
   streaming.value = true
-  streamText.value = ''
+  clearStreamText()
   // Ready-phase deadline (~90s); refreshed after sandbox is ready for stream phase.
   startTurnDeadline(gen)
   readyAbort = new AbortController()
@@ -1063,7 +1086,7 @@ async function send(text?: string, explicitImages?: ClarifyImage[]) {
   turnClosed = false
   sending.value = true
   streaming.value = true
-  streamText.value = ''
+  clearStreamText()
   startTurnDeadline(gen)
   if (fromInput) input.value = ''
   try {
@@ -1124,7 +1147,7 @@ function stop() {
       /* ignore */
     }
   }
-  streamText.value = ''
+  clearStreamText()
   resuming.value = false
   void failTurn('stopped')
 }
@@ -1140,7 +1163,7 @@ async function retryTurn(userMessageId: string) {
   turnClosed = false
   sending.value = true
   streaming.value = true
-  streamText.value = ''
+  clearStreamText()
   clearFailedPartial(userMessageId)
   startTurnDeadline(gen)
   try {
@@ -1183,6 +1206,8 @@ onMounted(() => {
   void loadThreads().then(() => applyRestoreMobileChat())
 })
 onBeforeUnmount(() => {
+  unsubStreamHtml()
+  streamPreview.reset()
   resetTurnLocal()
   closeWs()
 })
@@ -1489,7 +1514,7 @@ onBeforeUnmount(() => {
                 <Icon name="spinner" :size="13" class="animate-spin text-accent-2" />
                 {{ t('pages.projectDetail.pm.resuming') }}
               </div>
-              <div v-else-if="streamText" class="md" v-html="renderMarkdown(streamText)" />
+              <div v-else-if="streamText" class="md" v-html="streamHtml" />
               <div v-else-if="showStreamTypingDots" class="typing-dots py-1">
                 <i /><i /><i />
               </div>

--- a/web/src/lib/markdown.test.ts
+++ b/web/src/lib/markdown.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('dompurify', () => ({
+  default: {
+    sanitize: (html: string) => html,
+  },
+}))
+
+import {
+  clearMarkdownCache,
+  getMarkdownParseCount,
+  markdownCacheSize,
+  renderMarkdown,
+  resetMarkdownParseCount,
+} from './markdown'
+
+afterEach(() => {
+  clearMarkdownCache()
+  resetMarkdownParseCount()
+})
+
+describe('renderMarkdown cache', () => {
+  it('parses once for identical source and returns the same HTML', () => {
+    const src = '# Hello\n\n**world**'
+    const a = renderMarkdown(src)
+    expect(getMarkdownParseCount()).toBe(1)
+    expect(a).toContain('<strong>world</strong>')
+
+    const b = renderMarkdown(src)
+    expect(getMarkdownParseCount()).toBe(1)
+    expect(b).toBe(a)
+    expect(markdownCacheSize()).toBe(1)
+  })
+
+  it('parses again when source text changes', () => {
+    renderMarkdown('one')
+    renderMarkdown('two')
+    expect(getMarkdownParseCount()).toBe(2)
+    expect(markdownCacheSize()).toBe(2)
+  })
+
+  it('evicts oldest entries beyond LRU capacity', () => {
+    for (let i = 0; i < 70; i++) {
+      renderMarkdown(`doc-${i}`)
+    }
+    expect(markdownCacheSize()).toBe(64)
+    // Oldest should be gone → re-parse
+    const before = getMarkdownParseCount()
+    renderMarkdown('doc-0')
+    expect(getMarkdownParseCount()).toBe(before + 1)
+  })
+})

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -3,7 +3,50 @@ import DOMPurify from 'dompurify'
 
 marked.setOptions({ breaks: true, gfm: true })
 
+/** Max distinct source strings retained (LRU via Map insertion order). */
+const CACHE_MAX = 64
+
+const htmlCache = new Map<string, string>()
+
+/** Test/observability: how many times marked+DOMPurify actually ran. */
+let parseCount = 0
+
+export function getMarkdownParseCount(): number {
+  return parseCount
+}
+
+export function resetMarkdownParseCount(): void {
+  parseCount = 0
+}
+
+export function clearMarkdownCache(): void {
+  htmlCache.clear()
+}
+
+export function markdownCacheSize(): number {
+  return htmlCache.size
+}
+
+/**
+ * Render markdown → sanitized HTML with an LRU cache keyed by source text.
+ * Identical inputs reuse the previous HTML and skip marked+DOMPurify.
+ */
 export function renderMarkdown(src: string): string {
-  const raw = marked.parse(src ?? '', { async: false }) as string
-  return DOMPurify.sanitize(raw)
+  const key = src ?? ''
+  const hit = htmlCache.get(key)
+  if (hit !== undefined) {
+    // Refresh LRU order
+    htmlCache.delete(key)
+    htmlCache.set(key, hit)
+    return hit
+  }
+  parseCount += 1
+  const raw = marked.parse(key, { async: false }) as string
+  const html = DOMPurify.sanitize(raw)
+  htmlCache.set(key, html)
+  if (htmlCache.size > CACHE_MAX) {
+    const oldest = htmlCache.keys().next().value
+    if (oldest !== undefined) htmlCache.delete(oldest)
+  }
+  return html
 }

--- a/web/src/lib/streamMarkdownPreview.test.ts
+++ b/web/src/lib/streamMarkdownPreview.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createStreamMarkdownPreview } from './streamMarkdownPreview'
+
+describe('createStreamMarkdownPreview', () => {
+  it('coalesces many deltas into a single render per scheduled flush', () => {
+    const renders: string[] = []
+    const render = vi.fn((src: string) => {
+      renders.push(src)
+      return `<p>${src}</p>`
+    })
+    const queued: Array<() => void> = []
+    const preview = createStreamMarkdownPreview({
+      render,
+      schedule: (cb) => {
+        queued.push(cb)
+        return queued.length
+      },
+      cancel: () => {
+        queued.length = 0
+      },
+    })
+
+    preview.append('a')
+    preview.append('b')
+    preview.append('c')
+    expect(render).not.toHaveBeenCalled()
+    expect(queued).toHaveLength(1)
+
+    queued.shift()!()
+    expect(render).toHaveBeenCalledTimes(1)
+    expect(render).toHaveBeenCalledWith('abc')
+    expect(preview.getHtml()).toBe('<p>abc</p>')
+
+    preview.append('d')
+    expect(queued).toHaveLength(1)
+    queued.shift()!()
+    expect(render).toHaveBeenCalledTimes(2)
+    expect(render).toHaveBeenLastCalledWith('abcd')
+  })
+
+  it('setText replaces absolute snapshot without appending', () => {
+    const render = vi.fn((src: string) => src)
+    const queued: Array<() => void> = []
+    const preview = createStreamMarkdownPreview({
+      render,
+      schedule: (cb) => {
+        queued.push(cb)
+        return queued.length
+      },
+      cancel: () => {
+        queued.length = 0
+      },
+    })
+    preview.append('old')
+    queued.shift()!()
+    preview.setText('fresh')
+    queued.shift()!()
+    expect(preview.getText()).toBe('fresh')
+    expect(render).toHaveBeenLastCalledWith('fresh')
+  })
+
+  it('flush forces an immediate render without waiting', () => {
+    const render = vi.fn((src: string) => src)
+    const preview = createStreamMarkdownPreview({
+      render,
+      schedule: () => 0,
+      cancel: () => {},
+    })
+    preview.append('x')
+    expect(render).not.toHaveBeenCalled()
+    preview.flush()
+    expect(render).toHaveBeenCalledWith('x')
+  })
+})

--- a/web/src/lib/streamMarkdownPreview.ts
+++ b/web/src/lib/streamMarkdownPreview.ts
@@ -1,0 +1,91 @@
+/**
+ * Coalesce rapid stream text updates into at most one markdown render per
+ * animation frame so token deltas cannot flood marked+DOMPurify.
+ */
+
+export type StreamMarkdownPreviewOptions = {
+  render: (src: string) => string
+  /** Inject for tests; defaults to requestAnimationFrame. */
+  schedule?: (cb: () => void) => number
+  cancel?: (id: number) => void
+}
+
+export type StreamMarkdownPreview = {
+  /** Absolute replace (resume snapshot / clear). */
+  setText: (text: string) => void
+  /** Append a delta and schedule a coalesced render. */
+  append: (delta: string) => void
+  /** Current raw stream text. */
+  getText: () => string
+  /** Last rendered HTML (may lag text by up to one frame). */
+  getHtml: () => string
+  /** Force flush (tests / end-of-stream). */
+  flush: () => void
+  /** Cancel pending frame and clear. */
+  reset: () => void
+  /** Subscribe to HTML updates; returns unsubscribe. */
+  subscribe: (listener: (html: string) => void) => () => void
+}
+
+export function createStreamMarkdownPreview(
+  opts: StreamMarkdownPreviewOptions,
+): StreamMarkdownPreview {
+  const schedule = opts.schedule ?? ((cb) => requestAnimationFrame(cb))
+  const cancel = opts.cancel ?? ((id) => cancelAnimationFrame(id))
+  let text = ''
+  let html = ''
+  let pending = false
+  let handle = 0
+  const listeners = new Set<(html: string) => void>()
+
+  function notify() {
+    for (const l of listeners) l(html)
+  }
+
+  function flush() {
+    if (pending) {
+      cancel(handle)
+      pending = false
+      handle = 0
+    }
+    html = text ? opts.render(text) : ''
+    notify()
+  }
+
+  function scheduleFlush() {
+    if (pending) return
+    pending = true
+    handle = schedule(() => flush())
+  }
+
+  return {
+    setText(next: string) {
+      text = next
+      scheduleFlush()
+    },
+    append(delta: string) {
+      if (!delta) return
+      text += delta
+      scheduleFlush()
+    },
+    getText: () => text,
+    getHtml: () => html,
+    flush,
+    reset() {
+      text = ''
+      html = ''
+      if (pending) {
+        cancel(handle)
+        pending = false
+        handle = 0
+      }
+      notify()
+    },
+    subscribe(listener) {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+  }
+}

--- a/web/src/lib/workflowCanvasFlow.test.ts
+++ b/web/src/lib/workflowCanvasFlow.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import {
+  flowFingerprint,
+  pruneFlowCache,
+  reuseFlowElement,
+  unchangedIdsKeepIdentity,
+  type FlowNodeCacheEntry,
+} from './workflowCanvasFlow'
+
+type N = { id: string; selected: boolean; label: string; status?: string }
+
+function buildNodes(
+  cache: Map<string, FlowNodeCacheEntry<N>>,
+  ids: string[],
+  selectedId: string | null,
+  statusMap: Record<string, string> = {},
+): N[] {
+  return ids.map((id) => {
+    const status = statusMap[id]
+    const selected = selectedId === id
+    const fingerprint = flowFingerprint({ id, label: `L-${id}`, status })
+    return reuseFlowElement(cache, id, fingerprint, selected, () => ({
+      id,
+      selected,
+      label: `L-${id}`,
+      status,
+    }))
+  })
+}
+
+describe('workflowCanvasFlow selection identity', () => {
+  it('keeps object identity for nodes whose selected flag did not change', () => {
+    const cache = new Map<string, FlowNodeCacheEntry<N>>()
+    const ids = ['a', 'b', 'c', 'd']
+    const before = buildNodes(cache, ids, 'a')
+    const after = buildNodes(cache, ids, 'b')
+
+    expect(unchangedIdsKeepIdentity(before, after, new Set(['a', 'b']))).toBe(true)
+    expect(before.find((n) => n.id === 'c')).toBe(after.find((n) => n.id === 'c'))
+    expect(before.find((n) => n.id === 'd')).toBe(after.find((n) => n.id === 'd'))
+    expect(before.find((n) => n.id === 'a')).not.toBe(after.find((n) => n.id === 'a'))
+    expect(before.find((n) => n.id === 'b')).not.toBe(after.find((n) => n.id === 'b'))
+    expect(after.find((n) => n.id === 'b')?.selected).toBe(true)
+  })
+
+  it('rebuilds a node when status fingerprint changes', () => {
+    const cache = new Map<string, FlowNodeCacheEntry<N>>()
+    const ids = ['a', 'b']
+    const before = buildNodes(cache, ids, 'a', { a: 'running' })
+    const after = buildNodes(cache, ids, 'a', { a: 'completed' })
+    expect(before.find((n) => n.id === 'a')).not.toBe(after.find((n) => n.id === 'a'))
+    expect(before.find((n) => n.id === 'b')).toBe(after.find((n) => n.id === 'b'))
+  })
+
+  it('prunes stale cache entries', () => {
+    const cache = new Map<string, FlowNodeCacheEntry<N>>()
+    buildNodes(cache, ['a', 'b', 'c'], 'a')
+    pruneFlowCache(cache, ['a', 'c'])
+    expect([...cache.keys()].sort()).toEqual(['a', 'c'])
+  })
+})

--- a/web/src/lib/workflowCanvasFlow.ts
+++ b/web/src/lib/workflowCanvasFlow.ts
@@ -1,0 +1,75 @@
+/**
+ * Stable Vue Flow node/edge object identity helpers.
+ * Only selected (or other field) changes replace that element's object;
+ * untouched elements keep the previous reference so Vue Flow can skip reconcile.
+ */
+
+export type FlowNodeCacheEntry<T extends { id: string; selected?: boolean }> = {
+  /** Structural fingerprint excluding `selected`. */
+  fingerprint: string
+  selected: boolean
+  obj: T
+}
+
+export type FlowEdgeCacheEntry<T extends { id: string; selected?: boolean }> = {
+  fingerprint: string
+  selected: boolean
+  obj: T
+}
+
+/** Build a fingerprint string from structural fields (must exclude selected). */
+export function flowFingerprint(parts: unknown): string {
+  return JSON.stringify(parts)
+}
+
+/**
+ * Reuse the previous flow element object when only `selected` changed;
+ * rebuild when the structural fingerprint differs.
+ */
+export function reuseFlowElement<T extends { id: string; selected?: boolean }>(
+  cache: Map<string, FlowNodeCacheEntry<T>>,
+  id: string,
+  fingerprint: string,
+  selected: boolean,
+  build: () => T,
+): T {
+  const prev = cache.get(id)
+  if (prev && prev.fingerprint === fingerprint) {
+    if (prev.selected === selected) return prev.obj
+    const obj = { ...prev.obj, selected }
+    cache.set(id, { fingerprint, selected, obj })
+    return obj
+  }
+  const obj = build()
+  cache.set(id, { fingerprint, selected, obj })
+  return obj
+}
+
+/** Drop cache entries for ids no longer present in the graph. */
+export function pruneFlowCache<T extends { id: string; selected?: boolean }>(
+  cache: Map<string, FlowNodeCacheEntry<T>>,
+  liveIds: Iterable<string>,
+): void {
+  const keep = new Set(liveIds)
+  for (const id of cache.keys()) {
+    if (!keep.has(id)) cache.delete(id)
+  }
+}
+
+/**
+ * Assert helper for tests: given two consecutive reconcile results after a
+ * selection-only change, unchanged node ids must keep object identity.
+ */
+export function unchangedIdsKeepIdentity<T extends { id: string }>(
+  before: T[],
+  after: T[],
+  changedIds: Set<string>,
+): boolean {
+  const beforeById = new Map(before.map((n) => [n.id, n]))
+  for (const n of after) {
+    if (changedIds.has(n.id)) continue
+    const prev = beforeById.get(n.id)
+    if (!prev || prev !== n) return false
+  }
+  return true
+}

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -548,6 +548,7 @@
       "loadingWorkflow": "Loading…",
       "loadingRun": "Loading run details…",
       "loadingChip": "Loading…",
+      "switchingNode": "Switching node…",
       "loadFailedTitle": "Unable to load run details right now",
       "loadFailedDesc": "A network or service error occurred. Please retry shortly. Contact an admin if it persists.",
       "loadFailedChip": "Load failed",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -548,6 +548,7 @@
       "loadingWorkflow": "加载中…",
       "loadingRun": "加载运行详情…",
       "loadingChip": "加载中…",
+      "switchingNode": "切换节点…",
       "loadFailedTitle": "暂时无法加载运行详情",
       "loadFailedDesc": "网络或服务异常，请稍后重试。若持续失败请联系管理员。",
       "loadFailedChip": "加载失败",

--- a/web/src/views/RunDetailView.test.ts
+++ b/web/src/views/RunDetailView.test.ts
@@ -188,8 +188,12 @@ describe('RunDetailView ACP log rehydrate state machine', () => {
     expect(src).toMatch(/function retryRehydrate/)
     expect(src).toMatch(/:rehydrate-status="selRehydrateStatus"/)
     expect(src).toMatch(/@retry-rehydrate="retryRehydrate"/)
-    // Rehydrate runs on enter regardless of active tab; default tab logic unchanged.
+    // Rehydrate runs on enter (init + paint-then-work selection path); default tab logic unchanged.
     expect(src).toMatch(/void rehydrateNodeEvents\(selected\.value\)/)
+    expect(src).toMatch(/async function runSelectionSideEffects/)
+    expect(src).toMatch(/panelSwitching/)
+    expect(src).toMatch(/afterNextPaint/)
+    expect(src).toMatch(/data-testid="run-detail-panel-switching"/)
     expect(src).toMatch(/else if \(hasLog\.value\) nodeTab\.value = 'log'/)
     // Failed rehydrate must not auto-recover via the 2s poll.
     expect(src).toMatch(/if \(rh === 'error' \|\| rh === 'loading'\)/)

--- a/web/src/views/RunDetailView.vue
+++ b/web/src/views/RunDetailView.vue
@@ -1077,11 +1077,42 @@ watch(
 
 const sbxLog = computed(() => (selected.value ? sbxLogs[selected.value] : null) || null)
 
-// Pull the node's event + container logs whenever the selection changes (covers
-// refresh / re-entry: the running node's logs are read back from its container).
-watch(selected, (id) => {
+// Paint-then-work: commit selection + brief right-panel loading first, then
+// rehydrate/sandbox after a frame so pointer INP is not blocked by heavy work.
+const panelSwitching = ref(false)
+let selectionWorkGen = 0
+
+function afterNextPaint(): Promise<void> {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => resolve())
+  })
+}
+
+async function runSelectionSideEffects(id: string | null) {
+  const gen = ++selectionWorkGen
+  if (!id) {
+    panelSwitching.value = false
+    void rehydrateNodeEvents(null)
+    fetchSandboxLog(null)
+    return
+  }
+  panelSwitching.value = true
+  await nextTick()
+  await afterNextPaint()
+  if (gen !== selectionWorkGen) return
   void rehydrateNodeEvents(id)
   fetchSandboxLog(id)
+  // Yield once more so heavy tab mounts land after the loading frame paints.
+  await afterNextPaint()
+  if (gen !== selectionWorkGen) return
+  panelSwitching.value = false
+}
+
+// Pull the node's event + container logs whenever the selection changes (covers
+// refresh / re-entry: the running node's logs are read back from its container).
+// Deferred via paint-then-work so selected highlight paints before rehydrate.
+watch(selected, (id) => {
+  void runSelectionSideEffects(id)
 })
 
 // The right panel is scoped to the selected node with node-relevant tabs.
@@ -1704,6 +1735,12 @@ function selectExecution(nodeId: string, idx: number) {
             <AppTabs :tabs="nodeTabs" v-model="nodeTab" />
           </div>
           <div class="min-h-0 flex-1">
+            <ArtifactLoadingPane
+              v-if="panelSwitching"
+              data-testid="run-detail-panel-switching"
+              message-key="pages.runDetail.switchingNode"
+            />
+            <template v-else>
             <GateApproval
               v-if="nodeTab === 'gate' && run.gate"
               :gate="run.gate"
@@ -1861,6 +1898,7 @@ function selectExecution(nodeId: string, idx: number) {
               </div>
             </div>
             <NodeOutputPanel v-else :node="selNode" :node-run="selRunView" :run="run" />
+            </template>
           </div>
         </template>
         <EmptyState v-else :title="t('common.empty.selectNode')" :desc="t('common.empty.selectNodeDesc')" />


### PR DESCRIPTION
## Summary
- Cut Run detail / editor canvas selection INP by keeping stable Vue Flow node/edge object identity when only `selected` changes (`workflowCanvasFlow` + `WorkflowCanvas`).
- Align Run detail with Demo「修后·跟手」: paint selection first, brief right-panel loading, then deferred rehydrate/sandbox (`panelSwitching` + `afterNextPaint`).
- Add LRU `renderMarkdown` cache and rAF-batched PM Leader stream preview so streaming no longer runs marked+DOMPurify on every token.

## Evidence list (页面/交互 → 修前问题 → 修法 → 修后 INP/观感)

| 页面/交互 | 修前问题 | 修法 | 修后 INP/观感 |
|---|---|---|---|
| **P0 Run 详情画布点选节点** | 用户 Chrome pointer INP **~1,384ms**（poor）；`selected` 触发整表 `flowNodes` map + 同 tick `rehydrate`/sandbox/重型 Tab | 选中局部对象复用；`runSelectionSideEffects`：先高亮 → `nextTick`+rAF → 短暂 loading → rehydrate | 目标：Local INP P75 ≤200ms，无稳定 >500ms/>1s；观感：高亮 → 短暂「切换节点…」→ 正确内容 |
| **P0 工作流编辑器画布点选** | 与 Run 共用 `WorkflowCanvas`，同源整表重建 | 同上选中引用稳定；statusMap/activePath 仍按 fingerprint 刷新 | 点选不掉成秒级；拖拽/连线语义不变 |
| **P0 PM Leader 流式发送** | 每 delta 全量 `renderMarkdown(streamText)` | `createStreamMarkdownPreview` 每帧最多解析一次；历史气泡受益于 LRU 缓存 | 流式中点击保持响应；结束后 markdown 正确 |
| **P1 Artifact / Gates / Board** | 静态嫌疑：JSON highlight、Gate 挂载、Board 轮询 | **本 PR 未专项**（沙箱未复现稳定 >500ms）；markdown 缓存自然惠及 Artifact/Gates markdown 面 | Follow-up：手测若稳定 >500ms 再定点修 |
| **P2 Studio / 沙箱** | 非本轮热路径 | **未改**（未测到稳定 >500ms） | Follow-up |

动机截图：用户 2026-07-26 Chrome Performance **pointer INP 1,384ms**（Run 详情画布）。同机未必复现到 ~1.3s，不以该绝对值为合并阻塞；以同机修前/修后对比 + 硬门禁为准。

## Test plan
- [x] `vitest`: `markdown.test.ts`（缓存命中/LRU）、`streamMarkdownPreview.test.ts`（多 delta 单次 flush）、`workflowCanvasFlow.test.ts`（选中未变节点引用稳定）、`RunDetailView.test.ts`（paint-then-work / panelSwitching 接线）
- [x] `vue-tsc --noEmit`
- [ ] 手测 Run 详情连续点节点：高亮 → loading → 内容；Local INP 落入目标带
- [ ] 手测编辑器画布点选/拖拽
- [ ] 手测 PM 流式期间点击发送/控件
- [ ] 中英切换：`pages.runDetail.switchingNode` 文案正常

## Notes
- 不为刷分取消必要拉取；仅延后到 paint 之后。
- 不建 CI INP 门禁。

Made with [Cursor](https://cursor.com)