### PR TITLE
fix(onboarding): light workflow wiring, layout, and review

### DIFF
--- a/docs/content/en/guide/quick-start.md
+++ b/docs/content/en/guide/quick-start.md
@@ -32,7 +32,7 @@ Then open:
 
 `./start.sh` also pulls **four sandbox runtime** images from GHCR (one per acpBackend: cursor / claude_code / codebuddy / trae; large). Until that finishes, sandbox chats may stay on “starting sandbox…”.
 
-Agent / workspace / platform-rules data lives on a named volume (`/app/data`); `./start.sh restart` and `./start.sh down` (without `-v`) keep it. **Do not run `docker compose down -v`** — that wipes Agent config and SQLite.
+Agent / workspace / platform-rules and SQLite live under `./.localdata/` on the host (bind mounts, not named volumes). `./start.sh restart` / `down` keep them; wipe with `./start.sh down && rm -rf .localdata`.
 
 ## Common commands
 
@@ -40,7 +40,7 @@ Agent / workspace / platform-rules data lives on a named volume (`/app/data`); `
 ./start.sh logs
 ./start.sh down
 ./start.sh pull          # refresh GHCR images (including four sandbox runtimes)
-./start.sh restart       # down + up -d (keeps named volumes)
+./start.sh restart       # down + up -d (keeps ./.localdata)
 ./start.sh dev -d        # source stack: go run + Vite HMR
 ```
 
