### PR TITLE
feature/clarify chat completed single reltime

### DIFF
--- a/web/e2e/clarify-completed-reltime.spec.ts
+++ b/web/e2e/clarify-completed-reltime.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Temporary / verification E2E for keep_footer_hide_bottom (dual「刚刚」fix).
+ * Asserts completed agent turns keep a single relTime channel in the footer.
+ */
+import { test, expect } from '@playwright/test'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const shotDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../.tmp-clarify-reltime-shots',
+)
+
+test.describe('ClarifyChat 完成态相对时间单通道', () => {
+  test('完成态：已完成脚注一处相对时间，无底部重复', async ({ page }) => {
+    await page.setViewportSize({ width: 1100, height: 900 })
+    await page.goto('/clarify-session-ux.html')
+    await expect(page.getByTestId('clarify-ux-root')).toBeVisible({ timeout: 15_000 })
+
+    await page.getByTestId('sim-four-phase-complete').click()
+    await expect(page.getByText('四阶段正文输出。')).toBeVisible()
+
+    const completed = page.getByTestId('clarify-turn-completed')
+    await expect(completed).toBeVisible()
+    await expect(completed).toContainText('已完成')
+    await expect(completed).toContainText('刚刚')
+    const footerText = await completed.innerText()
+    expect(footerText.match(/刚刚/g)?.length ?? 0).toBe(1)
+
+    // Agent completed turn must not render bottom time; human turn still may.
+    const bottomTimes = page.getByTestId('clarify-turn-bottom-time')
+    await expect(bottomTimes).toHaveCount(1)
+
+    // Within the completed agent column, only the footer channel shows 刚刚
+    const agentMsg = page.getByTestId('clarify-agent-message')
+    await expect(agentMsg).toBeVisible()
+    const agentColumn = agentMsg.locator(
+      'xpath=ancestor::*[.//*[@data-testid="clarify-turn-completed"]][1]',
+    )
+    await expect(agentColumn.getByTestId('clarify-turn-bottom-time')).toHaveCount(0)
+
+    await page.screenshot({
+      path: path.join(shotDir, '01-completed-single-reltime.png'),
+      fullPage: true,
+    })
+  })
+
+  test('流式中：无完成脚注，底部时间仍保留', async ({ page }) => {
+    await page.setViewportSize({ width: 1100, height: 900 })
+    await page.goto('/clarify-session-ux.html')
+    await expect(page.getByTestId('clarify-ux-root')).toBeVisible({ timeout: 15_000 })
+
+    await page.getByTestId('clarify-input').fill('流式探测')
+    await page.getByTestId('clarify-send-label').click()
+    await page.getByTestId('sim-turn-stream').click()
+    await expect(page.getByText('流式产出正文（非整轮一次性）。')).toBeVisible()
+
+    await expect(page.getByTestId('clarify-turn-completed')).toHaveCount(0)
+    await expect(page.getByTestId('clarify-stream-caret')).toBeVisible()
+    // human + streaming agent
+    await expect(page.getByTestId('clarify-turn-bottom-time')).toHaveCount(2)
+
+    await page.screenshot({
+      path: path.join(shotDir, '02-streaming-keeps-bottom-time.png'),
+      fullPage: true,
+    })
+  })
+})

