### PR TITLE
fix(clarify): 澄清会话对齐沙箱队列/流式/Cancel + 刷新续传

### DIFF
--- a/server/internal/engine/clarify_session_test.go
+++ b/server/internal/engine/clarify_session_test.go
@@ -1,0 +1,137 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+)
+
+// TestClarifySessionQueueAndCancelKeepNext: clarify Cancel keeps pending FIFO
+// and pumps the next item (Demo semantics; NOT review clear-queue).
+func TestClarifySessionQueueAndCancelKeepNext(t *testing.T) {
+	eng, db, provider := setupEngineGraphP(t, reactOnlyGraph())
+	hold := make(chan struct{})
+	provider.reactHold = hold
+	provider.reactPending = 10 // keep dialogue open so Cancel path is exercised
+
+	run, err := eng.StartRun("wf", nil, "test")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitReactPause(t, db, run.ID, "clarify")
+
+	if _, err := eng.EnqueueClarifyTurn(run.ID, "clarify", "第一条", nil, nil); err != nil {
+		t.Fatalf("enqueue1: %v", err)
+	}
+	if _, err := eng.EnqueueClarifyTurn(run.ID, "clarify", "第二条", nil, nil); err != nil {
+		t.Fatalf("enqueue2: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		w, thinking := eng.ReviewSessionState(run.ID, "clarify")
+		if thinking && w >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	w, thinking := eng.ReviewSessionState(run.ID, "clarify")
+	if !thinking || w < 1 {
+		t.Fatalf("expected active + pending, got waiting=%d thinking=%v", w, thinking)
+	}
+
+	if err := eng.CancelClarifyTurn(run.ID, "clarify"); err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+	// Clear hold BEFORE the pump starts item 2 (item 1 still has a local hold
+	// ref and unblocks via ctx cancel). Otherwise item 2 blocks forever.
+	provider.mu.Lock()
+	provider.reactHold = nil
+	provider.mu.Unlock()
+	close(hold)
+
+	deadline = time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		provider.mu.Lock()
+		n := provider.reactReplyCalls["clarify"]
+		provider.mu.Unlock()
+		if n >= 2 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	provider.mu.Lock()
+	calls := provider.reactReplyCalls["clarify"]
+	provider.mu.Unlock()
+	if calls < 2 {
+		t.Fatalf("clarify Cancel must keep queue and pump next; reactReplyCalls=%d", calls)
+	}
+	if err := eng.waitReviewReadyForTest(run.ID, "clarify", 5*time.Second); err != nil {
+		t.Fatalf("wait after cancel+next: %v", err)
+	}
+
+	var conv models.ReactConversation
+	if err := db.Where("run_id = ? AND node_id = ?", run.ID, "clarify").First(&conv).Error; err != nil {
+		t.Fatalf("load conv: %v", err)
+	}
+	var sawInterrupted, sawSecondHuman bool
+	for _, m := range conv.Messages {
+		if m.Role == "agent" && m.Interrupted {
+			sawInterrupted = true
+		}
+		if m.Role == "human" && strings.Contains(m.Text, "第二条") {
+			sawSecondHuman = true
+		}
+	}
+	if !sawInterrupted {
+		t.Fatalf("expected interrupted agent after Cancel: %+v", conv.Messages)
+	}
+	if !sawSecondHuman {
+		t.Fatalf("expected second human turn after keep-queue Cancel: %+v", conv.Messages)
+	}
+}
+
+// TestClarifyReactReplyEnqueues: classic ReactReply(!force) returns before the
+// turn finishes and exposes waiting via ReviewSessionState.
+func TestClarifyReactReplyEnqueues(t *testing.T) {
+	eng, db, provider := setupEngineGraphP(t, reactOnlyGraph())
+	hold := make(chan struct{})
+	provider.reactHold = hold
+	provider.reactPending = 1
+
+	run, err := eng.StartRun("wf", nil, "test")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitReactPause(t, db, run.ID, "clarify")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- eng.ReactReply(run.ID, "clarify", "异步入队", nil, nil, false)
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("enqueue reply: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ReactReply(!force) should return immediately after enqueue")
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, thinking := eng.ReviewSessionState(run.ID, "clarify"); thinking {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	_, thinking := eng.ReviewSessionState(run.ID, "clarify")
+	if !thinking {
+		t.Fatal("expected thinking after enqueue")
+	}
+	close(hold)
+	provider.reactHold = nil
+	if err := eng.waitReviewReadyForTest(run.ID, "clarify", 5*time.Second); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+}

--- a/server/internal/engine/engine_misc_test.go
+++ b/server/internal/engine/engine_misc_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cocofhu/approving/internal/database"
 	"github.com/cocofhu/approving/internal/mcp"
@@ -366,6 +367,9 @@ func TestReactMultiRound(t *testing.T) {
 	if err := eng.ReactReply(run.ID, "clarify", "第一轮", nil, nil, false); err != nil {
 		t.Fatalf("reply 1: %v", err)
 	}
+	if err := eng.waitReviewReadyForTest(run.ID, "clarify", 5*time.Second); err != nil {
+		t.Fatalf("wait after reply 1: %v", err)
+	}
 	var conv models.ReactConversation
 	db.Where("run_id = ? AND node_id = ?", run.ID, "clarify").Order("iteration desc").First(&conv)
 	if conv.Done {
@@ -378,6 +382,9 @@ func TestReactMultiRound(t *testing.T) {
 	// Second reply -> agent finishes; run completes.
 	if err := eng.ReactReply(run.ID, "clarify", "第二轮", nil, nil, false); err != nil {
 		t.Fatalf("reply 2: %v", err)
+	}
+	if err := eng.waitReviewReadyForTest(run.ID, "clarify", 5*time.Second); err != nil {
+		t.Fatalf("wait after reply 2: %v", err)
 	}
 	waitRunStatus(t, db, run.ID, "completed")
 

--- a/server/internal/engine/engine_test.go
+++ b/server/internal/engine/engine_test.go
@@ -144,6 +144,9 @@ func TestClarifyToDesignRun(t *testing.T) {
 	if err := eng.ReactReply(run.ID, "clarify", "邮箱验证码,5 分钟有效", nil, nil, false); err != nil {
 		t.Fatalf("clarify reply: %v", err)
 	}
+	if err := eng.waitReviewReadyForTest(run.ID, "clarify", 5*time.Second); err != nil {
+		t.Fatalf("wait clarify turn: %v", err)
+	}
 
 	// design (agent) and review_design (review) run automatically, then the
 	// human gate pauses.

--- a/server/internal/engine/fakeprovider_test.go
+++ b/server/internal/engine/fakeprovider_test.go
@@ -113,6 +113,8 @@ type fakeProvider struct {
 	// reviseHold (test-only): when non-nil, ReviseInPlace blocks until the
 	// channel is closed (simulates a long in-flight turn for Cancel/ready tests).
 	reviseHold <-chan struct{}
+	// reactHold (test-only): same for ReactReply / clarify session Cancel.
+	reactHold <-chan struct{}
 }
 
 // nextStructuredBody returns the reserved-artifact body to write for nodeID on
@@ -396,7 +398,16 @@ func (f *fakeProvider) ReactReply(ctx context.Context, req runtime.NodeReq, hist
 		f.reactPending--
 	}
 	skip := f.reactSkipProduces
+	hold := f.reactHold
 	f.mu.Unlock()
+	if hold != nil {
+		select {
+		case <-hold:
+		case <-ctx.Done():
+			return runtime.ReactTurn{Msg: "(已中断)", Done: false, Err: ctx.Err(),
+				Events: []models.AcpEvent{{Kind: "message", Text: "clarify-cancelled"}}}
+		}
+	}
 	// Still gathering info: keep the dialogue open with another question.
 	if pending > 0 && !force {
 		if f.recordCalls {

--- a/server/internal/engine/react_sandbox_fail_test.go
+++ b/server/internal/engine/react_sandbox_fail_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/cocofhu/approving/internal/models"
 	"github.com/cocofhu/approving/internal/services"
@@ -145,6 +146,9 @@ func TestPlanSandboxFailureStillFinishesRun(t *testing.T) {
 	waitReactPause(t, db, run.ID, "clarify")
 	if err := eng.ReactReply(run.ID, "clarify", "ok", nil, nil, false); err != nil {
 		t.Fatalf("clarify reply: %v", err)
+	}
+	if err := eng.waitReviewReadyForTest(run.ID, "clarify", 5*time.Second); err != nil {
+		t.Fatalf("wait clarify: %v", err)
 	}
 
 	waitRunStatus(t, db, run.ID, "failed")

--- a/server/internal/engine/resume.go
+++ b/server/internal/engine/resume.go
@@ -335,6 +335,9 @@ func (e *Engine) snapshotPreviewIssues(c *execCtx, runID, nodeID string) error {
 // without Agent wrap-up, re-validates, and advances the FSM ("确认并流转").
 // Annotations are folded into the human instruction so the agent edits the
 // exact cited spots on revise turns.
+//
+// Non-force clarify and review turns enqueue onto the platform FIFO and return
+// immediately (SandboxChat-aligned); human/agent bubbles materialize on turn_begin.
 func (e *Engine) ReactReply(runID, nodeID, humanText string, images []models.PromptImage, annotations []models.ReactAnnotation, force bool) error {
 	if e.IsHalted() {
 		return errors.New("server is shutting down")
@@ -342,10 +345,29 @@ func (e *Engine) ReactReply(runID, nodeID, humanText string, images []models.Pro
 
 	cPeek, peekErr := e.loadCtx(runID)
 	if peekErr == nil {
-		if n := cPeek.graph.FindNode(nodeID); n != nil && isReviewNode(n.Type) {
-			// Review !force: enqueue onto the platform FIFO (SandboxChat-aligned)
-			// and return immediately — human/agent bubbles materialize on turn_begin.
-			if !force {
+		if n := cPeek.graph.FindNode(nodeID); n != nil {
+			if isReviewNode(n.Type) {
+				// Review !force: enqueue onto the platform FIFO (SandboxChat-aligned)
+				// and return immediately — human/agent bubbles materialize on turn_begin.
+				if !force {
+					var convPeek models.ReactConversation
+					if err := e.db.Where("run_id = ? AND node_id = ?", runID, nodeID).
+						Order("iteration desc, id desc").First(&convPeek).Error; err != nil {
+						return errors.New("no react conversation")
+					}
+					if convPeek.Done {
+						return errors.New("react already done")
+					}
+					_, err := e.EnqueueReviewTurn(runID, nodeID, humanText, images, annotations, "node", "")
+					return err
+				}
+				// Review force (确认并流转): only when ready (no active turn, empty queue).
+				// Cancel ≠ confirm — do not preempt via RetireSession while busy.
+				if !e.ReviewSessionReady(runID, nodeID) {
+					return errors.New("复审进行中或待发送队列非空,请先 Cancel 或等待完成后再确认")
+				}
+			} else if n.Type == "react" && !force {
+				// Classic clarify !force: same FIFO / WS / refresh-resume as review.
 				var convPeek models.ReactConversation
 				if err := e.db.Where("run_id = ? AND node_id = ?", runID, nodeID).
 					Order("iteration desc, id desc").First(&convPeek).Error; err != nil {
@@ -354,13 +376,13 @@ func (e *Engine) ReactReply(runID, nodeID, humanText string, images []models.Pro
 				if convPeek.Done {
 					return errors.New("react already done")
 				}
-				_, err := e.EnqueueReviewTurn(runID, nodeID, humanText, images, annotations, "node", "")
+				_, err := e.EnqueueClarifyTurn(runID, nodeID, humanText, images, annotations)
 				return err
-			}
-			// Review force (确认并流转): only when ready (no active turn, empty queue).
-			// Cancel ≠ confirm — do not preempt via RetireSession while busy.
-			if !e.ReviewSessionReady(runID, nodeID) {
-				return errors.New("复审进行中或待发送队列非空,请先 Cancel 或等待完成后再确认")
+			} else if n.Type == "react" && force {
+				// Clarify force finish: only when session idle (no in-flight / queue).
+				if !e.ReviewSessionReady(runID, nodeID) {
+					return errors.New("澄清进行中或待发送队列非空,请先 Cancel 或等待完成后再结束")
+				}
 			}
 		}
 	}
@@ -402,6 +424,12 @@ func (e *Engine) ReactReply(runID, nodeID, humanText string, images []models.Pro
 			Images: images, Annotations: annotations})
 		logDB(e.db.Save(&conv), runID, "save react human turn")
 		return e.reviewReply(c, node, &conv, renderReviewHuman(humanText, annotations), images, true)
+	}
+
+	// Classic clarify !force already returned via EnqueueClarifyTurn above.
+	// Only force wrap-up remains on the synchronous path.
+	if !force {
+		return errors.New("internal: clarify non-force must enqueue")
 	}
 
 	now := time.Now().Format(time.RFC3339)

--- a/server/internal/engine/review_session.go
+++ b/server/internal/engine/review_session.go
@@ -476,12 +476,9 @@ func (e *Engine) executeClarifyTurn(ctx context.Context, s *reviewSession, item 
 	}
 
 	// Auto-clarify: recommended options while auto_var is on.
+	// autoAdvanceReact already appends human/agent turns to conv.
 	if !force && !t.Done && len(t.Questions) > 0 && e.autoReactEnabled(c, node) {
 		t = e.autoAdvanceReact(c, node, &conv, req, t)
-		// Refresh last agent message after auto-advance.
-		if n := len(conv.Messages); n > 0 && conv.Messages[n-1].Role == "agent" {
-			// autoAdvance already appended; nothing to replace
-		}
 	}
 
 	if !t.Done {

--- a/server/internal/engine/review_session.go
+++ b/server/internal/engine/review_session.go
@@ -17,13 +17,22 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// MaxReviewQueueItems caps pending (not-yet-started) review turns per parked
-// producer session. Aligned with the sandbox-gateway bridge PromptQueue
-// (MaxPromptQueueItems=32). The platform FIFO is authoritative for UI waiting;
-// Cancel clears this queue and calls ACP Cancel (which clears the bridge queue).
+// MaxReviewQueueItems caps pending (not-yet-started) review/clarify turns per
+// parked producer session. Aligned with the sandbox-gateway bridge PromptQueue
+// (MaxPromptQueueItems=32). The platform FIFO is authoritative for UI waiting.
+// Review Cancel clears this queue; clarify Cancel keeps it and pumps the next item.
 const MaxReviewQueueItems = 32
 
-// reviewQueueItem is one not-yet-started (or active) review turn on a producer
+// sessionKind distinguishes post-run review (ReviseInPlace) from classic react
+// clarify (ReactReply). Both share FIFO / WS frames; Cancel policy forks.
+type sessionKind string
+
+const (
+	sessionKindReview  sessionKind = "review"
+	sessionKindClarify sessionKind = "clarify"
+)
+
+// reviewQueueItem is one not-yet-started (or active) turn on a producer
 // session. Source distinguishes node-inline review vs gate hot-revise for
 // turn_begin/gate BodyMd refresh; both share the same FIFO.
 type reviewQueueItem struct {
@@ -34,14 +43,16 @@ type reviewQueueItem struct {
 	Annotations []models.ReactAnnotation
 	Source      string // "node" | "gate"
 	GateNodeID  string
+	Force       bool // clarify force wrap-up (rare via enqueue; normally sync)
 }
 
 // reviewSession is the platform-authoritative controller for one parked
 // producer ACP session: FIFO pending queue + single worker pump, mirroring
-// SandboxChat's per-conn queue/worker model.
+// SandboxChat's per-conn queue/worker model. Used by both review and clarify.
 type reviewSession struct {
 	runID      string
 	producerID string
+	kind       sessionKind
 
 	mu       sync.Mutex
 	queue    []*reviewQueueItem
@@ -58,7 +69,7 @@ func (e *Engine) reviewSessionKey(runID, producerID string) string {
 	return runID + "|" + producerID
 }
 
-func (e *Engine) getOrCreateReviewSession(runID, producerID string) *reviewSession {
+func (e *Engine) getOrCreateReviewSession(runID, producerID string, kind sessionKind) *reviewSession {
 	key := e.reviewSessionKey(runID, producerID)
 	e.reviewMu.Lock()
 	defer e.reviewMu.Unlock()
@@ -67,8 +78,10 @@ func (e *Engine) getOrCreateReviewSession(runID, producerID string) *reviewSessi
 	}
 	s := e.reviewSess[key]
 	if s == nil {
-		s = &reviewSession{runID: runID, producerID: producerID}
+		s = &reviewSession{runID: runID, producerID: producerID, kind: kind}
 		e.reviewSess[key] = s
+	} else if s.kind == "" {
+		s.kind = kind
 	}
 	return s
 }
@@ -116,17 +129,85 @@ func (e *Engine) ReviewSessionState(runID, producerID string) (waiting int, thin
 	return s.waiting, s.active != nil
 }
 
+// ReviewSessionSnapshot is the refresh-resume DTO for one parked session.
+type ReviewSessionSnapshot struct {
+	NodeID     string           `json:"nodeId"`
+	Kind       string           `json:"kind"`
+	Waiting    int              `json:"waiting"`
+	Busy       bool             `json:"busy"`
+	Items      []map[string]any `json:"items"`
+	ActiveItem map[string]any   `json:"activeItem,omitempty"`
+}
+
+// ReviewSessionsForRun returns authoritative busy/queue snapshots for refresh resume.
+func (e *Engine) ReviewSessionsForRun(runID string) []ReviewSessionSnapshot {
+	e.reviewMu.Lock()
+	defer e.reviewMu.Unlock()
+	var out []ReviewSessionSnapshot
+	for _, s := range e.reviewSess {
+		if s == nil || s.runID != runID {
+			continue
+		}
+		s.mu.Lock()
+		snap := ReviewSessionSnapshot{
+			NodeID:  s.producerID,
+			Kind:    string(s.kind),
+			Waiting: s.waiting,
+			Busy:    s.active != nil,
+			Items:   s.queueSnapshotLocked(),
+		}
+		if s.active != nil {
+			snap.ActiveItem = map[string]any{
+				"id":          s.active.ID,
+				"text":        s.active.Text,
+				"images":      s.active.Images,
+				"annotations": s.active.Annotations,
+			}
+		}
+		s.mu.Unlock()
+		out = append(out, snap)
+	}
+	return out
+}
+
+// BroadcastReviewSessions re-emits queue_state (+ active hint) for every session
+// on a run — used on WS connect so refresh can resume busy/queue/stream.
+func (e *Engine) BroadcastReviewSessions(runID string) {
+	for _, snap := range e.ReviewSessionsForRun(runID) {
+		payload := map[string]any{
+			"waiting": snap.Waiting,
+			"items":   snap.Items,
+			"busy":    snap.Busy,
+			"kind":    snap.Kind,
+		}
+		if snap.ActiveItem != nil {
+			payload["activeItem"] = snap.ActiveItem
+		}
+		e.publishReview(runID, snap.NodeID, "queue_state", payload)
+	}
+}
+
 // EnqueueReviewTurn queues a revise turn for the parked producer session and
 // returns immediately with the new waiting count. Serial pump starts if idle.
 // Both ReactReply(force=false) and GateReactRevise share this entry (FR5).
 func (e *Engine) EnqueueReviewTurn(runID, producerID, text string, images []models.PromptImage, annotations []models.ReactAnnotation, source, gateNodeID string) (waiting int, err error) {
+	return e.enqueueReactTurn(runID, producerID, text, images, annotations, source, gateNodeID, sessionKindReview)
+}
+
+// EnqueueClarifyTurn queues a classic react (需求澄清) turn onto the same platform
+// FIFO / WS frame protocol as review, returning immediately.
+func (e *Engine) EnqueueClarifyTurn(runID, nodeID, text string, images []models.PromptImage, annotations []models.ReactAnnotation) (waiting int, err error) {
+	return e.enqueueReactTurn(runID, nodeID, text, images, annotations, "node", "", sessionKindClarify)
+}
+
+func (e *Engine) enqueueReactTurn(runID, producerID, text string, images []models.PromptImage, annotations []models.ReactAnnotation, source, gateNodeID string, kind sessionKind) (waiting int, err error) {
 	if e.IsHalted() {
 		return 0, errors.New("server is shutting down")
 	}
 	if strings.TrimSpace(text) == "" && len(images) == 0 && len(annotations) == 0 {
 		return 0, errors.New("text, images, or annotations required")
 	}
-	s := e.getOrCreateReviewSession(runID, producerID)
+	s := e.getOrCreateReviewSession(runID, producerID, kind)
 	item := &reviewQueueItem{
 		ID:          uuid.NewString(),
 		Text:        text,
@@ -140,7 +221,11 @@ func (e *Engine) EnqueueReviewTurn(runID, producerID, text string, images []mode
 	s.mu.Lock()
 	if s.waiting >= MaxReviewQueueItems {
 		s.mu.Unlock()
-		return 0, errors.New("复审消息队列已满,请稍候")
+		fullMsg := "复审消息队列已满,请稍候"
+		if kind == sessionKindClarify {
+			fullMsg = "澄清消息队列已满,请稍候"
+		}
+		return 0, errors.New(fullMsg)
 	}
 	s.queue = append(s.queue, item)
 	s.waiting++
@@ -154,6 +239,8 @@ func (e *Engine) EnqueueReviewTurn(runID, producerID, text string, images []mode
 	e.publishReview(runID, producerID, "queue_state", map[string]any{
 		"waiting": waiting,
 		"items":   s.queueSnapshot(),
+		"busy":    true,
+		"kind":    string(kind),
 	})
 	if startPump {
 		go e.pumpReviewSession(s)
@@ -164,6 +251,10 @@ func (e *Engine) EnqueueReviewTurn(runID, producerID, text string, images []mode
 func (s *reviewSession) queueSnapshot() []map[string]any {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.queueSnapshotLocked()
+}
+
+func (s *reviewSession) queueSnapshotLocked() []map[string]any {
 	out := make([]map[string]any, 0, len(s.queue))
 	for _, it := range s.queue {
 		out = append(out, map[string]any{
@@ -177,25 +268,49 @@ func (s *reviewSession) queueSnapshot() []map[string]any {
 // CancelReviewSession clears all not-yet-started queue items, requests ACP
 // Cancel on the active turn (bridge PromptQueue cleared via session/cancel),
 // and keeps the session parked for further edits. Does not AbortRun / RetireSession.
+// Used by post-run review / gate hot-revise (#77 clear-queue semantics).
 func (e *Engine) CancelReviewSession(runID, producerID string) error {
+	return e.cancelReactSession(runID, producerID, true)
+}
+
+// CancelClarifyTurn stops only the in-flight clarify turn, keeps the pending
+// FIFO, and lets the pump start the next item (Demo keep-queue+pump-next).
+func (e *Engine) CancelClarifyTurn(runID, nodeID string) error {
+	return e.cancelReactSession(runID, nodeID, false)
+}
+
+// cancelReactSession aborts the active turn. When clearQueue is true (review),
+// pending items are dropped; when false (clarify), they remain and the pump continues.
+func (e *Engine) cancelReactSession(runID, producerID string, clearQueue bool) error {
 	e.reviewMu.Lock()
 	s := e.reviewSess[e.reviewSessionKey(runID, producerID)]
 	e.reviewMu.Unlock()
 	if s == nil {
 		// Still best-effort ACP cancel in case a legacy sync turn is in flight.
 		e.cancelProviderTurn(runID, producerID)
-		e.publishReview(runID, producerID, "queue_state", map[string]any{"waiting": 0, "items": []any{}})
+		e.publishReview(runID, producerID, "queue_state", map[string]any{"waiting": 0, "items": []any{}, "busy": false})
 		return nil
 	}
 
 	s.mu.Lock()
-	s.queue = nil
-	s.waiting = 0
+	if clearQueue {
+		s.queue = nil
+		s.waiting = 0
+	}
 	s.cancelRequested = true
+	waiting := s.waiting
+	items := s.queueSnapshotLocked()
+	busy := s.active != nil
+	kind := string(s.kind)
 	cancelFn := s.cancelFn
 	s.mu.Unlock()
 
-	e.publishReview(runID, producerID, "queue_state", map[string]any{"waiting": 0, "items": []any{}})
+	e.publishReview(runID, producerID, "queue_state", map[string]any{
+		"waiting": waiting,
+		"items":   items,
+		"busy":    busy,
+		"kind":    kind,
+	})
 	e.cancelProviderTurn(runID, producerID)
 	if cancelFn != nil {
 		cancelFn()
@@ -252,6 +367,8 @@ func (e *Engine) pumpReviewSession(s *reviewSession) {
 		e.publishReview(s.runID, s.producerID, "queue_state", map[string]any{
 			"waiting": waiting,
 			"items":   s.queueSnapshot(),
+			"busy":    true,
+			"kind":    string(s.kind),
 		})
 		e.publishReview(s.runID, s.producerID, "turn_begin", map[string]any{
 			"item": map[string]any{
@@ -262,9 +379,16 @@ func (e *Engine) pumpReviewSession(s *reviewSession) {
 			},
 			"gateNodeId": item.GateNodeID,
 			"source":     item.Source,
+			"kind":       string(s.kind),
 		})
 
-		interrupted, turnErr := e.executeReviewTurn(ctx, s, item)
+		var interrupted bool
+		var turnErr error
+		if s.kind == sessionKindClarify {
+			interrupted, turnErr = e.executeClarifyTurn(ctx, s, item)
+		} else {
+			interrupted, turnErr = e.executeReviewTurn(ctx, s, item)
+		}
 
 		cancel()
 		s.mu.Lock()
@@ -285,6 +409,131 @@ func (e *Engine) pumpReviewSession(s *reviewSession) {
 			})
 		}
 	}
+}
+
+// executeClarifyTurn persists the human turn, runs provider.ReactReply (with
+// cancelable ctx), persists the agent turn (marking interrupted on cancel), and
+// finalizes the node when the agent is Done — mirroring the former sync ReactReply
+// path but under the shared FIFO pump so refresh can resume busy/queue/stream.
+func (e *Engine) executeClarifyTurn(ctx context.Context, s *reviewSession, item *reviewQueueItem) (interrupted bool, err error) {
+	unlock := e.lockResume(s.runID + ":" + s.producerID)
+	defer unlock()
+
+	c, loadErr := e.loadCtx(s.runID)
+	if loadErr != nil {
+		return false, loadErr
+	}
+	node := c.graph.FindNode(s.producerID)
+	if node == nil || node.Type != "react" {
+		return false, errors.New("react node not found")
+	}
+
+	var conv models.ReactConversation
+	if cerr := e.db.Where("run_id = ? AND node_id = ?", s.runID, s.producerID).
+		Order("iteration desc, id desc").First(&conv).Error; cerr != nil {
+		return false, errors.New("no react conversation")
+	}
+	if conv.Done {
+		return false, errors.New("react already done")
+	}
+
+	now := time.Now().Format(time.RFC3339)
+	conv.Messages = append(conv.Messages, models.ReactMessage{
+		Role: "human", Text: item.Text, At: now,
+		Images: item.Images, Annotations: item.Annotations,
+	})
+	logDB(e.db.Save(&conv), s.runID, "save clarify human turn (turn_begin)")
+	e.broker.Publish(s.runID, jsonMsg("react", s.runID, s.producerID))
+
+	req := e.nodeReq(c, node)
+	force := item.Force
+	t := e.provider.ReactReply(ctx, req, conv.Messages, item.Effective, item.Images, force)
+
+	s.mu.Lock()
+	cancelled := s.cancelRequested || ctx.Err() != nil
+	s.mu.Unlock()
+	if cancelled {
+		interrupted = true
+	}
+
+	agentMsg := models.ReactMessage{
+		Role: "agent", Text: t.Msg, At: time.Now().Format(time.RFC3339),
+		Questions: t.Questions, Interrupted: interrupted,
+	}
+	if interrupted && strings.TrimSpace(agentMsg.Text) == "" {
+		agentMsg.Text = "(已中断)"
+	}
+	conv.Messages = append(conv.Messages, agentMsg)
+
+	if interrupted {
+		logDB(e.db.Save(&conv), s.runID, "save clarify agent turn (interrupted)")
+		e.flushMcpCalls(s.runID, s.producerID)
+		e.flushTokenUsage(s.runID, s.producerID, t.Usage)
+		log.Info().Str("run_id", s.runID).Str("node", s.producerID).
+			Msg("clarify turn interrupted by Cancel; queue kept for next item")
+		e.broker.Publish(s.runID, jsonMsg("react", s.runID, s.producerID))
+		return true, nil
+	}
+
+	// Auto-clarify: recommended options while auto_var is on.
+	if !force && !t.Done && len(t.Questions) > 0 && e.autoReactEnabled(c, node) {
+		t = e.autoAdvanceReact(c, node, &conv, req, t)
+		// Refresh last agent message after auto-advance.
+		if n := len(conv.Messages); n > 0 && conv.Messages[n-1].Role == "agent" {
+			// autoAdvance already appended; nothing to replace
+		}
+	}
+
+	if !t.Done {
+		logDB(e.db.Save(&conv), s.runID, "save clarify conversation")
+		e.flushMcpCalls(s.runID, s.producerID)
+		e.flushTokenUsage(s.runID, s.producerID, t.Usage)
+		e.broker.Publish(s.runID, jsonMsg("react", s.runID, s.producerID))
+		return false, nil
+	}
+
+	conv.Done = true
+	logDB(e.db.Save(&conv), s.runID, "finish clarify conversation")
+
+	if t.Err != nil {
+		outcome := nodeOutcome{status: "failed", err: t.Err.Error(), outputMd: t.Msg, events: t.Events, usage: t.Usage}
+		e.saveState(c, node, outcome)
+		e.appendTrace(c, models.TraceEntry{NodeID: s.producerID, Event: "resume", Detail: "react 失败"})
+		next := e.routeFailure(c, node, outcome)
+		if next == "" {
+			e.finish(s.runID, "failed")
+			return false, nil
+		}
+		go e.resumeAdmitted(s.runID, next)
+		return false, nil
+	}
+
+	outcome := e.finishAgentOutcome(c, node, t.Result, func(r runtime.NodeResult) nodeOutcome {
+		return e.completeProduces(c, node, r)
+	})
+	e.saveState(c, node, outcome)
+	e.appendTrace(c, models.TraceEntry{NodeID: s.producerID, Event: "resume", Detail: "react 完成"})
+
+	if outcome.status == "failed" {
+		next := e.routeFailure(c, node, outcome)
+		if next == "" {
+			e.finish(s.runID, "failed")
+			return false, nil
+		}
+		go e.resumeAdmitted(s.runID, next)
+		return false, nil
+	}
+
+	c.nodeOutputs[s.producerID] = t.Result.Outputs
+	e.appendTrace(c, models.TraceEntry{NodeID: s.producerID, Event: "exit"})
+
+	next := e.routeSuccess(c, node, outcome)
+	if next == "" {
+		e.finish(s.runID, "completed")
+		return false, nil
+	}
+	go e.resumeAdmitted(s.runID, next)
+	return false, nil
 }
 
 // executeReviewTurn persists the human turn, runs ReviseInPlace, persists the

--- a/server/internal/engine/revise_trace_test.go
+++ b/server/internal/engine/revise_trace_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cocofhu/approving/internal/database"
 	"github.com/cocofhu/approving/internal/mcp"
@@ -170,6 +171,9 @@ func TestReactMultiTurnTraceAccumulates(t *testing.T) {
 	for _, msg := range []string{"答复1", "答复2", "答复3"} {
 		if err := eng.ReactReply(run.ID, "clarify", msg, nil, nil, false); err != nil {
 			t.Fatalf("reply %q: %v", msg, err)
+		}
+		if err := eng.waitReviewReadyForTest(run.ID, "clarify", 5*time.Second); err != nil {
+			t.Fatalf("wait after %q: %v", msg, err)
 		}
 	}
 	waitRunStatus(t, db, run.ID, "completed")

--- a/server/internal/handlers/dto.go
+++ b/server/internal/handlers/dto.go
@@ -204,6 +204,19 @@ func (h *Handlers) runDetailDTO(r models.Run) gin.H {
 		clarifyByNode[conv.NodeID] = gin.H{"nodeId": conv.NodeID, "iteration": conv.Iteration, "turns": conv.Messages, "done": conv.Done}
 	}
 	out["clarifyByNode"] = clarifyByNode
+	// Authoritative busy/queue for refresh resume (clarify + review sessions).
+	if h.Eng != nil {
+		if snaps := h.Eng.ReviewSessionsForRun(r.ID); len(snaps) > 0 {
+			byNode := gin.H{}
+			for _, s := range snaps {
+				byNode[s.NodeID] = gin.H{
+					"kind": s.Kind, "waiting": s.Waiting, "busy": s.Busy,
+					"items": s.Items, "activeItem": s.ActiveItem,
+				}
+			}
+			out["reactSessions"] = byNode
+		}
+	}
 	// Lift a Run-level failure reason for any failed run so the Web detail banner
 	// (and clients) can read a human message without opening a node. Successful
 	// runs omit these fields entirely.

--- a/server/internal/handlers/dto.go
+++ b/server/internal/handlers/dto.go
@@ -206,14 +206,7 @@ func (h *Handlers) runDetailDTO(r models.Run) gin.H {
 	out["clarifyByNode"] = clarifyByNode
 	// Authoritative busy/queue for refresh resume (clarify + review sessions).
 	if h.Eng != nil {
-		if snaps := h.Eng.ReviewSessionsForRun(r.ID); len(snaps) > 0 {
-			byNode := gin.H{}
-			for _, s := range snaps {
-				byNode[s.NodeID] = gin.H{
-					"kind": s.Kind, "waiting": s.Waiting, "busy": s.Busy,
-					"items": s.Items, "activeItem": s.ActiveItem,
-				}
-			}
+		if byNode := reactSessionsDTO(h.Eng.ReviewSessionsForRun(r.ID)); byNode != nil {
 			out["reactSessions"] = byNode
 		}
 	}

--- a/server/internal/handlers/handlers.go
+++ b/server/internal/handlers/handlers.go
@@ -858,11 +858,23 @@ func (h *Handlers) ReactReply(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 
-// ReactCancel aborts the current review turn and clears the pending FIFO for
-// the producer node (轮级 Cancel). Does not cancel the whole run.
+// ReactCancel aborts the current turn. Review clears the pending FIFO (#77);
+// classic clarify keeps the queue and lets the pump start the next item (Demo).
 func (h *Handlers) ReactCancel(c *gin.Context) {
 	runID, nodeID := c.Param("id"), c.Param("nodeId")
-	if err := h.Eng.CancelReviewSession(runID, nodeID); err != nil {
+	clearQueue := true
+	if run, ok := h.Runs.Get(runID); ok {
+		if n := run.Graph.FindNode(nodeID); n != nil && n.Type == "react" {
+			clearQueue = false
+		}
+	}
+	var err error
+	if clearQueue {
+		err = h.Eng.CancelReviewSession(runID, nodeID)
+	} else {
+		err = h.Eng.CancelClarifyTurn(runID, nodeID)
+	}
+	if err != nil {
 		_ = c.Error(err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return

--- a/server/internal/handlers/inbox_context.go
+++ b/server/internal/handlers/inbox_context.go
@@ -97,7 +97,7 @@ func (h *Handlers) inboxContextClarify(c *gin.Context, runID, nodeID string, ite
 		}
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	out := gin.H{
 		"type":           "clarify",
 		"status":         run.Status,
 		"nodes":          graphNodesDTO(run.Graph),
@@ -110,5 +110,12 @@ func (h *Handlers) inboxContextClarify(c *gin.Context, runID, nodeID string, ite
 			"done":      conv.Done,
 			"label":     services.ClarifyLabel(run.Graph, conv.NodeID),
 		},
-	})
+	}
+	// Authoritative busy/queue for GatesInbox refresh-resume (parity with runDetailDTO).
+	if h.Eng != nil {
+		if byNode := reactSessionsDTO(h.Eng.ReviewSessionsForRun(runID)); byNode != nil {
+			out["reactSessions"] = byNode
+		}
+	}
+	c.JSON(http.StatusOK, out)
 }

--- a/server/internal/handlers/inbox_context_test.go
+++ b/server/internal/handlers/inbox_context_test.go
@@ -94,6 +94,11 @@ func TestRunInboxContextClarify(t *testing.T) {
 	if strings.Contains(body, "should-not-appear") {
 		t.Error("nodeExecutions must be slim (no events)")
 	}
+	// Idle (no in-memory session): reactSessions omitted — presence when busy is
+	// covered by TestReactSessionsDTO + GatesInbox hard-load restore vitest.
+	if strings.Contains(body, `"reactSessions"`) {
+		t.Error("idle clarify inbox-context should omit empty reactSessions")
+	}
 }
 
 func TestRunInboxContextClarifyResearchReview(t *testing.T) {

--- a/server/internal/handlers/react_sessions_dto.go
+++ b/server/internal/handlers/react_sessions_dto.go
@@ -1,0 +1,23 @@
+package handlers
+
+import (
+	"github.com/cocofhu/approving/internal/engine"
+
+	"github.com/gin-gonic/gin"
+)
+
+// reactSessionsDTO maps engine review/clarify session snapshots to the
+// per-node gin.H used by runDetailDTO and clarify inbox-context (refresh-resume).
+func reactSessionsDTO(snaps []engine.ReviewSessionSnapshot) gin.H {
+	if len(snaps) == 0 {
+		return nil
+	}
+	byNode := gin.H{}
+	for _, s := range snaps {
+		byNode[s.NodeID] = gin.H{
+			"kind": s.Kind, "waiting": s.Waiting, "busy": s.Busy,
+			"items": s.Items, "activeItem": s.ActiveItem,
+		}
+	}
+	return byNode
+}

--- a/server/internal/handlers/react_sessions_dto_test.go
+++ b/server/internal/handlers/react_sessions_dto_test.go
@@ -1,0 +1,50 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/cocofhu/approving/internal/engine"
+	"github.com/gin-gonic/gin"
+)
+
+func TestReactSessionsDTO(t *testing.T) {
+	if reactSessionsDTO(nil) != nil {
+		t.Fatal("nil snaps → nil DTO")
+	}
+	if reactSessionsDTO([]engine.ReviewSessionSnapshot{}) != nil {
+		t.Fatal("empty snaps → nil DTO")
+	}
+	out := reactSessionsDTO([]engine.ReviewSessionSnapshot{{
+		NodeID:  "react",
+		Kind:    "clarify",
+		Waiting: 1,
+		Busy:    true,
+		Items:   []map[string]any{{"id": "q2", "text": "乙"}},
+		ActiveItem: map[string]any{
+			"id": "q1", "text": "甲",
+		},
+	}})
+	if out == nil {
+		t.Fatal("expected DTO")
+	}
+	node, ok := out["react"].(gin.H)
+	if !ok {
+		t.Fatalf("node entry type %T", out["react"])
+	}
+	if node["busy"] != true {
+		t.Fatalf("busy=%v", node["busy"])
+	}
+	if node["waiting"] != 1 {
+		t.Fatalf("waiting=%v", node["waiting"])
+	}
+	if node["kind"] != "clarify" {
+		t.Fatalf("kind=%v", node["kind"])
+	}
+	active, _ := node["activeItem"].(map[string]any)
+	if active == nil {
+		t.Fatal("missing activeItem")
+	}
+	if active["text"] != "甲" {
+		t.Fatalf("activeItem.text=%v", active["text"])
+	}
+}

--- a/server/internal/handlers/ws.go
+++ b/server/internal/handlers/ws.go
@@ -54,6 +54,8 @@ func (h *Handlers) RunEvents(c *gin.Context) {
 	if run, ok := h.Runs.Get(runID); ok {
 		_ = conn.WriteJSON(gin.H{"type": "snapshot", "run": h.runDetailDTO(run)})
 	}
+	// Re-emit authoritative queue/busy so refresh can resume mid-stream.
+	h.Eng.BroadcastReviewSessions(runID)
 
 	ping := time.NewTicker(25 * time.Second)
 	defer ping.Stop()
@@ -105,7 +107,19 @@ func (h *Handlers) handleRunWSControl(runID string, data []byte) {
 		if nodeID == "" {
 			return
 		}
-		if err := h.Eng.CancelReviewSession(runID, nodeID); err != nil {
+		clearQueue := true
+		if run, ok := h.Runs.Get(runID); ok {
+			if n := run.Graph.FindNode(nodeID); n != nil && n.Type == "react" {
+				clearQueue = false
+			}
+		}
+		var err error
+		if clearQueue {
+			err = h.Eng.CancelReviewSession(runID, nodeID)
+		} else {
+			err = h.Eng.CancelClarifyTurn(runID, nodeID)
+		}
+		if err != nil {
 			h.publishReviewWSError(runID, nodeID, err.Error())
 		}
 	case "review_chat", "chat":
@@ -119,6 +133,15 @@ func (h *Handlers) handleRunWSControl(runID string, data []byte) {
 				h.publishReviewWSError(runID, nodeID, err.Error())
 			}
 			return
+		}
+		// Classic react → clarify FIFO; review-capable nodes → review FIFO.
+		if run, ok := h.Runs.Get(runID); ok {
+			if n := run.Graph.FindNode(nodeID); n != nil && n.Type == "react" {
+				if _, err := h.Eng.EnqueueClarifyTurn(runID, nodeID, m.Content, m.Images, m.Annotations); err != nil {
+					h.publishReviewWSError(runID, nodeID, err.Error())
+				}
+				return
+			}
 		}
 		if _, err := h.Eng.EnqueueReviewTurn(runID, nodeID, m.Content, m.Images, m.Annotations, "node", ""); err != nil {
 			h.publishReviewWSError(runID, nodeID, err.Error())

--- a/web/e2e/clarify-session-ux-main.ts
+++ b/web/e2e/clarify-session-ux-main.ts
@@ -4,6 +4,7 @@ import { i18n } from '../src/lib/i18n'
 import { initLocale } from '../src/lib/locale'
 import { setTheme } from '../src/lib/theme'
 import ClarifyChat from '../src/components/run/ClarifyChat.vue'
+import type { ClarifyTurn } from '../src/lib/types'
 
 initLocale()
 setTheme('light')
@@ -11,14 +12,30 @@ setTheme('light')
 /**
  * Clarify (non-reviewMode) harness — Demo Cancel keep-queue + refresh resume.
  * Contrasts with review-session-ux (Cancel clears queue / #77).
+ * Also covers host integration: props.turns catch-up while live streaming (no double human).
  */
 const App = defineComponent({
   name: 'ClarifySessionUxHarness',
   setup() {
+    const turns = ref<ClarifyTurn[]>([])
+    const hostSkipRefresh = ref(0)
+    const hostDidRefresh = ref(0)
     const chatRef = ref<{
       applyReviewFrame?: (f: Record<string, unknown>) => void
       applyAcpEvents?: (e: { kind: string; text: string }[]) => void
+      isSessionBusy?: () => boolean
     } | null>(null)
+
+    /** Host narrow-update gate mirror (RunDetail/GatesInbox busy skip). */
+    function maybeHostRefresh(reason: string) {
+      const busy = !!chatRef.value?.isSessionBusy?.()
+      if (busy) {
+        hostSkipRefresh.value += 1
+        return
+      }
+      hostDidRefresh.value += 1
+      void reason
+    }
 
     onMounted(async () => {
       await nextTick()
@@ -34,9 +51,34 @@ const App = defineComponent({
         nodeId: 'clarify',
       })
       await nextTick()
+      // Host would see react WS here — must skip full refresh while busy.
+      maybeHostRefresh('react')
       c.applyAcpEvents?.([{ kind: 'thought', text: '思考增量…' }])
       await nextTick()
       c.applyAcpEvents?.([{ kind: 'message', text: '流式产出正文（非整轮一次性）。' }])
+    }
+
+    /** Mid-stream: inject persisted human (softRefresh/loadRun catch-up) — must not double. */
+    async function simTranscriptCatchUp() {
+      const c = chatRef.value
+      if (!c?.applyReviewFrame) return
+      c.applyReviewFrame({
+        event: 'turn_begin',
+        item: { text: '澄清意见甲（队列首条）' },
+        nodeId: 'clarify',
+      })
+      await nextTick()
+      c.applyAcpEvents?.([{ kind: 'message', text: '流式产出正文（非整轮一次性）。' }])
+      await nextTick()
+      turns.value = [
+        {
+          role: 'human',
+          text: '澄清意见甲（队列首条）',
+          at: new Date().toISOString(),
+        },
+      ]
+      await nextTick()
+      maybeHostRefresh('react-mid-stream')
     }
 
     async function simRefreshResume() {
@@ -72,11 +114,29 @@ const App = defineComponent({
             'button',
             {
               type: 'button',
+              'data-testid': 'sim-transcript-catchup',
+              class: 'px-3 py-1.5 rounded border text-sm',
+              onClick: () => void simTranscriptCatchUp(),
+            },
+            '模拟 transcript 追上',
+          ),
+          h(
+            'button',
+            {
+              type: 'button',
               'data-testid': 'sim-refresh-resume',
               class: 'px-3 py-1.5 rounded border text-sm',
               onClick: () => void simRefreshResume(),
             },
             '模拟刷新续传',
+          ),
+          h(
+            'span',
+            {
+              'data-testid': 'host-skip-refresh',
+              class: 'text-xs text-txt3 self-center',
+            },
+            `hostSkip=${hostSkipRefresh.value}`,
           ),
         ]),
         h(ClarifyChat, {
@@ -84,7 +144,7 @@ const App = defineComponent({
           runId: 'run-clarify-e2e',
           nodeId: 'clarify',
           iteration: 1,
-          turns: [],
+          turns: turns.value,
           done: false,
           active: true,
           reviewMode: false,

--- a/web/e2e/clarify-session-ux-main.ts
+++ b/web/e2e/clarify-session-ux-main.ts
@@ -45,6 +45,16 @@ const App = defineComponent({
     async function simTurnBeginStream() {
       const c = chatRef.value
       if (!c?.applyReviewFrame) return
+      // Real pump order: queue_state(remaining, busy) then turn_begin(active).
+      // Dual-send harness leaves 甲+乙 in local queue; trim to 乙 before begin.
+      c.applyReviewFrame({
+        event: 'queue_state',
+        nodeId: 'clarify',
+        waiting: 1,
+        items: [{ text: '澄清意见乙（仍在队列）' }],
+        busy: true,
+      })
+      await nextTick()
       c.applyReviewFrame({
         event: 'turn_begin',
         item: { text: '澄清意见甲（队列首条）' },
@@ -56,6 +66,27 @@ const App = defineComponent({
       c.applyAcpEvents?.([{ kind: 'thought', text: '思考增量…' }])
       await nextTick()
       c.applyAcpEvents?.([{ kind: 'message', text: '流式产出正文（非整轮一次性）。' }])
+    }
+
+    /** Dual-message pump frame order probe (review v2): assert 甲 live, 乙 queued. */
+    async function simPumpOrderDual() {
+      const c = chatRef.value
+      if (!c?.applyReviewFrame) return
+      c.applyReviewFrame({
+        event: 'queue_state',
+        nodeId: 'clarify',
+        waiting: 1,
+        items: [{ text: '澄清意见乙（仍在队列）' }],
+        busy: true,
+      })
+      await nextTick()
+      c.applyReviewFrame({
+        event: 'turn_begin',
+        item: { text: '澄清意见甲（队列首条）' },
+        nodeId: 'clarify',
+      })
+      await nextTick()
+      maybeHostRefresh('react')
     }
 
     /** Mid-stream: inject persisted human (softRefresh/loadRun catch-up) — must not double. */
@@ -109,6 +140,16 @@ const App = defineComponent({
               onClick: () => void simTurnBeginStream(),
             },
             '模拟 turn_begin+流式',
+          ),
+          h(
+            'button',
+            {
+              type: 'button',
+              'data-testid': 'sim-pump-order-dual',
+              class: 'px-3 py-1.5 rounded border text-sm',
+              onClick: () => void simPumpOrderDual(),
+            },
+            '模拟真实泵帧序',
           ),
           h(
             'button',

--- a/web/e2e/clarify-session-ux-main.ts
+++ b/web/e2e/clarify-session-ux-main.ts
@@ -1,0 +1,99 @@
+import '../src/styles/global.css'
+import { createApp, defineComponent, h, nextTick, onMounted, ref } from 'vue'
+import { i18n } from '../src/lib/i18n'
+import { initLocale } from '../src/lib/locale'
+import { setTheme } from '../src/lib/theme'
+import ClarifyChat from '../src/components/run/ClarifyChat.vue'
+
+initLocale()
+setTheme('light')
+
+/**
+ * Clarify (non-reviewMode) harness — Demo Cancel keep-queue + refresh resume.
+ * Contrasts with review-session-ux (Cancel clears queue / #77).
+ */
+const App = defineComponent({
+  name: 'ClarifySessionUxHarness',
+  setup() {
+    const chatRef = ref<{
+      applyReviewFrame?: (f: Record<string, unknown>) => void
+      applyAcpEvents?: (e: { kind: string; text: string }[]) => void
+    } | null>(null)
+
+    onMounted(async () => {
+      await nextTick()
+      ;(window as unknown as { __clarifyChat: typeof chatRef.value }).__clarifyChat = chatRef.value
+    })
+
+    async function simTurnBeginStream() {
+      const c = chatRef.value
+      if (!c?.applyReviewFrame) return
+      c.applyReviewFrame({
+        event: 'turn_begin',
+        item: { text: '澄清意见甲（队列首条）' },
+        nodeId: 'clarify',
+      })
+      await nextTick()
+      c.applyAcpEvents?.([{ kind: 'thought', text: '思考增量…' }])
+      await nextTick()
+      c.applyAcpEvents?.([{ kind: 'message', text: '流式产出正文（非整轮一次性）。' }])
+    }
+
+    async function simRefreshResume() {
+      const c = chatRef.value
+      if (!c?.applyReviewFrame) return
+      // Simulate page reload: authoritative queue_state with busy + activeItem.
+      c.applyReviewFrame({
+        event: 'queue_state',
+        nodeId: 'clarify',
+        waiting: 1,
+        items: [{ text: '澄清意见乙（仍在队列）' }],
+        busy: true,
+        activeItem: { text: '澄清意见甲（队列首条）' },
+      })
+      await nextTick()
+      c.applyAcpEvents?.([{ kind: 'message', text: '刷新后续上的流式正文。' }])
+    }
+
+    return () =>
+      h('div', { class: 'min-h-screen p-4 max-w-3xl mx-auto', 'data-testid': 'clarify-ux-root' }, [
+        h('div', { class: 'flex gap-2 mb-3 flex-wrap' }, [
+          h(
+            'button',
+            {
+              type: 'button',
+              'data-testid': 'sim-turn-stream',
+              class: 'px-3 py-1.5 rounded border text-sm',
+              onClick: () => void simTurnBeginStream(),
+            },
+            '模拟 turn_begin+流式',
+          ),
+          h(
+            'button',
+            {
+              type: 'button',
+              'data-testid': 'sim-refresh-resume',
+              class: 'px-3 py-1.5 rounded border text-sm',
+              onClick: () => void simRefreshResume(),
+            },
+            '模拟刷新续传',
+          ),
+        ]),
+        h(ClarifyChat, {
+          ref: chatRef,
+          runId: 'run-clarify-e2e',
+          nodeId: 'clarify',
+          iteration: 1,
+          turns: [],
+          done: false,
+          active: true,
+          reviewMode: false,
+          annotateEnabled: true,
+          hideFinish: true,
+          sendLabel: '发送澄清回复',
+        }),
+      ])
+  },
+})
+
+createApp(App).use(i18n).mount('#app')

--- a/web/e2e/clarify-session-ux.html
+++ b/web/e2e/clarify-session-ux.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Clarify Session UX Harness</title>
+  </head>
+  <body class="bg-base text-ink">
+    <div id="app"></div>
+    <script type="module" src="./clarify-session-ux-main.ts"></script>
+  </body>
+</html>

--- a/web/e2e/clarify-session-ux.spec.ts
+++ b/web/e2e/clarify-session-ux.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const shotDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../.tmp-clarify-ux-shots')
+
+async function sendClarify(page: import('@playwright/test').Page, text: string) {
+  const box = page.locator('[data-testid="clarify-input"]')
+  await box.fill(text)
+  await page.getByTestId('clarify-send-label').click()
+}
+
+test.describe('ClarifyChat 非 reviewMode 澄清会话', () => {
+  test('排队 → 流式 → Cancel 保留队列 → 刷新续传', async ({ page }) => {
+    await page.setViewportSize({ width: 1100, height: 900 })
+    await page.goto('/clarify-session-ux.html')
+    await expect(page.getByTestId('clarify-ux-root')).toBeVisible({ timeout: 15_000 })
+
+    await sendClarify(page, '澄清意见甲（队列首条）')
+    await sendClarify(page, '澄清意见乙（仍在队列）')
+    const queue = page.getByTestId('clarify-review-queue')
+    await expect(queue).toBeVisible()
+    await expect(queue).toContainText('待发送队列')
+    await expect(queue).toContainText('澄清意见甲')
+    await expect(queue).toContainText('澄清意见乙')
+    await page.screenshot({ path: path.join(shotDir, '01-clarify-queue.png'), fullPage: true })
+
+    await page.getByTestId('sim-turn-stream').click()
+    await expect(page.getByText('流式产出正文（非整轮一次性）。')).toBeVisible()
+    await expect(queue).toContainText('澄清意见乙')
+    await page.screenshot({ path: path.join(shotDir, '02-clarify-stream.png'), fullPage: true })
+
+    // Demo Cancel: keep queue (乙 remains), mark interrupted.
+    await page.getByTestId('clarify-review-cancel').click()
+    await expect(page.getByTestId('clarify-interrupted')).toBeVisible()
+    await expect(page.getByTestId('clarify-review-queue')).toContainText('澄清意见乙')
+    await page.screenshot({ path: path.join(shotDir, '03-clarify-cancel-keep.png'), fullPage: true })
+
+    // Refresh resume: busy + activeItem + continued stream.
+    await page.getByTestId('sim-refresh-resume').click()
+    await expect(page.getByText('刷新后续上的流式正文。')).toBeVisible()
+    await expect(page.getByTestId('clarify-review-queue')).toContainText('澄清意见乙')
+    await page.screenshot({ path: path.join(shotDir, '04-clarify-refresh-resume.png'), fullPage: true })
+  })
+})

--- a/web/e2e/clarify-session-ux.spec.ts
+++ b/web/e2e/clarify-session-ux.spec.ts
@@ -28,6 +28,8 @@ test.describe('ClarifyChat 非 reviewMode 澄清会话', () => {
     await page.getByTestId('sim-turn-stream').click()
     await expect(page.getByText('流式产出正文（非整轮一次性）。')).toBeVisible()
     await expect(queue).toContainText('澄清意见乙')
+    // Host busy gate: react mid-turn must skip full refresh.
+    await expect(page.getByTestId('host-skip-refresh')).toContainText('hostSkip=1')
     await page.screenshot({ path: path.join(shotDir, '02-clarify-stream.png'), fullPage: true })
 
     // Demo Cancel: keep queue (乙 remains), mark interrupted.
@@ -41,5 +43,20 @@ test.describe('ClarifyChat 非 reviewMode 澄清会话', () => {
     await expect(page.getByText('刷新后续上的流式正文。')).toBeVisible()
     await expect(page.getByTestId('clarify-review-queue')).toContainText('澄清意见乙')
     await page.screenshot({ path: path.join(shotDir, '04-clarify-refresh-resume.png'), fullPage: true })
+  })
+
+  test('transcript 追上 + live streaming 不双显 human', async ({ page }) => {
+    await page.setViewportSize({ width: 1100, height: 900 })
+    await page.goto('/clarify-session-ux.html')
+    await expect(page.getByTestId('clarify-ux-root')).toBeVisible({ timeout: 15_000 })
+
+    await page.getByTestId('sim-transcript-catchup').click()
+    await expect(page.getByText('流式产出正文（非整轮一次性）。')).toBeVisible()
+    const scroller = page.getByTestId('clarify-scroller')
+    const text = await scroller.innerText()
+    const matches = text.match(/澄清意见甲（队列首条）/g) || []
+    expect(matches.length).toBe(1)
+    await expect(page.getByTestId('host-skip-refresh')).toContainText(/hostSkip=[1-9]/)
+    await page.screenshot({ path: path.join(shotDir, '05-clarify-no-dup-human.png'), fullPage: true })
   })
 })

--- a/web/e2e/clarify-session-ux.spec.ts
+++ b/web/e2e/clarify-session-ux.spec.ts
@@ -27,7 +27,14 @@ test.describe('ClarifyChat 非 reviewMode 澄清会话', () => {
 
     await page.getByTestId('sim-turn-stream').click()
     await expect(page.getByText('流式产出正文（非整轮一次性）。')).toBeVisible()
+    // After real pump order, live human must be 甲 (not blind-shifted 乙).
+    const scrollerAfterBegin = page.getByTestId('clarify-scroller')
+    await expect(scrollerAfterBegin).toContainText('澄清意见甲（队列首条）')
+    const beginText = await scrollerAfterBegin.innerText()
+    expect(beginText.match(/澄清意见甲（队列首条）/g)?.length ?? 0).toBe(1)
+    expect(beginText).not.toContain('澄清意见乙（仍在队列）')
     await expect(queue).toContainText('澄清意见乙')
+    await expect(queue).not.toContainText('澄清意见甲')
     // Host busy gate: react mid-turn must skip full refresh.
     await expect(page.getByTestId('host-skip-refresh')).toContainText('hostSkip=1')
     await page.screenshot({ path: path.join(shotDir, '02-clarify-stream.png'), fullPage: true })
@@ -43,6 +50,26 @@ test.describe('ClarifyChat 非 reviewMode 澄清会话', () => {
     await expect(page.getByText('刷新后续上的流式正文。')).toBeVisible()
     await expect(page.getByTestId('clarify-review-queue')).toContainText('澄清意见乙')
     await page.screenshot({ path: path.join(shotDir, '04-clarify-refresh-resume.png'), fullPage: true })
+  })
+
+  test('真实泵帧序：queue_state→turn_begin 双消息不踩踏', async ({ page }) => {
+    await page.setViewportSize({ width: 1100, height: 900 })
+    await page.goto('/clarify-session-ux.html')
+    await expect(page.getByTestId('clarify-ux-root')).toBeVisible({ timeout: 15_000 })
+
+    await sendClarify(page, '澄清意见甲（队列首条）')
+    await sendClarify(page, '澄清意见乙（仍在队列）')
+    await page.getByTestId('sim-pump-order-dual').click()
+
+    const scroller = page.getByTestId('clarify-scroller')
+    await expect(scroller).toContainText('澄清意见甲（队列首条）')
+    const text = await scroller.innerText()
+    expect(text.match(/澄清意见甲（队列首条）/g)?.length ?? 0).toBe(1)
+    expect(text).not.toContain('澄清意见乙（仍在队列）')
+    const queue = page.getByTestId('clarify-review-queue')
+    await expect(queue).toContainText('澄清意见乙（仍在队列）')
+    await expect(queue).not.toContainText('澄清意见甲')
+    await page.screenshot({ path: path.join(shotDir, '06-clarify-pump-order.png'), fullPage: true })
   })
 
   test('transcript 追上 + live streaming 不双显 human', async ({ page }) => {

--- a/web/src/components/run/AnnotationChip.vue
+++ b/web/src/components/run/AnnotationChip.vue
@@ -36,6 +36,15 @@ const kindLabel = computed(() => {
 })
 
 const path = computed(() => props.ann.jsonPath || props.ann.selector || '')
+/** Whole-field chips often set label === path (e.g. #launchInput); show once. */
+const fieldLabel = computed(() => {
+  const label = (props.ann.label || '').trim()
+  const p = path.value
+  if (!label || label === p) return ''
+  return label
+})
+const showFieldPath = computed(() => !!path.value)
+const showFieldLabel = computed(() => kind.value === 'field' && !!fieldLabel.value)
 </script>
 
 <template>
@@ -50,7 +59,7 @@ const path = computed(() => props.ann.jsonPath || props.ann.selector || '')
     <span v-else class="mt-0.5 shrink-0 text-[12px] leading-none" aria-hidden="true">❝</span>
     <span class="flex min-w-0 flex-col gap-0.5">
       <span class="text-[9px] font-semibold uppercase tracking-wide opacity-75">{{ kindLabel }}</span>
-      <span v-if="path" class="truncate font-mono text-[9px] text-txt3" :title="path">{{ path }}</span>
+      <span v-if="showFieldPath" class="truncate font-mono text-[9px] text-txt3" :title="path">{{ path }}</span>
       <span v-if="kind !== 'field'" class="break-words [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:3] overflow-hidden">
         {{ ann.quote }}
         <span
@@ -58,7 +67,8 @@ const path = computed(() => props.ann.jsonPath || props.ann.selector || '')
           class="ml-1 inline-block border border-current px-0.5 text-[9px] opacity-80"
         >{{ t('pages.reviewComposer.chipTruncated') }}</span>
       </span>
-      <span v-else class="truncate">{{ ann.label || path }}</span>
+      <span v-else-if="showFieldLabel" class="truncate">{{ fieldLabel }}</span>
+      <span v-else-if="kind === 'field' && !showFieldPath" class="truncate">{{ ann.label || path }}</span>
     </span>
     <button
       v-if="removable"

--- a/web/src/components/run/ClarifyChat.test.ts
+++ b/web/src/components/run/ClarifyChat.test.ts
@@ -166,7 +166,7 @@ describe('ClarifyChat', () => {
     wrapper.unmount()
   })
 
-  it('shows optimistic annotation chips with text after send', async () => {
+  it('enqueue shows queue panel (not optimistic transcript bubble)', async () => {
     const anns: ReactAnnotation[] = [{ label: '提案标题', jsonPath: 'proposals[0].title' }]
     const wrapper = mountChat({
       annotateEnabled: true,
@@ -180,14 +180,16 @@ describe('ClarifyChat', () => {
     expect(payload[0]).toBe('请看这里')
     expect(payload[2]).toEqual(anns)
 
-    // Thinking window: body text + chip both visible
-    expect(wrapper.text()).toContain('请看这里')
-    expect(wrapper.text()).toContain('提案标题')
+    // Session UX: message lives in queue panel until turn_begin
+    const queue = wrapper.find('[data-testid="clarify-review-queue"]')
+    expect(queue.exists()).toBe(true)
+    expect(queue.text()).toContain('请看这里')
+    expect(wrapper.find('[data-testid="clarify-review-cancel"]').exists()).toBe(true)
     expect(wrapper.text()).toMatch(/思考/)
     wrapper.unmount()
   })
 
-  it('shows only annotation chips without empty body bubble when text is empty', async () => {
+  it('enqueue annotation-only shows queue row without transcript bubble', async () => {
     const anns: ReactAnnotation[] = [{ label: 'Hero', selector: '#hero' }]
     const wrapper = mountChat({
       annotateEnabled: true,
@@ -200,14 +202,13 @@ describe('ClarifyChat', () => {
     expect(payload[0]).toBe('')
     expect(payload[2]).toEqual(anns)
 
-    // Chip is the visual subject; no markdown body bubble for empty text
-    expect(wrapper.text()).toContain('Hero')
+    expect(wrapper.find('[data-testid="clarify-review-queue"]').exists()).toBe(true)
     expect(wrapper.findAll('.md.rounded-lg').length).toBe(0)
     expect(wrapper.text()).toMatch(/思考/)
     wrapper.unmount()
   })
 
-  it('keeps optimistic annotation chips after composer annotations are cleared', async () => {
+  it('keeps queued text after composer annotations are cleared', async () => {
     const anns: ReactAnnotation[] = [{ label: '字段路径', jsonPath: 'summary' }]
     const wrapper = mountChat({
       annotateEnabled: true,
@@ -223,10 +224,9 @@ describe('ClarifyChat', () => {
     await wrapper.setProps({ annotations: cleared, draft: '' })
     await flushPromises()
 
-    // Composer staging cleared, but optimistic bubble still shows the snapshot chip
+    // Composer staging cleared; queue panel still shows the enqueued text
     expect(wrapper.props('annotations')).toEqual([])
-    expect(wrapper.text()).toContain('字段路径')
-    expect(wrapper.text()).toContain('核对引用')
+    expect(wrapper.find('[data-testid="clarify-review-queue"]').text()).toContain('核对引用')
     expect(wrapper.text()).toMatch(/思考/)
     wrapper.unmount()
   })

--- a/web/src/components/run/ClarifyChat.vue
+++ b/web/src/components/run/ClarifyChat.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { ref, computed, watch, nextTick, onMounted } from 'vue'
+import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Icon from '../ui/Icon.vue'
 import ClarifyDemoFrame from './ClarifyDemoFrame.vue'
 import { renderMarkdown } from '@/lib/markdown'
+import { createStreamMarkdownPreview } from '@/lib/streamMarkdownPreview'
 import { relTime } from '@/lib/format'
 import {
   demoGridColsClass,
@@ -27,8 +28,8 @@ type QueueItem = { text: string; images: ClarifyImage[]; annotations: ReactAnnot
 // waiting_human). When false (completed/failed/cancelled) the chat input is
 // hidden — a finished run must not accept further replies.
 // reviewMode: post-run ReAct review of a producer node's product (vs. the
-// classic clarify dialogue). Enables annotation chips and relabels the finish
-// action to "确认并流转到下一节点".
+// classic clarify dialogue). Relabels the finish action to "确认并流转";
+// session UX (queue/stream/Cancel/refresh) is shared with clarify.
 // annotateEnabled: show chip UI without forcing reviewMode finish semantics
 // (inbox clarify binds annotations + review-mode affordances but only「发送澄清回复」).
 // hideFinish: suppress finish / confirmFlow button (clarify send-only).
@@ -63,7 +64,7 @@ const showAnnotationChips = computed(() => props.reviewMode || props.annotateEna
 const emit = defineEmits<{
   (e: 'send', text: string, images: ClarifyImage[], annotations: ReactAnnotation[]): void
   (e: 'finish'): void
-  /** Review 轮级 Cancel (≠ confirm ≠ AbortRun). */
+  /** 轮级 Cancel (≠ confirm ≠ AbortRun). Review clears queue; clarify keeps it. */
   (e: 'cancel'): void
 }>()
 
@@ -81,16 +82,23 @@ const annotations = defineModel<ReactAnnotation[]>('annotations', { default: () 
 const thinking = ref(false)
 /** Review confirm mid-state: re-validating product (not Agent thinking). */
 const validating = ref(false)
-// Review mode: SandboxChat/AgentChatTester-aligned pending-send queue. Items live
-// ONLY in the bottom panel until turn_begin materializes transcript bubbles.
+// SandboxChat-aligned pending-send queue (clarify + review). Items live ONLY in
+// the bottom panel until turn_begin materializes transcript bubbles.
 const queued = ref<QueueItem[]>([])
-/** In-flight review turn bubbles (human + streaming agent) before props.turns catch up. */
+/** In-flight turn bubbles (human + streaming agent) before props.turns catch up. */
 const liveTurns = ref<ClarifyTurn[]>([])
 const liveAgentIdx = ref(-1)
+/** Coalesced markdown HTML for the live streaming agent bubble. */
+const liveStreamHtml = ref('')
+const streamPreview = createStreamMarkdownPreview({ render: renderMarkdown })
+const unsubStream = streamPreview.subscribe((html) => {
+  liveStreamHtml.value = html
+})
 const scroller = ref<HTMLElement>()
 const fileInput = ref<HTMLInputElement | null>(null)
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
 const overflowScroll = ref(false)
+const composing = ref(false)
 
 /** Near-bottom threshold (px), aligned with PmLeaderChat / approved Demo. */
 const STICK_THRESHOLD = 48
@@ -100,6 +108,10 @@ const unreadCount = ref(0)
 const showUnreadFab = computed(() => unreadCount.value >= 1 && !stickToBottom.value)
 const unreadFabLabel = computed(() =>
   translate('pages.clarify.unreadFab', { n: unreadCount.value }),
+)
+
+const sessionBusy = computed(
+  () => thinking.value || queued.value.length > 0 || liveAgentIdx.value >= 0,
 )
 
 function isNearBottom(el: HTMLElement): boolean {
@@ -164,11 +176,14 @@ function onTextInput() {
   autoGrow()
 }
 
-// Optimistically show the just-sent human message (+ its images/annotations)
-// until the backend snapshot (props.turns) catches up. Cleared whenever real
-// turns arrive. Annotations are snapshotted at send so composer clear does not
-// wipe chips from the optimistic bubble.
+// Optimistically show choice-card session replies until backend catches up.
+// Authoritative send path uses queue + liveTurns (no pending human bubble).
 const pending = ref<{ text: string; images: ClarifyImage[]; annotations: ReactAnnotation[] } | null>(null)
+
+onBeforeUnmount(() => {
+  unsubStream()
+  streamPreview.reset()
+})
 
 /** Legacy zh-CN prefix for messages persisted before i18n or in sessionStorage. */
 const LEGACY_CHOICE_PREFIX = '我的选择:'
@@ -255,11 +270,12 @@ const latestQuestionAnswered = computed(() => {
 
 const turns = computed<ClarifyTurn[]>(() => {
   let list = props.turns
-  // Review: never inject optimistic pending into transcript (queue panel only).
-  if (props.reviewMode) {
-    if (liveTurns.value.length) list = [...list, ...liveTurns.value]
+  // Session UX: live in-flight bubbles until persisted transcript catches up.
+  if (liveTurns.value.length) {
+    list = [...list, ...liveTurns.value]
     return list
   }
+  // Choice-card sessionStorage echo only (not used for free-text send).
   if (pending.value) {
     list = [
       ...list,
@@ -294,19 +310,19 @@ function turnsSemanticKey(turnList: ClarifyTurn[]): string {
   return `${turnList.length}:${last.at}:${last.role}:${last.text}`
 }
 
-// Real turns streamed back from the run: drop the optimistic bubble + spinner.
-// Scroll only when stuck to bottom; unread is owned by the length watcher below.
+// Real turns streamed back from the run: drop optimistic choice echo + clear
+// settled live bubbles. Scroll only when stuck to bottom.
 watch(
   () => turnsSemanticKey(props.turns),
   (key, prevKey) => {
     if (prevKey !== undefined && key === prevKey) return
     const turnList = props.turns
     pending.value = null
-    if (!props.reviewMode) thinking.value = false
-    // Review: clear live bubbles once persisted transcript includes them.
-    if (props.reviewMode && liveTurns.value.length && !liveTurns.value.some((t) => t.streaming)) {
+    // Clear live bubbles once persisted transcript includes them (not while streaming).
+    if (liveTurns.value.length && !liveTurns.value.some((t) => t.streaming)) {
       liveTurns.value = []
       liveAgentIdx.value = -1
+      streamPreview.reset()
       if (queued.value.length === 0) thinking.value = false
     }
     const qIdx = latestQuestionTurnIndex(turnList)
@@ -420,22 +436,11 @@ function removeAttachment(i: number) {
 function sendMessage(text: string, imgs: ClarifyImage[] = [], anns: ReactAnnotation[] = []) {
   const t = text.trim()
   if ((!t && imgs.length === 0 && anns.length === 0) || props.done || !props.active) return
-  if (props.reviewMode) {
-    // Enqueue only — bubbles materialize on turn_begin (AgentChatTester / Demo).
-    queued.value.push({ text: t, images: imgs, annotations: anns.slice() })
-    thinking.value = true
-    emit('send', t, imgs, anns)
-    stickToBottom.value = true
-    unreadCount.value = 0
-    void scrollBottom(true)
-    return
-  }
-  // Snapshot annotations (same list as emit) so clearing the composer model
-  // leaves the optimistic bubble's chips intact during the thinking window.
-  pending.value = { text: t, images: imgs, annotations: anns.slice() }
+  // Enqueue only — bubbles materialize on turn_begin (AgentChatTester / Demo).
+  // Busy may still enqueue; never open a concurrent turn via optimistic pending.
+  queued.value.push({ text: t, images: imgs, annotations: anns.slice() })
   thinking.value = true
   emit('send', t, imgs, anns)
-  // User send always force-sticks and clears unread (send turn must not linger on FAB).
   stickToBottom.value = true
   unreadCount.value = 0
   void scrollBottom(true)
@@ -450,6 +455,14 @@ function sendFromComposer() {
   attachments.value = []
   annotations.value = []
   sendMessage(t, imgs, anns)
+}
+
+function onComposerKeydown(e: KeyboardEvent) {
+  if (e.key !== 'Enter' || e.shiftKey) return
+  // IME: composition Enter / keyCode 229 must not send (prevents double-fire).
+  if (composing.value || e.isComposing || e.keyCode === 229) return
+  e.preventDefault()
+  send()
 }
 
 function removeAnnotation(i: number) {
@@ -635,14 +648,17 @@ function finishEarly() {
 }
 
 const confirmDisabled = computed(() => {
-  if (!props.reviewMode) return thinking.value
-  // FR4: thinking or pending-send queue non-empty → disable 确认并流转.
+  // Force finish / 确认并流转: only when session idle (no in-flight / queue).
   return validating.value || thinking.value || queued.value.length > 0 || liveAgentIdx.value >= 0
 })
 
 function cancelReview() {
-  if (!props.reviewMode || props.done) return
-  queued.value = []
+  if (props.done || !sessionBusy.value) return
+  // Review: clear local queue (matches CancelReviewSession clear-queue).
+  // Clarify: keep local queue; authoritative queue_state will reconcile (Demo).
+  if (props.reviewMode) {
+    queued.value = []
+  }
   if (liveAgentIdx.value >= 0 && liveTurns.value[liveAgentIdx.value]) {
     liveTurns.value[liveAgentIdx.value].streaming = false
     liveTurns.value[liveAgentIdx.value].interrupted = true
@@ -651,7 +667,8 @@ function cancelReview() {
     }
   }
   liveAgentIdx.value = -1
-  thinking.value = false
+  streamPreview.reset()
+  thinking.value = queued.value.length > 0
   emit('cancel')
   void scrollBottom()
 }
@@ -661,7 +678,7 @@ function cancelReview() {
  * so the pending-send panel and FR4 confirm gate do not stick forever.
  */
 function discardLastQueued() {
-  if (!props.reviewMode || queued.value.length === 0) return
+  if (queued.value.length === 0) return
   queued.value.pop()
   if (queued.value.length === 0 && liveAgentIdx.value < 0) {
     thinking.value = false
@@ -672,43 +689,63 @@ function discardLastQueued() {
  * Reconcile local pending-send panel with platform-authoritative queue_state.
  * waiting===0 clears ghost rows after remote Cancel; items[] rebuilds/trims
  * while allowing at most one local-ahead item when no live turn (HTTP ack /
- * turn_begin in flight).
+ * turn_begin in flight). busy+activeItem restores live bubble after refresh.
  */
-function applyQueueState(waiting: number, items: { text?: string }[] | null) {
-  if (waiting === 0) {
+function applyQueueState(
+  waiting: number,
+  items: { text?: string }[] | null,
+  busy?: boolean,
+  activeItem?: { text?: string; images?: ClarifyImage[]; annotations?: ReactAnnotation[] } | null,
+) {
+  if (waiting === 0 && !busy) {
     queued.value = []
     if (liveAgentIdx.value < 0) thinking.value = false
-    return
-  }
-  if (!items) {
-    thinking.value = liveAgentIdx.value >= 0 || queued.value.length > 0
-    return
-  }
-  const rebuilt: QueueItem[] = items.map((it) => {
-    const text = it.text ?? ''
-    const local = queued.value.find((q) => q.text === text)
-    return {
-      text,
-      images: local?.images ?? [],
-      annotations: local?.annotations ?? [],
+  } else if (items) {
+    const rebuilt: QueueItem[] = items.map((it) => {
+      const text = it.text ?? ''
+      const local = queued.value.find((q) => q.text === text)
+      return {
+        text,
+        images: local?.images ?? [],
+        annotations: local?.annotations ?? [],
+      }
+    })
+    const maxLocal = liveAgentIdx.value >= 0 || busy ? rebuilt.length : rebuilt.length + 1
+    if (queued.value.length > maxLocal) {
+      const optimistic = queued.value.slice(rebuilt.length).slice(0, Math.max(0, maxLocal - rebuilt.length))
+      queued.value = [...rebuilt, ...optimistic]
+    } else if (queued.value.length < rebuilt.length) {
+      queued.value = rebuilt
+    } else {
+      const optimistic = queued.value.slice(rebuilt.length)
+      queued.value = [...rebuilt, ...optimistic]
     }
-  })
-  const maxLocal = liveAgentIdx.value >= 0 ? rebuilt.length : rebuilt.length + 1
-  if (queued.value.length > maxLocal) {
-    // Keep trailing optimistic-only rows that still fit the maxLocal budget.
-    const optimistic = queued.value.slice(rebuilt.length).slice(0, Math.max(0, maxLocal - rebuilt.length))
-    queued.value = [...rebuilt, ...optimistic]
-  } else if (queued.value.length < rebuilt.length) {
-    queued.value = rebuilt
-  } else {
-    // Same length or one ahead: refresh texts from server, keep local extras.
-    const optimistic = queued.value.slice(rebuilt.length)
-    queued.value = [...rebuilt, ...optimistic]
   }
-  thinking.value = liveAgentIdx.value >= 0 || queued.value.length > 0
+  // Refresh resume: recreate streaming agent bubble from activeItem when busy.
+  if (busy && activeItem && liveAgentIdx.value < 0) {
+    const text = activeItem.text ?? ''
+    liveTurns.value = [
+      {
+        role: 'human',
+        text,
+        at: new Date().toISOString(),
+        images: activeItem.images,
+        annotations: activeItem.annotations,
+      },
+      {
+        role: 'agent',
+        text: '',
+        at: new Date().toISOString(),
+        streaming: true,
+      },
+    ]
+    liveAgentIdx.value = 1
+    streamPreview.reset()
+  }
+  thinking.value = liveAgentIdx.value >= 0 || queued.value.length > 0 || !!busy
 }
 
-/** Parent (RunDetailView) feeds review WS frames here. */
+/** Parent feeds review/clarify WS frames here (shared session protocol). */
 function applyReviewFrame(frame: {
   event?: string
   nodeId?: string
@@ -717,8 +754,9 @@ function applyReviewFrame(frame: {
   interrupted?: boolean
   waiting?: number
   items?: { text?: string }[]
+  busy?: boolean
+  activeItem?: { text?: string; images?: ClarifyImage[]; annotations?: ReactAnnotation[] }
 }) {
-  if (!props.reviewMode) return
   // Defense: ignore frames for other producer sessions on the same run.
   if (frame.nodeId && frame.nodeId !== props.nodeId) return
   switch (frame.event) {
@@ -741,6 +779,7 @@ function applyReviewFrame(frame: {
           at: new Date().toISOString(),
           streaming: true,
         }) - 1
+      streamPreview.reset()
       thinking.value = true
       break
     }
@@ -748,6 +787,7 @@ function applyReviewFrame(frame: {
       if (liveAgentIdx.value >= 0 && liveTurns.value[liveAgentIdx.value]) {
         liveTurns.value[liveAgentIdx.value].streaming = false
         if (frame.interrupted) liveTurns.value[liveAgentIdx.value].interrupted = true
+        streamPreview.flush()
       }
       liveAgentIdx.value = -1
       thinking.value = queued.value.length > 0
@@ -759,6 +799,7 @@ function applyReviewFrame(frame: {
         liveTurns.value[liveAgentIdx.value].text =
           liveTurns.value[liveAgentIdx.value].text || frame.message || 'error'
         if (frame.interrupted) liveTurns.value[liveAgentIdx.value].interrupted = true
+        streamPreview.flush()
       }
       liveAgentIdx.value = -1
       thinking.value = queued.value.length > 0
@@ -768,6 +809,8 @@ function applyReviewFrame(frame: {
       applyQueueState(
         typeof frame.waiting === 'number' ? frame.waiting : 0,
         Array.isArray(frame.items) ? frame.items : null,
+        frame.busy,
+        frame.activeItem ?? null,
       )
       break
   }
@@ -776,7 +819,7 @@ function applyReviewFrame(frame: {
 
 /** Consume publishAcp events for the streaming agent bubble (dialogue surface). */
 function applyAcpEvents(events: AcpEvent[] | undefined, nodeId?: string) {
-  if (!props.reviewMode || liveAgentIdx.value < 0 || !events?.length) return
+  if (liveAgentIdx.value < 0 || !events?.length) return
   if (nodeId && nodeId !== props.nodeId) return
   const agent = liveTurns.value[liveAgentIdx.value]
   if (!agent) return
@@ -786,8 +829,10 @@ function applyAcpEvents(events: AcpEvent[] | undefined, nodeId?: string) {
     if (ev.kind === 'message' && ev.text) msg = ev.text
     if (ev.kind === 'thought' && ev.text) thought = ev.text
   }
-  agent.text = msg
-  if (thought && !msg) agent.text = thought
+  const next = msg || thought
+  agent.text = next
+  streamPreview.setText(next)
+  // Stick-gated only — never force-drag while user scrolled up.
   void scrollBottom()
 }
 
@@ -858,10 +903,10 @@ defineExpose({ applyReviewFrame, applyAcpEvents, cancelReview, discardLastQueued
             </div>
           </div>
           <div
-            v-else-if="t.text"
+            v-else-if="t.text || (t.streaming && liveStreamHtml)"
             class="md rounded-lg border px-3 py-2 text-[13px] leading-relaxed"
             :class="t.role === 'agent' ? 'border-line bg-elevated text-txt' : 'border-accent/30 bg-accent-dim/60 text-txt'"
-            v-html="renderMarkdown(t.text)"
+            v-html="t.streaming && liveStreamHtml ? liveStreamHtml : renderMarkdown(t.text)"
           />
 
           <!-- Structured choice questions (ask_question). The latest agent turn
@@ -1049,7 +1094,7 @@ defineExpose({ applyReviewFrame, applyAcpEvents, cancelReview, discardLastQueued
           <div class="mt-1 text-[10px] text-txt3" :class="t.role === 'human' ? 'text-right' : ''">{{ locale && relTime(t.at) }}</div>
         </div>
       </div>
-      <div v-if="thinking && !validating && !(reviewMode && liveAgentIdx >= 0)" class="flex items-center gap-2 pl-9 text-[12px] text-txt3">
+      <div v-if="thinking && !validating && liveAgentIdx < 0" class="flex items-center gap-2 pl-9 text-[12px] text-txt3">
         <span class="typing-dots"><i /><i /><i /></span>
         {{ translate('pages.clarify.thinking') }}
       </div>
@@ -1075,9 +1120,9 @@ defineExpose({ applyReviewFrame, applyAcpEvents, cancelReview, discardLastQueued
       <Icon name="close" :size="13" class="-mt-0.5 mr-1 inline" />{{ translate('pages.clarify.closed') }}
     </div>
     <div v-else class="border-t border-line p-3">
-      <!-- pending-send queue panel (Demo / AgentChatTester): review mode only -->
+      <!-- pending-send queue panel (Demo / AgentChatTester): clarify + review -->
       <div
-        v-if="reviewMode && queued.length"
+        v-if="queued.length"
         class="mb-2 rounded-md border border-line bg-base/40 px-2.5 py-2"
         data-testid="clarify-review-queue"
       >
@@ -1133,7 +1178,9 @@ defineExpose({ applyReviewFrame, applyAcpEvents, cancelReview, discardLastQueued
           :placeholder="inputPlaceholder"
           data-testid="clarify-input"
           @input="onTextInput"
-          @keydown.enter.exact.prevent="send"
+          @keydown="onComposerKeydown"
+          @compositionstart="composing = true"
+          @compositionend="composing = false"
           @paste="onPaste"
         />
         <button
@@ -1154,6 +1201,16 @@ defineExpose({ applyReviewFrame, applyAcpEvents, cancelReview, discardLastQueued
         >
           <Icon name="send" :size="17" />
         </button>
+        <button
+          v-if="sessionBusy"
+          type="button"
+          class="inline-flex h-10 shrink-0 items-center gap-1 rounded-md border border-line bg-elevated px-3 text-xs font-semibold text-txt2 hover:border-line-strong"
+          data-testid="clarify-review-cancel"
+          title="Cancel"
+          @click="cancelReview"
+        >
+          Cancel
+        </button>
       </div>
       <div v-if="!hideFinish" class="mt-2 flex items-center justify-between gap-2">
         <p
@@ -1164,16 +1221,6 @@ defineExpose({ applyReviewFrame, applyAcpEvents, cancelReview, discardLastQueued
           {{ validating ? translate('pages.clarify.validating') : translate('pages.clarify.confirmFlowHint') }}
         </p>
         <span v-else class="flex-1" />
-        <button
-          v-if="reviewMode && (thinking || queued.length > 0 || liveAgentIdx >= 0)"
-          type="button"
-          class="inline-flex shrink-0 items-center gap-1 rounded-md border border-line bg-elevated px-3 py-1.5 text-xs font-semibold text-txt2 hover:border-line-strong"
-          data-testid="clarify-review-cancel"
-          title="Cancel"
-          @click="cancelReview"
-        >
-          Cancel
-        </button>
         <button
           v-if="reviewMode"
           class="inline-flex shrink-0 items-center gap-1 rounded-md bg-ok px-3 py-1.5 text-xs font-semibold text-white hover:bg-ok/90 disabled:opacity-50"

--- a/web/src/components/run/ClarifyChat.vue
+++ b/web/src/components/run/ClarifyChat.vue
@@ -5,6 +5,7 @@ import Icon from '../ui/Icon.vue'
 import ClarifyDemoFrame from './ClarifyDemoFrame.vue'
 import { renderMarkdown } from '@/lib/markdown'
 import { createStreamMarkdownPreview } from '@/lib/streamMarkdownPreview'
+import { mergePersistedAndLiveTurns } from '@/lib/mergeClarifyLiveTurns'
 import { relTime } from '@/lib/format'
 import {
   demoGridColsClass,
@@ -271,9 +272,9 @@ const latestQuestionAnswered = computed(() => {
 const turns = computed<ClarifyTurn[]>(() => {
   let list = props.turns
   // Session UX: live in-flight bubbles until persisted transcript catches up.
+  // Dedupe against props.turns so mid-stream softRefresh/loadRun human does not double-render.
   if (liveTurns.value.length) {
-    list = [...list, ...liveTurns.value]
-    return list
+    return mergePersistedAndLiveTurns(list, liveTurns.value)
   }
   // Choice-card sessionStorage echo only (not used for free-text send).
   if (pending.value) {
@@ -836,7 +837,14 @@ function applyAcpEvents(events: AcpEvent[] | undefined, nodeId?: string) {
   void scrollBottom()
 }
 
-defineExpose({ applyReviewFrame, applyAcpEvents, cancelReview, discardLastQueued })
+defineExpose({
+  applyReviewFrame,
+  applyAcpEvents,
+  cancelReview,
+  discardLastQueued,
+  /** Host narrow-update gate: skip loadRun/softRefresh while true. */
+  isSessionBusy: () => sessionBusy.value,
+})
 </script>
 
 <template>

--- a/web/src/components/run/ClarifyChat.vue
+++ b/web/src/components/run/ClarifyChat.vue
@@ -762,13 +762,22 @@ function applyReviewFrame(frame: {
   if (frame.nodeId && frame.nodeId !== props.nodeId) return
   switch (frame.event) {
     case 'turn_begin': {
-      const item = queued.value.shift()
-      const text = item?.text ?? frame.item?.text ?? ''
-      const images = item?.images ?? frame.item?.images
-      const annotations = item?.annotations ?? frame.item?.annotations
+      // Pump order: queue_state(remaining, no active) → turn_begin(item=active).
+      // frame.item is server-authoritative; match-remove from local queue — never
+      // blind-shift (that would bind live human to the next waiter after trim).
+      const auth = frame.item
+      const text = auth?.text ?? ''
+      const matchIdx = text ? queued.value.findIndex((q) => q.text === text) : -1
+      const local = matchIdx >= 0 ? queued.value.splice(matchIdx, 1)[0] : undefined
+      const images =
+        auth?.images && auth.images.length > 0 ? auth.images : local?.images
+      const annotations =
+        auth?.annotations && auth.annotations.length > 0
+          ? auth.annotations
+          : local?.annotations
       liveTurns.value.push({
         role: 'human',
-        text,
+        text: text || local?.text || '',
         at: new Date().toISOString(),
         images,
         annotations,

--- a/web/src/components/run/ClarifyChat.vue
+++ b/web/src/components/run/ClarifyChat.vue
@@ -23,7 +23,12 @@ import type {
 } from '@/lib/types'
 import AnnotationChip from './AnnotationChip.vue'
 
-type QueueItem = { text: string; images: ClarifyImage[]; annotations: ReactAnnotation[] }
+type QueueItem = {
+  id?: string
+  text: string
+  images: ClarifyImage[]
+  annotations: ReactAnnotation[]
+}
 
 // active: whether the run is still in an interactive state (queued/running/
 // waiting_human). When false (completed/failed/cancelled) the chat input is
@@ -694,9 +699,14 @@ function discardLastQueued() {
  */
 function applyQueueState(
   waiting: number,
-  items: { text?: string }[] | null,
+  items: { id?: string; text?: string }[] | null,
   busy?: boolean,
-  activeItem?: { text?: string; images?: ClarifyImage[]; annotations?: ReactAnnotation[] } | null,
+  activeItem?: {
+    id?: string
+    text?: string
+    images?: ClarifyImage[]
+    annotations?: ReactAnnotation[]
+  } | null,
 ) {
   if (waiting === 0 && !busy) {
     queued.value = []
@@ -704,8 +714,13 @@ function applyQueueState(
   } else if (items) {
     const rebuilt: QueueItem[] = items.map((it) => {
       const text = it.text ?? ''
-      const local = queued.value.find((q) => q.text === text)
+      const id = typeof it.id === 'string' && it.id ? it.id : undefined
+      // Prefer server id match; text fallback for optimistic rows not yet reconciled.
+      const local = id
+        ? queued.value.find((q) => q.id === id) ?? queued.value.find((q) => !q.id && q.text === text)
+        : queued.value.find((q) => q.text === text)
       return {
+        id: id ?? local?.id,
         text,
         images: local?.images ?? [],
         annotations: local?.annotations ?? [],
@@ -750,24 +765,43 @@ function applyQueueState(
 function applyReviewFrame(frame: {
   event?: string
   nodeId?: string
-  item?: { text?: string; images?: ClarifyImage[]; annotations?: ReactAnnotation[] }
+  item?: {
+    id?: string
+    text?: string
+    images?: ClarifyImage[]
+    annotations?: ReactAnnotation[]
+  }
   message?: string
   interrupted?: boolean
   waiting?: number
-  items?: { text?: string }[]
+  items?: { id?: string; text?: string }[]
   busy?: boolean
-  activeItem?: { text?: string; images?: ClarifyImage[]; annotations?: ReactAnnotation[] }
+  activeItem?: {
+    id?: string
+    text?: string
+    images?: ClarifyImage[]
+    annotations?: ReactAnnotation[]
+  }
 }) {
   // Defense: ignore frames for other producer sessions on the same run.
   if (frame.nodeId && frame.nodeId !== props.nodeId) return
   switch (frame.event) {
     case 'turn_begin': {
       // Pump order: queue_state(remaining, no active) → turn_begin(item=active).
-      // frame.item is server-authoritative; match-remove from local queue — never
-      // blind-shift (that would bind live human to the next waiter after trim).
+      // frame.item is server-authoritative; match-remove by id first, text fallback —
+      // never blind-shift (that would bind live human to the next waiter after trim).
       const auth = frame.item
+      const id = typeof auth?.id === 'string' && auth.id ? auth.id : undefined
       const text = auth?.text ?? ''
-      const matchIdx = text ? queued.value.findIndex((q) => q.text === text) : -1
+      let matchIdx = -1
+      if (id) {
+        matchIdx = queued.value.findIndex((q) => q.id === id)
+      } else if (text) {
+        // No server id: text match for optimistic rows only.
+        matchIdx = queued.value.findIndex((q) => q.text === text)
+      }
+      // If auth carried an id but it is already absent (queue_state trimmed it),
+      // do NOT fall back to text — that would steal a different same-text waiter.
       const local = matchIdx >= 0 ? queued.value.splice(matchIdx, 1)[0] : undefined
       const images =
         auth?.images && auth.images.length > 0 ? auth.images : local?.images
@@ -1150,7 +1184,8 @@ defineExpose({
         <div class="space-y-1">
           <div
             v-for="(q, qi) in queued"
-            :key="qi"
+            :key="q.id || qi"
+            data-testid="clarify-queue-item"
             class="flex items-center gap-2 rounded border border-line bg-surface px-2 py-1 text-[12px] text-txt2"
           >
             <span class="flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-line text-[9px] text-txt3">{{ qi + 1 }}</span>

--- a/web/src/components/run/clarifySessionUx.probe.test.ts
+++ b/web/src/components/run/clarifySessionUx.probe.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment happy-dom
+/**
+ * Acceptance probes: ClarifyChat non-reviewMode (需求澄清) queue / stream /
+ * Cancel keep-queue / refresh resume / IME — aligned with Demo「修复后」.
+ */
+import { createI18n } from 'vue-i18n'
+import { flushPromises, mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import { beforeEach, describe, expect, it } from 'vitest'
+import common from '@/locales/zh-CN/common.json'
+import pages from '@/locales/zh-CN/pages.json'
+import ClarifyChat from './ClarifyChat.vue'
+import AnnotationChip from './AnnotationChip.vue'
+import type { ReactAnnotation } from '@/lib/types'
+
+function mountClarify(nodeId = 'clarify') {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common, ...pages } },
+  })
+  return mount(ClarifyChat, {
+    props: {
+      runId: 'run-1',
+      nodeId,
+      iteration: 1,
+      turns: [],
+      done: false,
+      active: true,
+      reviewMode: false,
+      annotateEnabled: true,
+      hideFinish: true,
+      sendLabel: '发送澄清回复',
+    },
+    global: {
+      plugins: [i18n],
+      stubs: { Icon: true, ClarifyDemoFrame: true },
+    },
+  })
+}
+
+async function sendText(wrapper: ReturnType<typeof mountClarify>, text: string) {
+  await wrapper.find('textarea').setValue(text)
+  await wrapper.find('[data-testid="clarify-send-label"]').trigger('click')
+  await flushPromises()
+}
+
+describe('[approving] ClarifyChat clarify-path UX (non-reviewMode)', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('enqueue shows queue; Cancel keeps queue (Demo keep-queue)', async () => {
+    const w = mountClarify()
+    await sendText(w, '澄清意见甲')
+    await sendText(w, '澄清意见乙')
+    const queue = w.find('[data-testid="clarify-review-queue"]')
+    expect(queue.exists()).toBe(true)
+    expect(queue.text()).toContain('澄清意见甲')
+    expect(queue.text()).toContain('澄清意见乙')
+
+    const vm = w.vm as unknown as {
+      applyReviewFrame: (f: Record<string, unknown>) => void
+      applyAcpEvents: (e: { kind: string; text: string }[]) => void
+    }
+    vm.applyReviewFrame({ event: 'turn_begin', item: { text: '澄清意见甲' }, nodeId: 'clarify' })
+    await nextTick()
+    vm.applyAcpEvents([{ kind: 'message', text: '流式正文增量' }])
+    await nextTick()
+    expect(w.text()).toContain('流式正文增量')
+
+    await w.find('[data-testid="clarify-review-cancel"]').trigger('click')
+    await flushPromises()
+    // Demo: queue kept (乙 still pending); interrupted marker on current turn.
+    expect(w.find('[data-testid="clarify-review-queue"]').text()).toContain('澄清意见乙')
+    expect(w.find('[data-testid="clarify-interrupted"]').exists()).toBe(true)
+    expect(w.emitted('cancel')).toBeTruthy()
+    w.unmount()
+  })
+
+  it('refresh resume via queue_state busy+activeItem recreates live stream bubble', async () => {
+    const w = mountClarify()
+    const vm = w.vm as unknown as {
+      applyReviewFrame: (f: Record<string, unknown>) => void
+      applyAcpEvents: (e: { kind: string; text: string }[]) => void
+    }
+    vm.applyReviewFrame({
+      event: 'queue_state',
+      nodeId: 'clarify',
+      waiting: 1,
+      items: [{ text: '排队中的下一条' }],
+      busy: true,
+      activeItem: { text: '刷新前进行中的提问' },
+    })
+    await nextTick()
+    expect(w.text()).toContain('刷新前进行中的提问')
+    expect(w.find('[data-testid="clarify-review-queue"]').text()).toContain('排队中的下一条')
+    vm.applyAcpEvents([{ kind: 'message', text: '续上的流式正文' }])
+    await nextTick()
+    expect(w.text()).toContain('续上的流式正文')
+    w.unmount()
+  })
+
+  it('IME composing Enter does not send', async () => {
+    const w = mountClarify()
+    const ta = w.find('[data-testid="clarify-input"]')
+    await ta.setValue('中文输入')
+    await ta.trigger('compositionstart')
+    await ta.trigger('keydown', { key: 'Enter', keyCode: 229, isComposing: true })
+    await flushPromises()
+    expect(w.emitted('send')).toBeFalsy()
+    await ta.trigger('compositionend')
+    await ta.trigger('keydown', { key: 'Enter', keyCode: 13, isComposing: false })
+    await flushPromises()
+    expect(w.emitted('send')).toBeTruthy()
+    w.unmount()
+  })
+
+  it('AnnotationChip path===label shows once', () => {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const ann: ReactAnnotation = { label: '#launchInput', selector: '#launchInput' }
+    const w = mount(AnnotationChip, {
+      props: { ann, testId: 'chip-dup' },
+      global: { plugins: [i18n], stubs: { Icon: true } },
+    })
+    const text = w.text()
+    const matches = text.match(/#launchInput/g) || []
+    expect(matches.length).toBe(1)
+    w.unmount()
+  })
+
+  it('AnnotationChip path!==label shows both', () => {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const ann: ReactAnnotation = { label: '启动输入', jsonPath: '#launchInput' }
+    const w = mount(AnnotationChip, {
+      props: { ann },
+      global: { plugins: [i18n], stubs: { Icon: true } },
+    })
+    expect(w.text()).toContain('#launchInput')
+    expect(w.text()).toContain('启动输入')
+    w.unmount()
+  })
+})

--- a/web/src/components/run/clarifySessionUx.probe.test.ts
+++ b/web/src/components/run/clarifySessionUx.probe.test.ts
@@ -148,4 +148,52 @@ describe('[approving] ClarifyChat clarify-path UX (non-reviewMode)', () => {
     expect(w.text()).toContain('启动输入')
     w.unmount()
   })
+
+  it('props.turns catching human while live streaming does not double human bubble', async () => {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const w = mount(ClarifyChat, {
+      props: {
+        runId: 'run-1',
+        nodeId: 'clarify',
+        iteration: 1,
+        turns: [],
+        done: false,
+        active: true,
+        reviewMode: false,
+        annotateEnabled: true,
+        hideFinish: true,
+        sendLabel: '发送澄清回复',
+      },
+      global: {
+        plugins: [i18n],
+        stubs: { Icon: true, ClarifyDemoFrame: true },
+      },
+    })
+    const vm = w.vm as unknown as {
+      applyReviewFrame: (f: Record<string, unknown>) => void
+      applyAcpEvents: (e: { kind: string; text: string }[]) => void
+    }
+    vm.applyReviewFrame({
+      event: 'turn_begin',
+      item: { text: '澄清意见甲' },
+      nodeId: 'clarify',
+    })
+    await nextTick()
+    vm.applyAcpEvents([{ kind: 'message', text: '流式正文' }])
+    await nextTick()
+    // Host softRefresh/loadRun caught up with persisted human mid-stream.
+    await w.setProps({
+      turns: [{ role: 'human', text: '澄清意见甲', at: '2026-07-27T00:00:00Z' }],
+    })
+    await nextTick()
+    const body = w.find('[data-testid="clarify-scroller"]').text()
+    const matches = body.match(/澄清意见甲/g) || []
+    expect(matches.length).toBe(1)
+    expect(body).toContain('流式正文')
+    w.unmount()
+  })
 })

--- a/web/src/components/run/clarifySessionUx.probe.test.ts
+++ b/web/src/components/run/clarifySessionUx.probe.test.ts
@@ -148,6 +148,78 @@ describe('[approving] ClarifyChat clarify-path UX (non-reviewMode)', () => {
     w.unmount()
   })
 
+  it('turn_begin prefers queue item id over duplicate text', async () => {
+    const w = mountClarify()
+    // Two identical texts — text-only match would be ambiguous.
+    await sendText(w, '同一文案')
+    await sendText(w, '同一文案')
+    const vm = w.vm as unknown as {
+      applyReviewFrame: (f: Record<string, unknown>) => void
+    }
+    // Authoritative reconcile assigns server ids before turn_begin.
+    vm.applyReviewFrame({
+      event: 'queue_state',
+      nodeId: 'clarify',
+      waiting: 2,
+      items: [
+        { id: 'id-a', text: '同一文案' },
+        { id: 'id-b', text: '同一文案' },
+      ],
+      busy: false,
+    })
+    await nextTick()
+    // Pump: remaining = id-b only, then turn_begin starts id-a (not in queue).
+    vm.applyReviewFrame({
+      event: 'queue_state',
+      nodeId: 'clarify',
+      waiting: 1,
+      items: [{ id: 'id-b', text: '同一文案' }],
+      busy: true,
+    })
+    await nextTick()
+    vm.applyReviewFrame({
+      event: 'turn_begin',
+      nodeId: 'clarify',
+      item: { id: 'id-a', text: '同一文案' },
+    })
+    await nextTick()
+    const queue = w.find('[data-testid="clarify-review-queue"]')
+    expect(queue.exists()).toBe(true)
+    // id-a was already trimmed; must NOT steal id-b via text fallback.
+    expect(queue.findAll('[data-testid="clarify-queue-item"]').length).toBe(1)
+    expect(queue.text()).toContain('同一文案')
+    w.unmount()
+  })
+
+  it('turn_begin removes matching id from local queue when still present', async () => {
+    const w = mountClarify()
+    await sendText(w, '同一文案')
+    await sendText(w, '同一文案')
+    const vm = w.vm as unknown as {
+      applyReviewFrame: (f: Record<string, unknown>) => void
+    }
+    vm.applyReviewFrame({
+      event: 'queue_state',
+      nodeId: 'clarify',
+      waiting: 2,
+      items: [
+        { id: 'id-a', text: '同一文案' },
+        { id: 'id-b', text: '同一文案' },
+      ],
+      busy: false,
+    })
+    await nextTick()
+    // turn_begin before trim (id still in local queue) — remove by id.
+    vm.applyReviewFrame({
+      event: 'turn_begin',
+      nodeId: 'clarify',
+      item: { id: 'id-a', text: '同一文案' },
+    })
+    await nextTick()
+    expect(w.findAll('[data-testid="clarify-queue-item"]').length).toBe(1)
+    w.unmount()
+  })
+
   it('AnnotationChip path===label shows once', () => {
     const i18n = createI18n({
       legacy: false,

--- a/web/src/components/run/clarifySessionUx.probe.test.ts
+++ b/web/src/components/run/clarifySessionUx.probe.test.ts
@@ -78,6 +78,38 @@ describe('[approving] ClarifyChat clarify-path UX (non-reviewMode)', () => {
     w.unmount()
   })
 
+  it('real pump order: queue_state(remaining) then turn_begin(active) binds 甲 not 乙', async () => {
+    // Server pump: queue_state items=剩余(不含 active) → turn_begin item=当前轮.
+    // Blind shift after trim would wrongly show 乙 as live human (review v1).
+    const w = mountClarify()
+    await sendText(w, '澄清意见甲')
+    await sendText(w, '澄清意见乙')
+    const vm = w.vm as unknown as {
+      applyReviewFrame: (f: Record<string, unknown>) => void
+    }
+    vm.applyReviewFrame({
+      event: 'queue_state',
+      nodeId: 'clarify',
+      waiting: 1,
+      items: [{ text: '澄清意见乙' }],
+      busy: true,
+    })
+    await nextTick()
+    vm.applyReviewFrame({
+      event: 'turn_begin',
+      nodeId: 'clarify',
+      item: { text: '澄清意见甲' },
+    })
+    await nextTick()
+    const scroller = w.find('[data-testid="clarify-scroller"]').text()
+    const humanMatches = scroller.match(/澄清意见甲/g) || []
+    expect(humanMatches.length).toBe(1)
+    expect(scroller).not.toMatch(/澄清意见乙/)
+    expect(w.find('[data-testid="clarify-review-queue"]').text()).toContain('澄清意见乙')
+    expect(w.find('[data-testid="clarify-review-queue"]').text()).not.toContain('澄清意见甲')
+    w.unmount()
+  })
+
   it('refresh resume via queue_state busy+activeItem recreates live stream bubble', async () => {
     const w = mountClarify()
     const vm = w.vm as unknown as {

--- a/web/src/lib/inboxContext.test.ts
+++ b/web/src/lib/inboxContext.test.ts
@@ -84,4 +84,33 @@ describe('adaptInboxContextToRun', () => {
     expect(run.nodeExecutions?.research_1[0].outputs?.research).toContain('ok')
     expect(run.clarifyByNode?.research_1.done).toBe(false)
   })
+
+  it('maps clarify reactSessions for refresh-resume', () => {
+    const run = adaptInboxContextToRun(
+      {
+        type: 'clarify',
+        status: 'waiting_human',
+        reactSessions: {
+          react: {
+            kind: 'clarify',
+            waiting: 1,
+            busy: true,
+            items: [{ id: 'q2', text: '乙' }],
+            activeItem: { id: 'q1', text: '甲' },
+          },
+        },
+        clarify: {
+          nodeId: 'react',
+          iteration: 1,
+          turns: [],
+          done: false,
+          label: '澄清',
+        },
+      },
+      'r-sess',
+    )
+    expect(run.reactSessions?.react?.busy).toBe(true)
+    expect(run.reactSessions?.react?.items?.[0]?.id).toBe('q2')
+    expect(run.reactSessions?.react?.activeItem?.text).toBe('甲')
+  })
 })

--- a/web/src/lib/inboxContext.ts
+++ b/web/src/lib/inboxContext.ts
@@ -16,6 +16,8 @@ export type ClarifyInboxContext = {
   artifacts?: Artifact[]
   /** Slim executions for current node ∪ parseable upstream refs. */
   nodeExecutions?: Record<string, NodeRun[]>
+  /** Authoritative busy/queue for refresh-resume (parity with Run detail). */
+  reactSessions?: Run['reactSessions']
   clarify: {
     nodeId: string
     iteration?: number
@@ -57,6 +59,7 @@ export function adaptInboxContextToRun(ctx: InboxContextResponse, runId: string)
     nodes: ctx.nodes,
     artifacts: ctx.artifacts ?? [],
     nodeExecutions: ctx.nodeExecutions,
+    reactSessions: ctx.reactSessions,
     clarifyByNode: {
       [ctx.clarify.nodeId]: {
         nodeId: ctx.clarify.nodeId,

--- a/web/src/lib/mergeClarifyLiveTurns.test.ts
+++ b/web/src/lib/mergeClarifyLiveTurns.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { mergePersistedAndLiveTurns } from './mergeClarifyLiveTurns'
+import type { ClarifyTurn } from '@/lib/types'
+
+describe('mergePersistedAndLiveTurns', () => {
+  it('appends live when persisted has not caught up', () => {
+    const persisted: ClarifyTurn[] = [{ role: 'agent', text: '问', at: 't0' }]
+    const live: ClarifyTurn[] = [
+      { role: 'human', text: '答', at: 't1' },
+      { role: 'agent', text: '流', at: 't2', streaming: true },
+    ]
+    expect(mergePersistedAndLiveTurns(persisted, live)).toEqual([...persisted, ...live])
+  })
+
+  it('dedupes human when props.turns catches up while agent still streaming', () => {
+    const persisted: ClarifyTurn[] = [
+      { role: 'agent', text: '问', at: 't0' },
+      { role: 'human', text: '澄清意见甲', at: 't1' },
+    ]
+    const live: ClarifyTurn[] = [
+      { role: 'human', text: '澄清意见甲', at: 't1-live' },
+      { role: 'agent', text: '流式中…', at: 't2', streaming: true },
+    ]
+    const merged = mergePersistedAndLiveTurns(persisted, live)
+    const humans = merged.filter((t) => t.role === 'human' && t.text === '澄清意见甲')
+    expect(humans).toHaveLength(1)
+    expect(merged[merged.length - 1].streaming).toBe(true)
+    expect(merged[merged.length - 1].text).toBe('流式中…')
+  })
+
+  it('returns persisted only when live empty', () => {
+    const persisted: ClarifyTurn[] = [{ role: 'agent', text: 'x', at: 't0' }]
+    expect(mergePersistedAndLiveTurns(persisted, [])).toEqual(persisted)
+  })
+})

--- a/web/src/lib/mergeClarifyLiveTurns.ts
+++ b/web/src/lib/mergeClarifyLiveTurns.ts
@@ -1,0 +1,41 @@
+import type { ClarifyTurn } from '@/lib/types'
+
+/**
+ * Merge persisted transcript with in-flight liveTurns without duplicating
+ * human/agent bubbles that softRefresh/loadRun already wrote into props.turns.
+ *
+ * Finds the longest prefix of `live` that matches the suffix of `persisted`
+ * by role+text (streaming turns never match persisted), then appends only the
+ * unmatched live tail (typically the streaming agent).
+ */
+export function mergePersistedAndLiveTurns(
+  persisted: ClarifyTurn[],
+  live: ClarifyTurn[],
+): ClarifyTurn[] {
+  if (!live.length) return persisted
+  if (!persisted.length) return [...persisted, ...live]
+
+  const maxK = Math.min(live.length, persisted.length)
+  let matched = 0
+  for (let candidate = maxK; candidate >= 1; candidate--) {
+    let ok = true
+    for (let i = 0; i < candidate; i++) {
+      const lt = live[i]
+      if (lt.streaming) {
+        ok = false
+        break
+      }
+      const pt = persisted[persisted.length - candidate + i]
+      if (pt.role !== lt.role || (pt.text || '') !== (lt.text || '')) {
+        ok = false
+        break
+      }
+    }
+    if (ok) {
+      matched = candidate
+      break
+    }
+  }
+  if (matched === 0) return [...persisted, ...live]
+  return [...persisted, ...live.slice(matched)]
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -626,6 +626,17 @@ export interface Run {
   // Per-node react conversations, keyed by node id (a run may have several
   // react nodes). Lets each react node show its own dialogue immediately.
   clarifyByNode?: Record<string, { nodeId: string; iteration?: number; turns: ClarifyTurn[]; done: boolean }>
+  /** Authoritative busy/queue snapshots for refresh-resume (clarify + review). */
+  reactSessions?: Record<
+    string,
+    {
+      kind?: string
+      waiting?: number
+      busy?: boolean
+      items?: { id?: string; text?: string }[]
+      activeItem?: { text?: string; images?: ClarifyImage[]; annotations?: ReactAnnotation[] }
+    }
+  >
   git?: { pushed: boolean; pushedSha?: string; branch?: string; mrUrl?: string } | null
   trace?: StateTraceEntry[]
   vars?: RunVar[]

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -634,7 +634,12 @@ export interface Run {
       waiting?: number
       busy?: boolean
       items?: { id?: string; text?: string }[]
-      activeItem?: { text?: string; images?: ClarifyImage[]; annotations?: ReactAnnotation[] }
+      activeItem?: {
+        id?: string
+        text?: string
+        images?: ClarifyImage[]
+        annotations?: ReactAnnotation[]
+      }
     }
   >
   git?: { pushed: boolean; pushedSha?: string; branch?: string; mrUrl?: string } | null

--- a/web/src/views/GatesInboxView.inboxLifecycle.test.ts
+++ b/web/src/views/GatesInboxView.inboxLifecycle.test.ts
@@ -151,11 +151,31 @@ const GateApprovalStub = defineComponent({
   template: '<button data-testid="resolve-btn" @click="$emit(\'resolve\', \'approve\', {})">resolve</button>',
 })
 
+/** Captures applyReviewFrame for hard-load / early-WS restore assertions (review v1). */
+const composerFrames = vi.hoisted(() => ({
+  applied: [] as Record<string, unknown>[],
+  busy: false,
+}))
+
 const ReviewComposerStub = defineComponent({
   name: 'ReviewComposer',
-  emits: ['send', 'finish'],
+  emits: ['send', 'finish', 'cancel'],
+  setup(_, { expose }) {
+    expose({
+      applyReviewFrame: (f: Record<string, unknown>) => {
+        composerFrames.applied.push(f)
+        if (f.event === 'turn_begin') composerFrames.busy = true
+        if (f.event === 'turn_done' || f.event === 'error') composerFrames.busy = false
+        if (f.event === 'queue_state' && typeof f.busy === 'boolean') composerFrames.busy = !!f.busy
+      },
+      applyAcpEvents: () => {},
+      discardLastQueued: () => {},
+      isSessionBusy: () => composerFrames.busy,
+    })
+    return {}
+  },
   template:
-    `<div>
+    `<div data-testid="review-composer-stub">
       <button data-testid="clarify-send" @click="$emit('send', 'hi', [], [], true)">finish</button>
       <button data-testid="clarify-turn" @click="$emit('send', 'hi', [], [], false)">turn</button>
     </div>`,
@@ -210,6 +230,8 @@ function inboxCallsFor(runId: string, nodeId: string, iteration = 1) {
 
 beforeEach(async () => {
   vi.clearAllMocks()
+  composerFrames.applied = []
+  composerFrames.busy = false
   FakeWebSocket.instances = []
   vi.stubGlobal('WebSocket', FakeWebSocket as unknown as typeof WebSocket)
   mocks.resumeGate.mockResolvedValue({ status: 'ok' })
@@ -1002,6 +1024,93 @@ describe('GatesInboxView inbox-context lifecycle', () => {
     expect(wrapper.text()).not.toContain('Gate solo')
     expect(wrapper.text()).not.toMatch(/Run #\s*-/)
     expect(usePendingGates().totalCount.value).toBe(0)
+    wrapper.unmount()
+  })
+
+  it('clarify hard load: early queue_state/snapshot still restores live+queue after mount (review v1)', async () => {
+    const item = clarifyItem('resume')
+    mocks.listGates.mockResolvedValue(paged([item]))
+
+    let releaseContext!: (v: unknown) => void
+    const hung = new Promise((resolve) => {
+      releaseContext = resolve
+    })
+    mocks.inboxContext.mockImplementationOnce(() => hung as Promise<unknown>)
+
+    const wrapper = mountInbox()
+    await flushPromises()
+    await nextTick()
+
+    // Hard load in flight: composer unmounted (loading pane). WS already connected.
+    const ws = FakeWebSocket.instances.find((w) => w.url.includes('run-resume'))
+    expect(ws).toBeTruthy()
+    expect(wrapper.find('[data-testid="review-composer-stub"]').exists()).toBe(false)
+
+    // Broadcast / snapshot arrive before chat mounts — must not be dropped.
+    ws!.emit('snapshot', {
+      run: {
+        reactSessions: {
+          'clarify-resume': {
+            kind: 'clarify',
+            waiting: 1,
+            busy: true,
+            items: [{ id: 'q-b', text: '乙' }],
+            activeItem: { id: 'q-a', text: '甲' },
+          },
+        },
+      },
+    })
+    ws!.emit('review', {
+      event: 'queue_state',
+      nodeId: 'clarify-resume',
+      waiting: 1,
+      items: [{ id: 'q-b', text: '乙' }],
+      busy: true,
+      activeItem: { id: 'q-a', text: '甲' },
+    })
+    await flushPromises()
+    expect(composerFrames.applied.length).toBe(0)
+
+    releaseContext({
+      type: 'clarify',
+      status: 'waiting_human',
+      nodes: [{ id: 'clarify-resume', type: 'react', label: '澄清' }],
+      artifacts: [],
+      nodeExecutions: {},
+      reactSessions: {
+        'clarify-resume': {
+          kind: 'clarify',
+          waiting: 1,
+          busy: true,
+          items: [{ id: 'q-b', text: '乙' }],
+          activeItem: { id: 'q-a', text: '甲' },
+        },
+      },
+      clarify: {
+        nodeId: 'clarify-resume',
+        iteration: 1,
+        turns: [],
+        done: false,
+        label: '澄清',
+      },
+    })
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="review-composer-stub"]').exists()).toBe(true)
+    // REST restore and/or buffered WS frames projected after mount.
+    const queueFrames = composerFrames.applied.filter((f) => f.event === 'queue_state')
+    expect(queueFrames.length).toBeGreaterThanOrEqual(1)
+    const last = queueFrames[queueFrames.length - 1] as {
+      busy?: boolean
+      activeItem?: { text?: string }
+      items?: { text?: string }[]
+    }
+    expect(last.busy).toBe(true)
+    expect(last.activeItem?.text).toBe('甲')
+    expect(last.items?.some((it) => it.text === '乙')).toBe(true)
     wrapper.unmount()
   })
 })

--- a/web/src/views/GatesInboxView.inboxLifecycle.test.ts
+++ b/web/src/views/GatesInboxView.inboxLifecycle.test.ts
@@ -733,6 +733,10 @@ describe('GatesInboxView inbox-context lifecycle', () => {
     ws!.emit('react')
     await flushPromises()
     expect(inboxCallsFor('run-a', 'clarify-a', 1).length).toBe(afterBegin)
+    // artifact_edit mid-busy must also skip softRefresh (review v4).
+    ws!.emit('artifact_edit')
+    await flushPromises()
+    expect(inboxCallsFor('run-a', 'clarify-a', 1).length).toBe(afterBegin)
 
     // Idle react (no busy) may softRefresh.
     ws!.emit('review', { event: 'turn_done', nodeId: 'clarify-a' })

--- a/web/src/views/GatesInboxView.inboxLifecycle.test.ts
+++ b/web/src/views/GatesInboxView.inboxLifecycle.test.ts
@@ -702,7 +702,8 @@ describe('GatesInboxView inbox-context lifecycle', () => {
     const before = inboxCallsFor('run-a', 'clarify-a', 1).length
     expect(before).toBeGreaterThan(0)
 
-    // Ordinary turn: stay pending; status must not softRefresh, react may.
+    // Ordinary turn: stay pending; status must not softRefresh.
+    // Mid-turn react is gated by liveBusy (turn_begin) — must not softRefresh.
     await wrapper.get('[data-testid="clarify-turn"]').trigger('click')
     await flushPromises()
     await nextTick()
@@ -725,9 +726,22 @@ describe('GatesInboxView inbox-context lifecycle', () => {
     await flushPromises()
     expect(inboxCallsFor('run-a', 'clarify-a', 1).length).toBe(afterTurn)
 
+    // turn_begin marks live busy → react must not softRefresh (stale reactSessions gate was the bug).
+    ws!.emit('review', { event: 'turn_begin', nodeId: 'clarify-a' })
+    await flushPromises()
+    const afterBegin = inboxCallsFor('run-a', 'clarify-a', 1).length
     ws!.emit('react')
     await flushPromises()
-    expect(inboxCallsFor('run-a', 'clarify-a', 1).length).toBe(afterTurn + 1)
+    expect(inboxCallsFor('run-a', 'clarify-a', 1).length).toBe(afterBegin)
+
+    // Idle react (no busy) may softRefresh.
+    ws!.emit('review', { event: 'turn_done', nodeId: 'clarify-a' })
+    await flushPromises()
+    const afterDone = inboxCallsFor('run-a', 'clarify-a', 1).length
+    expect(afterDone).toBeGreaterThan(afterBegin)
+    ws!.emit('react')
+    await flushPromises()
+    expect(inboxCallsFor('run-a', 'clarify-a', 1).length).toBe(afterDone + 1)
 
     // Force finish: short-circuit symmetric with gate resolve.
     const afterReact = inboxCallsFor('run-a', 'clarify-a', 1).length

--- a/web/src/views/GatesInboxView.vue
+++ b/web/src/views/GatesInboxView.vue
@@ -79,6 +79,13 @@ const reviewChatRef = ref<{
   discardLastQueued?: () => void
   isSessionBusy?: () => boolean
 } | null>(null)
+/**
+ * Review/clarify WS frames that arrived while ClarifyChat was unmounted
+ * (hard loadActiveRun nulls activeRun → ReviewComposer gone). Flushed after mount.
+ */
+let pendingReviewFrames: Record<string, unknown>[] = []
+/** Snapshot reactSessions stashed when activeRun is still null during hard load. */
+let pendingSnapshotSessions: Run['reactSessions'] | null = null
 const { selected } = usePipelineFilter()
 const { selected: selectedProject, ensureHydrated: hydrateProject } = useProjectContext()
 
@@ -445,6 +452,65 @@ function closeActiveRunWs() {
   activeRunWs = undefined
   activeRunWsRunId = ''
   clarifyLiveBusy.value = false
+  pendingReviewFrames = []
+  pendingSnapshotSessions = null
+}
+
+/** Project authoritative busy/queue onto ClarifyChat (RunDetail.restoreReactSessions parity). */
+function restoreReactSessions(r: { reactSessions?: Run['reactSessions'] } | null) {
+  const nodeId = active.value?.type === 'clarify' ? active.value.nodeId : null
+  if (!nodeId) return
+  const sessions = r?.reactSessions ?? pendingSnapshotSessions
+  if (!sessions) return
+  const snap = sessions[nodeId]
+  if (!snap || typeof snap !== 'object') return
+  clarifyLiveBusy.value = !!snap.busy
+  const frame = {
+    event: 'queue_state',
+    nodeId,
+    waiting: snap.waiting ?? 0,
+    items: snap.items ?? [],
+    busy: !!snap.busy,
+    activeItem: snap.activeItem,
+  }
+  if (reviewChatRef.value?.applyReviewFrame) {
+    reviewChatRef.value.applyReviewFrame(frame)
+  } else {
+    pendingReviewFrames.push(frame)
+  }
+  pendingSnapshotSessions = null
+}
+
+function flushPendingReviewFrames() {
+  if (!pendingReviewFrames.length) return
+  const frames = pendingReviewFrames
+  pendingReviewFrames = []
+  for (const frame of frames) {
+    reviewChatRef.value?.applyReviewFrame?.(frame)
+  }
+}
+
+/** Deliver review frame to chat, or buffer until ClarifyChat remounts after hard load. */
+function applyOrBufferReviewFrame(m: Record<string, unknown>) {
+  gateApprovalRef.value?.applyReviewFrame?.(m)
+  if (reviewChatRef.value?.applyReviewFrame) {
+    reviewChatRef.value.applyReviewFrame(m)
+    return
+  }
+  if (active.value?.type === 'clarify') {
+    pendingReviewFrames.push(m)
+  }
+}
+
+/**
+ * After hard load / soft refresh: project reactSessions + flush frames buffered
+ * while ReviewComposer was unmounted (WS Broadcast race).
+ */
+async function projectClarifySessionAfterLoad(r: Run) {
+  await nextTick()
+  restoreReactSessions(r)
+  await nextTick()
+  flushPendingReviewFrames()
 }
 
 function connectActiveRunWs(runId: string) {
@@ -469,17 +535,33 @@ function connectActiveRunWs(runId: string) {
       nodeId?: string
       events?: any[]
       busy?: boolean
+      run?: { reactSessions?: Run['reactSessions'] }
     }
     try {
       m = JSON.parse(String(ev.data))
     } catch {
       return
     }
+    // WS connect snapshot may carry reactSessions before BroadcastReviewSessions.
+    if (m.type === 'snapshot') {
+      const sessions = m.run?.reactSessions
+      if (sessions && active.value?.type === 'clarify' && active.value.runId === runId) {
+        if (activeRun.value) {
+          activeRun.value = { ...activeRun.value, reactSessions: sessions }
+          void nextTick(() => {
+            restoreReactSessions(activeRun.value)
+            flushPendingReviewFrames()
+          })
+        } else {
+          pendingSnapshotSessions = sessions
+        }
+      }
+      return
+    }
     if (m.type === 'review') {
       if (m.event === 'turn_begin') clarifyLiveBusy.value = true
       if (m.event === 'queue_state' && typeof m.busy === 'boolean') clarifyLiveBusy.value = !!m.busy
-      gateApprovalRef.value?.applyReviewFrame?.(m)
-      reviewChatRef.value?.applyReviewFrame?.(m)
+      applyOrBufferReviewFrame(m as Record<string, unknown>)
       if (m.event === 'turn_done' || m.event === 'error') {
         clarifyLiveBusy.value = false
         if (active.value && active.value.runId === runId) void softRefreshActiveRun()
@@ -490,7 +572,10 @@ function connectActiveRunWs(runId: string) {
       if (typeof m.busy === 'boolean') clarifyLiveBusy.value = !!m.busy
       const nodeId = (m as { nodeId?: string }).nodeId
       gateApprovalRef.value?.applyAcpEvents?.(m.events)
-      reviewChatRef.value?.applyAcpEvents?.(m.events, nodeId)
+      if (reviewChatRef.value?.applyAcpEvents) {
+        reviewChatRef.value.applyAcpEvents(m.events, nodeId)
+      }
+      // ACP chunks need a live bubble; no buffer — restore+queue_state recreates it.
       return
     }
     if (m.type === 'artifact_edit' || m.type === 'react' || m.type === 'trace' || m.type === 'status') {
@@ -537,6 +622,8 @@ async function softRefreshActiveRun() {
     if (isProcessedTriple(target)) return
     activeRun.value = adaptInboxContextToRun(ctx, target.runId)
     activeRunLoadError.value = false
+    // Soft refresh keeps chat mounted — only merge reactSessions onto run; do not
+    // re-project live bubbles (would reset stream). Hard-load path restores below.
   } catch (e) {
     if (isAbortError(e) || signal.aborted) return
     if (
@@ -576,13 +663,18 @@ async function loadActiveRun(hard = true) {
     activeRun.value = null
     activeRunLoadError.value = false
     activeRunLoading.value = true
+    // Chat unmounts — clear stale buffer for this load cycle (WS may refill).
+    pendingReviewFrames = []
   }
+  let projectAfterLoad = false
   try {
     const ctx = await api.inboxContext(target.runId, target.nodeId, target.iteration ?? 1, { signal })
     if (!active.value || inboxTripleKey(active.value) !== triple) return
     if (isProcessedTriple(target)) return
     activeRun.value = adaptInboxContextToRun(ctx, target.runId)
     activeRunLoadError.value = false
+    // Must project AFTER loading flag clears so ReviewComposer can mount.
+    projectAfterLoad = hard && target.type === 'clarify'
   } catch (e) {
     if (isAbortError(e) || signal.aborted) return
     if (
@@ -600,6 +692,9 @@ async function loadActiveRun(hard = true) {
   } finally {
     releaseInboxContextSignal(triple, signal)
     if (hard) activeRunLoading.value = false
+  }
+  if (projectAfterLoad && activeRun.value) {
+    await projectClarifySessionAfterLoad(activeRun.value)
   }
 }
 watch(

--- a/web/src/views/GatesInboxView.vue
+++ b/web/src/views/GatesInboxView.vue
@@ -77,6 +77,7 @@ const reviewChatRef = ref<{
   applyReviewFrame?: (frame: any) => void
   applyAcpEvents?: (events: any[] | undefined, nodeId?: string) => void
   discardLastQueued?: () => void
+  isSessionBusy?: () => boolean
 } | null>(null)
 const { selected } = usePipelineFilter()
 const { selected: selectedProject, ensureHydrated: hydrateProject } = useProjectContext()
@@ -426,11 +427,24 @@ const activeRunLoadError = ref(false)
 /** Active-run event socket — mirrors RunDetailView artifact_edit/react → reload. */
 let activeRunWs: WebSocket | undefined
 let activeRunWsRunId = ''
+/**
+ * Live busy from review/acp WS frames (not stale activeRun.reactSessions snapshot).
+ * Used to gate softRefresh while clarify session is mid-turn (g3.2 / review v3).
+ */
+const clarifyLiveBusy = ref(false)
+
+function isClarifySoftRefreshBlocked(): boolean {
+  if (active.value?.type !== 'clarify') return false
+  if (clarifyLiveBusy.value) return true
+  if (reviewChatRef.value?.isSessionBusy?.()) return true
+  return false
+}
 
 function closeActiveRunWs() {
   activeRunWs?.close()
   activeRunWs = undefined
   activeRunWsRunId = ''
+  clarifyLiveBusy.value = false
 }
 
 function connectActiveRunWs(runId: string) {
@@ -449,21 +463,31 @@ function connectActiveRunWs(runId: string) {
     return
   }
   activeRunWs.onmessage = (ev) => {
-    let m: { type?: string; event?: string; nodeId?: string; events?: any[] }
+    let m: {
+      type?: string
+      event?: string
+      nodeId?: string
+      events?: any[]
+      busy?: boolean
+    }
     try {
       m = JSON.parse(String(ev.data))
     } catch {
       return
     }
     if (m.type === 'review') {
+      if (m.event === 'turn_begin') clarifyLiveBusy.value = true
+      if (m.event === 'queue_state' && typeof m.busy === 'boolean') clarifyLiveBusy.value = !!m.busy
       gateApprovalRef.value?.applyReviewFrame?.(m)
       reviewChatRef.value?.applyReviewFrame?.(m)
       if (m.event === 'turn_done' || m.event === 'error') {
+        clarifyLiveBusy.value = false
         if (active.value && active.value.runId === runId) void softRefreshActiveRun()
       }
       return
     }
     if (m.type === 'acp') {
+      if (typeof m.busy === 'boolean') clarifyLiveBusy.value = !!m.busy
       const nodeId = (m as { nodeId?: string }).nodeId
       gateApprovalRef.value?.applyAcpEvents?.(m.events)
       reviewChatRef.value?.applyAcpEvents?.(m.events, nodeId)
@@ -487,8 +511,8 @@ function connectActiveRunWs(runId: string) {
       if (active.value.type === 'clarify') {
         if (m.type === 'artifact_edit') void softRefreshActiveRun()
         if (m.type === 'react') {
-          const sess = (activeRun.value as any)?.reactSessions?.[active.value.nodeId]
-          if (!sess?.busy) void softRefreshActiveRun()
+          // Gate on live WS busy / sessionBusy — not stale reactSessions snapshot.
+          if (!isClarifySoftRefreshBlocked()) void softRefreshActiveRun()
         }
       }
     }

--- a/web/src/views/GatesInboxView.vue
+++ b/web/src/views/GatesInboxView.vue
@@ -506,11 +506,10 @@ function connectActiveRunWs(runId: string) {
         if (m.type === 'artifact_edit') void softRefreshActiveRun()
         return
       }
-      // Clarify: allow artifact_edit; react mid-turn is projected via review/acp
-      // frames — skip softRefresh so we do not wipe busy/queue/stream.
+      // Clarify: react/artifact_edit mid-turn projected via review/acp — skip
+      // softRefresh while busy so we do not wipe busy/queue/stream (g3.2 / review v4).
       if (active.value.type === 'clarify') {
-        if (m.type === 'artifact_edit') void softRefreshActiveRun()
-        if (m.type === 'react') {
+        if (m.type === 'artifact_edit' || m.type === 'react') {
           // Gate on live WS busy / sessionBusy — not stale reactSessions snapshot.
           if (!isClarifySoftRefreshBlocked()) void softRefreshActiveRun()
         }

--- a/web/src/views/GatesInboxView.vue
+++ b/web/src/views/GatesInboxView.vue
@@ -482,9 +482,14 @@ function connectActiveRunWs(runId: string) {
         if (m.type === 'artifact_edit') void softRefreshActiveRun()
         return
       }
-      // Clarify: allow react (turns) and artifact_edit; still ignore status/trace.
+      // Clarify: allow artifact_edit; react mid-turn is projected via review/acp
+      // frames — skip softRefresh so we do not wipe busy/queue/stream.
       if (active.value.type === 'clarify') {
-        if (m.type === 'artifact_edit' || m.type === 'react') void softRefreshActiveRun()
+        if (m.type === 'artifact_edit') void softRefreshActiveRun()
+        if (m.type === 'react') {
+          const sess = (activeRun.value as any)?.reactSessions?.[active.value.nodeId]
+          if (!sess?.busy) void softRefreshActiveRun()
+        }
       }
     }
   }
@@ -815,18 +820,16 @@ async function onClarifySend(
       rollbackProcessingIntent(it)
       return
     }
-    // Non-force review enqueue failed: roll back optimistic queue + surface error.
-    if (reviewActive.value) {
-      reviewChatRef.value?.discardLastQueued?.()
-      clarifyConfirmError.value = msg
-    }
+    // Non-force enqueue failed: roll back optimistic queue + surface error.
+    reviewChatRef.value?.discardLastQueued?.()
+    clarifyConfirmError.value = msg
   }
-  const submittedKey = itemKey(it)
-  const prevList = listItems.value.slice()
   const finished = force && ok
 
   // Force-finish: mirror onResolve — local converge + unlock in finally even if refresh throws.
   if (force) {
+    const submittedKey = itemKey(it)
+    const prevList = listItems.value.slice()
     let stillThere = true
     try {
       showProcessedBanner.value = false
@@ -855,31 +858,8 @@ async function onClarifySend(
     return
   }
 
-  // Review enqueue returns before the turn finishes — keep live queue/stream bubbles.
-  if (reviewActive.value) return
-
-  // Ordinary turn: conversation stays pending — no processingLock / markProcessed.
-  showProcessedBanner.value = false
-  try {
-    await refresh({ source: 'submit', mode: 'force' })
-    await loadList()
-  } catch {
-    /* soft-fail; apply list binding below from whatever we have */
-  }
-  const stillThere = listItems.value.some((k) => itemKey(k) === submittedKey)
-  if (stillThere) {
-    active.value = listItems.value.find((k) => itemKey(k) === submittedKey) || listItems.value[0] || null
-  } else {
-    // Left pending unexpectedly (e.g. concurrent finish): drop ghost and pick neighbor.
-    markProcessed(it)
-    closeActiveRunWs()
-    removeListItemLocally(submittedKey)
-    selectActiveAfterRemove(prevList, submittedKey)
-  }
-  if (!active.value) {
-    activeRun.value = null
-    activeRunLoadError.value = false
-  }
+  // Ordinary turn enqueue returns before the turn finishes — keep live
+  // queue/stream bubbles (clarify + review shared session UX). No force refresh.
 }
 
 // Review: confirm product & advance (same contract as RunDetailView.onClarifyFinish).

--- a/web/src/views/RunDetailView.test.ts
+++ b/web/src/views/RunDetailView.test.ts
@@ -329,3 +329,13 @@ describe('RunDetailView load failure split', () => {
     expect(src).not.toMatch(/请检查网络或确认 Run 是否存在/)
   })
 })
+
+describe('RunDetailView clarify session narrow update (g3.2)', () => {
+  it('skips react/focus loadRun while clarify session busy', () => {
+    expect(src).toMatch(/function isClarifySessionBusy\(/)
+    expect(src).toMatch(/if \(m\.type === 'react' && isClarifySessionBusy\(\)\) return/)
+    expect(src).toMatch(/if \(isClarifySessionBusy\(\)\) return/)
+    expect(src).toMatch(/liveBusy\[m\.nodeId\] = true/)
+    expect(src).toMatch(/m\.event === 'turn_begin'/)
+  })
+})

--- a/web/src/views/RunDetailView.test.ts
+++ b/web/src/views/RunDetailView.test.ts
@@ -331,9 +331,12 @@ describe('RunDetailView load failure split', () => {
 })
 
 describe('RunDetailView clarify session narrow update (g3.2)', () => {
-  it('skips react/focus loadRun while clarify session busy', () => {
+  it('skips react/status/trace/artifact_edit/focus loadRun while clarify session busy', () => {
     expect(src).toMatch(/function isClarifySessionBusy\(/)
-    expect(src).toMatch(/if \(m\.type === 'react' && isClarifySessionBusy\(\)\) return/)
+    // All four event types share one busy gate (review v3) — not react-only.
+    expect(src).toMatch(
+      /m\.type === 'trace'[\s\S]*?m\.type === 'status'[\s\S]*?m\.type === 'react'[\s\S]*?m\.type === 'artifact_edit'[\s\S]*?if \(isClarifySessionBusy\(\)\) return/,
+    )
     expect(src).toMatch(/if \(isClarifySessionBusy\(\)\) return/)
     expect(src).toMatch(/liveBusy\[m\.nodeId\] = true/)
     expect(src).toMatch(/m\.event === 'turn_begin'/)

--- a/web/src/views/RunDetailView.vue
+++ b/web/src/views/RunDetailView.vue
@@ -365,9 +365,30 @@ async function fetchRunData(): Promise<true | RunLoadErrorKind> {
     } else if (r.workflowId) {
       wf.value = await api.getWorkflow(r.workflowId)
     }
+    // Refresh-resume: project authoritative busy/queue into ClarifyChat.
+    nextTick(() => restoreReactSessions(r))
     return true
   } catch (err) {
     return classifyRunLoadError(err)
+  }
+}
+
+function restoreReactSessions(r: { reactSessions?: Record<string, any> }) {
+  const sessions = r.reactSessions
+  if (!sessions) return
+  for (const [nodeId, snap] of Object.entries(sessions)) {
+    if (!snap || typeof snap !== 'object') continue
+    liveBusy[nodeId] = !!snap.busy
+    if (selClarify.value?.nodeId === nodeId) {
+      reviewChatRef.value?.applyReviewFrame?.({
+        event: 'queue_state',
+        nodeId,
+        waiting: snap.waiting ?? 0,
+        items: snap.items ?? [],
+        busy: !!snap.busy,
+        activeItem: snap.activeItem,
+      })
+    }
   }
 }
 
@@ -388,7 +409,15 @@ async function initAfterLoadSuccess() {
   if (!timer) {
     timer = window.setInterval(() => {
       if (run.value.status === 'running' || run.value.status === 'waiting_human') {
-        loadRun(false)
+        // Clarify/review session busy: skip full loadRun so we do not wipe
+        // live stream / send lock / input focus (narrow updates via WS frames).
+        const clarifyBusy =
+          !!selClarify.value &&
+          (liveBusy[selClarify.value.nodeId] === true ||
+            !!(run.value as any).reactSessions?.[selClarify.value.nodeId]?.busy)
+        if (!clarifyBusy) {
+          loadRun(false)
+        }
         const sel = selected.value
         // Only skip REST once we already have displayable live events;
         // busy-only / empty live frames must keep the 2s poll fallback.
@@ -575,14 +604,13 @@ async function onClarifySend(
     // already completed) instead of leaving the input enabled to re-click.
     console.warn('reactReply failed', e?.message || e)
     const msg = e?.message || t('pages.runDetail.gateError')
-    if (reviewActive.value) {
-      // Non-force: roll back optimistic pending-send row so FR4 confirm is not stuck.
-      if (!force) reviewChatRef.value?.discardLastQueued?.()
-      clarifyConfirmError.value = msg
-    }
+    // Non-force: roll back optimistic pending-send row so FR4 / send lock is not stuck.
+    if (!force) reviewChatRef.value?.discardLastQueued?.()
+    clarifyConfirmError.value = msg
   }
-  // Review enqueue returns before the turn finishes — avoid wiping live bubbles.
-  if (force || !reviewActive.value) {
+  // Enqueue returns before the turn finishes — avoid wiping live bubbles.
+  // Force finish still needs a snapshot refresh.
+  if (force) {
     await loadRun(false)
   }
 }

--- a/web/src/views/RunDetailView.vue
+++ b/web/src/views/RunDetailView.vue
@@ -542,8 +542,9 @@ function connectWs() {
       m.type === 'artifact_edit'
     ) {
       // Node finished / transitioned / human artifact edit: pull authoritative snapshot.
-      // Mid-clarify: react is projected via review/acp frames — do not full-page rebind.
-      if (m.type === 'react' && isClarifySessionBusy()) return
+      // Mid-clarify: review/acp frames project the session — skip full-page rebind for
+      // react/status/trace/artifact_edit alike (g3.2 / review v3).
+      if (isClarifySessionBusy()) return
       if (m.type === 'status') liveNode.value = null
       loadRun(false)
     }

--- a/web/src/views/RunDetailView.vue
+++ b/web/src/views/RunDetailView.vue
@@ -111,7 +111,18 @@ const reviewChatRef = ref<{
   applyReviewFrame?: (frame: any) => void
   applyAcpEvents?: (events: AcpEvent[] | undefined, nodeId?: string) => void
   discardLastQueued?: () => void
+  isSessionBusy?: () => boolean
 } | null>(null)
+
+/** Clarify/review session in-flight: skip full-page loadRun (g3.2 / review v1). */
+function isClarifySessionBusy(): boolean {
+  const nodeId = selClarify.value?.nodeId
+  if (!nodeId) return false
+  if (liveBusy[nodeId] === true) return true
+  if (!!(run.value as any)?.reactSessions?.[nodeId]?.busy) return true
+  if (reviewChatRef.value?.isSessionBusy?.()) return true
+  return false
+}
 const gateApprovalRef = ref<{
   applyReviewFrame?: (frame: any) => void
   applyAcpEvents?: (events: AcpEvent[] | undefined) => void
@@ -411,11 +422,7 @@ async function initAfterLoadSuccess() {
       if (run.value.status === 'running' || run.value.status === 'waiting_human') {
         // Clarify/review session busy: skip full loadRun so we do not wipe
         // live stream / send lock / input focus (narrow updates via WS frames).
-        const clarifyBusy =
-          !!selClarify.value &&
-          (liveBusy[selClarify.value.nodeId] === true ||
-            !!(run.value as any).reactSessions?.[selClarify.value.nodeId]?.busy)
-        if (!clarifyBusy) {
+        if (!isClarifySessionBusy()) {
           loadRun(false)
         }
         const sel = selected.value
@@ -518,11 +525,14 @@ function connectWs() {
       }
     } else if (m.type === 'review' && m.nodeId) {
       // Prefer matching producer; components also filter by nodeId defensively.
+      if (m.event === 'turn_begin') liveBusy[m.nodeId] = true
+      if (m.event === 'queue_state' && typeof m.busy === 'boolean') liveBusy[m.nodeId] = !!m.busy
       if (!selClarify.value || selClarify.value.nodeId === m.nodeId) {
         reviewChatRef.value?.applyReviewFrame?.(m)
       }
       gateApprovalRef.value?.applyReviewFrame?.(m)
       if (m.event === 'turn_done' || m.event === 'error') {
+        liveBusy[m.nodeId] = false
         loadRun(false)
       }
     } else if (
@@ -532,6 +542,8 @@ function connectWs() {
       m.type === 'artifact_edit'
     ) {
       // Node finished / transitioned / human artifact edit: pull authoritative snapshot.
+      // Mid-clarify: react is projected via review/acp frames — do not full-page rebind.
+      if (m.type === 'react' && isClarifySessionBusy()) return
       if (m.type === 'status') liveNode.value = null
       loadRun(false)
     }
@@ -547,6 +559,8 @@ onMounted(async () => {
   window.addEventListener('focus', onFocusRefresh)
 })
 function onFocusRefresh() {
+  // Clarify/review mid-turn: skip focus/visibility full reload (keeps stream + input focus).
+  if (isClarifySessionBusy()) return
   if (!runLoading.value && !loadError.value) loadRun(false)
 }
 function onVisible() {


### PR DESCRIPTION
## Summary
- 经典 react 澄清接入与复审同源的平台 FIFO / WS 帧（`queue_state` / `turn_begin` / `turn_done`）与刷新可恢复 `busy/queue/timeline`；HTTP 入队立即返回，禁止纯前端 `pending/thinking` 冒充权威。
- Cancel 按入口分叉：澄清 = keep-queue + pump-next（Demo）；复审保持 clear-queue（#77 不变）。
- ClarifyChat 去掉 `reviewMode` 半套门闩：双入口（待审批 composer + Run 详情）统一帧消费、队列面板、Cancel、流式气泡；接入 `createStreamMarkdownPreview`；澄清回合跳过整页 `loadRun`/softRefresh 重绑。
- 发送锁 + IME Enter 守卫；`AnnotationChip` path===label 只显一次。

## Test plan
- [x] `go test ./internal/engine/`（含 `TestClarifySessionQueueAndCancelKeepNext` / `TestClarifyReactReplyEnqueues`）
- [x] vitest：`ClarifyChat.test.ts` / `clarifySessionUx.probe.test.ts` / `reviewSessionUx.probe.test.ts`
- [x] playwright：`clarify-session-ux.spec.ts`（排队→流式→Cancel 保留队列→刷新续传）+ `review-session-ux.spec.ts`（回归清空队列）
- [ ] **人工门禁（必须）**：需求澄清场景手测 Demo 主路径——发送→流式→入队→刷新续传→Cancel 保留队列并自动开下一条；仅测复审不算过

## plan_coverage evidence hints
- g1.1–g1.3：`review_session.go` EnqueueClarifyTurn / executeClarifyTurn / CancelClarifyTurn；`resume.go` 经典 react 入队；`ws.go`/`dto.go` 刷新广播与 `reactSessions`
- g2.1–g2.2：`ClarifyChat.vue` 统一 applyFrame；`ReviewComposer(mode=clarify)` + RunDetail 挂载
- g3.1–g3.2：streamMarkdownPreview；RunDetail 2s loadRun skip when busy；GatesInbox softRefresh 窄化
- g4.1–g4.2：IME/composing；AnnotationChip 同值去重
- g5.1–g5.3：clarify_session_test + probe + e2e harness + 本 PR


Made with [Cursor](https://cursor.com)