### PR TITLE
fix(web): Run list click nav while refreshing

### DIFF
--- a/web/e2e/delete-run-list.spec.ts
+++ b/web/e2e/delete-run-list.spec.ts
@@ -168,20 +168,35 @@ test.describe('RunListView delete run acceptance', () => {
     await openRunList(page, { width: 390, height: 844 })
     await expect(page.locator('table')).toHaveCount(0)
 
-    const completedCard = page.locator('[role="button"]', { hasText: '已结束流水线' })
+    // Cards use RouterLink custom → role=link (not role=button / bare <a>)
+    const completedCard = page.locator('[role="link"]', { hasText: '已结束流水线' })
     await expect(completedCard.getByTestId('delete-run-btn')).toBeVisible()
     await expect(completedCard.getByTestId('cancel-run-btn')).toHaveCount(0)
 
-    const runningCard = page.locator('[role="button"]', { hasText: '运行中流水线' })
+    const runningCard = page.locator('[role="link"]', { hasText: '运行中流水线' })
     await expect(runningCard.getByTestId('cancel-run-btn')).toBeVisible()
     await expect(runningCard.getByTestId('delete-run-btn')).toHaveCount(0)
 
-    const cancelledCard = page.locator('[role="button"]', { hasText: '已取消流水线' })
+    const cancelledCard = page.locator('[role="link"]', { hasText: '已取消流水线' })
     await expect(cancelledCard.getByTestId('delete-run-btn')).toBeVisible()
     await expect(cancelledCard.getByTestId('run-ops-placeholder')).toHaveCount(0)
 
     await completedCard.getByTestId('delete-run-btn').click()
     await expect(page.getByText('确认删除该次运行？')).toBeVisible()
     await expect(page.getByTestId('run-detail-page')).toHaveCount(0)
+    // Ops stop must not navigate away from the list
+    await expect(page.getByRole('heading', { name: '运行' })).toBeVisible()
+
+    // Cancel on running card: confirm only, no jump to /runs/:id
+    await page
+      .locator('.fixed.inset-0')
+      .filter({ hasText: '确认删除该次运行？' })
+      .getByRole('button', { name: '取消' })
+      .click()
+    await runningCard.getByTestId('cancel-run-btn').click()
+    await expect(page.getByText('取消运行？')).toBeVisible()
+    await expect(page.getByTestId('run-detail-page')).toHaveCount(0)
+    await expect(page).toHaveURL(/run-list\.html/)
+    await expect(page.getByRole('heading', { name: '运行' })).toBeVisible()
   })
 })

--- a/web/src/views/RunListView.test.ts
+++ b/web/src/views/RunListView.test.ts
@@ -6,6 +6,44 @@ import { describe, expect, it } from 'vitest'
 
 const src = readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'RunListView.vue'), 'utf8')
 
