### PR TITLE
fix(web,server): eliminate 12PM34 in token consumption rank

### DIFF
--- a/server/internal/services/project_token_stats.go
+++ b/server/internal/services/project_token_stats.go
@@ -443,17 +443,8 @@ func buildConsumptionRank(totals map[string]int64, names map[string]string, pmTo
 			Kind:  TokenStatsKindOther,
 		})
 	}
-	// Sort all rank rows by total desc so PM sits at its natural position.
-	sort.SliceStable(out, func(i, j int) bool {
-		if out[i].Total != out[j].Total {
-			return out[i].Total > out[j].Total
-		}
-		// Keep "other" at the end on ties.
-		if out[i].Other != out[j].Other {
-			return !out[i].Other
-		}
-		return out[i].Name < out[j].Name
-	})
+	// Fixed slot order: Top workflows (already desc) → PM (if any) → other (if any).
+	// Do not re-sort by Total — that would insert PM between workflow rows (12PM34).
 	return out
 }
 

--- a/server/internal/services/project_token_stats_test.go
+++ b/server/internal/services/project_token_stats_test.go
@@ -391,6 +391,124 @@ func TestTokenStatsAggregation(t *testing.T) {
 	})
 }
 
+// TestBuildConsumptionRankOrder locks the fixed slot order: Top workflows → PM → other.
+// Even when PM.total exceeds some workflow totals, PM must not insert mid-workflow (no 12PM34).
+func TestBuildConsumptionRankOrder(t *testing.T) {
+	assertOrder := func(t *testing.T, rows []TokenStatsWorkflow) {
+		t.Helper()
+		var sawPM, sawOther bool
+		for i, w := range rows {
+			switch w.Kind {
+			case TokenStatsKindWorkflow:
+				if sawPM || sawOther {
+					t.Fatalf("workflow after pm/other at [%d]: %+v", i, rows)
+				}
+			case TokenStatsKindPM:
+				if sawOther {
+					t.Fatalf("pm after other at [%d]: %+v", i, rows)
+				}
+				if sawPM {
+					t.Fatalf("duplicate pm at [%d]: %+v", i, rows)
+				}
+				sawPM = true
+			case TokenStatsKindOther:
+				if !w.Other {
+					t.Fatalf("other kind without Other flag: %+v", w)
+				}
+				if sawOther {
+					t.Fatalf("duplicate other at [%d]: %+v", i, rows)
+				}
+				sawOther = true
+				if i != len(rows)-1 {
+					t.Fatalf("other must be last: %+v", rows)
+				}
+			default:
+				t.Fatalf("unexpected kind %q at [%d]", w.Kind, i)
+			}
+		}
+	}
+
+	t.Run("pm_between_top_and_other_even_when_pm_total_high", func(t *testing.T) {
+		totals := map[string]int64{
+			"wf-a": 1000,
+			"wf-b": 100,
+			"wf-c": 50,
+		}
+		names := map[string]string{
+			"wf-a": "approve-main",
+			"wf-b": "doc-review",
+			"wf-c": "调研",
+		}
+		// PM total (800) sits between wf-a and wf-b; old full-sort would yield 12PM34.
+		rows := buildConsumptionRank(totals, names, 800, true)
+		assertOrder(t, rows)
+		if len(rows) != 4 {
+			t.Fatalf("len=%d want 4 (3 wf + pm)", len(rows))
+		}
+		if rows[0].Kind != TokenStatsKindWorkflow || rows[0].Total != 1000 {
+			t.Fatalf("top1=%+v", rows[0])
+		}
+		if rows[1].Kind != TokenStatsKindWorkflow || rows[1].Total != 100 {
+			t.Fatalf("top2=%+v", rows[1])
+		}
+		if rows[2].Kind != TokenStatsKindWorkflow || rows[2].Total != 50 {
+			t.Fatalf("top3=%+v", rows[2])
+		}
+		if rows[3].Kind != TokenStatsKindPM || rows[3].Total != 800 {
+			t.Fatalf("pm=%+v want last before other", rows[3])
+		}
+	})
+
+	t.Run("with_other_pm_before_other", func(t *testing.T) {
+		totals := map[string]int64{}
+		names := map[string]string{}
+		for i := 1; i <= 12; i++ {
+			id := "w" + itoa(i)
+			totals[id] = int64(i * 100)
+			names[id] = id
+		}
+		rows := buildConsumptionRank(totals, names, 9999, true)
+		assertOrder(t, rows)
+		if len(rows) != 12 { // Top10 + PM + other
+			t.Fatalf("len=%d want 12", len(rows))
+		}
+		if rows[10].Kind != TokenStatsKindPM || rows[10].Total != 9999 {
+			t.Fatalf("pm slot=%+v", rows[10])
+		}
+		if rows[11].Kind != TokenStatsKindOther || !rows[11].Other {
+			t.Fatalf("other slot=%+v", rows[11])
+		}
+		// Top block still desc by total.
+		for i := 1; i < 10; i++ {
+			if rows[i].Total > rows[i-1].Total {
+				t.Fatalf("top not desc at %d: %+v", i, rows[:10])
+			}
+		}
+	})
+
+	t.Run("no_pm_no_pm_row", func(t *testing.T) {
+		totals := map[string]int64{"a": 10, "b": 5}
+		names := map[string]string{"a": "A", "b": "B"}
+		rows := buildConsumptionRank(totals, names, 0, false)
+		assertOrder(t, rows)
+		for _, w := range rows {
+			if w.Kind == TokenStatsKindPM {
+				t.Fatalf("unexpected pm: %+v", rows)
+			}
+		}
+	})
+
+	t.Run("pm_without_other", func(t *testing.T) {
+		totals := map[string]int64{"a": 10}
+		names := map[string]string{"a": "A"}
+		rows := buildConsumptionRank(totals, names, 3, true)
+		assertOrder(t, rows)
+		if len(rows) != 2 || rows[1].Kind != TokenStatsKindPM {
+			t.Fatalf("want Top→PM: %+v", rows)
+		}
+	})
+}
+
 func itoa(n int) string {
 	if n == 0 {
 		return "0"

--- a/web/e2e/board-token-stats.spec.ts
+++ b/web/e2e/board-token-stats.spec.ts
@@ -57,9 +57,10 @@ const STATS_30D = {
     total: 2000,
   },
   workflows: [
+    // Fixed order: Top workflows (desc) → PM → other (no mid-insert PM / 12PM34)
     { workflowId: 'wf-a', name: 'approve-main', total: 1200, kind: 'workflow' },
-    { name: 'PM', total: 500, kind: 'pm' },
     { workflowId: 'wf-b', name: 'doc-review', total: 300, kind: 'workflow' },
+    { name: 'PM', total: 500, kind: 'pm' },
     { name: '其他', total: 200, other: true, kind: 'other' },
   ],
 }
@@ -226,6 +227,20 @@ test.describe('看板 Token 统计图', () => {
     await expect(panel).toContainText('消耗排行')
     await expect(panel).toContainText('按来源堆叠')
     await expect(page.getByTestId('token-rank-list').locator('[data-kind="pm"]')).toBeVisible()
+
+    // Continuous numeric badges: Top→PM→其他 → 1,2,3,· (no 12PM34 / no "PM" text badge)
+    const rankList = page.getByTestId('token-rank-list')
+    const kinds = await rankList.locator('li').evaluateAll((lis) =>
+      lis.map((li) => li.getAttribute('data-kind')),
+    )
+    expect(kinds).toEqual(['workflow', 'workflow', 'pm', 'other'])
+    const badges = await rankList.locator('li').evaluateAll((lis) =>
+      lis.map((li) => {
+        const badge = li.querySelector('span')
+        return (badge?.textContent || '').trim()
+      }),
+    )
+    expect(badges).toEqual(['1', '2', '3', '·'])
 
     // Panel sits above Run columns
     const panelBox = await panel.boundingBox()

--- a/web/src/components/board/token-stats/TokenCharts.test.ts
+++ b/web/src/components/board/token-stats/TokenCharts.test.ts
@@ -182,13 +182,14 @@ describe('Token charts (g2.3/g2.4)', () => {
     wrapper.unmount()
   })
 
-  it('renders consumption rank with PM same-purple row (not amber) and other as non-PM (g3.1/g1)', () => {
+  it('renders consumption rank with continuous numeric badges for workflow+PM (no 12PM34)', () => {
     const wrapper = mount(TokenWorkflowRank, {
       props: {
+        // Fixed API order: Top workflows → PM → other
         workflows: [
           { workflowId: 'a', name: 'approve-main', total: 1_020_000, kind: 'workflow' },
-          { name: 'PM', total: 80_000, kind: 'pm' },
           { workflowId: 'b', name: 'doc-review', total: 40_000, kind: 'workflow' },
+          { name: 'PM', total: 80_000, kind: 'pm' },
           { name: 'other', total: 20_000, other: true, kind: 'other' },
         ],
       },
@@ -202,13 +203,21 @@ describe('Token charts (g2.3/g2.4)', () => {
     expect(wrapper.text()).toContain('PM')
     expect(wrapper.text()).toContain('其他')
 
-    // PM badge text is "PM" (not a numeric rank); workflow ranks remain 1, 2
+    // Continuous numeric badges for workflow+PM; other stays "·" (Demo: 1→2→3→·)
     const pmRow = wrapper.find('[data-kind="pm"]')
-    expect(pmRow.text()).toMatch(/^PM/)
     const badges = wrapper.findAll('li').map((li) => li.find('span').text())
-    expect(badges).toEqual(['1', 'PM', '2', '·'])
+    expect(badges).toEqual(['1', '2', '3', '·'])
+    expect(pmRow.find('span').text()).toBe('3')
+    // PM badge style matches workflow numeric badge (accent for rank ≤3); no special w-auto/min-w
+    const pmBadge = pmRow.find('span')
+    expect(pmBadge.classes()).toEqual(
+      expect.arrayContaining(['w-[22px]', 'bg-accent-dim', 'text-accent-2']),
+    )
+    expect(pmBadge.classes()).not.toEqual(expect.arrayContaining(['w-auto', 'min-w-[22px]', 'px-1.5']))
+    const wfBadge = items[0]!.find('span')
+    expect(wfBadge.classes()).toEqual(pmBadge.classes())
 
-    // Same purple as workflow — no amber (#f59e0b / #d97706 / #fbbf24)
+    // Same purple bar as workflow — no amber (#f59e0b / #d97706 / #fbbf24)
     const pmHtml = pmRow.html()
     expect(pmHtml).toContain('#6d5cff')
     expect(pmHtml).toContain('#9b8cff')
@@ -216,9 +225,61 @@ describe('Token charts (g2.3/g2.4)', () => {
 
     // Compact K/M main values remain visible on the right
     const values = wrapper.findAll('[data-testid="token-rank-value"]').map((v) => v.text())
-    expect(values).toEqual(['1.02M', '80K', '40K', '20K'])
+    expect(values).toEqual(['1.02M', '40K', '80K', '20K'])
     expect(wrapper.find('[data-testid="token-rank-value"]').attributes('title')).toBeTruthy()
     wrapper.unmount()
+  })
+
+  it('Demo sample: 4 workflows + PM + other → badges 1→2→3→4→5→· (g3.3)', () => {
+    const wrapper = mount(TokenWorkflowRank, {
+      props: {
+        workflows: [
+          { workflowId: '1', name: '自我迭代', total: 1200, kind: 'workflow' },
+          { workflowId: '2', name: '自我迭代·轻量', total: 240, kind: 'workflow' },
+          { workflowId: '3', name: '调研', total: 140, kind: 'workflow' },
+          { workflowId: '4', name: '产品宣传文章', total: 70, kind: 'workflow' },
+          { name: 'PM', total: 180, kind: 'pm' },
+          { name: 'other', total: 55, other: true, kind: 'other' },
+        ],
+      },
+      global: { plugins: [i18n()] },
+    })
+    const badges = wrapper.findAll('li').map((li) => li.find('span').text())
+    expect(badges).toEqual(['1', '2', '3', '4', '5', '·'])
+    expect(wrapper.find('[data-kind="pm"]').find('span').text()).toBe('5')
+    // rank 5 uses dim elevated style same as a workflow at #5 would
+    expect(wrapper.find('[data-kind="pm"]').find('span').classes()).toEqual(
+      expect.arrayContaining(['w-[22px]', 'bg-elevated', 'text-txt3']),
+    )
+    wrapper.unmount()
+  })
+
+  it('hides PM row when absent; no-other still continuous (g3.3)', () => {
+    const noPm = mount(TokenWorkflowRank, {
+      props: {
+        workflows: [
+          { workflowId: 'a', name: 'approve-main', total: 100, kind: 'workflow' },
+          { name: 'other', total: 20, other: true, kind: 'other' },
+        ],
+      },
+      global: { plugins: [i18n()] },
+    })
+    expect(noPm.find('[data-kind="pm"]').exists()).toBe(false)
+    expect(noPm.findAll('li').map((li) => li.find('span').text())).toEqual(['1', '·'])
+    noPm.unmount()
+
+    const noOther = mount(TokenWorkflowRank, {
+      props: {
+        workflows: [
+          { workflowId: 'a', name: 'approve-main', total: 100, kind: 'workflow' },
+          { name: 'PM', total: 50, kind: 'pm' },
+        ],
+      },
+      global: { plugins: [i18n()] },
+    })
+    expect(noOther.find('[data-kind="other"]').exists()).toBe(false)
+    expect(noOther.findAll('li').map((li) => li.find('span').text())).toEqual(['1', '2'])
+    noOther.unmount()
   })
 
   it('trend PM dataset shares workflow purple and uses borderDash (g2.2/g3.1)', () => {

--- a/web/src/components/board/token-stats/TokenWorkflowRank.vue
+++ b/web/src/components/board/token-stats/TokenWorkflowRank.vue
@@ -32,20 +32,19 @@ function barWidth(total: number): string {
 }
 
 function badgeLabel(w: TokenStatsWorkflow, i: number): string {
-  if (isPM(w)) return 'PM'
   if (isOther(w)) return '·'
+  // Workflow + PM share one continuous numeric sequence (no "PM" text badge / no 12PM34).
   let n = 0
   for (let j = 0; j <= i; j++) {
     const row = props.workflows[j]
-    if (row && !isPM(row) && !isOther(row)) n += 1
+    if (row && !isOther(row)) n += 1
   }
   return String(n)
 }
 
 function badgeClass(w: TokenStatsWorkflow, i: number): string {
-  // PM uses the same purple badge palette as workflow (no amber); identity via "PM" label.
-  if (isPM(w)) return 'w-auto min-w-[22px] px-1.5 bg-[rgba(109,92,255,0.18)] text-[#6d5cff]'
   if (isOther(w)) return 'w-[22px] bg-elevated text-txt3'
+  // PM uses the same numeric badge classes as workflow rows (Demo-aligned).
   const n = Number(badgeLabel(w, i))
   return n <= 3
     ? 'w-[22px] bg-accent-dim text-accent-2'


### PR DESCRIPTION
Keep fixed Top→PM→other API order and continuous numeric badges so PM no longer interrupts workflow ranks.

Co-authored-by: Cursor <cursoragent@cursor.com>
