### PR TITLE
feat(services): omit Content from artifact list queries

### DIFF
--- a/server/internal/services/artifact.go
+++ b/server/internal/services/artifact.go
@@ -90,10 +90,10 @@ func (s *ArtifactService) List(runID string) []mcp.ArtifactInfo {
 	return out
 }
 
-// ByRun returns full artifact records for a run (for the API).
+// ByRun returns artifact records for a run (for the API). Content is omitted.
 func (s *ArtifactService) ByRun(runID string) []models.Artifact {
 	var arts []models.Artifact
-	s.db.Where("run_id = ?", runID).Order("created_at").Find(&arts)
+	s.db.Where("run_id = ?", runID).Omit("Content").Order("created_at").Find(&arts)
 	return arts
 }
 
@@ -108,7 +108,9 @@ func (s *ArtifactService) DeleteForRuns(runIDs ...string) error {
 
 func (s *ArtifactService) allQuery(wf, projectID, q string) *gorm.DB {
 	query := s.db.Table("artifacts").
-		Select("artifacts.*, runs.title as run_title").
+		Select(`artifacts.id, artifacts.run_id, artifacts.node_id, artifacts.workflow_id, artifacts.workflow_name,
+			artifacts.name, artifacts.kind, artifacts.size_bytes, artifacts.created_at, artifacts.updated_at,
+			runs.title as run_title`).
 		Joins("LEFT JOIN runs ON runs.id = artifacts.run_id")
 	if wf == unnamedGroupKey {
 		query = query.Where("(artifacts.workflow_id IS NULL OR artifacts.workflow_id = '')")

--- a/server/internal/services/helpers_more_test.go
+++ b/server/internal/services/helpers_more_test.go
@@ -34,13 +34,29 @@ func TestEscapeLikeAndInboxHelpers(t *testing.T) {
 func TestArtifactAllPage(t *testing.T) {
 	db := newTestDB(t)
 	arts := NewArtifactService(db)
-	db.Create(&models.Run{ID: "r-art", WorkflowID: "wf", WorkflowName: "W", Status: "succeeded"})
-	if _, err := arts.Save("r-art", "n", "a.md", "markdown", "hi"); err != nil {
+	db.Create(&models.Run{ID: "r-art", WorkflowID: "wf", WorkflowName: "W", Title: "Run Title", Status: "succeeded"})
+	id, err := arts.Save("r-art", "n", "a.md", "markdown", "hi")
+	if err != nil {
 		t.Fatal(err)
 	}
 	page, total := arts.AllPage("wf", "", 1, 10, "")
 	if total < 1 || len(page) < 1 {
 		t.Fatalf("AllPage: total=%d n=%d", total, len(page))
+	}
+	for _, a := range page {
+		if a.Content != "" {
+			t.Fatalf("AllPage should omit Content, got %q for %s", a.Content, a.Name)
+		}
+		if a.Name == "" || a.SizeBytes == 0 {
+			t.Fatalf("AllPage meta incomplete: %+v", a)
+		}
+		if a.RunTitle != "Run Title" {
+			t.Fatalf("AllPage run_title: got %q", a.RunTitle)
+		}
+	}
+	rec, ok := arts.GetByID(id)
+	if !ok || rec.Content != "hi" {
+		t.Fatalf("GetByID should include Content: %+v ok=%v", rec, ok)
 	}
 	page, total = arts.AllPage("wf", "", 1, 10, "a_")
 	_ = page

--- a/server/internal/services/services_core_test.go
+++ b/server/internal/services/services_core_test.go
@@ -698,12 +698,31 @@ func TestArtifactService(t *testing.T) {
 	if len(s.ByRun("r1")) != 2 {
 		t.Fatal("byrun")
 	}
+	for _, a := range s.ByRun("r1") {
+		if a.Content != "" {
+			t.Fatalf("ByRun should omit Content, got %q for %s", a.Content, a.Name)
+		}
+		if a.Name == "" || a.SizeBytes == 0 {
+			t.Fatalf("ByRun meta incomplete: %+v", a)
+		}
+	}
 	if len(s.All()) != 2 {
 		t.Fatal("all")
+	}
+	for _, a := range s.All() {
+		if a.Content != "" {
+			t.Fatalf("All should omit Content, got %q for %s", a.Content, a.Name)
+		}
+		if a.Name == "" || a.SizeBytes == 0 {
+			t.Fatalf("All meta incomplete: %+v", a)
+		}
 	}
 	rec, ok := s.GetByID(id)
 	if !ok || rec.WorkflowName != "WF" {
 		t.Fatalf("getbyid: %+v %v", rec, ok)
+	}
+	if rec.Content != "updated" {
+		t.Fatalf("GetByID should include Content, got %q", rec.Content)
 	}
 	if _, ok := s.GetByID("ghost"); ok {
 		t.Fatal("missing id")


### PR DESCRIPTION
## Summary
- **ByRun**: add `Omit("Content")` so list queries do not materialize blob content from SQLite into Go memory.
- **All / AllPage** (`allQuery`): replace `artifacts.*` with explicit meta column select (content excluded) plus `runs.title AS run_title`.
- **GetByID / content / download** unchanged — still load full Content for preview and download paths.

## Test plan
- [x] `TestArtifactService`: ByRun / All omit Content; Name/SizeBytes meta intact; GetByID retains Content
- [x] `TestArtifactAllPage`: AllPage omits Content; run_title meta intact; GetByID retains Content
- [x] Handler regression (`Artifact|Download|InboxContext`) — all green

## Scope
In scope: `server/internal/services/artifact.go` + service-layer test assertions only.

Out of scope (not touched): MCP List, Handler/DTO refactor, frontend, GetRun/WS/inbox/broker/gateway.

## Plan coverage evidence
- f1: service tests assert Content empty on ByRun / All / AllPage
- f2: service tests assert Name, SizeBytes, run_title unchanged
- f3: GetByID Content assertion + handler content/download tests pass
- f4: services + handlers regression green

Branch: `feature/artifact-list-omit-content`

Made with [Cursor](https://cursor.com)