+describe('RunListView click UX (loading / nav / prefetch)', () => {
+  it('keeps table-loading opacity without pointer-events:none blocking the list', () => {
+    const blockStart = src.indexOf('.table-loading {')
+    expect(blockStart).toBeGreaterThanOrEqual(0)
+    const blockEnd = src.indexOf('}', blockStart)
+    const block = src.slice(blockStart, blockEnd + 1)
+    expect(block).toMatch(/opacity:\s*0\.55/)
+    expect(block).not.toMatch(/pointer-events:\s*none/)
+    // Entire source must not reintroduce list-level pointer-events:none under table-loading
+    expect(src).not.toMatch(/\.table-loading\s*\{[^}]*pointer-events:\s*none/)
+  })
+
+  it('uses RouterLink / to for run rows and cards', () => {
+    expect(src).toMatch(/<RouterLink/)
+    expect(src).toMatch(/:to="runHref\(r\.id\)"/)
+    expect(src).toMatch(/function runHref\(id: string\)/)
+    expect(src).toMatch(/return '\/runs\/' \+ id/)
+    // Mobile card is a real link; desktop uses custom slot + navigate on tr
+    expect(src).toMatch(/custom\s*\n\s*v-slot="\{ navigate, href \}"/)
+    expect(src).toMatch(/@click="navigate"/)
+  })
+
+  it('prefetches RunDetail chunk on hover / touchstart / pointerdown', () => {
+    expect(src).toMatch(/function prefetchRunDetail\(/)
+    expect(src).toMatch(/import\('@\/views\/RunDetailView\.vue'\)/)
+    expect(src).toMatch(/@mouseenter="prefetchRunDetail"/)
+    expect(src).toMatch(/@touchstart\.passive="prefetchRunDetail"/)
+    expect(src).toMatch(/@pointerdown="prefetchRunDetail"/)
+  })
+
+  it('skips poll assignment when list fingerprint is unchanged', () => {
+    expect(src).toMatch(/function runsListUnchanged\(/)
+    expect(src).toMatch(/function runListFingerprint\(/)
+    expect(src).toMatch(/if \(!runsListUnchanged\(/)
+    expect(src).toMatch(/setInterval\(load, 3000\)/)
+  })
+})
+
 describe('RunListView cancel run', () => {
   it('exposes inline cancel for queued, running, and waiting_human', () => {
     expect(src).toMatch(/data-testid="cancel-run-btn"/)
@@ -36,7 +74,8 @@ describe('RunListView cancel run', () => {
   it('keeps cancel confirm copy distinct from delete and supports mobile cards', () => {
     expect(src).toMatch(/pages\.runDetail\.cancelWarning/)
     expect(src).toMatch(/pages\.runList\.cancelConfirm/)
-    expect(src).toMatch(/role="button"/)
+    // Mobile cards navigate via RouterLink (not role=button + openRun)
+    expect(src).toMatch(/<!-- Mobile card list -->[\s\S]*?<RouterLink/)
     expect(src).toMatch(/@click\.stop @keydown\.stop/)
   })
 })
@@ -57,7 +96,7 @@ describe('RunListView delete run and ops column', () => {
     )
     const deleteFn = src.slice(
       src.indexOf('function canDeleteRun(r: Run)'),
-      src.indexOf('function openRun(r: Run)'),
+      src.indexOf('function prefetchRunDetail('),
     )
     expect(cancelFn).not.toMatch(/completed|failed/)
     expect(deleteFn).not.toMatch(/queued|running|waiting_human/)

--- a/web/src/views/RunListView.test.ts
+++ b/web/src/views/RunListView.test.ts
@@ -23,9 +23,10 @@ describe('RunListView click UX (loading / nav / prefetch)', () => {
     expect(src).toMatch(/:to="runHref\(r\.id\)"/)
     expect(src).toMatch(/function runHref\(id: string\)/)
     expect(src).toMatch(/return '\/runs\/' \+ id/)
-    // Mobile card is a real link; desktop uses custom slot + navigate on tr
-    expect(src).toMatch(/custom\s*\n\s*v-slot="\{ navigate, href \}"/)
-    expect(src).toMatch(/@click="navigate"/)
+    // Both mobile cards and desktop rows use custom + navigate (no bare <a> wrapping ops)
+    expect(src.match(/custom\s*\n\s*v-slot="\{ navigate, href \}"/g)?.length).toBeGreaterThanOrEqual(2)
+    expect(src.match(/@click="navigate"/g)?.length).toBeGreaterThanOrEqual(2)
+    expect(src).toMatch(/role="link"/)
   })
 
   it('prefetches RunDetail chunk on hover / touchstart / pointerdown', () => {
@@ -74,9 +75,14 @@ describe('RunListView cancel run', () => {
   it('keeps cancel confirm copy distinct from delete and supports mobile cards', () => {
     expect(src).toMatch(/pages\.runDetail\.cancelWarning/)
     expect(src).toMatch(/pages\.runList\.cancelConfirm/)
-    // Mobile cards navigate via RouterLink (not role=button + openRun)
+    // Mobile cards: RouterLink custom + role=link (not bare <a> / role=button + openRun)
     expect(src).toMatch(/<!-- Mobile card list -->[\s\S]*?<RouterLink/)
-    expect(src).toMatch(/@click\.stop @keydown\.stop/)
+    const mobileBlock = src.slice(src.indexOf('<!-- Mobile card list -->'), src.indexOf('<!-- Desktop table -->'))
+    expect(mobileBlock).toMatch(/custom/)
+    expect(mobileBlock).toMatch(/v-slot="\{ navigate, href \}"/)
+    expect(mobileBlock).toMatch(/role="link"/)
+    expect(mobileBlock).not.toMatch(/<RouterLink[^>]*\n[^>]*class="/)
+    expect(mobileBlock).toMatch(/@click\.stop @keydown\.stop/)
   })
 })
 
@@ -145,6 +151,11 @@ describe('RunListView delete run and ops column', () => {
     expect(src).toMatch(/data-testid="run-ops-placeholder"/)
     // desktop ops cell and mobile ops wrapper both stop click
     expect(src.match(/data-testid="run-ops"[^>]*@click\.stop/g)?.length).toBeGreaterThanOrEqual(2)
+    // Regression: mobile must use custom+navigate so ops @click.stop does not enable native <a> href
+    const mobileBlock = src.slice(src.indexOf('<!-- Mobile card list -->'), src.indexOf('<!-- Desktop table -->'))
+    expect(mobileBlock).toMatch(/custom/)
+    expect(mobileBlock).toMatch(/@click="navigate"/)
+    expect(mobileBlock).toMatch(/role="link"/)
   })
 
   it('keeps cancel confirm flow and does not drop cancel modal', () => {

--- a/web/src/views/RunListView.vue
+++ b/web/src/views/RunListView.vue
@@ -468,75 +468,90 @@ onUnmounted(() => {
         {{ emptyMessage }}
       </div>
       <div v-else class="flex flex-col gap-2">
+        <!--
+          custom + navigate (not a real <a>): ops @click.stop must not sit inside
+          a native link, or stopPropagation blocks Vue Router's preventDefault and
+          the browser follows href (cancel/delete → whole-page jump to /runs/:id).
+        -->
         <RouterLink
           v-for="r in runs"
           :key="r.id"
           :to="runHref(r.id)"
-          class="flex w-full cursor-pointer flex-col gap-2 rounded-lg border border-line bg-surface p-3 text-left no-underline transition hover:border-line-strong hover:bg-elevated"
-          @mouseenter="prefetchRunDetail"
-          @touchstart.passive="prefetchRunDetail"
-          @pointerdown="prefetchRunDetail"
+          custom
+          v-slot="{ navigate, href }"
         >
-          <div class="flex items-start justify-between gap-3">
-            <div class="min-w-0 flex-1">
-              <div
-                v-if="r.title"
-                class="truncate text-sm font-semibold text-txt"
-                :title="r.title.length > 60 ? r.title : undefined"
-              >{{ truncateText(r.title, 60) }}</div>
-              <div
-                class="font-mono text-xs text-txt3"
-                :class="r.title ? 'mt-0.5' : 'text-[13px] font-medium'"
-              >#{{ runIdShort(r.id) }}</div>
-            </div>
-            <StatusPill :status="r.status" size="sm" />
-          </div>
-          <div class="flex flex-wrap items-center gap-1.5">
-            <PriorityBadge :priority="r.priority" />
-          </div>
-          <div class="flex min-w-0 flex-col gap-1">
-            <div class="flex items-center gap-2">
-              <div class="h-1.5 w-20 shrink-0 overflow-hidden rounded-full bg-elevated">
-                <div class="h-full rounded-full bg-accent" :style="{ width: r.progress * 100 + '%' }" />
+          <div
+            role="link"
+            :data-href="href"
+            tabindex="0"
+            class="flex w-full cursor-pointer flex-col gap-2 rounded-lg border border-line bg-surface p-3 text-left no-underline transition hover:border-line-strong hover:bg-elevated"
+            @click="navigate"
+            @keydown.enter.prevent="() => navigate()"
+            @mouseenter="prefetchRunDetail"
+            @touchstart.passive="prefetchRunDetail"
+            @pointerdown="prefetchRunDetail"
+          >
+            <div class="flex items-start justify-between gap-3">
+              <div class="min-w-0 flex-1">
+                <div
+                  v-if="r.title"
+                  class="truncate text-sm font-semibold text-txt"
+                  :title="r.title.length > 60 ? r.title : undefined"
+                >{{ truncateText(r.title, 60) }}</div>
+                <div
+                  class="font-mono text-xs text-txt3"
+                  :class="r.title ? 'mt-0.5' : 'text-[13px] font-medium'"
+                >#{{ runIdShort(r.id) }}</div>
               </div>
-              <span class="text-[11px] tabular-nums text-txt3">{{ Math.round(r.progress * 100) }}%</span>
+              <StatusPill :status="r.status" size="sm" />
             </div>
-            <div
-              v-if="showNodeLabel(r)"
-              :key="`${r.id}-${r.currentNodeLabel}`"
-              class="node-label-fade max-w-full truncate text-[11px]"
-              :class="r.status === 'waiting_human' ? 'text-warn' : 'text-txt3'"
-              :title="r.currentNodeLabel!.length > 60 ? r.currentNodeLabel : undefined"
-            >{{ truncateText(r.currentNodeLabel!, 60) }}</div>
-          </div>
-          <div class="flex min-w-0 items-center justify-between gap-2">
-            <div class="flex min-w-0 items-center gap-1.5 text-[12px] text-txt2">
-              <span class="truncate">{{ r.workflowName }}</span>
-              <span v-if="r.workflowVersion" class="chip shrink-0">v{{ r.workflowVersion }}</span>
+            <div class="flex flex-wrap items-center gap-1.5">
+              <PriorityBadge :priority="r.priority" />
             </div>
-            <div class="shrink-0" data-testid="run-ops" @click.stop @keydown.stop>
-              <AppButton
-                v-if="canCancelRun(r)"
-                data-testid="cancel-run-btn"
-                variant="danger"
-                size="sm"
-                :disabled="cancellingRun && cancelTarget?.id === r.id"
-                @click="openCancelConfirm(r)"
-              >{{ t('common.buttons.cancel') }}</AppButton>
-              <AppButton
-                v-else-if="canDeleteRun(r)"
-                data-testid="delete-run-btn"
-                variant="danger"
-                size="sm"
-                :disabled="deletingRun && deleteTarget?.id === r.id"
-                @click="openDeleteConfirm(r)"
-              >{{ t('common.buttons.delete') }}</AppButton>
-              <span
-                v-else
-                data-testid="run-ops-placeholder"
-                class="select-none px-1 text-sm text-txt3/50"
-                aria-hidden="true"
-              >—</span>
+            <div class="flex min-w-0 flex-col gap-1">
+              <div class="flex items-center gap-2">
+                <div class="h-1.5 w-20 shrink-0 overflow-hidden rounded-full bg-elevated">
+                  <div class="h-full rounded-full bg-accent" :style="{ width: r.progress * 100 + '%' }" />
+                </div>
+                <span class="text-[11px] tabular-nums text-txt3">{{ Math.round(r.progress * 100) }}%</span>
+              </div>
+              <div
+                v-if="showNodeLabel(r)"
+                :key="`${r.id}-${r.currentNodeLabel}`"
+                class="node-label-fade max-w-full truncate text-[11px]"
+                :class="r.status === 'waiting_human' ? 'text-warn' : 'text-txt3'"
+                :title="r.currentNodeLabel!.length > 60 ? r.currentNodeLabel : undefined"
+              >{{ truncateText(r.currentNodeLabel!, 60) }}</div>
+            </div>
+            <div class="flex min-w-0 items-center justify-between gap-2">
+              <div class="flex min-w-0 items-center gap-1.5 text-[12px] text-txt2">
+                <span class="truncate">{{ r.workflowName }}</span>
+                <span v-if="r.workflowVersion" class="chip shrink-0">v{{ r.workflowVersion }}</span>
+              </div>
+              <div class="shrink-0" data-testid="run-ops" @click.stop @keydown.stop>
+                <AppButton
+                  v-if="canCancelRun(r)"
+                  data-testid="cancel-run-btn"
+                  variant="danger"
+                  size="sm"
+                  :disabled="cancellingRun && cancelTarget?.id === r.id"
+                  @click="openCancelConfirm(r)"
+                >{{ t('common.buttons.cancel') }}</AppButton>
+                <AppButton
+                  v-else-if="canDeleteRun(r)"
+                  data-testid="delete-run-btn"
+                  variant="danger"
+                  size="sm"
+                  :disabled="deletingRun && deleteTarget?.id === r.id"
+                  @click="openDeleteConfirm(r)"
+                >{{ t('common.buttons.delete') }}</AppButton>
+                <span
+                  v-else
+                  data-testid="run-ops-placeholder"
+                  class="select-none px-1 text-sm text-txt3/50"
+                  aria-hidden="true"
+                >—</span>
+              </div>
             </div>
           </div>
         </RouterLink>

--- a/web/src/views/RunListView.vue
+++ b/web/src/views/RunListView.vue
@@ -118,8 +118,44 @@ function canDeleteRun(r: Run) {
   return r.status === 'completed' || r.status === 'failed' || r.status === 'cancelled'
 }
 
-function openRun(r: Run) {
-  router.push('/runs/' + r.id)
+/** Prefetch RunDetail chunk once so list → detail navigation feels snappy. */
+let runDetailPrefetch: Promise<unknown> | null = null
+function prefetchRunDetail() {
+  if (!runDetailPrefetch) {
+    runDetailPrefetch = import('@/views/RunDetailView.vue')
+  }
+}
+
+function runHref(id: string) {
+  return '/runs/' + id
+}
+
+/** Display fields compared before poll/list assignment to skip no-op re-renders. */
+function runListFingerprint(r: Run): string {
+  return [
+    r.id,
+    r.status,
+    r.title ?? '',
+    r.priority ?? '',
+    r.progress,
+    r.durationSec,
+    r.currentNodeLabel ?? '',
+    r.workflowName,
+    r.workflowVersion ?? '',
+    r.trigger,
+    r.startedAt,
+    r.createdAt ?? '',
+  ].join('\0')
+}
+
+function runsListUnchanged(next: Run[], nextTotal: number): boolean {
+  if (nextTotal !== total.value) return false
+  const prev = runs.value
+  if (prev.length !== next.length) return false
+  for (let i = 0; i < next.length; i++) {
+    if (runListFingerprint(prev[i]) !== runListFingerprint(next[i])) return false
+  }
+  return true
 }
 
 function openCancelConfirm(r: Run) {
@@ -254,9 +290,11 @@ async function load({ showLoading = false }: { showLoading?: boolean } = {}) {
     const data = await api.listRuns(listParams())
     if (localSeq === requestSeq) {
       if (isPaginated(data)) {
-        runs.value = data.items
-        total.value = data.total
-      } else {
+        if (!runsListUnchanged(data.items, data.total)) {
+          runs.value = data.items
+          total.value = data.total
+        }
+      } else if (!runsListUnchanged(data, data.length)) {
         runs.value = data
         total.value = data.length
       }
@@ -430,14 +468,14 @@ onUnmounted(() => {
         {{ emptyMessage }}
       </div>
       <div v-else class="flex flex-col gap-2">
-        <div
+        <RouterLink
           v-for="r in runs"
           :key="r.id"
-          role="button"
-          tabindex="0"
-          class="flex w-full cursor-pointer flex-col gap-2 rounded-lg border border-line bg-surface p-3 text-left transition hover:border-line-strong hover:bg-elevated"
-          @click="openRun(r)"
-          @keydown.enter.prevent="openRun(r)"
+          :to="runHref(r.id)"
+          class="flex w-full cursor-pointer flex-col gap-2 rounded-lg border border-line bg-surface p-3 text-left no-underline transition hover:border-line-strong hover:bg-elevated"
+          @mouseenter="prefetchRunDetail"
+          @touchstart.passive="prefetchRunDetail"
+          @pointerdown="prefetchRunDetail"
         >
           <div class="flex items-start justify-between gap-3">
             <div class="min-w-0 flex-1">
@@ -501,7 +539,7 @@ onUnmounted(() => {
               >—</span>
             </div>
           </div>
-        </div>
+        </RouterLink>
       </div>
       <Pagination v-if="total > PAGE_SIZE" v-model:page="page" :page-size="PAGE_SIZE" :total="total" />
     </div>
@@ -605,79 +643,92 @@ onUnmounted(() => {
             </td>
           </tr>
           <template v-else>
-            <tr
+            <RouterLink
               v-for="r in runs"
               :key="r.id"
-              class="cursor-pointer border-t border-line transition hover:bg-elevated"
-              @click="openRun(r)"
+              :to="runHref(r.id)"
+              custom
+              v-slot="{ navigate, href }"
             >
-              <td class="max-w-[340px] px-5 py-3">
-                <template v-if="r.title">
-                  <div
-                    class="max-w-[320px] truncate font-semibold text-txt"
-                    :title="r.title.length > 60 ? r.title : undefined"
-                  >{{ truncateText(r.title, 60) }}</div>
-                  <div class="mt-0.5 font-mono text-xs text-txt3">#{{ runIdShort(r.id) }}</div>
-                </template>
-                <span v-else class="font-mono text-[13px] font-medium text-txt3">#{{ runIdShort(r.id) }}</span>
-              </td>
-              <td class="px-5 py-3 text-txt2">
-                {{ r.workflowName }}
-                <span v-if="r.workflowVersion" class="chip ml-1.5">v{{ r.workflowVersion }}</span>
-              </td>
-              <td class="px-5 py-3 text-txt3">{{ formatTrigger(r.trigger) }}</td>
-              <td class="px-5 py-3 text-txt3">
-                <template v-if="r.status === 'queued'">
-                  {{ fmtTime(r.createdAt ?? '') }}
-                  <span class="ml-1 text-[10px] text-[#7B61FF]">{{ t('pages.runList.queued') }}</span>
-                </template>
-                <template v-else>{{ fmtTime(r.startedAt) }}</template>
-              </td>
-              <td class="px-5 py-3 text-txt3">{{ fmtDuration(r.durationSec) }}</td>
-              <td class="px-5 py-3">
-                <div class="min-w-[148px] max-w-[168px]">
-                  <div class="flex items-center gap-2">
-                    <div class="h-1.5 w-20 shrink-0 overflow-hidden rounded-full bg-elevated">
-                      <div class="h-full rounded-full bg-accent" :style="{ width: r.progress * 100 + '%' }" />
+              <tr
+                role="link"
+                :data-href="href"
+                tabindex="0"
+                class="cursor-pointer border-t border-line transition hover:bg-elevated"
+                @click="navigate"
+                @keydown.enter.prevent="() => navigate()"
+                @mouseenter="prefetchRunDetail"
+                @touchstart.passive="prefetchRunDetail"
+                @pointerdown="prefetchRunDetail"
+              >
+                <td class="max-w-[340px] px-5 py-3">
+                  <template v-if="r.title">
+                    <div
+                      class="max-w-[320px] truncate font-semibold text-txt"
+                      :title="r.title.length > 60 ? r.title : undefined"
+                    >{{ truncateText(r.title, 60) }}</div>
+                    <div class="mt-0.5 font-mono text-xs text-txt3">#{{ runIdShort(r.id) }}</div>
+                  </template>
+                  <span v-else class="font-mono text-[13px] font-medium text-txt3">#{{ runIdShort(r.id) }}</span>
+                </td>
+                <td class="px-5 py-3 text-txt2">
+                  {{ r.workflowName }}
+                  <span v-if="r.workflowVersion" class="chip ml-1.5">v{{ r.workflowVersion }}</span>
+                </td>
+                <td class="px-5 py-3 text-txt3">{{ formatTrigger(r.trigger) }}</td>
+                <td class="px-5 py-3 text-txt3">
+                  <template v-if="r.status === 'queued'">
+                    {{ fmtTime(r.createdAt ?? '') }}
+                    <span class="ml-1 text-[10px] text-[#7B61FF]">{{ t('pages.runList.queued') }}</span>
+                  </template>
+                  <template v-else>{{ fmtTime(r.startedAt) }}</template>
+                </td>
+                <td class="px-5 py-3 text-txt3">{{ fmtDuration(r.durationSec) }}</td>
+                <td class="px-5 py-3">
+                  <div class="min-w-[148px] max-w-[168px]">
+                    <div class="flex items-center gap-2">
+                      <div class="h-1.5 w-20 shrink-0 overflow-hidden rounded-full bg-elevated">
+                        <div class="h-full rounded-full bg-accent" :style="{ width: r.progress * 100 + '%' }" />
+                      </div>
+                      <span class="text-[11px] text-txt3">{{ Math.round(r.progress * 100) }}%</span>
                     </div>
-                    <span class="text-[11px] text-txt3">{{ Math.round(r.progress * 100) }}%</span>
+                    <div
+                      v-if="showNodeLabel(r)"
+                      :key="`${r.id}-${r.currentNodeLabel}`"
+                      class="node-label-fade mt-1 max-w-[148px] truncate text-[11px]"
+                      :class="r.status === 'waiting_human' ? 'text-warn' : 'text-txt3'"
+                      :title="r.currentNodeLabel!.length > 60 ? r.currentNodeLabel : undefined"
+                    >{{ truncateText(r.currentNodeLabel!, 60) }}</div>
                   </div>
-                  <div
-                    v-if="showNodeLabel(r)"
-                    :key="`${r.id}-${r.currentNodeLabel}`"
-                    class="node-label-fade mt-1 max-w-[148px] truncate text-[11px]"
-                    :class="r.status === 'waiting_human' ? 'text-warn' : 'text-txt3'"
-                    :title="r.currentNodeLabel!.length > 60 ? r.currentNodeLabel : undefined"
-                  >{{ truncateText(r.currentNodeLabel!, 60) }}</div>
-                </div>
-              </td>
-              <td class="px-5 py-3"><StatusPill :status="r.status" size="sm" /></td>
-              <td class="px-5 py-3"><PriorityBadge :priority="r.priority" /></td>
-              <td class="px-5 py-3 text-right" data-testid="run-ops" @click.stop>
-                <AppButton
-                  v-if="canCancelRun(r)"
-                  data-testid="cancel-run-btn"
-                  variant="danger"
-                  size="sm"
-                  :disabled="cancellingRun && cancelTarget?.id === r.id"
-                  @click="openCancelConfirm(r)"
-                >{{ t('common.buttons.cancel') }}</AppButton>
-                <AppButton
-                  v-else-if="canDeleteRun(r)"
-                  data-testid="delete-run-btn"
-                  variant="danger"
-                  size="sm"
-                  :disabled="deletingRun && deleteTarget?.id === r.id"
-                  @click="openDeleteConfirm(r)"
-                >{{ t('common.buttons.delete') }}</AppButton>
-                <span
-                  v-else
-                  data-testid="run-ops-placeholder"
-                  class="select-none px-1 text-sm text-txt3/50"
-                  aria-hidden="true"
-                >—</span>
-              </td>
-            </tr>
+                </td>
+                <td class="px-5 py-3"><StatusPill :status="r.status" size="sm" /></td>
+                <td class="px-5 py-3"><PriorityBadge :priority="r.priority" /></td>
+                <td class="px-5 py-3 text-right" data-testid="run-ops" @click.stop>
+                  <AppButton
+                    v-if="canCancelRun(r)"
+                    data-testid="cancel-run-btn"
+                    variant="danger"
+                    size="sm"
+                    :disabled="cancellingRun && cancelTarget?.id === r.id"
+                    @click="openCancelConfirm(r)"
+                  >{{ t('common.buttons.cancel') }}</AppButton>
+                  <AppButton
+                    v-else-if="canDeleteRun(r)"
+                    data-testid="delete-run-btn"
+                    variant="danger"
+                    size="sm"
+                    :disabled="deletingRun && deleteTarget?.id === r.id"
+                    @click="openDeleteConfirm(r)"
+                  >{{ t('common.buttons.delete') }}</AppButton>
+                  <span
+                    v-else
+                    data-testid="run-ops-placeholder"
+                    class="select-none px-1 text-sm text-txt3/50"
+                    aria-hidden="true"
+                  >—</span>
+                </td>
+              </tr>
+            </RouterLink>
           </template>
         </tbody>
       </table>
@@ -759,7 +810,6 @@ onUnmounted(() => {
 <style scoped>
 .table-loading {
   opacity: 0.55;
-  pointer-events: none;
 }
 
 @keyframes nodeLabelFadeIn {


### PR DESCRIPTION
## Summary
- Remove `pointer-events: none` from `.table-loading` so filter/pagination refresh opacity no longer blocks row/card taps (main mobile “no response” cause); keep ~0.55 opacity.
- Desktop rows and mobile cards use `RouterLink` **custom + navigate** (`role=link`) to `/runs/:id` so cancel/delete `@click.stop` does not fight a real `<a href>` navigation; ops remain stop-only.
- Prefetch `RunDetailView` on mouseenter / touchstart / pointerdown; skip poll list assignment when total + display fingerprints are unchanged.

## Test plan
- [x] Semi-transparent loading: click row/card → enters run detail (`pointer-events: auto`)
- [x] Desktop: click `tr[role=link]` → detail; delete only confirms
- [x] Mobile: card tap opens detail; cancel only confirms, no navigation
- [x] `npx vitest run src/views/RunListView.test.ts` (14) + `vue-tsc --noEmit`
- [x] `npx playwright test e2e/delete-run-list.spec.ts` (5)

## Follow-up
- RunDetailView code-splitting / reduce sync deps for first-hit cold load (out of scope)

Made with [Cursor](https://cursor.com)