### PR TITLE
fix(web): 人工门禁 PreviewIssues 冷会话下退回按钮

### DIFF
--- a/web/src/components/run/GateApproval.test.ts
+++ b/web/src/components/run/GateApproval.test.ts
@@ -915,11 +915,12 @@ describe('GateApproval content-fit layout branches', () => {
 
     const form = wrapper.find('[data-testid="content-fit-form"]')
     const buttons = form.findAll('button')
-    // Standard UI: only 确认并流转 (disabled while open issues), never 退回
-    expect(buttons.some((b) => b.text().includes('确认并流转'))).toBe(true)
-    expect(buttons.every((b) => !b.text().includes('退回') && !b.text().includes('打回'))).toBe(true)
-    const confirm = buttons.find((b) => b.text().includes('确认并流转'))!
-    expect((confirm.element as HTMLButtonElement).disabled).toBe(true)
+    // With ≥1 open issue (resolved ones don't count): only the negative exit
+    // (退回/返回修改) is offered, enabled — no 确认并流转, no disabled dead end.
+    expect(buttons.some((b) => b.text().includes('确认并流转'))).toBe(false)
+    const revise = buttons.find((b) => b.text().includes('返回修改'))!
+    expect(revise).toBeTruthy()
+    expect((revise.element as HTMLButtonElement).disabled).toBe(false)
     wrapper.unmount()
   })
 
@@ -2133,6 +2134,14 @@ describe('GateApproval HTML preview load gate (fillPreview)', () => {
         },
       ],
     })
+    apiMocks.createPreviewIssue.mockResolvedValue({
+      id: 'iss-new',
+      runId: 'run-1',
+      nodeId: 'hg-visual',
+      body: '请调整主色',
+      status: 'open',
+      createdAt: '2026-07-18T00:02:00Z',
+    })
     const wrapper = mountApproval({
       fillPreview: true,
       gate: baseGate({ nodeId: 'hg-visual' }),
@@ -2144,13 +2153,26 @@ describe('GateApproval HTML preview load gate (fillPreview)', () => {
     await form.find('[data-testid="paragraph-input"]').setValue('请调整主色')
     await flushPromises()
 
-    // Cold / standard UI: no 退回 — only 确认并流转 (disabled while open issues)
+    // With ≥1 open issue: only 退回/返回修改 is offered (enabled), no 确认并流转.
     const buttons = form.findAll('button')
-    expect(buttons.every((b) => !b.text().includes('退回') && !b.text().includes('打回'))).toBe(true)
-    const confirm = buttons.find((b) => b.text().includes('确认并流转'))!
-    expect(confirm).toBeTruthy()
-    expect((confirm.element as HTMLButtonElement).disabled).toBe(true)
-    expect(wrapper.emitted('resolve')).toBeFalsy()
+    expect(buttons.some((b) => b.text().includes('确认并流转'))).toBe(false)
+    const revise = buttons.find((b) => b.text().includes('返回修改'))!
+    expect(revise).toBeTruthy()
+    expect((revise.element as HTMLButtonElement).disabled).toBe(false)
+
+    await revise.trigger('click')
+    await flushPromises()
+
+    // Unsent draft text is flushed into PreviewIssue history before the gate resolves.
+    expect(apiMocks.createPreviewIssue).toHaveBeenCalledWith(
+      'run-1',
+      'hg-visual',
+      '请调整主色',
+      expect.any(String),
+      0,
+      expect.any(Array),
+    )
+    expect(wrapper.emitted('resolve')?.[0]?.[0]).toBe('revise')
     wrapper.unmount()
   })
 
@@ -2207,12 +2229,17 @@ describe('GateApproval HTML preview load gate (fillPreview)', () => {
 
     const form = wrapper.find('[data-testid="content-fit-form"]')
     const buttons = form.findAll('button')
-    expect(buttons.some((b) => b.text().includes('确认并流转'))).toBe(true)
-    expect(buttons.every((b) => !b.text().includes('退回') && !b.text().includes('返回修改'))).toBe(true)
-    const confirm = buttons.find((b) => b.text().includes('确认并流转'))!
-    expect((confirm.element as HTMLButtonElement).disabled).toBe(true)
-    expect(wrapper.text()).toMatch(/待处理意见|仅可退回|不可确认/)
-    expect(wrapper.emitted('resolve')).toBeFalsy()
+    // ≥1 open issue: 确认并流转 is hidden entirely; 返回修改 is enabled and
+    // does not require the (now-hidden) form comment to be filled.
+    expect(buttons.some((b) => b.text().includes('确认并流转'))).toBe(false)
+    const revise = buttons.find((b) => b.text().includes('返回修改'))!
+    expect(revise).toBeTruthy()
+    expect((revise.element as HTMLButtonElement).disabled).toBe(false)
+
+    await revise.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.emitted('resolve')?.[0]?.[0]).toBe('revise')
     wrapper.unmount()
   })
 
@@ -2331,11 +2358,16 @@ describe('GateApproval app_preview reject without form', () => {
 
     expect(wrapper.find('[data-testid="paragraph-input"]').exists()).toBe(false)
     const buttons = wrapper.findAll('button')
-    expect(buttons.every((b) => !b.text().includes('退回'))).toBe(true)
-    const confirm = buttons.find((b) => b.text().includes('确认并流转'))!
-    expect(confirm).toBeTruthy()
-    expect((confirm.element as HTMLButtonElement).disabled).toBe(true)
-    expect(wrapper.emitted('resolve')).toBeFalsy()
+    // ≥1 open issue: 确认并流转 is hidden; the gate's own 退回 exit is offered, enabled.
+    expect(buttons.some((b) => b.text().includes('确认并流转'))).toBe(false)
+    const reject = buttons.find((b) => b.text().includes('退回'))!
+    expect(reject).toBeTruthy()
+    expect((reject.element as HTMLButtonElement).disabled).toBe(false)
+
+    await reject.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.emitted('resolve')?.[0]?.[0]).toBe('fail')
     wrapper.unmount()
   })
 

