### PR TITLE
fix(gates): stop approval preview flicker from noisy softRefresh

### DIFF
--- a/web/src/components/run/GateApproval.test.ts
+++ b/web/src/components/run/GateApproval.test.ts
@@ -1729,7 +1729,41 @@ describe('GateApproval HTML preview load gate (fillPreview)', () => {
     wrapper.unmount()
   })
 
-  it('pending live gate reloads when artifact sizeBytes/updatedAt change (store write signal)', async () => {
+  it('pending live gate ignores pure updatedAt noise (no reload)', async () => {
+    apiMocks.artifactContent.mockResolvedValue({
+      content: pageHtml,
+      etag: 'W/"p1"',
+      updatedAt: '2026-07-18T00:00:00Z',
+      sizeBytes: 40,
+    })
+    const run = visualEditableRun()
+    const wrapper = mountApproval({
+      fillPreview: true,
+      gate: baseGate({ nodeId: 'hg-visual' }),
+      run,
+    })
+    await flushPromises()
+    expect(apiMocks.artifactContent).toHaveBeenCalledTimes(1)
+
+    const artifact = run.artifacts![0]
+    await wrapper.setProps({
+      run: {
+        ...run,
+        artifacts: [
+          {
+            ...artifact,
+            updatedAt: '2026-07-18T01:00:00Z',
+          },
+        ],
+      } as Run,
+    })
+    await flushPromises()
+
+    expect(apiMocks.artifactContent).toHaveBeenCalledTimes(1)
+    wrapper.unmount()
+  })
+
+  it('pending live gate reloads when artifact sizeBytes or etag change (store write signal)', async () => {
     const liveHtml = '<!doctype html><html><body>live-v2</body></html>'
     apiMocks.artifactContent
       .mockResolvedValueOnce({
@@ -1760,6 +1794,7 @@ describe('GateApproval HTML preview load gate (fillPreview)', () => {
         artifacts: [
           {
             ...artifact,
+            etag: 'W/"p2"',
             updatedAt: '2026-07-18T01:00:00Z',
             sizeBytes: liveHtml.length,
           },
@@ -1768,10 +1803,55 @@ describe('GateApproval HTML preview load gate (fillPreview)', () => {
     })
     await flushPromises()
 
-    // Pending gates follow live store; meta change must force reload.
+    // Pending gates follow live store; size/etag change must force reload.
     expect(apiMocks.artifactContent).toHaveBeenCalledTimes(2)
     const preview = wrapper.findComponent({ name: 'HtmlPreview' })
     expect(preview.props('html')).toContain('live-v2')
+    wrapper.unmount()
+  })
+
+  it('pending live gate does not reassign productHtml when fetched body is unchanged', async () => {
+    const sameHtml = pageHtml
+    apiMocks.artifactContent
+      .mockResolvedValueOnce({
+        content: sameHtml,
+        etag: 'W/"p1"',
+        updatedAt: '2026-07-18T00:00:00Z',
+        sizeBytes: 40,
+      })
+      .mockResolvedValueOnce({
+        content: sameHtml,
+        etag: 'W/"p1"',
+        updatedAt: '2026-07-18T01:00:00Z',
+        sizeBytes: 99,
+      })
+    const run = visualEditableRun()
+    const wrapper = mountApproval({
+      fillPreview: true,
+      gate: baseGate({ nodeId: 'hg-visual' }),
+      run,
+    })
+    await flushPromises()
+    const preview = wrapper.findComponent({ name: 'HtmlPreview' })
+    const htmlBefore = preview.props('html')
+
+    const artifact = run.artifacts![0]
+    await wrapper.setProps({
+      run: {
+        ...run,
+        artifacts: [
+          {
+            ...artifact,
+            sizeBytes: 99,
+            updatedAt: '2026-07-18T01:00:00Z',
+          },
+        ],
+      } as Run,
+    })
+    await flushPromises()
+
+    expect(apiMocks.artifactContent).toHaveBeenCalledTimes(2)
+    expect(preview.props('html')).toBe(htmlBefore)
     wrapper.unmount()
   })
 

--- a/web/src/components/run/GateApproval.vue
+++ b/web/src/components/run/GateApproval.vue
@@ -577,13 +577,16 @@ function buildProductLoadFingerprint(): string {
   ]
   for (const p of products) {
     const a = props.run?.artifacts.find((x) => x.name === p.name)
-    // Resolved/history: ignore updatedAt/sizeBytes poll noise — content changes are
-    // detected via snap hash. Pending/live: also include sizeBytes/updatedAt so a
-    // store-only write (before outputs sync lands) still forces a reload; etag is
-    // usually empty on the list DTO poll path.
+    // Resolved/history: ignore sizeBytes poll noise — content changes are
+    // detected via snap hash. Pending/live: include sizeBytes (not updatedAt)
+    // so a store-only write still forces a reload; etag is usually empty on the
+    // list DTO poll path. Pure updatedAt bumps from Artifact.Save must not reload.
     parts.push(`${p.name}:${a?.etag ?? ''}`)
+    // Pending/live: sizeBytes alone (not updatedAt) — Artifact.Save bumps UpdatedAt on
+    // every upsert, so timestamp noise would force page.html reload → srcdoc flicker.
+    // Content/snap hash below still catch same-size rewrites after fetch.
     if (pending && a) {
-      parts.push(`meta:${a.sizeBytes ?? 0}:${a.updatedAt ?? ''}`)
+      parts.push(`meta:${a.sizeBytes ?? 0}`)
     }
     if (p.name === 'page.html' || p.outputKey === 'page') {
       const ref =
@@ -743,7 +746,8 @@ async function loadProduct(opts?: { force?: boolean }) {
     const primary = products[0]
     const text = next[primary.name] || ''
     if (primary.name === 'page.html') {
-      productHtml.value = text
+      // Avoid HtmlPreview srcdoc reassignment when body is unchanged (no iframe flicker).
+      if (productHtml.value !== text) productHtml.value = text
       productDoc.value = null
     } else if (isStructuredArtifactName(primary.name)) {
       try {

--- a/web/src/components/run/GateProductEditor.test.ts
+++ b/web/src/components/run/GateProductEditor.test.ts
@@ -183,6 +183,46 @@ describe('GateProductEditor', () => {
     wrapper.unmount()
   })
 
+  it('keeps edit draft/mode when artifacts array reference changes without identity change', async () => {
+    const art = {
+      id: 'a-html',
+      name: 'page.html',
+      kind: 'html' as const,
+      nodeId: 'visual',
+      runId: 'run-1',
+      workflowName: 'w',
+      sizeBytes: sampleHtml.length,
+      createdAt: '2026-07-18T00:00:00Z',
+      updatedAt: '2026-07-18T00:00:00Z',
+      etag: 'W/"h1"',
+    }
+    const wrapper = mountHtmlEditor({ artifacts: [art] })
+    await flushPromises()
+    await wrapper.find('[data-testid="gate-mode-edit"]').trigger('click')
+    await flushPromises()
+    const ta = wrapper.find('[data-testid="gate-artifact-textarea"]')
+    expect(ta.exists()).toBe(true)
+    await ta.setValue('<!doctype html><html><body><p>drafting</p></body></html>')
+    await flushPromises()
+
+    // softRefresh-style: new array / bumped updatedAt, same id/etag/size
+    await wrapper.setProps({
+      artifacts: [
+        {
+          ...art,
+          updatedAt: '2026-07-18T01:00:00Z',
+        },
+      ],
+    })
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="gate-artifact-textarea"]').exists()).toBe(true)
+    expect(
+      (wrapper.find('[data-testid="gate-artifact-textarea"]').element as HTMLTextAreaElement).value,
+    ).toContain('drafting')
+    wrapper.unmount()
+  })
+
   it('shows readonly badge and disables edit/save for image products', async () => {
     const i18n = createI18n({
       legacy: false,

--- a/web/src/components/run/GateProductEditor.vue
+++ b/web/src/components/run/GateProductEditor.vue
@@ -199,8 +199,23 @@ watch(
   { immediate: true },
 )
 
+/** Stable identity for softRefresh: ignore array ref / updatedAt noise. */
+function artifactsIdentityFingerprint(arts: Artifact[] | undefined): string {
+  return (arts || [])
+    .map((a) => `${a.name}:${a.id}:${a.etag ?? ''}:${a.sizeBytes ?? 0}`)
+    .join('|')
+}
+
 watch(
-  () => [activeName.value, activeProduct.value?.kind, activeProduct.value?.readonly, props.artifacts] as const,
+  // Join to a string so array-ref churn from softRefresh does not re-fire when
+  // the identity fingerprint is unchanged (Object.is on a fresh tuple always differs).
+  () =>
+    [
+      activeName.value,
+      activeProduct.value?.kind ?? '',
+      String(activeProduct.value?.readonly ?? ''),
+      artifactsIdentityFingerprint(props.artifacts),
+    ].join('\0'),
   () => {
     draft.value = savedText.value
     saveError.value = null

--- a/web/src/views/GatesInboxView.inboxLifecycle.test.ts
+++ b/web/src/views/GatesInboxView.inboxLifecycle.test.ts
@@ -140,8 +140,8 @@ class FakeWebSocket {
     this.readyState = 3
     this.onclose?.()
   }
-  emit(type: string) {
-    this.onmessage?.({ data: JSON.stringify({ type }) })
+  emit(type: string, extra?: Record<string, unknown>) {
+    this.onmessage?.({ data: JSON.stringify({ type, ...extra }) })
   }
 }
 
@@ -383,10 +383,10 @@ describe('GatesInboxView inbox-context lifecycle', () => {
     await flushPromises()
     await nextTick()
 
-    // Trigger soft refresh via WS after initial load
+    // Trigger soft refresh via artifact_edit after initial load
     const ws = FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
     expect(ws).toBeTruthy()
-    ws.emit('status')
+    ws.emit('artifact_edit')
     await flushPromises()
     await nextTick()
     await flushPromises()
@@ -396,6 +396,7 @@ describe('GatesInboxView inbox-context lifecycle', () => {
     expect(wrapper.text()).not.toContain('Gate a')
     expect(wrapper.text()).toContain('Gate b')
     const callsForA = inboxCallsFor('run-a', 'gate-a', 1).length
+    // Irrelevant status must not re-fetch the processed triple
     ws.emit('status')
     await flushPromises()
     expect(inboxCallsFor('run-a', 'gate-a', 1).length).toBe(callsForA)
@@ -534,7 +535,7 @@ describe('GatesInboxView inbox-context lifecycle', () => {
     expect(wrapper.find('[data-testid="resolve-btn"]').exists()).toBe(true)
     const ws = FakeWebSocket.instances.find((w) => w.url.includes('run-a'))
     expect(ws).toBeTruthy()
-    ws!.emit('status')
+    ws!.emit('artifact_edit')
     await flushPromises()
 
     expect(loadCount).toBeGreaterThanOrEqual(2)
@@ -558,7 +559,7 @@ describe('GatesInboxView inbox-context lifecycle', () => {
     wrapper.unmount()
   })
 
-  it('softRefresh single-flight: concurrent WS status does not fan out requests', async () => {
+  it('softRefresh single-flight: concurrent artifact_edit does not fan out requests', async () => {
     const a = gateItem('a')
     mocks.listGates.mockResolvedValue(paged([a]))
 
@@ -588,9 +589,15 @@ describe('GatesInboxView inbox-context lifecycle', () => {
 
     const ws = FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
     expect(ws).toBeTruthy()
-    ws.emit('status')
+    // status/trace must not softRefresh; only artifact_edit starts the in-flight refresh.
     ws.emit('status')
     ws.emit('trace')
+    await flushPromises()
+    expect(calls).toBe(1)
+
+    ws.emit('artifact_edit')
+    ws.emit('artifact_edit')
+    ws.emit('status')
     await flushPromises()
 
     // Single-flight drops duplicates while the first request is in flight.
@@ -603,6 +610,40 @@ describe('GatesInboxView inbox-context lifecycle', () => {
       nodeExecutions: {},
     })
     await flushPromises()
+    wrapper.unmount()
+  })
+
+  it('gate: irrelevant status/trace/react do not softRefresh; artifact_edit and turn_done do', async () => {
+    const a = gateItem('a')
+    mocks.listGates.mockResolvedValue(paged([a]))
+
+    const wrapper = mountInbox()
+    await flushPromises()
+    await nextTick()
+
+    const before = inboxCallsFor('run-a', 'gate-a', 1).length
+    expect(before).toBeGreaterThan(0)
+    const ws = FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
+    expect(ws).toBeTruthy()
+
+    ws.emit('status')
+    ws.emit('trace')
+    ws.emit('react')
+    await flushPromises()
+    expect(inboxCallsFor('run-a', 'gate-a', 1).length).toBe(before)
+
+    ws.emit('artifact_edit')
+    await flushPromises()
+    expect(inboxCallsFor('run-a', 'gate-a', 1).length).toBe(before + 1)
+
+    ws.emit('review', { event: 'turn_done' })
+    await flushPromises()
+    expect(inboxCallsFor('run-a', 'gate-a', 1).length).toBe(before + 2)
+
+    ws.emit('review', { event: 'error' })
+    await flushPromises()
+    expect(inboxCallsFor('run-a', 'gate-a', 1).length).toBe(before + 3)
+
     wrapper.unmount()
   })
 
@@ -661,7 +702,7 @@ describe('GatesInboxView inbox-context lifecycle', () => {
     const before = inboxCallsFor('run-a', 'clarify-a', 1).length
     expect(before).toBeGreaterThan(0)
 
-    // Ordinary turn: stay pending, may softRefresh.
+    // Ordinary turn: stay pending; status must not softRefresh, react may.
     await wrapper.get('[data-testid="clarify-turn"]').trigger('click')
     await flushPromises()
     await nextTick()
@@ -678,12 +719,18 @@ describe('GatesInboxView inbox-context lifecycle', () => {
     const ws = FakeWebSocket.instances.find((w) => w.url.includes('run-a'))
     expect(ws).toBeTruthy()
     expect(ws!.readyState).toBe(1)
+    const afterTurn = inboxCallsFor('run-a', 'clarify-a', 1).length
     ws!.emit('status')
+    ws!.emit('trace')
     await flushPromises()
-    expect(inboxCallsFor('run-a', 'clarify-a', 1).length).toBeGreaterThan(before)
+    expect(inboxCallsFor('run-a', 'clarify-a', 1).length).toBe(afterTurn)
+
+    ws!.emit('react')
+    await flushPromises()
+    expect(inboxCallsFor('run-a', 'clarify-a', 1).length).toBe(afterTurn + 1)
 
     // Force finish: short-circuit symmetric with gate resolve.
-    const afterTurn = inboxCallsFor('run-a', 'clarify-a', 1).length
+    const afterReact = inboxCallsFor('run-a', 'clarify-a', 1).length
     list = [b]
     await wrapper.get('[data-testid="clarify-send"]').trigger('click')
     await flushPromises()
@@ -698,7 +745,7 @@ describe('GatesInboxView inbox-context lifecycle', () => {
       true,
       [],
     )
-    expect(inboxCallsFor('run-a', 'clarify-a', 1).length).toBe(afterTurn)
+    expect(inboxCallsFor('run-a', 'clarify-a', 1).length).toBe(afterReact)
     expect(wrapper.text()).toContain('Clarify b')
     wrapper.unmount()
   })

--- a/web/src/views/GatesInboxView.vue
+++ b/web/src/views/GatesInboxView.vue
@@ -473,7 +473,19 @@ function connectActiveRunWs(runId: string) {
       // Ignore events for runs that no longer match the current pending active item.
       if (!active.value || active.value.runId !== runId) return
       if (isProcessedTriple(active.value) || !isActiveStillInList()) return
-      void softRefreshActiveRun()
+      // status/trace are noisy (run transitions / appendTrace) and must not softRefresh
+      // while reviewing — peek/list cover "left pending" awareness instead.
+      if (m.type === 'status' || m.type === 'trace') return
+      // Visual gates: only artifact_edit here; review turn_done/error already refresh above.
+      // Ignore react (e.g. turn_begin) — no product change yet.
+      if (active.value.type === 'gate') {
+        if (m.type === 'artifact_edit') void softRefreshActiveRun()
+        return
+      }
+      // Clarify: allow react (turns) and artifact_edit; still ignore status/trace.
+      if (active.value.type === 'clarify') {
+        if (m.type === 'artifact_edit' || m.type === 'react') void softRefreshActiveRun()
+      }
     }
   }
   activeRunWs.onclose = () => {


### PR DESCRIPTION
## Summary
- Narrow Gates Inbox active-run WebSocket softRefresh: gates only on `artifact_edit` / review `turn_done`/`error`; clarify also allows `react`; ignore `status`/`trace` for both.
- Drop pure `updatedAt` from pending product load fingerprints; short-circuit `productHtml` when fetched body is unchanged to avoid HtmlPreview srcdoc flicker.
- Make GateProductEditor watch a stable artifacts identity fingerprint so softRefresh array-ref replacement does not reset draft/mode.

## Test plan
- [x] `npx vitest run src/views/GatesInboxView.inboxLifecycle.test.ts src/components/run/GateApproval.test.ts src/components/run/GateProductEditor.test.ts` (105 passed)
- [ ] Manual: open stationary `waiting_human` gate with `page.html` — no periodic preview flicker on status/trace/turn_begin
- [ ] Manual: `artifact_edit` / `turn_done` still updates preview body
- [ ] Manual: annotations/form/edit draft survive irrelevant WS events


Made with [Cursor](https://cursor.com)