### PR TITLE
fix(onboarding): allow onboarding_embed markdown in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,7 +23,9 @@ sandbox-gateway/
 .env
 .github/
 
-# 文档缩小上下文；但 skills_embed 里的 .md 必须进镜像(go:embed)
+# 文档缩小上下文；但 go:embed 依赖的 .md 必须进镜像
 **/*.md
 !server/internal/sandbox/skills_embed/
 !server/internal/sandbox/skills_embed/**/*.md
+!server/internal/services/onboarding_embed/
+!server/internal/services/onboarding_embed/**/*.md

--- a/server/internal/services/onboarding_embed_test.go
+++ b/server/internal/services/onboarding_embed_test.go
@@ -1,0 +1,42 @@
+package services
+
+import (
+	"io/fs"
+	"path"
+	"strings"
+	"testing"
+)
+
+// TestOnboardingEmbedFSHasWorkspaceMarkdown guards the GHCR regression where
+// .dockerignore excluded **/*.md and emptied go:embed workspaces.
+func TestOnboardingEmbedFSHasWorkspaceMarkdown(t *testing.T) {
+	for _, name := range OnboardingAgentNames {
+		root := path.Join(onboardingEmbedRoot, name, WorkDirName)
+		md := 0
+		err := fs.WalkDir(onboardingEmbedFS, root, func(p string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if strings.HasSuffix(p, ".md") {
+				md++
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("%s workspace walk: %v", name, err)
+		}
+		if md == 0 {
+			t.Fatalf("%s workspace has no .md files in embed FS (check .dockerignore allowlist)", name)
+		}
+		agent, err := loadOnboardingAgentTemplate(name)
+		if err != nil {
+			t.Fatalf("loadOnboardingAgentTemplate(%s): %v", name, err)
+		}
+		if len(agent.Files) == 0 {
+			t.Fatalf("%s template Files empty after embed load", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Allowlist `server/internal/services/onboarding_embed/**/*.md` in `.dockerignore` (same pattern as `skills_embed`) so `go:embed` workspaces are present in GHCR images
- Add embed FS regression test that workspace `.md` files load

## Test plan
- [x] `go test ./internal/services/ -run OnboardingEmbedFSHasWorkspaceMarkdown`
- [ ] After merge: retag `v0.0.4-beta` and wait `publish-image` green


Made with [Cursor](https://cursor.com)