### PR TITLE
fix: make inspect pick toggle cancelable on app_preview and visual

### DIFF
--- a/server/internal/browser/rod.go
+++ b/server/internal/browser/rod.go
@@ -65,8 +65,9 @@ type rodPage struct {
 	page   *rod.Page
 	ctxID  proto.BrowserBrowserContextID
 
-	mu     sync.Mutex
-	onPick func(Pick)
+	mu                sync.Mutex
+	onPick            func(Pick)
+	onInspectCanceled func()
 }
 
 func (rp *rodPage) OnPick(cb func(Pick)) {
@@ -79,6 +80,18 @@ func (rp *rodPage) getPick() func(Pick) {
 	rp.mu.Lock()
 	defer rp.mu.Unlock()
 	return rp.onPick
+}
+
+func (rp *rodPage) OnInspectCanceled(cb func()) {
+	rp.mu.Lock()
+	rp.onInspectCanceled = cb
+	rp.mu.Unlock()
+}
+
+func (rp *rodPage) getInspectCanceled() func() {
+	rp.mu.Lock()
+	defer rp.mu.Unlock()
+	return rp.onInspectCanceled
 }
 
 func (rp *rodPage) StartScreencast(onFrame func(Frame)) error {
@@ -205,19 +218,27 @@ func (rp *rodPage) Close() error {
 	return err
 }
 
-// installPickListener wires OverlayInspectNodeRequested → Pick callback.
+// installPickListener wires Overlay pick + cancel events to page callbacks.
 func (rp *rodPage) installPickListener() {
-	go rp.page.EachEvent(func(e *proto.OverlayInspectNodeRequested) {
-		cb := rp.getPick()
-		if cb == nil {
-			return
-		}
-		if pick, err := rp.describeBackendNode(e.BackendNodeID); err == nil {
-			cb(pick)
-		}
-		// One-shot: leave inspect mode after a pick.
-		_ = rp.SetInspect(false)
-	})()
+	go rp.page.EachEvent(
+		func(e *proto.OverlayInspectNodeRequested) {
+			cb := rp.getPick()
+			if cb == nil {
+				return
+			}
+			if pick, err := rp.describeBackendNode(e.BackendNodeID); err == nil {
+				cb(pick)
+			}
+			// One-shot: leave inspect mode after a pick.
+			_ = rp.SetInspect(false)
+		},
+		func(_ *proto.OverlayInspectModeCanceled) {
+			// User Esc (or equivalent) canceled SearchForNode — notify UI to clear sticky toggle.
+			if cb := rp.getInspectCanceled(); cb != nil {
+				cb()
+			}
+		},
+	)()
 }
 
 // pickScript computes a stable-ish CSS selector, tag, outerHTML and box for the

--- a/server/internal/browser/service_test.go
+++ b/server/internal/browser/service_test.go
@@ -21,6 +21,7 @@ func (p *fakePage) DispatchKey(KeyEvent) error          { return nil }
 func (p *fakePage) SetViewport(int, int, float64) error { return nil }
 func (p *fakePage) SetInspect(on bool) error            { p.inspect = on; return nil }
 func (p *fakePage) OnPick(cb func(Pick))                { p.onPick = cb }
+func (p *fakePage) OnInspectCanceled(func())            {}
 func (p *fakePage) Navigate(string) error               { return nil }
 func (p *fakePage) Goto(string) error                   { return nil }
 func (p *fakePage) Close() error                        { p.closed = true; return nil }

--- a/server/internal/browser/types.go
+++ b/server/internal/browser/types.go
@@ -66,6 +66,9 @@ type Page interface {
 	// SetInspect toggles element-pick (inspect) mode; picks fire the OnPick cb.
 	SetInspect(on bool) error
 	OnPick(func(Pick))
+	// OnInspectCanceled is invoked when the user cancels CDP inspect mode
+	// (e.g. Esc → Overlay.inspectModeCanceled). Callers sync UI button state.
+	OnInspectCanceled(func())
 	// Navigate performs "reload" | "back" | "forward".
 	Navigate(action string) error
 	// Goto navigates the tab to url (e.g. about:blank or http://…).

--- a/server/internal/handlers/preview_vnc.go
+++ b/server/internal/handlers/preview_vnc.go
@@ -120,6 +120,10 @@ func (h *Handlers) PreviewVNC(c *gin.Context) {
 	sess.Page().OnPick(func(p browser.Pick) {
 		pushJSON(gin.H{"type": "picked", "pick": p})
 	})
+	sess.Page().OnInspectCanceled(func() {
+		// Remote Esc left CDP inspect; frontend must clear button pressed state.
+		pushJSON(gin.H{"type": "inspect-canceled"})
+	})
 
 	pushJSON(gin.H{"type": "ready", "url": navigateURL})
 
@@ -170,7 +174,9 @@ func (h *Handlers) PreviewVNC(c *gin.Context) {
 func (h *Handlers) applyVncMsg(page browser.Page, m vncClientMsg) {
 	switch m.Type {
 	case "inspect":
-		_ = page.SetInspect(m.On)
+		if err := page.SetInspect(m.On); err != nil {
+			log.Warn().Err(err).Bool("on", m.On).Msg("preview-vnc SetInspect failed")
+		}
 	case "navigate":
 		if m.Action == "goto" || m.URL != "" {
 			url := m.URL

--- a/server/internal/handlers/preview_vnc_test.go
+++ b/server/internal/handlers/preview_vnc_test.go
@@ -22,6 +22,7 @@ func (p *vncRecPage) DispatchKey(browser.KeyEvent) error        { return nil }
 func (p *vncRecPage) SetViewport(int, int, float64) error       { return nil }
 func (p *vncRecPage) SetInspect(on bool) error                  { p.inspect = &on; return nil }
 func (p *vncRecPage) OnPick(func(browser.Pick))                 {}
+func (p *vncRecPage) OnInspectCanceled(func())                  {}
 func (p *vncRecPage) Navigate(a string) error                   { p.navs = append(p.navs, a); return nil }
 func (p *vncRecPage) Goto(u string) error                       { p.gotos = append(p.gotos, u); return nil }
 func (p *vncRecPage) Close() error                              { return nil }
@@ -41,6 +42,10 @@ func TestApplyVncMsgInspectNavigate(t *testing.T) {
 	h.applyVncMsg(p, decodeVnc(t, `{"type":"inspect","on":true}`))
 	if p.inspect == nil || !*p.inspect {
 		t.Fatal("inspect should be enabled")
+	}
+	h.applyVncMsg(p, decodeVnc(t, `{"type":"inspect","on":false}`))
+	if p.inspect == nil || *p.inspect {
+		t.Fatal("inspect should be disabled on on:false")
 	}
 	h.applyVncMsg(p, decodeVnc(t, `{"type":"navigate","action":"reload"}`))
 	if len(p.navs) != 1 || p.navs[0] != "reload" {

--- a/web/src/components/run/NovncPreviewPanel.test.ts
+++ b/web/src/components/run/NovncPreviewPanel.test.ts
@@ -13,13 +13,21 @@ class MockWebSocket {
   onmessage: ((ev: { data: string }) => void) | null = null
   onclose: (() => void) | null = null
   onerror: (() => void) | null = null
+  sent: string[] = []
   constructor(_url: string) {
+    MockWebSocket.instances.push(this)
     queueMicrotask(() => {
       this.onopen?.()
       this.onmessage?.({ data: JSON.stringify({ type: 'ready', url: 'http://localhost:5173' }) })
     })
   }
-  send() {}
+  static instances: MockWebSocket[] = []
+  static reset() {
+    MockWebSocket.instances = []
+  }
+  send(data: string) {
+    this.sent.push(data)
+  }
   close() {}
 }
 
@@ -76,8 +84,27 @@ function mountNovnc(props: Record<string, unknown> = {}) {
   })
 }
 
+function inspectButton(wrapper: ReturnType<typeof mountNovnc>) {
+  return wrapper.find('[data-testid="novnc-inspect-toggle"]')
+}
+
+function lastInspectCtrl(): { type: string; on: boolean } | null {
+  const ws = MockWebSocket.instances[0]
+  if (!ws) return null
+  for (let i = ws.sent.length - 1; i >= 0; i--) {
+    try {
+      const msg = JSON.parse(ws.sent[i]) as { type?: string; on?: boolean }
+      if (msg.type === 'inspect') return msg as { type: string; on: boolean }
+    } catch {
+      /* ignore */
+    }
+  }
+  return null
+}
+
 describe('NovncPreviewPanel', () => {
   beforeEach(() => {
+    MockWebSocket.reset()
     vi.stubGlobal('WebSocket', MockWebSocket)
   })
 
@@ -91,8 +118,8 @@ describe('NovncPreviewPanel', () => {
     await flushPromises()
     expect(apiMocks.previewVncWsUrl).toHaveBeenCalledWith('run-1', 'node-1', 5173)
     expect(wrapper.text()).toMatch(/已连接|连接中/)
-    const inspectBtn = wrapper.findAll('button').find((b) => b.text().includes('取点标注'))
-    expect(inspectBtn).toBeTruthy()
+    expect(inspectButton(wrapper).exists()).toBe(true)
+    expect(inspectButton(wrapper).text()).toContain('取点标注')
     wrapper.unmount()
   })
 
@@ -104,14 +131,87 @@ describe('NovncPreviewPanel', () => {
     wrapper.unmount()
   })
 
-  it('toggles inspect mode in preview toolbar', async () => {
+  it('toggles inspect with stable label and aria-pressed; second click sends on:false', async () => {
     const wrapper = mountNovnc()
     await flushPromises()
-    const inspectBtn = wrapper.findAll('button').find((b) => b.text().includes('取点标注'))
-    expect(inspectBtn).toBeTruthy()
-    await inspectBtn!.trigger('click')
+    const btn = inspectButton(wrapper)
+    expect(btn.attributes('aria-pressed')).toBe('false')
+    expect(btn.text()).toContain('取点标注')
+    expect(wrapper.text()).not.toContain('取消取点')
+
+    await btn.trigger('click')
     await flushPromises()
-    expect(wrapper.text()).toContain('取消取点')
+    expect(btn.attributes('aria-pressed')).toBe('true')
+    expect(btn.text()).toContain('取点标注')
+    expect(wrapper.text()).not.toContain('取消取点')
+    expect(lastInspectCtrl()).toEqual({ type: 'inspect', on: true })
+
+    await btn.trigger('click')
+    await flushPromises()
+    expect(btn.attributes('aria-pressed')).toBe('false')
+    expect(btn.text()).toContain('取点标注')
+    expect(lastInspectCtrl()).toEqual({ type: 'inspect', on: false })
+    wrapper.unmount()
+  })
+
+  it('Esc while inspecting clears pressed state but keeps staged pick', async () => {
+    const wrapper = mountNovnc()
+    await flushPromises()
+    const ws = MockWebSocket.instances[0]
+    expect(ws).toBeTruthy()
+
+    await inspectButton(wrapper).trigger('click')
+    await flushPromises()
+    expect(inspectButton(wrapper).attributes('aria-pressed')).toBe('true')
+
+    ws!.onmessage?.({
+      data: JSON.stringify({
+        type: 'picked',
+        pick: { selector: '#x', tagName: 'div', outerHTML: '<div id="x"></div>' },
+      }),
+    })
+    await flushPromises()
+    // pick auto-exits inspect; re-enter then Esc must keep staged
+    expect(inspectButton(wrapper).attributes('aria-pressed')).toBe('false')
+    expect(wrapper.text()).toContain('#x')
+
+    await inspectButton(wrapper).trigger('click')
+    await flushPromises()
+    expect(inspectButton(wrapper).attributes('aria-pressed')).toBe('true')
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await flushPromises()
+    expect(inspectButton(wrapper).attributes('aria-pressed')).toBe('false')
+    expect(wrapper.text()).toContain('#x')
+    expect(lastInspectCtrl()).toEqual({ type: 'inspect', on: false })
+    wrapper.unmount()
+  })
+
+  it('remote inspect-canceled clears button without clearing staged pick', async () => {
+    const wrapper = mountNovnc()
+    await flushPromises()
+    const ws = MockWebSocket.instances[0]!
+
+    await inspectButton(wrapper).trigger('click')
+    await flushPromises()
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: 'picked',
+        pick: { selector: '#keep', tagName: 'span', outerHTML: '<span id="keep"></span>' },
+      }),
+    })
+    await flushPromises()
+    expect(wrapper.text()).toContain('#keep')
+
+    await inspectButton(wrapper).trigger('click')
+    await flushPromises()
+    const beforeLen = ws.sent.length
+    ws.onmessage?.({ data: JSON.stringify({ type: 'inspect-canceled' }) })
+    await flushPromises()
+    expect(inspectButton(wrapper).attributes('aria-pressed')).toBe('false')
+    expect(wrapper.text()).toContain('#keep')
+    // Remote already off — do not echo another inspect on:false
+    expect(ws.sent.slice(beforeLen)).toEqual([])
     wrapper.unmount()
   })
 })

--- a/web/src/components/run/NovncPreviewPanel.vue
+++ b/web/src/components/run/NovncPreviewPanel.vue
@@ -109,8 +109,13 @@ function handleCtrlText(data: string) {
       break
     case 'picked':
       picked.value = msg.pick
-      setInspect(false)
+      // Server already left inspect mode after one-shot pick.
+      clearInspect('picked', { syncRemote: false })
       if (msg.pick) emit('staged-pick', msg.pick)
+      break
+    case 'inspect-canceled':
+      // Remote Esc (Overlay.inspectModeCanceled) — keep staged pick.
+      clearInspect('remote-esc', { syncRemote: false })
       break
     case 'closed':
       status.value = 'closed'
@@ -134,9 +139,27 @@ function handleCtrlText(data: string) {
   }
 }
 
+/**
+ * Single exit for inspect mode (toolbar off / Esc / pick / remote cancel).
+ * Never clears staged pick — Esc must keep temporarily picked annotations.
+ */
+function clearInspect(_reason: string, opts?: { syncRemote?: boolean }) {
+  const syncRemote = opts?.syncRemote !== false
+  if (!inspect.value) {
+    if (syncRemote) sendCtrl({ type: 'inspect', on: false })
+    return
+  }
+  inspect.value = false
+  if (syncRemote) sendCtrl({ type: 'inspect', on: false })
+}
+
 function setInspect(on: boolean) {
-  inspect.value = on
-  sendCtrl({ type: 'inspect', on })
+  if (on) {
+    inspect.value = true
+    sendCtrl({ type: 'inspect', on: true })
+    return
+  }
+  clearInspect('setInspect')
 }
 
 function resolveWsUrl(): string | null {
@@ -261,13 +284,14 @@ function reconnect() {
 }
 
 function toggleInspect() {
-  setInspect(!inspect.value)
+  if (inspect.value) clearInspect('toolbar-toggle')
+  else setInspect(true)
 }
 
 function clearPick() {
   picked.value = null
   emit('staged-pick', null)
-  if (inspect.value) setInspect(false)
+  if (inspect.value) clearInspect('clearPick')
 }
 
 function nav(action: 'reload' | 'back' | 'forward') {
@@ -297,9 +321,10 @@ function onFsChange() {
 
 function onKeydown(ev: KeyboardEvent) {
   if (ev.key !== 'Escape') return
+  // Inspect Esc: exit mode only (keep staged). Non-inspect Esc clears staged pick.
   if (inspect.value) {
     ev.preventDefault()
-    setInspect(false)
+    clearInspect('host-esc')
     return
   }
   if (picked.value) {
@@ -370,10 +395,12 @@ onBeforeUnmount(() => {
         type="button"
         class="rounded px-2 py-0.5 text-[11px] transition"
         :class="inspect ? 'bg-ok/20 text-ok' : 'text-txt2 hover:bg-overlay'"
-        :title="inspect ? t('pages.appPreview.novnc.cancelInspect') : t('pages.appPreview.novnc.inspect')"
+        :title="t('pages.appPreview.novnc.inspect')"
+        :aria-pressed="inspect ? 'true' : 'false'"
+        data-testid="novnc-inspect-toggle"
         @click="toggleInspect"
       >
-        {{ inspect ? t('pages.appPreview.novnc.cancelInspect') : t('pages.appPreview.novnc.inspect') }}
+        {{ t('pages.appPreview.novnc.inspect') }}
       </button>
       <button
         type="button"

--- a/web/src/components/ui/HtmlPreview.test.ts
+++ b/web/src/components/ui/HtmlPreview.test.ts
@@ -4,10 +4,12 @@ import { createI18n } from 'vue-i18n'
 import { mount, flushPromises } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import common from '@/locales/zh-CN/common.json'
+import pages from '@/locales/zh-CN/pages.json'
 import {
   HTML_PREVIEW_DEFAULT_TOOLBAR_PX,
   RESIZE_HEIGHT_EPSILON,
   RESIZE_MESSAGE_TYPE,
+  INSPECT_CANCELED_TYPE,
   contentFitPreviewCapPx,
 } from '@/lib/htmlPreviewSandbox'
 import HtmlPreview from './HtmlPreview.vue'
@@ -27,7 +29,7 @@ function mountPreview(props: Record<string, unknown> = {}) {
   const i18n = createI18n({
     legacy: false,
     locale: 'zh-CN',
-    messages: { 'zh-CN': { ...common } },
+    messages: { 'zh-CN': { ...common, ...pages } },
   })
   return mount(HtmlPreview, {
     props: {
@@ -332,6 +334,78 @@ describe('HtmlPreview inline/fillParent enlarge', () => {
     await wrapper.find('[data-testid="html-preview-enlarge"]').trigger('click')
     await nextTick()
     expect(wrapper.findComponent(AppModalStub).props('title')).toBe('窗口放大查看')
+    wrapper.unmount()
+  })
+})
+
+describe('HtmlPreview inspect toggle', () => {
+  beforeEach(() => {
+    vi.stubGlobal('crypto', { randomUUID: () => FIXED_ID })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('toggles with stable 取点标注 label and aria-pressed round-trip', async () => {
+    const wrapper = mountPreview({
+      mode: 'inline',
+      fitContent: false,
+      fillParent: true,
+      inspectable: true,
+      enlargeable: false,
+    })
+    await flushPromises()
+    const btn = wrapper.find('[data-testid="html-preview-inspect-toggle"]')
+    expect(btn.exists()).toBe(true)
+    expect(btn.text()).toContain('取点标注')
+    expect(btn.attributes('aria-pressed')).toBe('false')
+    expect(wrapper.text()).not.toContain('取消取点')
+
+    await btn.trigger('click')
+    await nextTick()
+    expect(btn.attributes('aria-pressed')).toBe('true')
+    expect(btn.text()).toContain('取点标注')
+    expect(wrapper.text()).not.toContain('取消取点')
+
+    await btn.trigger('click')
+    await nextTick()
+    expect(btn.attributes('aria-pressed')).toBe('false')
+    expect(btn.text()).toContain('取点标注')
+    wrapper.unmount()
+  })
+
+  it('clears pressed state when iframe posts inspect-canceled (Esc)', async () => {
+    const wrapper = mountPreview({
+      mode: 'inline',
+      fitContent: false,
+      fillParent: true,
+      inspectable: true,
+      enlargeable: false,
+    })
+    await flushPromises()
+
+    const iframe = wrapper.find('iframe')
+    const el = iframe.element as HTMLIFrameElement
+    Object.defineProperty(el, 'contentWindow', {
+      value: window,
+      configurable: true,
+    })
+
+    const btn = wrapper.find('[data-testid="html-preview-inspect-toggle"]')
+    await btn.trigger('click')
+    await nextTick()
+    expect(btn.attributes('aria-pressed')).toBe('true')
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: INSPECT_CANCELED_TYPE, id: FIXED_ID },
+        source: window,
+      }),
+    )
+    await nextTick()
+    await flushPromises()
+    expect(btn.attributes('aria-pressed')).toBe('false')
     wrapper.unmount()
   })
 })

--- a/web/src/components/ui/HtmlPreview.vue
+++ b/web/src/components/ui/HtmlPreview.vue
@@ -15,6 +15,7 @@ import {
   parseResizeMessage,
   isValidInspectPickMessage,
   parseInspectPickMessage,
+  isValidInspectCanceledMessage,
   buildInspectCommand,
 } from '@/lib/htmlPreviewSandbox'
 import Icon from './Icon.vue'
@@ -226,14 +227,34 @@ function postInspectCommand(enabled: boolean) {
   win.postMessage(buildInspectCommand(instanceId, enabled), '*')
 }
 
+/**
+ * Single exit for inspect mode (toolbar off / Esc / pick). Keeps last pick emit
+ * result with the parent — Esc must only clear the button/mode, not staged UI.
+ */
+function clearInspect(_reason: string, opts?: { syncIframe?: boolean }) {
+  const syncIframe = opts?.syncIframe !== false
+  if (!props.inspectable) return
+  if (!inspecting.value) {
+    if (syncIframe) postInspectCommand(false)
+    return
+  }
+  inspecting.value = false
+  if (syncIframe) postInspectCommand(false)
+}
+
 function setInspecting(on: boolean) {
   if (!props.inspectable) return
-  inspecting.value = on
-  postInspectCommand(on)
+  if (on) {
+    inspecting.value = true
+    postInspectCommand(true)
+    return
+  }
+  clearInspect('setInspecting')
 }
 
 function toggleInspect() {
-  setInspecting(!inspecting.value)
+  if (inspecting.value) clearInspect('toolbar-toggle')
+  else setInspecting(true)
 }
 
 defineExpose({ openEnlarge, closeEnlarge, setInspecting })
@@ -280,11 +301,16 @@ function handlePreviewMessage(event: MessageEvent) {
     return
   }
 
+  if (props.inspectable && isValidInspectCanceledMessage(event.data)) {
+    // iframe Esc — sandbox already disabled inspect; sync parent button only.
+    clearInspect('iframe-esc', { syncIframe: false })
+    return
+  }
+
   if (props.inspectable && isValidInspectPickMessage(event.data)) {
     const parsed = parseInspectPickMessage(event.data)
     if (!parsed) return
-    inspecting.value = false
-    postInspectCommand(false)
+    clearInspect('picked', { syncIframe: true })
     emit('pick', {
       selector: parsed.selector,
       tagName: parsed.tagName,
@@ -397,15 +423,13 @@ watch(needsMessageListener, (enabled, wasEnabled) => {
             ? 'border-accent bg-accent-dim/50 text-accent'
             : 'border-line text-txt2 hover:text-txt'
         "
+        :aria-pressed="inspecting ? 'true' : 'false'"
+        :title="t('pages.appPreview.novnc.inspect')"
         data-testid="html-preview-inspect-toggle"
         @click="toggleInspect"
       >
         <Icon name="crosshair" :size="13" />
-        {{
-          inspecting
-            ? t('pages.appPreview.novnc.cancelInspect')
-            : t('pages.appPreview.novnc.inspect')
-        }}
+        {{ t('pages.appPreview.novnc.inspect') }}
       </button>
       <button
         v-if="enlargeable"
@@ -502,15 +526,13 @@ watch(needsMessageListener, (enabled, wasEnabled) => {
             ? 'border-accent bg-accent-dim/50 text-accent'
             : 'border-line text-txt2 hover:text-txt'
         "
+        :aria-pressed="inspecting ? 'true' : 'false'"
+        :title="t('pages.appPreview.novnc.inspect')"
         data-testid="html-preview-inspect-toggle"
         @click="toggleInspect"
       >
         <Icon name="crosshair" :size="13" />
-        {{
-          inspecting
-            ? t('pages.appPreview.novnc.cancelInspect')
-            : t('pages.appPreview.novnc.inspect')
-        }}
+        {{ t('pages.appPreview.novnc.inspect') }}
       </button>
       <button
         v-if="enlargeable"

--- a/web/src/lib/htmlPreviewSandbox.test.ts
+++ b/web/src/lib/htmlPreviewSandbox.test.ts
@@ -6,6 +6,7 @@ import {
   RESIZE_MESSAGE_TYPE,
   INSPECT_MESSAGE_TYPE,
   INSPECT_COMMAND_TYPE,
+  INSPECT_CANCELED_TYPE,
   SANDBOX_ATTR,
   CONTENT_FIT_PREVIEW_MAX_VH,
   CONTENT_FIT_REVIEWING_STRIP_PX,
@@ -19,6 +20,7 @@ import {
   parseResizeMessage,
   isValidInspectPickMessage,
   parseInspectPickMessage,
+  isValidInspectCanceledMessage,
   dataUrlToImageParts,
   buildInspectCommand,
 } from './htmlPreviewSandbox'
@@ -180,11 +182,14 @@ describe('parseResizeMessage', () => {
 })
 
 describe('injectInlineInspectScript', () => {
-  it('injects inspect message types and pickScript-style path helpers', () => {
+  it('injects inspect message types, Esc cancel, and pickScript-style path helpers', () => {
     const html = '<!doctype html><html><body><p id="x">hi</p></body></html>'
     const result = injectInlineInspectScript(html, TEST_ID)
     expect(result).toContain(INSPECT_MESSAGE_TYPE)
     expect(result).toContain(INSPECT_COMMAND_TYPE)
+    expect(result).toContain(INSPECT_CANCELED_TYPE)
+    expect(result).toContain("ev.key!=='Escape'")
+    expect(result).toContain('keydown')
     expect(result).toContain(TEST_ID)
     expect(result).toContain('nth-of-type')
     expect(result).toContain('foreignObject')
@@ -255,5 +260,16 @@ describe('buildInspectCommand', () => {
       id: TEST_ID,
       enabled: true,
     })
+  })
+})
+
+describe('isValidInspectCanceledMessage', () => {
+  it('accepts iframe Esc cancel messages', () => {
+    expect(isValidInspectCanceledMessage({ type: INSPECT_CANCELED_TYPE, id: TEST_ID })).toBe(true)
+  })
+
+  it('rejects missing id or wrong type', () => {
+    expect(isValidInspectCanceledMessage({ type: INSPECT_CANCELED_TYPE, id: '' })).toBe(false)
+    expect(isValidInspectCanceledMessage({ type: INSPECT_MESSAGE_TYPE, id: TEST_ID })).toBe(false)
   })
 })

--- a/web/src/lib/htmlPreviewSandbox.ts
+++ b/web/src/lib/htmlPreviewSandbox.ts
@@ -69,6 +69,9 @@ export const INSPECT_COMMAND_TYPE = 'html-preview-inspect-cmd'
 /** iframe → parent: element pick with CSS selector + element screenshot. */
 export const INSPECT_MESSAGE_TYPE = 'html-preview-inspect'
 
+/** iframe → parent: user canceled inspect (Esc) inside opaque-origin sandbox. */
+export const INSPECT_CANCELED_TYPE = 'html-preview-inspect-canceled'
+
 /** Timeout before falling back to fixed inline height when no resize message arrives. */
 export const RESIZE_TIMEOUT_MS = 2500
 
@@ -90,6 +93,11 @@ export interface InspectPickMessage {
   selector: string
   tagName: string
   imageDataUrl: string
+}
+
+export interface InspectCanceledMessage {
+  type: typeof INSPECT_CANCELED_TYPE
+  id: string
 }
 
 function escapeForSingleQuotedJs(value: string): string {
@@ -142,6 +150,7 @@ function buildInspectScript(instanceId: string): string {
 var instanceId='${safeId}';
 var cmdType='${INSPECT_COMMAND_TYPE}';
 var pickType='${INSPECT_MESSAGE_TYPE}';
+var cancelType='${INSPECT_CANCELED_TYPE}';
 var enabled=false;
 var hoverEl=null;
 var styleEl=null;
@@ -261,6 +270,8 @@ function onClick(ev){
   var selector=path(t);
   var tagName=t.tagName.toLowerCase();
   clearHover();
+  // One-shot: leave inspect after pick (parent also clears button state).
+  setEnabled(false);
   captureElement(t).then(function(imageDataUrl){
     parent.postMessage({
       type:pickType,
@@ -271,6 +282,14 @@ function onClick(ev){
     },'*');
   });
 }
+function onKeydown(ev){
+  if(!enabled)return;
+  if(ev.key!=='Escape'&&ev.key!=='Esc')return;
+  ev.preventDefault();
+  ev.stopPropagation();
+  setEnabled(false);
+  parent.postMessage({type:cancelType,id:instanceId},'*');
+}
 window.addEventListener('message',function(ev){
   var data=ev.data;
   if(!data||typeof data!=='object')return;
@@ -279,6 +298,7 @@ window.addEventListener('message',function(ev){
 });
 document.addEventListener('mousemove',onMove,true);
 document.addEventListener('click',onClick,true);
+document.addEventListener('keydown',onKeydown,true);
 })();<\/script>`
 }
 
@@ -366,6 +386,14 @@ export function parseInspectPickMessage(data: unknown): InspectPickMessage | nul
     tagName: data.tagName,
     imageDataUrl: data.imageDataUrl,
   }
+}
+
+export function isValidInspectCanceledMessage(data: unknown): data is InspectCanceledMessage {
+  if (!data || typeof data !== 'object') return false
+  const msg = data as Record<string, unknown>
+  if (msg.type !== INSPECT_CANCELED_TYPE) return false
+  if (typeof msg.id !== 'string' || !msg.id) return false
+  return true
 }
 
 /** Build parent→iframe inspect command (caller posts to iframe contentWindow). */

--- a/web/vite.e2e.config.ts
+++ b/web/vite.e2e.config.ts
@@ -61,14 +61,25 @@ function handleMockVncUpgrade(
     const sendReady = () => ws.send(JSON.stringify({ type: 'ready', url: 'http://mock-app:3000/' }))
     if (connectDelayMs > 0) setTimeout(sendReady, connectDelayMs)
     else sendReady()
+    /** Deferred pick so on:false can cancel before forced pick masks toggle-off. */
+    let pendingPick: ReturnType<typeof setTimeout> | null = null
     ws.on('message', (data, isBinary) => {
       if (isBinary) return
       const text = typeof data === 'string' ? data : data.toString()
       try {
         const msg = JSON.parse(text) as { type?: string; on?: boolean }
-        if (msg.type === 'inspect' && msg.on) {
-          ws.send(JSON.stringify({ type: 'picked', pick: mockPick }))
+        if (msg.type !== 'inspect') return
+        if (pendingPick != null) {
+          clearTimeout(pendingPick)
+          pendingPick = null
         }
+        if (msg.on) {
+          pendingPick = setTimeout(() => {
+            pendingPick = null
+            ws.send(JSON.stringify({ type: 'picked', pick: mockPick }))
+          }, 300)
+        }
+        // on:false: cancel pending pick; do not force inspect-canceled (client already cleared)
       } catch {
         // ignore non-JSON client frames
       }


### PR DESCRIPTION
Unify clearInspect exit paths (toolbar, Esc, pick, remote cancel), keep
stable「取点标注」+ aria-pressed, and forward Overlay.inspectModeCanceled
so remote Esc no longer leaves a sticky toolbar state.

Co-authored-by: Cursor <cursoragent@cursor.com>
