### PR TITLE
fix(sandbox-console): IDE/ACP lazy mount + log contrast

### DIFF
--- a/web/src/views/SandboxConsoleView.lazyMount.test.ts
+++ b/web/src/views/SandboxConsoleView.lazyMount.test.ts
@@ -1,0 +1,220 @@
+// @vitest-environment happy-dom
+import { defineComponent, h, nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
+import { createMemoryHistory, createRouter, RouterView } from 'vue-router'
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import common from '@/locales/zh-CN/common.json'
+import pages from '@/locales/zh-CN/pages.json'
+import type { SandboxView } from '@/lib/api'
+
+const apiMocks = vi.hoisted(() => ({
+  getSandbox: vi.fn(),
+  listSandboxes: vi.fn(),
+  sandboxLog: vi.fn(),
+  sandboxIdeUrl: (_id: number) => 'about:blank#ide',
+  sandboxBridgeUrl: (_id: number) => 'about:blank#acp',
+  sandboxTerminalWsUrl: (id: number) => `wss://test.local/sandboxes/${id}/terminal`,
+}))
+
+vi.mock('@/lib/api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/api')>('@/lib/api')
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getSandbox: apiMocks.getSandbox,
+      listSandboxes: apiMocks.listSandboxes,
+      sandboxLog: apiMocks.sandboxLog,
+      sandboxIdeUrl: apiMocks.sandboxIdeUrl,
+      sandboxBridgeUrl: apiMocks.sandboxBridgeUrl,
+      sandboxTerminalWsUrl: apiMocks.sandboxTerminalWsUrl,
+    },
+  }
+})
+
+vi.mock('@/lib/useToast', () => ({
+  useToast: () => ({ success: vi.fn(), error: vi.fn() }),
+}))
+
+vi.mock('@xterm/xterm', () => {
+  class Terminal {
+    cols = 80
+    rows = 24
+    loadAddon() {}
+    open() {}
+    write() {}
+    dispose() {}
+    onData() {
+      return { dispose() {} }
+    }
+  }
+  return { Terminal }
+})
+
+vi.mock('@xterm/addon-fit', () => {
+  class FitAddon {
+    fit() {}
+  }
+  return { FitAddon }
+})
+
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}))
+
+vi.mock('@/components/run/NovncPreviewPanel.vue', () => ({
+  default: {
+    name: 'NovncPreviewPanel',
+    props: ['sandboxId', 'fill'],
+    template: '<div data-testid="novnc-stub" />',
+  },
+}))
+
+import SandboxConsoleView from './SandboxConsoleView.vue'
+
+const MOCK_SANDBOX: SandboxView = {
+  id: 42,
+  name: 'sb-42',
+  profile: 'default',
+  purpose: 'test',
+  status: 'running',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  containerStatus: 'running',
+  busy: false,
+  connected: true,
+  hasCodeServer: true,
+  hasAcp: true,
+}
+
+class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+  readyState = MockWebSocket.OPEN
+  binaryType = 'arraybuffer'
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  constructor(_url: string) {
+    queueMicrotask(() => this.onopen?.(new Event('open')))
+  }
+  send() {}
+  close() {
+    this.readyState = MockWebSocket.CLOSED
+  }
+}
+
+async function mountConsole(tabQuery?: string): Promise<VueWrapper> {
+  apiMocks.getSandbox.mockResolvedValue(MOCK_SANDBOX)
+  apiMocks.listSandboxes.mockResolvedValue([MOCK_SANDBOX])
+  apiMocks.sandboxLog.mockResolvedValue({ content: '', live: false, found: false })
+
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common, ...pages } },
+  })
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/sandboxes', component: { render: () => h('div') } },
+      { path: '/sandboxes/:id/console', component: SandboxConsoleView },
+    ],
+  })
+  await router.push({
+    path: '/sandboxes/42/console',
+    query: tabQuery ? { tab: tabQuery } : {},
+  })
+  await router.isReady()
+
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        return () => h(RouterView)
+      },
+    }),
+    {
+      global: {
+        plugins: [i18n, router],
+        stubs: { Icon: true },
+      },
+      attachTo: document.body,
+    },
+  )
+  await flushPromises()
+  await nextTick()
+  return wrapper
+}
+
+describe('SandboxConsoleView IDE/ACP lazy mount', () => {
+  beforeEach(() => {
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        disconnect() {}
+        unobserve() {}
+      },
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  it('default terminal tab does not mount IDE/ACP iframes', async () => {
+    const wrapper = await mountConsole()
+    expect(wrapper.find('iframe[title="code-server"]').exists()).toBe(false)
+    expect(wrapper.find('iframe[title="ACP bridge"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('mounts IDE iframe on first IDE tab click and keeps it after switch back', async () => {
+    const wrapper = await mountConsole()
+    expect(wrapper.find('iframe[title="code-server"]').exists()).toBe(false)
+
+    const ideBtn = wrapper.findAll('button').find((b) => b.text().includes('IDE'))
+    expect(ideBtn).toBeTruthy()
+    await ideBtn!.trigger('click')
+    await flushPromises()
+    await nextTick()
+
+    const ideIframe = wrapper.find('iframe[title="code-server"]')
+    expect(ideIframe.exists()).toBe(true)
+    expect(wrapper.find('iframe[title="ACP bridge"]').exists()).toBe(false)
+
+    const termBtn = wrapper.findAll('button').find((b) => b.text().includes('终端'))
+    expect(termBtn).toBeTruthy()
+    await termBtn!.trigger('click')
+    await nextTick()
+
+    expect(wrapper.find('iframe[title="code-server"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('?tab=ide deep link mounts IDE iframe', async () => {
+    const wrapper = await mountConsole('ide')
+    await flushPromises()
+    expect(wrapper.find('iframe[title="code-server"]').exists()).toBe(true)
+    expect(wrapper.find('iframe[title="ACP bridge"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('?tab=acp-native deep link mounts ACP iframe; legacy ?tab=acp does not', async () => {
+    const native = await mountConsole('acp-native')
+    await flushPromises()
+    expect(native.find('iframe[title="ACP bridge"]').exists()).toBe(true)
+    native.unmount()
+
+    const legacy = await mountConsole('acp')
+    await flushPromises()
+    expect(legacy.find('iframe[title="ACP bridge"]').exists()).toBe(false)
+    expect(legacy.find('iframe[title="code-server"]').exists()).toBe(false)
+    legacy.unmount()
+  })
+})

--- a/web/src/views/SandboxConsoleView.vue
+++ b/web/src/views/SandboxConsoleView.vue
@@ -35,9 +35,11 @@ function initialConsoleTab(): ConsoleTab {
 
 const sandbox = ref<SandboxView | null>(null)
 const tab = ref<ConsoleTab>(initialConsoleTab())
-// Lazily mount noVNC on first open, then keep alive (v-show) so the RFB
-// session survives tab switches — same pattern as the terminal pane.
+// Lazily mount heavy panes on first open, then keep alive (v-show) so
+// sessions survive tab switches — same pattern as the terminal pane.
 const novncMounted = ref(false)
+const ideMounted = ref(false)
+const acpMounted = ref(false)
 
 const tabItems = computed(() => [
   { k: 'terminal', l: t('pages.sandboxConsole.tabs.terminal'), i: 'terminal' },
@@ -177,12 +179,16 @@ function sendResize() {
 
 watch(tab, (t) => {
   if (t === 'terminal') nextTick(() => { initTerminal(); doFit() })
+  if (t === 'ide') ideMounted.value = true
+  if (t === 'acp') acpMounted.value = true
   if (t === 'novnc') novncMounted.value = true
   if (t === 'log') fetchLog()
 })
 
 onMounted(async () => {
   tab.value = initialConsoleTab()
+  if (tab.value === 'ide') ideMounted.value = true
+  if (tab.value === 'acp') acpMounted.value = true
   if (tab.value === 'novnc') novncMounted.value = true
   await loadMeta()
   nextTick(() => {
@@ -250,12 +256,15 @@ onBeforeUnmount(() => {
 
       <div v-show="tab === 'ide'" class="h-full">
         <iframe
-          v-if="sandbox?.hasCodeServer"
+          v-if="ideMounted && sandbox?.hasCodeServer"
           :src="api.sandboxIdeUrl(id)"
           class="h-full w-full border-0 bg-white"
           title="code-server"
         />
-        <div v-else class="flex h-full items-center justify-center px-6 text-center text-sm text-txt3">
+        <div
+          v-else-if="ideMounted"
+          class="flex h-full items-center justify-center px-6 text-center text-sm text-txt3"
+        >
           {{ t('pages.sandboxConsole.ideUnavailable') }}
         </div>
       </div>
@@ -263,12 +272,15 @@ onBeforeUnmount(() => {
       <!-- ACP: in-container acp-bridge web UI (8765); was acp-native -->
       <div v-show="tab === 'acp'" class="h-full">
         <iframe
-          v-if="sandbox?.hasAcp"
+          v-if="acpMounted && sandbox?.hasAcp"
           :src="api.sandboxBridgeUrl(id)"
           class="h-full w-full border-0 bg-white"
           title="ACP bridge"
         />
-        <div v-else class="flex h-full items-center justify-center px-6 text-center text-sm text-txt3">
+        <div
+          v-else-if="acpMounted"
+          class="flex h-full items-center justify-center px-6 text-center text-sm text-txt3"
+        >
           {{ t('pages.sandboxConsole.acpNativeUnavailable') }}
         </div>
       </div>
@@ -293,8 +305,8 @@ onBeforeUnmount(() => {
           <button class="text-txt3 hover:text-txt" :title="t('common.buttons.refresh')" @click="fetchLog"><Icon name="refresh" :size="12" /></button>
         </div>
         <div class="scroll-area min-h-0 flex-1 overflow-auto bg-[#0b0e14] p-3">
-          <pre v-if="log?.content" class="whitespace-pre-wrap break-all font-mono text-[11px] leading-relaxed text-txt2">{{ log.content }}</pre>
-          <div v-else class="flex h-full items-center justify-center text-center text-[12px] text-txt3">
+          <pre v-if="log?.content" class="whitespace-pre-wrap break-all font-mono text-[11px] leading-relaxed text-[#cdd6f4]">{{ log.content }}</pre>
+          <div v-else class="flex h-full items-center justify-center text-center text-[12px] text-[#cdd6f4]">
             {{ logLoading ? t('common.buttons.loading') : t('pages.sandboxConsole.logEmpty') }}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Sandbox Console: IDE/ACP panels lazy-mount on first visit (aligned with `novncMounted`), keeping shells alive via `v-show` after mount.
- Log panel: dark content area body/empty-state text uses `#cdd6f4` for readable contrast on `#0b0e14`.
- Minimal vitest coverage for default Terminal (no heavy iframes), first-tab mount + keepalive, and deep links (`?tab=ide` / `?tab=acp-native`; legacy `?tab=acp` unchanged).

## Test plan
- [x] `npm test -- src/views/SandboxConsoleView.lazyMount.test.ts` (4 passed)
- [x] `npx playwright test e2e/console.spec.ts` (7 passed)
- [x] Browser check: default Terminal has no code-server/ACP iframes
- [x] Browser check: first IDE/ACP visit mounts; switch back keeps iframe in DOM
- [x] Browser check: Log tab light theme → bg `#0b0e14` + text `#cdd6f4`
- [x] CI checks green (web / web-e2e / gate / CodeQL / gitleaks)

## Notes
- Out of scope: proxy URL, noVNC protocol, `?tab=acp` legacy→Terminal mapping / related e2e.
- Ready to squash-merge into `main`.