--- a/web/src/components/run/ClarifyChat.test.ts
+++ b/web/src/components/run/ClarifyChat.test.ts
@@ -1,11 +1,20 @@
 // @vitest-environment happy-dom
 import { createI18n } from 'vue-i18n'
 import { flushPromises, mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import common from '@/locales/zh-CN/common.json'
 import pages from '@/locales/zh-CN/pages.json'
+import { i18n } from '@/lib/i18n'
+import { loadLocaleMessages } from '@/lib/loadLocaleMessages'
 import type { ClarifyTurn, ReactAnnotation } from '@/lib/types'
 import ClarifyChat from './ClarifyChat.vue'
+
+beforeAll(async () => {
+  // relTime() reads global i18n; load zh-CN so completion footer shows「刚刚」
+  const zh = await loadLocaleMessages('zh-CN')
+  i18n.global.setLocaleMessage('zh-CN', zh)
+  i18n.global.locale.value = 'zh-CN'
+})
 
 function mountChat(opts: {
   turns?: ClarifyTurn[]
@@ -751,8 +760,50 @@ describe('ClarifyChat', () => {
       expect(wrapper.find('[data-testid="clarify-stream-caret"]').exists()).toBe(false)
       expect(wrapper.find('[data-testid="clarify-thought"]').text()).toContain('思考内容')
       expect(wrapper.find('[data-testid="clarify-agent-message"]').text()).toContain('正文内容')
-      expect(wrapper.find('[data-testid="clarify-turn-completed"]').exists()).toBe(true)
-      expect(wrapper.find('[data-testid="clarify-turn-completed"]').text()).toContain('已完成')
+      const completed = wrapper.find('[data-testid="clarify-turn-completed"]')
+      expect(completed.exists()).toBe(true)
+      expect(completed.text()).toContain('已完成')
+      // keep_footer_hide_bottom: footer keeps one relTime; completed agent has no bottom time row
+      expect(completed.text()).toContain('刚刚')
+      expect(completed.text().match(/刚刚/g)?.length).toBe(1)
+      // human turn still has bottom time; completed agent turn must not
+      expect(wrapper.findAll('[data-testid="clarify-turn-bottom-time"]').length).toBe(1)
+      wrapper.unmount()
+    })
+
+    it('historical completed turn keeps single relTime channel (no bottom time)', () => {
+      const wrapper = mountChat({
+        turns: [{ role: 'agent', text: '历史已完成正文', at: new Date().toISOString() }],
+      })
+      const completed = wrapper.find('[data-testid="clarify-turn-completed"]')
+      expect(completed.exists()).toBe(true)
+      expect(completed.text()).toContain('已完成')
+      expect(completed.text()).toContain('刚刚')
+      expect(completed.text().match(/刚刚/g)?.length).toBe(1)
+      expect(wrapper.find('[data-testid="clarify-turn-bottom-time"]').exists()).toBe(false)
+      expect(wrapper.text().match(/刚刚/g)?.length).toBe(1)
+      wrapper.unmount()
+    })
+
+    it('streaming agent keeps bottom time without 已完成 footnote', async () => {
+      const wrapper = mountChat({ draft: '请复审' })
+      await clickSend(wrapper)
+      const vm = wrapper.vm as unknown as {
+        applyReviewFrame: (f: Record<string, unknown>) => void
+        applyAcpEvents: (e: { kind: string; text: string }[], nodeId?: string) => void
+      }
+      vm.applyReviewFrame({
+        event: 'turn_begin',
+        nodeId: 'react-1',
+        item: { text: '请复审' },
+      })
+      vm.applyAcpEvents([{ kind: 'message', text: '流式中正文' }], 'react-1')
+      await flushPromises()
+
+      expect(wrapper.find('[data-testid="clarify-turn-completed"]').exists()).toBe(false)
+      expect(wrapper.find('[data-testid="clarify-stream-caret"]').exists()).toBe(true)
+      // human + streaming agent both keep bottom time channel
+      expect(wrapper.findAll('[data-testid="clarify-turn-bottom-time"]').length).toBe(2)
       wrapper.unmount()
     })
 
@@ -772,6 +823,9 @@ describe('ClarifyChat', () => {
       vm.applyReviewFrame({ event: 'turn_done', nodeId: 'react-1', interrupted: true })
       await flushPromises()
       expect(wrapper.find('[data-testid="clarify-turn-completed"]').exists()).toBe(false)
+      expect(wrapper.find('[data-testid="clarify-interrupted"]').exists()).toBe(true)
+      // interrupted is non-completed: keep bottom time (human + interrupted agent)
+      expect(wrapper.findAll('[data-testid="clarify-turn-bottom-time"]').length).toBe(2)
       wrapper.unmount()
     })
 

--- a/web/src/components/run/ClarifyChat.vue
+++ b/web/src/components/run/ClarifyChat.vue
@@ -1271,7 +1271,13 @@ defineExpose({
           >
             interrupted
           </div>
-          <div class="mt-1 text-[10px] text-txt3" :class="t.role === 'human' ? 'text-right' : ''">{{ locale && relTime(t.at) }}</div>
+          <!-- Keep footer time; hide bottom time when completion footnote is shown (keep_footer_hide_bottom) -->
+          <div
+            v-if="!showTurnCompleted(t)"
+            class="mt-1 text-[10px] text-txt3"
+            :class="t.role === 'human' ? 'text-right' : ''"
+            data-testid="clarify-turn-bottom-time"
+          >{{ locale && relTime(t.at) }}</div>
         </div>
       </div>
       <div v-if="thinking && !validating && liveAgentIdx < 0" class="flex items-center gap-2 pl-9 text-[12px] text-txt3">


### PR DESCRIPTION
- **fix(clarify): hide bottom relTime when completion footnote shows**
- **test(clarify): add e2e for completed-state single relTime channel**
