### PR TITLE
ci(gateway): PR smoke-build Dockerfile to catch Go baseline drift

### DIFF
--- a/.github/workflows/ci-gateway.yml
+++ b/.github/workflows/ci-gateway.yml
@@ -1,12 +1,14 @@
 name: ci-gateway
 
 # Path-filtered suite for sandbox-gateway/gateway (control plane).
-# Keeps PR CI light: go vet + unit tests with a 90% coverage gate.
+# Keeps PR CI light: go vet + unit tests with a 90% coverage gate,
+# plus a Dockerfile smoke build so go.mod / image Go baseline drift fails the PR.
 # Image publish remains in publish-gateway (v* tags); not merged into ci-sandbox.
 on:
   push:
     paths:
       - "sandbox-gateway/gateway/**"
+      - "sandbox-gateway/Dockerfile"
       - "sandbox-gateway/scripts/cover-check.sh"
       - ".github/workflows/ci-gateway.yml"
       - ".github/scripts/coverage-badge-color.sh"
@@ -15,6 +17,7 @@ on:
   pull_request:
     paths:
       - "sandbox-gateway/gateway/**"
+      - "sandbox-gateway/Dockerfile"
       - "sandbox-gateway/scripts/cover-check.sh"
       - ".github/workflows/ci-gateway.yml"
       - ".github/scripts/coverage-badge-color.sh"
@@ -68,3 +71,18 @@ jobs:
             coverage-gateway \
             "$pct" \
             "$color"
+
+  # Smoke-build sandbox-gateway/Dockerfile (same context/file as publish-gateway).
+  # push:false — PR gate only; catches go.mod vs image Go baseline drift before merge.
+  gateway-image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v4
+      - name: Build sandbox-gateway Dockerfile
+        uses: docker/build-push-action@v7
+        with:
+          context: ./sandbox-gateway
+          file: ./sandbox-gateway/Dockerfile
+          push: false


### PR DESCRIPTION
## Summary
- Add `sandbox-gateway/Dockerfile` to `ci-gateway` push/pull_request path filters so Dockerfile-only changes trigger the workflow.
- Add independent `gateway-image` job: `docker/setup-buildx-action@v4` + `docker/build-push-action@v7` with `context=./sandbox-gateway`, `file=./sandbox-gateway/Dockerfile`, `push:false` (same coords as publish-gateway).
- Leave existing `gateway` lint/vet/coverage job unchanged.

This closes the gap where Dependabot/#84 could bump `go.mod` while the image stayed on an older Go baseline (`GOTOOLCHAIN=local`) and PR CI stayed green.

## Out of scope (review note only)
- Server Dockerfile PR smoke CI (same class of gap) — open separately if desired.
- No changes to publish-gateway, Go versions, branch protection, or sandbox full-image CI.

## Test plan
- [ ] PR triggers `ci-gateway` (this workflow file change is in paths).
- [ ] Job `gateway-image` runs and builds successfully (`push:false`).
- [ ] Job `gateway` still green (lint/vet/90% coverage).
- [ ] Confirm a hypothetical go.mod bump without Dockerfile sync would fail at `gateway-image` (build failure ⇒ workflow red).


Made with [Cursor](https://cursor.com)