### PR TITLE
chore: release stack data via .localdata bind mounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ server/config.yaml
 # --- local docker-compose dev env (see start.sh) ---
 /.env
 /.devdata/
+/.localdata/
 /release-evidence/
 
 # 本地 Agent profiles（含 API key 等密钥，勿提交）

--- a/compose.release.yaml
+++ b/compose.release.yaml
@@ -15,7 +15,7 @@ services:
       SBGW_API_KEYS: ${SANDBOX_GATEWAY_API_KEY:-approving-local-demo}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - gateway-data:/data
+      - ./.localdata/gateway:/data
     # Image is debian-slim + binary only (no wget/curl). Probe TCP listen.
     healthcheck:
       test:
@@ -48,9 +48,9 @@ services:
       APPROVING_DEPLOYMENT_MODE: ${APPROVING_DEPLOYMENT_MODE:-local-demo}
       APPROVING_AUTH_USERS: ${APPROVING_AUTH_USERS:-}
     volumes:
-      - approving-data:/data
+      - ./.localdata/db:/data
       # Agent profiles / org / platform-rules (WORKDIR-relative data/*). Keep separate from SQLite /data.
-      - approving-app-data:/app/data
+      - ./.localdata/app-data:/app/data
     depends_on:
       gateway:
         condition: service_healthy
@@ -68,8 +68,3 @@ services:
       retries: 24
       start_period: 10s
     restart: unless-stopped
-
-volumes:
-  approving-data:
-  approving-app-data:
-  gateway-data:

--- a/docs/content/en/guide/quick-start.md
+++ b/docs/content/en/guide/quick-start.md
@@ -32,7 +32,7 @@ Then open:
 
 `./start.sh` also pulls **four sandbox runtime** images from GHCR (one per acpBackend: cursor / claude_code / codebuddy / trae; large). Until that finishes, sandbox chats may stay on “starting sandbox…”.
 
-Agent / workspace / platform-rules data lives on a named volume (`/app/data`); `./start.sh restart` and `./start.sh down` (without `-v`) keep it. **Do not run `docker compose down -v`** — that wipes Agent config and SQLite.
+Agent / workspace / platform-rules and SQLite data live under `.localdata` at the repo root (bind mounts: `gateway` / `db` / `app-data`). `./start.sh restart` and `./start.sh down` keep that directory. To wipe: `./start.sh down && rm -rf .localdata`.
 
 ## Common commands
 
@@ -40,7 +40,7 @@ Agent / workspace / platform-rules data lives on a named volume (`/app/data`); `
 ./start.sh logs
 ./start.sh down
 ./start.sh pull          # refresh GHCR images (including four sandbox runtimes)
-./start.sh restart       # down + up -d (keeps named volumes)
+./start.sh restart       # down + up -d (keeps .localdata)
 ./start.sh dev -d        # source stack: go run + Vite HMR
 ```
 

--- a/docs/content/guide/quick-start.md
+++ b/docs/content/guide/quick-start.md
@@ -32,7 +32,7 @@ cd approving
 
 `./start.sh` 还会从 GHCR 拉取 **四个 sandbox runtime** 镜像（按 acpBackend：cursor / claude_code / codebuddy / trae，体积较大）。完成前，沙箱对话可能停留在 “starting sandbox…”。
 
-Agent / workspace / platform-rules 持久在命名卷（`/app/data`）；`./start.sh restart` 与 `./start.sh down`（无 `-v`）会保留。**勿用 `docker compose down -v`**，否则会清空 Agent 配置与 SQLite。
+Agent / workspace / platform-rules 与 SQLite 持久在仓库根 `.localdata` 宿主机目录（bind mount：`gateway` / `db` / `app-data`）。`./start.sh restart` 与 `./start.sh down` 会保留该目录。清空数据：`./start.sh down && rm -rf .localdata`。
 
 ## 常用命令
 
@@ -40,7 +40,7 @@ Agent / workspace / platform-rules 持久在命名卷（`/app/data`）；`./star
 ./start.sh logs
 ./start.sh down
 ./start.sh pull          # 刷新 GHCR 镜像（含四个 sandbox runtime）
-./start.sh restart       # down + up -d（保留命名卷）
+./start.sh restart       # down + up -d（保留 .localdata）
 ./start.sh dev -d        # 源码栈：go run + Vite HMR
 ```
 

--- a/release-smoke.sh
+++ b/release-smoke.sh
@@ -36,6 +36,7 @@ export SBGW_API_KEYS="${SBGW_API_KEYS:-$SANDBOX_GATEWAY_API_KEY}"
 
 cleanup() {
   docker compose -f "$COMPOSE_FILE" down --volumes --remove-orphans >>"$LOG" 2>&1 || true
+  rm -rf .localdata
 }
 trap cleanup EXIT INT TERM
 

--- a/start.sh
+++ b/start.sh
@@ -164,6 +164,7 @@ ensure_sandbox_runtime_image() {
 
 up_release() {
   local detach="${1:-}"
+  mkdir -p .localdata/gateway .localdata/db .localdata/app-data
   echo "pulling GHCR images (approving + gateway + sandbox)..."
   "${COMPOSE[@]}" -f "$RELEASE_COMPOSE_FILE" pull
   ensure_sandbox_runtime_image
@@ -173,6 +174,8 @@ up_release() {
     wait_for_url "http://127.0.0.1:${APPROVING_PORT}/api/health" "api"
     echo "started (GHCR)"
     print_release_endpoints
+    echo "data: .localdata/{gateway,db,app-data} (bind mounts)"
+    echo "wipe: ./start.sh down && rm -rf .localdata"
     echo "logs: ./start.sh logs   stop: ./start.sh down"
   else
     echo "starting (foreground) — UI http://localhost:${APPROVING_PORT}"


### PR DESCRIPTION
## Summary
- `compose.release.yaml`: replace named volumes with `./.localdata/{gateway,db,app-data}` bind mounts; remove the `volumes:` section
- `start.sh` `up_release`: `mkdir -p` those dirs; detached success hints show data paths and wipe command (`./start.sh down && rm -rf .localdata`)
- `.gitignore`: ignore `/.localdata/`
- docs quick-start (zh/en): document bind mounts + wipe instead of named volumes / `down -v`
- `release-smoke.sh` cleanup: `rm -rf .localdata` after down

## Test plan
- [ ] `./start.sh -d` creates `.localdata/{gateway,db,app-data}` and writes data there
- [ ] `./start.sh down` keeps `.localdata`
- [ ] `./start.sh down && rm -rf .localdata` then `./start.sh -d` starts with empty DB/config
- [ ] `docker-compose.yml` / local-demo / `.devdata` behavior unchanged
- [ ] `release-smoke` cleanup removes `.localdata`


Made with [Cursor](https://cursor.com)