### PR TITLE
fix(sandbox): mount /tmp on the sandbox PVC

### DIFF
--- a/sandbox-gateway/gateway/internal/driver/kubernetes/kubernetes.go
+++ b/sandbox-gateway/gateway/internal/driver/kubernetes/kubernetes.go
@@ -442,7 +442,9 @@ func (d *Driver) ensureDeployment(ctx context.Context, spec driver.Spec, resLimi
 		Ports:           containerPorts,
 		Resources:       res,
 		SecurityContext: &corev1.SecurityContext{Privileged: &privileged},
-		// Persist workspace + tool caches on the sandbox PVC (subPaths).
+		// Persist workspace + tool caches + /tmp on the sandbox PVC (subPaths).
+		// /tmp must sit on the PVC: the container rootfs is often overlay with
+		// multi-hundred-ms fsync, which makes sqlite/go test / mktemp workloads crawl.
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "data", MountPath: "/root/workspace", SubPath: "workspace"},
 			{Name: "data", MountPath: "/root/.cache", SubPath: "cache"},
@@ -451,6 +453,7 @@ func (d *Driver) ensureDeployment(ctx context.Context, spec driver.Spec, resLimi
 			{Name: "data", MountPath: "/root/go/pkg/mod", SubPath: "go-mod"},
 			{Name: "data", MountPath: "/var/lib/docker", SubPath: "docker"},
 			{Name: "data", MountPath: "/var/lib/buildkit", SubPath: "buildkit"},
+			{Name: "data", MountPath: "/tmp", SubPath: "tmp"},
 		},
 	}
 	if spec.WorkspaceDir != "" {

--- a/sandbox-gateway/gateway/internal/driver/kubernetes/kubernetes_test.go
+++ b/sandbox-gateway/gateway/internal/driver/kubernetes/kubernetes_test.go
@@ -878,6 +878,7 @@ func TestCreatePVCVolumeMounts(t *testing.T) {
 		"/root/go/pkg/mod":  "go-mod",
 		"/var/lib/docker":   "docker",
 		"/var/lib/buildkit": "buildkit",
+		"/tmp":              "tmp",
 	}
 	got := map[string]string{}
 	for _, m := range dep.Spec.Template.Spec.Containers[0].VolumeMounts {

--- a/sandbox-gateway/sandbox/scripts/startup.sh
+++ b/sandbox-gateway/sandbox/scripts/startup.sh
@@ -14,6 +14,9 @@ set -e
 #   GITHUB_TOKEN, GITHUB_URL, GITLAB_TOKEN, GITLAB_URL, GIT_SSH_PRIVATE_KEY, GIT_SSH_KNOWN_HOSTS,
 #   ACP_BACKEND, ACP_BRIDGE_PORT, ACP_BRIDGE_PASSWORD, ACP_BRIDGE_MODEL
 
+# PVC subPath 挂上来的 /tmp 目录默认不是 1777；补 sticky bit，避免 mktemp/多用户写入失败。
+chmod 1777 /tmp 2>/dev/null || true
+
 # DinD：在容器内启动 Docker 守护进程（宿主机需 --privileged；SKIP_INNER_DOCKER=1 可跳过）
 if command -v dockerd >/dev/null 2>&1 && [ "${SKIP_INNER_DOCKER:-0}" != "1" ]; then
   if ! docker info >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Mount `/tmp` onto the sandbox data PVC (`subPath: tmp`) alongside workspace/caches, so temp files and sqlite test DBs avoid the slow overlay rootfs fsync path.
- Ensure sticky bit `1777` on `/tmp` after the PVC subPath mount in `startup.sh`.
- Extend `TestCreatePVCVolumeMounts` to assert the new mount.

## Test plan
- [x] `go test ./internal/driver/kubernetes/ -run TestCreatePVCVolumeMounts`
- [ ] Reinstall/recreate an existing K8s sandbox and confirm `findmnt /tmp` points at the data PVC
- [ ] `mktemp` / a sqlite-using `go test` package no longer spends ~60s+ on cold `/tmp` I/O


Made with [Cursor](https://cursor.com)