### PR TITLE
fix(mcp): type=http for CodeBuddy artifact-store injection

### DIFF
--- a/server/internal/runtime/acp_more2_test.go
+++ b/server/internal/runtime/acp_more2_test.go
@@ -123,6 +123,9 @@ func TestMcpServersFromAgentConfig(t *testing.T) {
 	if !strings.Contains(s, "artifact-store") || !strings.Contains(s, "\"command\":\"run\"") {
 		t.Fatalf("mcpServers json missing url/command entries: %s", s)
 	}
+	if !strings.Contains(s, `"type":"http"`) {
+		t.Fatalf("mcpServers HTTP entry missing type:http (codebuddy skips url-only): %s", s)
+	}
 	// gitToken resolves from the agent env.
 	if tok := p.gitToken(req); tok != "tok" {
 		t.Errorf("gitToken = %q, want tok", tok)

--- a/server/internal/runtime/acp_provider.go
+++ b/server/internal/runtime/acp_provider.go
@@ -1762,7 +1762,8 @@ func (c *acpProvider) mcpServers(req NodeReq) json.RawMessage {
 	for _, m := range specs {
 		switch {
 		case m.URL != "":
-			entry := map[string]any{"name": m.Name, "url": m.URL}
+			// type:http required by Claude Code / CodeBuddy; url-only is skipped.
+			entry := map[string]any{"name": m.Name, "type": "http", "url": m.URL}
 			if len(m.Headers) > 0 {
 				hs := make([]map[string]string, 0, len(m.Headers))
 				for k, v := range m.Headers {

--- a/server/internal/sandbox/confighome.go
+++ b/server/internal/sandbox/confighome.go
@@ -117,6 +117,10 @@ func BuildConfigHome(spec ConfigHomeSpec) (string, error) {
 		}
 		entry := map[string]any{}
 		if m.URL != "" {
+			// Claude Code / CodeBuddy (--strict-mcp-config): a url without type is
+			// treated as a broken stdio server and skipped. Cursor accepts url-only;
+			// type:http is required for Claude-family HTTP/streamable-http MCP.
+			entry["type"] = "http"
 			entry["url"] = m.URL
 			if len(m.Headers) > 0 {
 				entry["headers"] = m.Headers

--- a/server/internal/sandbox/confighome_test.go
+++ b/server/internal/sandbox/confighome_test.go
@@ -69,6 +69,53 @@ func TestBuildConfigHome(t *testing.T) {
 	if len(doc.MCPServers) != 2 {
 		t.Errorf("mcp servers = %d, want 2", len(doc.MCPServers))
 	}
+	// HTTP MCP entries must carry type:http (Claude Code / CodeBuddy skip url-only).
+	for name, raw := range doc.MCPServers {
+		var entry map[string]any
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			t.Fatalf("server %s: %v", name, err)
+		}
+		if _, hasURL := entry["url"]; !hasURL {
+			continue
+		}
+		if entry["type"] != "http" {
+			t.Errorf("server %s: type=%v, want http (url-only is skipped by codebuddy)", name, entry["type"])
+		}
+	}
+}
+
+func TestBuildConfigHomeHTTPTypeRequired(t *testing.T) {
+	HomeBaseDir = ""
+	dir, err := BuildConfigHome(ConfigHomeSpec{
+		MCP: []MCPServerSpec{{
+			Name: "artifact-store",
+			URL:  "http://host.docker.internal:8080/mcp/runs/r1",
+			Headers: map[string]string{
+				"Authorization": "Bearer tok",
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("BuildConfigHome: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	b, err := os.ReadFile(filepath.Join(dir, "mcp.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		MCPServers map[string]map[string]any `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatal(err)
+	}
+	got := doc.MCPServers["artifact-store"]
+	if got["type"] != "http" {
+		t.Fatalf("mcp.json missing type:http: %s", b)
+	}
+	if got["url"] == nil || got["headers"] == nil {
+		t.Fatalf("mcp.json incomplete: %s", b)
+	}
 }
 
 func TestBuildConfigHomeMinimal(t *testing.T) {

--- a/server/internal/services/sandbox.go
+++ b/server/internal/services/sandbox.go
@@ -1386,7 +1386,8 @@ func mcpServersJSON(specs []sandbox.MCPServerSpec) json.RawMessage {
 	for _, m := range specs {
 		switch {
 		case m.URL != "":
-			entry := map[string]any{"name": m.Name, "url": m.URL}
+			// type:http required by Claude Code / CodeBuddy; url-only is skipped.
+			entry := map[string]any{"name": m.Name, "type": "http", "url": m.URL}
 			if len(m.Headers) > 0 {
 				hs := make([]map[string]string, 0, len(m.Headers))
 				for k, v := range m.Headers {


### PR DESCRIPTION
## Summary
- Inject `"type": "http"` for URL-based MCP servers in `mcp.json` and ACP `mcpServers` (artifact-store / `node_complete` / `set_*`).
- CodeBuddy (`--strict-mcp-config`) and Claude Code skip url-only entries as broken stdio; Cursor previously masked this on the global-cursor path.
- Unit coverage: `TestBuildConfigHomeHTTPTypeRequired` + ACP mcpServers assertion.

## Test plan
- [x] `go test ./internal/sandbox/ -run TestBuildConfigHome`
- [x] `go test ./internal/runtime/ -run 'TestResolvedMCP|TestMcpURL|TestAcp'`
- [ ] After merge: rebuild/republish `approving:0.0.4-beta` (and pin if needed), then re-run a codebuddy clarify node and confirm `node_complete` / `set_clarified_requirement` are available
- [ ] Optional: in sandbox, `codebuddy mcp list` shows artifact-store Connected **and** agent can call `write_artifact`


Made with [Cursor](https://cursor.com)