### PR TITLE
fix(onboarding): clone repos and keep Studio agents clean

### DIFF
--- a/server/internal/runtime/acp_provider.go
+++ b/server/internal/runtime/acp_provider.go
@@ -2291,22 +2291,35 @@ func parseReposVar(v any) []repoEntry {
 			return nil
 		}
 		var repos []repoEntry
-		if json.Unmarshal([]byte(s), &repos) != nil {
+		if json.Unmarshal([]byte(s), &repos) == nil {
+			out := make([]repoEntry, 0, len(repos))
+			for _, r := range repos {
+				r.Name = strings.TrimSpace(r.Name)
+				r.URL = strings.TrimSpace(r.URL)
+				r.Branch = strings.TrimSpace(r.Branch)
+				// A blank name defaults to the repo derived from its clone URL.
+				if r.Name == "" {
+					r.Name = repoNameFromURL(r.URL)
+				}
+				if !safeRepoName(r.Name) {
+					continue
+				}
+				out = append(out, r)
+			}
+			return out
+		}
+		// Wire format used by GIT_REPOS / onboarding bootstrap literals:
+		// comma-separated name|url|branch.
+		wire := sandbox.DecodeRepos(s)
+		if len(wire) == 0 {
 			return nil
 		}
-		out := make([]repoEntry, 0, len(repos))
-		for _, r := range repos {
-			r.Name = strings.TrimSpace(r.Name)
-			r.URL = strings.TrimSpace(r.URL)
-			r.Branch = strings.TrimSpace(r.Branch)
-			// A blank name defaults to the repo derived from its clone URL.
-			if r.Name == "" {
-				r.Name = repoNameFromURL(r.URL)
-			}
+		out := make([]repoEntry, 0, len(wire))
+		for _, r := range wire {
 			if !safeRepoName(r.Name) {
 				continue
 			}
-			out = append(out, r)
+			out = append(out, repoEntry{Name: r.Name, URL: r.URL, Branch: r.Branch})
 		}
 		return out
 	case []any:

--- a/server/internal/runtime/multirepo_test.go
+++ b/server/internal/runtime/multirepo_test.go
@@ -32,6 +32,12 @@ func TestParseReposVar(t *testing.T) {
 		t.Errorf("anyForm = %+v", got2)
 	}
 
+	// Wire format (GIT_REPOS / onboarding literal) is accepted alongside JSON.
+	wire := parseReposVar("demo|https://github.com/heroku/nodejs-getting-started.git|main")
+	if len(wire) != 1 || wire[0].Name != "demo" || wire[0].Branch != "main" {
+		t.Errorf("wire form = %+v", wire)
+	}
+
 	// Blank / invalid -> nil (single-repo mode).
 	if parseReposVar("") != nil || parseReposVar(nil) != nil || parseReposVar("not json") != nil {
 		t.Errorf("blank/invalid should be nil")

--- a/server/internal/sandbox/manager.go
+++ b/server/internal/sandbox/manager.go
@@ -180,6 +180,52 @@ func EncodeRepos(repos []RepoSpec) string {
 	return strings.Join(parts, ",")
 }
 
+// DecodeRepos parses the GIT_REPOS wire format (comma-separated
+// "name|url|branch" entries) produced by EncodeRepos. Entries missing a URL,
+// with an unsafe name, or with fewer than two '|' fields are skipped. A blank
+// name is derived from the URL when possible.
+func DecodeRepos(s string) []RepoSpec {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]RepoSpec, 0, len(parts))
+	seen := map[string]bool{}
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		fields := strings.SplitN(part, "|", 3)
+		if len(fields) < 2 {
+			continue
+		}
+		name := strings.TrimSpace(fields[0])
+		url := strings.TrimSpace(fields[1])
+		branch := ""
+		if len(fields) >= 3 {
+			branch = strings.TrimSpace(fields[2])
+		}
+		if name == "" {
+			name = RepoNameFromURL(url)
+		}
+		if name == "" || url == "" || seen[name] {
+			continue
+		}
+		// Same escape guard as runtime.safeRepoName / startup.sh.
+		if name == "." || name == ".." || strings.ContainsAny(name, "/\\") {
+			continue
+		}
+		seen[name] = true
+		out = append(out, RepoSpec{Name: name, URL: url, Branch: branch})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 // Sandbox is a running sandbox handle. Host/Port point at the ACP session
 // endpoint (8765) the gateway published; SSHHost/SSHPort at the sshd endpoint
 // (22) used for the data plane.

--- a/server/internal/sandbox/repospec_test.go
+++ b/server/internal/sandbox/repospec_test.go
@@ -64,3 +64,32 @@ func TestEncodeRepos(t *testing.T) {
 		t.Errorf("nil repos should encode to empty, got %q", got3)
 	}
 }
+
+func TestDecodeRepos(t *testing.T) {
+	got := DecodeRepos("web|https://h/w.git|dev,api|https://h/a.git")
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2 (%+v)", len(got), got)
+	}
+	if got[0] != (RepoSpec{Name: "web", URL: "https://h/w.git", Branch: "dev"}) {
+		t.Errorf("entry0 = %+v", got[0])
+	}
+	if got[1] != (RepoSpec{Name: "api", URL: "https://h/a.git"}) {
+		t.Errorf("entry1 = %+v", got[1])
+	}
+
+	// Blank name derives from URL; unsafe / duplicate names dropped.
+	got2 := DecodeRepos("|https://h/org/demo.git|main,../etc|https://h/x.git,demo|https://h/org/demo.git|main")
+	if len(got2) != 1 || got2[0].Name != "demo" || got2[0].Branch != "main" {
+		t.Errorf("derive/dedupe/unsafe = %+v", got2)
+	}
+
+	if DecodeRepos("") != nil || DecodeRepos("   ") != nil || DecodeRepos("not-a-wire") != nil {
+		t.Errorf("blank/invalid wire should be nil")
+	}
+
+	// Round-trip with EncodeRepos.
+	wire := "demo|https://github.com/heroku/nodejs-getting-started.git|main"
+	if enc := EncodeRepos(DecodeRepos(wire)); enc != wire {
+		t.Errorf("round-trip = %q, want %q", enc, wire)
+	}
+}

