### PR TITLE
fix(web): include goto adjacency in output source options

### DIFF
--- a/web/src/components/canvas/OutputSourcesEditor.test.ts
+++ b/web/src/components/canvas/OutputSourcesEditor.test.ts
@@ -1,19 +1,22 @@
 // @vitest-environment happy-dom
 import { createI18n } from 'vue-i18n'
 import { mount } from '@vue/test-utils'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import common from '@/locales/zh-CN/common.json'
 import pages from '@/locales/zh-CN/pages.json'
 import type { WFEdge, WFNode } from '@/lib/types'
 import OutputSourcesEditor from './OutputSourcesEditor.vue'
 
-function mountEditor() {
+const EMPTY_AVAILABLE =
+  '连接上游节点后可选。将分支、测试/评审门禁或人工门禁连到本输出节点后，可映射的结构化产物会出现在此列表。'
+
+function mountEditor(opts?: { withUpstream?: boolean; results?: string[] }) {
   const node: WFNode = {
     id: 'output',
     type: 'output',
     label: '输出',
     position: { x: 0, y: 0 },
-    config: { results: [] },
+    config: { results: opts?.results ?? [] },
   }
   const upstream: WFNode = {
     id: 'research',
@@ -22,14 +25,18 @@ function mountEditor() {
     position: { x: -200, y: 0 },
     config: {},
   }
-  const edges: WFEdge[] = [{ id: 'e1', source: 'research', target: 'output', kind: 'success' }]
+  const edges: WFEdge[] =
+    opts?.withUpstream === false
+      ? []
+      : [{ id: 'e1', source: 'research', target: 'output', kind: 'success' }]
+  const allNodes = opts?.withUpstream === false ? [node] : [node, upstream]
   const i18n = createI18n({
     legacy: false,
     locale: 'zh-CN',
     messages: { 'zh-CN': { ...common, ...pages } },
   })
   return mount(OutputSourcesEditor, {
-    props: { node, allNodes: [node, upstream], edges },
+    props: { node, allNodes, edges },
     global: { plugins: [i18n], stubs: { Icon: true } },
   })
 }
@@ -39,6 +46,25 @@ describe('OutputSourcesEditor', () => {
     const wrapper = mountEditor()
     expect(Array.isArray(wrapper.props('node').config.results)).toBe(true)
     expect(wrapper.text().length).toBeGreaterThan(0)
+    wrapper.unmount()
+  })
+
+  it('shows Demo empty-available guide when no mappable options', () => {
+    // plan_coverage: g2.2 / g3.2 — availableOptions 为空时展示 Demo 长文案
+    const wrapper = mountEditor({ withUpstream: false })
+    const empty = wrapper.find('[data-testid="output-sources-empty-available"]')
+    expect(empty.exists()).toBe(true)
+    expect(empty.text()).toBe(EMPTY_AVAILABLE)
+    expect(wrapper.text()).toContain('未选择任何来源')
+    wrapper.unmount()
+  })
+
+  it('hides empty-available guide when options exist', () => {
+    // plan_coverage: g2.2 / g3.2 — 非空时不展示空态引导
+    const wrapper = mountEditor({ withUpstream: true })
+    expect(wrapper.find('[data-testid="output-sources-empty-available"]').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain(EMPTY_AVAILABLE)
+    expect(wrapper.text()).toContain('调研')
     wrapper.unmount()
   })
 })

--- a/web/src/components/canvas/OutputSourcesEditor.vue
+++ b/web/src/components/canvas/OutputSourcesEditor.vue
@@ -121,6 +121,13 @@ function onDrop(target: string) {
       <div class="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-txt3">
         {{ t('pages.workflowEditor.inspector.outputSources.availableSection') }}
       </div>
+      <div
+        v-if="!availableOptions.length"
+        data-testid="output-sources-empty-available"
+        class="border border-dashed border-line px-3 py-4 text-[12px] leading-relaxed text-txt3"
+      >
+        {{ t('pages.workflowEditor.inspector.outputSources.emptyAvailable') }}
+      </div>
       <button
         v-for="opt in availableOptions"
         :key="opt.value"

--- a/web/src/lib/outputSourceOptions.test.ts
+++ b/web/src/lib/outputSourceOptions.test.ts
@@ -27,8 +27,8 @@ describe('outputSourceOptions', () => {
   ]
 
   it('walks transitive upstream ids', () => {
-    expect([...upstreamNodeIds('gate', edges)].sort()).toEqual(['agent', 'in', 'plan'])
-    expect(upstreamNodeIds('in', edges).size).toBe(0)
+    expect([...upstreamNodeIds('gate', edges, nodes)].sort()).toEqual(['agent', 'in', 'plan'])
+    expect(upstreamNodeIds('in', edges, nodes).size).toBe(0)
   })
 
   it('builds structured/agent/artifact options and resolves labels', () => {
@@ -41,6 +41,108 @@ describe('outputSourceOptions', () => {
     expect(labelForOutputTemplate(hit.value, nodes, edges, 'gate', t)).toBe(hit.label)
     expect(labelForOutputTemplate('{{custom}}', nodes, edges, 'gate', t)).toContain(
       'common.gateBodyLabels.custom',
+    )
+  })
+
+  it('includes upstream via test exit.goto only (no real edge to output)', () => {
+    // plan_coverage: g1.1 / g3.1 — test|review exits.pass.goto
+    const graph = [
+      node('research', 'research', '调研'),
+      node('test', 'test', '测试', {
+        exits: { pass: { goto: 'output' }, fail: { goto: 'research' } },
+      }),
+      node('output', 'output', '输出'),
+    ]
+    const realEdges: WFEdge[] = [{ id: 'e1', source: 'research', target: 'test' }]
+    const upstream = upstreamNodeIds('output', realEdges, graph)
+    expect(upstream.has('test')).toBe(true)
+    expect(upstream.has('research')).toBe(true)
+
+    const opts = buildOutputSourceOptions(graph, realEdges, 'output', t)
+    expect(opts.length).toBeGreaterThan(0)
+    expect(opts.some((o) => o.value.includes('nodes.research.outputs.research'))).toBe(true)
+    expect(opts.some((o) => o.value.includes('nodes.test.outputs.test_result'))).toBe(true)
+  })
+
+  it('includes upstream via review exit.goto only', () => {
+    // plan_coverage: g3.1 — review exit.goto（仅第二段为 goto，无指向 output 的真实边）
+    const graph = [
+      node('implement', 'implement', '实现'),
+      node('review', 'review', '评审', {
+        exits: { pass: { goto: 'output' }, fail: { goto: 'implement' } },
+      }),
+      node('output', 'output', '输出'),
+    ]
+    const realEdges: WFEdge[] = [{ id: 'e1', source: 'implement', target: 'review' }]
+    const opts = buildOutputSourceOptions(graph, realEdges, 'output', t)
+    expect(opts.some((o) => o.value.includes('nodes.implement.outputs.implementation_result'))).toBe(
+      true,
+    )
+    expect(opts.some((o) => o.value.includes('nodes.review.outputs.review'))).toBe(true)
+  })
+
+  it('includes upstream via human_gate action.goto only', () => {
+    // plan_coverage: g1.1 / g3.1 — human_gate.actions[].goto
+    const graph = [
+      node('research', 'research', '调研'),
+      node('gate', 'human_gate', '门禁', {
+        actions: [{ id: 'approve', label: '通过', goto: 'output' }],
+      }),
+      node('output', 'output', '输出'),
+    ]
+    const realEdges: WFEdge[] = [{ id: 'e1', source: 'research', target: 'gate' }]
+    const opts = buildOutputSourceOptions(graph, realEdges, 'output', t)
+    expect(opts.some((o) => o.value.includes('nodes.research.outputs.research'))).toBe(true)
+  })
+
+  it('includes upstream via branch case.goto only', () => {
+    // plan_coverage: g1.1 / g3.1 — branch.cases[].goto
+    const graph = [
+      node('research', 'research', '调研'),
+      node('branch', 'branch', '分支', {
+        cases: [{ label: 'ok', goto: 'output' }],
+      }),
+      node('output', 'output', '输出'),
+    ]
+    const realEdges: WFEdge[] = [{ id: 'e1', source: 'research', target: 'branch' }]
+    const opts = buildOutputSourceOptions(graph, realEdges, 'output', t)
+    expect(opts.some((o) => o.value.includes('nodes.research.outputs.research'))).toBe(true)
+  })
+
+  it('unions edges and goto, dedupes option templates', () => {
+    // plan_coverage: g1.2 / g3.1 — edges ∪ goto 并集去重
+    const graph = [
+      node('implement', 'implement', '实现'),
+      node('test', 'test', '测试', {
+        exits: { pass: { goto: 'output' }, fail: { goto: 'implement' } },
+      }),
+      node('output', 'output', '输出'),
+    ]
+    const realEdges: WFEdge[] = [
+      { id: 'e1', source: 'implement', target: 'test' },
+      { id: 'e2', source: 'implement', target: 'output', kind: 'success' },
+      { id: 'e3', source: 'test', target: 'output', kind: 'success' },
+    ]
+    const opts = buildOutputSourceOptions(graph, realEdges, 'output', t)
+    const implValues = opts.filter((o) =>
+      o.value.includes('nodes.implement.outputs.implementation_result'),
+    )
+    expect(implValues).toHaveLength(1)
+    expect(opts.some((o) => o.value.includes('nodes.test.outputs.test_result'))).toBe(true)
+  })
+
+  it('keeps real-edge implement→output options (no regression)', () => {
+    // plan_coverage: g1.3 / g3.1 — 真实边对照不回归
+    const graph = [
+      node('implement', 'implement', '实现'),
+      node('output', 'output', '输出'),
+    ]
+    const realEdges: WFEdge[] = [
+      { id: 'e1', source: 'implement', target: 'output', kind: 'success' },
+    ]
+    const opts = buildOutputSourceOptions(graph, realEdges, 'output', t)
+    expect(opts.some((o) => o.value.includes('nodes.implement.outputs.implementation_result'))).toBe(
+      true,
     )
   })
 })

--- a/web/src/lib/outputSourceOptions.ts
+++ b/web/src/lib/outputSourceOptions.ts
@@ -17,10 +17,39 @@ const STRUCTURED_OUT: Partial<Record<string, { key: string; labelKey: string }>>
   visual: { key: 'page', labelKey: 'common.gateBodyLabels.pagePreview' },
 }
 
-/** Collect upstream node ids reachable via edges (transitive predecessors). */
-export function upstreamNodeIds(nodeId: string, edges: WFEdge[]): Set<string> {
+function addPred(preds: Record<string, string[]>, source: string, target: string) {
+  if (!source || !target || source === target) return
+  ;(preds[target] ||= []).push(source)
+}
+
+/**
+ * Collect upstream node ids reachable via real edges ∪ goto adjacency
+ * (branch.cases / human_gate.actions / test|review exits), transitive.
+ * Mirrors canvasLayout.buildAdjacency predecessor semantics for option discovery.
+ */
+export function upstreamNodeIds(nodeId: string, edges: WFEdge[], nodes: WFNode[] = []): Set<string> {
   const preds: Record<string, string[]> = {}
-  for (const e of edges) (preds[e.target] ||= []).push(e.source)
+  for (const e of edges) addPred(preds, e.source, e.target)
+
+  for (const n of nodes) {
+    if (n.type === 'branch') {
+      for (const c of (n.config?.cases as { goto?: string }[]) || []) {
+        if (c?.goto) addPred(preds, n.id, c.goto)
+      }
+    }
+    if (n.type === 'human_gate') {
+      for (const a of (n.config?.actions as { id?: string; goto?: string }[]) || []) {
+        if (a?.goto) addPred(preds, n.id, a.goto)
+      }
+    }
+    if (n.type === 'test' || n.type === 'review') {
+      const exits = (n.config?.exits as Record<string, { goto?: string }>) || {}
+      for (const key of ['pass', 'fail']) {
+        if (exits[key]?.goto) addPred(preds, n.id, exits[key].goto!)
+      }
+    }
+  }
+
   const seen = new Set<string>()
   const stack = [...(preds[nodeId] || [])]
   while (stack.length) {
@@ -46,7 +75,7 @@ export function buildOutputSourceOptions(
     seen.add(value)
     opts.push({ value, label })
   }
-  const upstreamIds = upstreamNodeIds(targetNodeId, edges)
+  const upstreamIds = upstreamNodeIds(targetNodeId, edges, allNodes)
   for (const n of allNodes) {
     if (!upstreamIds.has(n.id)) continue
     const so = STRUCTURED_OUT[n.type]

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -737,6 +737,7 @@
         "outputSources": {
           "migrationBanner": "Legacy field <code>config.result</code> detected and migrated to <code>config.results = [result]</code>. Save to persist the new field.",
           "emptySelected": "No sources selected — runtime will show \"Workflow complete.\"",
+          "emptyAvailable": "Connect upstream nodes first. After linking a branch, test/review gate, or human gate to this output node, mappable structured artifacts will appear in this list.",
           "availableSection": "Available upstream sources",
           "alreadyAdded": "Added",
           "duplicateHint": "Each source can only be added once",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -737,6 +737,7 @@
         "outputSources": {
           "migrationBanner": "检测到旧字段 <code>config.result</code>，已自动迁移为 <code>config.results = [result]</code>。保存时将写入新字段。",
           "emptySelected": "未选择任何来源 — 运行时将显示「工作流完成。」",
+          "emptyAvailable": "连接上游节点后可选。将分支、测试/评审门禁或人工门禁连到本输出节点后，可映射的结构化产物会出现在此列表。",
           "availableSection": "可添加上游来源",
           "alreadyAdded": "已添加",
           "duplicateHint": "同一来源不可重复添加",


### PR DESCRIPTION
Mirror canvasLayout edges∪goto predecessors so final-result sources
appear when only branch/human_gate/test|review goto connect to output,
and show Demo empty-available guidance when the list is empty.

Co-authored-by: Cursor <cursoragent@cursor.com>