@@ -48,7 +48,7 @@ Image tags / digests can be overridden in `.env` — see [`.env.example`](https:
 
 ## Next steps
 
-- After login, an empty project can use **Project quick start** to configure backend + API Key and generate 5 Agents plus the published light workflow (default git: public Heroku nodejs-getting-started).
+- After login, an empty project can use **Project quick start** to configure backend + API Key and generate 6 Agents plus the published light workflow (default git: public Heroku nodejs-getting-started; agents: Clarify/Visual/Implement/Test/Review/Preview).
 - [Core concepts](../concepts/) — FSM, gates, sandbox, artifacts
 - [Configuration summary](../../help/configuration/) — points to full `CONFIGURATION.md`
 - [Gateway summary](../../help/gateway/) — points to `GATEWAY.md`

--- a/docs/content/guide/quick-start.md
+++ b/docs/content/guide/quick-start.md
@@ -32,7 +32,7 @@ cd approving
 
 `./start.sh` 还会从 GHCR 拉取 **四个 sandbox runtime** 镜像（按 acpBackend：cursor / claude_code / codebuddy / trae，体积较大）。完成前，沙箱对话可能停留在 “starting sandbox…”。
 
-Agent / workspace / platform-rules 持久在命名卷（`/app/data`）；`./start.sh restart` 与 `./start.sh down`（无 `-v`）会保留。**勿用 `docker compose down -v`**，否则会清空 Agent 配置与 SQLite。
+Agent / workspace / platform-rules 与 SQLite 持久在宿主机目录 `./.localdata/`（bind mount，非命名卷）。`./start.sh restart` / `down` 会保留；清空数据：`./start.sh down && rm -rf .localdata`。
 
 ## 常用命令
 
@@ -48,7 +48,7 @@ Agent / workspace / platform-rules 持久在命名卷（`/app/data`）；`./star
 
 ## 下一步
 
-- 登录后进入空项目时，可按「首次上手引导」配置后端与 API Key，一键生成 5 个 Agent 与「快速上手·轻量」工作流（默认 clone Heroku 官方 nodejs-getting-started 公开仓）。引导使用固定 Agent 名（Clarify/Visual/Implement/Test/Preview），同一 Approving 实例内仅一个项目可完成该引导。
+- 登录后进入空项目时，可按「首次上手引导」配置后端与 API Key，一键生成 6 个 Agent 与「快速上手·轻量」工作流（默认 clone Heroku 官方 nodejs-getting-started 公开仓）。引导使用固定 Agent 名（Clarify/Visual/Implement/Test/Review/Preview），同一 Approving 实例内仅一个项目可完成该引导。
 - [核心概念](../concepts/) — FSM、gate、sandbox、artifact
 - [配置摘要](../../help/configuration/) — 指向完整 `CONFIGURATION.md`
 - [网关摘要](../../help/gateway/) — 指向 `GATEWAY.md`

--- a/server/internal/handlers/onboarding.go
+++ b/server/internal/handlers/onboarding.go
@@ -11,7 +11,7 @@ import (
 )
 
 // BootstrapProjectOnboarding handles POST /api/projects/:id/bootstrap-onboarding.
-// It writes project auth, creates/reuses 5 agents, and publishes the light workflow.
+// It writes project auth, creates/reuses onboarding agents, and publishes the light workflow.
 // It never starts a Run. Missing apiKey → 400 with no partial resources created
 // (auth/agents/workflow are only written after the key check).
 func (h *Handlers) BootstrapProjectOnboarding(c *gin.Context) {

--- a/server/internal/services/onboarding.go
+++ b/server/internal/services/onboarding.go
@@ -48,7 +48,7 @@ type OnboardingBootstrapResult struct {
 	Published  bool     `json:"published"`
 }
 
-// OnboardingService atomically bootstraps project auth + 5 agents + light workflow.
+// OnboardingService atomically bootstraps project auth + onboarding agents + light workflow.
 type OnboardingService struct {
 	Projects *ProjectService
 	Skills   *SkillService
@@ -60,13 +60,13 @@ func NewOnboardingService(projects *ProjectService, skills *SkillService, wf *Wo
 	return &OnboardingService{Projects: projects, Skills: skills, WF: wf}
 }
 
-// Bootstrap writes project sandboxEnv auth, saves five agents from embed templates,
-// and publishes the light onboarding workflow. It is idempotent for the fixed names
-// within the same project. Cross-project name conflicts are rejected with
-// ErrOnboardingAgentConflict (no overwrite of another project's agents).
-// It never starts a Run. Missing apiKey rejects without creating resources.
-// Templates and the light graph are validated before any auth/agent writes to
-// reduce mid-flight partial state.
+// Bootstrap writes project sandboxEnv auth, saves onboarding agents from embed
+// templates, and publishes the light onboarding workflow. It is idempotent for
+// the fixed names within the same project. Cross-project name conflicts are
+// rejected with ErrOnboardingAgentConflict (no overwrite of another project's
+// agents). It never starts a Run. Missing apiKey rejects without creating
+// resources. Templates and the light graph are validated before any auth/agent
+// writes to reduce mid-flight partial state.
 func (s *OnboardingService) Bootstrap(projectID string, req OnboardingBootstrapRequest) (OnboardingBootstrapResult, error) {
 	projectID = strings.TrimSpace(projectID)
 	if projectID == "" {
@@ -287,7 +287,7 @@ func (s *OnboardingService) upsertLightWorkflow(projectID, repos, feature string
 		}
 	}
 	if existing != nil {
-		existing.Description = "空项目快速上手轻量示例（clarify→visual→gate→implement→test→preview）"
+		existing.Description = "空项目快速上手轻量示例（clarify→visual→gate→implement→test→review→preview）"
 		existing.NeedsRepo = true
 		existing.Graph = graph
 		if err := s.WF.Save(existing); err != nil {
@@ -299,7 +299,7 @@ func (s *OnboardingService) upsertLightWorkflow(projectID, repos, feature string
 		ID:          uuid.NewString(),
 		ProjectID:   projectID,
 		Name:        OnboardingWorkflowName,
-		Description: "空项目快速上手轻量示例（clarify→visual→gate→implement→test→preview）",
+		Description: "空项目快速上手轻量示例（clarify→visual→gate→implement→test→review→preview）",
 		Status:      "draft",
 		Version:     1,
 		NeedsRepo:   true,
@@ -317,10 +317,17 @@ func BuildOnboardingLightGraphForTest(repos, feature string) models.Graph {
 }
 
 func buildOnboardingLightGraph(repos, feature string) models.Graph {
-	implementPrompt := "轻量链路：用 get_clarified_requirement 读取澄清结论，并结合视觉产物 page.html 与 {{vars.preview_issues}}（如有）实现改动。" +
+	implementPrompt := "轻量链路：用 get_clarified_requirement 读取澄清结论，并结合视觉产物 page.html 与 {{vars.preview_issues}} / {{vars.reason}}（如有）实现改动。" +
 		"勿依赖实施计划。在仓库中完成需求后提交推送，并调用 set_implementation_result。"
 	visualPrompt := "根据澄清后的需求做一个简洁美观的可视化网页 demo（原型），用 write_artifact 写入 page.html。勿依赖 plan。"
 	previewPrompt := "在沙箱内启动 Heroku Node Getting Started 示例（或工作流 repos 指向的公开仓）：PORT=5006，监听 0.0.0.0，调用 set_preview(5006)。"
+	reviewPrompt := "轻量评审上游实现：只拦正确性/回归/明显安全问题；文案与风格非阻塞。用 set_review 写入结论。无 plan 时可省略计划覆盖。"
+
+	// Positions: never use (0,0) — the canvas treats that as "invalid" and
+	// session-layouts the node to the right of all others (input appeared last).
+	const y = 200
+	step := 220
+	x := func(i int) float64 { return float64(40 + i*step) }
 
 	return models.Graph{
 		Variables: []models.Variable{
@@ -337,9 +344,9 @@ func buildOnboardingLightGraph(repos, feature string) models.Graph {
 			},
 		},
 		Nodes: []models.Node{
-			{ID: "input", Type: "input", Label: "输入", Position: models.Position{X: 0, Y: 0}, Config: map[string]any{}},
+			{ID: "input", Type: "input", Label: "输入", Position: models.Position{X: x(0), Y: y}, Config: map[string]any{}},
 			{
-				ID: "clarify", Type: "react", Label: "澄清", Position: models.Position{X: 220, Y: 0},
+				ID: "clarify", Type: "react", Label: "澄清", Position: models.Position{X: x(1), Y: y},
 				Config: map[string]any{
 					"skill_profile": "ClarifyAgent",
 					"max_rounds":    6,
@@ -347,35 +354,41 @@ func buildOnboardingLightGraph(repos, feature string) models.Graph {
 				},
 			},
 			{
-				ID: "visual", Type: "visual", Label: "视觉", Position: models.Position{X: 440, Y: 0},
+				ID: "visual", Type: "visual", Label: "视觉", Position: models.Position{X: x(2), Y: y},
 				Config: map[string]any{
 					"skill_profile": "VisualAgent",
 					"prompt":        visualPrompt,
 				},
 			},
 			{
-				ID: "gate", Type: "human_gate", Label: "视觉确认", Position: models.Position{X: 660, Y: 0},
+				ID: "gate", Type: "human_gate", Label: "视觉确认", Position: models.Position{X: x(3), Y: y},
 				Config: map[string]any{
 					"title":         "确认视觉原型",
 					"body_template": "{{nodes.visual.outputs.page}}",
 					"output_var":    "action",
 					"form":          []any{},
+					// goto on actions is the primary canvas/engine route; When
+					// edges below remain as fallback for older clients.
 					"actions": []any{
-						map[string]any{"id": "approve", "label": "批准"},
-						map[string]any{"id": "revise", "label": "退回修改"},
+						map[string]any{"id": "approve", "label": "批准", "goto": "implement"},
+						map[string]any{"id": "revise", "label": "退回修改", "goto": "visual"},
 					},
 				},
 			},
 			{
-				ID: "implement", Type: "implement", Label: "实现", Position: models.Position{X: 880, Y: 0},
+				ID: "implement", Type: "implement", Label: "实现", Position: models.Position{X: x(4), Y: y},
 				Config: map[string]any{
 					"skill_profile": "ImplementAgent",
 					"max_rounds":    3,
 					"prompt":        implementPrompt,
+					"conditional_prompt": map[string]any{
+						"when_var": "reason",
+						"text":     "测试/评审/预览未通过：{{vars.reason}}\n按反馈最小修复后重新 PUSH。",
+					},
 				},
 			},
 			{
-				ID: "test", Type: "test", Label: "测试", Position: models.Position{X: 1100, Y: 0},
+				ID: "test", Type: "test", Label: "测试", Position: models.Position{X: x(5), Y: y},
 				Config: map[string]any{
 					"skill_profile":    "TestAgent",
 					"reason_var":       "reason",
@@ -383,13 +396,25 @@ func buildOnboardingLightGraph(repos, feature string) models.Graph {
 					"block_on_skipped": false,
 					"prompt":           "对上游实现执行测试并如实记录结果,用 set_test_result 写入测试总结。无 plan 叶子时可省略 plan_coverage。",
 					"exits": map[string]any{
+						"pass": map[string]any{"goto": "review"},
+						"fail": map[string]any{"goto": "implement"},
+					},
+				},
+			},
+			{
+				ID: "review", Type: "review", Label: "复审", Position: models.Position{X: x(6), Y: y},
+				Config: map[string]any{
+					"skill_profile": "ReviewAgent",
+					"reason_var":    "reason",
+					"prompt":        reviewPrompt,
+					"exits": map[string]any{
 						"pass": map[string]any{"goto": "preview"},
 						"fail": map[string]any{"goto": "implement"},
 					},
 				},
 			},
 			{
-				ID: "preview", Type: "app_preview", Label: "预览", Position: models.Position{X: 1320, Y: 0},
+				ID: "preview", Type: "app_preview", Label: "预览", Position: models.Position{X: x(7), Y: y},
 				Config: map[string]any{
 					"skill_profile": "PreviewAgent",
 					"max_rounds":    3,
@@ -398,12 +423,12 @@ func buildOnboardingLightGraph(repos, feature string) models.Graph {
 					"prompt":        previewPrompt,
 					"form":          []any{},
 					"actions": []any{
-						map[string]any{"id": "pass", "label": "通过"},
-						map[string]any{"id": "fail", "label": "退回"},
+						map[string]any{"id": "pass", "label": "通过", "goto": "output"},
+						map[string]any{"id": "fail", "label": "退回", "goto": "implement"},
 					},
 				},
 			},
-			{ID: "output", Type: "output", Label: "输出", Position: models.Position{X: 1540, Y: 0}, Config: map[string]any{}},
+			{ID: "output", Type: "output", Label: "输出", Position: models.Position{X: x(8), Y: y}, Config: map[string]any{}},
 		},
 		Edges: []models.Edge{
 			{ID: "e1", Source: "input", Target: "clarify"},
@@ -412,11 +437,13 @@ func buildOnboardingLightGraph(repos, feature string) models.Graph {
 			{ID: "e4", Source: "gate", Target: "implement", When: "action == 'approve'", Kind: models.EdgeSuccess},
 			{ID: "e5", Source: "gate", Target: "visual", When: "action == 'revise'", Kind: models.EdgeSuccess},
 			{ID: "e6", Source: "implement", Target: "test"},
-			{ID: "e7", Source: "test", Target: "preview", Kind: models.EdgeSuccess},
+			{ID: "e7", Source: "test", Target: "review", Kind: models.EdgeSuccess},
 			{ID: "e8", Source: "test", Target: "implement", Kind: models.EdgeFailure},
-			{ID: "e9", Source: "preview", Target: "output", When: "action == 'pass'", Kind: models.EdgeSuccess},
-			{ID: "e10", Source: "preview", Target: "implement", When: "action == 'fail'", Kind: models.EdgeSuccess},
-			{ID: "e11", Source: "preview", Target: "implement", Kind: models.EdgeFailure},
+			{ID: "e9", Source: "review", Target: "preview", Kind: models.EdgeSuccess},
+			{ID: "e10", Source: "review", Target: "implement", Kind: models.EdgeFailure},
+			{ID: "e11", Source: "preview", Target: "output", When: "action == 'pass'", Kind: models.EdgeSuccess},
+			{ID: "e12", Source: "preview", Target: "implement", When: "action == 'fail'", Kind: models.EdgeSuccess},
+			{ID: "e13", Source: "preview", Target: "implement", Kind: models.EdgeFailure},
 		},
 	}
 }

--- a/server/internal/services/onboarding_embed.go
+++ b/server/internal/services/onboarding_embed.go
@@ -20,6 +20,7 @@ var OnboardingAgentNames = []string{
 	"VisualAgent",
 	"ImplementAgent",
 	"TestAgent",
+	"ReviewAgent",
 	"PreviewAgent",
 }
 

--- a/server/internal/services/onboarding_embed/ReviewAgent/agent.json
+++ b/server/internal/services/onboarding_embed/ReviewAgent/agent.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "acpBackend": "cursor",
+  "mcp": [
+    {
+      "name": "artifact-store",
+      "url": "${APPROVING_ARTIFACT_URL}",
+      "headers": {
+        "Authorization": "Bearer ${APPROVING_ARTIFACT_TOKEN}"
+      }
+    }
+  ],
+  "name": "ReviewAgent"
+}

--- a/server/internal/services/onboarding_embed/ReviewAgent/workspace/AGENTS.md
+++ b/server/internal/services/onboarding_embed/ReviewAgent/workspace/AGENTS.md
@@ -1,0 +1,18 @@
+# ReviewAgent
+
+## 使命
+
+作为评审专家，对实现与设计做结构化评审，给出结论与按严重度排序的意见。
+
+## 唯一交付
+
+唯一交付：`set_review`。
+
+对应工具：set_review。
+
+## 禁止事项
+
+- 禁止用 `write_artifact` 旁路，或越权调用 `set_clarified_requirement` / `set_research` / `set_proposals` / `set_plan` / `set_implementation_result` / `set_test_result`。
+- 不承担其他 SDLC 节点职责；本包不是万能超级 Agent。
+- 密钥与凭据不得出现在本工作区或提交中。
+- 不削弱平台嵌入的契约与门禁；本包只补充角色身份与质量棘轮。

--- a/server/internal/services/onboarding_embed/ReviewAgent/workspace/rules/role.md
+++ b/server/internal/services/onboarding_embed/ReviewAgent/workspace/rules/role.md
@@ -1,0 +1,34 @@
+---
+description: ReviewAgent 角色人设与交付边界（始终应用）
+alwaysApply: true
+---
+
+# ReviewAgent 角色边界
+
+你是 **ReviewAgent**，与平台 SDLC 节点 1:1 对应，`skill_profile` 同名引用。
+
+## 人设
+
+作为评审专家，对实现与设计做结构化评审，给出结论与按严重度排序的意见。
+
+## 唯一交付声明
+
+唯一交付：`set_review`。
+
+完成前不得声称节点已交付。
+
+## 边界
+
+禁止用 `write_artifact` 旁路，或越权调用 `set_clarified_requirement` / `set_research` / `set_proposals` / `set_plan` / `set_implementation_result` / `set_test_result`。
+
+## 通用禁止事项（角色内拷贝）
+
+- **禁止密钥入库**：不得把 ACP Key、Git Token、密码、私钥或可用凭据写入仓库、`agents/` 源码或 ZIP；凭据仅在 Agent Studio / 运行时环境配置。
+- **禁止 write_artifact 旁路**：结构化节点交付必须走对应的 `set_*`（及澄清的 `ask_question`），不得用 `write_artifact` 假装完成门禁。
+- **禁止越权交付**：只完成本角色唯一交付，不代替上下游节点写入其结论。
+- **禁止削弱平台门禁**：不得复制或改写完整平台节点规则正文；不得暗示可以跳过 `open_questions` 非空、计划未完成、测试 failed、`request_changes` 等门禁语义。
+
+
+## 与平台规则的关系
+
+平台嵌入规则保证契约底线与门禁；本文件只声明身份、唯一交付与禁止旁路。遇到冲突时以平台节点契约为准，不得用本包内容削弱门禁。

--- a/server/internal/services/onboarding_embed/ReviewAgent/workspace/skills/review-checklist/SKILL.md
+++ b/server/internal/services/onboarding_embed/ReviewAgent/workspace/skills/review-checklist/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: review-checklist
+description: ReviewAgent 专业质量检查清单（简体中文）
+---
+
+# ReviewAgent 检查清单
+
+在调用唯一交付工具之前，逐项自检：
+
+1. verdict 与 findings 一致：request_changes/reject 须有对应高优先级意见
+2. findings 按严重度标注，尽量带 file/line 与 suggestion
+3. 关注正确性、安全、可维护性与是否偏离澄清/计划
+4. 不把风格偏好升级为 critical；真正阻断项要说清楚
+5. action_items 可执行，便于实现节点回修
+
+## 交付核对
+
+- [ ] 唯一交付工具已正确调用：set_review
+- [ ] 未使用 `write_artifact` 旁路门禁
+- [ ] 未写入任何密钥或可用凭据
+- [ ] 未越权完成其他节点的 `set_*` 交付
+- [ ] 未削弱平台门禁语义
+
+## 质量棘轮
+
+- verdict 与 findings 严重度一致：request_changes/reject 必有 high/critical 依据
+- findings 尽量带 file/line 与 suggestion；风格偏好不得标为 critical
+- action_items 可执行且可指回实现节点回修，不与澄清/计划验收点冲突

--- a/server/internal/services/onboarding_embed_sync_test.go
+++ b/server/internal/services/onboarding_embed_sync_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // TestOnboardingEmbedMatchesAgentsSource guards against agents/ vs onboarding_embed/ drift
-// for the five bootstrap packages (review v6).
+// for bootstrap packages (includes ReviewAgent).
 func TestOnboardingEmbedMatchesAgentsSource(t *testing.T) {
 	_, thisFile, _, ok := runtime.Caller(0)
 	if !ok {

--- a/server/internal/services/onboarding_test.go
+++ b/server/internal/services/onboarding_test.go
@@ -43,8 +43,8 @@ func TestOnboardingBootstrapCreatesAgentsAndPublishedWorkflow(t *testing.T) {
 	if res.WorkflowID == "" {
 		t.Fatal("missing workflowId")
 	}
-	if len(res.AgentIDs) != 5 {
-		t.Fatalf("want 5 agents, got %v", res.AgentIDs)
+	if len(res.AgentIDs) != len(services.OnboardingAgentNames) {
+		t.Fatalf("want %d agents, got %v", len(services.OnboardingAgentNames), res.AgentIDs)
 	}
 	if res.Repos != services.DefaultOnboardingRepos {
 		t.Fatalf("repos = %q", res.Repos)
@@ -167,7 +167,7 @@ func TestOnboardingBootstrapIdempotent(t *testing.T) {
 	if r1.WorkflowID != r2.WorkflowID {
 		t.Fatalf("workflow id changed: %s vs %s", r1.WorkflowID, r2.WorkflowID)
 	}
-	if len(svc.Skills.List()) != 5 {
+	if len(svc.Skills.List()) != len(services.OnboardingAgentNames) {
 		t.Fatalf("agents doubled: %d", len(svc.Skills.List()))
 	}
 	if n := len(svc.WF.List(projectID)); n != 1 {
@@ -240,8 +240,8 @@ func TestOnboardingBootstrapAllowsClaimingUnboundAgents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bootstrap should claim unbound: %v", err)
 	}
-	if len(res.AgentIDs) != 5 {
-		t.Fatalf("want 5 agents, got %v", res.AgentIDs)
+	if len(res.AgentIDs) != len(services.OnboardingAgentNames) {
+		t.Fatalf("want %d agents, got %v", len(services.OnboardingAgentNames), res.AgentIDs)
 	}
 	a, ok := svc.Skills.Get("ClarifyAgent")
 	if !ok || a.ProjectID != projectID {
@@ -294,33 +294,80 @@ func assertOnboardingGraph(t *testing.T, g models.Graph) {
 	for _, n := range g.Nodes {
 		byID[n.ID] = n
 	}
-	for _, id := range []string{"input", "clarify", "visual", "gate", "implement", "test", "preview", "output"} {
+	for _, id := range []string{"input", "clarify", "visual", "gate", "implement", "test", "review", "preview", "output"} {
 		if _, ok := byID[id]; !ok {
 			t.Fatalf("missing node %s", id)
 		}
 	}
-	for _, banned := range []string{"research", "proposal", "plan", "review"} {
+	for _, banned := range []string{"research", "proposal", "plan"} {
 		for _, n := range g.Nodes {
 			if n.Type == banned {
 				t.Fatalf("unexpected node type %s", banned)
 			}
 		}
 	}
+	if byID["review"].Type != "review" {
+		t.Fatalf("review node type = %s", byID["review"].Type)
+	}
+	// (0,0) is invalid for the canvas session layout (node gets shoved right).
+	for _, n := range g.Nodes {
+		if n.Position.X == 0 && n.Position.Y == 0 {
+			t.Fatalf("node %s has invalid position (0,0)", n.ID)
+		}
+	}
 	gate := byID["gate"]
 	if bt, _ := gate.Config["body_template"].(string); bt != "{{nodes.visual.outputs.page}}" {
 		t.Fatalf("gate body_template = %v", gate.Config["body_template"])
 	}
+	gateActions, _ := gate.Config["actions"].([]any)
+	var approveGoto, reviseGoto string
+	for _, raw := range gateActions {
+		a, _ := raw.(map[string]any)
+		switch a["id"] {
+		case "approve":
+			approveGoto, _ = a["goto"].(string)
+		case "revise":
+			reviseGoto, _ = a["goto"].(string)
+		}
+	}
+	if approveGoto != "implement" || reviseGoto != "visual" {
+		t.Fatalf("gate action goto approve=%q revise=%q", approveGoto, reviseGoto)
+	}
 	testCfg := byID["test"].Config
 	exits, _ := testCfg["exits"].(map[string]any)
 	fail, _ := exits["fail"].(map[string]any)
+	pass, _ := exits["pass"].(map[string]any)
 	if fail["goto"] != "implement" {
 		t.Fatalf("test fail goto = %v", fail["goto"])
+	}
+	if pass["goto"] != "review" {
+		t.Fatalf("test pass goto = %v want review", pass["goto"])
+	}
+	revExits, _ := byID["review"].Config["exits"].(map[string]any)
+	revPass, _ := revExits["pass"].(map[string]any)
+	revFail, _ := revExits["fail"].(map[string]any)
+	if revPass["goto"] != "preview" || revFail["goto"] != "implement" {
+		t.Fatalf("review exits pass=%v fail=%v", revPass["goto"], revFail["goto"])
+	}
+	previewActions, _ := byID["preview"].Config["actions"].([]any)
+	var previewPassGoto, previewFailGoto string
+	for _, raw := range previewActions {
+		a, _ := raw.(map[string]any)
+		switch a["id"] {
+		case "pass":
+			previewPassGoto, _ = a["goto"].(string)
+		case "fail":
+			previewFailGoto, _ = a["goto"].(string)
+		}
+	}
+	if previewPassGoto != "output" || previewFailGoto != "implement" {
+		t.Fatalf("preview action goto pass=%q fail=%q", previewPassGoto, previewFailGoto)
 	}
 	implPrompt, _ := byID["implement"].Config["prompt"].(string)
 	if strings.Contains(implPrompt, "get_plan") {
 		t.Fatal("light implement prompt must not require get_plan")
 	}
-	var hasRevise, hasApprove, hasPreviewFail bool
+	var hasRevise, hasApprove, hasPreviewFail, hasReviewEdge bool
 	for _, e := range g.Edges {
 		if e.Source == "gate" && e.Target == "visual" && strings.Contains(e.When, "revise") {
 			hasRevise = true
@@ -331,9 +378,12 @@ func assertOnboardingGraph(t *testing.T, g models.Graph) {
 		if e.Source == "preview" && e.Target == "implement" {
 			hasPreviewFail = true
 		}
+		if e.Source == "test" && e.Target == "review" {
+			hasReviewEdge = true
+		}
 	}
-	if !hasRevise || !hasApprove || !hasPreviewFail {
-		t.Fatalf("missing revise/fail loops: revise=%v approve=%v previewFail=%v", hasRevise, hasApprove, hasPreviewFail)
+	if !hasRevise || !hasApprove || !hasPreviewFail || !hasReviewEdge {
+		t.Fatalf("missing loops/edges: revise=%v approve=%v previewFail=%v reviewEdge=%v", hasRevise, hasApprove, hasPreviewFail, hasReviewEdge)
 	}
 	if err := g.Validate(); err != nil {
 		t.Fatalf("graph validate: %v", err)

--- a/web/e2e/onboarding-wizard.spec.ts
+++ b/web/e2e/onboarding-wizard.spec.ts
@@ -21,7 +21,7 @@ test('空项目上手引导五步向导浏览器验收', async ({ page }) => {
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({
-          agentIds: ['ClarifyAgent', 'VisualAgent', 'ImplementAgent', 'TestAgent', 'PreviewAgent'],
+          agentIds: ['ClarifyAgent', 'VisualAgent', 'ImplementAgent', 'TestAgent', 'ReviewAgent', 'PreviewAgent'],
           workflowId: 'wf-onboard-1',
           repos: body.repos || 'demo|https://github.com/heroku/nodejs-getting-started.git|main',
           feature: '把首页欢迎文案与主按钮文案改得更清晰友好',

--- a/web/src/components/onboarding/OnboardingWizard.test.ts
+++ b/web/src/components/onboarding/OnboardingWizard.test.ts
@@ -12,7 +12,7 @@ import {
 vi.mock('@/lib/api', () => ({
   api: {
     bootstrapProjectOnboarding: vi.fn(async () => ({
-      agentIds: ['ClarifyAgent', 'VisualAgent', 'ImplementAgent', 'TestAgent', 'PreviewAgent'],
+      agentIds: ['ClarifyAgent', 'VisualAgent', 'ImplementAgent', 'TestAgent', 'ReviewAgent', 'PreviewAgent'],
       workflowId: 'wf-1',
       repos: 'demo|https://github.com/heroku/nodejs-getting-started.git|main',
       feature: '把首页欢迎文案与主按钮文案改得更清晰友好',

--- a/web/src/lib/canvasLayout.test.ts
+++ b/web/src/lib/canvasLayout.test.ts
@@ -53,4 +53,19 @@ describe('computeSessionLayout', () => {
     expect(layout.has('anchor')).toBe(false)
     expect(layout.get('bad')!.x).toBeGreaterThan(400)
   })
+
+  it('uses app_preview action goto for adjacency like human_gate', () => {
+    const nodes = [
+      node('input', 'input', { x: 0, y: 0 }),
+      node('preview', 'app_preview', { x: 0, y: 0 }, {
+        actions: [{ id: 'pass', goto: 'out' }, { id: 'fail', goto: 'input' }],
+      }),
+      node('out', 'output', { x: 0, y: 0 }),
+    ]
+    const edges: WFEdge[] = [{ id: 'e1', source: 'input', target: 'preview' }]
+    const layout = computeSessionLayout(nodes, edges)
+    expect(layout.size).toBe(3)
+    // out should be layered after preview via action goto, not stuck at layer 0.
+    expect(layout.get('out')!.x).toBeGreaterThan(layout.get('preview')!.x)
+  })
 })

--- a/web/src/lib/canvasLayout.ts
+++ b/web/src/lib/canvasLayout.ts
@@ -35,7 +35,8 @@ function buildAdjacency(nodes: WFNode[], edges: WFEdge[]) {
         if (c?.goto) addEdge(adj, inDeg, n.id, c.goto)
       }
     }
-    if (n.type === 'human_gate') {
+    // human_gate and app_preview both route via actions[].goto (engine resume).
+    if (n.type === 'human_gate' || n.type === 'app_preview') {
       for (const a of (n.config?.actions as { id?: string; goto?: string }[]) || []) {
         if (a?.goto) addEdge(adj, inDeg, n.id, a.goto)
       }

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -124,7 +124,7 @@
       "startRun": "Start sample Run",
       "cta": "Start onboarding",
       "emptyTitle": "Empty project — start onboarding",
-      "emptyDesc": "Configure backend + API Key to create 5 Agents and the published「快速上手·轻量」workflow. Default git is the public Heroku sample.",
+      "emptyDesc": "Configure backend + API Key to create 6 Agents and the published light quick-start workflow. Default git is the public Heroku sample.",
       "head": {
         "overview": "What you will get",
         "acp": "Choose ACP backend",
@@ -141,7 +141,7 @@
         "review": "Review"
       },
       "overview": {
-        "meta": "This writes project auth, creates 5 Agents, and publishes the light quick-start workflow. It will not start a Run automatically.",
+        "meta": "This writes project auth, creates 6 Agents, and publishes the light quick-start workflow. It will not start a Run automatically.",
         "agents": "Agents",
         "agentsList": "Clarify / Visual / Implement / Test / Preview",
         "repo": "Repo",
@@ -175,7 +175,7 @@
       },
       "success": {
         "title": "Setup ready",
-        "desc": "Project auth written; 5 Agents and the published light workflow are ready.",
+        "desc": "Project auth written; 6 Agents and the published light workflow are ready.",
         "repo": "Sample repository",
         "limit": "Public repos usually cannot be pushed; Preview may not show Implement changes. Success means Agents/workflow were created.",
         "runStarted": "Sample Run started"

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -124,7 +124,7 @@
       "startRun": "启动示例 Run",
       "cta": "开始上手引导",
       "emptyTitle": "空项目，开始上手引导",
-      "emptyDesc": "配置后端与 API Key，一键生成 5 个 Agent 与「快速上手·轻量」工作流。默认使用 Heroku 公开示例仓。",
+      "emptyDesc": "配置后端与 API Key，一键生成 6 个 Agent 与「快速上手·轻量」工作流。默认使用 Heroku 公开示例仓。",
       "head": {
         "overview": "看看这次会生成什么",
         "acp": "选择运行后端",
@@ -141,7 +141,7 @@
         "review": "确认"
       },
       "overview": {
-        "meta": "完成以下步骤后，将写入项目鉴权、创建 5 个 Agent，并发布「快速上手·轻量」工作流。不会自动开跑。",
+        "meta": "完成以下步骤后，将写入项目鉴权、创建 6 个 Agent，并发布「快速上手·轻量」工作流。不会自动开跑。",
         "agents": "Agent",
         "agentsList": "Clarify / Visual / Implement / Test / Preview",
         "repo": "代码仓",
@@ -175,7 +175,7 @@
       },
       "success": {
         "title": "配置已生成",
-        "desc": "已写入项目鉴权，并生成 5 个 Agent 与已发布的「快速上手·轻量」工作流。",
+        "desc": "已写入项目鉴权，并生成 6 个 Agent 与已发布的「快速上手·轻量」工作流。",
         "repo": "示例代码仓",
         "limit": "公开仓通常无法 push；Preview 未必看到 Implement 改动。引导成败以 Agent/工作流是否生成为准。",
         "runStarted": "已启动示例 Run"


### PR DESCRIPTION
## Summary
- Fix「快速上手·轻量」canvas: action `goto` on gate/preview (remove「未设 goto → 按 when 路由」), never seed `(0,0)` positions (input was laid out last).
- Add **复审** (`review` + `ReviewAgent`) between test and preview.
- Session layout now uses `app_preview` action gotos like `human_gate`.

## Test plan
- [x] `go test ./internal/services/ -run Onboarding|Embed`
- [x] `vitest` canvasLayout
- [ ] Re-run empty-project bootstrap (or re-bootstrap) and confirm canvas order: 输入→…→复审→预览→输出；gate/preview no longer show「未设 goto」


Made with [Cursor](https://cursor.com)