### PR TITLE
fix(web): add 12px padding to artifact image preview canvases

### DIFF
--- a/web/src/components/run/ArtifactPreview.image.test.ts
+++ b/web/src/components/run/ArtifactPreview.image.test.ts
@@ -102,6 +102,18 @@ describe('ArtifactPreview image preview UI', () => {
     wrapper.unmount()
   })
 
+  it('applies p-3 padding on inline image-wrap success canvas', async () => {
+    const wrapper = mountPreview()
+    await flushPromises()
+    const wrap = wrapper.find('[data-testid="artifact-preview-image-wrap"]')
+    expect(wrap.exists()).toBe(true)
+    expect(wrap.classes()).toContain('p-3')
+    // loading/error branches must not be the padded canvas
+    expect(wrapper.find('[data-testid="artifact-preview-image-loading"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="artifact-preview-image-error"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
   it('shows loading until download completes', async () => {
     let resolveFetch: (value: unknown) => void = () => {}
     vi.stubGlobal(
@@ -170,6 +182,19 @@ describe('ArtifactPreview image preview UI', () => {
     const zoom = wrapper.find('[data-testid="artifact-preview-zoom-image"]')
     expect(zoom.exists()).toBe(true)
     expect(zoom.find('img').attributes('src')).toBe('blob:mock-image')
+    wrapper.unmount()
+  })
+
+  it('applies p-3 padding on zoom success image container', async () => {
+    const wrapper = mountPreview()
+    await flushPromises()
+    await wrapper.find('button[title="放大查看"]').trigger('click')
+    await flushPromises()
+    const zoom = wrapper.find('[data-testid="artifact-preview-zoom-image"]')
+    expect(zoom.exists()).toBe(true)
+    const successContainer = zoom.find('img').element.parentElement
+    expect(successContainer).toBeTruthy()
+    expect(successContainer!.classList.contains('p-3')).toBe(true)
     wrapper.unmount()
   })
 })

--- a/web/src/components/run/ArtifactPreview.vue
+++ b/web/src/components/run/ArtifactPreview.vue
@@ -343,7 +343,7 @@ onBeforeUnmount(() => {
         </div>
         <div
           v-else
-          class="flex h-full min-h-[320px] w-full items-center justify-center border border-line bg-base"
+          class="flex h-full min-h-[320px] w-full items-center justify-center border border-line bg-base p-3"
           data-testid="artifact-preview-image-wrap"
         >
           <img
@@ -446,7 +446,7 @@ onBeforeUnmount(() => {
       >
         {{ t('pages.artifactPreview.loading') }}
       </div>
-      <div v-else class="flex h-full min-h-[360px] w-full items-center justify-center">
+      <div v-else class="flex h-full min-h-[360px] w-full items-center justify-center p-3">
         <img
           :src="imageSrc!"
           :alt="artifact.name"


### PR DESCRIPTION
Keep images from hugging the bordered wrap and zoom success container,
matching the approved Demo (p-3) without changing outer p-4 or download logic.

Co-authored-by: Cursor <cursoragent@cursor.com>
