### PR TITLE
fix(web): left-align run filter trigger labels

### DIFF
--- a/web/src/components/ui/PipelineFilter.vue
+++ b/web/src/components/ui/PipelineFilter.vue
@@ -82,7 +82,7 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
       @click.stop="toggle"
     >
       <Icon name="branch" :size="15" class="text-txt3" />
-      <span class="min-w-0 flex-1 truncate md:max-w-[160px] md:flex-none">{{ selectedName }}</span>
+      <span class="min-w-0 flex-1 truncate text-left md:max-w-[160px] md:flex-none">{{ selectedName }}</span>
       <span v-if="typeof count === 'number'" class="chip">{{ count }}</span>
       <Icon name="chevron-down" :size="14" class="shrink-0 text-txt3" />
     </button>

--- a/web/src/components/ui/StatusFilter.vue
+++ b/web/src/components/ui/StatusFilter.vue
@@ -97,7 +97,7 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
       @click.stop="toggle"
     >
       <Icon name="clock" :size="15" class="text-txt3" />
-      <span class="min-w-0 flex-1 truncate md:max-w-[160px] md:flex-none">{{ buttonLabel }}</span>
+      <span class="min-w-0 flex-1 truncate text-left md:max-w-[160px] md:flex-none">{{ buttonLabel }}</span>
       <span v-if="typeof count === 'number'" class="chip">{{ count }}</span>
       <Icon name="chevron-down" :size="14" class="shrink-0 text-txt3" />
     </button>

--- a/web/src/components/ui/TagFilter.vue
+++ b/web/src/components/ui/TagFilter.vue
@@ -179,7 +179,7 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
       @click.stop="toggle"
     >
       <Icon name="tag" :size="15" class="text-txt3" />
-      <span class="min-w-0 flex-1 truncate md:flex-none">{{ t('common.tagFilter.label') }}</span>
+      <span class="min-w-0 flex-1 truncate text-left md:flex-none">{{ t('common.tagFilter.label') }}</span>
       <span v-if="hasFilter" class="chip" data-testid="tag-filter-count">{{ modelValue.length }}</span>
       <Icon name="chevron-down" :size="14" class="shrink-0 text-txt3" />
     </button>


### PR DESCRIPTION
TagFilter/StatusFilter/PipelineFilter trigger labels lacked text-left,
so button default centering made mobile filter rows look misaligned
versus ProjectFilter.

Co-authored-by: Cursor <cursoragent@cursor.com>
