### PR TITLE
fix(capa): CAPA A2–A8 MCP observability & regression locks (run-94650e47)

### DIFF
--- a/docs/postmortems/2026-07-28-capa-from-run-94650e47.md
+++ b/docs/postmortems/2026-07-28-capa-from-run-94650e47.md
@@ -1,0 +1,43 @@
+# CAPA from run-94650e47（CodeBuddy MCP 工具表为空）
+
+来源：复盘 Run `run-94650e47`。业务根因已由 PR #116（A1）修复。本文件记录 P0 Open 项（A2–A8）落地说明与限制。
+
+## A1（Done，本 Run 不重做）
+
+CodeBuddy 在 `--strict-mcp-config` 下附加 `--mcp-config <ConfigRoot>/mcp.json`；Cursor BaseArgs 含 `--approve-mcps`；空默认会话在 connect 非空 `mcpServers` 时重建。
+
+## A2–A4 单测金锁
+
+| ID | 测试 | 位置 |
+|----|------|------|
+| A2 | `TestCodeBuddyArgsGoldenStrictPlusMcpConfig` | `sandbox-gateway/sandbox/internal/agents/registry_test.go` |
+| A3 | `TestCursorBaseArgsIncludeApproveMcps` | 同上 |
+| A4 | `TestEnsureAgentRebuildsOnEmptyToNonEmptyMCP` | `sandbox-gateway/sandbox/internal/service/bridge_connect_mcp_test.go` |
+
+## A5 限制（降级验收）
+
+`TestE2E_CodeBuddyOneshotToolsListNonEmpty` 在无真 `codebuddy` CLI / 含该二进制的 sandbox 镜像时，**不**做真实 `tools/list` 非空 E2E。
+
+本 Run：
+
+- 用与生产相同的 registry BaseArgs，经 `ArgsForTest` 锁死 `--strict-mcp-config` + `--mcp-config /root/.codebuddy/mcp.json`（依赖 A2）。
+- **不做** tag / `0.0.4-beta` 镜像发版。
+- 真 CLI `tools/list` 非空验证 follow-up：需含 `codebuddy` 的 sandbox 镜像。
+
+## A6 可观测日志
+
+- oneshot spawn：`oneshot: spawn agent=… argv_redacted=…`（保留 MCP flag+path，脱敏 prompt / Authorization）。
+- connect：`mcp_servers_count=… names=…`。
+
+## A7 outcome 失败分流
+
+- 零 MCP host 调用 + 缺 `node_complete` → `MCP 工具面为空/不可达，无法完成 node_complete`
+- 有 MCP 流量仍无 mark → `未调用 node_complete 标记完成`
+
+## A8 CI/e2e
+
+`e2e-ci.sh` / `e2e-docker.sh`：禁止仅 `test -f mcp.json`；增加 `mcpServers`（及 artifact-store / e2e）内容 smoke。`configHomePresent` 运维探针未改。
+
+## 明确不做
+
+A9 Provider checklist、A10 值班 Playbook、A11 Docker 盘运维、发版打 tag。

--- a/sandbox-gateway/sandbox/internal/agents/registry_test.go
+++ b/sandbox-gateway/sandbox/internal/agents/registry_test.go
@@ -65,6 +65,75 @@ func TestCodeBuddyKeepsStrictMcpIsolation(t *testing.T) {
 	}
 }
 
