### PR TITLE
fix(web): 审批/澄清硬刷新续流与四阶段流式 UX

### DIFF
--- a/server/internal/handlers/inbox_context.go
+++ b/server/internal/handlers/inbox_context.go
@@ -67,12 +67,36 @@ func (h *Handlers) inboxContextGate(c *gin.Context, runID, gateNodeID string, it
 		}
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	out := gin.H{
 		"type":           "gate",
 		"nodes":          graphNodesDTO(run.Graph),
 		"artifacts":      artsDTO,
 		"nodeExecutions": slimExecs,
-	})
+	}
+	// Gate DTO subset + reactSessions for Inbox hard-refresh seed-then-live
+	// (parity with runDetailDTO / clarify inbox-context).
+	if g, ok := h.Runs.PendingGate(runID); ok && g.NodeID == gateNodeID {
+		gateDTO := gin.H{
+			"runId": g.RunID, "nodeId": g.NodeID, "iteration": g.Iteration,
+			"workflowId": g.WorkflowID, "workflowName": g.WorkflowName,
+			"title": g.Title, "bodyMd": g.BodyMd, "actions": g.Actions, "form": g.Form,
+			"upstreamNodeId": g.UpstreamNodeID, "upstreamIteration": g.UpstreamIteration,
+			"requestedAt": g.RequestedAt,
+		}
+		if h.Eng != nil {
+			if pid, alive := h.Eng.GateReactInfo(runID, g.NodeID); pid != "" {
+				gateDTO["reactUpstreamNodeId"] = pid
+				gateDTO["reactSessionAlive"] = alive
+			}
+		}
+		out["gate"] = gateDTO
+	}
+	if h.Eng != nil {
+		if byNode := reactSessionsDTO(h.Eng.ReviewSessionsForRun(runID)); byNode != nil {
+			out["reactSessions"] = byNode
+		}
+	}
+	c.JSON(http.StatusOK, out)
 }
 
 func (h *Handlers) inboxContextClarify(c *gin.Context, runID, nodeID string, iteration int) {

--- a/server/internal/handlers/inbox_context_test.go
+++ b/server/internal/handlers/inbox_context_test.go
@@ -46,6 +46,13 @@ func TestRunInboxContextGate(t *testing.T) {
 	if strings.Contains(body, "should-not-appear") {
 		t.Error("nodeExecutions must be slim (no events)")
 	}
+	// Idle (no in-memory hot session): reactSessions omitted; gate DTO present.
+	if !strings.Contains(body, `"gate"`) {
+		t.Error("gate inbox-context should include gate DTO subset")
+	}
+	if strings.Contains(body, `"reactSessions"`) {
+		t.Error("idle gate inbox-context should omit empty reactSessions")
+	}
 }
 
 func TestRunInboxContextClarify(t *testing.T) {

--- a/web/e2e/clarify-session-ux-main.ts
+++ b/web/e2e/clarify-session-ux-main.ts
@@ -128,6 +128,55 @@ const App = defineComponent({
       c.applyAcpEvents?.([{ kind: 'message', text: '刷新后续上的流式正文。' }])
     }
 
+    /**
+     * Hard-load ACP race (g4.2): slot rebuild first, then delayed seed of prior
+     * thought/message — mirrors Inbox pending buffer flush after remount.
+     */
+    async function simHardRefreshAcpRace() {
+      const c = chatRef.value
+      if (!c?.applyReviewFrame) return
+      c.applyReviewFrame({
+        event: 'queue_state',
+        nodeId: 'clarify',
+        waiting: 0,
+        items: [],
+        busy: true,
+        activeItem: { text: '硬刷新竞态提问' },
+      })
+      await nextTick()
+      // Delayed seed (buffered ACP / nodeEvents), not same-tick apply.
+      await new Promise((r) => setTimeout(r, 30))
+      c.applyAcpEvents?.([
+        { kind: 'thought', text: '竞态恢复的思考…' },
+        { kind: 'message', text: '竞态恢复的正文续流。' },
+      ])
+      await nextTick()
+      c.applyAcpEvents?.([
+        { kind: 'thought', text: '竞态恢复的思考…' },
+        { kind: 'message', text: '竞态恢复的正文续流。继续追加。' },
+      ])
+    }
+
+    /** Full four-phase path ending in restrained completion footnote. */
+    async function simFourPhaseComplete() {
+      const c = chatRef.value
+      if (!c?.applyReviewFrame) return
+      c.applyReviewFrame({
+        event: 'turn_begin',
+        item: { text: '四阶段提问' },
+        nodeId: 'clarify',
+      })
+      await nextTick()
+      c.applyAcpEvents?.([{ kind: 'thought', text: '四阶段思考内容' }])
+      await nextTick()
+      c.applyAcpEvents?.([
+        { kind: 'thought', text: '四阶段思考内容' },
+        { kind: 'message', text: '四阶段正文输出。' },
+      ])
+      await nextTick()
+      c.applyReviewFrame({ event: 'turn_done', nodeId: 'clarify' })
+    }
+
     return () =>
       h('div', { class: 'min-h-screen p-4 max-w-3xl mx-auto', 'data-testid': 'clarify-ux-root' }, [
         h('div', { class: 'flex gap-2 mb-3 flex-wrap' }, [
@@ -170,6 +219,26 @@ const App = defineComponent({
               onClick: () => void simRefreshResume(),
             },
             '模拟刷新续传',
+          ),
+          h(
+            'button',
+            {
+              type: 'button',
+              'data-testid': 'sim-hard-refresh-acp-race',
+              class: 'px-3 py-1.5 rounded border text-sm',
+              onClick: () => void simHardRefreshAcpRace(),
+            },
+            '模拟硬刷新ACP竞态',
+          ),
+          h(
+            'button',
+            {
+              type: 'button',
+              'data-testid': 'sim-four-phase-complete',
+              class: 'px-3 py-1.5 rounded border text-sm',
+              onClick: () => void simFourPhaseComplete(),
+            },
+            '模拟四阶段完成',
           ),
           h(
             'span',

--- a/web/e2e/clarify-session-ux.spec.ts
+++ b/web/e2e/clarify-session-ux.spec.ts
@@ -86,4 +86,34 @@ test.describe('ClarifyChat 非 reviewMode 澄清会话', () => {
     await expect(page.getByTestId('host-skip-refresh')).toContainText(/hostSkip=[1-9]/)
     await page.screenshot({ path: path.join(shotDir, '05-clarify-no-dup-human.png'), fullPage: true })
   })
+
+  test('硬刷新 ACP 竞态：延迟 seed 恢复 thought/message 并续流', async ({ page }) => {
+    await page.setViewportSize({ width: 1100, height: 900 })
+    await page.goto('/clarify-session-ux.html')
+    await expect(page.getByTestId('clarify-ux-root')).toBeVisible({ timeout: 15_000 })
+
+    await page.getByTestId('sim-hard-refresh-acp-race').click()
+    await expect(page.getByTestId('clarify-thought')).toContainText('竞态恢复的思考', {
+      timeout: 5_000,
+    })
+    await expect(page.getByText('竞态恢复的正文续流。继续追加。')).toBeVisible()
+    await expect(page.getByTestId('clarify-busy-status')).toContainText('输出中')
+    await expect(page.getByTestId('clarify-stream-caret')).toBeVisible()
+    await page.screenshot({ path: path.join(shotDir, '07-clarify-hard-refresh-acp-race.png'), fullPage: true })
+  })
+
+  test('四阶段完成态：输出中三件套消失 + 已完成脚注', async ({ page }) => {
+    await page.setViewportSize({ width: 1100, height: 900 })
+    await page.goto('/clarify-session-ux.html')
+    await expect(page.getByTestId('clarify-ux-root')).toBeVisible({ timeout: 15_000 })
+
+    await page.getByTestId('sim-four-phase-complete').click()
+    await expect(page.getByText('四阶段正文输出。')).toBeVisible()
+    await expect(page.getByTestId('clarify-busy-status')).toHaveCount(0)
+    await expect(page.getByTestId('clarify-stream-caret')).toHaveCount(0)
+    await expect(page.getByTestId('clarify-turn-completed')).toContainText('已完成')
+    // Thought default-collapsed after message / done.
+    await expect(page.getByTestId('clarify-thought')).not.toHaveAttribute('open')
+    await page.screenshot({ path: path.join(shotDir, '08-clarify-four-phase-done.png'), fullPage: true })
+  })
 })

--- a/web/src/components/run/ClarifyChat.test.ts
+++ b/web/src/components/run/ClarifyChat.test.ts
@@ -682,7 +682,7 @@ describe('ClarifyChat', () => {
       wrapper.unmount()
     })
 
-    it('thought is visible and default-open; message does not erase thought', async () => {
+    it('thought is visible and default-open; collapses when message starts', async () => {
       const wrapper = mountChat({ draft: '请复审' })
       await clickSend(wrapper)
       const vm = wrapper.vm as unknown as {
@@ -715,8 +715,11 @@ describe('ClarifyChat', () => {
       await flushPromises()
 
       expect(wrapper.find('[data-testid="clarify-thought"]').text()).toContain('先核对边界与分轨')
+      // Demo: collapse thought once message streaming starts.
+      expect(wrapper.find('[data-testid="clarify-thought"]').attributes('open')).toBeUndefined()
       expect(wrapper.find('[data-testid="clarify-agent-message"]').text()).toContain('已核对完成')
       expect(wrapper.find('[data-testid="clarify-busy-status"]').text()).toContain('输出中')
+      expect(wrapper.find('[data-testid="clarify-stream-caret"]').exists()).toBe(true)
       wrapper.unmount()
     })
 
@@ -745,8 +748,30 @@ describe('ClarifyChat', () => {
       vm.applyReviewFrame({ event: 'turn_done', nodeId: 'react-1' })
       await flushPromises()
       expect(wrapper.find('[data-testid="clarify-busy-status"]').exists()).toBe(false)
+      expect(wrapper.find('[data-testid="clarify-stream-caret"]').exists()).toBe(false)
       expect(wrapper.find('[data-testid="clarify-thought"]').text()).toContain('思考内容')
       expect(wrapper.find('[data-testid="clarify-agent-message"]').text()).toContain('正文内容')
+      expect(wrapper.find('[data-testid="clarify-turn-completed"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="clarify-turn-completed"]').text()).toContain('已完成')
+      wrapper.unmount()
+    })
+
+    it('interrupted turn_done does not show 已完成 footnote', async () => {
+      const wrapper = mountChat({ draft: '请复审' })
+      await clickSend(wrapper)
+      const vm = wrapper.vm as unknown as {
+        applyReviewFrame: (f: Record<string, unknown>) => void
+        applyAcpEvents: (e: { kind: string; text: string }[], nodeId?: string) => void
+      }
+      vm.applyReviewFrame({
+        event: 'turn_begin',
+        nodeId: 'react-1',
+        item: { text: '请复审' },
+      })
+      vm.applyAcpEvents([{ kind: 'message', text: '半截正文' }], 'react-1')
+      vm.applyReviewFrame({ event: 'turn_done', nodeId: 'react-1', interrupted: true })
+      await flushPromises()
+      expect(wrapper.find('[data-testid="clarify-turn-completed"]').exists()).toBe(false)
       wrapper.unmount()
     })
 

--- a/web/src/components/run/ClarifyChat.vue
+++ b/web/src/components/run/ClarifyChat.vue
@@ -100,6 +100,17 @@ const streamPreview = createStreamMarkdownPreview({ render: renderMarkdown })
 const unsubStream = streamPreview.subscribe((html) => {
   liveStreamHtml.value = html
 })
+/** Coalesced thought text (rAF) — same cadence as message preview. */
+const liveThoughtText = ref('')
+const thoughtPreview = createStreamMarkdownPreview({ render: (s) => s })
+const unsubThought = thoughtPreview.subscribe((text) => {
+  liveThoughtText.value = text
+})
+/**
+ * Manual thought expand/collapse overrides (index → open).
+ * Default: open while thought-only streaming; collapsed once message starts / done.
+ */
+const thoughtOpenOverride = ref<Record<number, boolean>>({})
 const scroller = ref<HTMLElement>()
 const fileInput = ref<HTMLInputElement | null>(null)
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
@@ -188,7 +199,9 @@ const pending = ref<{ text: string; images: ClarifyImage[]; annotations: ReactAn
 
 onBeforeUnmount(() => {
   unsubStream()
+  unsubThought()
   streamPreview.reset()
+  thoughtPreview.reset()
 })
 
 /** Legacy zh-CN prefix for messages persisted before i18n or in sessionStorage. */
@@ -757,7 +770,9 @@ function applyQueueState(
       },
     ]
     liveAgentIdx.value = 1
+    thoughtOpenOverride.value = {}
     streamPreview.reset()
+    thoughtPreview.reset()
   }
   thinking.value = liveAgentIdx.value >= 0 || queued.value.length > 0 || !!busy
 }
@@ -825,15 +840,20 @@ function applyReviewFrame(frame: {
           at: new Date().toISOString(),
           streaming: true,
         }) - 1
+      thoughtOpenOverride.value = {}
       streamPreview.reset()
+      thoughtPreview.reset()
       thinking.value = true
       break
     }
     case 'turn_done': {
       if (liveAgentIdx.value >= 0 && liveTurns.value[liveAgentIdx.value]) {
-        liveTurns.value[liveAgentIdx.value].streaming = false
-        if (frame.interrupted) liveTurns.value[liveAgentIdx.value].interrupted = true
+        const agent = liveTurns.value[liveAgentIdx.value]
+        agent.streaming = false
+        agent.at = new Date().toISOString()
+        if (frame.interrupted) agent.interrupted = true
         streamPreview.flush()
+        thoughtPreview.flush()
       }
       liveAgentIdx.value = -1
       thinking.value = queued.value.length > 0
@@ -844,8 +864,10 @@ function applyReviewFrame(frame: {
         liveTurns.value[liveAgentIdx.value].streaming = false
         liveTurns.value[liveAgentIdx.value].text =
           liveTurns.value[liveAgentIdx.value].text || frame.message || 'error'
+        liveTurns.value[liveAgentIdx.value].at = new Date().toISOString()
         if (frame.interrupted) liveTurns.value[liveAgentIdx.value].interrupted = true
         streamPreview.flush()
+        thoughtPreview.flush()
       }
       liveAgentIdx.value = -1
       thinking.value = queued.value.length > 0
@@ -880,6 +902,7 @@ function applyAcpEvents(events: AcpEvent[] | undefined, nodeId?: string) {
   agent.thought = thought
   agent.text = msg
   streamPreview.setText(msg)
+  thoughtPreview.setText(thought)
   // Stick-gated only — never force-drag while user scrolled up.
   void scrollBottom()
 }
@@ -887,6 +910,37 @@ function applyAcpEvents(events: AcpEvent[] | undefined, nodeId?: string) {
 /** Live agent bubble has visible message body (text or coalesced markdown). */
 function agentHasMessage(t: ClarifyTurn): boolean {
   return !!(t.text || (t.streaming && liveStreamHtml.value))
+}
+
+/** Display thought (coalesced while this live agent is streaming). */
+function agentThoughtDisplay(t: ClarifyTurn, idx: number): string {
+  if (t.streaming && idx === liveAgentIdx.value && liveThoughtText.value) {
+    return liveThoughtText.value
+  }
+  return t.thought || ''
+}
+
+/** Default open while thought-only; collapse once message exists (Demo). */
+function isThoughtOpen(idx: number, t: ClarifyTurn): boolean {
+  if (thoughtOpenOverride.value[idx] !== undefined) {
+    return thoughtOpenOverride.value[idx]!
+  }
+  return !!(t.streaming && t.thought && !agentHasMessage(t))
+}
+
+function onThoughtToggle(idx: number, e: Event) {
+  const el = e.target as HTMLDetailsElement
+  thoughtOpenOverride.value = { ...thoughtOpenOverride.value, [idx]: el.open }
+}
+
+/** Normal completion footnote (not interrupted / error). */
+function showTurnCompleted(t: ClarifyTurn): boolean {
+  return (
+    t.role === 'agent' &&
+    !t.streaming &&
+    !t.interrupted &&
+    !!(t.text || t.thought)
+  )
 }
 
 defineExpose({
@@ -962,7 +1016,7 @@ defineExpose({
               </div>
             </div>
           </div>
-          <!-- Agent busy / thought / message (Demo C: no air bubble) -->
+          <!-- Agent busy / thought / message (Demo: four-phase + restrained done) -->
           <template v-else-if="t.role === 'agent'">
             <!-- Waiting first token: dots + 思考中… inside bubble -->
             <div
@@ -989,26 +1043,44 @@ defineExpose({
             >
               {{ translate('pages.clarify.outputting') }}
             </div>
-            <!-- Thought block: default open; not auto-collapsed when message arrives -->
+            <!-- Thought: open while thought-only; default collapsed once message starts -->
             <details
               v-if="t.thought"
-              open
               class="mb-2 w-full rounded-md border border-line bg-base/60 text-[11.5px] text-txt3"
               data-testid="clarify-thought"
+              :open="isThoughtOpen(i, t)"
+              @toggle="onThoughtToggle(i, $event)"
             >
               <summary class="flex cursor-pointer select-none items-center gap-1.5 px-2.5 py-1.5 text-txt3 hover:text-txt2">
                 <Icon name="sparkles" :size="11" class="text-accent-2" />
                 {{ translate('pages.clarify.thought') }}
               </summary>
-              <div class="whitespace-pre-wrap border-t border-dashed border-line px-2.5 pb-2 pt-1.5 font-mono leading-5">{{ t.thought }}</div>
+              <div class="whitespace-pre-wrap border-t border-dashed border-line px-2.5 pb-2 pt-1.5 font-mono leading-5">{{ agentThoughtDisplay(t, i) }}</div>
             </details>
-            <!-- Message body -->
+            <!-- Message body + streaming caret -->
             <div
               v-if="agentHasMessage(t)"
               class="md rounded-lg border border-line bg-elevated px-3 py-2 text-[13px] leading-relaxed text-txt"
               data-testid="clarify-agent-message"
-              v-html="t.streaming && liveStreamHtml ? liveStreamHtml : renderMarkdown(t.text)"
-            />
+            >
+              <span
+                v-html="t.streaming && liveStreamHtml ? liveStreamHtml : renderMarkdown(t.text)"
+              /><span
+                v-if="t.streaming"
+                class="clarify-stream-caret"
+                data-testid="clarify-stream-caret"
+                aria-hidden="true"
+              />
+            </div>
+            <!-- Restrained completion footnote (Demo); never for interrupted/error -->
+            <div
+              v-if="showTurnCompleted(t)"
+              class="mt-1.5 flex items-center justify-between gap-2 text-[11px] text-txt3"
+              data-testid="clarify-turn-completed"
+            >
+              <span class="text-txt2">{{ translate('pages.clarify.turnCompleted') }}</span>
+              <span>{{ relTime(t.at) }}</span>
+            </div>
           </template>
           <!-- Human free-text bubble (agent branch handled above; role narrowed to human) -->
           <div
@@ -1420,5 +1492,21 @@ defineExpose({
   background-clip: text;
   -webkit-text-fill-color: transparent;
   animation: shimmer 3.5s ease-in-out infinite;
+}
+
+/* Streaming caret at message tail (Demo phase 3) */
+.clarify-stream-caret {
+  display: inline-block;
+  width: 7px;
+  height: 1em;
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  background: rgb(var(--c-accent));
+  animation: clarify-caret-blink 0.9s step-end infinite;
+}
+@keyframes clarify-caret-blink {
+  50% {
+    opacity: 0;
+  }
 }
 </style>

--- a/web/src/components/run/GateApproval.test.ts
+++ b/web/src/components/run/GateApproval.test.ts
@@ -2773,6 +2773,51 @@ describe('GateApproval mobileFillRemaining layout', () => {
     expect(wrapper.find('[data-testid="gate-react-stream"]').text()).toContain('续上的思考')
     expect(wrapper.find('[data-testid="gate-react-stream"]').text()).toContain('续上的正文')
     expect(wrapper.find('[data-testid="gate-busy-status"]').text()).toContain('输出中')
+    expect(wrapper.find('[data-testid="gate-react-thought"]').attributes('open')).toBeUndefined()
+    expect(wrapper.find('[data-testid="gate-stream-caret"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('four-phase complete: turn_done shows 已完成 footnote; interrupted does not (g3/g2.1)', async () => {
+    breakpointMocks.isMobile.value = false
+    const pageHtml = '<!doctype html><html><body><h1>gate done</h1></body></html>'
+    const { gate, run } = visualGateRun(pageHtml)
+    const wrapper = mountApproval({
+      fillPreview: true,
+      mobileFillRemaining: false,
+      gate: { ...gate, reactSessionAlive: true, reactUpstreamNodeId: 'visual' },
+      run,
+    })
+    await flushPromises()
+    const vm = wrapper.vm as any
+    vm.applyReviewFrame?.({
+      event: 'queue_state',
+      nodeId: 'visual',
+      waiting: 0,
+      items: [],
+      busy: true,
+      activeItem: { text: '完成态' },
+    })
+    vm.applyAcpEvents?.([
+      { kind: 'thought', text: '完成前思考' },
+      { kind: 'message', text: '完成前正文' },
+    ])
+    await flushPromises()
+    vm.applyReviewFrame?.({ event: 'turn_done', nodeId: 'visual' })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="gate-turn-completed"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="gate-turn-completed"]').text()).toContain('已完成')
+    expect(wrapper.find('[data-testid="gate-stream-caret"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="gate-busy-status"]').exists()).toBe(false)
+
+    vm.applyReviewFrame?.({
+      event: 'turn_begin',
+      nodeId: 'visual',
+    })
+    vm.applyAcpEvents?.([{ kind: 'message', text: '半截' }])
+    vm.applyReviewFrame?.({ event: 'turn_done', nodeId: 'visual', interrupted: true })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="gate-turn-completed"]').exists()).toBe(false)
     wrapper.unmount()
   })
 

--- a/web/src/components/run/GateApproval.test.ts
+++ b/web/src/components/run/GateApproval.test.ts
@@ -2741,6 +2741,41 @@ describe('GateApproval mobileFillRemaining layout', () => {
     wrapper.unmount()
   })
 
+  it('refresh resume: busy+activeItem (waiting=0) keeps thinking and consumes ACP (g2.1/g4.4)', async () => {
+    breakpointMocks.isMobile.value = false
+    const pageHtml = '<!doctype html><html><body><h1>gate resume</h1></body></html>'
+    const { gate, run } = visualGateRun(pageHtml)
+    const wrapper = mountApproval({
+      fillPreview: true,
+      mobileFillRemaining: false,
+      gate: { ...gate, reactSessionAlive: true, reactUpstreamNodeId: 'visual' },
+      run,
+    })
+    await flushPromises()
+    const vm = wrapper.vm as any
+    // Hard refresh snapshot: only busy+activeItem, waiting already drained.
+    vm.applyReviewFrame?.({
+      event: 'queue_state',
+      nodeId: 'visual',
+      waiting: 0,
+      items: [],
+      busy: true,
+      activeItem: { text: '热修刷新续流' },
+    })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="gate-busy-placeholder"]').exists()).toBe(true)
+
+    vm.applyAcpEvents?.([
+      { kind: 'thought', text: '续上的思考' },
+      { kind: 'message', text: '续上的正文' },
+    ])
+    await flushPromises()
+    expect(wrapper.find('[data-testid="gate-react-stream"]').text()).toContain('续上的思考')
+    expect(wrapper.find('[data-testid="gate-react-stream"]').text()).toContain('续上的正文')
+    expect(wrapper.find('[data-testid="gate-busy-status"]').text()).toContain('输出中')
+    wrapper.unmount()
+  })
+
   it('keeps Inbox-style path on 60vh content-fit when mobileFillRemaining is off', async () => {
     const pageHtml = '<!doctype html><html><body><h1>Inbox</h1></body></html>'
     const { gate, run } = visualGateRun(pageHtml)

--- a/web/src/components/run/GateApproval.vue
+++ b/web/src/components/run/GateApproval.vue
@@ -973,6 +973,8 @@ function applyReviewFrame(frame: {
   message?: string
   waiting?: number
   items?: { text?: string }[]
+  busy?: boolean
+  activeItem?: { text?: string } | null
 }) {
   const producer = props.gate.reactUpstreamNodeId
   if (producer && frame.nodeId && frame.nodeId !== producer) return
@@ -998,16 +1000,29 @@ function applyReviewFrame(frame: {
       break
     case 'queue_state': {
       // Platform-authoritative: remote Cancel / cross-entry must clear ghost rows.
+      // Refresh resume: busy+activeItem must keep thinking/inFlight even when waiting=0.
       const waiting = typeof frame.waiting === 'number' ? frame.waiting : 0
       const items = Array.isArray(frame.items) ? frame.items : null
+      const busy = !!frame.busy
+      const activeItem = frame.activeItem
+      if (busy && activeItem && !reactInFlight.value) {
+        reactInFlight.value = true
+        reactThinking.value = true
+        // Empty rails — host seeds ACP (pending buffer / nodeEvents) next.
+        if (!reactStreamText.value && !reactStreamThought.value) {
+          reactStreamText.value = ''
+          reactStreamThought.value = ''
+        }
+      }
       if (waiting === 0) {
         reactQueued.value = []
-        if (!reactInFlight.value) reactThinking.value = false
+        if (!reactInFlight.value && !busy) reactThinking.value = false
+        else reactThinking.value = reactInFlight.value || busy
         break
       }
       if (items) {
         const rebuilt = items.map((it) => ({ text: it.text ?? '' }))
-        const maxLocal = reactInFlight.value ? rebuilt.length : rebuilt.length + 1
+        const maxLocal = reactInFlight.value || busy ? rebuilt.length : rebuilt.length + 1
         if (reactQueued.value.length > maxLocal) {
           const optimistic = reactQueued.value
             .slice(rebuilt.length)
@@ -1020,14 +1035,16 @@ function applyReviewFrame(frame: {
           reactQueued.value = [...rebuilt, ...optimistic]
         }
       }
-      reactThinking.value = reactInFlight.value || reactQueued.value.length > 0
+      reactThinking.value = reactInFlight.value || reactQueued.value.length > 0 || busy
       break
     }
   }
 }
 
 function applyAcpEvents(events: { kind?: string; text?: string }[] | undefined) {
-  if (!reactThinking.value || !events?.length) return
+  // Accept ACP while busy/inFlight even if waiting=0 cleared the queue panel.
+  if ((!reactThinking.value && !reactInFlight.value) || !events?.length) return
+  if (!reactThinking.value) reactThinking.value = true
   for (const ev of events) {
     // Ignore tool_call / plan UI; keep rails separate so thought is never overwritten.
     if (ev.kind === 'message' && ev.text) reactStreamText.value = ev.text

--- a/web/src/components/run/GateApproval.vue
+++ b/web/src/components/run/GateApproval.vue
@@ -44,6 +44,7 @@ import ArtifactLoadingPane from './ArtifactLoadingPane.vue'
 import UpstreamRequirementContext from './UpstreamRequirementContext.vue'
 import ReviewShell from './ReviewShell.vue'
 import ReviewComposer from './ReviewComposer.vue'
+import GateReactStreamPanel from './GateReactStreamPanel.vue'
 import { REVIEW_SHELL_WIDTH_KEY_APPROVAL } from '@/lib/reviewLayoutBudget'
 import { OUTPUT_KEY_TO_ARTIFACT } from '@/lib/structuredArtifacts'
 import {
@@ -941,6 +942,8 @@ const reactStreamText = ref('')
 /** ACP thought rail (separate from message — Demo: thought must not be dropped). */
 const reactStreamThought = ref('')
 const reactInterrupted = ref(false)
+/** Normal completion timestamp for restrained「已完成」footnote (Demo phase 4). */
+const reactStreamCompletedAt = ref<string | null>(null)
 const reactError = ref<string | null>(null)
 const feedbackChatRef = ref<{
   send: (opts?: { body?: string }) => Promise<boolean>
@@ -986,16 +989,23 @@ function applyReviewFrame(frame: {
       reactStreamText.value = ''
       reactStreamThought.value = ''
       reactInterrupted.value = false
+      reactStreamCompletedAt.value = null
       break
     case 'turn_done':
       reactInFlight.value = false
       reactThinking.value = reactQueued.value.length > 0
-      if (frame.interrupted) reactInterrupted.value = true
+      if (frame.interrupted) {
+        reactInterrupted.value = true
+        reactStreamCompletedAt.value = null
+      } else if (reactStreamText.value || reactStreamThought.value) {
+        reactStreamCompletedAt.value = new Date().toISOString()
+      }
       break
     case 'error':
       reactInFlight.value = false
       reactThinking.value = reactQueued.value.length > 0
       reactError.value = frame.message || reactError.value
+      reactStreamCompletedAt.value = null
       if (frame.interrupted) reactInterrupted.value = true
       break
     case 'queue_state': {
@@ -1008,6 +1018,7 @@ function applyReviewFrame(frame: {
       if (busy && activeItem && !reactInFlight.value) {
         reactInFlight.value = true
         reactThinking.value = true
+        reactStreamCompletedAt.value = null
         // Empty rails — host seeds ACP (pending buffer / nodeEvents) next.
         if (!reactStreamText.value && !reactStreamThought.value) {
           reactStreamText.value = ''
@@ -1058,6 +1069,7 @@ async function cancelReactRevise() {
   reactThinking.value = false
   reactInFlight.value = false
   reactInterrupted.value = true
+  reactStreamCompletedAt.value = null
   try {
     await api.gateReactCancel(props.run.id, props.gate.nodeId)
   } catch (e: any) {
@@ -1605,50 +1617,13 @@ function onComposerReject() {
                     {{ qi + 1 }}. {{ q.text }}
                   </div>
                 </div>
-                <div
-                  v-if="reactThinking"
-                  class="mt-2 max-h-40 space-y-1.5 overflow-y-auto rounded border border-line bg-surface px-2 py-1.5 text-[12px] text-txt2"
-                  data-testid="gate-react-stream"
-                >
-                  <div
-                    v-if="!reactStreamText && !reactStreamThought"
-                    class="inline-flex items-center gap-2 text-txt3"
-                    data-testid="gate-busy-placeholder"
-                  >
-                    <span class="typing-dots" aria-hidden="true"><i /><i /><i /></span>
-                    <span>{{ t('pages.clarify.thinkingBusy') }}</span>
-                  </div>
-                  <div
-                    v-else-if="!reactStreamText && reactStreamThought"
-                    class="text-txt3"
-                    data-testid="gate-busy-status"
-                  >
-                    {{ t('pages.clarify.thinkingBusy') }}
-                  </div>
-                  <div
-                    v-else-if="reactStreamText"
-                    class="gate-outputting"
-                    data-testid="gate-busy-status"
-                  >
-                    {{ t('pages.clarify.outputting') }}
-                  </div>
-                  <details
-                    v-if="reactStreamThought"
-                    open
-                    class="rounded border border-line bg-base/60 text-[11.5px] text-txt3"
-                    data-testid="gate-react-thought"
-                  >
-                    <summary class="flex cursor-pointer select-none items-center gap-1 px-2 py-1 hover:text-txt2">
-                      <Icon name="sparkles" :size="11" class="text-accent-2" />
-                      {{ t('pages.clarify.thought') }}
-                    </summary>
-                    <div class="whitespace-pre-wrap border-t border-dashed border-line px-2 pb-1.5 pt-1 font-mono leading-5">{{ reactStreamThought }}</div>
-                  </details>
-                  <div v-if="reactStreamText">
-                    {{ reactStreamText }}
-                    <span v-if="reactInterrupted" class="ml-1 text-[10px] text-warn">interrupted</span>
-                  </div>
-                </div>
+                <GateReactStreamPanel
+                  :thinking="reactThinking"
+                  :stream-text="reactStreamText"
+                  :stream-thought="reactStreamThought"
+                  :interrupted="reactInterrupted"
+                  :completed-at="reactStreamCompletedAt"
+                />
               </div>
               <div v-else class="mt-2 flex shrink-0 flex-wrap gap-3">
                 <button
@@ -1945,50 +1920,13 @@ function onComposerReject() {
                     {{ qi + 1 }}. {{ q.text }}
                   </div>
                 </div>
-                <div
-                  v-if="reactThinking"
-                  class="mt-2 max-h-40 space-y-1.5 overflow-y-auto rounded border border-line bg-surface px-2 py-1.5 text-[12px] text-txt2"
-                  data-testid="gate-react-stream"
-                >
-                  <div
-                    v-if="!reactStreamText && !reactStreamThought"
-                    class="inline-flex items-center gap-2 text-txt3"
-                    data-testid="gate-busy-placeholder"
-                  >
-                    <span class="typing-dots" aria-hidden="true"><i /><i /><i /></span>
-                    <span>{{ t('pages.clarify.thinkingBusy') }}</span>
-                  </div>
-                  <div
-                    v-else-if="!reactStreamText && reactStreamThought"
-                    class="text-txt3"
-                    data-testid="gate-busy-status"
-                  >
-                    {{ t('pages.clarify.thinkingBusy') }}
-                  </div>
-                  <div
-                    v-else-if="reactStreamText"
-                    class="gate-outputting"
-                    data-testid="gate-busy-status"
-                  >
-                    {{ t('pages.clarify.outputting') }}
-                  </div>
-                  <details
-                    v-if="reactStreamThought"
-                    open
-                    class="rounded border border-line bg-base/60 text-[11.5px] text-txt3"
-                    data-testid="gate-react-thought"
-                  >
-                    <summary class="flex cursor-pointer select-none items-center gap-1 px-2 py-1 hover:text-txt2">
-                      <Icon name="sparkles" :size="11" class="text-accent-2" />
-                      {{ t('pages.clarify.thought') }}
-                    </summary>
-                    <div class="whitespace-pre-wrap border-t border-dashed border-line px-2 pb-1.5 pt-1 font-mono leading-5">{{ reactStreamThought }}</div>
-                  </details>
-                  <div v-if="reactStreamText">
-                    {{ reactStreamText }}
-                    <span v-if="reactInterrupted" class="ml-1 text-[10px] text-warn">interrupted</span>
-                  </div>
-                </div>
+                <GateReactStreamPanel
+                  :thinking="reactThinking"
+                  :stream-text="reactStreamText"
+                  :stream-thought="reactStreamThought"
+                  :interrupted="reactInterrupted"
+                  :completed-at="reactStreamCompletedAt"
+                />
               </div>
               <!-- Non-preview hot (structured etc.): keep ReviewComposer. -->
               <ReviewComposer
@@ -2012,6 +1950,7 @@ function onComposerReject() {
                 :stream-text="reactStreamText"
                 :stream-thought="reactStreamThought"
                 :interrupted="reactInterrupted"
+                :stream-completed-at="reactStreamCompletedAt"
                 @reject="onComposerReject"
                 @pass="onComposerPass"
                 @cancel="cancelReactRevise"
@@ -2107,6 +2046,7 @@ function onComposerReject() {
               :stream-text="reactStreamText"
               :stream-thought="reactStreamThought"
               :interrupted="reactInterrupted"
+              :stream-completed-at="reactStreamCompletedAt"
               @reject="onComposerReject"
               @pass="onComposerPass"
               @cancel="cancelReactRevise"
@@ -2327,6 +2267,7 @@ function onComposerReject() {
             :stream-text="reactStreamText"
             :stream-thought="reactStreamThought"
             :interrupted="reactInterrupted"
+            :stream-completed-at="reactStreamCompletedAt"
             @reject="onComposerReject"
             @pass="onComposerPass"
             @cancel="cancelReactRevise"
@@ -2362,43 +2303,5 @@ function onComposerReject() {
 </template>
 
 <style scoped>
-.typing-dots {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-}
-.typing-dots i {
-  width: 5px;
-  height: 5px;
-  border-radius: 9999px;
-  background: #22d3ee;
-  animation: typing-bounce 1.2s infinite ease-in-out both;
-}
-.typing-dots i:nth-child(2) {
-  animation-delay: 0.16s;
-}
-.typing-dots i:nth-child(3) {
-  animation-delay: 0.32s;
-}
-@keyframes typing-bounce {
-  0%,
-  70%,
-  100% {
-    transform: translateY(0);
-    opacity: 0.35;
-  }
-  35% {
-    transform: translateY(-4px);
-    opacity: 1;
-  }
-}
-.gate-outputting {
-  color: rgb(var(--c-accent-2));
-  background: var(--grad-logo);
-  background-size: var(--grad-logo-size);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  animation: shimmer 3.5s ease-in-out infinite;
-}
+/* Stream four-phase UI styles live in GateReactStreamPanel. */
 </style>

--- a/web/src/components/run/GateReactStreamPanel.vue
+++ b/web/src/components/run/GateReactStreamPanel.vue
@@ -1,0 +1,191 @@
+<script setup lang="ts">
+/**
+ * Shared four-phase busy stream for GateApproval / ReviewComposer(gate):
+ * placeholder → collapsible thought → outputting (shimmer+caret) → restrained done.
+ */
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Icon from '../ui/Icon.vue'
+import { relTime } from '@/lib/format'
+
+const props = withDefaults(
+  defineProps<{
+    thinking?: boolean
+    streamText?: string
+    streamThought?: string
+    interrupted?: boolean
+    /** ISO timestamp when turn completed normally (not interrupted/error). */
+    completedAt?: string | null
+  }>(),
+  {
+    thinking: false,
+    streamText: '',
+    streamThought: '',
+    interrupted: false,
+    completedAt: null,
+  },
+)
+
+const { t, locale } = useI18n()
+
+const thoughtOpenOverride = ref<boolean | undefined>(undefined)
+
+watch(
+  () => [props.streamText, props.streamThought, props.thinking, props.completedAt] as const,
+  () => {
+    // Reset manual override when rails / phase change so Demo defaults apply.
+    thoughtOpenOverride.value = undefined
+  },
+)
+
+const hasThought = computed(() => !!props.streamThought)
+const hasMessage = computed(() => !!props.streamText)
+const streaming = computed(() => !!props.thinking && !props.completedAt)
+const showCompleted = computed(
+  () =>
+    !!props.completedAt &&
+    !props.interrupted &&
+    !props.thinking &&
+    (hasThought.value || hasMessage.value),
+)
+const showPanel = computed(
+  () =>
+    props.thinking ||
+    showCompleted.value ||
+    (props.interrupted && (hasThought.value || hasMessage.value)),
+)
+
+/** Default open while thought-only streaming; collapse once message / done. */
+const thoughtOpen = computed(() => {
+  if (thoughtOpenOverride.value !== undefined) return thoughtOpenOverride.value
+  return !!(streaming.value && hasThought.value && !hasMessage.value)
+})
+
+function onThoughtToggle(e: Event) {
+  const el = e.target as HTMLDetailsElement
+  thoughtOpenOverride.value = el.open
+}
+</script>
+
+<template>
+  <div
+    v-if="showPanel"
+    class="mt-2 max-h-40 space-y-1.5 overflow-y-auto rounded border border-line bg-surface px-2 py-1.5 text-[12px] text-txt2"
+    data-testid="gate-react-stream"
+  >
+    <div
+      v-if="streaming && !hasMessage && !hasThought"
+      class="inline-flex items-center gap-2 text-txt3"
+      data-testid="gate-busy-placeholder"
+    >
+      <span class="typing-dots" aria-hidden="true"><i /><i /><i /></span>
+      <span>{{ t('pages.clarify.thinkingBusy') }}</span>
+    </div>
+    <div
+      v-else-if="streaming && hasThought && !hasMessage"
+      class="text-txt3"
+      data-testid="gate-busy-status"
+    >
+      {{ t('pages.clarify.thinkingBusy') }}
+    </div>
+    <div
+      v-else-if="streaming && hasMessage"
+      class="gate-stream-outputting"
+      data-testid="gate-busy-status"
+    >
+      {{ t('pages.clarify.outputting') }}
+    </div>
+
+    <details
+      v-if="hasThought"
+      class="rounded border border-line bg-base/60 text-[11.5px] text-txt3"
+      data-testid="gate-react-thought"
+      :open="thoughtOpen"
+      @toggle="onThoughtToggle"
+    >
+      <summary class="flex cursor-pointer select-none items-center gap-1 px-2 py-1 hover:text-txt2">
+        <Icon name="sparkles" :size="11" class="text-accent-2" />
+        {{ t('pages.clarify.thought') }}
+      </summary>
+      <div class="whitespace-pre-wrap border-t border-dashed border-line px-2 pb-1.5 pt-1 font-mono leading-5">
+        {{ streamThought }}
+      </div>
+    </details>
+
+    <div v-if="hasMessage" data-testid="gate-react-message">
+      {{ streamText }}
+      <span
+        v-if="streaming"
+        class="gate-stream-caret"
+        data-testid="gate-stream-caret"
+        aria-hidden="true"
+      />
+      <span v-if="interrupted" class="ml-1 text-[10px] text-warn">interrupted</span>
+    </div>
+
+    <div
+      v-if="showCompleted"
+      class="flex items-center justify-between gap-2 border-t border-line pt-1.5 text-[11px] text-txt3"
+      data-testid="gate-turn-completed"
+    >
+      <span class="text-txt2">{{ t('pages.clarify.turnCompleted') }}</span>
+      <span>{{ locale && completedAt ? relTime(completedAt) : '' }}</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.typing-dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+.typing-dots i {
+  width: 5px;
+  height: 5px;
+  border-radius: 9999px;
+  background: #22d3ee;
+  animation: typing-bounce 1.2s infinite ease-in-out both;
+}
+.typing-dots i:nth-child(2) {
+  animation-delay: 0.16s;
+}
+.typing-dots i:nth-child(3) {
+  animation-delay: 0.32s;
+}
+@keyframes typing-bounce {
+  0%,
+  70%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.35;
+  }
+  35% {
+    transform: translateY(-4px);
+    opacity: 1;
+  }
+}
+.gate-stream-outputting {
+  color: rgb(var(--c-accent-2));
+  background: var(--grad-logo);
+  background-size: var(--grad-logo-size);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: shimmer 3.5s ease-in-out infinite;
+}
+.gate-stream-caret {
+  display: inline-block;
+  width: 7px;
+  height: 1em;
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  background: rgb(var(--c-accent));
+  animation: gate-caret-blink 0.9s step-end infinite;
+}
+@keyframes gate-caret-blink {
+  50% {
+    opacity: 0;
+  }
+}
+</style>

--- a/web/src/components/run/ReviewComposer.test.ts
+++ b/web/src/components/run/ReviewComposer.test.ts
@@ -11,6 +11,7 @@ function mountGate(opts: {
   streamText?: string
   streamThought?: string
   interrupted?: boolean
+  streamCompletedAt?: string | null
 } = {}) {
   const i18n = createI18n({
     legacy: false,
@@ -24,6 +25,7 @@ function mountGate(opts: {
       streamText: opts.streamText ?? '',
       streamThought: opts.streamThought ?? '',
       interrupted: opts.interrupted ?? false,
+      streamCompletedAt: opts.streamCompletedAt ?? null,
       canReject: true,
       canPass: true,
     },
@@ -60,7 +62,7 @@ describe('ReviewComposer gate busy status (C-tier)', () => {
     wrapper.unmount()
   })
 
-  it('message switches status to 输出中 and keeps thought', async () => {
+  it('message switches status to 输出中, collapses thought, shows caret', async () => {
     const wrapper = mountGate({
       thinking: true,
       streamThought: '旁路思考',
@@ -69,6 +71,8 @@ describe('ReviewComposer gate busy status (C-tier)', () => {
     await flushPromises()
     expect(wrapper.find('[data-testid="gate-busy-status"]').text()).toContain('输出中')
     expect(wrapper.find('[data-testid="gate-react-thought"]').text()).toContain('旁路思考')
+    expect(wrapper.find('[data-testid="gate-react-thought"]').attributes('open')).toBeUndefined()
+    expect(wrapper.find('[data-testid="gate-stream-caret"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="gate-react-stream"]').text()).toContain('旁路正文流')
     wrapper.unmount()
   })
@@ -81,7 +85,32 @@ describe('ReviewComposer gate busy status (C-tier)', () => {
     wrapper.unmount()
   })
 
-  it('idle (not thinking) hides stream panel', async () => {
+  it('completed footnote shows without caret; interrupted never shows 已完成', async () => {
+    const done = mountGate({
+      thinking: false,
+      streamThought: '思考',
+      streamText: '正文',
+      streamCompletedAt: new Date().toISOString(),
+    })
+    await flushPromises()
+    expect(done.find('[data-testid="gate-turn-completed"]').exists()).toBe(true)
+    expect(done.find('[data-testid="gate-turn-completed"]').text()).toContain('已完成')
+    expect(done.find('[data-testid="gate-stream-caret"]').exists()).toBe(false)
+    done.unmount()
+
+    const bad = mountGate({
+      thinking: false,
+      streamText: '半截',
+      interrupted: true,
+      streamCompletedAt: null,
+    })
+    await flushPromises()
+    expect(bad.find('[data-testid="gate-turn-completed"]').exists()).toBe(false)
+    expect(bad.text()).toContain('interrupted')
+    bad.unmount()
+  })
+
+  it('idle (not thinking, no completed) hides stream panel', async () => {
     const wrapper = mountGate({
       thinking: false,
       streamText: '残留',
@@ -89,6 +118,17 @@ describe('ReviewComposer gate busy status (C-tier)', () => {
     })
     await flushPromises()
     expect(wrapper.find('[data-testid="gate-react-stream"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+})
+
+describe('ReviewComposer nested ClarifyChat delivery', () => {
+  it('applyAcpEvents returns false when ClarifyChat not mounted (gate mode)', async () => {
+    const wrapper = mountGate({ thinking: true })
+    await flushPromises()
+    const vm = wrapper.vm as any
+    expect(vm.applyAcpEvents?.([{ kind: 'message', text: 'x' }])).toBe(false)
+    expect(vm.isChatReady?.()).toBe(false)
     wrapper.unmount()
   })
 })

--- a/web/src/components/run/ReviewComposer.vue
+++ b/web/src/components/run/ReviewComposer.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import Icon from '../ui/Icon.vue'
 import ClarifyChat from './ClarifyChat.vue'
 import ParagraphInput from '../ui/ParagraphInput.vue'
+import GateReactStreamPanel from './GateReactStreamPanel.vue'
 import type { ClarifyTurn, ClarifyImage, ReactAnnotation, AcpEvent } from '@/lib/types'
 import AnnotationChip from './AnnotationChip.vue'
 
@@ -54,6 +55,8 @@ const props = withDefaults(
     /** ACP thought rail (separate from streamText). */
     streamThought?: string
     interrupted?: boolean
+    /** ISO when turn completed normally — drives restrained「已完成」footnote. */
+    streamCompletedAt?: string | null
   }>(),
   {
     iteration: 1,
@@ -76,6 +79,7 @@ const props = withDefaults(
     streamText: '',
     streamThought: '',
     interrupted: false,
+    streamCompletedAt: null,
   },
 )
 
@@ -95,11 +99,20 @@ const chatRef = ref<{
 } | null>(null)
 
 defineExpose({
-  applyReviewFrame: (frame: any) => chatRef.value?.applyReviewFrame(frame),
-  applyAcpEvents: (events: AcpEvent[] | undefined, nodeId?: string) =>
-    chatRef.value?.applyAcpEvents(events, nodeId),
+  /** Returns false when ClarifyChat is not mounted yet (hard-load race). */
+  applyReviewFrame: (frame: any): boolean => {
+    if (!chatRef.value?.applyReviewFrame) return false
+    chatRef.value.applyReviewFrame(frame)
+    return true
+  },
+  applyAcpEvents: (events: AcpEvent[] | undefined, nodeId?: string): boolean => {
+    if (!chatRef.value?.applyAcpEvents) return false
+    chatRef.value.applyAcpEvents(events, nodeId)
+    return true
+  },
   cancelReview: () => chatRef.value?.cancelReview(),
   discardLastQueued: () => chatRef.value?.discardLastQueued(),
+  isChatReady: () => !!chatRef.value,
 })
 
 const { t } = useI18n()
@@ -266,50 +279,13 @@ function onPass() {
           {{ qi + 1 }}. {{ q.text }}
         </div>
       </div>
-      <div
-        v-if="thinking"
-        class="mt-2 max-h-40 space-y-1.5 overflow-y-auto rounded border border-line bg-surface px-2 py-1.5 text-[12px] text-txt2"
-        data-testid="gate-react-stream"
-      >
-        <div
-          v-if="!streamText && !streamThought"
-          class="inline-flex items-center gap-2 text-txt3"
-          data-testid="gate-busy-placeholder"
-        >
-          <span class="typing-dots" aria-hidden="true"><i /><i /><i /></span>
-          <span>{{ t('pages.clarify.thinkingBusy') }}</span>
-        </div>
-        <div
-          v-else-if="!streamText && streamThought"
-          class="text-txt3"
-          data-testid="gate-busy-status"
-        >
-          {{ t('pages.clarify.thinkingBusy') }}
-        </div>
-        <div
-          v-else-if="streamText"
-          class="composer-outputting"
-          data-testid="gate-busy-status"
-        >
-          {{ t('pages.clarify.outputting') }}
-        </div>
-        <details
-          v-if="streamThought"
-          open
-          class="rounded border border-line bg-base/60 text-[11.5px] text-txt3"
-          data-testid="gate-react-thought"
-        >
-          <summary class="flex cursor-pointer select-none items-center gap-1 px-2 py-1 hover:text-txt2">
-            <Icon name="sparkles" :size="11" class="text-accent-2" />
-            {{ t('pages.clarify.thought') }}
-          </summary>
-          <div class="whitespace-pre-wrap border-t border-dashed border-line px-2 pb-1.5 pt-1 font-mono leading-5">{{ streamThought }}</div>
-        </details>
-        <div v-if="streamText">
-          {{ streamText }}
-          <span v-if="interrupted" class="ml-1 text-[10px] text-warn">interrupted</span>
-        </div>
-      </div>
+      <GateReactStreamPanel
+        :thinking="thinking"
+        :stream-text="streamText"
+        :stream-thought="streamThought"
+        :interrupted="interrupted"
+        :completed-at="streamCompletedAt"
+      />
       <p class="mt-2 text-[11px] leading-relaxed text-txt3" data-testid="review-composer-footer-hint">
         {{ gateFooterHint }}
       </p>
@@ -318,43 +294,5 @@ function onPass() {
 </template>
 
 <style scoped>
-.typing-dots {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-}
-.typing-dots i {
-  width: 5px;
-  height: 5px;
-  border-radius: 9999px;
-  background: #22d3ee;
-  animation: typing-bounce 1.2s infinite ease-in-out both;
-}
-.typing-dots i:nth-child(2) {
-  animation-delay: 0.16s;
-}
-.typing-dots i:nth-child(3) {
-  animation-delay: 0.32s;
-}
-@keyframes typing-bounce {
-  0%,
-  70%,
-  100% {
-    transform: translateY(0);
-    opacity: 0.35;
-  }
-  35% {
-    transform: translateY(-4px);
-    opacity: 1;
-  }
-}
-.composer-outputting {
-  color: rgb(var(--c-accent-2));
-  background: var(--grad-logo);
-  background-size: var(--grad-logo-size);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  animation: shimmer 3.5s ease-in-out infinite;
-}
+/* typing-dots / outputting / caret live in GateReactStreamPanel */
 </style>

--- a/web/src/components/run/clarifySessionUx.probe.test.ts
+++ b/web/src/components/run/clarifySessionUx.probe.test.ts
@@ -133,6 +133,42 @@ describe('[approving] ClarifyChat clarify-path UX (non-reviewMode)', () => {
     w.unmount()
   })
 
+  it('hard-refresh seed: thought-only then message after remount (g4.1)', async () => {
+    // Simulate host seed-then-live: rebuild slot → seed ACP after (re)mount.
+    const w = mountClarify()
+    const vm = w.vm as unknown as {
+      applyReviewFrame: (f: Record<string, unknown>) => void
+      applyAcpEvents: (e: { kind: string; text: string }[]) => void
+    }
+    vm.applyReviewFrame({
+      event: 'queue_state',
+      nodeId: 'clarify',
+      waiting: 0,
+      items: [],
+      busy: true,
+      activeItem: { text: '硬刷新前的提问' },
+    })
+    await nextTick()
+    expect(w.find('[data-testid="clarify-busy-placeholder"]').exists()).toBe(true)
+
+    // Seed thought recovered from LiveNodeEvents / pending ACP buffer.
+    vm.applyAcpEvents([{ kind: 'thought', text: '已恢复的思考增量' }])
+    await nextTick()
+    expect(w.find('[data-testid="clarify-busy-placeholder"]').exists()).toBe(false)
+    expect(w.find('[data-testid="clarify-thought"]').text()).toContain('已恢复的思考增量')
+    expect(w.find('[data-testid="clarify-busy-status"]').text()).toContain('思考中')
+
+    vm.applyAcpEvents([
+      { kind: 'thought', text: '已恢复的思考增量' },
+      { kind: 'message', text: '续流正文' },
+    ])
+    await nextTick()
+    expect(w.text()).toContain('续流正文')
+    expect(w.find('[data-testid="clarify-busy-status"]').text()).toContain('输出中')
+    expect(w.find('[data-testid="clarify-stream-caret"]').exists()).toBe(true)
+    w.unmount()
+  })
+
   it('IME composing Enter does not send', async () => {
     const w = mountClarify()
     const ta = w.find('[data-testid="clarify-input"]')

--- a/web/src/lib/dialogueAcpDelivery.test.ts
+++ b/web/src/lib/dialogueAcpDelivery.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest'
+import { deliverOrBufferDialogueAcp } from './dialogueAcpDelivery'
+import type { AcpEvent } from './types'
+
+const sample: AcpEvent[] = [
+  { kind: 'thought', text: 't1', t: 1 },
+  { kind: 'message', text: 'm1', t: 2 },
+]
+
+describe('deliverOrBufferDialogueAcp', () => {
+  it('buffers when neither surface matches', () => {
+    expect(
+      deliverOrBufferDialogueAcp({
+        forClarify: false,
+        forGate: false,
+        events: sample,
+        nodeId: 'n1',
+      }),
+    ).toBe('buffer')
+  })
+
+  it('buffers when ReviewComposer exposes apply but inner chat not ready (returns false)', () => {
+    const applyClarify = vi.fn(() => false)
+    expect(
+      deliverOrBufferDialogueAcp({
+        forClarify: true,
+        forGate: false,
+        events: sample,
+        nodeId: 'clarify-1',
+        applyClarify,
+      }),
+    ).toBe('buffer')
+    expect(applyClarify).toHaveBeenCalledWith(sample, 'clarify-1')
+  })
+
+  it('marks applied when clarify apply succeeds (void/true)', () => {
+    const applyClarify = vi.fn(() => undefined)
+    expect(
+      deliverOrBufferDialogueAcp({
+        forClarify: true,
+        forGate: false,
+        events: sample,
+        nodeId: 'clarify-1',
+        applyClarify,
+      }),
+    ).toBe('applied')
+  })
+
+  it('applies gate and buffers clarify when only gate ready', () => {
+    const applyGate = vi.fn(() => true)
+    const applyClarify = vi.fn(() => false)
+    expect(
+      deliverOrBufferDialogueAcp({
+        forClarify: true,
+        forGate: true,
+        events: sample,
+        nodeId: 'producer',
+        applyClarify,
+        applyGate,
+      }),
+    ).toBe('applied')
+    expect(applyGate).toHaveBeenCalled()
+  })
+
+  it('buffers when both apply helpers report not ready', () => {
+    expect(
+      deliverOrBufferDialogueAcp({
+        forClarify: true,
+        forGate: true,
+        events: sample,
+        nodeId: 'producer',
+        applyClarify: () => false,
+        applyGate: () => false,
+      }),
+    ).toBe('buffer')
+  })
+})

--- a/web/src/lib/dialogueAcpDelivery.ts
+++ b/web/src/lib/dialogueAcpDelivery.ts
@@ -1,0 +1,28 @@
+import type { AcpEvent } from './types'
+
+export type DialogueAcpApplyResult = 'applied' | 'buffer'
+
+/**
+ * Deliver cumulative ACP to clarify and/or gate surfaces.
+ * `apply*` must return false when the inner chat/gate is not ready
+ * (e.g. ReviewComposer wrapping ClarifyChat before mount); undefined/true = ok.
+ */
+export function deliverOrBufferDialogueAcp(opts: {
+  forClarify: boolean
+  forGate: boolean
+  events: AcpEvent[]
+  nodeId: string
+  applyClarify?: (events: AcpEvent[], nodeId: string) => boolean | void
+  applyGate?: (events: AcpEvent[]) => boolean | void
+}): DialogueAcpApplyResult {
+  const { forClarify, forGate, events, nodeId } = opts
+  if (!forClarify && !forGate) return 'buffer'
+  let applied = false
+  if (forClarify && opts.applyClarify) {
+    if (opts.applyClarify(events, nodeId) !== false) applied = true
+  }
+  if (forGate && opts.applyGate) {
+    if (opts.applyGate(events) !== false) applied = true
+  }
+  return applied ? 'applied' : 'buffer'
+}

--- a/web/src/lib/inboxContext.ts
+++ b/web/src/lib/inboxContext.ts
@@ -1,10 +1,14 @@
-import type { Artifact, ClarifyTurn, NodeRun, Run, WFNode } from './types'
+import type { Artifact, ClarifyTurn, Gate, NodeRun, Run, WFNode } from './types'
 
 export type GateInboxContext = {
   type: 'gate'
   nodes: WFNode[]
   artifacts: Artifact[]
   nodeExecutions: Record<string, NodeRun[]>
+  /** Authoritative busy/queue for Inbox gate hard-refresh resume. */
+  reactSessions?: Run['reactSessions']
+  /** Gate DTO subset (reactUpstream / sessionAlive) for hot-revise seed. */
+  gate?: Gate
 }
 
 export type ClarifyInboxContext = {
@@ -50,6 +54,8 @@ export function adaptInboxContextToRun(ctx: InboxContextResponse, runId: string)
       nodes: ctx.nodes,
       artifacts: ctx.artifacts,
       nodeExecutions: ctx.nodeExecutions,
+      reactSessions: ctx.reactSessions,
+      gate: ctx.gate,
     }
   }
 

--- a/web/src/lib/pendingAcpBuffer.test.ts
+++ b/web/src/lib/pendingAcpBuffer.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { createPendingAcpBuffer, pickAcpRails } from './pendingAcpBuffer'
+
+describe('pickAcpRails', () => {
+  it('returns empty rails for missing events', () => {
+    expect(pickAcpRails(undefined)).toEqual({ thought: '', message: '' })
+    expect(pickAcpRails([])).toEqual({ thought: '', message: '' })
+  })
+
+  it('keeps last cumulative thought and message', () => {
+    expect(
+      pickAcpRails([
+        { kind: 'thought', text: 't1', t: 1 },
+        { kind: 'thought', text: 't1 extended', t: 2 },
+        { kind: 'message', text: 'm1', t: 3 },
+        { kind: 'tool_call', text: 'read', t: 4 },
+        { kind: 'message', text: 'm1 more', t: 5 },
+      ]),
+    ).toEqual({ thought: 't1 extended', message: 'm1 more' })
+  })
+})
+
+describe('createPendingAcpBuffer', () => {
+  it('keeps latest cumulative events per nodeId', () => {
+    const buf = createPendingAcpBuffer()
+    buf.push({
+      nodeId: 'n1',
+      events: [{ kind: 'thought', text: 'a', t: 1 }],
+      busy: true,
+    })
+    buf.push({
+      nodeId: 'n1',
+      events: [
+        { kind: 'thought', text: 'ab', t: 2 },
+        { kind: 'message', text: 'hi', t: 3 },
+      ],
+      busy: true,
+    })
+    buf.push({ nodeId: 'n2', events: [{ kind: 'message', text: 'other', t: 1 }] })
+    expect(buf.size).toBe(2)
+    const all = buf.takeAll()
+    expect(all).toHaveLength(2)
+    const n1 = all.find((f) => f.nodeId === 'n1')!
+    expect(pickAcpRails(n1.events)).toEqual({ thought: 'ab', message: 'hi' })
+    expect(buf.size).toBe(0)
+  })
+
+  it('empty event frame preserves prior rails but can update busy', () => {
+    const buf = createPendingAcpBuffer()
+    buf.push({
+      nodeId: 'n1',
+      events: [{ kind: 'thought', text: 'keep', t: 1 }],
+      busy: true,
+    })
+    buf.push({ nodeId: 'n1', events: [], busy: false })
+    const [f] = buf.peekAll()
+    expect(pickAcpRails(f.events).thought).toBe('keep')
+    expect(f.busy).toBe(false)
+  })
+})

--- a/web/src/lib/pendingAcpBuffer.ts
+++ b/web/src/lib/pendingAcpBuffer.ts
@@ -1,0 +1,77 @@
+import type { AcpEvent } from './types'
+
+/** One WS ACP frame buffered while the dialogue surface is unmounted. */
+export type PendingAcpFrame = {
+  nodeId?: string
+  events: AcpEvent[]
+  busy?: boolean
+}
+
+/**
+ * Extract cumulative thought/message rails from an ACP event list.
+ * Later same-kind events overwrite (platform pushes cumulative snapshots).
+ */
+export function pickAcpRails(events: readonly AcpEvent[] | undefined | null): {
+  thought: string
+  message: string
+} {
+  let thought = ''
+  let message = ''
+  if (!events?.length) return { thought, message }
+  for (const ev of events) {
+    if (ev.kind === 'thought' && ev.text) thought = ev.text
+    if (ev.kind === 'message' && ev.text) message = ev.text
+  }
+  return { thought, message }
+}
+
+/**
+ * Buffer latest cumulative ACP per nodeId while ClarifyChat/GateApproval is gone
+ * (Inbox hard load / RunDetail remount). Empty event frames still update busy
+ * metadata but do not wipe a prior non-empty buffer for that node.
+ */
+export function createPendingAcpBuffer() {
+  const byNode = new Map<string, PendingAcpFrame>()
+  let anonymous: PendingAcpFrame | null = null
+
+  function keyOf(nodeId?: string): string {
+    return nodeId && nodeId.length > 0 ? nodeId : ''
+  }
+
+  return {
+    push(frame: PendingAcpFrame) {
+      const key = keyOf(frame.nodeId)
+      const prev = key ? byNode.get(key) : anonymous
+      const next: PendingAcpFrame = {
+        nodeId: frame.nodeId,
+        events: frame.events?.length ? frame.events : prev?.events ?? [],
+        busy: typeof frame.busy === 'boolean' ? frame.busy : prev?.busy,
+      }
+      if (key) byNode.set(key, next)
+      else anonymous = next
+    },
+    takeAll(): PendingAcpFrame[] {
+      const out: PendingAcpFrame[] = []
+      if (anonymous) out.push(anonymous)
+      for (const f of byNode.values()) out.push(f)
+      anonymous = null
+      byNode.clear()
+      return out
+    },
+    peekAll(): PendingAcpFrame[] {
+      const out: PendingAcpFrame[] = []
+      if (anonymous) out.push(anonymous)
+      for (const f of byNode.values()) out.push(f)
+      return out
+    },
+    clear() {
+      anonymous = null
+      byNode.clear()
+    },
+    get size() {
+      return byNode.size + (anonymous ? 1 : 0)
+    },
+  }
+}
+
+export type PendingAcpBuffer = ReturnType<typeof createPendingAcpBuffer>

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -1655,6 +1655,7 @@
       "thinkingBusy": "Thinking…",
       "outputting": "Writing",
       "thought": "Thought process",
+      "turnCompleted": "Done",
       "done": "Interaction complete — continuing",
       "closed": "Run ended — interaction closed",
       "addImage": "Add image",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -1655,6 +1655,7 @@
       "thinkingBusy": "思考中…",
       "outputting": "输出中",
       "thought": "思考过程",
+      "turnCompleted": "已完成",
       "done": "交互已完成，进入下一步",
       "closed": "该运行已结束，交互已关闭",
       "addImage": "添加图片",

--- a/web/src/views/GatesInboxView.inboxLifecycle.test.ts
+++ b/web/src/views/GatesInboxView.inboxLifecycle.test.ts
@@ -151,6 +151,22 @@ class FakeWebSocket {
 const GateApprovalStub = defineComponent({
   name: 'GateApproval',
   emits: ['resolve', 'react-revised'],
+  setup(_, { expose }) {
+    expose({
+      isEditing: false,
+      applyReviewFrame: (f: Record<string, unknown>) => {
+        composerFrames.applied.push(f)
+        if (f.event === 'turn_begin') composerFrames.busy = true
+        if (f.event === 'turn_done' || f.event === 'error') composerFrames.busy = false
+        if (f.event === 'queue_state' && typeof f.busy === 'boolean') composerFrames.busy = !!f.busy
+      },
+      applyAcpEvents: (events: unknown) => {
+        composerFrames.acp.push({ events })
+      },
+      cancelReactRevise: () => {},
+    })
+    return {}
+  },
   template: '<button data-testid="resolve-btn" @click="$emit(\'resolve\', \'approve\', {})">resolve</button>',
 })
 
@@ -1199,6 +1215,97 @@ describe('GatesInboxView inbox-context lifecycle', () => {
     })
     expect(seeded).toBe(true)
     expect(mocks.nodeEvents).toHaveBeenCalledWith('run-acp-race', 'clarify-acp-race', expect.anything())
+    wrapper.unmount()
+  })
+
+  it('gate hard load: early ACP is buffered and seeded after mount (g4.2 gate parity)', async () => {
+    const item = gateItem('acp-gate')
+    mocks.listGates.mockResolvedValue(paged([item]))
+    mocks.nodeEvents.mockResolvedValue({
+      events: [{ kind: 'thought', text: 'REST gate thought', t: 1 }],
+      live: true,
+    })
+
+    let releaseContext!: (v: unknown) => void
+    const hung = new Promise((resolve) => {
+      releaseContext = resolve
+    })
+    mocks.inboxContext.mockImplementationOnce(() => hung as Promise<unknown>)
+
+    const wrapper = mountInbox()
+    await flushPromises()
+    await nextTick()
+
+    const ws = FakeWebSocket.instances.find((w) => w.url.includes('run-acp-gate'))
+    expect(ws).toBeTruthy()
+    expect(wrapper.find('[data-testid="resolve-btn"]').exists()).toBe(false)
+
+    ws!.emit('acp', {
+      nodeId: 'visual-producer',
+      busy: true,
+      events: [
+        { kind: 'thought', text: 'buffered gate thought', t: 1 },
+        { kind: 'message', text: 'buffered gate message', t: 2 },
+      ],
+    })
+    await flushPromises()
+    expect(composerFrames.acp.length).toBe(0)
+
+    releaseContext({
+      type: 'gate',
+      nodes: [
+        { id: 'visual-producer', type: 'visual', label: '视觉' },
+        { id: 'gate-acp-gate', type: 'human_gate', label: '审批' },
+      ],
+      artifacts: [],
+      nodeExecutions: {},
+      reactSessions: {
+        'visual-producer': {
+          kind: 'review',
+          waiting: 0,
+          busy: true,
+          items: [],
+          activeItem: { id: 'q-a', text: '热修提问' },
+        },
+      },
+      gate: {
+        runId: 'run-acp-gate',
+        nodeId: 'gate-acp-gate',
+        iteration: 1,
+        title: 'Gate acp-gate',
+        bodyMd: '',
+        actions: [{ id: 'approve', label: 'Approve' }],
+        reactUpstreamNodeId: 'visual-producer',
+        reactSessionAlive: true,
+        requestedAt: new Date().toISOString(),
+      },
+    })
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="resolve-btn"]').exists()).toBe(true)
+    expect(composerFrames.acp.length).toBeGreaterThanOrEqual(1)
+    const seeded = composerFrames.acp.some((a) => {
+      const ev = a.events as { kind?: string; text?: string }[] | undefined
+      if (!Array.isArray(ev)) return false
+      return ev.some(
+        (e) =>
+          (e.kind === 'thought' &&
+            (e.text === 'buffered gate thought' || e.text === 'REST gate thought')) ||
+          (e.kind === 'message' && e.text === 'buffered gate message'),
+      )
+    })
+    expect(seeded).toBe(true)
+    expect(mocks.nodeEvents).toHaveBeenCalledWith(
+      'run-acp-gate',
+      'visual-producer',
+      expect.anything(),
+    )
+    const queueFrames = composerFrames.applied.filter((f) => f.event === 'queue_state')
+    expect(queueFrames.length).toBeGreaterThanOrEqual(1)
     wrapper.unmount()
   })
 })

--- a/web/src/views/GatesInboxView.inboxLifecycle.test.ts
+++ b/web/src/views/GatesInboxView.inboxLifecycle.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   inboxContext: vi.fn(),
   resumeGate: vi.fn(),
   reactReply: vi.fn(),
+  nodeEvents: vi.fn(),
   runEventsWsUrl: vi.fn((id: string) => `ws://test/runs/${id}/events`),
   toastError: vi.fn(),
   toastSuccess: vi.fn(),
@@ -27,6 +28,7 @@ vi.mock('@/lib/api', async () => {
       inboxContext: mocks.inboxContext,
       resumeGate: mocks.resumeGate,
       reactReply: mocks.reactReply,
+      nodeEvents: mocks.nodeEvents,
       runEventsWsUrl: mocks.runEventsWsUrl,
     },
   }
@@ -152,9 +154,10 @@ const GateApprovalStub = defineComponent({
   template: '<button data-testid="resolve-btn" @click="$emit(\'resolve\', \'approve\', {})">resolve</button>',
 })
 
-/** Captures applyReviewFrame for hard-load / early-WS restore assertions (review v1). */
+/** Captures applyReviewFrame / applyAcpEvents for hard-load restore assertions. */
 const composerFrames = vi.hoisted(() => ({
   applied: [] as Record<string, unknown>[],
+  acp: [] as { events: unknown; nodeId?: string }[],
   busy: false,
 }))
 
@@ -169,7 +172,9 @@ const ReviewComposerStub = defineComponent({
         if (f.event === 'turn_done' || f.event === 'error') composerFrames.busy = false
         if (f.event === 'queue_state' && typeof f.busy === 'boolean') composerFrames.busy = !!f.busy
       },
-      applyAcpEvents: () => {},
+      applyAcpEvents: (events: unknown, nodeId?: string) => {
+        composerFrames.acp.push({ events, nodeId })
+      },
       discardLastQueued: () => {},
       isSessionBusy: () => composerFrames.busy,
     })
@@ -232,11 +237,13 @@ function inboxCallsFor(runId: string, nodeId: string, iteration = 1) {
 beforeEach(async () => {
   vi.clearAllMocks()
   composerFrames.applied = []
+  composerFrames.acp = []
   composerFrames.busy = false
   FakeWebSocket.instances = []
   vi.stubGlobal('WebSocket', FakeWebSocket as unknown as typeof WebSocket)
   mocks.resumeGate.mockResolvedValue({ status: 'ok' })
   mocks.reactReply.mockResolvedValue({ status: 'ok' })
+  mocks.nodeEvents.mockResolvedValue({ events: [], live: false })
   if (filterState.pipelineSelected) filterState.pipelineSelected.value = ''
   if (filterState.projectSelected) filterState.projectSelected.value = ''
   // Reset singleton so each test starts from an empty pending badge/list.
@@ -1112,6 +1119,86 @@ describe('GatesInboxView inbox-context lifecycle', () => {
     expect(last.busy).toBe(true)
     expect(last.activeItem?.text).toBe('甲')
     expect(last.items?.some((it) => it.text === '乙')).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('clarify hard load: early ACP is buffered and seeded after mount (g4.2 hard gate)', async () => {
+    const item = clarifyItem('acp-race')
+    mocks.listGates.mockResolvedValue(paged([item]))
+    mocks.nodeEvents.mockResolvedValue({
+      events: [{ kind: 'thought', text: 'REST seed thought', t: 1 }],
+      live: true,
+    })
+
+    let releaseContext!: (v: unknown) => void
+    const hung = new Promise((resolve) => {
+      releaseContext = resolve
+    })
+    mocks.inboxContext.mockImplementationOnce(() => hung as Promise<unknown>)
+
+    const wrapper = mountInbox()
+    await flushPromises()
+    await nextTick()
+
+    const ws = FakeWebSocket.instances.find((w) => w.url.includes('run-acp-race'))
+    expect(ws).toBeTruthy()
+    expect(wrapper.find('[data-testid="review-composer-stub"]').exists()).toBe(false)
+
+    // ACP arrives while chat unmounted — must buffer (not drop).
+    ws!.emit('acp', {
+      nodeId: 'clarify-acp-race',
+      busy: true,
+      events: [
+        { kind: 'thought', text: 'buffered thought', t: 1 },
+        { kind: 'message', text: 'buffered message', t: 2 },
+      ],
+    })
+    await flushPromises()
+    expect(composerFrames.acp.length).toBe(0)
+
+    releaseContext({
+      type: 'clarify',
+      status: 'waiting_human',
+      nodes: [{ id: 'clarify-acp-race', type: 'react', label: '澄清' }],
+      artifacts: [],
+      nodeExecutions: {},
+      reactSessions: {
+        'clarify-acp-race': {
+          kind: 'clarify',
+          waiting: 0,
+          busy: true,
+          items: [],
+          activeItem: { id: 'q-a', text: '硬刷新提问' },
+        },
+      },
+      clarify: {
+        nodeId: 'clarify-acp-race',
+        iteration: 1,
+        turns: [],
+        done: false,
+        label: '澄清',
+      },
+    })
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="review-composer-stub"]').exists()).toBe(true)
+    // REST seed and/or buffered WS ACP applied after busy slot rebuild.
+    expect(composerFrames.acp.length).toBeGreaterThanOrEqual(1)
+    const seeded = composerFrames.acp.some((a) => {
+      const ev = a.events as { kind?: string; text?: string }[] | undefined
+      if (!Array.isArray(ev)) return false
+      return ev.some(
+        (e) =>
+          (e.kind === 'thought' && (e.text === 'buffered thought' || e.text === 'REST seed thought')) ||
+          (e.kind === 'message' && e.text === 'buffered message'),
+      )
+    })
+    expect(seeded).toBe(true)
+    expect(mocks.nodeEvents).toHaveBeenCalledWith('run-acp-race', 'clarify-acp-race', expect.anything())
     wrapper.unmount()
   })
 })

--- a/web/src/views/GatesInboxView.vue
+++ b/web/src/views/GatesInboxView.vue
@@ -41,8 +41,9 @@ import {
   pickNextActiveAfterRemove,
 } from '@/lib/inboxActiveSelection'
 import { isAbortError } from '@/lib/liveLogRehydrate'
+import { createPendingAcpBuffer } from '@/lib/pendingAcpBuffer'
 import { useToast } from '@/lib/useToast'
-import type { Gate, InboxItem, Run } from '@/lib/types'
+import type { AcpEvent, Gate, InboxItem, Run } from '@/lib/types'
 
 const router = useRouter()
 const route = useRoute()
@@ -87,6 +88,11 @@ const reviewChatRef = ref<{
  * (hard loadActiveRun nulls activeRun → ReviewComposer gone). Flushed after mount.
  */
 let pendingReviewFrames: Record<string, unknown>[] = []
+/**
+ * ACP frames during the same hard-load window (parity with review buffer).
+ * Latest cumulative events per nodeId; flushed after busy slot rebuild.
+ */
+const pendingAcpFrames = createPendingAcpBuffer()
 /** Snapshot reactSessions stashed when activeRun is still null during hard load. */
 let pendingSnapshotSessions: Run['reactSessions'] | null = null
 const { selected } = usePipelineFilter()
@@ -484,7 +490,55 @@ function closeActiveRunWs() {
   activeRunWsRunId = ''
   clarifyLiveBusy.value = false
   pendingReviewFrames = []
+  pendingAcpFrames.clear()
   pendingSnapshotSessions = null
+}
+
+/** Deliver ACP to chat/gate, or buffer until ClarifyChat remounts after hard load. */
+function applyOrBufferAcpFrame(m: {
+  nodeId?: string
+  events?: AcpEvent[]
+  busy?: boolean
+}) {
+  const events = m.events
+  const nodeId = m.nodeId
+  gateApprovalRef.value?.applyAcpEvents?.(events)
+  if (reviewChatRef.value?.applyAcpEvents) {
+    reviewChatRef.value.applyAcpEvents(events, nodeId)
+    return
+  }
+  // Hard-load race: chat unmounted — keep latest cumulative ACP for seed-then-live.
+  if (active.value?.type === 'clarify' || active.value?.type === 'gate') {
+    pendingAcpFrames.push({
+      nodeId,
+      events: Array.isArray(events) ? events : [],
+      busy: m.busy,
+    })
+  }
+}
+
+function flushPendingAcpFrames() {
+  if (!pendingAcpFrames.size) return
+  const frames = pendingAcpFrames.takeAll()
+  for (const frame of frames) {
+    gateApprovalRef.value?.applyAcpEvents?.(frame.events)
+    reviewChatRef.value?.applyAcpEvents?.(frame.events, frame.nodeId)
+  }
+}
+
+/**
+ * Best-effort REST seed from LiveNodeEvents / persisted snapshot after busy
+ * slot rebuild (authoritative when WS chunks were dropped mid hard-load).
+ */
+async function seedClarifyAcpFromNodeEvents(runId: string, nodeId: string) {
+  try {
+    const r = await api.nodeEvents(runId, nodeId, { limit: 50 })
+    if (!r.events?.length) return
+    gateApprovalRef.value?.applyAcpEvents?.(r.events)
+    reviewChatRef.value?.applyAcpEvents?.(r.events, nodeId)
+  } catch {
+    /* seed is best-effort; live WS continues */
+  }
 }
 
 /** Project authoritative busy/queue onto ClarifyChat (RunDetail.restoreReactSessions parity). */
@@ -536,12 +590,21 @@ function applyOrBufferReviewFrame(m: Record<string, unknown>) {
 /**
  * After hard load / soft refresh: project reactSessions + flush frames buffered
  * while ReviewComposer was unmounted (WS Broadcast race).
+ * Order: queue_state rebuilds streaming slot → seed REST/buffered ACP → live.
  */
 async function projectClarifySessionAfterLoad(r: Run) {
   await nextTick()
   restoreReactSessions(r)
   await nextTick()
   flushPendingReviewFrames()
+  await nextTick()
+  const nodeId = active.value?.type === 'clarify' ? active.value.nodeId : null
+  const snap = nodeId ? r.reactSessions?.[nodeId] : null
+  if (nodeId && snap?.busy && active.value?.runId) {
+    await seedClarifyAcpFromNodeEvents(active.value.runId, nodeId)
+    await nextTick()
+  }
+  flushPendingAcpFrames()
 }
 
 function connectActiveRunWs(runId: string) {
@@ -601,12 +664,7 @@ function connectActiveRunWs(runId: string) {
     }
     if (m.type === 'acp') {
       if (typeof m.busy === 'boolean') clarifyLiveBusy.value = !!m.busy
-      const nodeId = (m as { nodeId?: string }).nodeId
-      gateApprovalRef.value?.applyAcpEvents?.(m.events)
-      if (reviewChatRef.value?.applyAcpEvents) {
-        reviewChatRef.value.applyAcpEvents(m.events, nodeId)
-      }
-      // ACP chunks need a live bubble; no buffer — restore+queue_state recreates it.
+      applyOrBufferAcpFrame(m as { nodeId?: string; events?: AcpEvent[]; busy?: boolean })
       return
     }
     if (m.type === 'artifact_edit' || m.type === 'react' || m.type === 'trace' || m.type === 'status') {
@@ -696,6 +754,7 @@ async function loadActiveRun(hard = true) {
     activeRunLoading.value = true
     // Chat unmounts — clear stale buffer for this load cycle (WS may refill).
     pendingReviewFrames = []
+    pendingAcpFrames.clear()
   }
   let projectAfterLoad = false
   try {

--- a/web/src/views/GatesInboxView.vue
+++ b/web/src/views/GatesInboxView.vue
@@ -78,8 +78,8 @@ const listScrollTop = ref(0)
 const listEl = ref<HTMLElement | null>(null)
 const gateApprovalRef = ref<InstanceType<typeof GateApproval> | null>(null)
 const reviewChatRef = ref<{
-  applyReviewFrame?: (frame: any) => void
-  applyAcpEvents?: (events: any[] | undefined, nodeId?: string) => void
+  applyReviewFrame?: (frame: any) => boolean | void
+  applyAcpEvents?: (events: any[] | undefined, nodeId?: string) => boolean | void
   discardLastQueued?: () => void
   isSessionBusy?: () => boolean
 } | null>(null)
@@ -494,7 +494,21 @@ function closeActiveRunWs() {
   pendingSnapshotSessions = null
 }
 
-/** Deliver ACP to chat/gate, or buffer until ClarifyChat remounts after hard load. */
+/** Producer nodeId for busy session restore (clarify node or gate react upstream). */
+function activeDialogueNodeId(r?: Run | null): string | null {
+  if (active.value?.type === 'clarify') return active.value.nodeId
+  if (active.value?.type === 'gate') {
+    return (
+      r?.gate?.reactUpstreamNodeId ||
+      activeRun.value?.gate?.reactUpstreamNodeId ||
+      (active.value as Gate).reactUpstreamNodeId ||
+      null
+    )
+  }
+  return null
+}
+
+/** Deliver ACP to chat/gate, or buffer until surface remounts after hard load. */
 function applyOrBufferAcpFrame(m: {
   nodeId?: string
   events?: AcpEvent[]
@@ -502,13 +516,17 @@ function applyOrBufferAcpFrame(m: {
 }) {
   const events = m.events
   const nodeId = m.nodeId
-  gateApprovalRef.value?.applyAcpEvents?.(events)
-  if (reviewChatRef.value?.applyAcpEvents) {
-    reviewChatRef.value.applyAcpEvents(events, nodeId)
-    return
+  let applied = false
+  if (gateApprovalRef.value?.applyAcpEvents) {
+    gateApprovalRef.value.applyAcpEvents(events)
+    applied = true
   }
-  // Hard-load race: chat unmounted — keep latest cumulative ACP for seed-then-live.
-  if (active.value?.type === 'clarify' || active.value?.type === 'gate') {
+  if (reviewChatRef.value?.applyAcpEvents) {
+    const ok = reviewChatRef.value.applyAcpEvents(events, nodeId)
+    if (ok !== false) applied = true
+  }
+  // Hard-load race: surface unmounted — keep latest cumulative ACP for seed-then-live.
+  if (!applied && (active.value?.type === 'clarify' || active.value?.type === 'gate')) {
     pendingAcpFrames.push({
       nodeId,
       events: Array.isArray(events) ? events : [],
@@ -541,9 +559,9 @@ async function seedClarifyAcpFromNodeEvents(runId: string, nodeId: string) {
   }
 }
 
-/** Project authoritative busy/queue onto ClarifyChat (RunDetail.restoreReactSessions parity). */
-function restoreReactSessions(r: { reactSessions?: Run['reactSessions'] } | null) {
-  const nodeId = active.value?.type === 'clarify' ? active.value.nodeId : null
+/** Project authoritative busy/queue onto ClarifyChat / GateApproval. */
+function restoreReactSessions(r: { reactSessions?: Run['reactSessions']; gate?: Run['gate'] } | null) {
+  const nodeId = activeDialogueNodeId(r as Run | null)
   if (!nodeId) return
   const sessions = r?.reactSessions ?? pendingSnapshotSessions
   if (!sessions) return
@@ -558,11 +576,16 @@ function restoreReactSessions(r: { reactSessions?: Run['reactSessions'] } | null
     busy: !!snap.busy,
     activeItem: snap.activeItem,
   }
-  if (reviewChatRef.value?.applyReviewFrame) {
-    reviewChatRef.value.applyReviewFrame(frame)
-  } else {
-    pendingReviewFrames.push(frame)
+  let delivered = false
+  if (active.value?.type === 'gate' && gateApprovalRef.value?.applyReviewFrame) {
+    gateApprovalRef.value.applyReviewFrame(frame)
+    delivered = true
   }
+  if (reviewChatRef.value?.applyReviewFrame) {
+    const ok = reviewChatRef.value.applyReviewFrame(frame)
+    if (ok !== false) delivered = true
+  }
+  if (!delivered) pendingReviewFrames.push(frame)
   pendingSnapshotSessions = null
 }
 
@@ -571,26 +594,32 @@ function flushPendingReviewFrames() {
   const frames = pendingReviewFrames
   pendingReviewFrames = []
   for (const frame of frames) {
+    gateApprovalRef.value?.applyReviewFrame?.(frame)
     reviewChatRef.value?.applyReviewFrame?.(frame)
   }
 }
 
-/** Deliver review frame to chat, or buffer until ClarifyChat remounts after hard load. */
+/** Deliver review frame to chat/gate, or buffer until surface remounts after hard load. */
 function applyOrBufferReviewFrame(m: Record<string, unknown>) {
-  gateApprovalRef.value?.applyReviewFrame?.(m)
-  if (reviewChatRef.value?.applyReviewFrame) {
-    reviewChatRef.value.applyReviewFrame(m)
-    return
+  let applied = false
+  if (gateApprovalRef.value?.applyReviewFrame) {
+    gateApprovalRef.value.applyReviewFrame(m)
+    applied = true
   }
-  if (active.value?.type === 'clarify') {
+  if (reviewChatRef.value?.applyReviewFrame) {
+    const ok = reviewChatRef.value.applyReviewFrame(m)
+    if (ok !== false) applied = true
+  }
+  if (!applied && (active.value?.type === 'clarify' || active.value?.type === 'gate')) {
     pendingReviewFrames.push(m)
   }
 }
 
 /**
- * After hard load / soft refresh: project reactSessions + flush frames buffered
- * while ReviewComposer was unmounted (WS Broadcast race).
+ * After hard load: project reactSessions + flush frames buffered while
+ * ReviewComposer / GateApproval was unmounted (WS Broadcast race).
  * Order: queue_state rebuilds streaming slot → seed REST/buffered ACP → live.
+ * Covers clarify and gate (review v1 / g2).
  */
 async function projectClarifySessionAfterLoad(r: Run) {
   await nextTick()
@@ -598,7 +627,7 @@ async function projectClarifySessionAfterLoad(r: Run) {
   await nextTick()
   flushPendingReviewFrames()
   await nextTick()
-  const nodeId = active.value?.type === 'clarify' ? active.value.nodeId : null
+  const nodeId = activeDialogueNodeId(r)
   const snap = nodeId ? r.reactSessions?.[nodeId] : null
   if (nodeId && snap?.busy && active.value?.runId) {
     await seedClarifyAcpFromNodeEvents(active.value.runId, nodeId)
@@ -639,7 +668,11 @@ function connectActiveRunWs(runId: string) {
     // WS connect snapshot may carry reactSessions before BroadcastReviewSessions.
     if (m.type === 'snapshot') {
       const sessions = m.run?.reactSessions
-      if (sessions && active.value?.type === 'clarify' && active.value.runId === runId) {
+      const dialogueActive =
+        active.value &&
+        (active.value.type === 'clarify' || active.value.type === 'gate') &&
+        active.value.runId === runId
+      if (sessions && dialogueActive) {
         if (activeRun.value) {
           activeRun.value = { ...activeRun.value, reactSessions: sessions }
           void nextTick(() => {
@@ -763,8 +796,8 @@ async function loadActiveRun(hard = true) {
     if (isProcessedTriple(target)) return
     activeRun.value = adaptInboxContextToRun(ctx, target.runId)
     activeRunLoadError.value = false
-    // Must project AFTER loading flag clears so ReviewComposer can mount.
-    projectAfterLoad = hard && target.type === 'clarify'
+    // Must project AFTER loading flag clears so ReviewComposer / GateApproval can mount.
+    projectAfterLoad = hard && (target.type === 'clarify' || target.type === 'gate')
   } catch (e) {
     if (isAbortError(e) || signal.aborted) return
     if (

--- a/web/src/views/RunDetailView.test.ts
+++ b/web/src/views/RunDetailView.test.ts
@@ -205,6 +205,7 @@ describe('RunDetailView ACP log rehydrate state machine', () => {
   it('keeps session snapshot cache across hard remount and WS does not clear error', () => {
     expect(src).toMatch(/from '@\/lib\/liveLogSnapshotCache'/)
     expect(src).toMatch(/from '@\/lib\/applyLiveWsAcpPage'/)
+    expect(src).toMatch(/from '@\/lib\/pendingAcpBuffer'/)
     expect(src).toMatch(/restoreEventPagesFromCache/)
     expect(src).toMatch(/clearLiveLogSnapshotsExceptRun/)
     expect(src).toMatch(/syncEventPageToCache/)
@@ -217,6 +218,10 @@ describe('RunDetailView ACP log rehydrate state machine', () => {
     // WS merge must not promote rehydrate / clear soft warn.
     expect(src).toMatch(/WS only merges into the snapshot/)
     expect(src).not.toMatch(/rehydrateByNode\[m\.nodeId\]\s*=\s*['"]ready['"]/)
+    // Seed-then-live: busy restore seeds dialogue ACP; hard-load buffers when chat gone.
+    expect(src).toMatch(/seedDialogueAcpAfterRestore/)
+    expect(src).toMatch(/applyOrBufferDialogueAcp/)
+    expect(src).toMatch(/pendingDialogueAcp/)
   })
 })
 

--- a/web/src/views/RunDetailView.test.ts
+++ b/web/src/views/RunDetailView.test.ts
@@ -222,6 +222,10 @@ describe('RunDetailView ACP log rehydrate state machine', () => {
     expect(src).toMatch(/seedDialogueAcpAfterRestore/)
     expect(src).toMatch(/applyOrBufferDialogueAcp/)
     expect(src).toMatch(/pendingDialogueAcp/)
+    expect(src).toMatch(/projectDialogueAfterLoad/)
+    expect(src).toMatch(/deliverOrBufferDialogueAcp/)
+    // Real delivery: applyAcpEvents returning false must buffer (ReviewComposer nest).
+    expect(src).toMatch(/if \(!reviewChatRef\.value\?\.applyAcpEvents\) return false/)
   })
 })
 

--- a/web/src/views/RunDetailView.vue
+++ b/web/src/views/RunDetailView.vue
@@ -46,6 +46,7 @@ import { pickDefaultTimelineNodeId } from '@/lib/runStats'
 import { PRODUCT_NODE_TYPES } from '@/lib/productNodeArtifacts'
 import { applyLiveWsAcpPage } from '@/lib/applyLiveWsAcpPage'
 import { mergeAcpEvents, type MergedAcpEvent } from '@/lib/mergeAcpEvents'
+import { createPendingAcpBuffer } from '@/lib/pendingAcpBuffer'
 import type { LiveLogBootSession } from '@/lib/liveLogBootPhase'
 import {
   isAbortError,
@@ -127,6 +128,11 @@ const gateApprovalRef = ref<{
   applyReviewFrame?: (frame: any) => void
   applyAcpEvents?: (events: AcpEvent[] | undefined) => void
 } | null>(null)
+/**
+ * ACP frames that arrived while ClarifyChat / GateApproval was unmounted
+ * during hard load. Flushed after queue_state rebuilds the streaming slot.
+ */
+const pendingDialogueAcp = createPendingAcpBuffer()
 const manual = ref(false)
 // Per-node fetch generation: discard stale REST responses so a slow empty
 // reply cannot overwrite a newer non-empty write-back.
@@ -331,6 +337,7 @@ function resetRunState(id: string) {
   clearReactiveRecord(liveLogBootSessions as Record<string, unknown>)
   clearReactiveRecord(rehydrateByNode as Record<string, unknown>)
   sandboxLookup.value = null
+  pendingDialogueAcp.clear()
   // Prefer cached timeline so re-entry is not blanked by loading/error UI.
   restoreEventPagesFromCache(id)
 }
@@ -387,19 +394,85 @@ async function fetchRunData(): Promise<true | RunLoadErrorKind> {
 function restoreReactSessions(r: { reactSessions?: Record<string, any> }) {
   const sessions = r.reactSessions
   if (!sessions) return
+  const busyNodes: string[] = []
   for (const [nodeId, snap] of Object.entries(sessions)) {
     if (!snap || typeof snap !== 'object') continue
     liveBusy[nodeId] = !!snap.busy
-    if (selClarify.value?.nodeId === nodeId) {
-      reviewChatRef.value?.applyReviewFrame?.({
-        event: 'queue_state',
-        nodeId,
-        waiting: snap.waiting ?? 0,
-        items: snap.items ?? [],
-        busy: !!snap.busy,
-        activeItem: snap.activeItem,
-      })
+    if (snap.busy) busyNodes.push(nodeId)
+    const frame = {
+      event: 'queue_state',
+      nodeId,
+      waiting: snap.waiting ?? 0,
+      items: snap.items ?? [],
+      busy: !!snap.busy,
+      activeItem: snap.activeItem,
     }
+    if (selClarify.value?.nodeId === nodeId) {
+      reviewChatRef.value?.applyReviewFrame?.(frame)
+    }
+    // Gate hot-revise shares the producer reactSessions key.
+    if (run.value.gate?.reactUpstreamNodeId === nodeId) {
+      gateApprovalRef.value?.applyReviewFrame?.(frame)
+    }
+  }
+  if (busyNodes.length) {
+    void seedDialogueAcpAfterRestore(busyNodes)
+  }
+}
+
+/**
+ * Seed-then-live: after busy slot rebuild, replay eventPages / nodeEvents into
+ * the dialogue surface, then flush any ACP buffered during hard-load remount.
+ */
+async function seedDialogueAcpAfterRestore(nodeIds: string[]) {
+  await nextTick()
+  for (const nodeId of nodeIds) {
+    let events = eventPages[nodeId]?.events as AcpEvent[] | undefined
+    if (!events?.length) {
+      await fetchNodeEvents(nodeId)
+      events = eventPages[nodeId]?.events as AcpEvent[] | undefined
+    }
+    if (events?.length) {
+      if (selClarify.value?.nodeId === nodeId) {
+        reviewChatRef.value?.applyAcpEvents?.(events, nodeId)
+      }
+      if (run.value.gate?.reactUpstreamNodeId === nodeId) {
+        gateApprovalRef.value?.applyAcpEvents?.(events)
+      }
+    }
+  }
+  await nextTick()
+  flushPendingDialogueAcp()
+}
+
+function flushPendingDialogueAcp() {
+  if (!pendingDialogueAcp.size) return
+  for (const frame of pendingDialogueAcp.takeAll()) {
+    reviewChatRef.value?.applyAcpEvents?.(frame.events, frame.nodeId)
+    gateApprovalRef.value?.applyAcpEvents?.(frame.events)
+  }
+}
+
+/** Deliver ACP to dialogue surfaces or buffer until they remount. */
+function applyOrBufferDialogueAcp(
+  nodeId: string,
+  events: AcpEvent[],
+  busy?: boolean,
+) {
+  const forClarify = selClarify.value?.nodeId === nodeId
+  const forGate = run.value.gate?.reactUpstreamNodeId === nodeId
+  if (!forClarify && !forGate) return
+  let applied = false
+  if (forClarify && reviewChatRef.value?.applyAcpEvents) {
+    reviewChatRef.value.applyAcpEvents(events, nodeId)
+    applied = true
+  }
+  if (forGate && gateApprovalRef.value?.applyAcpEvents) {
+    gateApprovalRef.value.applyAcpEvents(events)
+    applied = true
+  }
+  if (!applied) {
+    pendingDialogueAcp.push({ nodeId, events, busy })
   }
 }
 
@@ -517,12 +590,7 @@ function connectWs() {
       liveNode.value = m.nodeId
       if (!manual.value) selected.value = m.nodeId
       // Dialogue-surface stream (ClarifyChat / GateApproval), not only LiveLog.
-      if (selClarify.value?.nodeId === m.nodeId) {
-        reviewChatRef.value?.applyAcpEvents?.(wsEvents, m.nodeId)
-      }
-      if (run.value.gate?.reactUpstreamNodeId === m.nodeId) {
-        gateApprovalRef.value?.applyAcpEvents?.(wsEvents)
-      }
+      applyOrBufferDialogueAcp(m.nodeId, wsEvents, m.busy)
     } else if (m.type === 'review' && m.nodeId) {
       // Prefer matching producer; components also filter by nodeId defensively.
       if (m.event === 'turn_begin') liveBusy[m.nodeId] = true

--- a/web/src/views/RunDetailView.vue
+++ b/web/src/views/RunDetailView.vue
@@ -47,6 +47,7 @@ import { PRODUCT_NODE_TYPES } from '@/lib/productNodeArtifacts'
 import { applyLiveWsAcpPage } from '@/lib/applyLiveWsAcpPage'
 import { mergeAcpEvents, type MergedAcpEvent } from '@/lib/mergeAcpEvents'
 import { createPendingAcpBuffer } from '@/lib/pendingAcpBuffer'
+import { deliverOrBufferDialogueAcp } from '@/lib/dialogueAcpDelivery'
 import type { LiveLogBootSession } from '@/lib/liveLogBootPhase'
 import {
   isAbortError,
@@ -109,10 +110,11 @@ const liveBusy = reactive<Record<string, boolean>>({})
 const liveNode = ref<string | null>(null)
 /** ClarifyChat / ReviewComposer surface for review WS frames (queue/stream/Cancel). */
 const reviewChatRef = ref<{
-  applyReviewFrame?: (frame: any) => void
-  applyAcpEvents?: (events: AcpEvent[] | undefined, nodeId?: string) => void
+  applyReviewFrame?: (frame: any) => boolean | void
+  applyAcpEvents?: (events: AcpEvent[] | undefined, nodeId?: string) => boolean | void
   discardLastQueued?: () => void
   isSessionBusy?: () => boolean
+  isChatReady?: () => boolean
 } | null>(null)
 
 /** Clarify/review session in-flight: skip full-page loadRun (g3.2 / review v1). */
@@ -383,12 +385,22 @@ async function fetchRunData(): Promise<true | RunLoadErrorKind> {
     } else if (r.workflowId) {
       wf.value = await api.getWorkflow(r.workflowId)
     }
-    // Refresh-resume: project authoritative busy/queue into ClarifyChat.
-    nextTick(() => restoreReactSessions(r))
+    // Refresh-resume: wait for dialogue surfaces to mount, then project busy/queue.
+    void projectDialogueAfterLoad(r)
     return true
   } catch (err) {
     return classifyRunLoadError(err)
   }
+}
+
+/**
+ * Align Inbox hard-load: multi nextTick so ReviewComposer/GateApproval mount
+ * before queue_state → seed → flush (avoids false-applied empty forward).
+ */
+async function projectDialogueAfterLoad(r: { reactSessions?: Record<string, any> }) {
+  await nextTick()
+  await nextTick()
+  restoreReactSessions(r)
 }
 
 function restoreReactSessions(r: { reactSessions?: Record<string, any> }) {
@@ -408,7 +420,10 @@ function restoreReactSessions(r: { reactSessions?: Record<string, any> }) {
       activeItem: snap.activeItem,
     }
     if (selClarify.value?.nodeId === nodeId) {
-      reviewChatRef.value?.applyReviewFrame?.(frame)
+      const ok = reviewChatRef.value?.applyReviewFrame?.(frame)
+      if (ok === false) {
+        /* inner ClarifyChat not ready — seed path still buffers ACP */
+      }
     }
     // Gate hot-revise shares the producer reactSessions key.
     if (run.value.gate?.reactUpstreamNodeId === nodeId) {
@@ -417,6 +432,8 @@ function restoreReactSessions(r: { reactSessions?: Record<string, any> }) {
   }
   if (busyNodes.length) {
     void seedDialogueAcpAfterRestore(busyNodes)
+  } else {
+    void nextTick(() => flushPendingDialogueAcp())
   }
 }
 
@@ -433,12 +450,7 @@ async function seedDialogueAcpAfterRestore(nodeIds: string[]) {
       events = eventPages[nodeId]?.events as AcpEvent[] | undefined
     }
     if (events?.length) {
-      if (selClarify.value?.nodeId === nodeId) {
-        reviewChatRef.value?.applyAcpEvents?.(events, nodeId)
-      }
-      if (run.value.gate?.reactUpstreamNodeId === nodeId) {
-        gateApprovalRef.value?.applyAcpEvents?.(events)
-      }
+      applyOrBufferDialogueAcp(nodeId, events, true)
     }
   }
   await nextTick()
@@ -447,10 +459,31 @@ async function seedDialogueAcpAfterRestore(nodeIds: string[]) {
 
 function flushPendingDialogueAcp() {
   if (!pendingDialogueAcp.size) return
+  const leftover: { nodeId?: string; events: AcpEvent[]; busy?: boolean }[] = []
   for (const frame of pendingDialogueAcp.takeAll()) {
-    reviewChatRef.value?.applyAcpEvents?.(frame.events, frame.nodeId)
-    gateApprovalRef.value?.applyAcpEvents?.(frame.events)
+    const nodeId = frame.nodeId || ''
+    const forClarify = !!selClarify.value?.nodeId && (selClarify.value.nodeId === nodeId || !nodeId)
+    const forGate =
+      !!run.value.gate?.reactUpstreamNodeId &&
+      (run.value.gate.reactUpstreamNodeId === nodeId || !nodeId)
+    const result = deliverOrBufferDialogueAcp({
+      forClarify,
+      forGate,
+      events: frame.events,
+      nodeId: nodeId || selClarify.value?.nodeId || run.value.gate?.reactUpstreamNodeId || '',
+      applyClarify: (events, nid) => {
+        if (!reviewChatRef.value?.applyAcpEvents) return false
+        return reviewChatRef.value.applyAcpEvents(events, nid)
+      },
+      applyGate: (events) => {
+        if (!gateApprovalRef.value?.applyAcpEvents) return false
+        gateApprovalRef.value.applyAcpEvents(events)
+        return true
+      },
+    })
+    if (result === 'buffer') leftover.push(frame)
   }
+  for (const frame of leftover) pendingDialogueAcp.push(frame)
 }
 
 /** Deliver ACP to dialogue surfaces or buffer until they remount. */
@@ -461,17 +494,22 @@ function applyOrBufferDialogueAcp(
 ) {
   const forClarify = selClarify.value?.nodeId === nodeId
   const forGate = run.value.gate?.reactUpstreamNodeId === nodeId
-  if (!forClarify && !forGate) return
-  let applied = false
-  if (forClarify && reviewChatRef.value?.applyAcpEvents) {
-    reviewChatRef.value.applyAcpEvents(events, nodeId)
-    applied = true
-  }
-  if (forGate && gateApprovalRef.value?.applyAcpEvents) {
-    gateApprovalRef.value.applyAcpEvents(events)
-    applied = true
-  }
-  if (!applied) {
+  const result = deliverOrBufferDialogueAcp({
+    forClarify,
+    forGate,
+    events,
+    nodeId,
+    applyClarify: (evs, nid) => {
+      if (!reviewChatRef.value?.applyAcpEvents) return false
+      return reviewChatRef.value.applyAcpEvents(evs, nid)
+    },
+    applyGate: (evs) => {
+      if (!gateApprovalRef.value?.applyAcpEvents) return false
+      gateApprovalRef.value.applyAcpEvents(evs)
+      return true
+    },
+  })
+  if (result === 'buffer') {
     pendingDialogueAcp.push({ nodeId, events, busy })
   }
 }


### PR DESCRIPTION
## Summary
- Inbox/RunDetail 补齐 ACP seed-then-live：硬加载窗口缓冲 cumulative ACP，busy 槽位重建后 flush，并用 `nodeEvents`/eventPages 回放已有 thought/message。
- GateApproval 对齐 `busy+activeItem`（waiting 可为 0）续流态，继续消费 ACP。
- ClarifyChat 对齐 Demo 四阶段：占位 → 可折叠思考 → 输出中（文案+shimmer+光标）→ 克制完成脚注「已完成 · 相对时间」；thought 补 rAF 合并。

## Test plan
- [x] `vitest`：`pendingAcpBuffer`、`ClarifyChat`、`clarifySessionUx.probe`、`GatesInboxView.inboxLifecycle`（含 ACP 竞态）、`GateApproval` refresh resume、`RunDetailView` 源码探针
- [ ] e2e `clarify-session-ux`：`sim-hard-refresh-acp-race`、`sim-four-phase-complete`
- [ ] 手工：Run Clarify / Review / Inbox / GateApproval 在 busy 硬刷新后可见已有内容并续流


Made with [Cursor](https://cursor.com)