--- a/server/internal/services/onboarding.go
+++ b/server/internal/services/onboarding.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cocofhu/approving/internal/models"
 	"github.com/cocofhu/approving/internal/runtime"
+	"github.com/cocofhu/approving/internal/sandbox"
 
 	"github.com/google/uuid"
 )
@@ -93,6 +94,8 @@ func (s *OnboardingService) Bootstrap(projectID string, req OnboardingBootstrapR
 		return OnboardingBootstrapResult{}, err
 	}
 
+	region := strings.TrimSpace(req.Region)
+
 	// Preload templates + validate graph before mutating project auth / agents.
 	templates := make([]Agent, 0, len(OnboardingAgentNames))
 	for _, name := range OnboardingAgentNames {
@@ -103,10 +106,19 @@ func (s *OnboardingService) Bootstrap(projectID string, req OnboardingBootstrapR
 		tmpl.Name = name
 		tmpl.ProjectID = projectID
 		tmpl.AcpBackend = backend
+		// Persist backend-specific layout so Studio opens clean (no dirty from
+		// client-side defaultConfigRoot fill).
+		tmpl.Layout.ConfigRoot = DefaultConfigRootForBackend(backend)
+		if strings.TrimSpace(tmpl.Layout.WorkspaceDir) == "" {
+			tmpl.Layout.WorkspaceDir = DefaultWorkspaceDir
+		}
 		if tmpl.Env == nil {
 			tmpl.Env = map[string]string{}
 		}
 		tmpl.Env["GIT_REPOS"] = "${vars.repos}"
+		// Mirror project auth region into Agent.env so Agent Studio's
+		// normalizeDraftRegions does not mark every bootstrap agent dirty.
+		applyOnboardingAgentRegion(tmpl.Env, backend, region)
 		templates = append(templates, tmpl)
 	}
 	graph := buildOnboardingLightGraph(repos, feature)
@@ -114,7 +126,7 @@ func (s *OnboardingService) Bootstrap(projectID string, req OnboardingBootstrapR
 		return OnboardingBootstrapResult{}, fmt.Errorf("onboarding graph invalid: %w", err)
 	}
 
-	if err := s.writeProjectAuth(projectID, backend, apiKey, strings.TrimSpace(req.Region)); err != nil {
+	if err := s.writeProjectAuth(projectID, backend, apiKey, region); err != nil {
 		return OnboardingBootstrapResult{}, err
 	}
 
@@ -222,6 +234,45 @@ func primaryAuthEnvKey(backend string) string {
 	}
 }
 
+// applyOnboardingAgentRegion writes the Studio-managed region env key into an
+// Agent env map for backends that require it (CodeBuddy / Trae). Empty region
+// falls back to the same defaults as writeProjectAuth / web regionPolicy.
+func applyOnboardingAgentRegion(env map[string]string, backend, region string) {
+	if env == nil {
+		return
+	}
+	switch NormalizeAcpBackend(backend) {
+	case AcpBackendCodeBuddy:
+		if region == "" {
+			region = "public"
+		}
+		env[runtime.EnvCodeBuddyRegion] = region
+	case AcpBackendTrae:
+		if region == "" {
+			region = "intl"
+		}
+		env[runtime.EnvTraeRegion] = region
+	}
+}
+
+// onboardingReposVarValue converts a GIT_REPOS wire literal into the structured
+// []any form expected by workflow variables of Type "repos" (and by parseReposVar).
+func onboardingReposVarValue(wire string) any {
+	specs := sandbox.DecodeRepos(wire)
+	if len(specs) == 0 {
+		specs = sandbox.DecodeRepos(DefaultOnboardingRepos)
+	}
+	out := make([]any, 0, len(specs))
+	for _, r := range specs {
+		m := map[string]any{"name": r.Name, "url": r.URL}
+		if r.Branch != "" {
+			m["branch"] = r.Branch
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
 func (s *OnboardingService) upsertLightWorkflow(projectID, repos, feature string) (models.WorkflowDef, error) {
 	graph := buildOnboardingLightGraph(repos, feature)
 	var existing *models.WorkflowDef
@@ -278,8 +329,11 @@ func buildOnboardingLightGraph(repos, feature string) models.Graph {
 				Desc: "示例需求", Ask: true, Required: true, Editable: true,
 			},
 			{
-				Name: "repos", Type: "string", Value: repos,
-				Desc: "代码仓（name|url|branch）", Ask: true, Required: true, Editable: true,
+				// Must be Type "repos" (structured [{name,url,branch}]) — not a
+				// string wire literal. Wire form does not render the repos editor
+				// and previously left GIT_REPOS empty after parseReposVar.
+				Name: "repos", Type: "repos", Value: onboardingReposVarValue(repos),
+				Desc: "仓库列表(平级,每个 clone 到 /root/workspace/<name>/)", Ask: true, Required: true, Editable: true,
 			},
 		},
 		Nodes: []models.Node{

--- a/server/internal/services/onboarding_test.go
+++ b/server/internal/services/onboarding_test.go
@@ -94,6 +94,62 @@ func TestOnboardingBootstrapCreatesAgentsAndPublishedWorkflow(t *testing.T) {
 		t.Fatalf("workflow meta: name=%s status=%s needsRepo=%v", wf.Name, wf.Status, wf.NeedsRepo)
 	}
 	assertOnboardingGraph(t, wf.Graph)
+	assertOnboardingReposVar(t, wf.Graph)
+}
+
+func TestOnboardingBootstrapWritesCodeBuddyRegionToAgents(t *testing.T) {
+	svc, projectID := newOnboardingHarness(t)
+	res, err := svc.Bootstrap(projectID, services.OnboardingBootstrapRequest{
+		AcpBackend: "codebuddy",
+		APIKey:     "cb-key",
+		Region:     "internal",
+	})
+	if err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	for _, name := range res.AgentIDs {
+		a, ok := svc.Skills.Get(name)
+		if !ok {
+			t.Fatalf("agent %s missing", name)
+		}
+		if a.AcpBackend != "codebuddy" {
+			t.Fatalf("agent %s backend = %q", name, a.AcpBackend)
+		}
+		if got := a.Env["APPROVING_CODEBUDDY_REGION"]; got != "internal" {
+			t.Fatalf("agent %s region = %q, want internal", name, got)
+		}
+		if a.Layout.ConfigRoot != "/root/.codebuddy" {
+			t.Fatalf("agent %s configRoot = %q", name, a.Layout.ConfigRoot)
+		}
+	}
+	p, _ := svc.Projects.Get(projectID)
+	foundRegion := false
+	for _, e := range p.SandboxEnv {
+		if e.Key == "APPROVING_CODEBUDDY_REGION" && e.Value == "internal" {
+			foundRegion = true
+		}
+	}
+	if !foundRegion {
+		t.Fatalf("project sandboxEnv missing region: %+v", p.SandboxEnv)
+	}
+}
+
+func TestOnboardingBootstrapDefaultsPublicRegionForCodeBuddy(t *testing.T) {
+	svc, projectID := newOnboardingHarness(t)
+	_, err := svc.Bootstrap(projectID, services.OnboardingBootstrapRequest{
+		AcpBackend: "codebuddy",
+		APIKey:     "cb-key",
+	})
+	if err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	a, ok := svc.Skills.Get("ImplementAgent")
+	if !ok {
+		t.Fatal("ImplementAgent missing")
+	}
+	if got := a.Env["APPROVING_CODEBUDDY_REGION"]; got != "public" {
+		t.Fatalf("default region = %q, want public", got)
+	}
 }
 
 func TestOnboardingBootstrapIdempotent(t *testing.T) {
@@ -200,6 +256,35 @@ func TestOnboardingLightGraphValidate(t *testing.T) {
 	)
 	if err := g.Validate(); err != nil {
 		t.Fatalf("graph invalid: %v", err)
+	}
+}
+
+func assertOnboardingReposVar(t *testing.T, g models.Graph) {
+	t.Helper()
+	var reposVar *models.Variable
+	for i := range g.Variables {
+		if g.Variables[i].Name == "repos" {
+			reposVar = &g.Variables[i]
+			break
+		}
+	}
+	if reposVar == nil {
+		t.Fatal("missing repos variable")
+	}
+	if reposVar.Type != "repos" {
+		t.Fatalf("repos type = %q, want repos", reposVar.Type)
+	}
+	list, ok := reposVar.Value.([]any)
+	if !ok || len(list) == 0 {
+		t.Fatalf("repos value want non-empty []any, got %T %#v", reposVar.Value, reposVar.Value)
+	}
+	first, ok := list[0].(map[string]any)
+	if !ok {
+		t.Fatalf("repos[0] = %T", list[0])
+	}
+	url, _ := first["url"].(string)
+	if !strings.Contains(url, "heroku/nodejs-getting-started") {
+		t.Fatalf("repos[0].url = %q", url)
 	}
 }
 

--- a/web/src/components/onboarding/OnboardingWizard.test.ts
+++ b/web/src/components/onboarding/OnboardingWizard.test.ts
@@ -117,5 +117,22 @@ describe('OnboardingWizard', () => {
     expect(repoBox.text()).toContain('main')
     expect(repoBox.text()).not.toContain('demo|https://')
     expect(isOnboardingDismissed('p5')).toBe(true)
+
+    await wrapper.find('[data-testid="onboarding-start-run"]').trigger('click')
+    await flushPromises()
+    expect(api.startRun).toHaveBeenCalledWith(
+      'wf-1',
+      {
+        feature: '把首页欢迎文案与主按钮文案改得更清晰友好',
+        repos: [
+          {
+            name: 'demo',
+            url: 'https://github.com/heroku/nodejs-getting-started.git',
+            branch: 'main',
+          },
+        ],
+      },
+      'manual',
+    )
   })
 })

--- a/web/src/components/onboarding/OnboardingWizard.vue
+++ b/web/src/components/onboarding/OnboardingWizard.vue
@@ -19,6 +19,7 @@ import {
   freshOnboardingDraft,
   hostLabelFromUrl,
   parseReposLiteral,
+  reposInputFromFields,
   type OnboardingBootstrapResult,
   type OnboardingDraft,
 } from '@/lib/onboardingWizard'
@@ -161,7 +162,11 @@ async function startSampleRun() {
       result.value.workflowId,
       {
         feature: result.value.feature || DEFAULT_ONBOARDING_FEATURE,
-        repos: result.value.repos || encodeReposLiteral(draft.value.repo),
+        // Structured repos (Type "repos"); wire literals also work server-side
+        // via parseReposVar, but prefer the array form used by the engine.
+        repos: reposInputFromFields(
+          parseReposLiteral(result.value.repos || encodeReposLiteral(draft.value.repo)),
+        ),
       },
       'manual',
     )

--- a/web/src/lib/onboardingWizard.test.ts
+++ b/web/src/lib/onboardingWizard.test.ts
@@ -10,6 +10,7 @@ import {
   isOnboardingDismissed,
   onboardingDismissKey,
   parseReposLiteral,
+  reposInputFromFields,
   shouldAutoOpenOnboarding,
 } from './onboardingWizard'
 
@@ -28,6 +29,16 @@ describe('onboardingWizard', () => {
   it('round-trips repos literal', () => {
     const lit = 'demo|https://github.com/heroku/nodejs-getting-started.git|main'
     expect(encodeReposLiteral(parseReposLiteral(lit))).toBe(lit)
+  })
+
+  it('builds structured repos input for StartRun', () => {
+    expect(reposInputFromFields(parseReposLiteral(DEFAULT_ONBOARDING_REPOS_LITERAL))).toEqual([
+      {
+        name: 'demo',
+        url: 'https://github.com/heroku/nodejs-getting-started.git',
+        branch: 'main',
+      },
+    ])
   })
 
   it('assembles bootstrap body with optional region', () => {

--- a/web/src/lib/onboardingWizard.ts
+++ b/web/src/lib/onboardingWizard.ts
@@ -162,6 +162,16 @@ export function parseReposLiteral(literal: string): OnboardingRepoFields {
   }
 }
 
+/** Structured repos value accepted by StartRun / workflow Type "repos". */
+export function reposInputFromFields(repo: OnboardingRepoFields): Array<{ name: string; url: string; branch: string }> {
+  const fields = {
+    name: (repo.name || '').trim() || DEFAULT_ONBOARDING_REPO.name,
+    url: (repo.url || '').trim() || DEFAULT_ONBOARDING_REPO.url,
+    branch: (repo.branch || '').trim() || DEFAULT_ONBOARDING_REPO.branch,
+  }
+  return [fields]
+}
+
 export function assembleBootstrapBody(draft: OnboardingDraft): OnboardingBootstrapBody {
   const body: OnboardingBootstrapBody = {
     acpBackend: draft.acpBackend,


### PR DESCRIPTION
## Summary
- Quick-start workflow `repos` variable is now Type **`repos`** with structured `[{name,url,branch}]` (was a `name|url|branch` string that `parseReposVar` ignored → empty `GIT_REPOS` → no clone).
- Also accept GIT_REPOS wire literals in `parseReposVar` as a safety net; StartRun sends structured repos.
- Bootstrap writes CodeBuddy/Trae region (+ layout.configRoot) into each Agent.env so Agent Studio no longer opens forever 「未保存」.

## Test plan
- [x] `go test` sandbox DecodeRepos / runtime ParseReposVar / services Onboarding*
- [x] vitest onboardingWizard + OnboardingWizard
- [ ] Empty project → 快速上手 (CodeBuddy) → agents open without 「未保存」
- [ ] Start sample run → sandbox log shows `Cloning demo from ...` and `/root/workspace/demo`


Made with [Cursor](https://cursor.com)