### PR TITLE
docs: rewrite bilingual README around harness narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ Module-specific lint, test, coverage, and E2E commands are documented in [`AGENT
 - [Contributing guide](CONTRIBUTING.md)
 - [Security policy](SECURITY.md)
 - [Support](SUPPORT.md)
-- [Chinese technical article: From Vibe Coding to Harness](docs/approving-harness-workflow.md)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 **Agent workflows that advance with humans — a new paradigm for multi-agent collaboration.**
 
-Approving turns coding agents into workflows you can trust: visual orchestration, sandboxed execution, and human Approve at critical nodes before continuing. Open-source and self-hostable, with rollback and human gates. See the [Site](https://www.approving-ai.com/) — This project was built with this workflow.
+Approving is an open-source, self-hostable platform for turning coding agents into visual, reviewable, and recoverable delivery workflows. Agents run in real Docker sandboxes, exchange structured artifacts, and pause for human **Approve** at critical nodes.
+
+[Website](https://www.approving-ai.com/) · [Quick start](https://www.approving-ai.com/en/guide/quick-start/) · [Contributing](CONTRIBUTING.md) · [Configuration](server/CONFIGURATION.md) · [Gateway](GATEWAY.md)
+
+**English | [简体中文](README.zh-CN.md)**
 
 [![CI Server](https://github.com/cocofhu/approving/actions/workflows/ci-server.yml/badge.svg)](https://github.com/cocofhu/approving/actions/workflows/ci-server.yml)
 [![CI Web](https://github.com/cocofhu/approving/actions/workflows/ci-web.yml/badge.svg)](https://github.com/cocofhu/approving/actions/workflows/ci-web.yml)
@@ -14,122 +18,183 @@ Approving turns coding agents into workflows you can trust: visual orchestration
 [![coverage-server](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcocofhu%2Fapproving%2Fcoverage-badges%2Fcoverage-server.json)](https://github.com/cocofhu/approving/actions/workflows/ci-server.yml)
 [![coverage-gateway](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcocofhu%2Fapproving%2Fcoverage-badges%2Fcoverage-gateway.json)](https://github.com/cocofhu/approving/actions/workflows/ci-gateway.yml)
 
-Security scans (CodeQL, web npm audit, gitleaks) run via the [security](https://github.com/cocofhu/approving/actions/workflows/security.yml) workflow on push/PR. View CodeQL under Security → Code scanning (or PR Checks); npm audit and gitleaks results are in the corresponding Actions job logs.
-
-[Site](https://www.approving-ai.com/) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Support](SUPPORT.md) · [Configuration](server/CONFIGURATION.md) · [Gateway](GATEWAY.md)
-
-**English | [简体中文](README.zh-CN.md)**
-
-## What is Approving?
-
-Approving helps agent workflows move forward with humans: visually orchestrate multi-agent collaboration, run in sandboxes, and pause for human Approve at critical nodes. Backends include Cursor, Claude Code, CodeBuddy, and Trae.
+> Approving is currently a public beta. It requires a Linux host with Docker Compose, and the first startup pulls a large sandbox runtime image.
 
 ## Why Approving?
 
-Named for Approve: in human–agent collaboration, critical nodes must be approved by a person before the workflow continues — trust is built into the path.
+A single coding agent is effective at completing one task. As work expands across research, design, implementation, testing, and review, new bottlenecks appear:
 
-## Features
+- collaboration is hidden inside conversations and is hard to reuse or audit;
+- once agents run in parallel, human understanding and review speed limit throughput;
+- agents lack stable, verifiable contracts for handing work to one another;
+- high-risk actions do not have explicit human decision points;
+- failures often require manual prompting instead of following designed recovery paths.
 
-Approving manages the full agent workflow: from graph design to sandboxed execution to artifact handoff.
+Approving adds a harness above coding agents: FSMs define the path, sandboxes isolate execution, MCP carries artifacts, and human approval becomes a first-class workflow node.
 
-- **Visual orchestration** — canvas FSM with when guards, checkpoints, and gates; rollback on failure
-- **Real Docker sandboxes** — agent and react nodes run in containers via ACP through the vendored `sandbox-gateway`. The web UI is API-driven.
-- **Multi-agent backends** — one platform for Cursor, Claude Code, CodeBuddy, and Trae. Pick `acpBackend` per agent; keys live on Agent meta env.
-- **Artifact contract + run-scoped MCP** — agents call `write_artifact` / `set_*` / `node_complete`. Each run is isolated by token.
-- **Git credentials in the sandbox** — configure `GITHUB_*`, `GITLAB_*`, or SSH on Agent meta env (values may reference `${vars.<name>}`). GitLab auto-MR via `glab` remains available; GitHub PRs use Agent-side `gh`.
-- **Single-repo self-host** — `sandbox-gateway` and sandbox image sources live in this repository. One clone is enough.
+```text
+Requirement
+    → Clarify Agent
+    → Research Agent
+    → Proposal Agent
+    → Human Gate
+    → Implement Agent
+    → Test Agent
+    → Review Agent
+    → PR / MR
+```
 
----
+## Core capabilities
 
-## Quick Start
+### Visual FSM orchestration
 
-Linux host with Docker Compose. The default path pulls published GHCR images (no local image build):
+Build workflows on a Vue Flow canvas with agent, react, and gate nodes. Edges describe success, failure, and rollback paths; `when` guards and checkpoints control transitions.
+
+### Human-in-the-loop gates
+
+Pause a run for proposal selection, visual acceptance, release confirmation, or another high-value decision. Reviewers can approve, reject, or request revision from structured artifacts instead of following every agent action.
+
+### Real Docker sandboxes
+
+Agent and react nodes execute in isolated containers through the vendored `sandbox-gateway`. The platform manages sandbox lifecycle, while the ACP bridge connects supported agent backends.
+
+### Multiple agent backends
+
+Use different backends in one workflow:
+
+- Cursor
+- Claude Code
+- CodeBuddy
+- Trae
+
+Each agent chooses its own `acpBackend`. Credentials live in Agent meta env and are not baked into platform images.
+
+### Run-scoped artifact contracts
+
+Every run receives an isolated artifact MCP and token. Agents use tools such as `write_artifact`, `read_artifact`, `set_*`, and `node_complete` to exchange structured results. Before advancing, the platform checks that required artifacts exist.
+
+### Git delivery
+
+Inject GitHub, GitLab, or SSH credentials per agent, including values referenced through `${vars.<name>}`. GitLab MRs can be created with `glab`; GitHub PRs are created by the agent with `gh` inside the sandbox.
+
+### Execution visibility
+
+Inspect run details, execution timelines, sandbox logs, artifacts, pending approvals, and token usage to understand status and resource consumption.
+
+## Typical workflow
+
+A software delivery workflow can separate responsibilities explicitly:
+
+```text
+Clarify → Research → Proposal → Human approval
+        → Plan → Implement → Test → Review
+        → Human confirmation → PR / MR
+```
+
+The repository includes Clarify, Research, Proposal, Plan, Implement, Test, and Review role packs. Run `agents/pack.sh` to package them for import through Agent Studio.
+
+## Quick start
+
+### Requirements
+
+- Linux host
+- Git
+- Docker and Docker Compose
+
+### Start
+
+The default path pulls published GHCR images and does not build them locally:
 
 ```bash
+git clone https://github.com/cocofhu/approving.git
+cd approving
 ./start.sh -d
 ```
 
-Then open:
+Open:
 
-- UI / API: http://localhost:8080
-- API health: http://localhost:8080/api/health
-- Gateway health: http://localhost:8899/healthz
-- Default login: `admin` / `demo1234` (local-demo)
+- UI / API: <http://localhost:8080>
+- API health: <http://localhost:8080/api/health>
+- Gateway health: <http://localhost:8899/healthz>
+- Local demo login: `admin` / `demo1234`
 
-`./start.sh` also pulls the **sandbox runtime** image from GHCR (several GB). Until that finishes, sandbox chat stays on “starting sandbox…”.
+> `./start.sh` also pulls the multi-gigabyte sandbox runtime image. Sandbox chat may remain on “starting sandbox…” until the pull completes.
 
 Useful commands:
 
 ```bash
-./start.sh logs
-./start.sh down
+./start.sh logs          # follow logs
+./start.sh down          # stop the stack
 ./start.sh pull          # refresh GHCR images
-./start.sh dev -d        # source stack: go run + Vite HMR
+./start.sh dev -d        # source stack: Go + Vite HMR
 ```
 
-Image tags and digests are overridable in `.env` — see [`.env.example`](.env.example). For release pinning and smoke tests, see [Contributing](CONTRIBUTING.md#release-images-and-smoke).
+Override image tags or digests in `.env`; see [`.env.example`](.env.example).
 
----
+## Build your first workflow
 
-## Getting Started
+1. Sign in with the local demo account. A fresh installation starts with an empty project and does not create a sample pipeline.
+2. Create an agent in **Agent Studio**, select `cursor`, `claude_code`, `codebuddy`, or `trae`, and configure the matching API key.
+3. Create a workflow and connect agent nodes, success/failure edges, rollback paths, and human gates.
+4. Publish and start a run. Observe sandbox execution, MCP artifacts, and nodes waiting for approval.
 
-### 1. Start the stack
-
-```bash
-./start.sh -d
-```
-
-Open http://localhost:8080 and sign in with `admin` / `demo1234`. Fresh installs start with an empty project — there is no sample pipeline.
-
-### 2. Configure an agent
-
-In **Agent Studio**, create or edit an agent. Set `acpBackend` (`cursor`, `claude_code`, `codebuddy`, or `trae`) and put the matching API key on Agent env. Details: [`server/README.md`](server/README.md).
-
-### 3. Create a workflow
-
-Use **New workflow** to create a pipeline, then build an FSM graph: agent / react nodes, success and failure edges, optional rollback paths, and human gates where someone must approve before the run continues.
-
-### 4. Run and observe
-
-Publish the pipeline if needed, then start a run. Watch sandbox execution, artifacts written via MCP, and any gate that waits for approval. Failed steps can follow failure or rollback edges instead of dying silently.
-
----
+See [`server/README.md`](server/README.md) for backend authentication and Agent env configuration.
 
 ## Architecture
 
+```text
+┌──────────────────┐     ┌──────────────────┐     ┌──────────────────┐
+│ Vue 3 + Vue Flow │────▶│ Go Backend       │────▶│ sandbox-gateway  │
+│ orchestration    │◀────│ FSM + API + MCP  │◀────│ control plane    │
+└──────────────────┘     └────────┬─────────┘     └────────┬─────────┘
+                                  │                        │
+                                  │                        ▼
+                                  │               ┌──────────────────┐
+                                  └──────────────▶│ Docker sandboxes │
+                                    artifacts     │ ACP backends     │
+                                                  └──────────────────┘
 ```
-┌──────────────┐     ┌──────────────────┐     ┌──────────────────┐
-│  Vue3 +      │────>│  Go Backend      │────>│ sandbox-gateway  │
-│  Vue Flow    │<────│  (FSM + MCP)     │<────│  (Docker)        │
-└──────────────┘     └────────┬─────────┘     └────────┬─────────┘
-                              │                        │
-                              │                        ▼
-                              │               ┌──────────────────┐
-                              └──────────────>│ universal sandbox│
-                                artifacts     │ (ACP backends)   │
-                                              └──────────────────┘
-```
 
-| Layer | Stack |
-|-------|-------|
-| Frontend | Vue 3 + Vue Flow |
-| Backend | Go (`approving-server`, env prefix `APPROVING_`) |
-| Execution | Vendored `sandbox-gateway` + universal sandbox images |
-| Agent backends | Cursor, Claude Code, CodeBuddy, Trae (ACP) |
+- `web/` — Vue 3 + Vue Flow canvas, run details, approvals, and Agent Studio.
+- `server/` — Go FSM engine, API, SQLite, artifact MCP, scheduling, and audit.
+- `sandbox-gateway/gateway/` — sandbox lifecycle control plane.
+- `sandbox-gateway/sandbox/` — universal sandbox image and ACP bridge.
+- `agents/` — importable role-agent workspaces.
+- `docs/` — project site and bilingual help content.
 
-## Development
+Configuration precedence is explicit environment variables > mounted config file > defaults. See [`server/CONFIGURATION.md`](server/CONFIGURATION.md) for all options and [`GATEWAY.md`](GATEWAY.md) for the gateway contract.
 
-For contributors working on the Approving codebase, see the [Contributing Guide](CONTRIBUTING.md). Critical-path Playwright e2e (CI `web-e2e`): see [CONTRIBUTING — Critical-path Playwright e2e](CONTRIBUTING.md#critical-path-playwright-e2e).
+## Development and quality
 
-**Prerequisites:** Go, Node.js, Docker Compose (Linux host for sandboxes)
+**Development requirements:** Go, Node.js, and Docker Compose; sandbox execution requires Linux.
 
 ```bash
 ./start.sh dev -d
 ```
 
-Source layout: `server/` (Go FSM + sandbox client + artifact MCP), `web/` (Vue UI), `sandbox-gateway/` (gateway + sandbox image sources).
+Module-specific lint, test, coverage, and E2E commands are documented in [`AGENTS.md`](AGENTS.md) and [`CONTRIBUTING.md`](CONTRIBUTING.md). The security workflow runs CodeQL, web `npm audit`, and gitleaks on pushes and pull requests.
 
-Configuration: [`server/CONFIGURATION.md`](server/CONFIGURATION.md) and `server/config.example.yaml`. Precedence: explicit env > mounted file > defaults. Git credentials for sandboxes stay on Agent meta env, not platform config.
+## Deployment and security notes
+
+- The default account is for local demos only. Configure your own authentication users before any shared or production deployment.
+- Keep ACP API keys and Git credentials in project or Agent env; never commit them.
+- Pin production images by digest; see [Release images and smoke](CONTRIBUTING.md#release-images-and-smoke).
+- Approving is still beta software. Perform your own security review, backups, and capacity validation before production use.
+
+## Documentation
+
+- [Core concepts](docs/content/en/guide/concepts.md)
+- [Quick start](docs/content/en/guide/quick-start.md)
+- [Full configuration](server/CONFIGURATION.md)
+- [Gateway contract](GATEWAY.md)
+- [Contributing guide](CONTRIBUTING.md)
+- [Security policy](SECURITY.md)
+- [Support](SUPPORT.md)
+- [Chinese technical article: From Vibe Coding to Harness](docs/approving-harness-workflow.md)
+
+## Contributing
+
+Issues and pull requests are welcome. Read [`CONTRIBUTING.md`](CONTRIBUTING.md), [`AGENTS.md`](AGENTS.md), and [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) before contributing.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,9 +4,7 @@
 
 Approving 是一个开源、可自托管的多 Agent 工作流平台。它把 coding agent 编排成可视化、可审查、可回滚的交付流程：Agent 在真实 Docker 沙箱中执行，关键节点由人 **Approve** 后再继续。
 
-![从 Vibe Coding 到 Harness：多 Agent 时代的人机协作新范式](docs/assets/approving-harness-article-cover.png)
-
-[项目站](https://www.approving-ai.com/) · [快速开始](https://www.approving-ai.com/guide/quick-start/) · [技术文章](docs/approving-harness-workflow.md) · [贡献指南](CONTRIBUTING.md) · [配置](server/CONFIGURATION.md)
+[项目站](https://www.approving-ai.com/) · [快速开始](https://www.approving-ai.com/guide/quick-start/) · [贡献指南](CONTRIBUTING.md) · [配置](server/CONFIGURATION.md)
 
 **[English](README.md) | 简体中文**
 
@@ -34,8 +32,6 @@ Approving 是一个开源、可自托管的多 Agent 工作流平台。它把 co
 
 Approving 在 Agent 之上提供一层 Harness：用 FSM 设计路径，用沙箱隔离执行，用 MCP 交接产物，并把人工审批变成工作流中的一等节点。
 
-![Approving 多 Agent 研发链路](docs/assets/approving-02-multi-agent-workflow.png)
-
 ## 核心能力
 
 ### 可视化 FSM 编排
@@ -45,8 +41,6 @@ Approving 在 Agent 之上提供一层 Harness：用 FSM 设计路径，用沙�
 ### Human-in-the-loop 门禁
 
 工作流可以在方案选择、视觉验收、发布确认等节点暂停。审批者查看结构化产物后，可批准、拒绝或退回修改，而不必持续跟踪 Agent 的每一步执行。
-
-![Agent 产出、契约校验、人工审批与继续执行](docs/assets/approving-04-human-approval-comic.png)
 
 ### 真实 Docker 沙箱
 
@@ -136,8 +130,6 @@ cd approving
 
 ## 系统架构
 
-![Approving 系统架构](docs/assets/approving-05-system-architecture.png)
-
 - `web/`：Vue 3 + Vue Flow，负责画布、运行详情、审批与 Agent Studio。
 - `server/`：Go 后端，负责 FSM 引擎、API、SQLite、artifact MCP、调度与审计。
 - `sandbox-gateway/gateway/`：沙箱生命周期控制面。
@@ -173,7 +165,6 @@ cd approving
 - [贡献指南](CONTRIBUTING.md)
 - [安全策略](SECURITY.md)
 - [支持渠道](SUPPORT.md)
-- [从 Vibe Coding 到 Harness](docs/approving-harness-workflow.md)
 
 ## 参与贡献
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,8 +1,14 @@
 # Approving
 
-**Agent 工作流与人类协同推进，开启多Agent协作新范式。**
+**Agent 工作流与人类协同推进，开启多 Agent 协作新范式。**
 
-Approving 把 coding agent 编成可信任的工作流：可视化编排、沙箱执行，关键节点由人 Approve 后再继续。开源、可自托管，支持可回滚与人工门禁。了解更多见 [Site](https://www.approving-ai.com/)，此项目由该工作流构建。
+Approving 是一个开源、可自托管的多 Agent 工作流平台。它把 coding agent 编排成可视化、可审查、可回滚的交付流程：Agent 在真实 Docker 沙箱中执行，关键节点由人 **Approve** 后再继续。
+
+![从 Vibe Coding 到 Harness：多 Agent 时代的人机协作新范式](docs/assets/approving-harness-article-cover.png)
+
+[项目站](https://www.approving-ai.com/) · [快速开始](https://www.approving-ai.com/guide/quick-start/) · [技术文章](docs/approving-harness-workflow.md) · [贡献指南](CONTRIBUTING.md) · [配置](server/CONFIGURATION.md)
+
+**[English](README.md) | 简体中文**
 
 [![CI Server](https://github.com/cocofhu/approving/actions/workflows/ci-server.yml/badge.svg)](https://github.com/cocofhu/approving/actions/workflows/ci-server.yml)
 [![CI Web](https://github.com/cocofhu/approving/actions/workflows/ci-web.yml/badge.svg)](https://github.com/cocofhu/approving/actions/workflows/ci-web.yml)
@@ -14,120 +20,164 @@ Approving 把 coding agent 编成可信任的工作流：可视化编排、沙�
 [![coverage-server](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcocofhu%2Fapproving%2Fcoverage-badges%2Fcoverage-server.json)](https://github.com/cocofhu/approving/actions/workflows/ci-server.yml)
 [![coverage-gateway](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcocofhu%2Fapproving%2Fcoverage-badges%2Fcoverage-gateway.json)](https://github.com/cocofhu/approving/actions/workflows/ci-gateway.yml)
 
-[项目站](https://www.approving-ai.com/) · [贡献指南](CONTRIBUTING.md) · [安全](SECURITY.md) · [支持](SUPPORT.md) · [配置](server/CONFIGURATION.md) · [网关](GATEWAY.md)
+> 当前版本为公开 Beta。需要 Linux 宿主和 Docker Compose；首次启动会拉取体积较大的沙箱运行时镜像。
 
-**[English](README.md) | 简体中文**
+## 为什么需要 Approving？
 
-## Approving 是什么？
+单 Agent 的 Vibe Coding 擅长完成一次任务，但当需求扩展到调研、方案、实现、测试和评审时，新的瓶颈会出现：
 
-Approving 让 Agent 工作流与人类协同推进：在可视化画布上编排多 Agent 协作，于沙箱中执行，并在关键节点等待人工 Approve。支持 Cursor、Claude Code、CodeBuddy、Trae 等后端。
+- 协作过程藏在对话中，难以复用和审计；
+- 多个 Agent 并行后，人的理解与审核速度限制整体吞吐；
+- Agent 之间缺少稳定、可验证的产物交接；
+- 高风险操作缺少明确的人类决策点；
+- 失败通常依赖人工重试，缺少显式的恢复与回滚路径。
 
-## 为什么叫 Approving？
+Approving 在 Agent 之上提供一层 Harness：用 FSM 设计路径，用沙箱隔离执行，用 MCP 交接产物，并把人工审批变成工作流中的一等节点。
 
-Approving 取自 Approve（批准）：人机协同下，关键节点须经人工批准后再继续，把「可信任」写进工作流本身。
+![Approving 多 Agent 研发链路](docs/assets/approving-02-multi-agent-workflow.png)
 
-## 特性
+## 核心能力
 
-Approving 覆盖完整 Agent 工作流：从图设计到沙箱执行，再到产物交接。
+### 可视化 FSM 编排
 
-- **可视化编排** — 画布 FSM，含 when 守卫、checkpoints、gates，支持失败回滚
-- **真实 Docker 沙箱** — agent / react 节点经 ACP、通过内嵌 `sandbox-gateway` 在容器中运行；Web UI 走 API。
-- **多 Agent 后端** — 同一平台支持 Cursor、Claude Code、CodeBuddy、Trae。按 Agent 选择 `acpBackend`；密钥放在 Agent 元信息 env。
-- **产物契约 + 按 run 隔离的 MCP** — Agent 调用 `write_artifact` / `set_*` / `node_complete`；每个 run 用 token 隔离。
-- **沙箱内 Git 凭据** — 在 Agent 元信息 env 配置 `GITHUB_*`、`GITLAB_*` 或 SSH（值可引用 `${vars.<name>}`）。GitLab 仍可用平台 `glab` 自动开 MR；GitHub PR 由 Agent 侧 `gh` 处理。
-- **单仓自托管** — `sandbox-gateway` 与沙箱镜像源码在本仓库内，一次 clone 即可跑通。
+通过 Vue Flow 画布编排 agent、react 和 gate 节点。边可以表达成功、失败与回滚路径，并可结合 `when` 守卫和 checkpoint 控制流程。
 
----
+### Human-in-the-loop 门禁
+
+工作流可以在方案选择、视觉验收、发布确认等节点暂停。审批者查看结构化产物后，可批准、拒绝或退回修改，而不必持续跟踪 Agent 的每一步执行。
+
+![Agent 产出、契约校验、人工审批与继续执行](docs/assets/approving-04-human-approval-comic.png)
+
+### 真实 Docker 沙箱
+
+agent / react 节点通过仓库内置的 `sandbox-gateway` 在独立容器中运行。平台统一管理沙箱生命周期，ACP bridge 负责连接不同 Agent 后端。
+
+### 多 Agent 后端
+
+同一套工作流可使用：
+
+- Cursor
+- Claude Code
+- CodeBuddy
+- Trae
+
+每个 Agent 独立选择 `acpBackend`，密钥放在 Agent 元信息 env 中，不写入平台镜像。
+
+### Run 级产物契约
+
+每次 run 拥有隔离的 artifact MCP 和 token。Agent 使用 `write_artifact`、`read_artifact`、`set_*`、`node_complete` 等工具完成结构化交接；平台在节点结束前检查必要产物是否存在。
+
+### Git 与交付
+
+GitHub、GitLab 或 SSH 凭据可按 Agent 注入沙箱，值支持 `${vars.<name>}` 引用。GitLab 可通过 `glab` 创建 MR；GitHub PR 由 Agent 在沙箱内使用 `gh` 创建。
+
+### 运行观测
+
+通过运行详情、执行时间线、沙箱日志、产物、待审批收件箱和 Token 统计查看任务状态与资源消耗。
+
+## 典型工作流
+
+一个完整的软件交付流程可以拆分为：
+
+```text
+需求澄清 → 技术调研 → 方案设计 → 人工审批
+        → 执行计划 → 代码实现 → 测试验证 → 代码评审
+        → 人工确认 → PR / MR
+```
+
+仓库内提供 Clarify、Research、Proposal、Plan、Implement、Test、Review 等角色 Agent 包，可通过 `agents/pack.sh` 打包后导入 Agent Studio。
 
 ## 快速开始
 
-需要 Linux 宿主与 Docker Compose。默认拉取已发布的 GHCR 镜像（无需本地构建）：
+### 前置条件
+
+- Linux 主机
+- Git
+- Docker 与 Docker Compose
+
+### 启动
+
+默认路径直接拉取已发布的 GHCR 镜像，无需本地构建：
 
 ```bash
+git clone https://github.com/cocofhu/approving.git
+cd approving
 ./start.sh -d
 ```
 
-然后打开：
+启动后访问：
 
-- UI / API：http://localhost:8080
-- API 健康检查：http://localhost:8080/api/health
-- 网关健康检查：http://localhost:8899/healthz
-- 默认登录：`admin` / `demo1234`（local-demo）
+- UI / API：<http://localhost:8080>
+- API 健康检查：<http://localhost:8080/api/health>
+- Gateway 健康检查：<http://localhost:8899/healthz>
+- 本地演示账号：`admin` / `demo1234`
 
-`./start.sh` 还会从 GHCR 拉取 **沙箱运行时镜像**（数 GB）。未拉完前，沙箱对话会停在「正在启动沙箱…」。
+> `./start.sh` 还会拉取数 GB 的沙箱运行时镜像。完成前，沙箱对话可能停留在“正在启动沙箱…”。
 
 常用命令：
 
 ```bash
-./start.sh logs
-./start.sh down
+./start.sh logs          # 查看日志
+./start.sh down          # 停止服务
 ./start.sh pull          # 刷新 GHCR 镜像
-./start.sh dev -d        # 源码栈：go run + Vite HMR
+./start.sh dev -d        # 源码开发栈：Go + Vite HMR
 ```
 
-镜像 tag / digest 可在 `.env` 覆盖 — 见 [`.env.example`](.env.example)。发布钉死与冒烟测试见 [贡献指南](CONTRIBUTING.md#release-images-and-smoke)。
+镜像 tag / digest 可在 `.env` 中覆盖，参见 [`.env.example`](.env.example)。
 
----
+## 四步创建第一个工作流
 
-## 上手
+1. 使用本地演示账号登录。全新安装默认是空项目，不会自动创建样例流水线。
+2. 在 **Agent Studio** 创建 Agent，选择 `cursor`、`claude_code`、`codebuddy` 或 `trae`，并配置对应 API Key。
+3. 新建工作流，在画布中连接 Agent 节点、成功/失败边、回滚路径与人工 gate。
+4. 发布并启动 run，观察沙箱执行、MCP 产物和待审批节点。
 
-### 1. 启动栈
+后端鉴权和 Agent env 配置详见 [`server/README.md`](server/README.md)。
 
-```bash
-./start.sh -d
-```
+## 系统架构
 
-打开 http://localhost:8080，使用 `admin` / `demo1234` 登录。全新安装默认是空项目，没有样例流水线。
+![Approving 系统架构](docs/assets/approving-05-system-architecture.png)
 
-### 2. 配置 Agent
+- `web/`：Vue 3 + Vue Flow，负责画布、运行详情、审批与 Agent Studio。
+- `server/`：Go 后端，负责 FSM 引擎、API、SQLite、artifact MCP、调度与审计。
+- `sandbox-gateway/gateway/`：沙箱生命周期控制面。
+- `sandbox-gateway/sandbox/`：通用沙箱镜像与 ACP bridge。
+- `agents/`：可导入的角色 Agent 工作区。
+- `docs/`：项目站和中英文帮助文档。
 
-在 **Agent Studio** 创建或编辑 Agent。设置 `acpBackend`（`cursor` / `claude_code` / `codebuddy` / `trae`），并把对应 API Key 写在 Agent env。详见 [`server/README.md`](server/README.md)。
+配置优先级为：显式环境变量 > 挂载配置文件 > 代码默认值。完整配置见 [`server/CONFIGURATION.md`](server/CONFIGURATION.md)，网关契约见 [`GATEWAY.md`](GATEWAY.md)。
 
-### 3. 新建流水线
+## 开发与质量
 
-通过「新建工作流」创建流水线，再搭建 FSM 图：agent / react 节点、成功与失败边、可选回滚路径，以及需要人工批准才能继续的门禁。
-
-### 4. 运行并观察
-
-如需发布流水线则先发布，再启动一次 run。观察沙箱执行、经 MCP 写入的产物，以及等待批准的门禁。失败步骤可走失败或回滚边，而不是静默中断。
-
----
-
-## 架构
-
-```
-┌──────────────┐     ┌──────────────────┐     ┌──────────────────┐
-│  Vue3 +      │────>│  Go Backend      │────>│ sandbox-gateway  │
-│  Vue Flow    │<────│  (FSM + MCP)     │<────│  (Docker)        │
-└──────────────┘     └────────┬─────────┘     └────────┬─────────┘
-                              │                        │
-                              │                        ▼
-                              │               ┌──────────────────┐
-                              └──────────────>│ universal sandbox│
-                                产物 MCP      │ (ACP backends)   │
-                                              └──────────────────┘
-```
-
-| 层 | 技术栈 |
-|----|--------|
-| 前端 | Vue 3 + Vue Flow |
-| 后端 | Go（`approving-server`，环境变量前缀 `APPROVING_`） |
-| 执行 | 内嵌 `sandbox-gateway` + universal 沙箱镜像 |
-| Agent 后端 | Cursor、Claude Code、CodeBuddy、Trae（ACP） |
-
-## 开发
-
-参与 Approving 代码贡献，请看 [贡献指南](CONTRIBUTING.md)。关键路径 Playwright e2e（CI `web-e2e`）见 [贡献指南 — Critical-path Playwright e2e](CONTRIBUTING.md#critical-path-playwright-e2e)。
-
-**前置要求：** Go、Node.js、Docker Compose（沙箱需 Linux 宿主）
+**开发前置：** Go、Node.js、Docker Compose；运行沙箱需要 Linux 宿主。
 
 ```bash
 ./start.sh dev -d
 ```
 
-源码布局：`server/`（Go FSM + 沙箱客户端 + 产物 MCP）、`web/`（Vue UI）、`sandbox-gateway/`（网关 + 沙箱镜像源码）。
+各模块的 lint、测试、覆盖率和 E2E 命令见 [`AGENTS.md`](AGENTS.md) 与 [`CONTRIBUTING.md`](CONTRIBUTING.md)。安全工作流在 push / PR 时运行 CodeQL、Web `npm audit` 和 gitleaks。
 
-配置见 [`server/CONFIGURATION.md`](server/CONFIGURATION.md) 与 `server/config.example.yaml`。优先级：显式环境变量 > 挂载配置文件 > 代码默认值。沙箱 Git 凭据放在 Agent 元信息 env，不进平台配置。
+## 部署与安全提示
+
+- 默认账号仅用于本地演示；共享或生产环境必须配置自己的鉴权用户。
+- ACP API Key 与 Git 凭据应配置在项目或 Agent env，不应提交到仓库。
+- 发布环境建议使用 digest 固定镜像，参考 [Release images and smoke](CONTRIBUTING.md#release-images-and-smoke)。
+- 项目仍处于 Beta 阶段，请在实际环境中完成安全评估、备份和容量验证。
+
+## 文档
+
+- [核心概念](docs/content/guide/concepts.md)
+- [快速开始](docs/content/guide/quick-start.md)
+- [完整配置](server/CONFIGURATION.md)
+- [Gateway 契约](GATEWAY.md)
+- [贡献指南](CONTRIBUTING.md)
+- [安全策略](SECURITY.md)
+- [支持渠道](SUPPORT.md)
+- [从 Vibe Coding 到 Harness](docs/approving-harness-workflow.md)
+
+## 参与贡献
+
+欢迎提交 Issue 和 Pull Request。请先阅读 [`CONTRIBUTING.md`](CONTRIBUTING.md)、[`AGENTS.md`](AGENTS.md) 与 [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)。
 
 ## 许可证
 


### PR DESCRIPTION
## Summary
- Refresh `README.md` / `README.zh-CN.md` with the updated harness-focused product narrative (problem framing, core capabilities, architecture, quick start).
- Keep CI/coverage badges and EN↔ZH language switcher; Chinese file stays at `README.zh-CN.md` (workspace `README-CN.md` mapped accordingly).
- Remove references to assets/article paths that are not in the repository yet.

## Test plan
- [ ] Preview EN README on GitHub
- [ ] Preview ZH README on GitHub
- [ ] Confirm language switcher links both ways
- [ ] Confirm no broken `docs/assets/*` or `docs/approving-harness-workflow.md` links