### PR TITLE
fix(gateway): bump Dockerfile to Go 1.25 for go.mod

### DIFF
--- a/sandbox-gateway/Dockerfile
+++ b/sandbox-gateway/Dockerfile
@@ -2,7 +2,7 @@
 # Build: docker build -t sandbox-gateway:local .
 # The universal sandbox image is built separately from sandbox/Dockerfile.
 
-FROM golang:1.24-bookworm AS build
+FROM golang:1.25-bookworm AS build
 WORKDIR /src
 
 # 国内 Go 模块代理


### PR DESCRIPTION
## Summary
- #84 (Dependabot) bumped `sandbox-gateway/gateway/go.mod` to `go 1.25.0`
- `sandbox-gateway/Dockerfile` still built with `golang:1.24-bookworm` + `GOTOOLCHAIN=local`, so `go mod download` fails
- Align Dockerfile with CI (`go-version: 1.25.x`) and `server/Dockerfile`

## Test plan
- [ ] CI gateway/sandbox green
- [ ] `docker build` for sandbox-gateway succeeds past `go mod download`


Made with [Cursor](https://cursor.com)