+// TestCodeBuddyArgsGoldenStrictPlusMcpConfig (CAPA A2): registry[CodeBuddy]
+// Args must simultaneously contain --strict-mcp-config and
+// --mcp-config /root/.codebuddy/mcp.json.
+func TestCodeBuddyArgsGoldenStrictPlusMcpConfig(t *testing.T) {
+	args := mustArgsForTest(t, registry[provider.CodeBuddy])
+	if !containsArg(args, "--strict-mcp-config") {
+		t.Fatalf("missing --strict-mcp-config in %v", args)
+	}
+	wantPath := "/root/.codebuddy/mcp.json"
+	if i := indexOfArg(args, "--mcp-config"); i < 0 || i+1 >= len(args) || args[i+1] != wantPath {
+		t.Fatalf("want --mcp-config %s in %v", wantPath, args)
+	}
+}
+
+// TestCursorBaseArgsIncludeApproveMcps (CAPA A3): Cursor Args must include
+// --approve-mcps so headless -p auto-approves seeded ~/.cursor/mcp.json.
+func TestCursorBaseArgsIncludeApproveMcps(t *testing.T) {
+	args := mustArgsForTest(t, registry[provider.Cursor])
+	if !containsArg(args, "--approve-mcps") {
+		t.Fatalf("missing --approve-mcps in %v", args)
+	}
+}
+
+// TestE2E_CodeBuddyOneshotToolsListNonEmpty (CAPA A5, degraded): without a real
+// codebuddy binary/image this locks the production BaseArgs argv surface that
+// makes MCP loadable. Full tools/list non-empty proof needs a sandbox image
+// with codebuddy (not in this Run; see docs/postmortems/2026-07-28-capa-from-run-94650e47.md).
+func TestE2E_CodeBuddyOneshotToolsListNonEmpty(t *testing.T) {
+	args := mustArgsForTest(t, registry[provider.CodeBuddy])
+	if !containsArg(args, "--strict-mcp-config") {
+		t.Fatalf("A5 argv lock: missing --strict-mcp-config: %v", args)
+	}
+	if i := indexOfArg(args, "--mcp-config"); i < 0 || i+1 >= len(args) || args[i+1] != "/root/.codebuddy/mcp.json" {
+		t.Fatalf("A5 argv lock: want --mcp-config /root/.codebuddy/mcp.json in %v", args)
+	}
+	t.Log("A5 degraded: argv golden lock only; real CLI tools/list requires codebuddy sandbox image")
+}
+
+type argsForTester interface {
+	ArgsForTest(opts provider.OpenOptions, prompt, resumeID string) []string
+}
+
+func mustArgsForTest(t *testing.T, p provider.Provider) []string {
+	t.Helper()
+	a, ok := p.(argsForTester)
+	if !ok {
+		t.Fatalf("provider %s does not expose ArgsForTest (oneshot stream-json expected)", p.Name())
+	}
+	return a.ArgsForTest(provider.OpenOptions{}, "", "")
+}
+
+func containsArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func indexOfArg(args []string, want string) int {
+	for i, a := range args {
+		if a == want {
+			return i
+		}
+	}
+	return -1
+}
+
 func TestClaudeFamilyDoesNotUseBareStrictMcp(t *testing.T) {
 	// Only codebuddy opts into --strict-mcp-config (with streamjson auto --mcp-config).
 	// Claude loads ~/.claude/mcp.json by default — do not add bare strict here.

--- a/sandbox-gateway/sandbox/internal/provider/oneshot/oneshot.go
+++ b/sandbox-gateway/sandbox/internal/provider/oneshot/oneshot.go
@@ -141,6 +141,12 @@ func (p *Provider) DefaultConfigRoot() string         { return p.c.ConfigRoot() 
 func (p *Provider) Transport() provider.TransportKind { return provider.OneShot }
 func (p *Provider) AuthEnv(env []string) []string     { return p.c.AuthEnv(env) }
 
+// ArgsForTest exposes codec.Args for registry golden locks (CAPA A2/A3).
+// Not part of provider.Provider; callers type-assert the concrete oneshot.Provider.
+func (p *Provider) ArgsForTest(opts provider.OpenOptions, prompt, resumeID string) []string {
+	return p.c.Args(opts, prompt, resumeID)
+}
+
 func (p *Provider) ListModels(ctx context.Context) ([]provider.Model, error) {
 	return p.c.Models(ctx)
 }
@@ -318,6 +324,8 @@ func (e *engine) runOnce(ctx context.Context, text string, images []provider.Pro
 	if len(args) == 0 {
 		return turnOutcome{stopReason: "failed"}, errors.New("oneshot: codec produced empty argv")
 	}
+	// CAPA A6: greppable redacted argv (MCP flags+paths retained; no prompt/Authorization).
+	log.Printf("oneshot: spawn agent=%s argv_redacted=%v", e.c.AgentName(), redactArgv(args))
 	// Use plain Command (not CommandContext) so we can kill the whole process
 	// group on cancel — many CLIs spawn children that would otherwise orphan.
 	cmd := exec.Command(e.binPath, args[1:]...)
@@ -613,4 +621,26 @@ func (s *stderrTail) String() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return strings.TrimSpace(string(s.buf))
+}
+
+// redactArgv returns a greppable argv snapshot for logs: keeps MCP-related
+// flags and config paths, redacts prompt text and Authorization-like values.
+func redactArgv(args []string) []string {
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		lower := strings.ToLower(a)
+		if strings.Contains(lower, "authorization") || strings.HasPrefix(a, "Bearer ") || strings.HasPrefix(a, "bearer ") {
+			out = append(out, "[redacted]")
+			continue
+		}
+		// -p <prompt> (PromptArg CLIs): redact the following non-flag value.
+		if (a == "-p" || a == "--message") && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+			out = append(out, a, "[prompt-redacted]")
+			i++
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
 }

--- a/sandbox-gateway/sandbox/internal/service/bridge.go
+++ b/sandbox-gateway/sandbox/internal/service/bridge.go
@@ -49,6 +49,9 @@ type Bridge struct {
 	// 最近一次 session/new 使用的 MCP 列表（JSON），重启 Agent 时复用
 	lastMCP json.RawMessage
 
+	// testConnect, when non-nil, replaces Connect inside EnsureAgent (unit tests only).
+	testConnect func(cwd, fsRoot string, mcp json.RawMessage, auto *bool) (provider.Session, error)
+
 	// 当前 session/prompt 一轮：取消时结束 Conn.Call 等待，并配合 session/cancel 通知 Agent
 	turnMu     sync.Mutex
 	activeTurn *promptTurn

--- a/sandbox-gateway/sandbox/internal/service/bridge_connect.go
+++ b/sandbox-gateway/sandbox/internal/service/bridge_connect.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -130,10 +131,17 @@ func (b *Bridge) EnsureAgent(cwd, fsRoot string, mcp json.RawMessage, auto *bool
 		}
 		log.Printf("acp: connect 带来非空 MCP，重建此前空 MCP 会话")
 		b.mu.Unlock()
-		return b.Connect(cwd, fsRoot, mcp, auto)
+		return b.connectOrTest(cwd, fsRoot, mcp, auto)
 	}
 	b.mu.Unlock()
 
+	return b.connectOrTest(cwd, fsRoot, mcp, auto)
+}
+
+func (b *Bridge) connectOrTest(cwd, fsRoot string, mcp json.RawMessage, auto *bool) (provider.Session, error) {
+	if b.testConnect != nil {
+		return b.testConnect(cwd, fsRoot, mcp, auto)
+	}
 	return b.Connect(cwd, fsRoot, mcp, auto)
 }
 
@@ -149,6 +157,33 @@ func mcpUpgradeNeeded(current, incoming json.RawMessage) bool {
 	return mcpEmpty(current) && !mcpEmpty(incoming)
 }
 
+// mcpServerSummary returns count + names for CAPA A6 connect logs (no headers/URLs).
+func mcpServerSummary(mcp json.RawMessage) (count int, names []string) {
+	if mcpEmpty(mcp) {
+		return 0, nil
+	}
+	var arr []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(mcp, &arr); err == nil && (len(arr) > 0 || string(mcp) == "[]") {
+		for _, s := range arr {
+			if n := strings.TrimSpace(s.Name); n != "" {
+				names = append(names, n)
+			}
+		}
+		return len(arr), names
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(mcp, &obj); err == nil {
+		for k := range obj {
+			names = append(names, k)
+		}
+		sort.Strings(names)
+		return len(names), names
+	}
+	return 0, nil
+}
+
 // Connect 启动或替换 Agent 会话（由 AGENT_PROVIDER 选定的 provider 负责拉起对应 transport）。
 func (b *Bridge) Connect(cwd, fsRoot string, mcp json.RawMessage, auto *bool) (provider.Session, error) {
 	if cwd == "" {
@@ -162,7 +197,8 @@ func (b *Bridge) Connect(cwd, fsRoot string, mcp json.RawMessage, auto *bool) (p
 	if fsEff == "" {
 		fsEff = cwd
 	}
-	log.Printf("acp: 实际使用目录 cwd=%q fsRoot=%q（前端留空时已用服务端当前目录或默认与 cwd 相同）", cwd, fsEff)
+	count, names := mcpServerSummary(mcp)
+	log.Printf("acp: 实际使用目录 cwd=%q fsRoot=%q（前端留空时已用服务端当前目录或默认与 cwd 相同） mcp_servers_count=%d names=%v", cwd, fsEff, count, names)
 
 	b.mu.Lock()
 	if b.sess != nil {

--- a/sandbox-gateway/sandbox/internal/service/bridge_connect_mcp_test.go
+++ b/sandbox-gateway/sandbox/internal/service/bridge_connect_mcp_test.go
@@ -1,15 +1,19 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
+	"sync/atomic"
 	"testing"
+
+	"backend/internal/provider"
 )
 
 func TestMcpUpgradeNeeded(t *testing.T) {
 	cases := []struct {
-		name      string
-		current   json.RawMessage
-		incoming  json.RawMessage
+		name        string
+		current     json.RawMessage
+		incoming    json.RawMessage
 		wantUpgrade bool
 	}{
 		{"empty to servers", json.RawMessage(`[]`), json.RawMessage(`[{"name":"artifact-store","type":"http","url":"http://x"}]`), true},
@@ -25,5 +29,92 @@ func TestMcpUpgradeNeeded(t *testing.T) {
 				t.Fatalf("mcpUpgradeNeeded(%s,%s)=%v want %v", tc.current, tc.incoming, got, tc.wantUpgrade)
 			}
 		})
+	}
+}
+
+func TestMcpServerSummary(t *testing.T) {
+	count, names := mcpServerSummary(json.RawMessage(`[{"name":"artifact-store"},{"name":"other"}]`))
+	if count != 2 || len(names) != 2 || names[0] != "artifact-store" || names[1] != "other" {
+		t.Fatalf("array summary count=%d names=%v", count, names)
+	}
+	count, names = mcpServerSummary(json.RawMessage(`{"artifact-store":{},"e2e":{}}`))
+	if count != 2 || len(names) != 2 {
+		t.Fatalf("object summary count=%d names=%v", count, names)
+	}
+	count, names = mcpServerSummary(json.RawMessage(`[]`))
+	if count != 0 || names != nil {
+		t.Fatalf("empty summary count=%d names=%v", count, names)
+	}
+}
+
+// stubSess is a minimal provider.Session for EnsureAgent rebuild tests.
+type stubSess struct {
+	id string
+}
+
+func (s *stubSess) SessionID() string                          { return s.id }
+func (s *stubSess) CWD() string                                { return "/tmp" }
+func (s *stubSess) FSRoot() string                             { return "/tmp" }
+func (s *stubSess) Info() provider.AgentInfo                   { return provider.AgentInfo{Name: "stub"} }
+func (s *stubSess) Prompt(context.Context, string, []provider.PromptImage) (provider.TurnResult, error) {
+	return provider.TurnResult{StopReason: "end_turn"}, nil
+}
+func (s *stubSess) ReportsUsage() bool                         { return false }
+func (s *stubSess) CumulativeUsage() map[string]provider.TokenUsage { return nil }
+func (s *stubSess) Cancel() error                              { return nil }
+func (s *stubSess) Close() error                               { return nil }
+func (s *stubSess) Done() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+func (s *stubSess) ExitInfo() (string, error) { return "stub exit", nil }
+
+// TestEnsureAgentRebuildsOnEmptyToNonEmptyMCP (CAPA A4): empty default session
+// + connect with non-empty mcpServers must rebuild (not reuse).
+func TestEnsureAgentRebuildsOnEmptyToNonEmptyMCP(t *testing.T) {
+	b := &Bridge{}
+	old := &stubSess{id: "sess-empty-mcp"}
+	b.mu.Lock()
+	b.sess = old
+	b.lastMCP = json.RawMessage(`[]`)
+	b.mu.Unlock()
+
+	var rebuilds atomic.Int32
+	newSess := &stubSess{id: "sess-with-mcp"}
+	b.testConnect = func(cwd, fsRoot string, mcp json.RawMessage, auto *bool) (provider.Session, error) {
+		rebuilds.Add(1)
+		if mcpEmpty(mcp) {
+			t.Fatalf("rebuild Connect called with empty mcp: %s", mcp)
+		}
+		b.mu.Lock()
+		b.sess = newSess
+		b.lastMCP = append(json.RawMessage(nil), mcp...)
+		b.mu.Unlock()
+		return newSess, nil
+	}
+
+	incoming := json.RawMessage(`[{"name":"artifact-store","type":"http","url":"http://x"}]`)
+	got, err := b.EnsureAgent("/tmp", "/tmp", incoming, nil)
+	if err != nil {
+		t.Fatalf("EnsureAgent: %v", err)
+	}
+	if rebuilds.Load() != 1 {
+		t.Fatalf("want exactly 1 rebuild Connect, got %d", rebuilds.Load())
+	}
+	if got.SessionID() != "sess-with-mcp" {
+		t.Fatalf("want rebuilt session, got %q", got.SessionID())
+	}
+
+	// Second EnsureAgent with same non-empty MCP must reuse (no second rebuild).
+	got2, err := b.EnsureAgent("/tmp", "/tmp", incoming, nil)
+	if err != nil {
+		t.Fatalf("EnsureAgent reuse: %v", err)
+	}
+	if rebuilds.Load() != 1 {
+		t.Fatalf("reuse path must not rebuild again, rebuilds=%d", rebuilds.Load())
+	}
+	if got2.SessionID() != "sess-with-mcp" {
+		t.Fatalf("want reused session, got %q", got2.SessionID())
 	}
 }

--- a/sandbox-gateway/scripts/e2e-ci.sh
+++ b/sandbox-gateway/scripts/e2e-ci.sh
@@ -122,7 +122,8 @@ fi
 
 INJECT_DIR="$(mktemp -d)"
 mkdir -p "$INJECT_DIR/seed/rules"
-echo '{"ok":true}' >"$INJECT_DIR/seed/mcp.json"
+# CAPA A8: seed must contain mcpServers (not a hollow {"ok":true} shell).
+echo '{"mcpServers":{"artifact-store":{"url":"http://example.invalid/mcp"}}}' >"$INJECT_DIR/seed/mcp.json"
 echo rule >"$INJECT_DIR/seed/rules/r.md"
 tar -C "$INJECT_DIR/seed" -czf "$INJECT_DIR/bundle.tgz" mcp.json rules
 
@@ -175,7 +176,9 @@ if [ "$code" != 200 ]; then
   exit 1
 fi
 
-docker exec "sbx-$ID" test -f /root/.cursor/mcp.json
+# CAPA A8: MCP health = file exists AND content smoke (mcpServers + artifact-store).
+# Do not treat `test -f mcp.json` alone as healthy.
+docker exec "sbx-$ID" bash -c 'test -f /root/.cursor/mcp.json && grep -q mcpServers /root/.cursor/mcp.json && grep -q artifact-store /root/.cursor/mcp.json'
 docker exec "sbx-$ID" test -f /root/.cursor/rules/r.md
 
 curl -sS -o /dev/null -w "%{http_code}" "$GW/api/v1/sandboxes/$ID/hosts/8765" | grep -q 200
@@ -191,7 +194,8 @@ for i in $(seq 1 40); do
   sleep 1
 done
 docker exec "sbx-$ID" sh -c '! test -f /root/.cursor/MARKER'
-docker exec "sbx-$ID" test -f /root/.cursor/mcp.json
+# CAPA A8: re-inject must also restore mcpServers content, not merely the file.
+docker exec "sbx-$ID" bash -c 'test -f /root/.cursor/mcp.json && grep -q mcpServers /root/.cursor/mcp.json && grep -q artifact-store /root/.cursor/mcp.json'
 
 curl -sS -X POST "$GW/api/v1/sandboxes/$ID/stop" | grep -q stopped
 curl -sS -X POST "$GW/api/v1/sandboxes/$ID/start" >/dev/null

--- a/sandbox-gateway/scripts/e2e-docker.sh
+++ b/sandbox-gateway/scripts/e2e-docker.sh
@@ -118,9 +118,9 @@ wait_http() {
 wait_http "http://$SESS/" '^(200)$'
 wait_http "http://$IDE/" '^(200|302)$'
 
-echo "==> inject files"
+echo "==> inject files (CAPA A8: content smoke, not only test -f)"
 docker exec "sbx-$ID" bash -c 'test -f /root/.cursor/mcp.json && test -f /root/.cursor/rules/e2e.md'
-docker exec "sbx-$ID" bash -c 'grep -q e2e /root/.cursor/mcp.json'
+docker exec "sbx-$ID" bash -c 'grep -q mcpServers /root/.cursor/mcp.json && grep -q e2e /root/.cursor/mcp.json'
 
 echo "==> hosts/:port"
 curl -sS -m10 -o /dev/null -w "%{http_code}" "$GW/api/v1/sandboxes/$ID/hosts/8765" | grep -q 200
@@ -137,7 +137,8 @@ for i in $(seq 1 30); do
   sleep 2
 done
 docker exec "sbx-$ID" bash -c '! test -f /root/.cursor/MARKER'
-docker exec "sbx-$ID" bash -c 'test -f /root/.cursor/mcp.json'
+# CAPA A8: re-inject restores mcpServers content (not file-existence alone).
+docker exec "sbx-$ID" bash -c 'test -f /root/.cursor/mcp.json && grep -q mcpServers /root/.cursor/mcp.json && grep -q e2e /root/.cursor/mcp.json'
 
 echo "==> stop/start/delete"
 curl -sS -m20 -X POST "$GW/api/v1/sandboxes/$ID/stop" | grep -q stopped

--- a/server/internal/engine/outcome.go
+++ b/server/internal/engine/outcome.go
@@ -12,13 +12,18 @@ import (
 
 // consumeNodeOutcome drains the agent's node_complete mark and merges its
 // outputs into res. Missing mark or status=failed yields a failed nodeOutcome.
+//
+// CAPA A7: when the mark is missing, distinguish "MCP tool surface empty /
+// unreachable" (expected MCP traffic but zero host calls) from "tools were
+// reachable but agent never called node_complete".
 func (e *Engine) consumeNodeOutcome(c *execCtx, node *models.Node, res *runtime.NodeResult) (nodeOutcome, bool) {
 	o, ok := e.host.TakeOutcome(c.run.ID, node.ID)
 	if !ok {
+		errMsg := missingOutcomeErr(e.host.PeekMcpCalls(c.run.ID, node.ID))
 		return nodeOutcome{
 			status:   "failed",
-			err:      "未调用 node_complete 标记完成",
-			outputMd: "节点失败:未调用 node_complete 标记完成",
+			err:      errMsg,
+			outputMd: "节点失败:" + errMsg,
 			outputs:  res.Outputs,
 			events:   res.Events,
 			usage:    res.Usage,
@@ -144,4 +149,13 @@ func agentExecNeedsOutcome(k nodereg.ExecKind) bool {
 	default:
 		return false
 	}
+}
+
+// missingOutcomeErr (CAPA A7) picks the failure reason when node_complete is absent.
+// Zero MCP host calls ⇒ tool surface empty/unreachable; any traffic ⇒ agent forgot mark.
+func missingOutcomeErr(calls []models.McpCall) string {
+	if len(calls) == 0 {
+		return "MCP 工具面为空/不可达，无法完成 node_complete"
+	}
+	return "未调用 node_complete 标记完成"
 }

--- a/server/internal/engine/outcome_test.go
+++ b/server/internal/engine/outcome_test.go
@@ -2,10 +2,12 @@ package engine
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/cocofhu/approving/internal/mcp"
 	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/runtime"
 )
 
 type countingRPC struct {
@@ -46,5 +48,74 @@ func TestAfterDefaultChecksRunsRPCOnSuccess(t *testing.T) {
 	}
 	if rpc.calls != 1 {
 		t.Fatalf("RPC calls = %d", rpc.calls)
+	}
+}
+
+// TestConsumeNodeOutcomeEmptyMCPSurface (CAPA A7): expected MCP + zero calls +
+// missing outcome ⇒ distinct "工具面为空/不可达" failure (not node_complete).
+func TestConsumeNodeOutcomeEmptyMCPSurface(t *testing.T) {
+	eng, _ := setupEngine(t)
+	runID := "r-empty-mcp"
+	nodeID := "research"
+	eng.host.RegisterRun(runID)
+	eng.host.SetActiveNode(runID, nodeID, "research")
+
+	c := &execCtx{run: &models.Run{ID: runID}}
+	node := &models.Node{ID: nodeID, Type: "research"}
+	res := &runtime.NodeResult{}
+	fail, ok := eng.consumeNodeOutcome(c, node, res)
+	if ok {
+		t.Fatal("want missing outcome failure")
+	}
+	want := "MCP 工具面为空/不可达，无法完成 node_complete"
+	if fail.err != want {
+		t.Fatalf("err=%q want %q", fail.err, want)
+	}
+	if !strings.Contains(fail.outputMd, want) {
+		t.Fatalf("outputMd=%q", fail.outputMd)
+	}
+}
+
+// TestConsumeNodeOutcomeMissingNodeComplete (CAPA A7): MCP traffic present but
+// no mark ⇒ keep classic「未调用 node_complete」wording.
+func TestConsumeNodeOutcomeMissingNodeComplete(t *testing.T) {
+	eng, _ := setupEngine(t)
+	runID := "r-has-mcp"
+	nodeID := "research"
+	tok := eng.host.RegisterRun(runID)
+	eng.host.SetActiveNode(runID, nodeID, "research")
+
+	// One built-in MCP call proves the tool surface was reachable.
+	st, resp := eng.host.ServeRPC(runID, tok, []byte(
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"write_artifact","arguments":{"name":"note.md","content":"x","kind":"markdown"}}}`))
+	if st != 200 {
+		t.Fatalf("ServeRPC status=%d resp=%s", st, resp)
+	}
+	if n := len(eng.host.PeekMcpCalls(runID, nodeID)); n != 1 {
+		t.Fatalf("PeekMcpCalls=%d want 1", n)
+	}
+
+	c := &execCtx{run: &models.Run{ID: runID}}
+	node := &models.Node{ID: nodeID, Type: "research"}
+	res := &runtime.NodeResult{}
+	fail, ok := eng.consumeNodeOutcome(c, node, res)
+	if ok {
+		t.Fatal("want missing outcome failure")
+	}
+	want := "未调用 node_complete 标记完成"
+	if fail.err != want {
+		t.Fatalf("err=%q want %q", fail.err, want)
+	}
+	if strings.Contains(fail.err, "工具面为空") {
+		t.Fatalf("must not use empty-surface wording when MCP traffic exists: %q", fail.err)
+	}
+}
+
+func TestMissingOutcomeErrBranches(t *testing.T) {
+	if got := missingOutcomeErr(nil); got != "MCP 工具面为空/不可达，无法完成 node_complete" {
+		t.Fatalf("nil calls: %q", got)
+	}
+	if got := missingOutcomeErr([]models.McpCall{{Tool: "write_artifact"}}); got != "未调用 node_complete 标记完成" {
+		t.Fatalf("with calls: %q", got)
 	}
 }

--- a/server/internal/mcp/host.go
+++ b/server/internal/mcp/host.go
@@ -182,6 +182,24 @@ func (h *Host) TakeMcpCalls(runID, nodeID string) []models.McpCall {
 	return cs
 }
 
+// PeekMcpCalls returns the buffered tool-call trace for (runID, nodeID) without
+// clearing (CAPA A7: distinguish empty MCP tool surface vs missing node_complete).
+func (h *Host) PeekMcpCalls(runID, nodeID string) []models.McpCall {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	byNode := h.calls[runID]
+	if byNode == nil {
+		return nil
+	}
+	cs := byNode[nodeID]
+	if len(cs) == 0 {
+		return nil
+	}
+	out := make([]models.McpCall, len(cs))
+	copy(out, cs)
+	return out
+}
+
 // SetActiveNode records which node (and its type) a run is currently executing
 // so MCP writes (write_artifact) can be attributed to the producing node and
 // clarify-only tools (ask_question) can be gated to react nodes. Runs execute


### PR DESCRIPTION
## Summary

落地复盘 run-94650e47 的 P0 Open CAPA（A2–A8）。A1 已由 #116 合入；本 PR **不重写** MCP 加载语义，只补金锁、可观测、outcome 分流与 e2e 健康判据。

## CAPA 对照

| ID | 改动 | 验收 |
|----|------|------|
| **A2** | `TestCodeBuddyArgsGoldenStrictPlusMcpConfig` + `oneshot.ArgsForTest` | registry[CodeBuddy] Args 同时含 `--strict-mcp-config` 与 `--mcp-config /root/.codebuddy/mcp.json` |
| **A3** | `TestCursorBaseArgsIncludeApproveMcps` | Cursor Args 含 `--approve-mcps` |
| **A4** | `TestEnsureAgentRebuildsOnEmptyToNonEmptyMCP` | 空默认会话 + 非空 mcpServers 必重建（stub Connect） |
| **A5** | `TestE2E_CodeBuddyOneshotToolsListNonEmpty`（降级）+ `docs/postmortems/2026-07-28-capa-from-run-94650e47.md` | 无真 CLI/镜像时用 A2 argv 金锁；文档写明限制 |
| **A6** | oneshot spawn `argv_redacted`；Connect `mcp_servers_count` / `names` | 日志可 grep；不含 Authorization/prompt |
| **A7** | `consumeNodeOutcome` + `PeekMcpCalls` + 单测两分支 | 零调用→工具面空文案；有流量→未调用 node_complete |
| **A8** | `e2e-ci.sh` / `e2e-docker.sh` 内容 smoke | 禁止仅 `test -f mcp.json` |

## Out of scope

- A9–A11、发版 / tag / 0.0.4-beta 镜像
- 无必要修改 #116 MCP 加载逻辑
- `configHomePresent` 运维探针

## Test plan

- [x] `go test ./internal/agents/ ./internal/service/ ./internal/provider/oneshot/`（sandbox）
- [x] `go test ./internal/engine/ -run 'TestConsumeNodeOutcome|TestMissingOutcome|TestAfterDefaultChecks'`
- [ ] CI e2e-ci / e2e-docker（内容 smoke 路径）


Made with [Cursor](https://cursor.com)