### PR TITLE
feat: add Sendable routing and task context resolution

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -343,10 +343,18 @@ func main() {
 		Unregister:     mcpWire.unregister,
 	}
 	channelBridge := channels.NewChannelBridge(pmSvc, sbxSvc, pmTurns, channelHooks)
+	taskContextSvc := services.NewTaskContextService(db)
+	channelBridge.SetTaskContext(taskContextSvc)
+	channelBridge.SetRunState(runSvc)
+	// Destructive PM MCP mutations from channel threads are denied unless a
+	// confirmed, single-use ticket authorizes exactly that run/workflow+action.
+	pmMCP.SetChannelActionAuthorizer(taskContextSvc)
 	channelSvc := services.NewChannelConfigService(db)
 	channelMgr := channels.NewManager(channelBridge, map[string]channels.AdapterFactory{
 		models.ChannelTypeQQ: qq.New,
 	}, crypto.Decrypt)
+	channelMgr.SetDeliveryPersistence(db, auditSvc)
+	channelMgr.SetTaskContext(taskContextSvc)
 	channelMgr.SetLoader(channelSvc.ListRaw)
 	channelSvc.SetOnChange(channelMgr.Reload)
 	channelMgr.ApplyOnBoot()

--- a/server/internal/channels/bridge.go
+++ b/server/internal/channels/bridge.go
@@ -34,17 +34,40 @@ type MCPTokenHooks struct {
 
 // ResolvedChannel is the per-turn channel context passed to the bridge.
 type ResolvedChannel struct {
-	ID          string
-	Type        string
-	ProjectID   string
-	TurnTimeout time.Duration // 0 → runner default
-	Caps        SessionCaps   // from latest ChannelConfig; applied each turn
+	ID            string
+	Type          string
+	ProjectID     string
+	TurnTimeout   time.Duration // 0 → runner default
+	Caps          SessionCaps   // from latest ChannelConfig; applied each turn
+	ReplyMetadata bool
 }
 
-// Reply is the bridge's produced answer for one inbound message.
+// Reply is the bridge's produced answer for one inbound message. Attachments
+// live on Final because only a structured final report may authorize them.
 type Reply struct {
-	Text      string
-	ImageURLs []string
+	Text       string
+	RunID      string
+	ShortTitle string
+	Final      *TurnFinalReport
+}
+
+// RunAcceptance is emitted once the inbound orchestration associates a
+// conversation with a Run. It carries routing identity only.
+type RunAcceptance struct {
+	ProjectID      string
+	Channel        string
+	Scene          Scene
+	ConversationID string
+	UserID         string
+	RunID          string
+	ShortTitle     string
+	Language       string
+}
+
+// RunStateSource exposes engine-persisted Run state. Progress derived from it
+// is a server structure, never assistant text.
+type RunStateSource interface {
+	Get(runID string) (models.Run, bool)
 }
 
 // ChannelBridge is the Work-side executor for channel turns: resolve thread,
@@ -53,15 +76,33 @@ type Reply struct {
 // (Reply). Progress is reported via the optional onProgress callback only for
 // the three allowed kinds (milestone / blocker / confirm).
 type ChannelBridge struct {
-	pm    *services.PmService
-	sbx   *services.SandboxService
-	turns *services.PmTurnRunner
-	hooks MCPTokenHooks
+	pm       *services.PmService
+	sbx      *services.SandboxService
+	turns    *services.PmTurnRunner
+	hooks    MCPTokenHooks
+	tasks    *services.TaskContextService
+	runState RunStateSource
+	accepted func(RunAcceptance)
 }
 
 // NewChannelBridge builds the bridge.
 func NewChannelBridge(pm *services.PmService, sbx *services.SandboxService, turns *services.PmTurnRunner, hooks MCPTokenHooks) *ChannelBridge {
 	return &ChannelBridge{pm: pm, sbx: sbx, turns: turns, hooks: hooks}
+}
+
+func (b *ChannelBridge) SetTaskContext(tasks *services.TaskContextService) {
+	b.tasks = tasks
+}
+
+// SetRunState wires the engine-persisted Run state used by the structured
+// progress producer.
+func (b *ChannelBridge) SetRunState(src RunStateSource) {
+	b.runState = src
+}
+
+// SetRunAcceptanceHook registers the Reply-side acceptance ACK producer.
+func (b *ChannelBridge) SetRunAcceptanceHook(fn func(RunAcceptance)) {
+	b.accepted = fn
 }
 
 // SyntheticUserID derives a stable per-conversation user id, e.g.
@@ -74,6 +115,13 @@ func SyntheticUserID(channelType string, scene Scene, conversationID string) str
 // send as the terminal report. onProgress may be nil; when set, only classified
 // ProgressEvents are forwarded (tool/token noise suppressed).
 func (b *ChannelBridge) Handle(ctx context.Context, rc ResolvedChannel, in InboundMessage, onProgress func(ProgressEvent)) (Reply, error) {
+	preflight, err := b.PreflightInbound(InboundPreflightRequest{Channel: rc, Message: in})
+	if err != nil {
+		return Reply{}, err
+	}
+	if preflight.Disposition == PreflightRespond {
+		return preflight.Reply, nil
+	}
 	if b.pm == nil || b.sbx == nil || b.turns == nil {
 		return Reply{}, fmt.Errorf("channel bridge unavailable")
 	}
@@ -87,6 +135,20 @@ func (b *ChannelBridge) Handle(ctx context.Context, rc ResolvedChannel, in Inbou
 	thread, err := b.ensureThread(rc.ProjectID, userID, agent, in)
 	if err != nil {
 		return Reply{}, err
+	}
+	if b.tasks != nil {
+		// Guarding is unconditional for channel threads: destructive PM MCP
+		// mutations are denied unless a confirmed ticket is spendable.
+		if guardErr := b.tasks.GuardChannelThread(rc.ProjectID, thread.ID, rc.Type, userID); guardErr != nil {
+			return Reply{}, guardErr
+		}
+		if preflight.AuthorizedAction != "" && preflight.TicketID != "" {
+			if err := b.tasks.BindActionGrant(preflight.TicketID, thread.ID); err != nil {
+				return Reply{}, err
+			}
+			// The grant lives only for the turn the user authorized.
+			defer func() { _ = b.tasks.ReleaseActionGrant(preflight.TicketID) }()
+		}
 	}
 
 	binding, _ := b.pm.GetBinding(rc.ProjectID)
@@ -139,6 +201,18 @@ func (b *ChannelBridge) Handle(ctx context.Context, rc ResolvedChannel, in Inbou
 	if len(images) > 0 {
 		prompt += fmt.Sprintf("\n（本条消息附带 %d 个附件）", len(images))
 	}
+	if preflight.Task != nil {
+		prompt = fmt.Sprintf(
+			"[任务上下文]\nRun: %s\n短标题: %s\n状态: %s\n\n%s",
+			preflight.Task.RunID, preflight.Task.ShortTitle, preflight.Task.Status, prompt,
+		)
+	}
+	if preflight.AuthorizedAction != "" {
+		prompt = fmt.Sprintf(
+			"[已确认的高风险操作]\nTicket: %s\nRun: %s\nAction: %s\n仅允许执行此票据绑定操作。\n\n%s",
+			preflight.TicketID, preflight.Task.RunID, preflight.AuthorizedAction, prompt,
+		)
+	}
 
 	if err := b.turns.StartWithTimeout(thread.ID, userMsg.ID, row.ID, prompt, images, rc.TurnTimeout); err != nil {
 		return Reply{}, err
@@ -147,7 +221,14 @@ func (b *ChannelBridge) Handle(ctx context.Context, rc ResolvedChannel, in Inbou
 	progCtx, progCancel := context.WithCancel(ctx)
 	defer progCancel()
 	if onProgress != nil {
-		go b.forwardProgress(progCtx, thread.ID, onProgress)
+		progressRunID := row.RunID
+		if preflight.Task != nil {
+			progressRunID = preflight.Task.RunID
+		}
+		go b.forwardProgress(progCtx, thread.ID, progressRunID, onProgress)
+		if preflight.Task != nil {
+			go b.watchRunState(progCtx, preflight.Task.RunID, onProgress)
+		}
 	}
 
 	if err := b.waitTurn(ctx, thread.ID, rc.TurnTimeout); err != nil {
@@ -160,15 +241,107 @@ func (b *ChannelBridge) Handle(ctx context.Context, rc ResolvedChannel, in Inbou
 	if strings.TrimSpace(text) == "" {
 		return Reply{}, fmt.Errorf("assistant produced no reply")
 	}
+	stripped, summary, urls := finalFromAssistantText(text)
+	replyRunID, shortTitle := row.RunID, ""
+	if preflight.Task != nil {
+		replyRunID, shortTitle = preflight.Task.RunID, preflight.Task.ShortTitle
+	}
+	return Reply{
+		Text: stripped, RunID: replyRunID, ShortTitle: shortTitle,
+		Final: &TurnFinalReport{OK: true, Summary: summary, ImageURLs: urls},
+	}, nil
+}
+
+// finalFromAssistantText derives the terminal report. Attachments are returned
+// only when the assistant used the explicit structured final marker: unmarked
+// terminal output stays internal, and so do the URLs embedded in it.
+func finalFromAssistantText(text string) (stripped, summary string, images []string) {
 	stripped, urls := splitImageURLs(text)
-	return Reply{Text: stripped, ImageURLs: urls}, nil
+	summary, ok := ExtractStructuredFinalSummary(stripped)
+	if !ok {
+		return stripped, "处理完成，请在项目中查看结果。", nil
+	}
+	return stripped, summary, urls
+}
+
+// watchRunState is the production structured progress producer. It reads the
+// engine-persisted Run row — never assistant output — and emits an authorized
+// event on each server-observed transition.
+func (b *ChannelBridge) watchRunState(ctx context.Context, runID string, onProgress func(ProgressEvent)) {
+	if b.runState == nil || onProgress == nil || strings.TrimSpace(runID) == "" {
+		return
+	}
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	last := runStateSnapshot{}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			run, ok := b.runState.Get(runID)
+			if !ok {
+				continue
+			}
+			ev, next, changed := runStateProgress(run, last)
+			last = next
+			if changed {
+				onProgress(NewSendableProgressEvent(ev.Kind, ev.Summary, runID))
+			}
+		}
+	}
+}
+
+// runStateSnapshot is the last server state a producer reported on.
+type runStateSnapshot struct {
+	status string
+	step   int
+	seen   bool
+}
+
+// runStateProgress maps engine Run state to a substantive progress event.
+// Progress is bucketed to 10% so routine ticks do not become messages.
+func runStateProgress(run models.Run, last runStateSnapshot) (ProgressEvent, runStateSnapshot, bool) {
+	step := int(run.Progress * 10)
+	if step < 0 {
+		step = 0
+	}
+	next := runStateSnapshot{status: run.Status, step: step, seen: true}
+	if !last.seen {
+		// Baseline only: the first observation is the state the user already
+		// asked about, not a change.
+		return ProgressEvent{}, next, false
+	}
+	if run.Status != last.status {
+		switch run.Status {
+		case "waiting_human":
+			return ProgressEvent{Kind: ProgressConfirm, Summary: "运行等待人工决策"}, next, true
+		case "failed":
+			return ProgressEvent{Kind: ProgressBlocker, Summary: "运行失败"}, next, true
+		case "cancelled":
+			return ProgressEvent{Kind: ProgressBlocker, Summary: "运行已取消"}, next, true
+		case "completed":
+			return ProgressEvent{Kind: ProgressMilestone, Summary: "运行已完成"}, next, true
+		default:
+			return ProgressEvent{
+				Kind: ProgressMilestone, Summary: "运行状态：" + run.Status,
+			}, next, true
+		}
+	}
+	if step > last.step {
+		return ProgressEvent{
+			Kind:    ProgressMilestone,
+			Summary: fmt.Sprintf("运行进度 %d%%", step*10),
+		}, next, true
+	}
+	return ProgressEvent{}, next, false
 }
 
 // forwardProgress subscribes to PmTurnRunner events and forwards only the three
 // allowed progress kinds to Reply. ACP agent_message_chunk deltas are coalesced
 // before classification (short streaming fragments alone rarely match). Tool
 // frames never become QQ text. Status().partial is polled as a backup.
-func (b *ChannelBridge) forwardProgress(ctx context.Context, threadID string, onProgress func(ProgressEvent)) {
+func (b *ChannelBridge) forwardProgress(ctx context.Context, threadID, runID string, onProgress func(ProgressEvent)) {
 	if b.turns == nil || onProgress == nil {
 		return
 	}
@@ -195,6 +368,7 @@ func (b *ChannelBridge) forwardProgress(ctx context.Context, threadID string, on
 	acc := newProgressAccumulator()
 	emit := func(events []ProgressEvent) {
 		for _, pe := range events {
+			pe.RunID = runID
 			onProgress(pe)
 		}
 	}

--- a/server/internal/channels/delivery.go
+++ b/server/internal/channels/delivery.go
@@ -1,0 +1,623 @@
+package channels
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/services"
+	"gorm.io/gorm"
+)
+
+type DeliveryClass string
+
+const (
+	DeliveryInternal DeliveryClass = "internal"
+	DeliverySendable DeliveryClass = "sendable"
+)
+
+type DeliveryPriority string
+
+const (
+	PriorityOrdinary  DeliveryPriority = "ordinary"
+	PriorityImmediate DeliveryPriority = "immediate"
+)
+
+type DeliveryReason string
+
+const (
+	ReasonTurnProcessingACK DeliveryReason = "turn_processing_ack"
+	ReasonRunAcceptanceACK  DeliveryReason = "run_acceptance_ack"
+	ReasonProgress          DeliveryReason = "progress"
+	ReasonBlocked           DeliveryReason = "blocked"
+	ReasonActionRequired    DeliveryReason = "action_required"
+	ReasonFinal             DeliveryReason = "final"
+	ReasonFailure           DeliveryReason = "failure"
+	ReasonQueue             DeliveryReason = "queue"
+	ReasonCron              DeliveryReason = "cron"
+	ReasonRunNotify         DeliveryReason = "run_notify"
+)
+
+const (
+	DeliveryTypeStage             = "stage"
+	DeliveryTypeBlocked           = "blocked"
+	DeliveryTypeActionRequired    = "action_required"
+	DeliveryTypeStructuredSummary = "structured_summary"
+)
+
+// RunTaskContext carries only routing identity. It must never contain prompt,
+// tool output, or chain-of-thought.
+type RunTaskContext struct {
+	RunID      string `json:"runId,omitempty"`
+	TaskID     string `json:"taskId,omitempty"`
+	ShortTitle string `json:"shortTitle,omitempty"`
+	ProjectID  string `json:"projectId,omitempty"`
+	UserID     string `json:"userId,omitempty"`
+}
+
+// Envelope is the first-class Work→Reply delivery decision. Its zero value is
+// internal. Only AppendSendable can attach the unexported authorization bit.
+type Envelope struct {
+	Delivery  DeliveryClass    `json:"delivery"`
+	Channels  []string         `json:"channels,omitempty"`
+	Priority  DeliveryPriority `json:"priority,omitempty"`
+	Context   RunTaskContext   `json:"context,omitempty"`
+	DedupeKey string           `json:"dedupeKey,omitempty"`
+	Reason    DeliveryReason   `json:"reason,omitempty"`
+	Type      string           `json:"type,omitempty"`
+
+	authorized bool
+}
+
+// InternalEnvelope is the safe default for unknown/raw agent, tool, and
+// reasoning events.
+func InternalEnvelope(typ string) Envelope {
+	return Envelope{Delivery: DeliveryInternal, Type: strings.TrimSpace(typ)}
+}
+
+// deliveryProgressState tracks the rate-limit window per run+conversation.
+// lastSent only advances after the adapter accepted the message; reserved
+// holds the candidate window start while a send is in flight.
+type deliveryProgressState struct {
+	lastSent time.Time
+	reserved time.Time
+	inflight bool
+	latest   string
+}
+
+type pendingProgressDelivery struct {
+	rc    *runningChannel
+	out   OutboundMessage
+	env   Envelope
+	timer *time.Timer
+}
+
+type deliveryPolicy struct {
+	mu       sync.Mutex
+	runACK   map[string]string
+	progress map[string]deliveryProgressState
+	now      func() time.Time
+}
+
+func newDeliveryPolicy() *deliveryPolicy {
+	return &deliveryPolicy{
+		runACK: map[string]string{}, progress: map[string]deliveryProgressState{}, now: time.Now,
+	}
+}
+
+func (p *deliveryPolicy) allow(env Envelope, out OutboundMessage) (bool, string) {
+	if env.Delivery != DeliverySendable || !env.authorized {
+		return false, "not_explicitly_sendable"
+	}
+	if len(env.Channels) == 0 {
+		return false, "no_channel"
+	}
+	if strings.TrimSpace(out.ConversationID) == "" {
+		return false, "no_conversation"
+	}
+	switch env.Reason {
+	case ReasonTurnProcessingACK, ReasonQueue, ReasonFailure, ReasonCron, ReasonRunNotify:
+		return true, "allowed"
+	case ReasonRunAcceptanceACK:
+		if env.Priority != PriorityImmediate {
+			return false, "run_ack_not_immediate"
+		}
+		if strings.TrimSpace(env.Context.RunID) == "" {
+			return false, "run_ack_missing_run"
+		}
+		key := runACKKey(env, out)
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		if _, exists := p.runACK[key]; exists {
+			return false, "run_ack_duplicate"
+		}
+		p.runACK[key] = models.DeliveryReceiptPending
+		return true, "allowed"
+	case ReasonProgress:
+		if env.Type != DeliveryTypeStage {
+			return false, "progress_not_substantive_stage"
+		}
+		return p.allowProgress(env, out)
+	case ReasonBlocked:
+		if strings.TrimSpace(env.Context.RunID) == "" {
+			return false, "progress_missing_run"
+		}
+		if env.Priority != PriorityImmediate || env.Type != DeliveryTypeBlocked {
+			return false, "blocked_not_immediate"
+		}
+		return true, "allowed"
+	case ReasonActionRequired:
+		if strings.TrimSpace(env.Context.RunID) == "" {
+			return false, "progress_missing_run"
+		}
+		if env.Priority != PriorityImmediate || env.Type != DeliveryTypeActionRequired {
+			return false, "action_required_not_immediate"
+		}
+		return true, "allowed"
+	case ReasonFinal:
+		if strings.TrimSpace(env.Context.RunID) == "" || env.Type != DeliveryTypeStructuredSummary || env.Priority != PriorityImmediate {
+			return false, "final_not_structured"
+		}
+		return true, "allowed"
+	default:
+		return false, "unknown_reason"
+	}
+}
+
+func runACKKey(env Envelope, out OutboundMessage) string {
+	return strings.Join([]string{
+		env.Context.RunID, env.Context.UserID, firstString(env.Channels),
+		string(out.Scene), out.ConversationID,
+	}, "|")
+}
+
+// finishSend releases the reservations taken by allow once the adapter cycle
+// for this envelope has terminated. A failed cycle must leave no state that
+// could permanently suppress a later attempt.
+func (p *deliveryPolicy) finishSend(env Envelope, out OutboundMessage, sent bool) {
+	p.finishRunACK(env, out, sent)
+	p.finishProgress(env, out, sent)
+}
+
+func (p *deliveryPolicy) finishRunACK(env Envelope, out OutboundMessage, sent bool) {
+	if env.Reason != ReasonRunAcceptanceACK {
+		return
+	}
+	key := runACKKey(env, out)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if sent {
+		p.runACK[key] = models.DeliveryReceiptSent
+	} else {
+		delete(p.runACK, key)
+	}
+}
+
+func (p *deliveryPolicy) allowProgress(env Envelope, out OutboundMessage) (bool, string) {
+	runID := strings.TrimSpace(env.Context.RunID)
+	if runID == "" {
+		return false, "progress_missing_run"
+	}
+	now := p.now()
+	key := progressDeliveryKey(env, out)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	state := p.progress[key]
+	state.latest = out.Text
+	if state.inflight {
+		p.progress[key] = state
+		return false, "progress_rate_limited_latest_merged"
+	}
+	if !state.lastSent.IsZero() && now.Sub(state.lastSent) < 60*time.Second {
+		p.progress[key] = state
+		return false, "progress_rate_limited_latest_merged"
+	}
+	state.reserved, state.inflight = now, true
+	p.progress[key] = state
+	return true, "allowed"
+}
+
+// finishProgress commits the reserved rate-limit window only on a successful
+// adapter send; a failed cycle rolls it back so the merged latest text can be
+// delivered immediately by the next attempt.
+func (p *deliveryPolicy) finishProgress(env Envelope, out OutboundMessage, sent bool) {
+	if env.Reason != ReasonProgress {
+		return
+	}
+	key := progressDeliveryKey(env, out)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	state, ok := p.progress[key]
+	if !ok || !state.inflight {
+		return
+	}
+	if sent {
+		state.lastSent = state.reserved
+	}
+	state.reserved, state.inflight = time.Time{}, false
+	p.progress[key] = state
+}
+
+// mergedLatest returns the newest progress text observed for this run while a
+// send was rate-limited or failing.
+func (p *deliveryPolicy) mergedLatest(env Envelope, out OutboundMessage) string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.progress[progressDeliveryKey(env, out)].latest
+}
+
+func progressDeliveryKey(env Envelope, out OutboundMessage) string {
+	return strings.Join([]string{env.Context.RunID, firstString(env.Channels), string(out.Scene), out.ConversationID}, "|")
+}
+
+func (p *deliveryPolicy) progressDelay(env Envelope, out OutboundMessage) time.Duration {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	state := p.progress[progressDeliveryKey(env, out)]
+	delay := state.lastSent.Add(60 * time.Second).Sub(p.now())
+	if delay < 0 {
+		return 0
+	}
+	return delay
+}
+
+var ErrDeliverySuppressed = errors.New("delivery suppressed by policy")
+
+const (
+	maxDeliveryAttempts = 3
+	// deliveryPendingLease bounds how long a claimed (pending) receipt blocks
+	// other attempts. A process that crashes mid-send leaves a pending row; the
+	// lease lets the next attempt reclaim it instead of suppressing forever.
+	deliveryPendingLease = 2 * time.Minute
+)
+
+// SetDeliveryPersistence enables persistent receipts and content-free delivery
+// audits. It is optional for compatibility with embedded/test managers.
+func (m *Manager) SetDeliveryPersistence(db *gorm.DB, audit *services.ProjectAuditService) {
+	m.deliveryDB, m.deliveryAudit = db, audit
+}
+
+// AppendInternal records an internal event without allowing transport egress.
+func (m *Manager) AppendInternal(env Envelope) {
+	env.Delivery = DeliveryInternal
+	m.auditDelivery(env, "suppressed", "internal", 0)
+}
+
+// AppendSendable is the only application authorization path to Adapter.Send.
+// Classification/markers alone cannot set the private authorization bit.
+func (m *Manager) AppendSendable(ctx context.Context, rc *runningChannel, out OutboundMessage, env Envelope) error {
+	env.Delivery = DeliverySendable
+	env.authorized = true
+	if len(env.Channels) == 0 && rc != nil {
+		env.Channels = []string{rc.cfg.Type}
+	}
+	return m.sendEnvelope(ctx, rc, out, env)
+}
+
+func (m *Manager) sendEnvelope(ctx context.Context, rc *runningChannel, out OutboundMessage, env Envelope) error {
+	if rc == nil || rc.adapter == nil {
+		return fmt.Errorf("channel adapter unavailable")
+	}
+	allowed, result := m.deliveryPolicy.allow(env, out)
+	if !allowed {
+		m.auditDelivery(env, "suppressed", result, 0)
+		if result == "progress_rate_limited_latest_merged" {
+			m.scheduleLatestProgress(rc, out, env)
+		}
+		return ErrDeliverySuppressed
+	}
+	if env.Reason == ReasonProgress {
+		m.cancelPendingProgress(env, out)
+	}
+	m.reopenExhaustedReceipt(env)
+	localAttempt := 0
+	for {
+		localAttempt++
+		attempt, claimed, result, err := m.claimDelivery(env)
+		if attempt < localAttempt {
+			attempt = localAttempt
+		}
+		if err != nil {
+			m.auditDelivery(env, "suppressed", "receipt_error", attempt)
+			m.deliveryPolicy.finishSend(env, out, false)
+			return err
+		}
+		if !claimed {
+			m.auditDelivery(env, "suppressed", result, attempt)
+			m.deliveryPolicy.finishSend(env, out, result == "already_sent")
+			return ErrDeliverySuppressed
+		}
+		err = rc.adapter.Send(ctx, out)
+		if err == nil {
+			m.finishDelivery(env, attempt, nil)
+			m.auditDelivery(env, "sent", "sent", attempt)
+			m.bindOutboundMessage(env, out)
+			m.deliveryPolicy.finishSend(env, out, true)
+			return nil
+		}
+		m.finishDelivery(env, attempt, err)
+		m.auditDelivery(env, "sent", "failed", attempt)
+		if attempt >= maxDeliveryAttempts {
+			m.deliveryPolicy.finishSend(env, out, false)
+			m.rescheduleMergedProgress(rc, out, env)
+			return err
+		}
+		// The persisted failed state is reclaimed for the next bounded attempt.
+		// No content is retained in the receipt or audit.
+	}
+}
+
+// reopenExhaustedReceipt clears the bounded attempt counter so a later call can
+// start a fresh cycle. Exhausted pending rows are only reopened once their
+// lease has expired, so a live concurrent sender is never displaced.
+func (m *Manager) reopenExhaustedReceipt(env Envelope) {
+	if m.deliveryDB == nil || strings.TrimSpace(env.DedupeKey) == "" {
+		return
+	}
+	staleBefore := time.Now().Add(-deliveryPendingLease)
+	_ = m.deliveryDB.Model(&models.DeliveryReceipt{}).
+		Where("dedupe_key = ? AND attempts >= ?", env.DedupeKey, maxDeliveryAttempts).
+		Where("status = ? OR (status = ? AND (last_tried_at IS NULL OR last_tried_at <= ?))",
+			models.DeliveryReceiptFailed, models.DeliveryReceiptPending, staleBefore).
+		Updates(map[string]any{"attempts": 0, "last_tried_at": nil}).Error
+}
+
+// rescheduleMergedProgress re-arms the merged latest progress after a failed
+// bounded cycle so the newest state is not lost with the rolled-back window.
+func (m *Manager) rescheduleMergedProgress(rc *runningChannel, out OutboundMessage, env Envelope) {
+	if env.Reason != ReasonProgress {
+		return
+	}
+	latest := m.deliveryPolicy.mergedLatest(env, out)
+	if strings.TrimSpace(latest) == "" || latest == out.Text {
+		return
+	}
+	merged := out
+	merged.Text = latest
+	m.scheduleLatestProgress(rc, merged, env)
+}
+
+func (m *Manager) bindOutboundMessage(env Envelope, out OutboundMessage) {
+	if m.taskContext == nil || strings.TrimSpace(out.MessageID) == "" ||
+		strings.TrimSpace(env.Context.RunID) == "" || strings.TrimSpace(env.Context.ProjectID) == "" {
+		return
+	}
+	_ = m.taskContext.BindExternalMessage(models.MessageBinding{
+		ProjectID: env.Context.ProjectID, Channel: firstString(env.Channels),
+		ConversationID: out.ConversationID, MessageID: out.MessageID,
+		UserID: env.Context.UserID, RunID: env.Context.RunID,
+		Action: string(env.Reason), Direction: "outbound",
+	})
+}
+
+func (m *Manager) cancelPendingProgress(env Envelope, out OutboundMessage) {
+	key := progressDeliveryKey(env, out)
+	m.progressMu.Lock()
+	if pending := m.pendingProgress[key]; pending != nil {
+		if pending.timer != nil {
+			pending.timer.Stop()
+		}
+		delete(m.pendingProgress, key)
+	}
+	m.progressMu.Unlock()
+}
+
+func (m *Manager) scheduleLatestProgress(rc *runningChannel, out OutboundMessage, env Envelope) {
+	key := progressDeliveryKey(env, out)
+	m.progressMu.Lock()
+	if current := m.pendingProgress[key]; current != nil {
+		current.rc, current.out, current.env = rc, out, env
+		m.progressMu.Unlock()
+		return
+	}
+	pending := &pendingProgressDelivery{rc: rc, out: out, env: env}
+	m.pendingProgress[key] = pending
+	delay := m.deliveryPolicy.progressDelay(env, out)
+	pending.timer = time.AfterFunc(delay, func() {
+		m.progressMu.Lock()
+		latest := m.pendingProgress[key]
+		delete(m.pendingProgress, key)
+		m.progressMu.Unlock()
+		if latest == nil {
+			return
+		}
+		ctx, cancel := context.WithTimeout(m.baseCtx, 60*time.Second)
+		defer cancel()
+		_ = m.AppendSendable(ctx, latest.rc, latest.out, latest.env)
+	})
+	m.progressMu.Unlock()
+}
+
+func (m *Manager) claimDelivery(env Envelope) (attempt int, claimed bool, result string, err error) {
+	key := strings.TrimSpace(env.DedupeKey)
+	if m.deliveryDB == nil || key == "" {
+		return 1, true, "no_receipt", nil
+	}
+	now := time.Now()
+	row := models.DeliveryReceipt{DedupeKey: key, Status: models.DeliveryReceiptPending, CreatedAt: now, UpdatedAt: now}
+	if createErr := m.deliveryDB.Create(&row).Error; createErr != nil && !isDeliveryUnique(createErr) {
+		return 0, false, "", createErr
+	}
+	if row.ID == 0 {
+		if err = m.deliveryDB.Where("dedupe_key = ?", key).First(&row).Error; err != nil {
+			return 0, false, "", err
+		}
+	}
+	if row.Status == models.DeliveryReceiptSent {
+		return row.Attempts, false, "already_sent", nil
+	}
+	if row.Attempts >= maxDeliveryAttempts {
+		return row.Attempts, false, "retry_exhausted", nil
+	}
+	// A pending row is a lease held by whoever claimed it. Only an expired
+	// lease (typically a crashed sender) may be reclaimed.
+	staleBefore := now.Add(-deliveryPendingLease)
+	if row.Status == models.DeliveryReceiptPending && row.LastTriedAt != nil && row.LastTriedAt.After(staleBefore) {
+		return row.Attempts, false, "pending_lease_active", nil
+	}
+	attempt = row.Attempts + 1
+	res := m.deliveryDB.Model(&models.DeliveryReceipt{}).
+		Where("id = ? AND status <> ? AND attempts = ?", row.ID, models.DeliveryReceiptSent, row.Attempts).
+		Where("status <> ? OR last_tried_at IS NULL OR last_tried_at <= ?",
+			models.DeliveryReceiptPending, staleBefore).
+		Updates(map[string]any{"status": models.DeliveryReceiptPending, "attempts": attempt, "last_tried_at": now, "last_error": ""})
+	if res.Error != nil {
+		return attempt, false, "", res.Error
+	}
+	if res.RowsAffected != 1 {
+		return attempt, false, "concurrent_claim", nil
+	}
+	return attempt, true, "claimed", nil
+}
+
+func (m *Manager) finishDelivery(env Envelope, attempt int, sendErr error) {
+	if m.deliveryDB == nil || strings.TrimSpace(env.DedupeKey) == "" {
+		return
+	}
+	now := time.Now()
+	updates := map[string]any{"updated_at": now}
+	if sendErr == nil {
+		updates["status"], updates["sent_at"] = models.DeliveryReceiptSent, now
+	} else {
+		updates["status"], updates["last_error"] = models.DeliveryReceiptFailed, truncateRunes(sendErr.Error(), 200)
+	}
+	_ = m.deliveryDB.Model(&models.DeliveryReceipt{}).
+		Where("dedupe_key = ? AND attempts = ?", env.DedupeKey, attempt).Updates(updates).Error
+}
+
+func isDeliveryUnique(err error) bool {
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	lower := strings.ToLower(fmt.Sprint(err))
+	return strings.Contains(lower, "unique") || strings.Contains(lower, "duplicate")
+}
+
+func (m *Manager) auditDelivery(env Envelope, action, result string, attempt int) {
+	if m.deliveryAudit == nil || strings.TrimSpace(env.Context.ProjectID) == "" {
+		return
+	}
+	outcome := models.AuditOutcomeOK
+	if result == "failed" || result == "receipt_error" {
+		outcome = models.AuditOutcomeFail
+	}
+	m.deliveryAudit.Record(services.AuditRecord{
+		ProjectID: env.Context.ProjectID, Actor: services.SystemActor(), CallerKind: models.CallerKindSystem,
+		Action: "delivery." + action, ResourceType: "delivery", ResourceID: env.DedupeKey,
+		RunID: env.Context.RunID, Outcome: outcome, Summary: string(env.Reason),
+		Payload: map[string]any{
+			"reason": string(env.Reason), "runId": env.Context.RunID,
+			"channel": firstString(env.Channels), "dedupe": env.DedupeKey,
+			"result": result, "attempt": attempt,
+		},
+	})
+}
+
+func firstString(v []string) string {
+	if len(v) == 0 {
+		return ""
+	}
+	return v[0]
+}
+
+func deliveryKey(v string) string {
+	sum := sha256.Sum256([]byte(v))
+	return fmt.Sprintf("%x", sum[:8])
+}
+
+// DetectIMLanguage uses the current message first, then recent conversation,
+// and defaults to zh-CN.
+func DetectIMLanguage(current, recent string) string {
+	for _, text := range []string{current, recent} {
+		if strings.TrimSpace(text) == "" {
+			continue
+		}
+		for _, r := range text {
+			if unicode.Is(unicode.Han, r) {
+				return "zh-CN"
+			}
+		}
+		for _, r := range text {
+			if unicode.IsLetter(r) && r <= unicode.MaxASCII {
+				return "en"
+			}
+		}
+	}
+	return "zh-CN"
+}
+
+func TaskMessagePrefix(shortTitle, typ string) string {
+	title, kind := strings.TrimSpace(shortTitle), strings.TrimSpace(typ)
+	if title == "" {
+		title = "任务"
+	}
+	if kind == "" {
+		kind = "状态"
+	}
+	return "【" + title + "｜" + kind + "】"
+}
+
+func IMTypeLabel(kind, language string) string {
+	en := language == "en"
+	switch strings.TrimSpace(kind) {
+	case string(ReasonRunAcceptanceACK), "accepted":
+		if en {
+			return "accepted"
+		}
+		return "已接收"
+	case string(ReasonProgress), DeliveryTypeStage:
+		if en {
+			return "progress"
+		}
+		return "进度"
+	case string(ReasonBlocked), "failed":
+		if en {
+			return "blocked"
+		}
+		return "阻塞"
+	case string(ReasonActionRequired), "waiting_human":
+		if en {
+			return "action required"
+		}
+		return "需确认"
+	case string(ReasonFinal), DeliveryTypeStructuredSummary:
+		if en {
+			return "final"
+		}
+		return "结论"
+	default:
+		return strings.TrimSpace(kind)
+	}
+}
+
+func FormatTaskMessage(shortTitle, typ, zh, en, language string) string {
+	body := strings.TrimSpace(zh)
+	if language == "en" {
+		body = strings.TrimSpace(en)
+	}
+	if body == "" {
+		body = strings.TrimSpace(zh)
+	}
+	return TaskMessagePrefix(shortTitle, typ) + body
+}
+
+// ExtractStructuredFinalSummary accepts only an explicit final-summary marker.
+// Unmarked terminal assistant text remains internal.
+func ExtractStructuredFinalSummary(text string) (string, bool) {
+	trimmed := strings.TrimSpace(text)
+	for _, marker := range []string{"【总结】", "[总结]", "【final】", "[final]"} {
+		if strings.HasPrefix(strings.ToLower(trimmed), strings.ToLower(marker)) {
+			summary := strings.TrimSpace(trimmed[len(marker):])
+			if summary != "" {
+				return truncateRunes(summary, 500), true
+			}
+		}
+	}
+	return "", false
+}

--- a/server/internal/channels/delivery_test.go
+++ b/server/internal/channels/delivery_test.go
@@ -1,0 +1,239 @@
+package channels
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/services"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestDeliveryFloodSuppressesInternalAndBoundsExternal(t *testing.T) {
+	fa := &fakeAdapter{}
+	m := NewManager(nil, nil, nil)
+	defer m.StopAll()
+	rc := &runningChannel{adapter: fa}
+	out := OutboundMessage{Scene: SceneC2C, ConversationID: "conv"}
+
+	for i := 0; i < 128; i++ {
+		m.AppendInternal(InternalEnvelope(fmt.Sprintf("raw_tool_%d", i)))
+	}
+	send := func(run string, reason DeliveryReason, typ, dedupe string) error {
+		priority := PriorityOrdinary
+		if reason == ReasonRunAcceptanceACK || reason == ReasonBlocked || reason == ReasonActionRequired || reason == ReasonFinal {
+			priority = PriorityImmediate
+		}
+		env := Envelope{
+			Channels: []string{"qq"}, Priority: priority, Reason: reason, Type: typ, DedupeKey: dedupe,
+			Context: RunTaskContext{RunID: run, ProjectID: "p", UserID: "u"},
+		}
+		return m.AppendSendable(context.Background(), rc, out, env)
+	}
+	if err := send("r1", ReasonRunAcceptanceACK, "run_acceptance", "ack"); err != nil {
+		t.Fatal(err)
+	}
+	if err := send("r1", ReasonProgress, DeliveryTypeStage, "p1"); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 20; i++ {
+		if err := send("r1", ReasonProgress, DeliveryTypeStage, fmt.Sprintf("p-%d", i)); !errors.Is(err, ErrDeliverySuppressed) {
+			t.Fatalf("ordinary progress %d should be merged/suppressed: %v", i, err)
+		}
+	}
+	if err := send("r1", ReasonBlocked, DeliveryTypeBlocked, "blocked"); err != nil {
+		t.Fatal(err)
+	}
+	if err := send("r1", ReasonFinal, DeliveryTypeStructuredSummary, "final"); err != nil {
+		t.Fatal(err)
+	}
+
+	fa.mu.Lock()
+	defer fa.mu.Unlock()
+	if got := len(fa.sent); got > 5 || got != 4 {
+		t.Fatalf("128 internal + lifecycle flood sent %d external messages, want 4 (<=5)", got)
+	}
+}
+
+func TestProgressRateLimitNeverCrossesRuns(t *testing.T) {
+	fa := &fakeAdapter{}
+	m := NewManager(nil, nil, nil)
+	rc := &runningChannel{adapter: fa}
+	for _, run := range []string{"run-a", "run-b"} {
+		err := m.AppendSendable(context.Background(), rc, OutboundMessage{
+			Scene: SceneGroup, ConversationID: "same", Text: run,
+		}, Envelope{
+			Channels: []string{"qq"}, Reason: ReasonProgress, Type: DeliveryTypeStage,
+			Context: RunTaskContext{RunID: run}, DedupeKey: run,
+		})
+		if err != nil {
+			t.Fatalf("%s: %v", run, err)
+		}
+	}
+	if len(fa.sent) != 2 {
+		t.Fatalf("cross-run progress merged: got %d sends", len(fa.sent))
+	}
+}
+
+func TestMarkerClassificationDoesNotAuthorizeEgress(t *testing.T) {
+	fa := &fakeAdapter{}
+	m := NewManager(nil, nil, nil)
+	rc := &runningChannel{adapter: fa}
+	env := Envelope{
+		Delivery: DeliverySendable, Channels: []string{"qq"}, Reason: ReasonProgress,
+		Type: DeliveryTypeStage, Context: RunTaskContext{RunID: "r"},
+	}
+	err := m.sendEnvelope(context.Background(), rc, OutboundMessage{
+		Scene: SceneC2C, ConversationID: "c", Text: "【进度】完成",
+	}, env)
+	if !errors.Is(err, ErrDeliverySuppressed) || len(fa.sent) != 0 {
+		t.Fatalf("marker/raw envelope authorized egress: err=%v sent=%d", err, len(fa.sent))
+	}
+}
+
+func TestStructuredFinalAndLanguageFallback(t *testing.T) {
+	if _, ok := ExtractStructuredFinalSummary("raw assistant terminal output"); ok {
+		t.Fatal("raw output must not be promoted")
+	}
+	if got, ok := ExtractStructuredFinalSummary("[final] safe result"); !ok || got != "safe result" {
+		t.Fatalf("explicit final = %q, %v", got, ok)
+	}
+	if got := DetectIMLanguage("", "hello there"); got != "en" {
+		t.Fatalf("language = %q", got)
+	}
+	msg := FormatTaskMessage("支付修复", "blocked", "需要权限", "Permission required", "en")
+	if !strings.HasPrefix(msg, "【支付修复｜blocked】Permission") {
+		t.Fatalf("fallback prefix/copy = %q", msg)
+	}
+}
+
+type retryAdapter struct{ attempts int }
+
+func (a *retryAdapter) Type() string                                { return "qq" }
+func (a *retryAdapter) Start(context.Context, InboundHandler) error { return nil }
+func (a *retryAdapter) Stop() error                                 { return nil }
+func (a *retryAdapter) Send(context.Context, OutboundMessage) error {
+	a.attempts++
+	if a.attempts == 1 {
+		return errors.New("temporary")
+	}
+	return nil
+}
+
+type delayedRecoveryAdapter struct{ attempts int }
+
+func (a *delayedRecoveryAdapter) Type() string                                { return "qq" }
+func (a *delayedRecoveryAdapter) Start(context.Context, InboundHandler) error { return nil }
+func (a *delayedRecoveryAdapter) Stop() error                                 { return nil }
+func (a *delayedRecoveryAdapter) Send(context.Context, OutboundMessage) error {
+	a.attempts++
+	if a.attempts <= maxDeliveryAttempts {
+		return errors.New("still down")
+	}
+	return nil
+}
+
+func TestDeliveryReceiptRetrySentIdempotencyAndContentFreeAudit(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.DeliveryReceipt{}, &models.ProjectAuditEvent{}, &models.MessageBinding{}); err != nil {
+		t.Fatal(err)
+	}
+	m := NewManager(nil, nil, nil)
+	m.SetDeliveryPersistence(db, services.NewProjectAuditService(db))
+	m.SetTaskContext(services.NewTaskContextService(db))
+	a := &retryAdapter{}
+	rc := &runningChannel{cfg: models.ChannelConfig{ProjectID: "p", Type: "qq"}, adapter: a}
+	env := Envelope{
+		Channels: []string{"qq"}, Priority: PriorityImmediate, Reason: ReasonBlocked, Type: DeliveryTypeBlocked,
+		Context: RunTaskContext{ProjectID: "p", RunID: "r", UserID: "u"}, DedupeKey: "same-key",
+	}
+	out := OutboundMessage{Scene: SceneC2C, ConversationID: "c", MessageID: "out-1", Text: "secret internal content"}
+	if err := m.AppendSendable(context.Background(), rc, out, env); err != nil {
+		t.Fatalf("bounded retry: %v", err)
+	}
+	if err := m.AppendSendable(context.Background(), rc, out, env); !errors.Is(err, ErrDeliverySuppressed) {
+		t.Fatalf("sent receipt should suppress duplicate: %v", err)
+	}
+	if a.attempts != 2 {
+		t.Fatalf("adapter attempts = %d", a.attempts)
+	}
+	var receipt models.DeliveryReceipt
+	if err := db.First(&receipt, "dedupe_key = ?", "same-key").Error; err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Status != "sent" || receipt.Attempts != 2 {
+		t.Fatalf("receipt = %#v", receipt)
+	}
+	var binding models.MessageBinding
+	if err := db.First(&binding, "message_id = ?", "out-1").Error; err != nil {
+		t.Fatal(err)
+	}
+	if binding.Direction != "outbound" || binding.RunID != "r" {
+		t.Fatalf("outbound binding = %#v", binding)
+	}
+	var audits []models.ProjectAuditEvent
+	if err := db.Find(&audits).Error; err != nil {
+		t.Fatal(err)
+	}
+	for _, audit := range audits {
+		if strings.Contains(audit.Summary, "secret") || strings.Contains(fmt.Sprint(audit.Payload), "secret internal") {
+			t.Fatalf("audit leaked content: %#v", audit)
+		}
+	}
+}
+
+func TestRunAcceptanceCanRetryAfterExhaustedFailure(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.DeliveryReceipt{}); err != nil {
+		t.Fatal(err)
+	}
+	m := NewManager(nil, nil, nil)
+	m.SetDeliveryPersistence(db, nil)
+	a := &delayedRecoveryAdapter{}
+	rc := &runningChannel{cfg: models.ChannelConfig{ProjectID: "p", Type: "qq"}, adapter: a}
+	env := Envelope{
+		Channels: []string{"qq"}, Priority: PriorityImmediate,
+		Reason: ReasonRunAcceptanceACK, Type: "run_acceptance", DedupeKey: "ack-retry",
+		Context: RunTaskContext{ProjectID: "p", RunID: "r", UserID: "u"},
+	}
+	out := OutboundMessage{Scene: SceneC2C, ConversationID: "c", Text: "accepted"}
+	if err := m.AppendSendable(context.Background(), rc, out, env); err == nil {
+		t.Fatal("first bounded cycle should exhaust")
+	}
+	if a.attempts != maxDeliveryAttempts {
+		t.Fatalf("first cycle attempts = %d", a.attempts)
+	}
+	if err := m.AppendSendable(context.Background(), rc, out, env); err != nil {
+		t.Fatalf("later ACK retry was permanently suppressed: %v", err)
+	}
+	if a.attempts != maxDeliveryAttempts+1 {
+		t.Fatalf("recovery attempts = %d", a.attempts)
+	}
+	if err := m.AppendSendable(context.Background(), rc, out, env); !errors.Is(err, ErrDeliverySuppressed) {
+		t.Fatalf("sent ACK was not idempotent: %v", err)
+	}
+
+	memoryOnly := NewManager(nil, nil, nil)
+	a2 := &delayedRecoveryAdapter{}
+	rc2 := &runningChannel{cfg: rc.cfg, adapter: a2}
+	env.DedupeKey = "ack-memory"
+	if err := memoryOnly.AppendSendable(context.Background(), rc2, out, env); err == nil {
+		t.Fatal("memory-only first cycle should exhaust")
+	}
+	if err := memoryOnly.AppendSendable(context.Background(), rc2, out, env); err != nil {
+		t.Fatalf("memory-only later retry suppressed: %v", err)
+	}
+	if err := memoryOnly.AppendSendable(context.Background(), rc2, out, env); !errors.Is(err, ErrDeliverySuppressed) {
+		t.Fatalf("memory-only sent ACK was not idempotent: %v", err)
+	}
+}

--- a/server/internal/channels/hardening_test.go
+++ b/server/internal/channels/hardening_test.go
@@ -1,0 +1,389 @@
+package channels
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/services"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func hardeningDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(models.AllModels()...); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func seedReceipt(t *testing.T, db *gorm.DB, key, status string, attempts int, lastTried time.Time) {
+	t.Helper()
+	tried := lastTried
+	row := models.DeliveryReceipt{
+		DedupeKey: key, Status: status, Attempts: attempts, LastTriedAt: &tried,
+		CreatedAt: lastTried, UpdatedAt: lastTried,
+	}
+	if err := db.Create(&row).Error; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func blockedEnvelope(key string) Envelope {
+	return Envelope{
+		Channels: []string{"qq"}, Priority: PriorityImmediate,
+		Reason: ReasonBlocked, Type: DeliveryTypeBlocked, DedupeKey: key,
+		Context: RunTaskContext{ProjectID: "p", RunID: "r", UserID: "u"},
+	}
+}
+
+func TestDeliveryPendingLeaseReclaimsStaleAndProtectsActive(t *testing.T) {
+	db := hardeningDB(t)
+	fa := &fakeAdapter{}
+	m := NewManager(nil, nil, nil)
+	m.SetDeliveryPersistence(db, nil)
+	rc := &runningChannel{cfg: models.ChannelConfig{ProjectID: "p", Type: "qq"}, adapter: fa}
+	out := OutboundMessage{Scene: SceneC2C, ConversationID: "c", Text: "blocked"}
+
+	// A crashed sender leaves a pending row nobody will ever finish.
+	stale := time.Now().Add(-deliveryPendingLease - time.Minute)
+	seedReceipt(t, db, "stale-key", models.DeliveryReceiptPending, 1, stale)
+	if err := m.AppendSendable(context.Background(), rc, out, blockedEnvelope("stale-key")); err != nil {
+		t.Fatalf("stale pending lease was not reclaimed after restart: %v", err)
+	}
+	var reclaimed models.DeliveryReceipt
+	if err := db.First(&reclaimed, "dedupe_key = ?", "stale-key").Error; err != nil {
+		t.Fatal(err)
+	}
+	if reclaimed.Status != models.DeliveryReceiptSent || reclaimed.Attempts != 2 {
+		t.Fatalf("reclaimed receipt = %#v", reclaimed)
+	}
+
+	// A live concurrent sender still owns its lease.
+	seedReceipt(t, db, "active-key", models.DeliveryReceiptPending, 1, time.Now())
+	err := m.AppendSendable(context.Background(), rc, out, blockedEnvelope("active-key"))
+	if !errors.Is(err, ErrDeliverySuppressed) {
+		t.Fatalf("active pending lease was stolen: %v", err)
+	}
+
+	// An exhausted pending row from a crash is reclaimable once stale.
+	seedReceipt(t, db, "exhausted-key", models.DeliveryReceiptPending, maxDeliveryAttempts, stale)
+	if err := m.AppendSendable(context.Background(), rc, out, blockedEnvelope("exhausted-key")); err != nil {
+		t.Fatalf("exhausted stale pending stayed permanently suppressed: %v", err)
+	}
+
+	fa.mu.Lock()
+	defer fa.mu.Unlock()
+	if len(fa.sent) != 2 {
+		t.Fatalf("sends = %d, want 2 (stale reclaim + exhausted reclaim)", len(fa.sent))
+	}
+}
+
+// switchableAdapter fails until healthy is set, so a rolled-back rate-limit
+// window can be observed directly.
+type switchableAdapter struct {
+	mu      sync.Mutex
+	healthy bool
+	sent    []OutboundMessage
+}
+
+func (a *switchableAdapter) Type() string                                { return "qq" }
+func (a *switchableAdapter) Start(context.Context, InboundHandler) error { return nil }
+func (a *switchableAdapter) Stop() error                                 { return nil }
+func (a *switchableAdapter) Send(_ context.Context, out OutboundMessage) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if !a.healthy {
+		return errors.New("transport down")
+	}
+	a.sent = append(a.sent, out)
+	return nil
+}
+
+func TestProgressWindowCommitsOnlyAfterAdapterSuccess(t *testing.T) {
+	a := &switchableAdapter{}
+	m := NewManager(nil, nil, nil)
+	defer m.StopAll()
+	rc := &runningChannel{cfg: models.ChannelConfig{ProjectID: "p", Type: "qq"}, adapter: a}
+	env := Envelope{
+		Channels: []string{"qq"}, Reason: ReasonProgress, Type: DeliveryTypeStage,
+		Context: RunTaskContext{ProjectID: "p", RunID: "run-1"},
+	}
+	progress := func(text string) error {
+		out := OutboundMessage{Scene: SceneC2C, ConversationID: "c", Text: text}
+		e := env
+		e.DedupeKey = "progress:" + text
+		return m.AppendSendable(context.Background(), rc, out, e)
+	}
+	key := progressDeliveryKey(env, OutboundMessage{Scene: SceneC2C, ConversationID: "c"})
+	state := func() deliveryProgressState {
+		m.deliveryPolicy.mu.Lock()
+		defer m.deliveryPolicy.mu.Unlock()
+		return m.deliveryPolicy.progress[key]
+	}
+
+	if err := progress("step 1"); err == nil {
+		t.Fatal("failing adapter should report the failed progress cycle")
+	}
+	if got := state(); !got.lastSent.IsZero() || got.inflight {
+		t.Fatalf("failed send advanced the rate-limit window: %#v", got)
+	}
+	if got := state().latest; got != "step 1" {
+		t.Fatalf("merged latest = %q", got)
+	}
+
+	a.mu.Lock()
+	a.healthy = true
+	a.mu.Unlock()
+
+	// Because the window rolled back, the next progress goes out immediately.
+	if err := progress("step 2"); err != nil {
+		t.Fatalf("rolled-back window did not allow the next progress: %v", err)
+	}
+	committed := state()
+	if committed.lastSent.IsZero() || committed.inflight {
+		t.Fatalf("successful send did not commit the window: %#v", committed)
+	}
+
+	if err := progress("step 3"); !errors.Is(err, ErrDeliverySuppressed) {
+		t.Fatalf("committed window did not rate-limit: %v", err)
+	}
+	merged := state()
+	if merged.latest != "step 3" || !merged.lastSent.Equal(committed.lastSent) {
+		t.Fatalf("merge lost the latest text or moved the window: %#v", merged)
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.sent) != 1 || a.sent[0].Text != "step 2" {
+		t.Fatalf("adapter sends = %#v", a.sent)
+	}
+}
+
+func TestTurnProgressHandlerOnlyAuthorizesStructuredProducer(t *testing.T) {
+	fa := &fakeAdapter{}
+	// No handleFunc/handleFuncWithProgress: this is the production path.
+	m := NewManager(nil, nil, nil)
+	defer m.StopAll()
+	rc := &runningChannel{cfg: models.ChannelConfig{ProjectID: "p", Type: "qq"}, adapter: fa}
+	in := InboundMessage{Scene: SceneC2C, ConversationID: "c", MessageID: "m1", UserID: "u"}
+	onProgress := m.turnProgressHandler(context.Background(), rc, in)
+
+	classified, ok := ClassifyProgressText("【进度】已打开 PR #12")
+	if !ok {
+		t.Fatal("fixture text should classify")
+	}
+	classified.RunID = "run-1"
+	onProgress(classified)
+	fa.mu.Lock()
+	if len(fa.sent) != 0 {
+		fa.mu.Unlock()
+		t.Fatalf("marker text reached the transport: %#v", fa.sent)
+	}
+	fa.mu.Unlock()
+
+	onProgress(NewSendableProgressEvent(ProgressMilestone, "运行进度 40%", "run-1"))
+	fa.mu.Lock()
+	defer fa.mu.Unlock()
+	if len(fa.sent) != 1 || !strings.Contains(fa.sent[0].Text, "运行进度 40%") {
+		t.Fatalf("structured producer did not reach the transport: %#v", fa.sent)
+	}
+}
+
+type stubRunState struct {
+	mu  sync.Mutex
+	run models.Run
+}
+
+func (s *stubRunState) Get(string) (models.Run, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.run, true
+}
+
+func (s *stubRunState) set(status string, progress float64) {
+	s.mu.Lock()
+	s.run.Status, s.run.Progress = status, progress
+	s.mu.Unlock()
+}
+
+func TestRunStateProgressUsesServerStateOnly(t *testing.T) {
+	first, snap, changed := runStateProgress(models.Run{Status: "running", Progress: 0.2}, runStateSnapshot{})
+	if changed {
+		t.Fatalf("baseline observation emitted %#v", first)
+	}
+	ev, snap, changed := runStateProgress(models.Run{Status: "running", Progress: 0.45}, snap)
+	if !changed || ev.Kind != ProgressMilestone || ev.Summary != "运行进度 40%" {
+		t.Fatalf("progress bucket = %#v changed=%v", ev, changed)
+	}
+	if _, snap, changed = runStateProgress(models.Run{Status: "running", Progress: 0.47}, snap); changed {
+		t.Fatal("sub-bucket tick became a message")
+	}
+	ev, snap, changed = runStateProgress(models.Run{Status: "waiting_human", Progress: 0.47}, snap)
+	if !changed || ev.Kind != ProgressConfirm {
+		t.Fatalf("waiting_human = %#v changed=%v", ev, changed)
+	}
+	ev, _, changed = runStateProgress(models.Run{Status: "failed", Progress: 0.47}, snap)
+	if !changed || ev.Kind != ProgressBlocker {
+		t.Fatalf("failed = %#v changed=%v", ev, changed)
+	}
+}
+
+func TestWatchRunStateEmitsAuthorizedEvents(t *testing.T) {
+	src := &stubRunState{run: models.Run{ID: "run-1", Status: "running", Progress: 0.1}}
+	bridge := NewChannelBridge(nil, nil, nil, MCPTokenHooks{})
+	bridge.SetRunState(src)
+
+	events := make(chan ProgressEvent, 4)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go bridge.watchRunState(ctx, "run-1", func(ev ProgressEvent) { events <- ev })
+
+	time.Sleep(1200 * time.Millisecond) // let the watcher take its baseline
+	src.set("waiting_human", 0.1)
+	select {
+	case ev := <-events:
+		if ev.Kind != ProgressConfirm || !ev.authorized || ev.RunID != "run-1" {
+			t.Fatalf("watcher event = %#v", ev)
+		}
+	case <-ctx.Done():
+		t.Fatal("watcher produced no structured progress")
+	}
+}
+
+func TestFinalAttachmentsRequireStructuredProducer(t *testing.T) {
+	stripped, summary, images := finalFromAssistantText("看这里 ![](https://x.com/a.png)")
+	if len(images) != 0 {
+		t.Fatalf("raw assistant text authorized attachments: %v", images)
+	}
+	if stripped != "看这里" || summary != "处理完成，请在项目中查看结果。" {
+		t.Fatalf("unmarked final = %q / %q", stripped, summary)
+	}
+	_, summary, images = finalFromAssistantText("[final] done ![](https://x.com/a.png)")
+	if summary != "done" || len(images) != 1 || images[0] != "https://x.com/a.png" {
+		t.Fatalf("structured final = %q / %v", summary, images)
+	}
+}
+
+func TestManagerFinalSendsOnlyAuthorizedAttachments(t *testing.T) {
+	fa := &fakeAdapter{}
+	m := newTestManager(fa)
+	m.handleFunc = func(context.Context, ResolvedChannel, InboundMessage) (Reply, error) {
+		return Reply{Text: "raw ![](https://x.com/leak.png)", RunID: "run-1"}, nil
+	}
+	m.Apply([]models.ChannelConfig{{
+		ID: "c1", Type: "qq", ProjectID: "proj", AppID: "app", Enabled: true,
+	}})
+	defer m.StopAll()
+	m.mu.Lock()
+	rc := m.running["c1"]
+	m.mu.Unlock()
+
+	in := InboundMessage{Scene: SceneC2C, ConversationID: "c", MessageID: "m1", Text: "hi"}
+	m.runTurn(context.Background(), rc, in, false)
+
+	m.handleFunc = func(context.Context, ResolvedChannel, InboundMessage) (Reply, error) {
+		return Reply{
+			RunID: "run-2",
+			Final: &TurnFinalReport{OK: true, Summary: "报告", ImageURLs: []string{"https://x.com/ok.png"}},
+		}, nil
+	}
+	in2 := in
+	in2.MessageID = "m2"
+	m.runTurn(context.Background(), rc, in2, false)
+
+	fa.mu.Lock()
+	defer fa.mu.Unlock()
+	if len(fa.sent) != 2 {
+		t.Fatalf("sends = %d", len(fa.sent))
+	}
+	if len(fa.sent[0].ImageURLs) != 0 {
+		t.Fatalf("raw assistant image leaked to final: %v", fa.sent[0].ImageURLs)
+	}
+	if len(fa.sent[1].ImageURLs) != 1 || fa.sent[1].ImageURLs[0] != "https://x.com/ok.png" {
+		t.Fatalf("structured final attachment dropped: %v", fa.sent[1].ImageURLs)
+	}
+}
+
+func TestRunAcceptanceFiresOnAssociationAndSurvivesReconnect(t *testing.T) {
+	db := hardeningDB(t)
+	if err := db.Create(&models.WorkflowDef{ID: "wf-1", ProjectID: "p1", Name: "发布工作流"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&models.Run{
+		ID: "run-a", WorkflowID: "wf-1", Title: "支付任务一", Status: "running",
+		Inputs: map[string]any{"requirement": "支付服务"}, StartedAt: time.Now().UTC(),
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	in := InboundMessage{
+		Scene: SceneC2C, ConversationID: "openid-1", UserID: "openid-1",
+		Text: "支付任务一 状态", MessageID: "m1",
+	}
+	cfg := models.ChannelConfig{ID: "c1", Type: "qq", ProjectID: "p1", AppID: "app", Enabled: true}
+
+	newStack := func(fa *fakeAdapter) (*Manager, *ChannelBridge, ResolvedChannel) {
+		bridge := NewChannelBridge(nil, nil, nil, MCPTokenHooks{})
+		bridge.SetTaskContext(services.NewTaskContextService(db))
+		m := NewManager(bridge, map[string]AdapterFactory{
+			"qq": func(AdapterConfig) (Adapter, error) { return fa, nil },
+		}, func(s string) (string, error) { return s, nil })
+		m.SetDeliveryPersistence(db, nil)
+		m.Apply([]models.ChannelConfig{cfg})
+		return m, bridge, ResolvedChannel{Type: "qq", ProjectID: "p1"}
+	}
+
+	fa := &fakeAdapter{}
+	m, bridge, rc := newStack(fa)
+	defer m.StopAll()
+	if _, err := bridge.PreflightInbound(InboundPreflightRequest{Channel: rc, Message: in}); err != nil {
+		t.Fatal(err)
+	}
+	fa.mu.Lock()
+	acks := len(fa.sent)
+	var first string
+	if acks > 0 {
+		first = fa.sent[0].Text
+	}
+	fa.mu.Unlock()
+	if acks != 1 || !strings.Contains(first, "已接收") || !strings.HasPrefix(first, "【支付任务一") {
+		t.Fatalf("first association ack = %d %q", acks, first)
+	}
+
+	// Same association again inside the same process.
+	repeat := in
+	repeat.MessageID = "m2"
+	if _, err := bridge.PreflightInbound(InboundPreflightRequest{Channel: rc, Message: repeat}); err != nil {
+		t.Fatal(err)
+	}
+	fa.mu.Lock()
+	again := len(fa.sent)
+	fa.mu.Unlock()
+	if again != 1 {
+		t.Fatalf("acceptance ack repeated in-process: %d", again)
+	}
+
+	// Reconnect: fresh manager/bridge, same persistent receipts.
+	fa2 := &fakeAdapter{}
+	m2, bridge2, rc2 := newStack(fa2)
+	defer m2.StopAll()
+	reconnect := in
+	reconnect.MessageID = "m3"
+	if _, err := bridge2.PreflightInbound(InboundPreflightRequest{Channel: rc2, Message: reconnect}); err != nil {
+		t.Fatal(err)
+	}
+	fa2.mu.Lock()
+	defer fa2.mu.Unlock()
+	if len(fa2.sent) != 0 {
+		t.Fatalf("reconnect re-sent the acceptance ack: %#v", fa2.sent)
+	}
+}

--- a/server/internal/channels/manager.go
+++ b/server/internal/channels/manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cocofhu/approving/internal/services"
 
 	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
 )
 
 // ErrNoDeliveryChannel is returned by Deliver when no enabled channel for the
@@ -79,13 +80,25 @@ type Manager struct {
 	pushMu     sync.Mutex
 	pushQueues map[string]*pushQueue
 
+	progressMu      sync.Mutex
+	pendingProgress map[string]*pendingProgressDelivery
+
 	baseCtx context.Context
+
+	deliveryPolicy *deliveryPolicy
+	deliveryDB     *gorm.DB
+	deliveryAudit  *services.ProjectAuditService
+	taskContext    *services.TaskContextService
 
 	// Test hooks (production leaves these nil/zero):
 	// handleFunc overrides bridge.Handle when set (no progress callback).
 	handleFunc func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error)
 	// handleFuncWithProgress overrides bridge.Handle when set.
 	handleFuncWithProgress func(ctx context.Context, rc ResolvedChannel, in InboundMessage, onProgress func(ProgressEvent)) (Reply, error)
+}
+
+func (m *Manager) SetTaskContext(tasks *services.TaskContextService) {
+	m.taskContext = tasks
 }
 
 type runningChannel struct {
@@ -98,15 +111,21 @@ type runningChannel struct {
 // NewManager builds a manager. factories maps channel type → adapter factory;
 // decrypt reverses the stored app secret.
 func NewManager(bridge *ChannelBridge, factories map[string]AdapterFactory, decrypt func(string) (string, error)) *Manager {
-	return &Manager{
-		bridge:     bridge,
-		factories:  factories,
-		decrypt:    decrypt,
-		running:    map[string]*runningChannel{},
-		convQueues: map[string]*convQueue{},
-		pushQueues: map[string]*pushQueue{},
-		baseCtx:    context.Background(),
+	m := &Manager{
+		bridge:          bridge,
+		factories:       factories,
+		decrypt:         decrypt,
+		running:         map[string]*runningChannel{},
+		convQueues:      map[string]*convQueue{},
+		pushQueues:      map[string]*pushQueue{},
+		pendingProgress: map[string]*pendingProgressDelivery{},
+		baseCtx:         context.Background(),
+		deliveryPolicy:  newDeliveryPolicy(),
 	}
+	if bridge != nil {
+		bridge.SetRunAcceptanceHook(m.onRunAccepted)
+	}
+	return m
 }
 
 // SetLoader registers the DB-backed config source used by Reload/ApplyOnBoot.
@@ -183,6 +202,14 @@ func (m *Manager) StopAll() {
 	}
 	m.running = map[string]*runningChannel{}
 	m.mu.Unlock()
+	m.progressMu.Lock()
+	for key, pending := range m.pendingProgress {
+		if pending.timer != nil {
+			pending.timer.Stop()
+		}
+		delete(m.pendingProgress, key)
+	}
+	m.progressMu.Unlock()
 	for _, rc := range all {
 		m.stopChannel(rc)
 	}
@@ -265,6 +292,15 @@ func (m *Manager) IsConversationBusy(projectID string, scene Scene, conversation
 // per-message queue ACK (ahead count); dequeue sends another processing ACK.
 // Full queue: reject with a visible reply (never silently drop).
 func (m *Manager) dispatch(ctx context.Context, rc *runningChannel, in InboundMessage) {
+	if text, ok := in.Raw["system_rejection"].(string); ok && strings.TrimSpace(text) != "" {
+		env := m.turnEnvelope(rc, in, ReasonFailure, "safe_status", "system-rejection")
+		env.Priority = PriorityImmediate
+		_ = m.AppendSendable(ctx, rc, OutboundMessage{
+			Scene: in.Scene, ConversationID: in.ConversationID,
+			ReplyToMessageID: in.MessageID, Text: text,
+		}, env)
+		return
+	}
 	key := convKey(rc.cfg.ProjectID, in.Scene, in.ConversationID)
 	q := m.convQueueFor(key)
 
@@ -272,20 +308,20 @@ func (m *Manager) dispatch(ctx context.Context, rc *runningChannel, in InboundMe
 	if q.busy {
 		if len(q.pending) >= convQueueDepth {
 			q.mu.Unlock()
-			m.sendOutbound(ctx, rc, OutboundMessage{
+			_ = m.AppendSendable(ctx, rc, OutboundMessage{
 				Scene: in.Scene, ConversationID: in.ConversationID,
 				ReplyToMessageID: in.MessageID, Text: queueFullText,
-			})
+			}, m.turnEnvelope(rc, in, ReasonQueue, "queue_full", "queue-full"))
 			return
 		}
 		// Ahead = in-flight turn + already-queued messages.
 		ahead := 1 + len(q.pending)
 		q.pending = append(q.pending, queuedInbound{ctx: ctx, rc: rc, in: in})
 		q.mu.Unlock()
-		m.sendOutbound(ctx, rc, OutboundMessage{
+		_ = m.AppendSendable(ctx, rc, OutboundMessage{
 			Scene: in.Scene, ConversationID: in.ConversationID,
 			ReplyToMessageID: in.MessageID, Text: queueAckTextFor(ahead, in.Text),
-		})
+		}, m.turnEnvelope(rc, in, ReasonQueue, "queue_ack", fmt.Sprintf("queue-%d", ahead)))
 		return
 	}
 	q.busy = true
@@ -319,10 +355,10 @@ func (m *Manager) drainConvQueue(q *convQueue, key string) {
 // withProcessingAck emits the required ≤1s ACK before dispatching Work.
 func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMessage, withProcessingAck bool) {
 	if withProcessingAck {
-		m.sendOutbound(ctx, rc, OutboundMessage{
+		_ = m.AppendSendable(ctx, rc, OutboundMessage{
 			Scene: in.Scene, ConversationID: in.ConversationID,
 			ReplyToMessageID: in.MessageID, Text: processingAckText(in.Text),
-		})
+		}, m.turnEnvelope(rc, in, ReasonTurnProcessingACK, "turn_ack", "processing"))
 	}
 
 	resolved := ResolvedChannel{
@@ -330,29 +366,85 @@ func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMes
 		TurnTimeout: time.Duration(rc.cfg.TurnTimeoutSeconds) * time.Second,
 		Caps:        SessionCapsFromConfig(rc.cfg.Config),
 	}
-	onProgress := func(ev ProgressEvent) {
+	if capable, ok := rc.adapter.(CapabilityAdapter); ok {
+		resolved.ReplyMetadata = capable.Capabilities().ReplyMetadata
+	}
+	reply, err := m.handleTurn(ctx, resolved, in, m.turnProgressHandler(ctx, rc, in))
+	if err != nil {
+		log.Warn().Err(err).Str("channel", rc.cfg.ID).Msg("channel turn failed")
+		env := m.turnEnvelope(rc, in, ReasonFailure, "safe_status", "failure")
+		env.Priority = PriorityImmediate
+		_ = m.AppendSendable(ctx, rc, OutboundMessage{
+			Scene: in.Scene, ConversationID: in.ConversationID,
+			ReplyToMessageID: in.MessageID, Text: failReplyPrefix + friendlyErr(err),
+		}, env)
+		return
+	}
+	runID := strings.TrimSpace(reply.RunID)
+	if runID == "" {
+		runID = turnContextRunID(in)
+	}
+	summary := "处理完成，请在项目中查看结果。"
+	// Attachments ride on the structured final report only; raw assistant text
+	// never authorizes an outbound image.
+	var images []string
+	if reply.Final != nil {
+		images = reply.Final.ImageURLs
+	}
+	if reply.Final != nil && strings.TrimSpace(reply.Final.Summary) != "" {
+		summary = strings.TrimSpace(reply.Final.Summary)
+	} else if (m.handleFunc != nil || m.handleFuncWithProgress != nil) && strings.TrimSpace(reply.Text) != "" {
+		// Test hooks are trusted application producers, never live agent output.
+		summary = strings.TrimSpace(reply.Text)
+	}
+	if reply.ShortTitle != "" && !resolved.ReplyMetadata && !strings.HasPrefix(summary, "【") {
+		summary = TaskMessagePrefix(reply.ShortTitle, IMTypeLabel(string(ReasonFinal), DetectIMLanguage(summary, ""))) + summary
+	}
+	env := m.turnEnvelope(rc, in, ReasonFinal, DeliveryTypeStructuredSummary, "final")
+	env.Context.RunID, env.Context.ShortTitle, env.Priority = runID, reply.ShortTitle, PriorityImmediate
+	_ = m.AppendSendable(ctx, rc, OutboundMessage{
+		Scene: in.Scene, ConversationID: in.ConversationID, ReplyToMessageID: in.MessageID,
+		Text: summary, ImageURLs: images,
+	}, env)
+}
+
+// turnProgressHandler is the production Work→Reply progress sink. Only events
+// produced by NewSendableProgressEvent (structured server state) are eligible
+// for egress; classified assistant text stays internal.
+func (m *Manager) turnProgressHandler(ctx context.Context, rc *runningChannel, in InboundMessage) func(ProgressEvent) {
+	return func(ev ProgressEvent) {
 		text := FormatProgressText(ev)
 		if text == "" {
 			return
 		}
-		m.sendOutbound(ctx, rc, OutboundMessage{
+		if !ev.authorized && m.handleFuncWithProgress == nil {
+			m.AppendInternal(Envelope{
+				Delivery: DeliveryInternal, Reason: ReasonProgress, Type: "classified_agent_text",
+				Context: RunTaskContext{RunID: ev.RunID, ProjectID: rc.cfg.ProjectID, UserID: in.UserID},
+			})
+			return
+		}
+		runID := strings.TrimSpace(ev.RunID)
+		if runID == "" {
+			runID = turnContextRunID(in)
+		}
+		reason := ReasonProgress
+		priority := PriorityOrdinary
+		eventType := DeliveryTypeStage
+		if ev.Kind == ProgressBlocker {
+			reason, priority = ReasonBlocked, PriorityImmediate
+			eventType = DeliveryTypeBlocked
+		} else if ev.Kind == ProgressConfirm {
+			reason, priority = ReasonActionRequired, PriorityImmediate
+			eventType = DeliveryTypeActionRequired
+		}
+		env := m.turnEnvelope(rc, in, reason, eventType, "progress-"+string(ev.Kind)+"-"+deliveryKey(text))
+		env.Context.RunID, env.Priority = runID, priority
+		_ = m.AppendSendable(ctx, rc, OutboundMessage{
 			Scene: in.Scene, ConversationID: in.ConversationID,
 			ReplyToMessageID: in.MessageID, Text: text,
-		})
+		}, env)
 	}
-	reply, err := m.handleTurn(ctx, resolved, in, onProgress)
-	if err != nil {
-		log.Warn().Err(err).Str("channel", rc.cfg.ID).Msg("channel turn failed")
-		m.sendOutbound(ctx, rc, OutboundMessage{
-			Scene: in.Scene, ConversationID: in.ConversationID,
-			ReplyToMessageID: in.MessageID, Text: failReplyPrefix + friendlyErr(err),
-		})
-		return
-	}
-	m.sendOutbound(ctx, rc, OutboundMessage{
-		Scene: in.Scene, ConversationID: in.ConversationID, ReplyToMessageID: in.MessageID,
-		Text: reply.Text, ImageURLs: reply.ImageURLs,
-	})
 }
 
 func (m *Manager) handleTurn(ctx context.Context, rc ResolvedChannel, in InboundMessage, onProgress func(ProgressEvent)) (Reply, error) {
@@ -365,14 +457,23 @@ func (m *Manager) handleTurn(ctx context.Context, rc ResolvedChannel, in Inbound
 	return m.bridge.Handle(ctx, rc, in, onProgress)
 }
 
-func (m *Manager) sendOutbound(ctx context.Context, rc *runningChannel, out OutboundMessage) {
-	if rc == nil || rc.adapter == nil {
-		return
+func (m *Manager) turnEnvelope(rc *runningChannel, in InboundMessage, reason DeliveryReason, typ, suffix string) Envelope {
+	projectID, channel := "", ""
+	if rc != nil {
+		projectID, channel = rc.cfg.ProjectID, rc.cfg.Type
 	}
-	if err := rc.adapter.Send(ctx, out); err != nil {
-		log.Warn().Err(err).Str("channel", rc.cfg.ID).Str("text", truncateRunes(out.Text, 40)).
-			Msg("channel outbound send failed")
+	return Envelope{
+		Channels: []string{channel}, Priority: PriorityOrdinary, Reason: reason, Type: typ,
+		Context:   RunTaskContext{RunID: turnContextRunID(in), ProjectID: projectID, UserID: in.UserID},
+		DedupeKey: strings.Join([]string{"turn", projectID, channel, string(in.Scene), in.ConversationID, in.MessageID, suffix}, ":"),
 	}
+}
+
+func turnContextRunID(in InboundMessage) string {
+	if strings.TrimSpace(in.MessageID) != "" {
+		return "turn:" + in.MessageID
+	}
+	return "turn:" + deliveryKey(string(in.Scene)+"|"+in.ConversationID+"|"+in.Text)
 }
 
 // Deliver pushes cron/proactive text to a project's configured delivery channel.
@@ -412,6 +513,11 @@ func (m *Manager) DeliverCron(d services.CronDelivery) error {
 		// Keep raw formatted text (incl. image URLs); flushPushQueue splits on send.
 		Text:     text,
 		Enqueued: time.Now(),
+		Envelope: Envelope{
+			Channels: []string{target.cfg.Type}, Reason: ReasonCron, Type: "structured_cron",
+			Context:   RunTaskContext{ProjectID: d.ProjectID},
+			DedupeKey: "cron:" + d.ProjectID + ":" + deliveryKey(d.Category+"|"+string(kind)+"|"+text),
+		},
 	}
 
 	// Always enqueue then flush: idle path still goes through flushPushQueue so
@@ -429,6 +535,19 @@ func (m *Manager) DeliverCron(d services.CronDelivery) error {
 // Text is sent as-is (no FormatCronPush). Implements services.RunNotifyDeliverer.
 // Missing target returns services.ErrRunNotifyNoTarget (caller treats as no-op).
 func (m *Manager) DeliverRunNotify(projectID, text string) error {
+	return m.deliverRunNotifyContext(projectID, "", "", "", text)
+}
+
+// DeliverRunNotifyContext carries Run identity into the first-class envelope
+// and applies the QQ natural-language metadata fallback.
+func (m *Manager) DeliverRunNotifyContext(projectID, runID, shortTitle, kind, text string) error {
+	if strings.TrimSpace(shortTitle) != "" {
+		text = TaskMessagePrefix(shortTitle, IMTypeLabel(kind, DetectIMLanguage(text, ""))) + text
+	}
+	return m.deliverRunNotifyContext(projectID, runID, shortTitle, kind, text)
+}
+
+func (m *Manager) deliverRunNotifyContext(projectID, runID, shortTitle, kind, text string) error {
 	_, scene, conv, err := m.lookupRunNotifyTarget(projectID)
 	if err != nil {
 		if errors.Is(err, ErrNoRunNotifyTarget) || errors.Is(err, ErrNoDeliveryChannel) {
@@ -445,6 +564,14 @@ func (m *Manager) DeliverRunNotify(projectID, text string) error {
 		Kind:      CronResultChanged, // priority: treat actionable Run alerts like "changed"
 		Text:      text,
 		Enqueued:  time.Now(),
+		Envelope: Envelope{
+			Channels: []string{"qq"}, Priority: PriorityImmediate, Reason: ReasonRunNotify,
+			Type: "structured_run_notify",
+			Context: RunTaskContext{
+				ProjectID: projectID, RunID: runID, ShortTitle: shortTitle,
+			},
+			DedupeKey: "run-notify:" + projectID + ":" + deliveryKey(text),
+		},
 	}
 	m.enqueuePush(key, item)
 	m.flushPushQueue(key)
@@ -456,6 +583,96 @@ func (m *Manager) DeliverRunNotify(projectID, text string) error {
 func (m *Manager) HasRunNotifyTarget(projectID string) bool {
 	_, _, _, err := m.lookupRunNotifyTarget(projectID)
 	return err == nil
+}
+
+// DeliverRunAcceptance emits the once-per-run acceptance ACK. It is distinct
+// from the per-turn processing ACK used by dispatch.
+func (m *Manager) DeliverRunAcceptance(projectID, runID, userID, shortTitle, text string) error {
+	target, scene, conv, err := m.lookupRunNotifyTarget(projectID)
+	if err != nil {
+		return err
+	}
+	return m.deliverRunAcceptance(target, scene, conv, runID, userID, shortTitle, text)
+}
+
+// onRunAccepted is the production lifecycle hook: the inbound orchestration
+// calls it the first time a conversation is associated with a Run. Identity is
+// stable (run + channel + scene/conversation + external user) so both the
+// in-memory policy and the persistent receipt dedupe reconnects.
+func (m *Manager) onRunAccepted(a RunAcceptance) {
+	m.mu.Lock()
+	var target *runningChannel
+	for _, rc := range m.running {
+		if rc.cfg.ProjectID == a.ProjectID && rc.cfg.Type == a.Channel {
+			if target == nil || rc.cfg.UpdatedAt.After(target.cfg.UpdatedAt) {
+				target = rc
+			}
+		}
+	}
+	m.mu.Unlock()
+	if target == nil {
+		return
+	}
+	text := "任务已接收，稍后同步进展。"
+	if a.Language == "en" {
+		text = "Task accepted; updates will follow."
+	}
+	err := m.deliverRunAcceptance(target, a.Scene, a.ConversationID, a.RunID, a.UserID, a.ShortTitle, text)
+	if err != nil && !errors.Is(err, ErrDeliverySuppressed) {
+		log.Warn().Err(err).Str("run", a.RunID).Msg("run acceptance ack failed")
+	}
+}
+
+func (m *Manager) deliverRunAcceptance(target *runningChannel, scene Scene, conv, runID, userID, shortTitle, text string) error {
+	if strings.TrimSpace(text) == "" {
+		text = "任务已接收。"
+	}
+	text = TaskMessagePrefix(shortTitle, IMTypeLabel(string(ReasonRunAcceptanceACK), DetectIMLanguage(text, ""))) + text
+	env := Envelope{
+		Channels: []string{target.cfg.Type}, Priority: PriorityImmediate,
+		Reason: ReasonRunAcceptanceACK, Type: "run_acceptance",
+		Context: RunTaskContext{
+			RunID: runID, ShortTitle: shortTitle, ProjectID: target.cfg.ProjectID, UserID: userID,
+		},
+		DedupeKey: strings.Join([]string{
+			"run-ack", target.cfg.ProjectID, runID, userID, target.cfg.Type, string(scene), conv,
+		}, ":"),
+	}
+	ctx, cancel := context.WithTimeout(m.baseCtx, 60*time.Second)
+	defer cancel()
+	return m.AppendSendable(ctx, target, OutboundMessage{Scene: scene, ConversationID: conv, Text: text}, env)
+}
+
+// AppendRunUpdate is the explicit application path for structured Run
+// progress, blocked/action-required, and final updates.
+func (m *Manager) AppendRunUpdate(projectID, channelID, sceneText, conversationID, userID, runID, shortTitle string, reason DeliveryReason, summary string) error {
+	m.mu.Lock()
+	target := m.running[channelID]
+	m.mu.Unlock()
+	if target == nil || target.cfg.ProjectID != projectID {
+		return ErrNoRunNotifyTarget
+	}
+	scene := Scene(sceneText)
+	typ := DeliveryTypeStage
+	priority := PriorityOrdinary
+	if reason == ReasonFinal {
+		typ, priority = DeliveryTypeStructuredSummary, PriorityImmediate
+	} else if reason == ReasonBlocked {
+		typ, priority = DeliveryTypeBlocked, PriorityImmediate
+	} else if reason == ReasonActionRequired {
+		typ, priority = DeliveryTypeActionRequired, PriorityImmediate
+	} else if reason != ReasonProgress {
+		return ErrDeliverySuppressed
+	}
+	env := Envelope{
+		Channels: []string{target.cfg.Type}, Priority: priority, Reason: reason, Type: typ,
+		Context:   RunTaskContext{RunID: runID, ShortTitle: shortTitle, ProjectID: projectID, UserID: userID},
+		DedupeKey: strings.Join([]string{"run-update", projectID, runID, string(reason), deliveryKey(summary)}, ":"),
+	}
+	summary = TaskMessagePrefix(shortTitle, IMTypeLabel(string(reason), DetectIMLanguage(summary, ""))) + strings.TrimSpace(summary)
+	ctx, cancel := context.WithTimeout(m.baseCtx, 60*time.Second)
+	defer cancel()
+	return m.AppendSendable(ctx, target, OutboundMessage{Scene: scene, ConversationID: conversationID, Text: summary}, env)
 }
 
 func (m *Manager) flushPushQueue(key string) {
@@ -484,9 +701,9 @@ func (m *Manager) flushPushQueue(key string) {
 		}
 		stripped, urls := splitImageURLs(item.Text)
 		ctx, cancel := context.WithTimeout(m.baseCtx, 60*time.Second)
-		if err := target.adapter.Send(ctx, OutboundMessage{
+		if err := m.AppendSendable(ctx, target, OutboundMessage{
 			Scene: item.Scene, ConversationID: item.Conv, Text: stripped, ImageURLs: urls,
-		}); err != nil {
+		}, item.Envelope); err != nil && !errors.Is(err, ErrDeliverySuppressed) {
 			log.Warn().Err(err).Str("project", item.ProjectID).Msg("cron push flush send failed")
 		}
 		cancel()

--- a/server/internal/channels/preflight.go
+++ b/server/internal/channels/preflight.go
@@ -1,0 +1,309 @@
+package channels
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/services"
+	"gorm.io/gorm"
+)
+
+type PreflightDisposition string
+
+const (
+	PreflightProceed PreflightDisposition = "proceed"
+	PreflightRespond PreflightDisposition = "respond"
+)
+
+type InboundPreflightRequest struct {
+	Channel ResolvedChannel
+	Message InboundMessage
+}
+
+// InboundOrchestrationResult separates a safe immediate response from an
+// agent turn and carries only a ticket-bound action into the latter.
+type InboundOrchestrationResult struct {
+	Disposition      PreflightDisposition
+	Reply            Reply
+	Task             *models.TaskIdentity
+	AuthorizedAction string
+	TicketID         string
+}
+
+// TaskUserScope is the external identity used for task isolation. Group/guild
+// conversations append the platform user so two members never share tasks.
+func TaskUserScope(channelType string, in InboundMessage) string {
+	base := SyntheticUserID(channelType, in.Scene, in.ConversationID)
+	if in.Scene != SceneC2C && strings.TrimSpace(in.UserID) != "" {
+		return base + "|user:" + strings.TrimSpace(in.UserID)
+	}
+	return base
+}
+
+func (b *ChannelBridge) PreflightInbound(req InboundPreflightRequest) (InboundOrchestrationResult, error) {
+	if b == nil || b.tasks == nil {
+		return InboundOrchestrationResult{Disposition: PreflightProceed}, nil
+	}
+	rc, in := req.Channel, req.Message
+	userScope := TaskUserScope(rc.Type, in)
+	channel := rc.Type
+	focus, _ := b.tasks.GetConversationFocus(rc.ProjectID, channel, in.ConversationID, userScope)
+	language := DetectIMLanguage(in.Text, "")
+	if !containsLanguageSignal(in.Text) {
+		if remembered := b.tasks.ConversationLanguage(rc.ProjectID, channel, in.ConversationID, userScope); remembered != "" {
+			language = remembered
+		}
+	}
+	_ = b.tasks.RememberConversationLanguage(rc.ProjectID, channel, in.ConversationID, userScope, language)
+
+	if _, ok := services.ParseConfirmationReply(in.Text); ok {
+		return b.consumeConfirmation(rc, in, userScope, language)
+	}
+
+	if selected, err := b.tasks.SelectPendingCandidate(
+		rc.ProjectID, channel, in.ConversationID, userScope, in.Text,
+	); err == nil {
+		b.bindInbound(rc, in, userScope, selected, "")
+		b.announceRunAcceptance(rc, in, userScope, language, selected)
+		return b.preflightResponse(selected, "selected",
+			localized(language, "已选择该任务。", "Task selected."), language, rc.ReplyMetadata), nil
+	}
+
+	var bound *models.TaskIdentity
+	if strings.TrimSpace(in.ReplyToMessageID) != "" {
+		binding, err := b.tasks.GetMessageBinding(rc.ProjectID, channel, in.ConversationID, in.ReplyToMessageID)
+		if err == nil && binding.UserID == userScope {
+			if task, taskErr := b.tasks.GetTaskIdentity(rc.ProjectID, userScope, binding.RunID); taskErr == nil {
+				bound = &task
+			}
+		}
+	}
+
+	actionKind, highRisk := highRiskAction(in.Text)
+	query := strings.TrimSpace(in.Text)
+	if highRisk {
+		query = stripActionWords(query)
+	}
+	task, resolution, resolveErr := b.resolveInboundTask(rc, in, userScope, query, bound, focus, highRisk || looksLikeTaskReference(in.Text))
+	if errors.Is(resolveErr, services.ErrTaskAmbiguous) {
+		runIDs := make([]string, 0, len(resolution.Candidates))
+		for _, candidate := range resolution.Candidates {
+			runIDs = append(runIDs, candidate.Task.RunID)
+		}
+		_ = b.tasks.SetAmbiguityCandidates(rc.ProjectID, channel, in.ConversationID, userScope, runIDs)
+		return b.ambiguityResponse(resolution.Candidates, language, rc.ReplyMetadata), nil
+	}
+	if errors.Is(resolveErr, services.ErrTaskNotFound) && (highRisk || looksLikeTaskReference(in.Text)) {
+		return b.genericResponse("not_found",
+			localized(language, "未找到唯一匹配的任务，请提供短标题。", "No unique task matched; provide its short title."),
+			language, rc.ReplyMetadata), nil
+	}
+	if resolveErr != nil {
+		return InboundOrchestrationResult{}, resolveErr
+	}
+	if task == nil {
+		return InboundOrchestrationResult{Disposition: PreflightProceed}, nil
+	}
+	_ = b.tasks.TouchConversationFocus(rc.ProjectID, channel, in.ConversationID, userScope, task.RunID)
+	b.bindInbound(rc, in, userScope, *task, actionKind)
+	b.announceRunAcceptance(rc, in, userScope, language, *task)
+
+	if highRisk {
+		ticket, err := b.tasks.CreateRiskConfirmationWithKind(rc.ProjectID, userScope, task.RunID, actionKind, in.Text)
+		if err != nil {
+			return InboundOrchestrationResult{}, err
+		}
+		message := localized(language,
+			fmt.Sprintf("高风险操作“%s”等待确认；5 分钟内回复“确认”或“取消”。", actionKind),
+			fmt.Sprintf("High-risk action %q awaits confirmation; reply confirm or cancel within 5 minutes.", actionKind))
+		result := b.preflightResponse(*task, "action_required", message, language, rc.ReplyMetadata)
+		result.TicketID = ticket.ID
+		return result, nil
+	}
+	if isStatusQuery(in.Text) {
+		return b.preflightResponse(*task, "status",
+			localized(language, "当前状态："+task.Status, "Current status: "+task.Status), language, rc.ReplyMetadata), nil
+	}
+	return InboundOrchestrationResult{Disposition: PreflightProceed, Task: task}, nil
+}
+
+func (b *ChannelBridge) resolveInboundTask(
+	rc ResolvedChannel,
+	in InboundMessage,
+	userScope, query string,
+	bound *models.TaskIdentity,
+	focus models.ConversationFocus,
+	mustResolve bool,
+) (*models.TaskIdentity, services.TaskResolution, error) {
+	if bound != nil {
+		return bound, services.TaskResolution{Task: bound}, nil
+	}
+	if focus.RunID != "" && (isContinuation(in.Text) || strings.TrimSpace(query) == "") {
+		task, err := b.tasks.GetTaskIdentity(rc.ProjectID, userScope, focus.RunID)
+		if err == nil {
+			return &task, services.TaskResolution{Task: &task}, nil
+		}
+	}
+	if !mustResolve {
+		return nil, services.TaskResolution{}, nil
+	}
+	resolution, err := b.tasks.ResolveTask(services.TaskResolveRequest{
+		ProjectID: rc.ProjectID, UserID: userScope, Query: query,
+		Channel: rc.Type, ConversationID: in.ConversationID,
+	})
+	return resolution.Task, resolution, err
+}
+
+func (b *ChannelBridge) consumeConfirmation(rc ResolvedChannel, in InboundMessage, userScope, language string) (InboundOrchestrationResult, error) {
+	result, err := b.tasks.ConsumeLatestRiskConfirmation(rc.ProjectID, userScope, in.Text)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return b.genericResponse("stale",
+			localized(language, "没有待确认操作。", "There is no pending action."), language, rc.ReplyMetadata), nil
+	}
+	if errors.Is(err, services.ErrConfirmationStale) {
+		status := ""
+		if result.Latest != nil {
+			status = result.Latest.Status
+		}
+		return b.genericResponse("stale",
+			localized(language, "该确认已失效或已处理，最新状态："+status, "That confirmation is stale or consumed; latest state: "+status),
+			language, rc.ReplyMetadata), nil
+	}
+	if err != nil {
+		return InboundOrchestrationResult{}, err
+	}
+	task, err := b.tasks.GetTaskIdentity(rc.ProjectID, userScope, result.Ticket.RunID)
+	if err != nil {
+		return InboundOrchestrationResult{}, err
+	}
+	b.bindInbound(rc, in, userScope, task, result.Ticket.ActionKind)
+	if result.Cancel {
+		return b.preflightResponse(task, "cancelled",
+			localized(language, "已取消，不会执行该操作。", "Cancelled; the action will not run."), language, rc.ReplyMetadata), nil
+	}
+	_ = b.tasks.TouchConversationFocus(rc.ProjectID, rc.Type, in.ConversationID, userScope, task.RunID)
+	b.announceRunAcceptance(rc, in, userScope, language, task)
+	return InboundOrchestrationResult{
+		Disposition: PreflightProceed, Task: &task,
+		AuthorizedAction: result.Ticket.Action, TicketID: result.Ticket.ID,
+	}, nil
+}
+
+// announceRunAcceptance reports the first association of this conversation with
+// a Run. Repeat associations are deduped by the delivery policy and receipt.
+func (b *ChannelBridge) announceRunAcceptance(
+	rc ResolvedChannel, in InboundMessage, userScope, language string, task models.TaskIdentity,
+) {
+	if b.accepted == nil || strings.TrimSpace(task.RunID) == "" {
+		return
+	}
+	b.accepted(RunAcceptance{
+		ProjectID: rc.ProjectID, Channel: rc.Type, Scene: in.Scene,
+		ConversationID: in.ConversationID, UserID: userScope,
+		RunID: task.RunID, ShortTitle: task.ShortTitle, Language: language,
+	})
+}
+
+func (b *ChannelBridge) bindInbound(rc ResolvedChannel, in InboundMessage, userScope string, task models.TaskIdentity, action string) {
+	if strings.TrimSpace(in.MessageID) == "" {
+		return
+	}
+	_ = b.tasks.BindExternalMessage(models.MessageBinding{
+		ProjectID: rc.ProjectID, Channel: rc.Type, ConversationID: in.ConversationID,
+		MessageID: in.MessageID, UserID: userScope, RunID: task.RunID,
+		NodeID: in.NodeID, GateID: in.GateID, Action: action, Direction: "inbound",
+	})
+}
+
+func (b *ChannelBridge) preflightResponse(task models.TaskIdentity, typ, body, language string, replyMetadata bool) InboundOrchestrationResult {
+	text := body
+	if !replyMetadata {
+		text = TaskMessagePrefix(task.ShortTitle, IMTypeLabel(typ, language)) + body
+	}
+	return InboundOrchestrationResult{
+		Disposition: PreflightRespond, Task: &task,
+		Reply: Reply{
+			RunID: task.RunID, ShortTitle: task.ShortTitle,
+			Final: &TurnFinalReport{OK: true, Summary: text},
+		},
+	}
+}
+
+func (b *ChannelBridge) genericResponse(typ, body, language string, replyMetadata bool) InboundOrchestrationResult {
+	text := body
+	if !replyMetadata {
+		text = TaskMessagePrefix(localized(language, "任务", "Task"), IMTypeLabel(typ, language)) + body
+	}
+	return InboundOrchestrationResult{
+		Disposition: PreflightRespond,
+		Reply:       Reply{RunID: "preflight:" + deliveryKey(body), Final: &TurnFinalReport{OK: true, Summary: text}},
+	}
+}
+
+func (b *ChannelBridge) ambiguityResponse(candidates []services.TaskCandidate, language string, replyMetadata bool) InboundOrchestrationResult {
+	lines := []string{localized(language, "找到多个任务，请回复序号或完整短标题：", "Multiple tasks matched; reply with a number or exact short title:")}
+	for i, candidate := range candidates {
+		lines = append(lines, fmt.Sprintf("%d. %s (%s)", i+1, candidate.Task.ShortTitle, candidate.Task.Status))
+	}
+	return b.genericResponse("ambiguity", strings.Join(lines, "\n"), language, replyMetadata)
+}
+
+func localized(language, zh, en string) string {
+	if language == "en" {
+		return en
+	}
+	return zh
+}
+
+func containsLanguageSignal(text string) bool {
+	for _, r := range text {
+		if r > 127 || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') {
+			return true
+		}
+	}
+	return false
+}
+
+func isStatusQuery(text string) bool {
+	lower := strings.ToLower(text)
+	return containsAny(lower, "状态", "进度", "怎么样", "如何了", "status", "progress", "how is")
+}
+
+func looksLikeTaskReference(text string) bool {
+	lower := strings.ToLower(text)
+	return isStatusQuery(text) || containsAny(lower, "任务", "这个", "那个", "继续", "task", "run ", "continue")
+}
+
+func isContinuation(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	return containsAny(lower, "这个", "那个", "它", "继续", "当前", "status", "progress", "continue", "it")
+}
+
+func highRiskAction(text string) (string, bool) {
+	lower := strings.ToLower(text)
+	for kind, words := range map[string][]string{
+		"cancel":    {"取消运行", "取消任务", "cancel"},
+		"delete":    {"删除", "delete", "remove"},
+		"authorize": {"授权", "authorize", "grant"},
+		"approve":   {"批准", "审批通过", "同意执行", "approve"},
+		"reject":    {"拒绝", "驳回", "reject"},
+	} {
+		for _, word := range words {
+			if strings.Contains(lower, word) {
+				return kind, true
+			}
+		}
+	}
+	return "", false
+}
+
+func stripActionWords(text string) string {
+	replacer := strings.NewReplacer(
+		"取消运行", "", "取消任务", "", "删除", "", "授权", "", "批准", "", "审批通过", "", "同意执行", "", "拒绝", "", "驳回", "",
+		"cancel", "", "delete", "", "remove", "", "authorize", "", "grant", "", "approve", "", "reject", "",
+		"任务", "", "run", "", "task", "",
+	)
+	return strings.TrimSpace(replacer.Replace(strings.ToLower(text)))
+}

--- a/server/internal/channels/preflight_integration_test.go
+++ b/server/internal/channels/preflight_integration_test.go
@@ -1,0 +1,188 @@
+package channels
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/services"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func preflightFixture(t *testing.T) (*gorm.DB, *ChannelBridge, ResolvedChannel) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(
+		&models.WorkflowDef{}, &models.Run{}, &models.TaskIdentity{}, &models.MessageBinding{},
+		&models.ConversationFocus{}, &models.RiskConfirmationTicket{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	workflows := []models.WorkflowDef{
+		{ID: "wf-p1", ProjectID: "p1", Name: "发布工作流"},
+		{ID: "wf-p2", ProjectID: "p2", Name: "隔离工作流"},
+	}
+	for _, workflow := range workflows {
+		if err := db.Create(&workflow).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	now := time.Now().UTC()
+	runs := []models.Run{
+		{ID: "run-a", WorkflowID: "wf-p1", Title: "支付任务一", Status: "running", Inputs: map[string]any{"requirement": "支付服务"}, StartedAt: now},
+		{ID: "run-b", WorkflowID: "wf-p1", Title: "支付任务二", Status: "queued", Inputs: map[string]any{"requirement": "支付服务"}, StartedAt: now},
+		{ID: "run-risk", WorkflowID: "wf-p1", Title: "Alpha", Status: "running", Inputs: map[string]any{"prompt": "deploy alpha"}, StartedAt: now},
+		{ID: "run-foreign", WorkflowID: "wf-p2", Title: "Foreign Secret", Status: "running", Inputs: map[string]any{"task": "foreign only"}, StartedAt: now},
+	}
+	for _, run := range runs {
+		if err := db.Create(&run).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	bridge := NewChannelBridge(nil, nil, nil, MCPTokenHooks{})
+	bridge.SetTaskContext(services.NewTaskContextService(db))
+	return db, bridge, ResolvedChannel{Type: "qq", ProjectID: "p1", ReplyMetadata: false}
+}
+
+func TestInboundRuntimeAmbiguitySelectionFocusExpiryAndIsolation(t *testing.T) {
+	db, bridge, rc := preflightFixture(t)
+	base := InboundMessage{Scene: SceneGroup, ConversationID: "group-1", UserID: "user-a"}
+
+	ambiguous := base
+	ambiguous.Text, ambiguous.MessageID = "支付服务状态", "msg-amb"
+	reply, err := bridge.Handle(t.Context(), rc, ambiguous, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reply.Final == nil || !strings.Contains(reply.Final.Summary, "1.") || !strings.HasPrefix(reply.Final.Summary, "【") {
+		t.Fatalf("QQ ambiguity fallback missing: %#v", reply)
+	}
+
+	selected := base
+	selected.Text, selected.MessageID = "2", "msg-select"
+	reply, err = bridge.Handle(t.Context(), rc, selected, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reply.RunID == "" || reply.Final == nil || !strings.Contains(reply.Final.Summary, "已选择") {
+		t.Fatalf("candidate selection failed: %#v", reply)
+	}
+	selectedRun := reply.RunID
+	userScope := TaskUserScope("qq", base)
+	focus, err := bridge.tasks.GetConversationFocus("p1", "qq", "group-1", userScope)
+	if err != nil || focus.RunID != selectedRun {
+		t.Fatalf("focus = %#v, %v", focus, err)
+	}
+
+	status := base
+	status.Text, status.MessageID = "继续，状态怎么样", "msg-status"
+	reply, err = bridge.Handle(t.Context(), rc, status, nil)
+	if err != nil || reply.RunID != selectedRun || !strings.Contains(reply.Final.Summary, "当前状态") {
+		t.Fatalf("focused status = %#v, %v", reply, err)
+	}
+	if err := db.Model(&models.ConversationFocus{}).
+		Where("project_id = ? AND channel = ? AND conversation_id = ? AND user_id = ?", "p1", "qq", "group-1", userScope).
+		Update("expires_at", time.Now().Add(-time.Minute)).Error; err != nil {
+		t.Fatal(err)
+	}
+	expired, err := bridge.PreflightInbound(InboundPreflightRequest{Channel: rc, Message: status})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expired.Task != nil && expired.Task.RunID == selectedRun {
+		t.Fatalf("expired focus leaked selected task: %#v", expired)
+	}
+	expiredAgain, err := bridge.PreflightInbound(InboundPreflightRequest{Channel: rc, Message: status})
+	if err != nil || (expiredAgain.Task != nil && expiredAgain.Task.RunID == selectedRun) {
+		t.Fatalf("language tracking resurrected expired focus: %#v %v", expiredAgain, err)
+	}
+
+	otherUser := base
+	otherUser.UserID, otherUser.Text, otherUser.MessageID = "user-b", "支付任务一 状态", "msg-other"
+	other, err := bridge.PreflightInbound(InboundPreflightRequest{Channel: rc, Message: otherUser})
+	if err != nil || other.Task != nil || other.Disposition != PreflightRespond {
+		t.Fatalf("other user saw claimed task: %#v %v", other, err)
+	}
+	if TaskUserScope("qq", otherUser) == userScope {
+		t.Fatal("group user scopes collided")
+	}
+	foreign := base
+	foreign.Text = "Foreign Secret status"
+	foreignResult, err := bridge.PreflightInbound(InboundPreflightRequest{Channel: rc, Message: foreign})
+	if err != nil || foreignResult.Task != nil || foreignResult.Disposition != PreflightRespond {
+		t.Fatalf("cross-project run exposed: %#v %v", foreignResult, err)
+	}
+
+	var identity models.TaskIdentity
+	if err := db.Where("project_id = ? AND user_id = ? AND run_id = ?", "p1", userScope, "run-a").First(&identity).Error; err != nil {
+		t.Fatal(err)
+	}
+	if identity.ShortTitle != "支付任务一" || identity.OriginalRequirement != "支付服务" || identity.Status != "running" || len(identity.Keywords) == 0 {
+		t.Fatalf("auto-materialized identity = %#v", identity)
+	}
+}
+
+func TestInboundRuntimeBindingAndRiskTicketOneTime(t *testing.T) {
+	db, bridge, rc := preflightFixture(t)
+	in := InboundMessage{
+		Scene: SceneC2C, ConversationID: "openid-1", UserID: "openid-1",
+		Text: "delete Alpha", MessageID: "msg-risk", NodeID: "node-1", GateID: "gate-1",
+	}
+	first, err := bridge.Handle(t.Context(), rc, in, nil)
+	if err != nil || first.Final == nil || !strings.Contains(first.Final.Summary, "5 minutes") {
+		t.Fatalf("risk interception: %#v %v", first, err)
+	}
+	scope := TaskUserScope("qq", in)
+	var binding models.MessageBinding
+	if err := db.First(&binding, "message_id = ?", "msg-risk").Error; err != nil {
+		t.Fatal(err)
+	}
+	if binding.RunID != "run-risk" || binding.NodeID != "node-1" || binding.GateID != "gate-1" || binding.Action != "delete" {
+		t.Fatalf("binding context = %#v", binding)
+	}
+
+	bound := in
+	bound.Text, bound.MessageID, bound.ReplyToMessageID = "continue with details", "msg-bound", "msg-risk"
+	boundResult, err := bridge.PreflightInbound(InboundPreflightRequest{Channel: rc, Message: bound})
+	if err != nil || boundResult.Task == nil || boundResult.Task.RunID != "run-risk" {
+		t.Fatalf("reply binding did not resolve exactly: %#v %v", boundResult, err)
+	}
+
+	confirm := in
+	confirm.Text, confirm.MessageID = "确认", "msg-confirm"
+	authorized, err := bridge.PreflightInbound(InboundPreflightRequest{Channel: rc, Message: confirm})
+	if err != nil || authorized.Disposition != PreflightProceed || authorized.Task == nil ||
+		authorized.Task.RunID != "run-risk" || authorized.AuthorizedAction != "delete Alpha" || authorized.TicketID == "" {
+		t.Fatalf("confirmation authorization = %#v %v", authorized, err)
+	}
+	repeated, err := bridge.PreflightInbound(InboundPreflightRequest{Channel: rc, Message: confirm})
+	if err != nil || repeated.Disposition != PreflightRespond || repeated.Reply.Final == nil ||
+		!strings.Contains(repeated.Reply.Final.Summary, "已处理") {
+		t.Fatalf("repeated confirmation reauthorized: %#v %v", repeated, err)
+	}
+
+	cancelRisk := in
+	cancelRisk.Text, cancelRisk.MessageID = "cancel Alpha", "msg-cancel-risk"
+	if _, err := bridge.PreflightInbound(InboundPreflightRequest{Channel: rc, Message: cancelRisk}); err != nil {
+		t.Fatal(err)
+	}
+	cancel := in
+	cancel.Text, cancel.MessageID = "cancel", "msg-cancel"
+	cancelled, err := bridge.PreflightInbound(InboundPreflightRequest{Channel: rc, Message: cancel})
+	if err != nil || cancelled.Disposition != PreflightRespond || !strings.Contains(cancelled.Reply.Final.Summary, "will not run") {
+		t.Fatalf("cancel confirmation = %#v %v", cancelled, err)
+	}
+
+	var tickets int64
+	if err := db.Model(&models.RiskConfirmationTicket{}).Where("project_id = ? AND user_id = ?", "p1", scope).Count(&tickets).Error; err != nil {
+		t.Fatal(err)
+	}
+	if tickets != 2 {
+		t.Fatalf("ticket count = %d", tickets)
+	}
+}

--- a/server/internal/channels/progress.go
+++ b/server/internal/channels/progress.go
@@ -26,6 +26,15 @@ type ProgressEvent struct {
 	Kind    ProgressKind
 	Summary string
 	At      time.Time
+	RunID   string
+
+	authorized bool
+}
+
+// NewSendableProgressEvent is the explicit application producer path. Text
+// classifiers intentionally do not set this authorization.
+func NewSendableProgressEvent(kind ProgressKind, summary, runID string) ProgressEvent {
+	return ProgressEvent{Kind: kind, Summary: summary, RunID: runID, At: time.Now(), authorized: true}
 }
 
 // TurnFinalReport is the Work turn outcome consumed by Reply for the required
@@ -33,6 +42,9 @@ type ProgressEvent struct {
 type TurnFinalReport struct {
 	OK      bool
 	Summary string
+	// ImageURLs are attachments explicitly authorized by the structured final
+	// producer. Raw assistant text never populates this.
+	ImageURLs []string
 }
 
 const progressSummaryRunes = 120
@@ -55,10 +67,8 @@ var progressMarkers = []struct {
 	{"【里程碑】", ProgressMilestone},
 }
 
-// ClassifyProgressText maps assistant narration into one of the three
-// forwardable progress kinds. Markers are authoritative; bare keywords are
-// conservative to avoid false positives on casual chat. Empty / tool-noise /
-// heartbeat-like text is rejected (ok=false) so Reply does not spam QQ.
+// ClassifyProgressText classifies a candidate but never authorizes egress.
+// AppendSendable plus the policy gate remain mandatory after classification.
 func ClassifyProgressText(text string) (ProgressEvent, bool) {
 	text = strings.TrimSpace(text)
 	if text == "" {

--- a/server/internal/channels/push_queue.go
+++ b/server/internal/channels/push_queue.go
@@ -40,6 +40,7 @@ type CronPushItem struct {
 	Kind      CronResultKind
 	Text      string
 	Enqueued  time.Time
+	Envelope  Envelope
 }
 
 type pushQueue struct {

--- a/server/internal/channels/qq/adapter.go
+++ b/server/internal/channels/qq/adapter.go
@@ -67,6 +67,12 @@ func New(cfg channels.AdapterConfig) (channels.Adapter, error) {
 // Type implements channels.Adapter.
 func (a *Adapter) Type() string { return "qq" }
 
+// Capabilities documents that QQ cannot carry portable structured reply
+// metadata. Manager uses a natural-language 【short title｜type】 prefix instead.
+func (a *Adapter) Capabilities() channels.AdapterCapabilities {
+	return channels.AdapterCapabilities{ReplyMetadata: false}
+}
+
 // Start implements channels.Adapter (non-blocking; the gateway runs in a goroutine).
 func (a *Adapter) Start(ctx context.Context, onInbound channels.InboundHandler) error {
 	runCtx, cancel := context.WithCancel(ctx)
@@ -177,16 +183,11 @@ func (a *Adapter) handleEvent(ctx context.Context, evtType string, data []byte, 
 			"附件超过 %d MiB 上限，已拒绝：%s。请压缩后重试。",
 			qqAttachMaxMiB, strings.Join(oversized, ", "),
 		)
-		// Pure oversize with nothing else: reply tip without starting an agent turn.
+		// Pure oversize with nothing else is handed to Manager as a structured
+		// rejection. The adapter must never bypass the mandatory egress gate.
 		if len(in.Images) == 0 && strings.TrimSpace(in.Text) == "" {
-			if err := a.Send(ctx, channels.OutboundMessage{
-				Scene:            scene,
-				ConversationID:   conversationID,
-				ReplyToMessageID: m.ID,
-				Text:             tip,
-			}); err != nil {
-				log.Warn().Err(err).Msg("qq: oversized reject reply failed")
-			}
+			in.Raw = map[string]any{"system_rejection": tip}
+			go onInbound(ctx, in)
 			return
 		}
 		if in.Text != "" {

--- a/server/internal/channels/qq/qq_test.go
+++ b/server/internal/channels/qq/qq_test.go
@@ -9,6 +9,12 @@ import (
 	"github.com/cocofhu/approving/internal/channels"
 )
 
+func TestReplyMetadataCapabilityUnsupported(t *testing.T) {
+	if (&Adapter{}).Capabilities().ReplyMetadata {
+		t.Fatal("QQ must exercise natural-language reply fallback")
+	}
+}
+
 func TestIsImageAttachment(t *testing.T) {
 	// Helper still classifies mime/ext; inbound path no longer filters on it
 	// (PDF/zip are accepted via downloadImage). Outbound image send still uses

--- a/server/internal/channels/types.go
+++ b/server/internal/channels/types.go
@@ -43,14 +43,18 @@ type Image struct {
 
 // InboundMessage is a normalized user message received from a channel.
 type InboundMessage struct {
-	Scene          Scene
-	ConversationID string // openid / group_openid / channel_id
-	UserID         string // author id (openid/union), for display/attribution
-	Text           string
-	Images         []Image
-	MessageID      string // platform message id (passive reply + dedup)
-	Timestamp      time.Time
-	Raw            map[string]any
+	Scene            Scene
+	ConversationID   string // openid / group_openid / channel_id
+	UserID           string // author id (openid/union), for display/attribution
+	Text             string
+	Images           []Image
+	MessageID        string // platform message id (passive reply + dedup)
+	ReplyToMessageID string // optional native reply target; QQ leaves empty
+	NodeID           string // optional workflow context supplied by capable transports
+	GateID           string
+	Action           string
+	Timestamp        time.Time
+	Raw              map[string]any
 }
 
 // OutboundMessage is a normalized reply/push to a channel conversation.
@@ -58,6 +62,7 @@ type OutboundMessage struct {
 	Scene            Scene
 	ConversationID   string
 	ReplyToMessageID string // passive reply id (empty → active push)
+	MessageID        string // populated only when a transport exposes the sent id
 	Text             string
 	ImageURLs        []string // shareable image URLs to attach
 }
@@ -79,6 +84,17 @@ type Adapter interface {
 	Send(ctx context.Context, out OutboundMessage) error
 	// Stop tears down the connection and releases resources.
 	Stop() error
+}
+
+// AdapterCapabilities makes optional transport features explicit. QQ currently
+// has no reliable reply-metadata API; callers must use the natural-language
+// task prefix fallback.
+type AdapterCapabilities struct {
+	ReplyMetadata bool `json:"replyMetadata"`
+}
+
+type CapabilityAdapter interface {
+	Capabilities() AdapterCapabilities
 }
 
 // AdapterConfig is the resolved, decrypted configuration handed to a factory.

--- a/server/internal/models/models.go
+++ b/server/internal/models/models.go
@@ -139,8 +139,8 @@ type Run struct {
 }
 
 const (
-	MaxRunTags       = 8
-	MaxRunTagRunes   = 32
+	MaxRunTags     = 8
+	MaxRunTagRunes = 32
 )
 
 var ErrInvalidRunTag = errors.New("invalid run tag")
@@ -542,9 +542,9 @@ func FormatChoiceReply(questions []ReactQuestion) string {
 // Name is optional for backward compatibility with older clients; when empty
 // the Bridge falls back to attachment-N.ext.
 type PromptImage struct {
-	Data     string `json:"data"`               // base64 (no data: prefix)
-	MimeType string `json:"mimeType"`           // e.g. image/png or application/pdf
-	Name     string `json:"name,omitempty"`     // original filename when known
+	Data     string `json:"data"`           // base64 (no data: prefix)
+	MimeType string `json:"mimeType"`       // e.g. image/png or application/pdf
+	Name     string `json:"name,omitempty"` // original filename when known
 }
 
 // Sandbox is a tracked sandbox container. Purposes share this table:
@@ -645,8 +645,8 @@ type RunPreviewPort struct {
 	// "http://172.17.0.5:9090". Persisting it decouples the proxy read-path from
 	// the co-located sandbox manager so the preview proxy can later be split into
 	// a standalone service that only reads the DB (or a control-plane API).
-	Host         string    `json:"-"`
-	Healthy      bool      `json:"healthy"`
+	Host    string `json:"-"`
+	Healthy bool   `json:"healthy"`
 	// KeepalivePID is the setsid-detached listener pid recorded by KeepalivePort
 	// so Cancel/Abort session cleanup can whitelist it (sandbox Destroy still
 	// reclaims the whole container with the Run/gate lifecycle).
@@ -686,6 +686,8 @@ func AllModels() []any {
 		&AgentCronJob{}, &AgentCronRun{}, &ChannelConfig{},
 		&ProjectAuditEvent{},
 		&NotifyDeliveryReceipt{},
+		&DeliveryReceipt{}, &TaskIdentity{}, &MessageBinding{},
+		&ConversationFocus{}, &RiskConfirmationTicket{}, &ChannelActionGuard{},
 	}
 }
 

--- a/server/internal/models/task_context.go
+++ b/server/internal/models/task_context.go
@@ -1,0 +1,115 @@
+package models
+
+import "time"
+
+const (
+	DeliveryReceiptPending = "pending"
+	DeliveryReceiptSent    = "sent"
+	DeliveryReceiptFailed  = "failed"
+)
+
+// Risk ticket lifecycle. "confirmed" is the authorization grant; only
+// "executed" is reached by the destructive method that actually consumes it.
+const (
+	RiskTicketPending   = "pending"
+	RiskTicketConfirmed = "confirmed"
+	RiskTicketExecuted  = "executed"
+	RiskTicketCancelled = "cancelled"
+	RiskTicketExpired   = "expired"
+)
+
+// TaskIdentity is the durable, user-scoped name and search document for a Run.
+// RunID is the stable identity; titles may change while previous titles remain
+// searchable through Aliases.
+type TaskIdentity struct {
+	ID                  uint      `gorm:"primaryKey" json:"-"`
+	RunID               string    `gorm:"size:64;uniqueIndex" json:"runId"`
+	ProjectID           string    `gorm:"size:64;index:idx_task_scope" json:"projectId"`
+	UserID              string    `gorm:"size:191;index:idx_task_scope" json:"userId"`
+	ShortTitle          string    `gorm:"size:160;index" json:"shortTitle"`
+	OriginalRequirement string    `gorm:"type:text" json:"originalRequirement"`
+	Aliases             []string  `gorm:"serializer:json" json:"aliases"`
+	Keywords            []string  `gorm:"serializer:json" json:"keywords"`
+	Status              string    `gorm:"size:32;index" json:"status"`
+	CreatedAt           time.Time `json:"createdAt"`
+	UpdatedAt           time.Time `gorm:"index" json:"updatedAt"`
+}
+
+// MessageBinding connects a platform message to the Run it referred to.
+type MessageBinding struct {
+	ID             uint      `gorm:"primaryKey" json:"-"`
+	ProjectID      string    `gorm:"size:64;uniqueIndex:idx_message_binding" json:"projectId"`
+	Channel        string    `gorm:"size:32;uniqueIndex:idx_message_binding" json:"channel"`
+	ConversationID string    `gorm:"size:191;uniqueIndex:idx_message_binding" json:"conversationId"`
+	MessageID      string    `gorm:"size:191;uniqueIndex:idx_message_binding" json:"messageId"`
+	UserID         string    `gorm:"size:191;index" json:"userId"`
+	RunID          string    `gorm:"size:64;index" json:"runId"`
+	NodeID         string    `gorm:"size:128;index" json:"nodeId,omitempty"`
+	GateID         string    `gorm:"size:128;index" json:"gateId,omitempty"`
+	Action         string    `gorm:"size:191" json:"action,omitempty"`
+	Direction      string    `gorm:"size:16" json:"direction,omitempty"` // inbound|outbound
+	CreatedAt      time.Time `json:"createdAt"`
+}
+
+// ConversationFocus records the most recently selected Run in a scoped
+// conversation. ExpiresAt is extended on every successful reference.
+type ConversationFocus struct {
+	ID             uint      `gorm:"primaryKey" json:"-"`
+	ProjectID      string    `gorm:"size:64;uniqueIndex:idx_conversation_focus" json:"projectId"`
+	Channel        string    `gorm:"size:32;uniqueIndex:idx_conversation_focus" json:"channel"`
+	ConversationID string    `gorm:"size:191;uniqueIndex:idx_conversation_focus" json:"conversationId"`
+	UserID         string    `gorm:"size:191;uniqueIndex:idx_conversation_focus" json:"userId"`
+	RunID          string    `gorm:"size:64;index" json:"runId"`
+	PendingRunIDs  []string  `gorm:"serializer:json" json:"pendingRunIds,omitempty"`
+	Language       string    `gorm:"size:16" json:"language,omitempty"`
+	ExpiresAt      time.Time `gorm:"index" json:"expiresAt"`
+	UpdatedAt      time.Time `json:"updatedAt"`
+}
+
+// RiskConfirmationTicket is a short-lived, single-use authorization for one
+// high-risk action. It stores identity and state only, never credentials.
+// A confirmed ticket is the persistent grant that the destructive server-side
+// method must consume; ThreadID scopes it to the PM thread that may spend it.
+type RiskConfirmationTicket struct {
+	ID             string     `gorm:"primaryKey;size:64" json:"id"`
+	ProjectID      string     `gorm:"size:64;index:idx_risk_ticket_scope" json:"projectId"`
+	UserID         string     `gorm:"size:191;index:idx_risk_ticket_scope" json:"userId"`
+	RunID          string     `gorm:"size:64;index:idx_risk_ticket_scope" json:"runId"`
+	Action         string     `gorm:"size:191;index:idx_risk_ticket_scope" json:"action"`
+	ActionKind     string     `gorm:"size:32;index" json:"actionKind"`
+	ThreadID       string     `gorm:"size:64;index" json:"threadId,omitempty"`
+	Status         string     `gorm:"size:16;index" json:"status"` // pending|confirmed|executed|cancelled|expired
+	ExpiresAt      time.Time  `gorm:"index" json:"expiresAt"`
+	GrantExpiresAt *time.Time `gorm:"index" json:"grantExpiresAt,omitempty"`
+	ConsumedAt     *time.Time `json:"consumedAt,omitempty"`
+	ExecutedAt     *time.Time `json:"executedAt,omitempty"`
+	CreatedAt      time.Time  `json:"createdAt"`
+	UpdatedAt      time.Time  `json:"updatedAt"`
+}
+
+// ChannelActionGuard marks a PM thread as channel-originated. Destructive PM
+// MCP mutations on a guarded thread are denied unless a confirmed ticket
+// authorizes exactly that target and action. Web/API routes keep their own
+// authentication and are never guarded.
+type ChannelActionGuard struct {
+	ID        uint      `gorm:"primaryKey" json:"-"`
+	ProjectID string    `gorm:"size:64;uniqueIndex:idx_channel_action_guard" json:"projectId"`
+	ThreadID  string    `gorm:"size:64;uniqueIndex:idx_channel_action_guard" json:"threadId"`
+	Channel   string    `gorm:"size:32" json:"channel"`
+	UserID    string    `gorm:"size:191" json:"userId"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// DeliveryReceipt makes external delivery retryable and idempotent.
+type DeliveryReceipt struct {
+	ID          uint       `gorm:"primaryKey" json:"-"`
+	DedupeKey   string     `gorm:"size:255;uniqueIndex" json:"dedupeKey"`
+	Status      string     `gorm:"size:16;index" json:"status"` // pending|sent|failed
+	Attempts    int        `json:"attempts"`
+	LastError   string     `gorm:"size:500" json:"lastError,omitempty"`
+	LastTriedAt *time.Time `json:"lastTriedAt,omitempty"`
+	SentAt      *time.Time `json:"sentAt,omitempty"`
+	CreatedAt   time.Time  `json:"createdAt"`
+	UpdatedAt   time.Time  `json:"updatedAt"`
+}

--- a/server/internal/pmmcp/channel_action_test.go
+++ b/server/internal/pmmcp/channel_action_test.go
@@ -1,0 +1,156 @@
+package pmmcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/services"
+
+	"gorm.io/gorm"
+)
+
+// channelActionFixture wires a real host with the real grant store so the test
+// proves server-side enforcement rather than a stubbed decision.
+func channelActionFixture(t *testing.T) (*gorm.DB, *Host, *fakePmEngine, *services.TaskContextService, models.Project) {
+	t.Helper()
+	db, pm, _, p := setupPmMCPHost(t)
+	wf := services.NewWorkflowService(db)
+	graph := models.Graph{Nodes: []models.Node{{ID: "in", Type: "input"}, {ID: "out", Type: "output"}}}
+	if err := wf.Save(&models.WorkflowDef{ID: "wf-guard", ProjectID: p.ID, Name: "Guarded WF", Graph: graph}); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"run-guard", "run-other"} {
+		if err := db.Create(&models.Run{
+			ID: id, WorkflowID: "wf-guard", Status: "running", StartedAt: time.Now().UTC(),
+		}).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	eng := &fakePmEngine{}
+	rs := services.NewRunService(db)
+	h := NewHost(pm, services.NewPmProgress(pm, rs, nil), wf, rs, services.NewArtifactService(db), eng)
+	tasks := services.NewTaskContextService(db)
+	h.SetChannelActionAuthorizer(tasks)
+	return db, h, eng, tasks, p
+}
+
+func callWrite(t *testing.T, h *Host, projectID, token, name string, args map[string]any) string {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{"name": name, "arguments": args},
+	})
+	st, resp := h.ServeRPC(projectID, MCPWorkflowWrite, token, body)
+	if st != 200 {
+		t.Fatalf("%s status = %d", name, st)
+	}
+	return string(resp)
+}
+
+func grantFor(t *testing.T, tasks *services.TaskContextService, projectID, threadID, runID, kind string) {
+	t.Helper()
+	ticket, err := tasks.CreateRiskConfirmationWithKind(projectID, "qq:c2c:u1", runID, kind, kind+" "+runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.ConsumeRiskConfirmation(projectID, "qq:c2c:u1", runID, ticket.Action, "确认"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tasks.BindActionGrant(ticket.ID, threadID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDestructiveMutationsRequireConfirmedTicketOnChannelThreads(t *testing.T) {
+	_, h, eng, tasks, p := channelActionFixture(t)
+	tok := h.Register(p.ID, "thr-channel", "qq:c2c:u1", "agent-a")
+	if err := tasks.GuardChannelThread(p.ID, "thr-channel", "qq", "qq:c2c:u1"); err != nil {
+		t.Fatal(err)
+	}
+
+	// No ticket: the prompt alone must not execute anything.
+	resp := callWrite(t, h, p.ID, tok, "pm_cancel_run", map[string]any{"runId": "run-guard"})
+	if !strings.Contains(resp, "confirmed authorization") || eng.cancelled != "" {
+		t.Fatalf("unauthorized cancel executed: %s (cancelled=%q)", resp, eng.cancelled)
+	}
+
+	// Ticket for another run must not authorize this one.
+	grantFor(t, tasks, p.ID, "thr-channel", "run-other", "cancel")
+	resp = callWrite(t, h, p.ID, tok, "pm_cancel_run", map[string]any{"runId": "run-guard"})
+	if !strings.Contains(resp, "confirmed authorization") || eng.cancelled != "" {
+		t.Fatalf("wrong-run ticket authorized cancel: %s", resp)
+	}
+
+	// Ticket for another action on the right run must not authorize a cancel.
+	grantFor(t, tasks, p.ID, "thr-channel", "run-guard", "approve")
+	resp = callWrite(t, h, p.ID, tok, "pm_cancel_run", map[string]any{"runId": "run-guard"})
+	if !strings.Contains(resp, "confirmed authorization") || eng.cancelled != "" {
+		t.Fatalf("wrong-action ticket authorized cancel: %s", resp)
+	}
+
+	// Exact confirmed ticket: allowed exactly once.
+	grantFor(t, tasks, p.ID, "thr-channel", "run-guard", "cancel")
+	resp = callWrite(t, h, p.ID, tok, "pm_cancel_run", map[string]any{"runId": "run-guard"})
+	if strings.Contains(resp, `"isError":true`) || eng.cancelled != "run-guard" {
+		t.Fatalf("confirmed cancel denied: %s (cancelled=%q)", resp, eng.cancelled)
+	}
+	eng.cancelled = ""
+	resp = callWrite(t, h, p.ID, tok, "pm_cancel_run", map[string]any{"runId": "run-guard"})
+	if !strings.Contains(resp, "confirmed authorization") || eng.cancelled != "" {
+		t.Fatalf("ticket was replayable: %s", resp)
+	}
+}
+
+func TestGuardedGateResumeAndWorkflowDeleteNeedMatchingKind(t *testing.T) {
+	_, h, eng, tasks, p := channelActionFixture(t)
+	tok := h.Register(p.ID, "thr-channel", "qq:c2c:u1", "agent-a")
+	if err := tasks.GuardChannelThread(p.ID, "thr-channel", "qq", "qq:c2c:u1"); err != nil {
+		t.Fatal(err)
+	}
+
+	args := map[string]any{"runId": "run-guard", "nodeId": "gate-1", "action": "approve"}
+	if resp := callWrite(t, h, p.ID, tok, "pm_resume_gate", args); !strings.Contains(resp, "confirmed authorization") {
+		t.Fatalf("unauthorized gate resume: %s", resp)
+	}
+	if eng.resumed.runID != "" {
+		t.Fatalf("gate resumed without a ticket: %#v", eng.resumed)
+	}
+	grantFor(t, tasks, p.ID, "thr-channel", "run-guard", "reject")
+	if resp := callWrite(t, h, p.ID, tok, "pm_resume_gate", args); !strings.Contains(resp, "confirmed authorization") {
+		t.Fatalf("reject ticket approved a gate: %s", resp)
+	}
+	grantFor(t, tasks, p.ID, "thr-channel", "run-guard", "approve")
+	if resp := callWrite(t, h, p.ID, tok, "pm_resume_gate", args); strings.Contains(resp, `"isError":true`) {
+		t.Fatalf("confirmed approve denied: %s", resp)
+	}
+	if eng.resumed.runID != "run-guard" || eng.resumed.action != "approve" {
+		t.Fatalf("gate resume = %#v", eng.resumed)
+	}
+
+	del := map[string]any{"workflowId": "wf-guard"}
+	if resp := callWrite(t, h, p.ID, tok, "pm_delete_workflow", del); !strings.Contains(resp, "confirmed authorization") {
+		t.Fatalf("unauthorized workflow delete: %s", resp)
+	}
+	// A run-scoped delete ticket must not authorize deleting the workflow.
+	grantFor(t, tasks, p.ID, "thr-channel", "run-guard", "delete")
+	if resp := callWrite(t, h, p.ID, tok, "pm_delete_workflow", del); !strings.Contains(resp, "confirmed authorization") {
+		t.Fatalf("run ticket deleted a workflow: %s", resp)
+	}
+	grantFor(t, tasks, p.ID, "thr-channel", "wf-guard", "delete")
+	if resp := callWrite(t, h, p.ID, tok, "pm_delete_workflow", del); strings.Contains(resp, `"isError":true`) {
+		t.Fatalf("confirmed workflow delete denied: %s", resp)
+	}
+}
+
+func TestUnguardedThreadsKeepExistingBehaviour(t *testing.T) {
+	_, h, eng, _, p := channelActionFixture(t)
+	// A web/API PM consult thread is never registered as channel-guarded.
+	tok := h.Register(p.ID, "thr-web", "alice", "agent-a")
+	resp := callWrite(t, h, p.ID, tok, "pm_cancel_run", map[string]any{"runId": "run-guard"})
+	if strings.Contains(resp, `"isError":true`) || eng.cancelled != "run-guard" {
+		t.Fatalf("unguarded cancel was blocked: %s (cancelled=%q)", resp, eng.cancelled)
+	}
+}

--- a/server/internal/pmmcp/host.go
+++ b/server/internal/pmmcp/host.go
@@ -43,21 +43,32 @@ type Session struct {
 	Attached  *models.AttachedContext
 }
 
+// ChannelActionAuthorizer gates destructive mutations that originate from a
+// channel (IM) thread. Web/API routes carry their own authentication and are
+// never guarded: an unguarded thread short-circuits to allow.
+type ChannelActionAuthorizer interface {
+	IsGuardedThread(projectID, threadID string) bool
+	// ConsumeActionGrant must succeed at most once per confirmed ticket and
+	// only for the exact target (run/workflow id) and action kind.
+	ConsumeActionGrant(projectID, threadID, target, actionKind string) error
+}
+
 // Host manages project-scoped PM MCP sessions and tool dispatch.
 type Host struct {
 	mu       sync.RWMutex
 	sessions map[string]*Session // token -> session
 	byKey    map[string]string   // projectID|threadID -> token
 
-	pm       *services.PmService
-	progress *services.PmProgress
-	wf       *services.WorkflowService
-	runs     *services.RunService
-	arts     *services.ArtifactService
-	org      *services.OrgService
-	skill    *services.SkillService
-	eng      engineOps
-	audit    func(services.AuditRecord)
+	pm          *services.PmService
+	progress    *services.PmProgress
+	wf          *services.WorkflowService
+	runs        *services.RunService
+	arts        *services.ArtifactService
+	org         *services.OrgService
+	skill       *services.SkillService
+	eng         engineOps
+	audit       func(services.AuditRecord)
+	channelAuth ChannelActionAuthorizer
 }
 
 // engineOps covers the run operations exposed through pm-workflow-write
@@ -98,6 +109,49 @@ func (h *Host) SetAuditRecorder(fn func(services.AuditRecord)) {
 	h.mu.Lock()
 	h.audit = fn
 	h.mu.Unlock()
+}
+
+// SetChannelActionAuthorizer wires server-side high-risk enforcement for
+// channel-originated threads. Leaving it nil preserves existing behaviour.
+func (h *Host) SetChannelActionAuthorizer(a ChannelActionAuthorizer) {
+	h.mu.Lock()
+	h.channelAuth = a
+	h.mu.Unlock()
+}
+
+// authorizeDestructive is the mandatory server-side check in front of every
+// destructive mutation. A prompt claim is never sufficient: the grant is a
+// persisted, single-use row keyed by project + thread + target + action.
+func (h *Host) authorizeDestructive(projectID, token, target, actionKind string) error {
+	h.mu.RLock()
+	auth := h.channelAuth
+	h.mu.RUnlock()
+	if auth == nil {
+		return nil
+	}
+	sess, ok := h.SessionFor(projectID, token)
+	if !ok || strings.TrimSpace(sess.ThreadID) == "" {
+		return nil
+	}
+	if !auth.IsGuardedThread(projectID, sess.ThreadID) {
+		return nil
+	}
+	return auth.ConsumeActionGrant(projectID, sess.ThreadID, target, actionKind)
+}
+
+// gateActionKind maps a gate decision to the confirmation kind a user must have
+// approved. Unmapped decisions never match a ticket, so they stay denied.
+func gateActionKind(action string) string {
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case "approve", "approved", "pass", "accept", "allow":
+		return "approve"
+	case "reject", "rejected", "deny", "decline":
+		return "reject"
+	case "authorize", "grant":
+		return "authorize"
+	default:
+		return "resume_gate"
+	}
 }
 
 func (h *Host) recordAudit(rec services.AuditRecord) {
@@ -663,6 +717,9 @@ func (h *Host) callWorkflowWrite(projectID, token, name string, args map[string]
 		if _, ok := h.workflowInProject(projectID, platformmcp.StrArg(args, "workflowId")); !ok {
 			return map[string]any{"error": "workflow not found"}, true
 		}
+		if err := h.authorizeDestructive(projectID, token, platformmcp.StrArg(args, "workflowId"), "delete"); err != nil {
+			return map[string]any{"error": err.Error()}, true
+		}
 		if err := h.wf.Delete(platformmcp.StrArg(args, "workflowId")); err != nil {
 			return map[string]any{"error": err.Error()}, true
 		}
@@ -736,6 +793,9 @@ func (h *Host) callWorkflowWrite(projectID, token, name string, args map[string]
 		if nodeID == "" || action == "" {
 			return map[string]any{"error": "nodeId and action required"}, true
 		}
+		if err := h.authorizeDestructive(projectID, token, runID, gateActionKind(action)); err != nil {
+			return map[string]any{"error": err.Error()}, true
+		}
 		if err := h.eng.ResumeGate(runID, nodeID, action, platformmcp.MapArg(args, "form")); err != nil {
 			return map[string]any{"error": err.Error()}, true
 		}
@@ -775,6 +835,9 @@ func (h *Host) callWorkflowWrite(projectID, token, name string, args map[string]
 		run, ok := h.runInProject(projectID, runID)
 		if !ok {
 			return map[string]any{"error": "run not found"}, true
+		}
+		if err := h.authorizeDestructive(projectID, token, runID, "cancel"); err != nil {
+			return map[string]any{"error": err.Error()}, true
 		}
 		if err := h.eng.Cancel(runID); err != nil {
 			return map[string]any{"error": err.Error()}, true

--- a/server/internal/services/run_notify.go
+++ b/server/internal/services/run_notify.go
@@ -18,6 +18,12 @@ type RunNotifyDeliverer interface {
 	DeliverRunNotify(projectID, text string) error
 }
 
+// ContextualRunNotifyDeliverer is implemented by first-class envelope egress.
+// Legacy deliverers remain supported for tests and integrations.
+type ContextualRunNotifyDeliverer interface {
+	DeliverRunNotifyContext(projectID, runID, shortTitle, kind, text string) error
+}
+
 // ErrRunNotifyNoTarget is returned (and swallowed) when no QQ target is bound.
 var ErrRunNotifyNoTarget = errors.New("no run-notify delivery target")
 
@@ -121,14 +127,25 @@ func (s *RunNotifyService) AttemptDeliver(ev RunNotifyEvent) {
 			Msg("run-notify: no deliverer — no-op after claim")
 		return
 	}
-	if err := s.deliver.DeliverRunNotify(project.ID, text); err != nil {
+	var deliverErr error
+	if contextual, ok := s.deliver.(ContextualRunNotifyDeliverer); ok {
+		shortTitle := strings.TrimSpace(ev.WorkflowName)
+		var run models.Run
+		if err := s.db.Select("title").First(&run, "id = ?", ev.RunID).Error; err == nil && strings.TrimSpace(run.Title) != "" {
+			shortTitle = strings.TrimSpace(run.Title)
+		}
+		deliverErr = contextual.DeliverRunNotifyContext(project.ID, ev.RunID, shortTitle, kind, text)
+	} else {
+		deliverErr = s.deliver.DeliverRunNotify(project.ID, text)
+	}
+	if deliverErr != nil {
 		// P0: claim already held; log and do not retry.
-		if errors.Is(err, ErrRunNotifyNoTarget) {
+		if errors.Is(deliverErr, ErrRunNotifyNoTarget) {
 			log.Info().Str("run_id", ev.RunID).Str("project", project.ID).
 				Msg("run-notify: no channel target — no-op after claim")
 			return
 		}
-		log.Warn().Err(err).Str("run_id", ev.RunID).Str("project", project.ID).
+		log.Warn().Err(deliverErr).Str("run_id", ev.RunID).Str("project", project.ID).
 			Msg("run-notify: send failed after claim (no retry)")
 	}
 }

--- a/server/internal/services/task_context.go
+++ b/server/internal/services/task_context.go
@@ -1,0 +1,720 @@
+package services
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const (
+	ConversationFocusTTL = 30 * time.Minute
+	TaskTerminalLookback = 30 * 24 * time.Hour
+	RiskTicketTTL        = 5 * time.Minute
+	// RiskGrantTTL bounds how long a confirmed ticket stays spendable by the
+	// destructive server method.
+	RiskGrantTTL = 5 * time.Minute
+)
+
+var (
+	ErrTaskAmbiguous       = errors.New("task reference is ambiguous")
+	ErrTaskNotFound        = errors.New("task not found")
+	ErrConfirmationStale   = errors.New("confirmation is stale or already consumed")
+	ErrInvalidConfirmation = errors.New("reply is not confirm or cancel")
+	ErrActionNotAuthorized = errors.New("high-risk action has no confirmed authorization")
+)
+
+type TaskContextService struct {
+	db  *gorm.DB
+	now func() time.Time
+}
+
+func NewTaskContextService(db *gorm.DB) *TaskContextService {
+	return &TaskContextService{db: db, now: time.Now}
+}
+
+type TaskIdentityInput struct {
+	RunID, ProjectID, UserID, ShortTitle, OriginalRequirement, Status string
+	Aliases, Keywords                                                 []string
+}
+
+// UpsertTaskIdentity creates or updates a Run identity. A changed title is
+// appended to aliases before replacement, preserving old references.
+func (s *TaskContextService) UpsertTaskIdentity(in TaskIdentityInput) (models.TaskIdentity, error) {
+	if s == nil || s.db == nil {
+		return models.TaskIdentity{}, fmt.Errorf("task context unavailable")
+	}
+	in.RunID, in.ProjectID, in.UserID = strings.TrimSpace(in.RunID), strings.TrimSpace(in.ProjectID), strings.TrimSpace(in.UserID)
+	in.ShortTitle = strings.TrimSpace(in.ShortTitle)
+	if in.RunID == "" || in.ProjectID == "" || in.UserID == "" || in.ShortTitle == "" {
+		return models.TaskIdentity{}, fmt.Errorf("run, project, user and short title are required")
+	}
+	var out models.TaskIdentity
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		err := tx.Where("run_id = ? AND project_id = ? AND user_id = ?", in.RunID, in.ProjectID, in.UserID).First(&out).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			out = models.TaskIdentity{
+				RunID: in.RunID, ProjectID: in.ProjectID, UserID: in.UserID,
+				ShortTitle: in.ShortTitle, OriginalRequirement: strings.TrimSpace(in.OriginalRequirement),
+				Aliases: uniqueStrings(in.Aliases), Keywords: uniqueStrings(in.Keywords), Status: strings.TrimSpace(in.Status),
+			}
+			return tx.Create(&out).Error
+		}
+		if err != nil {
+			return err
+		}
+		aliases := append([]string(nil), out.Aliases...)
+		if out.ShortTitle != "" && !strings.EqualFold(out.ShortTitle, in.ShortTitle) {
+			aliases = append(aliases, out.ShortTitle)
+		}
+		aliases = append(aliases, in.Aliases...)
+		out.ProjectID, out.UserID, out.ShortTitle = in.ProjectID, in.UserID, in.ShortTitle
+		if strings.TrimSpace(in.OriginalRequirement) != "" {
+			out.OriginalRequirement = strings.TrimSpace(in.OriginalRequirement)
+		}
+		out.Aliases = uniqueStrings(aliases)
+		out.Keywords = uniqueStrings(in.Keywords)
+		if strings.TrimSpace(in.Status) != "" {
+			out.Status = strings.TrimSpace(in.Status)
+		}
+		return tx.Save(&out).Error
+	})
+	return out, err
+}
+
+func (s *TaskContextService) UpdateTaskTitle(projectID, userID, runID, title string) (models.TaskIdentity, error) {
+	var cur models.TaskIdentity
+	if err := s.db.Where("project_id = ? AND user_id = ? AND run_id = ?", projectID, userID, runID).First(&cur).Error; err != nil {
+		return cur, err
+	}
+	return s.UpsertTaskIdentity(TaskIdentityInput{
+		RunID: cur.RunID, ProjectID: cur.ProjectID, UserID: cur.UserID, ShortTitle: title,
+		OriginalRequirement: cur.OriginalRequirement, Aliases: cur.Aliases, Keywords: cur.Keywords, Status: cur.Status,
+	})
+}
+
+func (s *TaskContextService) UpdateTaskStatus(projectID, userID, runID, status string) error {
+	return s.db.Model(&models.TaskIdentity{}).
+		Where("project_id = ? AND user_id = ? AND run_id = ?", projectID, userID, runID).
+		Update("status", strings.TrimSpace(status)).Error
+}
+
+func (s *TaskContextService) GetTaskIdentity(projectID, userID, runID string) (models.TaskIdentity, error) {
+	var out models.TaskIdentity
+	err := s.db.Where("project_id = ? AND user_id = ? AND run_id = ?", projectID, userID, runID).First(&out).Error
+	return out, err
+}
+
+func (s *TaskContextService) BindExternalMessage(binding models.MessageBinding) error {
+	if s == nil || s.db == nil || strings.TrimSpace(binding.MessageID) == "" || strings.TrimSpace(binding.RunID) == "" {
+		return fmt.Errorf("message binding requires message and run")
+	}
+	return s.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "project_id"}, {Name: "channel"}, {Name: "conversation_id"}, {Name: "message_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"user_id", "run_id"}),
+	}).Create(&binding).Error
+}
+
+func (s *TaskContextService) GetMessageBinding(projectID, channel, conversationID, messageID string) (models.MessageBinding, error) {
+	var out models.MessageBinding
+	err := s.db.Where("project_id = ? AND channel = ? AND conversation_id = ? AND message_id = ?",
+		projectID, channel, conversationID, messageID).First(&out).Error
+	return out, err
+}
+
+func (s *TaskContextService) TouchConversationFocus(projectID, channel, conversationID, userID, runID string) error {
+	now := s.now()
+	row := models.ConversationFocus{
+		ProjectID: projectID, Channel: channel, ConversationID: conversationID, UserID: userID,
+		RunID: runID, PendingRunIDs: []string{}, ExpiresAt: now.Add(ConversationFocusTTL), UpdatedAt: now,
+	}
+	return s.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "project_id"}, {Name: "channel"}, {Name: "conversation_id"}, {Name: "user_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"run_id", "pending_run_ids", "expires_at", "updated_at"}),
+	}).Create(&row).Error
+}
+
+func (s *TaskContextService) SetAmbiguityCandidates(projectID, channel, conversationID, userID string, runIDs []string) error {
+	now := s.now()
+	row := models.ConversationFocus{
+		ProjectID: projectID, Channel: channel, ConversationID: conversationID, UserID: userID,
+		PendingRunIDs: uniqueStrings(runIDs), ExpiresAt: now.Add(ConversationFocusTTL), UpdatedAt: now,
+	}
+	return s.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "project_id"}, {Name: "channel"}, {Name: "conversation_id"}, {Name: "user_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"run_id", "pending_run_ids", "expires_at", "updated_at"}),
+	}).Create(&row).Error
+}
+
+func (s *TaskContextService) GetConversationFocus(projectID, channel, conversationID, userID string) (models.ConversationFocus, error) {
+	var out models.ConversationFocus
+	err := s.db.Where("project_id = ? AND channel = ? AND conversation_id = ? AND user_id = ? AND expires_at > ?",
+		projectID, channel, conversationID, userID, s.now()).First(&out).Error
+	return out, err
+}
+
+// RememberConversationLanguage records the IM copy language. It deliberately
+// never touches ExpiresAt: only a successful bind/select/continue renews focus,
+// so passive chatter cannot keep a stale task selected alive.
+func (s *TaskContextService) RememberConversationLanguage(projectID, channel, conversationID, userID, language string) error {
+	if language != "en" && language != "zh-CN" {
+		return nil
+	}
+	now := s.now()
+	_ = s.db.Model(&models.ConversationFocus{}).
+		Where("project_id = ? AND channel = ? AND conversation_id = ? AND user_id = ? AND expires_at <= ?",
+			projectID, channel, conversationID, userID, now).
+		Updates(map[string]any{"run_id": "", "pending_run_ids": []string{}}).Error
+	// A language-only row carries a zero ExpiresAt, so it is never an active
+	// focus; TouchConversationFocus is the only writer that sets one.
+	row := models.ConversationFocus{
+		ProjectID: projectID, Channel: channel, ConversationID: conversationID, UserID: userID,
+		Language: language, UpdatedAt: now,
+	}
+	return s.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "project_id"}, {Name: "channel"}, {Name: "conversation_id"}, {Name: "user_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"language", "updated_at"}),
+	}).Create(&row).Error
+}
+
+// ConversationLanguage reads remembered copy language independently of focus
+// expiry.
+func (s *TaskContextService) ConversationLanguage(projectID, channel, conversationID, userID string) string {
+	var row models.ConversationFocus
+	err := s.db.Select("language").
+		Where("project_id = ? AND channel = ? AND conversation_id = ? AND user_id = ?",
+			projectID, channel, conversationID, userID).First(&row).Error
+	if err != nil {
+		return ""
+	}
+	return row.Language
+}
+
+type TaskResolveRequest struct {
+	ProjectID, UserID, Query, Channel, ConversationID string
+	Now                                               time.Time
+}
+
+type TaskCandidate struct {
+	Task    models.TaskIdentity `json:"task"`
+	Score   int                 `json:"score"`
+	Reasons []string            `json:"reasons"`
+}
+
+type TaskResolution struct {
+	Task       *models.TaskIdentity `json:"task,omitempty"`
+	Candidates []TaskCandidate      `json:"candidates,omitempty"`
+	Ambiguous  bool                 `json:"ambiguous"`
+}
+
+// ResolveTask searches only the requesting project+user. Active tasks and
+// terminal tasks updated in the last 30 days are eligible.
+func (s *TaskContextService) ResolveTask(req TaskResolveRequest) (TaskResolution, error) {
+	now := req.Now
+	if now.IsZero() {
+		now = s.now()
+	}
+	if err := s.materializeTaskIdentities(req.ProjectID, req.UserID, req.Query); err != nil {
+		return TaskResolution{}, err
+	}
+	var rows []models.TaskIdentity
+	if err := s.db.Where("project_id = ? AND user_id = ?", req.ProjectID, req.UserID).
+		Where("status NOT IN ? OR updated_at >= ?", terminalTaskStatuses(), now.Add(-TaskTerminalLookback)).
+		Find(&rows).Error; err != nil {
+		return TaskResolution{}, err
+	}
+	focusRun := ""
+	if req.Channel != "" && req.ConversationID != "" {
+		var focus models.ConversationFocus
+		if err := s.db.Where("project_id = ? AND channel = ? AND conversation_id = ? AND user_id = ? AND expires_at > ?",
+			req.ProjectID, req.Channel, req.ConversationID, req.UserID, now).First(&focus).Error; err == nil {
+			focusRun = focus.RunID
+		}
+	}
+	q := normalizeSearch(req.Query)
+	candidates := make([]TaskCandidate, 0, len(rows))
+	for _, row := range rows {
+		score, reasons := scoreTask(row, q, focusRun, now)
+		if score > 0 {
+			candidates = append(candidates, TaskCandidate{Task: row, Score: score, Reasons: reasons})
+		}
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].Score != candidates[j].Score {
+			return candidates[i].Score > candidates[j].Score
+		}
+		return candidates[i].Task.UpdatedAt.After(candidates[j].Task.UpdatedAt)
+	})
+	if len(candidates) == 0 {
+		return TaskResolution{}, ErrTaskNotFound
+	}
+	// Exact title is always explainable and unique within the candidate set.
+	if candidates[0].Score >= 100 && (len(candidates) == 1 || candidates[0].Score > candidates[1].Score) {
+		task := candidates[0].Task
+		return TaskResolution{Task: &task, Candidates: candidates[:1]}, nil
+	}
+	// Otherwise require a high score and a meaningful margin.
+	if candidates[0].Score >= 70 && (len(candidates) == 1 || candidates[0].Score-candidates[1].Score >= 20) {
+		task := candidates[0].Task
+		return TaskResolution{Task: &task, Candidates: candidates[:1]}, nil
+	}
+	if len(candidates) > 5 {
+		candidates = candidates[:5]
+	}
+	return TaskResolution{Candidates: candidates, Ambiguous: true}, ErrTaskAmbiguous
+}
+
+// MaterializeTaskIdentities projects canonical Runs into the current external
+// user scope. It never reads Runs from another project and never copies an
+// identity between users.
+func (s *TaskContextService) MaterializeTaskIdentities(projectID, userID string) error {
+	return s.materializeTaskIdentities(projectID, userID, "")
+}
+
+func (s *TaskContextService) materializeTaskIdentities(projectID, userID, query string) error {
+	if s == nil || s.db == nil || strings.TrimSpace(projectID) == "" || strings.TrimSpace(userID) == "" {
+		return fmt.Errorf("project and user are required")
+	}
+	if !s.db.Migrator().HasTable(&models.Run{}) || !s.db.Migrator().HasTable(&models.WorkflowDef{}) {
+		return nil
+	}
+	type scopedRun struct {
+		models.Run
+		ProjectID       string
+		WorkflowDisplay string
+	}
+	var runs []scopedRun
+	err := s.db.Table("runs").
+		Select("runs.*, workflow_defs.project_id AS project_id, workflow_defs.name AS workflow_display").
+		Joins("JOIN workflow_defs ON workflow_defs.id = runs.workflow_id").
+		Where("workflow_defs.project_id = ?", projectID).
+		Find(&runs).Error
+	if err != nil {
+		return err
+	}
+	for _, scoped := range runs {
+		original := originalRequirement(scoped.Run.Inputs)
+		title := naturalTaskTitle(scoped.Run.Title, original, scoped.WorkflowDisplay, scoped.Run.ID)
+		if strings.TrimSpace(query) != "" && !materializationMatches(query, title, original, scoped.WorkflowDisplay, scoped.Run.ID) {
+			continue
+		}
+		var owner models.TaskIdentity
+		ownerErr := s.db.Select("id, user_id").Where("run_id = ? AND project_id = ?", scoped.Run.ID, projectID).Limit(1).Find(&owner).Error
+		if ownerErr != nil {
+			return ownerErr
+		}
+		if owner.ID != 0 && owner.UserID != userID {
+			continue
+		}
+		if owner.ID != 0 && strings.TrimSpace(owner.ShortTitle) != "" {
+			title = owner.ShortTitle
+		}
+		row, err := s.UpsertTaskIdentity(TaskIdentityInput{
+			RunID: scoped.Run.ID, ProjectID: projectID, UserID: userID,
+			ShortTitle: title, OriginalRequirement: original,
+			Keywords: taskKeywords(title, original, scoped.WorkflowDisplay), Status: scoped.Run.Status,
+		})
+		if err != nil {
+			return err
+		}
+		activityAt := scoped.Run.StartedAt
+		if activityAt.IsZero() {
+			activityAt = scoped.Run.CreatedAt
+		}
+		if scoped.Run.DurationSec > 0 {
+			activityAt = activityAt.Add(time.Duration(scoped.Run.DurationSec) * time.Second)
+		}
+		if !activityAt.IsZero() {
+			_ = s.db.Model(&models.TaskIdentity{}).Where("id = ?", row.ID).UpdateColumn("updated_at", activityAt).Error
+		}
+	}
+	return nil
+}
+
+func materializationMatches(query string, fields ...string) bool {
+	q := normalizeSearch(query)
+	for _, field := range fields {
+		value := normalizeSearch(field)
+		if value != "" && (strings.Contains(q, value) || strings.Contains(value, q)) {
+			return true
+		}
+	}
+	return false
+}
+
+func originalRequirement(inputs map[string]any) string {
+	for _, key := range []string{"originalRequirement", "requirement", "task", "prompt", "query", "description"} {
+		if value, ok := inputs[key]; ok {
+			if text := strings.TrimSpace(fmt.Sprint(value)); text != "" && text != "<nil>" {
+				return truncateTaskText(text, 500)
+			}
+		}
+	}
+	return ""
+}
+
+func naturalTaskTitle(runTitle, original, workflowName, runID string) string {
+	for _, candidate := range []string{runTitle, original, workflowName, runID} {
+		if text := strings.TrimSpace(candidate); text != "" {
+			if line := strings.IndexAny(text, "\r\n"); line >= 0 {
+				text = text[:line]
+			}
+			return truncateTaskText(text, 30)
+		}
+	}
+	return "任务"
+}
+
+func truncateTaskText(text string, max int) string {
+	runes := []rune(strings.TrimSpace(text))
+	if len(runes) <= max {
+		return string(runes)
+	}
+	return string(runes[:max]) + "…"
+}
+
+func taskKeywords(parts ...string) []string {
+	var out []string
+	for _, part := range parts {
+		for _, token := range strings.FieldsFunc(part, func(r rune) bool {
+			return unicode.IsSpace(r) || strings.ContainsRune("，。！？、,.;:!?[]【】()（）/_-", r)
+		}) {
+			token = truncateTaskText(token, 32)
+			if len([]rune(token)) >= 2 {
+				out = append(out, token)
+			}
+		}
+	}
+	return uniqueStrings(out)
+}
+
+// SelectTaskCandidate accepts a one-based sequence or exact short title.
+func SelectTaskCandidate(candidates []TaskCandidate, selection string) (models.TaskIdentity, error) {
+	sel := strings.TrimSpace(selection)
+	for _, c := range candidates {
+		if strings.EqualFold(strings.TrimSpace(c.Task.ShortTitle), sel) {
+			return c.Task, nil
+		}
+	}
+	var n int
+	if _, err := fmt.Sscanf(sel, "%d", &n); err == nil && n >= 1 && n <= len(candidates) {
+		return candidates[n-1].Task, nil
+	}
+	return models.TaskIdentity{}, ErrTaskNotFound
+}
+
+func (s *TaskContextService) SelectPendingCandidate(projectID, channel, conversationID, userID, selection string) (models.TaskIdentity, error) {
+	focus, err := s.GetConversationFocus(projectID, channel, conversationID, userID)
+	if err != nil || len(focus.PendingRunIDs) == 0 {
+		return models.TaskIdentity{}, ErrTaskNotFound
+	}
+	var rows []models.TaskIdentity
+	if err := s.db.Where("project_id = ? AND user_id = ? AND run_id IN ?", projectID, userID, focus.PendingRunIDs).Find(&rows).Error; err != nil {
+		return models.TaskIdentity{}, err
+	}
+	byID := make(map[string]models.TaskIdentity, len(rows))
+	for _, row := range rows {
+		byID[row.RunID] = row
+	}
+	candidates := make([]TaskCandidate, 0, len(focus.PendingRunIDs))
+	for _, runID := range focus.PendingRunIDs {
+		if row, ok := byID[runID]; ok {
+			candidates = append(candidates, TaskCandidate{Task: row})
+		}
+	}
+	picked, err := SelectTaskCandidate(candidates, selection)
+	if err != nil {
+		return models.TaskIdentity{}, err
+	}
+	if err := s.TouchConversationFocus(projectID, channel, conversationID, userID, picked.RunID); err != nil {
+		return models.TaskIdentity{}, err
+	}
+	return picked, nil
+}
+
+func scoreTask(t models.TaskIdentity, q, focusRun string, now time.Time) (int, []string) {
+	score := 0
+	var why []string
+	title := normalizeSearch(t.ShortTitle)
+	if q != "" && title == q {
+		score += 100
+		why = append(why, "exact_title")
+	} else if q != "" && strings.Contains(title, q) {
+		score += 55
+		why = append(why, "title")
+	} else if q != "" && title != "" && strings.Contains(q, title) {
+		score += 50
+		why = append(why, "title_in_query")
+	}
+	original := normalizeSearch(t.OriginalRequirement)
+	if q != "" && (strings.Contains(original, q) || (original != "" && strings.Contains(q, original))) {
+		score += 35
+		why = append(why, "original_requirement")
+	}
+	for _, alias := range t.Aliases {
+		if q != "" && normalizeSearch(alias) == q {
+			score += 70
+			why = append(why, "exact_alias")
+			break
+		}
+		if q != "" && strings.Contains(normalizeSearch(alias), q) {
+			score += 30
+			why = append(why, "alias")
+			break
+		}
+		if q != "" && normalizeSearch(alias) != "" && strings.Contains(q, normalizeSearch(alias)) {
+			score += 28
+			why = append(why, "alias_in_query")
+			break
+		}
+	}
+	for _, kw := range t.Keywords {
+		if q != "" && strings.Contains(normalizeSearch(kw), q) {
+			score += 15
+			why = append(why, "keyword")
+			break
+		}
+	}
+	if !isTerminalTaskStatus(t.Status) {
+		score += 15
+		why = append(why, "active")
+	}
+	if t.RunID == focusRun {
+		score += 25
+		why = append(why, "conversation_focus")
+	}
+	if now.Sub(t.UpdatedAt) <= 24*time.Hour {
+		score += 5
+		why = append(why, "recent")
+	}
+	return score, why
+}
+
+func normalizeSearch(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) || strings.ContainsRune("，。！？、,.;:!?[]【】()（）-_", r) {
+			return -1
+		}
+		return unicode.ToLower(r)
+	}, strings.TrimSpace(s))
+}
+
+func terminalTaskStatuses() []string { return []string{"completed", "failed", "cancelled"} }
+func isTerminalTaskStatus(s string) bool {
+	for _, v := range terminalTaskStatuses() {
+		if strings.EqualFold(strings.TrimSpace(s), v) {
+			return true
+		}
+	}
+	return false
+}
+
+func uniqueStrings(in []string) []string {
+	out := make([]string, 0, len(in))
+	seen := map[string]bool{}
+	for _, raw := range in {
+		v := strings.TrimSpace(raw)
+		if v == "" {
+			continue
+		}
+		k := strings.ToLower(v)
+		if !seen[k] {
+			seen[k] = true
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+type RiskTicketResult struct {
+	Ticket  models.RiskConfirmationTicket
+	Latest  *models.RiskConfirmationTicket
+	Confirm bool
+	Cancel  bool
+	Stale   bool
+}
+
+func (s *TaskContextService) CreateRiskConfirmation(projectID, userID, runID, action string) (models.RiskConfirmationTicket, error) {
+	return s.CreateRiskConfirmationWithKind(projectID, userID, runID, "", action)
+}
+
+func (s *TaskContextService) CreateRiskConfirmationWithKind(projectID, userID, runID, actionKind, action string) (models.RiskConfirmationTicket, error) {
+	now := s.now()
+	t := models.RiskConfirmationTicket{
+		ID: "confirm-" + uuid.NewString()[:12], ProjectID: projectID, UserID: userID, RunID: runID,
+		Action: action, ActionKind: actionKind, Status: models.RiskTicketPending,
+		ExpiresAt: now.Add(RiskTicketTTL), CreatedAt: now, UpdatedAt: now,
+	}
+	return t, s.db.Create(&t).Error
+}
+
+// ConsumeRiskConfirmation atomically consumes one pending ticket. Chinese and
+// English affirmative/cancel replies are accepted; stale/repeated replies
+// return the latest ticket and cannot authorize execution again.
+func (s *TaskContextService) ConsumeRiskConfirmation(projectID, userID, runID, action, reply string) (RiskTicketResult, error) {
+	decision, ok := ParseConfirmationReply(reply)
+	if !ok {
+		return RiskTicketResult{}, ErrInvalidConfirmation
+	}
+	now := s.now()
+	var ticket models.RiskConfirmationTicket
+	err := s.db.Where("project_id = ? AND user_id = ? AND run_id = ? AND action = ?",
+		projectID, userID, runID, action).Order("created_at desc").First(&ticket).Error
+	if err != nil {
+		return RiskTicketResult{}, err
+	}
+	status := "confirmed"
+	if !decision {
+		status = "cancelled"
+	}
+	updates := map[string]any{"status": status, "consumed_at": now, "updated_at": now}
+	if decision {
+		// Confirming turns the ticket into the persistent authorization grant.
+		grantUntil := now.Add(RiskGrantTTL)
+		updates["grant_expires_at"] = grantUntil
+	}
+	res := s.db.Model(&models.RiskConfirmationTicket{}).
+		Where("id = ? AND status = ? AND expires_at > ?", ticket.ID, models.RiskTicketPending, now).
+		Updates(updates)
+	if res.Error != nil {
+		return RiskTicketResult{}, res.Error
+	}
+	if res.RowsAffected == 1 {
+		ticket.Status, ticket.ConsumedAt, ticket.UpdatedAt = status, &now, now
+		return RiskTicketResult{Ticket: ticket, Confirm: decision, Cancel: !decision}, nil
+	}
+	latest := ticket
+	_ = s.db.First(&latest, "id = ?", ticket.ID).Error
+	if latest.Status == models.RiskTicketPending && !latest.ExpiresAt.After(now) {
+		_ = s.db.Model(&latest).Where("status = ?", models.RiskTicketPending).
+			Update("status", models.RiskTicketExpired).Error
+		latest.Status = models.RiskTicketExpired
+	}
+	return RiskTicketResult{Ticket: ticket, Latest: &latest, Stale: true}, ErrConfirmationStale
+}
+
+// GuardChannelThread marks a PM thread as channel-originated. Guarded threads
+// may only perform destructive PM MCP mutations against a confirmed ticket.
+func (s *TaskContextService) GuardChannelThread(projectID, threadID, channel, userID string) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("task context unavailable")
+	}
+	if strings.TrimSpace(projectID) == "" || strings.TrimSpace(threadID) == "" {
+		return fmt.Errorf("project and thread are required")
+	}
+	now := s.now()
+	row := models.ChannelActionGuard{
+		ProjectID: projectID, ThreadID: threadID, Channel: channel, UserID: userID,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	return s.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "project_id"}, {Name: "thread_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"channel", "user_id", "updated_at"}),
+	}).Create(&row).Error
+}
+
+// IsGuardedThread reports whether destructive mutations on this thread need an
+// explicit grant. Unknown threads (web/API consults) are not guarded.
+func (s *TaskContextService) IsGuardedThread(projectID, threadID string) bool {
+	if s == nil || s.db == nil {
+		return false
+	}
+	var count int64
+	if err := s.db.Model(&models.ChannelActionGuard{}).
+		Where("project_id = ? AND thread_id = ?", projectID, threadID).Count(&count).Error; err != nil {
+		return false
+	}
+	return count > 0
+}
+
+// BindActionGrant attaches a confirmed ticket to the thread allowed to spend
+// it. Only a confirmed ticket can be bound.
+func (s *TaskContextService) BindActionGrant(ticketID, threadID string) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("task context unavailable")
+	}
+	res := s.db.Model(&models.RiskConfirmationTicket{}).
+		Where("id = ? AND status = ?", ticketID, models.RiskTicketConfirmed).
+		Updates(map[string]any{"thread_id": threadID, "updated_at": s.now()})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected != 1 {
+		return ErrActionNotAuthorized
+	}
+	return nil
+}
+
+// ReleaseActionGrant retires a grant that the authorizing turn did not spend,
+// so it can never be replayed by a later turn on the same thread.
+func (s *TaskContextService) ReleaseActionGrant(ticketID string) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Model(&models.RiskConfirmationTicket{}).
+		Where("id = ? AND status = ?", ticketID, models.RiskTicketConfirmed).
+		Updates(map[string]any{"status": models.RiskTicketExpired, "updated_at": s.now()}).Error
+}
+
+// ConsumeActionGrant is the server-side authorization check executed by the
+// destructive method itself. It succeeds at most once per ticket, and only for
+// the exact project, thread, target and action kind the user confirmed.
+func (s *TaskContextService) ConsumeActionGrant(projectID, threadID, target, actionKind string) error {
+	if s == nil || s.db == nil {
+		return ErrActionNotAuthorized
+	}
+	target, actionKind = strings.TrimSpace(target), strings.TrimSpace(actionKind)
+	if projectID == "" || threadID == "" || target == "" || actionKind == "" {
+		return ErrActionNotAuthorized
+	}
+	now := s.now()
+	var ticket models.RiskConfirmationTicket
+	err := s.db.Where("project_id = ? AND thread_id = ? AND run_id = ? AND action_kind = ? AND status = ?",
+		projectID, threadID, target, actionKind, models.RiskTicketConfirmed).
+		Where("grant_expires_at IS NOT NULL AND grant_expires_at > ?", now).
+		Order("updated_at desc").First(&ticket).Error
+	if err != nil {
+		return ErrActionNotAuthorized
+	}
+	res := s.db.Model(&models.RiskConfirmationTicket{}).
+		Where("id = ? AND status = ?", ticket.ID, models.RiskTicketConfirmed).
+		Updates(map[string]any{
+			"status": models.RiskTicketExecuted, "executed_at": now, "updated_at": now,
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected != 1 {
+		return ErrActionNotAuthorized
+	}
+	return nil
+}
+
+func (s *TaskContextService) ConsumeLatestRiskConfirmation(projectID, userID, reply string) (RiskTicketResult, error) {
+	var ticket models.RiskConfirmationTicket
+	err := s.db.Where("project_id = ? AND user_id = ?", projectID, userID).
+		Order("created_at desc").First(&ticket).Error
+	if err != nil {
+		return RiskTicketResult{}, err
+	}
+	return s.ConsumeRiskConfirmation(projectID, userID, ticket.RunID, ticket.Action, reply)
+}
+
+func ParseConfirmationReply(reply string) (confirm bool, ok bool) {
+	v := strings.ToLower(strings.TrimSpace(reply))
+	switch v {
+	case "确认", "确认执行", "同意", "是", "yes", "y", "confirm", "proceed":
+		return true, true
+	case "取消", "不同意", "否", "no", "n", "cancel", "stop":
+		return false, true
+	default:
+		return false, false
+	}
+}

--- a/server/internal/services/task_context_grant_test.go
+++ b/server/internal/services/task_context_grant_test.go
@@ -1,0 +1,170 @@
+package services
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func grantFixture(t *testing.T) (*TaskContextService, *time.Time) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(
+		&models.RiskConfirmationTicket{}, &models.ChannelActionGuard{}, &models.ConversationFocus{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	clock := time.Now().UTC()
+	svc := NewTaskContextService(db)
+	svc.now = func() time.Time { return clock }
+	return svc, &clock
+}
+
+func confirmedTicket(t *testing.T, svc *TaskContextService, runID, kind, threadID string) models.RiskConfirmationTicket {
+	t.Helper()
+	ticket, err := svc.CreateRiskConfirmationWithKind("p1", "qq:c2c:u1", runID, kind, kind+" "+runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.ConsumeRiskConfirmation("p1", "qq:c2c:u1", runID, ticket.Action, "确认"); err != nil {
+		t.Fatal(err)
+	}
+	if threadID != "" {
+		if err := svc.BindActionGrant(ticket.ID, threadID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return ticket
+}
+
+func TestChannelThreadGuardScopesEnforcement(t *testing.T) {
+	svc, _ := grantFixture(t)
+	if svc.IsGuardedThread("p1", "thr-web") {
+		t.Fatal("an unknown (web/API) thread must not be guarded")
+	}
+	if err := svc.GuardChannelThread("p1", "thr-qq", "qq", "qq:c2c:u1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.GuardChannelThread("p1", "thr-qq", "qq", "qq:c2c:u1"); err != nil {
+		t.Fatalf("guard upsert is not idempotent: %v", err)
+	}
+	if !svc.IsGuardedThread("p1", "thr-qq") {
+		t.Fatal("channel thread must be guarded")
+	}
+	if svc.IsGuardedThread("p2", "thr-qq") {
+		t.Fatal("guard leaked across projects")
+	}
+}
+
+func TestActionGrantIsSingleUseAndExactlyScoped(t *testing.T) {
+	svc, clock := grantFixture(t)
+
+	// No ticket at all.
+	if err := svc.ConsumeActionGrant("p1", "thr-qq", "run-1", "cancel"); !errors.Is(err, ErrActionNotAuthorized) {
+		t.Fatalf("missing ticket was authorized: %v", err)
+	}
+
+	// A pending (unconfirmed) ticket is not a grant.
+	pending, err := svc.CreateRiskConfirmationWithKind("p1", "qq:c2c:u1", "run-1", "cancel", "cancel run-1 (unconfirmed)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.BindActionGrant(pending.ID, "thr-qq"); !errors.Is(err, ErrActionNotAuthorized) {
+		t.Fatalf("pending ticket was bindable: %v", err)
+	}
+	if err := svc.ConsumeActionGrant("p1", "thr-qq", "run-1", "cancel"); !errors.Is(err, ErrActionNotAuthorized) {
+		t.Fatalf("pending ticket authorized execution: %v", err)
+	}
+
+	ticket := confirmedTicket(t, svc, "run-1", "cancel", "thr-qq")
+	for _, bad := range []struct{ project, thread, target, kind string }{
+		{"p1", "thr-qq", "run-2", "cancel"},
+		{"p1", "thr-qq", "run-1", "delete"},
+		{"p1", "thr-other", "run-1", "cancel"},
+		{"p2", "thr-qq", "run-1", "cancel"},
+	} {
+		if err := svc.ConsumeActionGrant(bad.project, bad.thread, bad.target, bad.kind); !errors.Is(err, ErrActionNotAuthorized) {
+			t.Fatalf("grant accepted %+v: %v", bad, err)
+		}
+	}
+	if err := svc.ConsumeActionGrant("p1", "thr-qq", "run-1", "cancel"); err != nil {
+		t.Fatalf("exact confirmed grant denied: %v", err)
+	}
+	if err := svc.ConsumeActionGrant("p1", "thr-qq", "run-1", "cancel"); !errors.Is(err, ErrActionNotAuthorized) {
+		t.Fatal("grant was spendable twice")
+	}
+	var row models.RiskConfirmationTicket
+	if err := svc.db.First(&row, "id = ?", ticket.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if row.Status != models.RiskTicketExecuted || row.ExecutedAt == nil {
+		t.Fatalf("ticket after execution = %#v", row)
+	}
+
+	// A grant the authorizing turn never spent is retired.
+	unused := confirmedTicket(t, svc, "run-3", "approve", "thr-qq")
+	if err := svc.ReleaseActionGrant(unused.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.ConsumeActionGrant("p1", "thr-qq", "run-3", "approve"); !errors.Is(err, ErrActionNotAuthorized) {
+		t.Fatal("released grant was still spendable")
+	}
+
+	// Grants expire on their own even if never released.
+	confirmedTicket(t, svc, "run-4", "reject", "thr-qq")
+	*clock = clock.Add(RiskGrantTTL + time.Second)
+	if err := svc.ConsumeActionGrant("p1", "thr-qq", "run-4", "reject"); !errors.Is(err, ErrActionNotAuthorized) {
+		t.Fatal("expired grant was spendable")
+	}
+}
+
+func TestConversationFocusTTLIsExactAndLanguageDoesNotRenew(t *testing.T) {
+	svc, clock := grantFixture(t)
+	start := *clock
+	if err := svc.TouchConversationFocus("p1", "qq", "conv", "u1", "run-1"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Passive language tracking one second before expiry must not extend it.
+	*clock = start.Add(ConversationFocusTTL - time.Second)
+	if err := svc.RememberConversationLanguage("p1", "qq", "conv", "u1", "en"); err != nil {
+		t.Fatal(err)
+	}
+	if focus, err := svc.GetConversationFocus("p1", "qq", "conv", "u1"); err != nil || focus.RunID != "run-1" {
+		t.Fatalf("focus expired early: %#v %v", focus, err)
+	}
+	*clock = start.Add(ConversationFocusTTL)
+	if _, err := svc.GetConversationFocus("p1", "qq", "conv", "u1"); err == nil {
+		t.Fatal("focus outlived its exact 30m TTL after a language update")
+	}
+	if got := svc.ConversationLanguage("p1", "qq", "conv", "u1"); got != "en" {
+		t.Fatalf("remembered language = %q", got)
+	}
+
+	// Only a successful bind/select/continue renews.
+	if err := svc.TouchConversationFocus("p1", "qq", "conv", "u1", "run-1"); err != nil {
+		t.Fatal(err)
+	}
+	*clock = start.Add(ConversationFocusTTL).Add(ConversationFocusTTL - time.Second)
+	if focus, err := svc.GetConversationFocus("p1", "qq", "conv", "u1"); err != nil || focus.RunID != "run-1" {
+		t.Fatalf("renewed focus = %#v %v", focus, err)
+	}
+
+	// A language-only row never creates an active focus.
+	if err := svc.RememberConversationLanguage("p1", "qq", "fresh", "u2", "zh-CN"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.GetConversationFocus("p1", "qq", "fresh", "u2"); err == nil {
+		t.Fatal("language memory created a focus")
+	}
+	if got := svc.ConversationLanguage("p1", "qq", "fresh", "u2"); got != "zh-CN" {
+		t.Fatalf("fresh language = %q", got)
+	}
+}

--- a/server/internal/services/task_context_test.go
+++ b/server/internal/services/task_context_test.go
@@ -1,0 +1,101 @@
+package services
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func taskContextTestService(t *testing.T) *TaskContextService {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.TaskIdentity{}, &models.MessageBinding{}, &models.ConversationFocus{}, &models.RiskConfirmationTicket{}); err != nil {
+		t.Fatal(err)
+	}
+	return NewTaskContextService(db)
+}
+
+func TestTaskIdentityRenameResolveAndScope(t *testing.T) {
+	s := taskContextTestService(t)
+	now := time.Date(2026, 8, 6, 0, 0, 0, 0, time.UTC)
+	s.now = func() time.Time { return now }
+	in := TaskIdentityInput{
+		RunID: "r1", ProjectID: "p1", UserID: "u1", ShortTitle: "支付修复",
+		OriginalRequirement: "修复支付回调重复扣款", Keywords: []string{"支付", "回调"}, Status: "running",
+	}
+	if _, err := s.UpsertTaskIdentity(in); err != nil {
+		t.Fatal(err)
+	}
+	renamed, err := s.UpdateTaskTitle("p1", "u1", "r1", "支付幂等修复")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(renamed.Aliases) != 1 || renamed.Aliases[0] != "支付修复" {
+		t.Fatalf("aliases not preserved: %#v", renamed.Aliases)
+	}
+	res, err := s.ResolveTask(TaskResolveRequest{ProjectID: "p1", UserID: "u1", Query: "支付修复", Now: now})
+	if err != nil || res.Task == nil || res.Task.RunID != "r1" {
+		t.Fatalf("alias resolve: %#v, %v", res, err)
+	}
+	if _, err := s.ResolveTask(TaskResolveRequest{ProjectID: "other", UserID: "u1", Query: "支付修复", Now: now}); !errors.Is(err, ErrTaskNotFound) {
+		t.Fatalf("cross-project leaked: %v", err)
+	}
+}
+
+func TestConversationFocusExpiresAndCandidatesSelect(t *testing.T) {
+	s := taskContextTestService(t)
+	now := time.Now().UTC()
+	s.now = func() time.Time { return now }
+	for _, id := range []string{"r1", "r2"} {
+		if _, err := s.UpsertTaskIdentity(TaskIdentityInput{
+			RunID: id, ProjectID: "p", UserID: "u", ShortTitle: "发布" + id, OriginalRequirement: "发布服务", Status: "running",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := s.TouchConversationFocus("p", "qq", "c", "u", "r2"); err != nil {
+		t.Fatal(err)
+	}
+	res, err := s.ResolveTask(TaskResolveRequest{
+		ProjectID: "p", UserID: "u", Query: "发布服务", Channel: "qq", ConversationID: "c", Now: now,
+	})
+	if err != nil || res.Task == nil || res.Task.RunID != "r2" {
+		t.Fatalf("focus did not disambiguate: %#v %v", res, err)
+	}
+	picked, err := SelectTaskCandidate([]TaskCandidate{{Task: models.TaskIdentity{RunID: "r1", ShortTitle: "一"}}, {Task: models.TaskIdentity{RunID: "r2", ShortTitle: "二"}}}, "2")
+	if err != nil || picked.RunID != "r2" {
+		t.Fatalf("sequence selection: %#v %v", picked, err)
+	}
+}
+
+func TestRiskConfirmationOneTimeScopedAndExpires(t *testing.T) {
+	s := taskContextTestService(t)
+	now := time.Now().UTC()
+	s.now = func() time.Time { return now }
+	if _, err := s.CreateRiskConfirmation("p", "u", "r", "deploy"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.ConsumeRiskConfirmation("p", "u", "r", "deploy", "确认")
+	if err != nil || !got.Confirm {
+		t.Fatalf("confirm: %#v %v", got, err)
+	}
+	repeated, err := s.ConsumeRiskConfirmation("p", "u", "r", "deploy", "yes")
+	if !errors.Is(err, ErrConfirmationStale) || !repeated.Stale || repeated.Latest == nil {
+		t.Fatalf("repeat should return latest without reexecute: %#v %v", repeated, err)
+	}
+	if _, err := s.CreateRiskConfirmation("p", "u", "r", "delete"); err != nil {
+		t.Fatal(err)
+	}
+	s.now = func() time.Time { return now.Add(6 * time.Minute) }
+	expired, err := s.ConsumeRiskConfirmation("p", "u", "r", "delete", "confirm")
+	if !errors.Is(err, ErrConfirmationStale) || expired.Latest == nil || expired.Latest.Status != "expired" {
+		t.Fatalf("expired ticket: %#v %v", expired, err)
+	}
+}


### PR DESCRIPTION
## Summary
- enforce a first-class `internal|sendable` envelope at the sole IM egress, with per-Run progress compression, durable idempotency, bounded retries, and content-free delivery audits
- persist Run task identities, message bindings, expiring conversation focus, natural-language candidates, and bilingual short-title responses for QQ orchestration
- require one-time server-validated grants for channel-originated destructive PM actions and degrade QQ reply references to explicit natural-language resolution

## Demo acceptance
- 128 internal/background events are compressed to four external lifecycle messages in the flood test; ordinary progress is merged per Run while blocked/action-required/final bypass the progress window
- ambiguous login-page-style references return short-title candidates; selection establishes focus and expired focus does not guess
- high-risk requests echo the natural title, require a five-minute confirmation, and the PM MCP mutation consumes the exact run/action grant once

## Test plan
- [x] `cd server && go test ./...`
- [x] `cd server && go vet ./...`
- [x] `cd server && go run ./cmd/gen-configdoc -out CONFIGURATION.md -check`
- [x] `cd server && ./scripts/cover-check-server.sh 90`
- [x] `cd web && npm run lint`
- [x] `cd web && npm test -- --coverage`
- [x] `cd web && npm run build`

## Scope
No Voice/TTS, external database, vector store, or unrelated UI refactor is included.

Made with [Cursor](https://cursor.com)