### PR TITLE
fix(sandbox): pin gopls + CI four-provider full image builds

### DIFF
--- a/.github/workflows/ci-sandbox.yml
+++ b/.github/workflows/ci-sandbox.yml
@@ -1,8 +1,8 @@
 name: ci-sandbox
 
 # Path-filtered suite for the universal sandbox image + its startup/scripts.
-# Full image publish still lives in publish-sandbox (v* tags); PR CI covers
-# scripts, Go packages, and the Dockerfile cli-tools stage (glab/gh).
+# PR CI: scripts/Go + cli-tools fast check + full final sandbox image build
+# for all four AGENT_PROVIDER values (aligned with publish-sandbox; push:false).
 on:
   push:
     paths:
@@ -120,3 +120,27 @@ jobs:
         run: |
           docker run --rm --entrypoint bash universal-sandbox-cli-tools:ci -lc \
             'command -v glab && glab --version && command -v gh && gh --version'
+
+  # Full final sandbox image for every provider (same context/file/build-args as
+  # publish-sandbox). No --target: must catch gopls + AGENT_PROVIDER layers.
+  # fail-fast:false shows all failures; any matrix failure still fails the job.
+  sandbox-images:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: [cursor, claude_code, codebuddy, trae]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v4
+      - name: Build final sandbox image (${{ matrix.provider }})
+        uses: docker/build-push-action@v7
+        with:
+          context: ./sandbox-gateway/sandbox
+          file: ./sandbox-gateway/sandbox/Dockerfile
+          push: false
+          tags: universal-sandbox-${{ matrix.provider }}:ci
+          build-args: |
+            AGENT_PROVIDER=${{ matrix.provider }}
+            BASE_IMAGE=ubuntu:22.04

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,12 @@ Pushing a `v*` tag runs:
 - `publish-gateway` → `ghcr.io/cocofhu/sandbox-gateway`
 - `publish-sandbox` → `ghcr.io/cocofhu/universal-sandbox-{cursor,claude_code,codebuddy,trae}`
 
+A release is complete only when all three workflows succeed, and
+`publish-sandbox` is green for every matrix provider
+(`cursor`, `claude_code`, `codebuddy`, `trae`). If any job fails, re-run the
+failed workflow via **Actions → workflow_dispatch** (e.g. re-run
+`publish-sandbox` for an existing `v*` tag such as `v0.0.3-beta`).
+
 Sandbox builds are large (often 30–90+ minutes). Packages may start private;
 set them Public under GitHub → Packages if anonymous pulls are required.
 

--- a/sandbox-gateway/sandbox/Dockerfile
+++ b/sandbox-gateway/sandbox/Dockerfile
@@ -223,8 +223,9 @@ RUN set -eux; \
 ENV PATH=$PATH:/usr/local/go/bin
 ENV GOPATH=/root/go
 ENV GOPROXY=https://goproxy.cn,direct
-# 预装 gopls
-RUN mkdir -p /root/go/bin && go install golang.org/x/tools/gopls@latest
+# 预装 gopls：钉 v0.21.1（go 1.25）对齐镜像 GO_VERSION；GOTOOLCHAIN=local 禁止 @latest 自动拉新 toolchain
+ENV GOTOOLCHAIN=local
+RUN mkdir -p /root/go/bin && go install golang.org/x/tools/gopls@v0.21.1
 ENV PATH=$PATH:/root/go/bin
 
 # Java


### PR DESCRIPTION
## Summary
- Pin `gopls@v0.21.1` with `GOTOOLCHAIN=local` in the sandbox Dockerfile so builds stay compatible with image Go 1.25 (no more `gopls@latest` / Go≥1.26 mismatch that broke `v0.0.3-beta` publish-sandbox for cursor/claude_code/trae).
- Add `ci-sandbox` matrix job `sandbox-images` that builds the **final** sandbox image for `cursor`, `claude_code`, `codebuddy`, and `trae` (same context/file/build-args as publish-sandbox, `push: false`, `timeout-minutes: 180`, `fail-fast: false`). Retains existing `cli-tools` fast check; any provider failure fails the workflow.
- Document in CONTRIBUTING that a `v*` release is complete only when publish-image / publish-gateway / publish-sandbox are all green, including the four-provider sandbox matrix; failed jobs can be re-run via workflow_dispatch.

## Test plan
- [x] PR `ci-sandbox` runs `cli-tools` and `sandbox-images` for all four providers
- [x] Confirm Dockerfile has no `gopls@latest`, uses `v0.21.1` + `GOTOOLCHAIN=local`, `GO_VERSION` still 1.25.0
- [x] Quality CI green → ready to squash-merge
- [ ] **After merge (ops follow-up, not hard AC):** Actions → `publish-sandbox` → workflow_dispatch re-run for tag `v0.0.3-beta`