### PR TITLE
fix: 中文通知策略关闭选项显示为「关闭」

### DIFF
--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -154,7 +154,7 @@
         "evCompleted": "P1 · 不投递（预留）",
         "saved": "通知设置已保存",
         "colPolicy": "通知策略",
-        "modeOff": "off",
+        "modeOff": "关闭",
         "modeInherit": "继承",
         "modeCustom": "自定义",
         "wfUpdated": "已更新"


### PR DESCRIPTION
项目详情「通知策略」三段式 modeOff 在 zh-CN 语言包中漏译为英文 off，改为「关闭」；协议枚举与点击取值仍为 off。

Co-authored-by: Cursor <cursoragent@cursor.com>
