### PR TITLE
chore(ci): align ci-sandbox static-js setup-node to v7/Node 24

### DIFF
--- a/.github/workflows/ci-sandbox.yml
+++ b/.github/workflows/ci-sandbox.yml
@@ -49,9 +49,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
       - name: safe_image_url unit tests
         run: node --test sandbox-gateway/sandbox/web/static/js/ui/safe_image_url_test.js
 


### PR DESCRIPTION
## Summary
- 告警来源：`.github/workflows/ci-sandbox.yml` 的 `static-js` job 仍使用 `actions/setup-node@v4`（action runtime 触发 Node.js 20 deprecation），且 `node-version: \"22\"`。
- 对齐点：同仓 `ci-web.yml` / `ci-docs.yml` / `security.yml` 已使用 `actions/setup-node@v7` + `node-version: \"24\"`。
- 最小改动：仅将 `static-js` 的 setup-node 改为 `@v7`，`node-version` 改为 `\"24\"`；不改业务代码、其它 job/workflow、golangci/Go 版本。

## Test plan
- [ ] PR CI 全绿（含 ci-sandbox `static-js`）
- [ ] `static-js` 日志中不再出现 setup-node@v4 / Node.js 20 deprecation 警告
- [ ] diff 仅含上述两行（或等价）变更


Made with [Cursor](https://cursor.com)