### PR TITLE
fix: revise failure must not show Done/已完成

### DIFF
--- a/server/internal/engine/review_live_sync_test.go
+++ b/server/internal/engine/review_live_sync_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -318,7 +319,8 @@ func TestStructuredRenderForArtifactCoversKnownNames(t *testing.T) {
 }
 
 // TestReviewReplyFailureDoesNotSyncOutputs: ReviseInPlace error must not refresh
-// outputs when the turn skipped writing a new product.
+// outputs when the turn skipped writing a new product. Failure is surfaced as
+// Interrupted=true + turn_done{interrupted:true} so UI never shows Done/已完成.
 func TestReviewReplyFailureDoesNotSyncOutputs(t *testing.T) {
 	db, err := database.OpenSQLiteTest(t.TempDir() + "/review-fail.db")
 	if err != nil {
@@ -363,11 +365,68 @@ func TestReviewReplyFailureDoesNotSyncOutputs(t *testing.T) {
 		t.Fatalf("expected initial demo page in outputs, got %q", before)
 	}
 
+	ch, unsub := eng.Broker().Subscribe(run.ID)
+	defer unsub()
+	gotTurnDone := make(chan bool, 1)
+	go func() {
+		deadline := time.After(5 * time.Second)
+		for {
+			select {
+			case <-deadline:
+				gotTurnDone <- false
+				return
+			case raw, ok := <-ch:
+				if !ok {
+					gotTurnDone <- false
+					return
+				}
+				var frame map[string]any
+				if json.Unmarshal(raw, &frame) != nil {
+					continue
+				}
+				if frame["type"] != "review" || frame["event"] != "turn_done" {
+					continue
+				}
+				interrupted, _ := frame["interrupted"].(bool)
+				gotTurnDone <- interrupted
+				return
+			}
+		}
+	}()
+
 	if err := eng.ReactReply(run.ID, "page", "改", nil, nil, false); err != nil {
 		t.Fatalf("revise reply should not fail HTTP: %v", err)
 	}
 	if err := eng.waitReviewReadyForTest(run.ID, "page", 5*time.Second); err != nil {
 		t.Fatalf("wait revise: %v", err)
+	}
+
+	select {
+	case interrupted := <-gotTurnDone:
+		if !interrupted {
+			t.Fatal("expected turn_done with interrupted:true on revise failure")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for turn_done on revise failure")
+	}
+
+	var conv models.ReactConversation
+	if err := db.Where("run_id = ? AND node_id = ?", run.ID, "page").
+		Order("id desc").First(&conv).Error; err != nil {
+		t.Fatalf("load conversation: %v", err)
+	}
+	var sawFailedAgent bool
+	for _, m := range conv.Messages {
+		if m.Role != "agent" || !strings.Contains(m.Text, "就地修改失败") {
+			continue
+		}
+		sawFailedAgent = true
+		if !m.Interrupted {
+			t.Fatalf("failed revise agent message must be Interrupted=true, got %+v", m)
+		}
+	}
+	if !sawFailedAgent {
+		t.Fatalf("expected agent failure message in conversation, got %+v", conv.Messages)
 	}
 
 	var sr models.StateRun
@@ -377,5 +436,10 @@ func TestReviewReplyFailureDoesNotSyncOutputs(t *testing.T) {
 	after, _ := sr.Outputs["page"].(string)
 	if after != before {
 		t.Fatalf("outputs.page changed on revise failure: before=%q after=%q", before, after)
+	}
+
+	// Session stays parked/retryable: enqueue again must still succeed.
+	if err := eng.ReactReply(run.ID, "page", "再试", nil, nil, false); err != nil {
+		t.Fatalf("retry after revise failure should still enqueue: %v", err)
 	}
 }

--- a/server/internal/engine/review_session.go
+++ b/server/internal/engine/review_session.go
@@ -592,7 +592,9 @@ func (e *Engine) executeReviewTurn(ctx context.Context, s *reviewSession, item *
 	s.mu.Lock()
 	cancelled := s.cancelRequested || ctx.Err() != nil
 	s.mu.Unlock()
-	if cancelled {
+	// Cancel and revise failure share Interrupted so UI never shows Done/已完成.
+	// Surface failure in chat; do not fail the enqueue API or the Run.
+	if cancelled || t.Err != nil {
 		interrupted = true
 	}
 
@@ -610,18 +612,15 @@ func (e *Engine) executeReviewTurn(ctx context.Context, s *reviewSession, item *
 	e.flushTokenUsage(s.runID, s.producerID, t.Usage, t.UsageByModel)
 
 	if interrupted {
-		log.Info().Str("run_id", s.runID).Str("producer", s.producerID).
-			Msg("review turn interrupted by Cancel; session kept parked")
+		if cancelled {
+			log.Info().Str("run_id", s.runID).Str("producer", s.producerID).
+				Msg("review turn interrupted by Cancel; session kept parked")
+		} else {
+			log.Warn().Err(t.Err).Str("run_id", s.runID).Str("producer", s.producerID).
+				Msg("review revise turn failed (session kept for retry)")
+		}
 		e.broker.Publish(s.runID, jsonMsg("react", s.runID, s.producerID))
 		return true, nil
-	}
-
-	if t.Err != nil {
-		log.Warn().Err(t.Err).Str("run_id", s.runID).Str("producer", s.producerID).
-			Msg("review revise turn failed (session kept for retry)")
-		e.broker.Publish(s.runID, jsonMsg("react", s.runID, s.producerID))
-		// Match prior reviewReply: surface failure in chat, do not fail the enqueue API.
-		return false, nil
 	}
 
 	e.refreshProducerOutputs(c, producer)

--- a/web/src/components/run/ClarifyChat.test.ts
+++ b/web/src/components/run/ClarifyChat.test.ts
@@ -932,6 +932,65 @@ describe('ClarifyChat', () => {
       wrapper.unmount()
     })
 
+    // g2.1: revise failure body must not look like success (live stream + history).
+    it('revise failure text + interrupted turn_done does not show 已完成/Done', async () => {
+      const failText = '(复审修改失败:acp chat idle timeout after 10m0s)'
+      const wrapper = mountChat({ draft: '请复审', reviewMode: true })
+      await clickSend(wrapper)
+      const vm = wrapper.vm as unknown as {
+        applyReviewFrame: (f: Record<string, unknown>) => void
+        applyAcpEvents: (e: { kind: string; text: string }[], nodeId?: string) => void
+      }
+      vm.applyReviewFrame({
+        event: 'turn_begin',
+        nodeId: 'react-1',
+        item: { text: '请复审' },
+      })
+      vm.applyAcpEvents(
+        [
+          { kind: 'thought', text: '半截思考' },
+          { kind: 'message', text: failText },
+        ],
+        'react-1',
+      )
+      vm.applyReviewFrame({ event: 'turn_done', nodeId: 'react-1', interrupted: true })
+      await flushPromises()
+      expect(wrapper.find('[data-testid="clarify-agent-message"]').text()).toContain('复审修改失败')
+      expect(wrapper.find('[data-testid="clarify-turn-completed"]').exists()).toBe(false)
+      expect(wrapper.text()).not.toMatch(/\bDone\b/)
+      expect(wrapper.find('[data-testid="clarify-interrupted"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="thought-summary-state"]').attributes('data-state')).toBe(
+        'interrupted',
+      )
+      expect(wrapper.find('[data-testid="thought-summary-state"]').text()).toContain('已中断')
+      expect(wrapper.find('[data-testid="thought-summary-state"]').text()).not.toContain('已完成')
+      wrapper.unmount()
+    })
+
+    it('historical Interrupted failure message does not show 已完成/Done', () => {
+      const wrapper = mountChat({
+        reviewMode: true,
+        turns: [
+          {
+            role: 'agent',
+            text: '(复审修改失败:acp chat idle timeout after 10m0s)',
+            at: new Date().toISOString(),
+            interrupted: true,
+          },
+        ],
+      })
+      expect(wrapper.text()).toContain('复审修改失败')
+      expect(wrapper.find('[data-testid="clarify-turn-completed"]').exists()).toBe(false)
+      expect(wrapper.find('[data-testid="clarify-interrupted"]').exists()).toBe(true)
+      expect(wrapper.text()).not.toMatch(/\bDone\b/)
+      const summary = wrapper.find('[data-testid="thought-summary-state"]')
+      if (summary.exists()) {
+        expect(summary.attributes('data-state')).toBe('interrupted')
+        expect(summary.text()).not.toContain('已完成')
+      }
+      wrapper.unmount()
+    })
+
     it('tool_call alone keeps 思考中… placeholder (no tool UI, no air bubble)', async () => {
       const wrapper = mountChat({ draft: '请复审' })
       await clickSend(wrapper)

--- a/web/src/components/run/GateApproval.test.ts
+++ b/web/src/components/run/GateApproval.test.ts
@@ -3021,6 +3021,43 @@ describe('GateApproval mobileFillRemaining layout', () => {
     wrapper.unmount()
   })
 
+  // g2.1: revise failure body + interrupted must never show Done/已完成.
+  it('revise failure text + interrupted turn_done does not show 已完成/Done', async () => {
+    breakpointMocks.isMobile.value = false
+    const pageHtml = '<!doctype html><html><body><h1>gate fail</h1></body></html>'
+    const { gate, run } = visualGateRun(pageHtml)
+    const wrapper = mountApproval({
+      fillPreview: true,
+      mobileFillRemaining: false,
+      gate: { ...gate, reactSessionAlive: true, reactUpstreamNodeId: 'visual' },
+      run,
+    })
+    await flushPromises()
+    const vm = wrapper.vm as any
+    vm.applyReviewFrame?.({
+      event: 'turn_begin',
+      nodeId: 'visual',
+    })
+    vm.applyAcpEvents?.([
+      { kind: 'thought', text: '半截思考' },
+      {
+        kind: 'message',
+        text: '(复审修改失败:acp chat idle timeout after 10m0s)',
+      },
+    ])
+    vm.applyReviewFrame?.({ event: 'turn_done', nodeId: 'visual', interrupted: true })
+    await flushPromises()
+    expect(wrapper.text()).toContain('复审修改失败')
+    expect(wrapper.find('[data-testid="gate-turn-completed"]').exists()).toBe(false)
+    expect(wrapper.text()).not.toMatch(/\bDone\b/)
+    const summary = wrapper.find('[data-testid="thought-summary-state"]')
+    expect(summary.exists()).toBe(true)
+    expect(summary.attributes('data-state')).toBe('interrupted')
+    expect(summary.text()).toContain('已中断')
+    expect(summary.text()).not.toContain('已完成')
+    wrapper.unmount()
+  })
+
   it('keeps Inbox-style path on 60vh content-fit when mobileFillRemaining is off', async () => {
     // Mobile content-fit path unchanged (no desktop flex-1 / fillParent).
     const pageHtml = '<!doctype html><html><body><h1>Inbox</h1></body></html>'

--- a/web/src/components/run/ReviewComposer.test.ts
+++ b/web/src/components/run/ReviewComposer.test.ts
@@ -151,6 +151,27 @@ describe('ReviewComposer gate busy status (C-tier)', () => {
     bad.unmount()
   })
 
+  // g2.1: failure body + interrupted shares cancel UI; never Done/已完成.
+  it('revise failure stream text + interrupted never shows 已完成/Done', async () => {
+    const fail = mountGate({
+      thinking: false,
+      streamThought: '半截思考',
+      streamText: '(复审修改失败:acp chat idle timeout after 10m0s)',
+      interrupted: true,
+      streamCompletedAt: null,
+    })
+    await flushPromises()
+    expect(fail.text()).toContain('复审修改失败')
+    expect(fail.find('[data-testid="gate-turn-completed"]').exists()).toBe(false)
+    expect(fail.text()).not.toMatch(/\bDone\b/)
+    expect(fail.find('[data-testid="thought-summary-state"]').attributes('data-state')).toBe(
+      'interrupted',
+    )
+    expect(fail.find('[data-testid="thought-summary-state"]').text()).toContain('已中断')
+    expect(fail.find('[data-testid="thought-summary-state"]').text()).not.toContain('已完成')
+    fail.unmount()
+  })
+
   it('idle (not thinking, no completed) hides stream panel', async () => {
     const wrapper = mountGate({
       thinking: false,

--- a/web/src/components/run/ThoughtSummaryStatus.test.ts
+++ b/web/src/components/run/ThoughtSummaryStatus.test.ts
@@ -58,4 +58,14 @@ describe('ThoughtSummaryStatus', () => {
     expect(el.text()).not.toContain('已完成')
     w.unmount()
   })
+
+  // g2.1: revise/cancel failure path must never look like Done (even if completed flagged).
+  it('interrupted wins over completed → no Done/已完成', () => {
+    const w = mountStatus({ busy: false, interrupted: true, completed: true })
+    const el = w.find('[data-testid="thought-summary-state"]')
+    expect(el.attributes('data-state')).toBe('interrupted')
+    expect(el.text()).not.toMatch(/\bDone\b/)
+    expect(el.text()).not.toContain('已完成')
+    w.unmount()
+  })
 })


### PR DESCRIPTION
## Summary
- `executeReviewTurn`: on `t.Err != nil`, persist agent `Interrupted=true` and return `true, nil` so pump emits `turn_done` + `interrupted:true` (same UI path as cancel).
- Failure body `(复审修改失败:…)` remains visible; enqueue still succeeds; outputs are not refreshed; Run/node are not failed.
- Add engine + web regression tests so failure/interrupted paths never show Done/已完成.

## Review
- Verdict: **approve** (review_lite). No blocking findings; CI green on gate/server/web/web-e2e/security.

## Test plan
- [x] `go test ./internal/engine/ -run TestReviewReplyFailureDoesNotSyncOutputs`
- [x] `npm test -- ClarifyChat/GateApproval/ReviewComposer/ThoughtSummaryStatus` (failure + interrupted cases)
- [ ] Manual (optional): trigger revise idle timeout → bubble shows failure text + 已中断, no green Done; retry enqueue still works