### PR TITLE
fix(web): align PM token rank/trend to workflow purple

### DIFF
--- a/web/src/components/board/token-stats/TokenCharts.test.ts
+++ b/web/src/components/board/token-stats/TokenCharts.test.ts
@@ -7,6 +7,7 @@ import pages from '@/locales/zh-CN/pages.json'
 import TokenTrendChart from './TokenTrendChart.vue'
 import TokenDonutChart from './TokenDonutChart.vue'
 import TokenWorkflowRank from './TokenWorkflowRank.vue'
+import { TOKEN_SOURCE_COLORS } from './tokenStatsShared'
 
 const i18n = () =>
   createI18n({
@@ -181,14 +182,14 @@ describe('Token charts (g2.3/g2.4)', () => {
     wrapper.unmount()
   })
 
-  it('renders consumption rank with PM amber row and other as non-PM (g3.2)', () => {
+  it('renders consumption rank with PM same-purple row (not amber) and other as non-PM (g3.1/g1)', () => {
     const wrapper = mount(TokenWorkflowRank, {
       props: {
         workflows: [
-          { workflowId: 'a', name: 'approve-main', total: 100, kind: 'workflow' },
-          { name: 'PM', total: 80, kind: 'pm' },
-          { workflowId: 'b', name: 'doc-review', total: 40, kind: 'workflow' },
-          { name: 'other', total: 20, other: true, kind: 'other' },
+          { workflowId: 'a', name: 'approve-main', total: 1_020_000, kind: 'workflow' },
+          { name: 'PM', total: 80_000, kind: 'pm' },
+          { workflowId: 'b', name: 'doc-review', total: 40_000, kind: 'workflow' },
+          { name: 'other', total: 20_000, other: true, kind: 'other' },
         ],
       },
       global: { plugins: [i18n()] },
@@ -200,6 +201,57 @@ describe('Token charts (g2.3/g2.4)', () => {
     expect(wrapper.find('[data-kind="pm"]').exists()).toBe(true)
     expect(wrapper.text()).toContain('PM')
     expect(wrapper.text()).toContain('其他')
+
+    // PM badge text is "PM" (not a numeric rank); workflow ranks remain 1, 2
+    const pmRow = wrapper.find('[data-kind="pm"]')
+    expect(pmRow.text()).toMatch(/^PM/)
+    const badges = wrapper.findAll('li').map((li) => li.find('span').text())
+    expect(badges).toEqual(['1', 'PM', '2', '·'])
+
+    // Same purple as workflow — no amber (#f59e0b / #d97706 / #fbbf24)
+    const pmHtml = pmRow.html()
+    expect(pmHtml).toContain('#6d5cff')
+    expect(pmHtml).toContain('#9b8cff')
+    expect(pmHtml).not.toMatch(/#f59e0b|#d97706|#fbbf24|245,\s*158,\s*11/)
+
+    // Compact K/M main values remain visible on the right
+    const values = wrapper.findAll('[data-testid="token-rank-value"]').map((v) => v.text())
+    expect(values).toEqual(['1.02M', '80K', '40K', '20K'])
+    expect(wrapper.find('[data-testid="token-rank-value"]').attributes('title')).toBeTruthy()
+    wrapper.unmount()
+  })
+
+  it('trend PM dataset shares workflow purple and uses borderDash (g2.2/g3.1)', () => {
+    expect(TOKEN_SOURCE_COLORS.pm).toBe(TOKEN_SOURCE_COLORS.workflow)
+    expect(TOKEN_SOURCE_COLORS.pm).toBe('#6d5cff')
+    expect(TOKEN_SOURCE_COLORS.pm).not.toBe('#f59e0b')
+
+    const wrapper = mount(TokenTrendChart, {
+      props: {
+        bucketWidth: 'day',
+        trend: sampleTrend(7),
+      },
+      global: { plugins: [i18n()] },
+    })
+    const exposed = wrapper.vm as unknown as {
+      chartData: {
+        datasets: {
+          label: string
+          borderColor: string
+          backgroundColor: string
+          borderDash?: number[]
+        }[]
+      }
+    }
+    const pmDs = exposed.chartData.datasets.find((d) => d.label === 'pm')
+    const wfDs = exposed.chartData.datasets.find((d) => d.label === 'workflow')
+    expect(pmDs).toBeTruthy()
+    expect(wfDs).toBeTruthy()
+    expect(pmDs!.borderColor).toBe(wfDs!.borderColor)
+    expect(pmDs!.borderColor).toBe('#6d5cff')
+    expect(pmDs!.borderDash).toEqual([5, 4])
+    expect(wfDs!.borderDash).toBeUndefined()
+    expect(String(pmDs!.backgroundColor)).not.toMatch(/245,\s*158,\s*11/)
     wrapper.unmount()
   })
 })

--- a/web/src/components/board/token-stats/TokenTrendChart.vue
+++ b/web/src/components/board/token-stats/TokenTrendChart.vue
@@ -91,8 +91,9 @@ const chartData = computed(() => {
         label: 'pm',
         data: pm,
         borderColor: PM_COLOR,
-        backgroundColor: 'rgba(245, 158, 11, 0.35)',
+        backgroundColor: 'rgba(109, 92, 255, 0.14)',
         borderWidth: 1.8,
+        borderDash: [5, 4],
         fill: true,
         tension: 0.15,
         pointRadius: 3.5,
@@ -175,7 +176,11 @@ defineExpose({ chartOptions, chartData })
         workflow
       </span>
       <span class="inline-flex items-center gap-1.5">
-        <i class="inline-block h-2 w-2 rounded-sm" :style="{ background: PM_COLOR }" />
+        <i
+          class="inline-block h-0 w-3 border-t-2 border-dashed"
+          :style="{ borderColor: PM_COLOR }"
+          aria-hidden="true"
+        />
         pm
       </span>
     </div>
@@ -201,7 +206,11 @@ defineExpose({ chartOptions, chartData })
       </div>
       <div class="flex justify-between gap-3 text-[#c7cbd4]">
         <span class="inline-flex items-center gap-1.5">
-          <i class="inline-block h-2 w-2 rounded-sm" :style="{ background: PM_COLOR }" />
+          <i
+            class="inline-block h-0 w-3 border-t-2 border-dashed"
+            :style="{ borderColor: PM_COLOR }"
+            aria-hidden="true"
+          />
           pm
         </span>
         <b class="font-normal tabular-nums text-white">{{ fmtTokenCount(tipBucket.pmTotal || 0) }}</b>

--- a/web/src/components/board/token-stats/TokenWorkflowRank.vue
+++ b/web/src/components/board/token-stats/TokenWorkflowRank.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { TokenStatsWorkflow } from '@/lib/types'
-import { fmtTokenCount } from '@/lib/tokenUsage'
+import { fmtCompactTokenCount, fmtTokenCount } from '@/lib/tokenUsage'
 
 const props = defineProps<{
   workflows: TokenStatsWorkflow[]
@@ -43,14 +43,17 @@ function badgeLabel(w: TokenStatsWorkflow, i: number): string {
 }
 
 function badgeClass(w: TokenStatsWorkflow, i: number): string {
-  if (isPM(w)) return 'bg-[rgba(245,158,11,0.18)] text-[#d97706]'
-  if (isOther(w)) return 'bg-elevated text-txt3'
+  // PM uses the same purple badge palette as workflow (no amber); identity via "PM" label.
+  if (isPM(w)) return 'w-auto min-w-[22px] px-1.5 bg-[rgba(109,92,255,0.18)] text-[#6d5cff]'
+  if (isOther(w)) return 'w-[22px] bg-elevated text-txt3'
   const n = Number(badgeLabel(w, i))
-  return n <= 3 ? 'bg-accent-dim text-accent-2' : 'bg-elevated text-txt3'
+  return n <= 3
+    ? 'w-[22px] bg-accent-dim text-accent-2'
+    : 'w-[22px] bg-elevated text-txt3'
 }
 
 function barClass(w: TokenStatsWorkflow): string {
-  if (isPM(w)) return 'bg-gradient-to-r from-[#f59e0b] to-[#fbbf24]'
+  // PM bar matches workflow purple gradient (#6d5cff → #9b8cff); other stays neutral grey.
   if (isOther(w)) return 'bg-gradient-to-r from-slate-400 to-slate-300'
   return 'bg-gradient-to-r from-[#6d5cff] to-[#9b8cff]'
 }
@@ -96,7 +99,7 @@ const tipRow = computed(() => (tip.value.idx >= 0 ? props.workflows[tip.value.id
       @click="showTip(i, $event)"
     >
       <span
-        class="grid h-[22px] w-[22px] place-items-center rounded-md text-[11px] font-bold"
+        class="grid h-[22px] place-items-center rounded-md text-[11px] font-bold"
         :class="badgeClass(w, i)"
       >
         {{ badgeLabel(w, i) }}
@@ -111,7 +114,11 @@ const tipRow = computed(() => (tip.value.idx >= 0 ? props.workflows[tip.value.id
           />
         </div>
       </div>
-      <span class="whitespace-nowrap text-xs tabular-nums text-txt3">{{ fmtTokenCount(w.total) }}</span>
+      <span
+        class="whitespace-nowrap text-xs tabular-nums text-txt3"
+        :title="fmtTokenCount(w.total)"
+        data-testid="token-rank-value"
+      >{{ fmtCompactTokenCount(w.total) }}</span>
     </li>
     <div
       v-if="tip.show && tipRow"

--- a/web/src/components/board/token-stats/tokenStatsShared.ts
+++ b/web/src/components/board/token-stats/tokenStatsShared.ts
@@ -6,10 +6,10 @@ export const TOKEN_PART_COLORS = {
   cacheWrite: '#f59e0b',
 } as const
 
-/** Trend/rank source colors (workflow / pm). Distinct from composition parts. */
+/** Trend/rank source colors (workflow / pm share purple; PM distinguished by dashed line). */
 export const TOKEN_SOURCE_COLORS = {
   workflow: '#6d5cff',
-  pm: '#f59e0b',
+  pm: '#6d5cff',
 } as const
 
 export type TokenPartKey = keyof typeof TOKEN_PART_COLORS


### PR DESCRIPTION
Unify PM badge/bar and trend stroke with #6d5cff, keep PM identity via badge text and borderDash, and show compact K/M values on rank rows.

Co-authored-by: Cursor <cursoragent@cursor.com>