--- a/web/src/components/run/GateApproval.vue
+++ b/web/src/components/run/GateApproval.vue
@@ -424,11 +424,20 @@ const openPreviewIssueCount = computed(
 )
 
 /**
- * Standard review UI only exposes the positive exit (approve/pass → 确认并流转).
- * Config-layer fail/revise actions remain on the gate DTO for silent edge compat
- * but are never rendered as dual buttons.
+ * Standard review UI only exposes a single exit at a time:
+ * - PreviewIssues with ≥1 open issue: the negative exit (fail/revise), since
+ *   the reviewer already recorded feedback via 框选+提交问题 — confirming
+ *   would silently drop it. Keep the gate's own configured label (e.g.
+ *   「退回修改」/「取消需求」) so the actual downstream effect stays clear.
+ * - Otherwise: the positive exit (approve/pass → 确认并流转), same as before.
+ * Config-layer actions beyond these two remain on the gate DTO for silent
+ * edge compat but are never rendered as dual buttons.
  */
 const visibleActions = computed(() => {
+  if (usesPreviewIssues.value && openPreviewIssueCount.value >= 1) {
+    const negative = props.gate.actions.filter((a) => FAIL_ACTION_IDS.has(a.id))
+    if (negative.length) return negative
+  }
   const positive = props.gate.actions.filter((a) => PASS_ACTION_IDS.has(a.id))
   return positive.map((a) => ({
     ...a,
@@ -465,6 +474,17 @@ const helpReviseDetailNoIssuesText = computed(() =>
   usesPreviewIssues.value || !hasFormFields.value
     ? t('pages.gateApproval.helpReviseDetailNoIssuesNoForm')
     : t('pages.gateApproval.helpReviseDetailNoIssues'),
+)
+
+/**
+ * Help line when n_open≥1 (PreviewIssues path): hot can still send in-place
+ * (确认并流转 stays disabled); without a live ReAct session there is no send —
+ * the footer swaps to the gate's own 退回/revise exit instead, so say that.
+ */
+const helpReviseWithIssuesText = computed(() =>
+  canReactRevise.value
+    ? t('pages.gateApproval.helpReviseWithIssuesDetail')
+    : t('pages.gateApproval.helpReviseWithIssuesColdDetail'),
 )
 
 /** Hot send label (review semantics — no「打回」verb). */
@@ -1554,10 +1574,13 @@ function onComposerReject() {
                 v-else-if="usesPreviewIssues && openPreviewIssueCount >= 1"
                 class="mb-2 shrink-0 text-[11px] leading-relaxed text-txt3"
               >
-                <b class="font-medium text-txt2">{{ t('pages.reviewComposer.send') }}</b>
-                {{ t('pages.gateApproval.helpReviseWithIssuesDetail') }}
-                <span class="mx-1">·</span>
-                {{ t('pages.reviewComposer.openIssuesConfirmHint') }}
+                <template v-if="canReactRevise">
+                  <b class="font-medium text-txt2">{{ t('pages.reviewComposer.send') }}</b>
+                  {{ t('pages.gateApproval.helpReviseWithIssuesDetail') }}
+                  <span class="mx-1">·</span>
+                  {{ t('pages.reviewComposer.openIssuesConfirmHint') }}
+                </template>
+                <template v-else>{{ helpReviseWithIssuesText }}</template>
               </p>
               <div
                 v-if="previewIssuesError"
@@ -1679,7 +1702,7 @@ function onComposerReject() {
                     :key="a.id"
                     class="inline-flex min-h-[44px] flex-1 items-center justify-center gap-1.5 rounded-md px-3.5 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50"
                     :class="actionVariantClasses(actionVariant(a.id))"
-                    :disabled="isActionDisabled(a.id) || reactSending || (usesPreviewIssues && openPreviewIssueCount >= 1)"
+                    :disabled="isActionDisabled(a.id) || reactSending"
                     :title="actionButtonTitle(a.id)"
                     data-testid="review-composer-pass"
                     @click="onSidebarAction(a.id)"
@@ -1864,10 +1887,13 @@ function onComposerReject() {
                 v-else-if="usesPreviewIssues && openPreviewIssueCount >= 1"
                 class="mb-2 shrink-0 text-[11px] leading-relaxed text-txt3"
               >
-                <b class="font-medium text-txt2">{{ t('pages.reviewComposer.send') }}</b>
-                {{ t('pages.gateApproval.helpReviseWithIssuesDetail') }}
-                <span class="mx-1">·</span>
-                {{ t('pages.reviewComposer.openIssuesConfirmHint') }}
+                <template v-if="canReactRevise">
+                  <b class="font-medium text-txt2">{{ t('pages.reviewComposer.send') }}</b>
+                  {{ t('pages.gateApproval.helpReviseWithIssuesDetail') }}
+                  <span class="mx-1">·</span>
+                  {{ t('pages.reviewComposer.openIssuesConfirmHint') }}
+                </template>
+                <template v-else>{{ helpReviseWithIssuesText }}</template>
               </p>
               <p v-else-if="canEditProducts" class="mb-2 shrink-0 text-[11px] leading-relaxed text-txt3">
                 <b class="font-medium text-txt2">{{ t('pages.clarify.confirmFlow') }}</b>
@@ -2033,7 +2059,7 @@ function onComposerReject() {
                       actionVariantClasses(actionVariant(a.id)),
                       isMobile ? 'min-h-[44px] flex-1' : 'py-2',
                     ]"
-                    :disabled="isActionDisabled(a.id) || reactSending || (usesPreviewIssues && openPreviewIssueCount >= 1)"
+                    :disabled="isActionDisabled(a.id) || reactSending"
                     :title="actionButtonTitle(a.id)"
                     data-testid="review-composer-pass"
                     @click="onSidebarAction(a.id)"
@@ -2315,10 +2341,13 @@ function onComposerReject() {
             v-else-if="usesPreviewIssues && openPreviewIssueCount >= 1"
             class="mb-2 text-[11px] leading-relaxed text-txt3"
           >
-            <b class="font-medium text-txt2">{{ t('pages.reviewComposer.send') }}</b>
-            {{ t('pages.gateApproval.helpReviseWithIssuesDetail') }}
-            <span class="mx-1">·</span>
-            {{ t('pages.reviewComposer.openIssuesConfirmHint') }}
+            <template v-if="canReactRevise">
+              <b class="font-medium text-txt2">{{ t('pages.reviewComposer.send') }}</b>
+              {{ t('pages.gateApproval.helpReviseWithIssuesDetail') }}
+              <span class="mx-1">·</span>
+              {{ t('pages.reviewComposer.openIssuesConfirmHint') }}
+            </template>
+            <template v-else>{{ helpReviseWithIssuesText }}</template>
           </p>
           <p v-else-if="canEditProducts" class="mb-2 text-[11px] leading-relaxed text-txt3">
             <b class="font-medium text-txt2">{{ t('pages.clarify.confirmFlow') }}</b>
@@ -2362,10 +2391,10 @@ function onComposerReject() {
                 actionVariantClasses(actionVariant(a.id)),
                 isMobile ? 'min-h-[44px] flex-1' : 'py-2',
               ]"
-              :disabled="isActionDisabled(a.id) || (usesPreviewIssues && openPreviewIssueCount >= 1)"
+              :disabled="isActionDisabled(a.id)"
               :title="actionButtonTitle(a.id)"
               data-testid="review-composer-pass"
-              @click="choose(a.id)"
+              @click="onSidebarAction(a.id)"
             >
               <Icon :name="actionIcon(a.id)" :size="14" />
               {{ a.label }}

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -1956,6 +1956,7 @@
       "helpReviseDetailNoIssuesNoForm": "You can Confirm & continue; to request changes, send review feedback first.",
       "helpReviseWithIssues": "Review feedback submitted:",
       "helpReviseWithIssuesDetail": "keep sending to revise in place; Confirm & continue stays disabled until open feedback is cleared.",
+      "helpReviseWithIssuesColdDetail": "Feedback has been recorded — use the button below to send it back together with the recorded issues; once cleared you can Confirm & continue.",
       "reviewFeedback": {
         "title": "Review feedback",
         "placeholder": "Enter review feedback…",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -1956,6 +1956,7 @@
       "helpReviseDetailNoIssuesNoForm": "可确认并流转；若需修改，请先发送评审意见就地改。",
       "helpReviseWithIssues": "已提交评审意见：",
       "helpReviseWithIssuesDetail": "可继续发送就地改；确认并流转已禁用，直至意见处理完毕。",
+      "helpReviseWithIssuesColdDetail": "已记录待处理意见，可点击下方按钮一并退回处理；意见清空后再确认并流转。",
       "reviewFeedback": {
         "title": "评审意见",
         "placeholder": "请输入评审意见…",


### PR DESCRIPTION
## Summary
- 冷会话(无存活 ReAct 会话)下的 PreviewIssues 复审：之前只要还有 `open` 状态的意见（即用户框选并提交问题），底部只会把「确认并流转」置灰，没有任何可点的出口。现在改为在这种状态下显示 gate 自身配置的「退回/返回修改」动作按钮（可点击），意见清空后恢复只显示「确认并流转」——同一时刻只出现一个按钮，不再有卡死的灰按钮，也没有警告框。
- 统一了三处底部按钮渲染分支（移动端 fill / 桌面 content-fit / 旧版兜底布局）的按钮来源、disabled 条件与点击处理，避免同一场景在不同布局下表现不一致。
- 同步更新了「仍有待处理意见」提示文案：有热会话时保留原文案（可继续发送就地改，确认并流转已禁用）；无热会话时换成新文案，说明可点下方按钮一并退回，不再声称"可以继续发送"。

## Test plan
- [x] `npx vitest run src/components/run/GateApproval.test.ts`（更新了 4 处断言旧行为的用例，全部通过）
- [x] `npx vitest run`（全量前端单测 191 files / 1315 tests 全部通过）
- [ ] 部署后在线上找一个有 open PreviewIssue 的冷会话 gate 人工验证一次

Made with [Cursor](https://cursor.com)