### PR TITLE
feat: add Sendable routing and task context

### DIFF
--- a/server/cmd/server/channel_notify.go
+++ b/server/cmd/server/channel_notify.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/cocofhu/approving/internal/channels"
+	"github.com/cocofhu/approving/internal/pmmcp"
 	"github.com/cocofhu/approving/internal/sendable"
 )
 
@@ -13,19 +14,19 @@ type channelIMNotifier struct {
 	mgr *channels.Manager
 }
 
-func (n channelIMNotifier) NotifyRunAccepted(projectID, runID, userID, shortTitle, language string) error {
+func (n channelIMNotifier) NotifyRunAccepted(projectID, runID string, target pmmcp.IMTarget, shortTitle, language string) error {
 	if n.mgr == nil {
 		return nil
 	}
-	qqUser := strings.TrimPrefix(userID, "qq:")
 	_, err := n.mgr.SendRunAcceptanceAck(context.Background(), channels.RunAcceptanceAck{
-		ProjectID: projectID, RunID: runID, Scene: channels.SceneC2C,
-		ConversationID: "", UserID: qqUser, ShortTitle: shortTitle, Language: language,
+		ProjectID: projectID, RunID: runID, Scene: channels.Scene(target.Scene),
+		ConversationID: target.ConversationID, UserID: target.UserID,
+		ShortTitle: shortTitle, Language: language,
 	})
 	return err
 }
 
-func (n channelIMNotifier) NotifyProgress(projectID, runID, userID, kind, text, stage, conclusion string, blocked, actionRequired bool) error {
+func (n channelIMNotifier) NotifyProgress(projectID, runID string, target pmmcp.IMTarget, kind, text, stage, conclusion string, blocked, actionRequired bool) error {
 	if n.mgr == nil {
 		return nil
 	}
@@ -42,9 +43,9 @@ func (n channelIMNotifier) NotifyProgress(projectID, runID, userID, kind, text, 
 	if stage == "" && !blocked && !actionRequired && conclusion == "" {
 		stage = strings.TrimSpace(text)
 	}
-	qqUser := strings.TrimPrefix(userID, "qq:")
 	_, err := n.mgr.ReportRunProgress(context.Background(), channels.SendableRequest{
-		ProjectID: projectID, RunID: runID, UserID: qqUser,
+		ProjectID: projectID, RunID: runID, Scene: channels.Scene(target.Scene),
+		ConversationID: target.ConversationID, UserID: target.UserID,
 		Kind: skind, Reason: "pm_notify_progress", Priority: priority,
 		Progress: sendable.ProgressFields{
 			Stage: stage, Blocked: blocked, ActionRequired: actionRequired, Conclusion: conclusion,

--- a/server/cmd/server/channel_notify.go
+++ b/server/cmd/server/channel_notify.go
@@ -26,9 +26,9 @@ func (n channelIMNotifier) NotifyRunAccepted(projectID, runID string, target pmm
 	return err
 }
 
-func (n channelIMNotifier) NotifyProgress(projectID, runID string, target pmmcp.IMTarget, kind, text, stage, conclusion string, blocked, actionRequired bool) error {
+func (n channelIMNotifier) NotifyProgress(projectID, runID string, target pmmcp.IMTarget, kind, text, stage, conclusion string, blocked, actionRequired bool) (pmmcp.IMDeliveryOutcome, error) {
 	if n.mgr == nil {
-		return nil
+		return pmmcp.IMDeliveryOutcome{}, nil
 	}
 	skind := sendable.KindProgress
 	priority := sendable.PriorityNormal
@@ -43,7 +43,7 @@ func (n channelIMNotifier) NotifyProgress(projectID, runID string, target pmmcp.
 	if stage == "" && !blocked && !actionRequired && conclusion == "" {
 		stage = strings.TrimSpace(text)
 	}
-	_, err := n.mgr.ReportRunProgress(context.Background(), channels.SendableRequest{
+	result, err := n.mgr.ReportRunProgress(context.Background(), channels.SendableRequest{
 		ProjectID: projectID, RunID: runID, Scene: channels.Scene(target.Scene),
 		ConversationID: target.ConversationID, UserID: target.UserID,
 		Kind: skind, Reason: "pm_notify_progress", Priority: priority,
@@ -52,5 +52,10 @@ func (n channelIMNotifier) NotifyProgress(projectID, runID string, target pmmcp.
 		},
 		Text: text,
 	})
-	return err
+	if err != nil {
+		return pmmcp.IMDeliveryOutcome{}, err
+	}
+	// Only a real failure reaches the error branch above; a suppressed delivery
+	// is reported as a structured outcome so the agent does not retry it.
+	return pmmcp.IMDeliveryOutcome{Sent: result.Sent, Reason: result.Reason()}, nil
 }

--- a/server/cmd/server/channel_notify.go
+++ b/server/cmd/server/channel_notify.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/cocofhu/approving/internal/channels"
+	"github.com/cocofhu/approving/internal/sendable"
+)
+
+// channelIMNotifier adapts channels.Manager to pmmcp.ExternalIMNotifier.
+type channelIMNotifier struct {
+	mgr *channels.Manager
+}
+
+func (n channelIMNotifier) NotifyRunAccepted(projectID, runID, userID, shortTitle, language string) error {
+	if n.mgr == nil {
+		return nil
+	}
+	qqUser := strings.TrimPrefix(userID, "qq:")
+	_, err := n.mgr.SendRunAcceptanceAck(context.Background(), channels.RunAcceptanceAck{
+		ProjectID: projectID, RunID: runID, Scene: channels.SceneC2C,
+		ConversationID: "", UserID: qqUser, ShortTitle: shortTitle, Language: language,
+	})
+	return err
+}
+
+func (n channelIMNotifier) NotifyProgress(projectID, runID, userID, kind, text, stage, conclusion string, blocked, actionRequired bool) error {
+	if n.mgr == nil {
+		return nil
+	}
+	skind := sendable.KindProgress
+	priority := sendable.PriorityNormal
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "blocked":
+		skind, priority, blocked = sendable.KindBlocked, sendable.PriorityCritical, true
+	case "action_required", "confirm":
+		skind, priority, actionRequired = sendable.KindActionRequired, sendable.PriorityCritical, true
+	case "final":
+		skind, priority = sendable.KindFinal, sendable.PriorityCritical
+	}
+	if stage == "" && !blocked && !actionRequired && conclusion == "" {
+		stage = strings.TrimSpace(text)
+	}
+	qqUser := strings.TrimPrefix(userID, "qq:")
+	_, err := n.mgr.ReportRunProgress(context.Background(), channels.SendableRequest{
+		ProjectID: projectID, RunID: runID, UserID: qqUser,
+		Kind: skind, Reason: "pm_notify_progress", Priority: priority,
+		Progress: sendable.ProgressFields{
+			Stage: stage, Blocked: blocked, ActionRequired: actionRequired, Conclusion: conclusion,
+		},
+		Text: text,
+	})
+	return err
+}

--- a/server/cmd/server/channel_notify_test.go
+++ b/server/cmd/server/channel_notify_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/channels"
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/pmmcp"
+	"github.com/cocofhu/approving/internal/sendable"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// notifyFakeAdapter is a transport stub that always accepts and reports no
+// channel message id.
+type notifyFakeAdapter struct{}
+
+func (notifyFakeAdapter) Type() string { return "qq" }
+
+func (notifyFakeAdapter) Start(ctx context.Context, onInbound channels.InboundHandler) error {
+	return nil
+}
+
+func (notifyFakeAdapter) Send(ctx context.Context, out channels.OutboundMessage) (channels.SendResult, error) {
+	return channels.SendResult{}, nil
+}
+
+func (notifyFakeAdapter) Stop() error { return nil }
+
+func notifyTestManager(t *testing.T) *channels.Manager {
+	t.Helper()
+	db, err := gorm.Open(
+		sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"),
+		&gorm.Config{Logger: logger.Discard},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	if err := db.AutoMigrate(models.AllModels()...); err != nil {
+		t.Fatal(err)
+	}
+	m := channels.NewManager(nil, map[string]channels.AdapterFactory{
+		"qq": func(cfg channels.AdapterConfig) (channels.Adapter, error) {
+			return notifyFakeAdapter{}, nil
+		},
+	}, func(s string) (string, error) { return s, nil })
+	m.SetSendablePolicy(sendable.NewPolicy(db, nil))
+	m.SetRetryBackoff(func(int) time.Duration { return 0 })
+	return m
+}
+
+// TestChannelNotifierReportsSuppressionWithoutAnError pins the production seam
+// between the channel Manager and pm_notify_progress: policy suppression must
+// arrive as a structured outcome, and only an unreachable target is an error.
+func TestChannelNotifierReportsSuppressionWithoutAnError(t *testing.T) {
+	m := notifyTestManager(t)
+	m.Apply([]models.ChannelConfig{{
+		ID: "c1", Type: "qq", ProjectID: "proj", AppID: "app", Enabled: true,
+		CronDeliver: true, CronDeliverTarget: "c2c:user1",
+	}})
+	defer m.StopAll()
+
+	n := channelIMNotifier{mgr: m}
+	target := pmmcp.IMTarget{Scene: "c2c", ConversationID: "user1", UserID: "u1"}
+
+	outcome, err := n.NotifyProgress("proj", "run-1", target, "progress", "已提交分支", "已提交分支", "", false, false)
+	if err != nil || !outcome.Sent {
+		t.Fatalf("first progress = %+v err=%v want sent", outcome, err)
+	}
+
+	outcome, err = n.NotifyProgress("proj", "run-1", target, "progress", "已提交分支", "已提交分支", "", false, false)
+	if err != nil {
+		t.Fatalf("policy suppression must not surface as an error: %v", err)
+	}
+	if outcome.Sent || outcome.Reason == "" {
+		t.Fatalf("suppressed progress = %+v want sent=false with a reason", outcome)
+	}
+}
+
+func TestChannelNotifierReportsMissingTargetAsError(t *testing.T) {
+	m := notifyTestManager(t)
+	defer m.StopAll()
+
+	n := channelIMNotifier{mgr: m}
+	outcome, err := n.NotifyProgress("proj", "run-1",
+		pmmcp.IMTarget{Scene: "c2c", ConversationID: "user1", UserID: "u1"},
+		"progress", "已提交分支", "已提交分支", "", false, false)
+	if !errors.Is(err, channels.ErrNoSendableTarget) {
+		t.Fatalf("missing egress target = %+v err=%v want ErrNoSendableTarget", outcome, err)
+	}
+	if outcome.Sent {
+		t.Fatalf("missing target reported a send: %+v", outcome)
+	}
+}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -366,10 +366,7 @@ func main() {
 		})
 	})
 	channelMgr.SetSendablePolicy(deliveryPolicy)
-	// Task identities are derived from real Runs on demand, so IM callers never
-	// have to pre-register a task before addressing it.
 	taskContextSvc := services.NewTaskContextService(db)
-	taskContextSvc.EnableRunBackfill()
 	channelMgr.SetTaskContextService(taskContextSvc)
 	riskSvc := services.NewRiskConfirmationService(db)
 	channelMgr.SetRiskConfirmationService(riskSvc)

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cocofhu/approving/internal/runtime"
 	"github.com/cocofhu/approving/internal/sandbox"
 	"github.com/cocofhu/approving/internal/schedulermcp"
+	"github.com/cocofhu/approving/internal/sendable"
 	"github.com/cocofhu/approving/internal/services"
 	"github.com/cocofhu/approving/internal/shutdown"
 
@@ -347,6 +348,29 @@ func main() {
 	channelMgr := channels.NewManager(channelBridge, map[string]channels.AdapterFactory{
 		models.ChannelTypeQQ: qq.New,
 	}, crypto.Decrypt)
+	deliveryPolicy := sendable.NewPolicy(db, func(entry sendable.AuditEntry) {
+		outcome := models.AuditOutcomeOK
+		if entry.Result == "failed" {
+			outcome = models.AuditOutcomeFail
+		}
+		auditSvc.Record(services.AuditRecord{
+			ProjectID: entry.ProjectID, Actor: services.SystemActor(),
+			CallerKind: models.CallerKindSystem, Action: models.AuditActionDelivery,
+			ResourceType: "delivery", ResourceID: entry.DedupeKey,
+			RunID: entry.RunID, Outcome: outcome, Summary: "channel delivery " + entry.Result,
+			Payload: map[string]any{
+				"reason": entry.Reason, "run": entry.RunID, "channel": string(entry.Channel),
+				"dedupe": entry.DedupeKey, "result": entry.Result, "attempt": entry.Attempt,
+			},
+		})
+	})
+	channelMgr.SetSendablePolicy(deliveryPolicy)
+	// Task identities are derived from real Runs on demand, so IM callers never
+	// have to pre-register a task before addressing it.
+	taskContextSvc := services.NewTaskContextService(db)
+	taskContextSvc.EnableRunBackfill()
+	channelMgr.SetTaskContextService(taskContextSvc)
+	channelMgr.SetRiskConfirmationService(services.NewRiskConfirmationService(db))
 	channelMgr.SetLoader(channelSvc.ListRaw)
 	channelSvc.SetOnChange(channelMgr.Reload)
 	channelMgr.ApplyOnBoot()

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -370,7 +371,27 @@ func main() {
 	taskContextSvc := services.NewTaskContextService(db)
 	taskContextSvc.EnableRunBackfill()
 	channelMgr.SetTaskContextService(taskContextSvc)
-	channelMgr.SetRiskConfirmationService(services.NewRiskConfirmationService(db))
+	riskSvc := services.NewRiskConfirmationService(db)
+	channelMgr.SetRiskConfirmationService(riskSvc)
+	channelMgr.SetRiskActionExecutor(func(projectID, runID, action string, meta map[string]string) error {
+		switch action {
+		case "cancel_run", "delete_run":
+			return eng.Cancel(runID)
+		case "resume_gate", "approve_gate", "reject_gate":
+			nodeID := meta["nodeId"]
+			gateAction := meta["gateAction"]
+			if gateAction == "" {
+				gateAction = "approve"
+			}
+			if nodeID == "" {
+				return fmt.Errorf("gate node id required")
+			}
+			return eng.ResumeGate(runID, nodeID, gateAction, nil)
+		default:
+			return fmt.Errorf("unsupported risk action %q", action)
+		}
+	})
+	pmMCP.SetTaskSafety(riskSvc, taskContextSvc, channelIMNotifier{mgr: channelMgr})
 	channelMgr.SetLoader(channelSvc.ListRaw)
 	channelSvc.SetOnChange(channelMgr.Reload)
 	channelMgr.ApplyOnBoot()

--- a/server/cmd/server/mcp_wiring.go
+++ b/server/cmd/server/mcp_wiring.go
@@ -105,7 +105,7 @@ func (w *platformMCPWire) registerCron(projectID, threadID, agent string) (strin
 // registerChannel mints a shared token for an IM channel turn. Memory/scheduler
 // write gates follow caps from ChannelConfig (default off for unauthenticated
 // channel senders).
-func (w *platformMCPWire) registerChannel(projectID, threadID, userID, agent string, enabledMcps []string, caps channels.SessionCaps) (string, []sandbox.MCPServerSpec) {
+func (w *platformMCPWire) registerChannel(projectID, threadID, userID, agent string, channel channels.ChannelSessionContext, enabledMcps []string, caps channels.SessionCaps) (string, []sandbox.MCPServerSpec) {
 	if w.pm == nil {
 		return "", nil
 	}
@@ -115,6 +115,10 @@ func (w *platformMCPWire) registerChannel(projectID, threadID, userID, agent str
 		return "", nil
 	}
 	tok := w.pm.Register(projectID, threadID, userID, agent)
+	w.pm.SetChannelContext(tok, pmmcp.ChannelContext{
+		ChannelType: channel.ChannelType, Scene: string(channel.Scene),
+		ConversationID: channel.ConversationID, ExternalUserID: channel.ExternalUserID,
+	})
 	if w.memory != nil {
 		w.memory.Restore(tok, projectID, agent, threadID, userID, caps.AllowMemoryWrite)
 	}
@@ -131,7 +135,7 @@ func (w *platformMCPWire) registerChannel(projectID, threadID, userID, agent str
 	return tok, specs
 }
 
-func (w *platformMCPWire) restoreChannel(projectID, threadID, userID, agent, token string, enabledMcps []string, caps channels.SessionCaps) {
+func (w *platformMCPWire) restoreChannel(projectID, threadID, userID, agent, token string, channel channels.ChannelSessionContext, enabledMcps []string, caps channels.SessionCaps) {
 	_ = enabledMcps
 	if !w.agentBoundToProject(projectID, agent) {
 		log.Warn().Str("project", projectID).Str("agent", agent).
@@ -140,6 +144,10 @@ func (w *platformMCPWire) restoreChannel(projectID, threadID, userID, agent, tok
 	}
 	if w.pm != nil {
 		w.pm.Restore(projectID, threadID, userID, agent, token)
+		w.pm.SetChannelContext(token, pmmcp.ChannelContext{
+			ChannelType: channel.ChannelType, Scene: string(channel.Scene),
+			ConversationID: channel.ConversationID, ExternalUserID: channel.ExternalUserID,
+		})
 	}
 	if w.memory != nil {
 		w.memory.Restore(token, projectID, agent, threadID, userID, caps.AllowMemoryWrite)

--- a/server/internal/channels/bridge.go
+++ b/server/internal/channels/bridge.go
@@ -23,13 +23,23 @@ import (
 type MCPTokenHooks struct {
 	// Register mints a shared token and returns the platform MCP inject specs
 	// for a fresh sandbox open. caps gate memory/scheduler writes for this turn.
-	Register func(projectID, threadID, userID, agent string, enabledMcps []string, caps SessionCaps) (token string, specs []sandbox.MCPServerSpec)
+	Register func(projectID, threadID, userID, agent string, channel ChannelSessionContext, enabledMcps []string, caps SessionCaps) (token string, specs []sandbox.MCPServerSpec)
 	// RestoreOnReuse rebinds the reused sandbox's existing token using the
 	// latest caps (so config changes apply on the next turn without reconnect).
-	RestoreOnReuse func(projectID, threadID, userID, agent, token string, enabledMcps []string, caps SessionCaps)
+	RestoreOnReuse func(projectID, threadID, userID, agent, token string, channel ChannelSessionContext, enabledMcps []string, caps SessionCaps)
 	// Unregister drops a token (used when discarding a freshly minted token
 	// after a sandbox reuse, or on open failure).
 	Unregister func(token string)
+}
+
+// ChannelSessionContext carries the concrete inbound identity and destination
+// alongside the conversation-scoped thread user id. PM MCP writes use it for
+// risk tickets and explicit lifecycle delivery without guessing a cron target.
+type ChannelSessionContext struct {
+	ChannelType    string
+	Scene          Scene
+	ConversationID string
+	ExternalUserID string
 }
 
 // ResolvedChannel is the per-turn channel context passed to the bridge.
@@ -97,7 +107,11 @@ func (b *ChannelBridge) Handle(ctx context.Context, rc ResolvedChannel, in Inbou
 	}
 
 	binding, _ := b.pm.GetBinding(rc.ProjectID)
-	token, specs := b.hooks.Register(rc.ProjectID, thread.ID, userID, agent, binding.EnabledMcps, rc.Caps)
+	channelCtx := ChannelSessionContext{
+		ChannelType: rc.Type, Scene: in.Scene,
+		ConversationID: in.ConversationID, ExternalUserID: in.UserID,
+	}
+	token, specs := b.hooks.Register(rc.ProjectID, thread.ID, userID, agent, channelCtx, binding.EnabledMcps, rc.Caps)
 	row, reused, err := b.sbx.OpenAgentSandbox(ctx, services.AgentSandboxOpenOpts{
 		Profile:       agent,
 		ProjectID:     rc.ProjectID,
@@ -119,7 +133,7 @@ func (b *ChannelBridge) Handle(ctx context.Context, rc ResolvedChannel, in Inbou
 		}
 		token = row.Token
 		if b.hooks.RestoreOnReuse != nil {
-			b.hooks.RestoreOnReuse(rc.ProjectID, thread.ID, userID, agent, token, binding.EnabledMcps, rc.Caps)
+			b.hooks.RestoreOnReuse(rc.ProjectID, thread.ID, userID, agent, token, channelCtx, binding.EnabledMcps, rc.Caps)
 		}
 	}
 	if err := b.pm.BindSandbox(thread.ID, row.ID); err != nil {
@@ -382,8 +396,8 @@ func extForMime(mime string) string {
 }
 
 var (
-	mdImageRe   = regexp.MustCompile(`!\[[^\]]*\]\((https?://[^)\s]+)\)`)
-	bareImageRe = regexp.MustCompile(`https?://[^\s)]+\.(?:png|jpe?g|gif|webp)(?:\?[^\s)]*)?`)
+	mdImageRe           = regexp.MustCompile(`!\[[^\]]*\]\((https?://[^)\s]+)\)`)
+	bareImageRe         = regexp.MustCompile(`https?://[^\s)]+\.(?:png|jpe?g|gif|webp)(?:\?[^\s)]*)?`)
 	finalSummaryMarkers = []string{"[摘要]", "【摘要】", "[最终]", "【最终】", "[Final]", "[Summary]"}
 )
 

--- a/server/internal/channels/bridge.go
+++ b/server/internal/channels/bridge.go
@@ -42,9 +42,16 @@ type ResolvedChannel struct {
 }
 
 // Reply is the bridge's produced answer for one inbound message.
+//
+// Text is the raw assistant output and is internal-only: it is persisted and
+// used for orchestration but must never reach an external channel. Only
+// FinalSummary — a structured, explicitly produced summary — is deliverable.
+// When FinalSummary is empty the Manager sends a fixed safe status notice
+// instead of leaking raw model output.
 type Reply struct {
-	Text      string
-	ImageURLs []string
+	Text         string
+	FinalSummary string
+	ImageURLs    []string
 }
 
 // ChannelBridge is the Work-side executor for channel turns: resolve thread,
@@ -161,7 +168,10 @@ func (b *ChannelBridge) Handle(ctx context.Context, rc ResolvedChannel, in Inbou
 		return Reply{}, fmt.Errorf("assistant produced no reply")
 	}
 	stripped, urls := splitImageURLs(text)
-	return Reply{Text: stripped, ImageURLs: urls}, nil
+	return Reply{
+		Text:      stripped,
+		ImageURLs: urls,
+	}, nil
 }
 
 // forwardProgress subscribes to PmTurnRunner events and forwards only the three

--- a/server/internal/channels/bridge.go
+++ b/server/internal/channels/bridge.go
@@ -169,8 +169,9 @@ func (b *ChannelBridge) Handle(ctx context.Context, rc ResolvedChannel, in Inbou
 	}
 	stripped, urls := splitImageURLs(text)
 	return Reply{
-		Text:      stripped,
-		ImageURLs: urls,
+		Text:         stripped,
+		FinalSummary: extractStructuredFinalSummary(stripped),
+		ImageURLs:    urls,
 	}, nil
 }
 
@@ -383,7 +384,23 @@ func extForMime(mime string) string {
 var (
 	mdImageRe   = regexp.MustCompile(`!\[[^\]]*\]\((https?://[^)\s]+)\)`)
 	bareImageRe = regexp.MustCompile(`https?://[^\s)]+\.(?:png|jpe?g|gif|webp)(?:\?[^\s)]*)?`)
+	finalSummaryMarkers = []string{"[摘要]", "【摘要】", "[最终]", "【最终】", "[Final]", "[Summary]"}
 )
+
+// extractStructuredFinalSummary pulls an orchestration-authored structured
+// summary line. Prompt markers alone never make raw narration sendable; only
+// this explicit extraction populates Reply.FinalSummary for the Manager gate.
+func extractStructuredFinalSummary(text string) string {
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		for _, marker := range finalSummaryMarkers {
+			if strings.HasPrefix(trimmed, marker) {
+				return truncateRunes(strings.TrimSpace(strings.TrimPrefix(trimmed, marker)), 240)
+			}
+		}
+	}
+	return ""
+}
 
 // splitImageURLs extracts shareable image URLs (markdown or bare) from an
 // assistant reply and returns the text with markdown image syntax removed.

--- a/server/internal/channels/capabilities.go
+++ b/server/internal/channels/capabilities.go
@@ -1,0 +1,52 @@
+package channels
+
+import (
+	"strings"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/services"
+)
+
+const (
+	// QQReplyCapability is fixed: QQ gives us no usable quote/reply reference,
+	// so task addressing must degrade to natural language selection.
+	QQReplyCapability = "unsupported"
+	// ReplyCapabilitySupported marks channels that do expose reply references.
+	ReplyCapabilitySupported = "supported"
+)
+
+// ReplyCapability reports whether a channel type exposes a usable reply/quote
+// reference for binding a message to a task.
+func ReplyCapability(channelType string) string {
+	switch strings.TrimSpace(strings.ToLower(channelType)) {
+	case models.ChannelTypeQQ, "":
+		return QQReplyCapability
+	default:
+		return ReplyCapabilitySupported
+	}
+}
+
+// SupportsReplyReference is the boolean form of ReplyCapability.
+func SupportsReplyReference(channelType string) bool {
+	return ReplyCapability(channelType) == ReplyCapabilitySupported
+}
+
+// QQReplyFallback explains that native quote/reply is unavailable and asks the
+// user to select by number or short title.
+func QQReplyFallback(currentMessage, recentLanguage string) string {
+	if services.DetectLanguage(currentMessage, recentLanguage) == "en" {
+		return "QQ reply references are unavailable here. Please choose a task by number or short title."
+	}
+	return "当前 QQ 会话不支持引用回复，请按序号或短标题选择任务。"
+}
+
+// FormatTaskMessage applies the stable user-facing task/type prefix.
+func FormatTaskMessage(shortTitle, kind, body, currentMessage, recentLanguage string) string {
+	language := services.DetectLanguage(currentMessage, recentLanguage)
+	prefix := services.FormatTaskType(shortTitle, kind, language)
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return prefix
+	}
+	return prefix + " " + body
+}

--- a/server/internal/channels/capabilities_test.go
+++ b/server/internal/channels/capabilities_test.go
@@ -1,0 +1,26 @@
+package channels
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestQQReplyCapabilityFallbackAndBilingualFormatting(t *testing.T) {
+	if QQReplyCapability != "unsupported" {
+		t.Fatalf("QQ reply capability=%q", QQReplyCapability)
+	}
+	zh := QQReplyFallback("请继续", "en")
+	if !strings.Contains(zh, "不支持引用回复") || !strings.Contains(zh, "序号") {
+		t.Fatalf("zh fallback=%q", zh)
+	}
+	en := QQReplyFallback("please continue", "zh-CN")
+	if !strings.Contains(en, "unavailable") || !strings.Contains(en, "number") {
+		t.Fatalf("en fallback=%q", en)
+	}
+	if got := FormatTaskMessage("登录页", "阻塞", "需要权限", "继续", ""); got != "【登录页｜阻塞】 需要权限" {
+		t.Fatalf("zh task message=%q", got)
+	}
+	if got := FormatTaskMessage("Login", "Blocked", "Need access", "continue", ""); got != "【Login｜Blocked】 Need access" {
+		t.Fatalf("en task message=%q", got)
+	}
+}

--- a/server/internal/channels/channels_test.go
+++ b/server/internal/channels/channels_test.go
@@ -328,7 +328,7 @@ func TestDispatchPassesSessionCapsFromConfig(t *testing.T) {
 	var gotCaps SessionCaps
 	m.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
 		gotCaps = rc.Caps
-		return Reply{Text: "ok"}, nil
+		return Reply{FinalSummary: "ok"}, nil
 	}
 	rc := testRunningChannel(fa)
 	rc.cfg.Config = map[string]any{
@@ -356,7 +356,7 @@ func TestDispatchImmediateAckWithSummary(t *testing.T) {
 	fa := &fakeAdapter{}
 	m := NewManager(nil, nil, nil)
 	m.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
-		return Reply{Text: "final-ok"}, nil
+		return Reply{FinalSummary: "final-ok"}, nil
 	}
 	long := strings.Repeat("处理下PR与相关检查项", 5) // >40 runes
 	m.dispatch(context.Background(), testRunningChannel(fa), testInboundText("m1", long))
@@ -381,7 +381,7 @@ func TestDispatchSuccessAckThenFinal(t *testing.T) {
 	m := NewManager(nil, nil, nil)
 	m.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
 		time.Sleep(30 * time.Millisecond)
-		return Reply{Text: "final-ok"}, nil
+		return Reply{FinalSummary: "final-ok"}, nil
 	}
 	m.dispatch(context.Background(), testRunningChannel(fa), testInbound("m2"))
 	got := sentTexts(fa)
@@ -415,7 +415,7 @@ func TestDispatchBusyEnqueuePerMessageAckAndDequeueAck(t *testing.T) {
 	m.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
 		once.Do(func() { close(started) })
 		time.Sleep(80 * time.Millisecond)
-		return Reply{Text: "final-" + in.MessageID}, nil
+		return Reply{FinalSummary: "final-" + in.MessageID}, nil
 	}
 	rc := testRunningChannel(fa)
 	done := make(chan struct{})
@@ -480,7 +480,7 @@ func TestDispatchFIFOOrderMultipleQueued(t *testing.T) {
 		handled = append(handled, in.MessageID)
 		orderMu.Unlock()
 		time.Sleep(20 * time.Millisecond)
-		return Reply{Text: "final-" + in.MessageID}, nil
+		return Reply{FinalSummary: "final-" + in.MessageID}, nil
 	}
 	rc := testRunningChannel(fa)
 	done := make(chan struct{})
@@ -528,7 +528,7 @@ func TestDispatchQueueFullVisibleReject(t *testing.T) {
 	m.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
 		once.Do(func() { close(started) })
 		<-gate
-		return Reply{Text: "final-" + in.MessageID}, nil
+		return Reply{FinalSummary: "final-" + in.MessageID}, nil
 	}
 	rc := testRunningChannel(fa)
 	done := make(chan struct{})
@@ -571,7 +571,7 @@ func TestDispatchPerMessageQueueAckAcrossBusyCycles(t *testing.T) {
 		if in.MessageID == "p0" {
 			<-release1
 		}
-		return Reply{Text: "final-" + in.MessageID}, nil
+		return Reply{FinalSummary: "final-" + in.MessageID}, nil
 	}
 	done1 := make(chan struct{})
 	go func() {
@@ -603,7 +603,7 @@ func TestDispatchPerMessageQueueAckAcrossBusyCycles(t *testing.T) {
 		if in.MessageID == "p3" {
 			<-release2
 		}
-		return Reply{Text: "final-" + in.MessageID}, nil
+		return Reply{FinalSummary: "final-" + in.MessageID}, nil
 	}
 	done2 := make(chan struct{})
 	go func() {
@@ -638,7 +638,7 @@ func TestDispatchFailureContinuesDrain(t *testing.T) {
 		if in.MessageID == "fail-me" {
 			return Reply{}, errors.New("boom")
 		}
-		return Reply{Text: "final-" + in.MessageID}, nil
+		return Reply{FinalSummary: "final-" + in.MessageID}, nil
 	}
 	rc := testRunningChannel(fa)
 	done := make(chan struct{})
@@ -677,7 +677,7 @@ func TestDispatchCrossConversationIndependent(t *testing.T) {
 		} else {
 			onceB.Do(func() { close(startedB) })
 		}
-		return Reply{Text: "final-" + in.MessageID}, nil
+		return Reply{FinalSummary: "final-" + in.MessageID}, nil
 	}
 	rc := testRunningChannel(fa)
 	inA := func(id string) InboundMessage {
@@ -719,7 +719,7 @@ func TestDispatchIdleSingleImmediateAckNoQueueAck(t *testing.T) {
 	m := NewManager(nil, nil, nil)
 	m.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
 		time.Sleep(20 * time.Millisecond)
-		return Reply{Text: "final-ok"}, nil
+		return Reply{FinalSummary: "final-ok"}, nil
 	}
 	m.dispatch(context.Background(), testRunningChannel(fa), testInbound("idle-1"))
 	got := sentTexts(fa)
@@ -896,27 +896,62 @@ func TestClassifyProgressFromACPMultiChunkSequence(t *testing.T) {
 	}
 }
 
-func TestDispatchForwardsFilteredProgress(t *testing.T) {
-	// plan g2.2: only milestone/blocker/confirm reach QQ; noise suppressed.
+func TestDispatchForwardsOnlyExplicitlySendableProgress(t *testing.T) {
+	// Only orchestration-marked progress, or a blocker/decision backed by a
+	// structured conclusion, may leave the platform.
 	fa := &fakeAdapter{}
 	m := NewManager(nil, nil, nil)
 	m.handleFuncWithProgress = func(ctx context.Context, rc ResolvedChannel, in InboundMessage, onProgress func(ProgressEvent)) (Reply, error) {
-		onProgress(ProgressEvent{Kind: ProgressMilestone, Summary: "已提交分支"})
-		onProgress(ProgressEvent{Kind: ProgressBlocker, Summary: "CI 红了"})
-		// Caller already classified; Manager formats. Noise never reaches onProgress
-		// in production — assert FormatProgressText prefixes.
-		return Reply{Text: "final-ok"}, nil
+		onProgress(ProgressEvent{
+			Kind: ProgressMilestone, Summary: "已提交分支",
+			Stage: "branch_pushed", RunID: "run-1", Sendable: true,
+		})
+		onProgress(ProgressEvent{
+			Kind: ProgressBlocker, Summary: "CI 红了",
+			Blocked: true, Conclusion: "CI 检查失败，需要人工介入", RunID: "run-1",
+		})
+		return Reply{FinalSummary: "final-ok"}, nil
 	}
 	m.dispatch(context.Background(), testRunningChannel(fa), testInbound("prog-1"))
 	got := sentTexts(fa)
 	if countText(got, "进度：已提交分支") != 1 {
-		t.Fatalf("missing milestone in %v", got)
+		t.Fatalf("missing sendable milestone in %v", got)
 	}
 	if countText(got, "阻塞：CI 红了") != 1 {
-		t.Fatalf("missing blocker in %v", got)
+		t.Fatalf("missing structured blocker in %v", got)
 	}
 	if countText(got, "final-ok") != 1 {
 		t.Fatalf("missing final in %v", got)
+	}
+}
+
+func TestClassifiedProgressMarkersNeverReachChannel(t *testing.T) {
+	// A prompt-shaped marker in model output must not be able to drive an
+	// external send: classification produces internal-only events.
+	fa := &fakeAdapter{}
+	m := NewManager(nil, nil, nil)
+	m.handleFuncWithProgress = func(ctx context.Context, rc ResolvedChannel, in InboundMessage, onProgress func(ProgressEvent)) (Reply, error) {
+		for _, raw := range []string{"[进度] 已打开 PR #12", "[阻塞] CI 红了", "[确认] 是否合并"} {
+			ev, ok := ClassifyProgressText(raw)
+			if !ok {
+				t.Fatalf("classification failed for %q", raw)
+			}
+			if ev.Deliverable() {
+				t.Fatalf("classified event %q must not be deliverable", raw)
+			}
+			onProgress(ev)
+		}
+		return Reply{FinalSummary: "final-ok"}, nil
+	}
+	m.dispatch(context.Background(), testRunningChannel(fa), testInbound("prog-marker"))
+	got := sentTexts(fa)
+	for _, text := range got {
+		if strings.HasPrefix(text, "进度：") || strings.HasPrefix(text, "阻塞：") || strings.HasPrefix(text, "需确认：") {
+			t.Fatalf("classified progress leaked to channel: %v", got)
+		}
+	}
+	if countText(got, "final-ok") != 1 {
+		t.Fatalf("final missing in %v", got)
 	}
 }
 
@@ -960,7 +995,7 @@ func TestDeliverCronBusySilentEnqueueThenFlush(t *testing.T) {
 	m.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
 		once.Do(func() { close(started) })
 		<-release
-		return Reply{Text: "final-user"}, nil
+		return Reply{FinalSummary: "final-user"}, nil
 	}
 
 	done := make(chan struct{})

--- a/server/internal/channels/channels_test.go
+++ b/server/internal/channels/channels_test.go
@@ -164,23 +164,31 @@ func TestFingerprintChanges(t *testing.T) {
 }
 
 // fakeAdapter records outbound sends and satisfies the Adapter interface.
+// messageIDs, when set, are handed back one per successful send to emulate a
+// channel that reports its own message ids.
 type fakeAdapter struct {
-	mu     sync.Mutex
-	sent   []OutboundMessage
-	onSend func(out OutboundMessage) // optional hook (called under mu)
+	mu         sync.Mutex
+	sent       []OutboundMessage
+	messageIDs []string
+	onSend     func(out OutboundMessage) // optional hook (called under mu)
 }
 
 func (f *fakeAdapter) Type() string                                              { return "fake" }
 func (f *fakeAdapter) Start(ctx context.Context, onInbound InboundHandler) error { return nil }
 func (f *fakeAdapter) Stop() error                                               { return nil }
-func (f *fakeAdapter) Send(ctx context.Context, out OutboundMessage) error {
+func (f *fakeAdapter) Send(ctx context.Context, out OutboundMessage) (SendResult, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.sent = append(f.sent, out)
 	if f.onSend != nil {
 		f.onSend(out)
 	}
-	return nil
+	messageID := ""
+	if len(f.messageIDs) > 0 {
+		messageID = f.messageIDs[0]
+		f.messageIDs = f.messageIDs[1:]
+	}
+	return SendResult{MessageID: messageID}, nil
 }
 
 func newTestManager(fa *fakeAdapter) *Manager {

--- a/server/internal/channels/delivery.go
+++ b/server/internal/channels/delivery.go
@@ -60,25 +60,38 @@ func (r SendableRequest) Envelope() sendable.DeliveryEnvelope {
 	return sendable.AppendSendable(e, sendable.ChannelQQ)
 }
 
+// DeliveryResult reports whether an outbound attempt was sent, suppressed, or
+// failed after policy evaluation and bounded transport retries.
+type DeliveryResult struct {
+	Decision sendable.Decision
+	Sent     bool
+}
+
+// ErrDeliverySuppressed is returned when policy intentionally blocked a send.
+var ErrDeliverySuppressed = errors.New("delivery suppressed by sendable policy")
+
+// ErrDeliveryFailed is returned when transport retries are exhausted.
+var ErrDeliveryFailed = errors.New("delivery failed after retries")
+
 // DeliverSendable is the explicit external egress for orchestration. Every
-// delivery still passes the Manager's single policy gate.
-func (m *Manager) DeliverSendable(ctx context.Context, req SendableRequest) error {
+// delivery still passes the Manager's single policy gate. Callers can tell
+// sent / suppressed / failed apart from the result.
+func (m *Manager) DeliverSendable(ctx context.Context, req SendableRequest) (DeliveryResult, error) {
 	if strings.TrimSpace(req.Text) == "" {
-		return errors.New("sendable text is empty")
+		return DeliveryResult{}, errors.New("sendable text is empty")
 	}
 	target, scene, conv, err := m.resolveSendableTarget(req)
 	if err != nil {
-		return err
+		return DeliveryResult{}, err
 	}
 	req.Scene, req.ConversationID = scene, conv
 	if ctx == nil {
 		ctx = m.baseCtx
 	}
-	m.sendOutbound(ctx, target, OutboundMessage{
+	return m.sendOutboundResult(ctx, target, OutboundMessage{
 		Scene: scene, ConversationID: conv, ReplyToMessageID: req.ReplyToMessageID,
 		Text: req.Text, ImageURLs: req.ImageURLs, Envelope: req.Envelope(),
-	})
-	return nil
+	}), nil
 }
 
 // RunAcceptanceAck confirms that a real Run was accepted for a user. It is
@@ -95,10 +108,10 @@ type RunAcceptanceAck struct {
 }
 
 // SendRunAcceptanceAck delivers the once-per-run acceptance ACK.
-func (m *Manager) SendRunAcceptanceAck(ctx context.Context, ack RunAcceptanceAck) error {
+func (m *Manager) SendRunAcceptanceAck(ctx context.Context, ack RunAcceptanceAck) (DeliveryResult, error) {
 	runID := strings.TrimSpace(ack.RunID)
 	if runID == "" {
-		return errors.New("run acceptance ack requires a real run id")
+		return DeliveryResult{}, errors.New("run acceptance ack requires a real run id")
 	}
 	language := services.DetectLanguage("", ack.Language)
 	kindLabel := "已接单"

--- a/server/internal/channels/delivery.go
+++ b/server/internal/channels/delivery.go
@@ -1,0 +1,377 @@
+package channels
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/sendable"
+	"github.com/cocofhu/approving/internal/services"
+)
+
+// ErrNoSendableTarget is returned when no running channel can reach the
+// requested project conversation.
+var ErrNoSendableTarget = errors.New("项目未配置可用的外发渠道目标")
+
+// SendableRequest is the explicit external-delivery request used by
+// orchestration. Callers must state a real RunID (Run lifecycle traffic) or a
+// TaskContext (conversation-scoped traffic); an inbound platform message id is
+// never a Run id.
+type SendableRequest struct {
+	ProjectID        string
+	Scene            Scene
+	ConversationID   string
+	UserID           string
+	ReplyToMessageID string
+
+	RunID       string
+	TaskContext string
+
+	Kind      sendable.Kind
+	Reason    string
+	Priority  sendable.Priority
+	DedupeKey string
+	Progress  sendable.ProgressFields
+
+	Text      string
+	ImageURLs []string
+}
+
+// Envelope renders the request as a channel-bound delivery envelope. It is
+// exported so callers can assert the delivery contract before sending.
+func (r SendableRequest) Envelope() sendable.DeliveryEnvelope {
+	priority := r.Priority
+	if priority == "" {
+		priority = sendable.PriorityNormal
+	}
+	e := sendable.DeliveryEnvelope{
+		Priority: priority, RunID: strings.TrimSpace(r.RunID),
+		TaskContext: strings.TrimSpace(r.TaskContext), ProjectID: r.ProjectID,
+		ConversationID: r.ConversationID, UserID: r.UserID,
+		DedupeKey: strings.TrimSpace(r.DedupeKey), Reason: r.Reason,
+		Kind: r.Kind, Progress: r.Progress,
+		// Everything routed through this API is composed by orchestration, not
+		// copied from raw model output.
+		Structured: true,
+	}
+	return sendable.AppendSendable(e, sendable.ChannelQQ)
+}
+
+// DeliverSendable is the explicit external egress for orchestration. Every
+// delivery still passes the Manager's single policy gate.
+func (m *Manager) DeliverSendable(ctx context.Context, req SendableRequest) error {
+	if strings.TrimSpace(req.Text) == "" {
+		return errors.New("sendable text is empty")
+	}
+	target, scene, conv, err := m.resolveSendableTarget(req)
+	if err != nil {
+		return err
+	}
+	req.Scene, req.ConversationID = scene, conv
+	if ctx == nil {
+		ctx = m.baseCtx
+	}
+	m.sendOutbound(ctx, target, OutboundMessage{
+		Scene: scene, ConversationID: conv, ReplyToMessageID: req.ReplyToMessageID,
+		Text: req.Text, ImageURLs: req.ImageURLs, Envelope: req.Envelope(),
+	})
+	return nil
+}
+
+// RunAcceptanceAck confirms that a real Run was accepted for a user. It is
+// distinct from the per-turn processing ACK and is delivered at most once per
+// run × conversation/user × channel.
+type RunAcceptanceAck struct {
+	ProjectID      string
+	RunID          string
+	Scene          Scene
+	ConversationID string
+	UserID         string
+	ShortTitle     string
+	Language       string
+}
+
+// SendRunAcceptanceAck delivers the once-per-run acceptance ACK.
+func (m *Manager) SendRunAcceptanceAck(ctx context.Context, ack RunAcceptanceAck) error {
+	runID := strings.TrimSpace(ack.RunID)
+	if runID == "" {
+		return errors.New("run acceptance ack requires a real run id")
+	}
+	language := services.DetectLanguage("", ack.Language)
+	kindLabel := "已接单"
+	body := "任务已接单，我会在有实质进展时同步。"
+	if language == "en" {
+		kindLabel, body = "Accepted", "Task accepted. I will report substantive progress."
+	}
+	return m.DeliverSendable(ctx, SendableRequest{
+		ProjectID: ack.ProjectID, Scene: ack.Scene, ConversationID: ack.ConversationID,
+		UserID: ack.UserID, RunID: runID,
+		Kind: sendable.KindRunAcceptanceAck, Reason: "run_accepted",
+		Priority:  sendable.PriorityHigh,
+		DedupeKey: runAcceptanceDedupeKey(runID, ack.ConversationID, ack.UserID),
+		Text:      services.FormatTaskType(ack.ShortTitle, kindLabel, language) + " " + body,
+	})
+}
+
+func runAcceptanceDedupeKey(runID, conversationID, userID string) string {
+	return strings.Join([]string{
+		"run-ack", runID, conversationID, userID, string(sendable.ChannelQQ),
+	}, ":")
+}
+
+func (m *Manager) resolveSendableTarget(req SendableRequest) (*runningChannel, Scene, string, error) {
+	if strings.TrimSpace(req.ConversationID) != "" {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		for _, rc := range m.running {
+			if rc.cfg.ProjectID == req.ProjectID {
+				scene := req.Scene
+				if scene == "" {
+					scene = SceneC2C
+				}
+				return rc, scene, req.ConversationID, nil
+			}
+		}
+		return nil, "", "", ErrNoSendableTarget
+	}
+	target, scene, conv, err := m.lookupRunNotifyTarget(req.ProjectID)
+	if err != nil {
+		return nil, "", "", ErrNoSendableTarget
+	}
+	return target, scene, conv, nil
+}
+
+// TaskReferenceStatus is the outcome of resolving which task a user meant.
+type TaskReferenceStatus string
+
+const (
+	TaskReferenceResolved  TaskReferenceStatus = "resolved"
+	TaskReferenceAmbiguous TaskReferenceStatus = "ambiguous"
+	TaskReferenceNotFound  TaskReferenceStatus = "not_found"
+	TaskReferenceNoContext TaskReferenceStatus = "no_context"
+)
+
+// TaskReferenceRequest is one inbound attempt to address an existing task.
+type TaskReferenceRequest struct {
+	ProjectID      string
+	ChannelType    string
+	Scene          Scene
+	ConversationID string
+	QQUserID       string
+	Text           string
+	// ReplyToMessageID is honoured only when the channel actually supports
+	// reply references; on QQ it is ignored and the user is told how to select.
+	ReplyToMessageID string
+}
+
+// TaskReferenceResult carries the resolution and the natural-language reply the
+// orchestration layer should surface.
+type TaskReferenceResult struct {
+	Status            TaskReferenceStatus
+	Task              *models.TaskIdentity
+	Options           []string
+	Message           string
+	Language          string
+	ReplyRefSupported bool
+	Reason            string
+}
+
+// ResolveTaskReference composes the IM-side task addressing flow: channel
+// capability detection → reply binding (skipped when unsupported) → ordinal /
+// short-title selection → conversation focus → scored search. Candidates are
+// always confined to this project and this synthetic QQ identity.
+func (m *Manager) ResolveTaskReference(req TaskReferenceRequest) (TaskReferenceResult, error) {
+	svc := m.taskContext
+	if svc == nil {
+		return TaskReferenceResult{}, errors.New("task context service is not configured")
+	}
+	channelType := strings.TrimSpace(req.ChannelType)
+	if channelType == "" {
+		channelType = models.ChannelTypeQQ
+	}
+	scope := services.TaskScope{
+		ProjectID:      req.ProjectID,
+		UserID:         services.SyntheticQQUserID(req.QQUserID),
+		Channel:        channelType,
+		ConversationID: req.ConversationID,
+	}
+	language := m.referenceLanguage(svc, scope, req.Text)
+	replySupported := SupportsReplyReference(channelType)
+
+	result := TaskReferenceResult{Language: language, ReplyRefSupported: replySupported}
+	text := strings.TrimSpace(req.Text)
+
+	resolveIn := services.ResolveTaskInput{Scope: scope, Query: text}
+	if replySupported {
+		resolveIn.ReplyMessageID = req.ReplyToMessageID
+	}
+	if ordinal := services.ParseOrdinal(text); ordinal > 0 {
+		// A bare number selects from the options the previous ambiguity prompt
+		// actually showed the user.
+		resolveIn.Ordinal = ordinal
+		resolveIn.Query = ""
+		resolveIn.Candidates = m.lastAmbiguityOptions(scope)
+	} else {
+		candidates, err := svc.Search(scope, text)
+		if err != nil {
+			return TaskReferenceResult{}, err
+		}
+		resolveIn.Candidates = candidates
+	}
+
+	res, err := svc.ResolveTask(resolveIn)
+	if err != nil {
+		return TaskReferenceResult{}, err
+	}
+	result.Reason = res.Reason
+	switch {
+	case res.Identity != nil:
+		result.Status = TaskReferenceResolved
+		result.Task = res.Identity
+		result.Message = FormatTaskMessage(res.Identity.ShortTitle, taskStatusLabel(res.Identity.Status, language),
+			"", req.Text, language)
+	case res.Ambiguous:
+		result.Status = TaskReferenceAmbiguous
+		result.Options = shortTitles(res.Candidates)
+		result.Message = ambiguityPrompt(result.Options, language, replySupported)
+		m.rememberAmbiguity(scope, res.Candidates)
+	case res.Reason == "focus_missing_or_expired":
+		result.Status = TaskReferenceNoContext
+		result.Message = noContextPrompt(language, replySupported)
+	default:
+		result.Status = TaskReferenceNotFound
+		result.Message = notFoundPrompt(language, replySupported)
+	}
+	return result, nil
+}
+
+func (m *Manager) referenceLanguage(svc *services.TaskContextService, scope services.TaskScope, text string) string {
+	recent := ""
+	if focus, err := svc.GetFocus(scope, false); err == nil {
+		recent = focus.Language
+	}
+	return services.DetectLanguage(text, recent)
+}
+
+// ambiguityMemory keeps the option list offered for the last ambiguous prompt so
+// a following bare ordinal selects from exactly what the user saw.
+type ambiguityMemory struct {
+	candidates []services.TaskCandidate
+	at         time.Time
+}
+
+func (m *Manager) rememberAmbiguity(scope services.TaskScope, candidates []services.TaskCandidate) {
+	m.ambiguityMu.Lock()
+	defer m.ambiguityMu.Unlock()
+	if m.ambiguity == nil {
+		m.ambiguity = map[string]ambiguityMemory{}
+	}
+	m.ambiguity[ambiguityKey(scope)] = ambiguityMemory{candidates: candidates, at: time.Now()}
+}
+
+func (m *Manager) lastAmbiguityOptions(scope services.TaskScope) []services.TaskCandidate {
+	m.ambiguityMu.Lock()
+	defer m.ambiguityMu.Unlock()
+	entry, ok := m.ambiguity[ambiguityKey(scope)]
+	if !ok || time.Since(entry.at) > services.TaskFocusTTL {
+		return nil
+	}
+	return entry.candidates
+}
+
+func ambiguityKey(scope services.TaskScope) string {
+	return strings.Join([]string{scope.ProjectID, scope.UserID, scope.Channel, scope.ConversationID}, "|")
+}
+
+func shortTitles(candidates []services.TaskCandidate) []string {
+	out := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		out = append(out, c.Identity.ShortTitle)
+	}
+	return out
+}
+
+func taskStatusLabel(status, language string) string {
+	if services.NormalizeLanguage(language) == "en" {
+		switch strings.ToLower(strings.TrimSpace(status)) {
+		case "completed", "done":
+			return "Completed"
+		case "failed":
+			return "Failed"
+		case "cancelled", "canceled":
+			return "Cancelled"
+		default:
+			return "In progress"
+		}
+	}
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "completed", "done":
+		return "已完成"
+	case "failed":
+		return "已失败"
+	case "cancelled", "canceled":
+		return "已取消"
+	default:
+		return "进行中"
+	}
+}
+
+func ambiguityPrompt(options []string, language string, replySupported bool) string {
+	en := services.NormalizeLanguage(language) == "en"
+	var b strings.Builder
+	if en {
+		b.WriteString("Several tasks match. Which one do you mean?")
+	} else {
+		b.WriteString("匹配到多个任务，你指的是哪一个？")
+	}
+	for i, option := range options {
+		b.WriteString("\n")
+		b.WriteString(strconv.Itoa(i + 1))
+		b.WriteString(". ")
+		b.WriteString(option)
+	}
+	b.WriteString("\n")
+	if !replySupported {
+		b.WriteString(QQReplyFallback("", language))
+		return b.String()
+	}
+	if en {
+		b.WriteString("Reply with the number or the short title.")
+	} else {
+		b.WriteString("请回复序号或短标题。")
+	}
+	return b.String()
+}
+
+func noContextPrompt(language string, replySupported bool) string {
+	en := services.NormalizeLanguage(language) == "en"
+	base := "当前会话没有正在跟进的任务（焦点已过期）。"
+	if en {
+		base = "This conversation has no active task in focus (it expired)."
+	}
+	if !replySupported {
+		return base + QQReplyFallback("", language)
+	}
+	if en {
+		return base + " Please name the task by short title."
+	}
+	return base + "请用短标题指明任务。"
+}
+
+func notFoundPrompt(language string, replySupported bool) string {
+	en := services.NormalizeLanguage(language) == "en"
+	base := "没有找到匹配的任务。"
+	if en {
+		base = "No matching task was found."
+	}
+	if !replySupported {
+		return base + QQReplyFallback("", language)
+	}
+	if en {
+		return base + " Please check the short title."
+	}
+	return base + "请确认短标题是否正确。"
+}

--- a/server/internal/channels/delivery.go
+++ b/server/internal/channels/delivery.go
@@ -62,20 +62,55 @@ func (r SendableRequest) Envelope() sendable.DeliveryEnvelope {
 
 // DeliveryResult reports whether an outbound attempt was sent, suppressed, or
 // failed after policy evaluation and bounded transport retries.
+// ExternalMessageID is the channel's own id for the delivered message when the
+// transport returned one.
 type DeliveryResult struct {
-	Decision sendable.Decision
-	Sent     bool
+	Decision          sendable.Decision
+	Sent              bool
+	ExternalMessageID string
 }
 
-// ErrDeliverySuppressed is returned when policy intentionally blocked a send.
-var ErrDeliverySuppressed = errors.New("delivery suppressed by sendable policy")
+// Reason exposes the policy reason behind the outcome ("" when sent without a
+// specific reason).
+func (r DeliveryResult) Reason() string { return r.Decision.Reason }
 
-// ErrDeliveryFailed is returned when transport retries are exhausted.
+// Suppressed reports a delivery that policy intentionally withheld: rate
+// limiting, dedupe/merge, an already-sent receipt, or a validation gate. It is a
+// normal outcome, not a delivery failure, so callers must not retry it or report
+// it as an error to an agent.
+func (r DeliveryResult) Suppressed() bool {
+	return !r.Sent && !deliveryFailureReasons[r.Decision.Reason]
+}
+
+// Failed reports a delivery that really did not reach the channel: no target,
+// transport error, exhausted retries, or a failed-closed policy evaluation.
+func (r DeliveryResult) Failed() bool {
+	return !r.Sent && deliveryFailureReasons[r.Decision.Reason]
+}
+
+// deliveryFailureReasons enumerates the policy/transport reasons that mean the
+// message did not reach the channel and the caller should surface an error.
+// Every other reason is a deliberate suppression (see DeliveryResult.Suppressed).
+var deliveryFailureReasons = map[string]bool{
+	"no_adapter":         true,
+	"policy_error":       true,
+	"transport_failed":   true,
+	"retry_claim_failed": true,
+	"retry_exhausted":    true,
+	"receipt_missing":    true,
+	"missing_dedupe_key": true,
+}
+
+// ErrDeliveryFailed is returned when a delivery really failed (no adapter,
+// transport error, retries exhausted). Policy suppression is NOT an error: it
+// comes back as a result with Sent=false and a reason.
 var ErrDeliveryFailed = errors.New("delivery failed after retries")
 
 // DeliverSendable is the explicit external egress for orchestration. Every
 // delivery still passes the Manager's single policy gate. Callers can tell
-// sent / suppressed / failed apart from the result.
+// sent / suppressed / failed apart from the result: only a real failure returns
+// an error, so a rate-limited or deduplicated message never looks like a broken
+// transport to the caller.
 func (m *Manager) DeliverSendable(ctx context.Context, req SendableRequest) (DeliveryResult, error) {
 	if strings.TrimSpace(req.Text) == "" {
 		return DeliveryResult{}, errors.New("sendable text is empty")
@@ -92,15 +127,10 @@ func (m *Manager) DeliverSendable(ctx context.Context, req SendableRequest) (Del
 		Scene: scene, ConversationID: conv, ReplyToMessageID: req.ReplyToMessageID,
 		Text: req.Text, ImageURLs: req.ImageURLs, Envelope: req.Envelope(),
 	})
-	if result.Sent {
-		return result, nil
-	}
-	switch result.Decision.Reason {
-	case "no_adapter", "policy_error", "transport_failed", "retry_claim_failed":
+	if result.Failed() {
 		return result, ErrDeliveryFailed
-	default:
-		return result, ErrDeliverySuppressed
 	}
+	return result, nil
 }
 
 // RunAcceptanceAck confirms that a real Run was accepted for a user. It is

--- a/server/internal/channels/delivery.go
+++ b/server/internal/channels/delivery.go
@@ -88,10 +88,19 @@ func (m *Manager) DeliverSendable(ctx context.Context, req SendableRequest) (Del
 	if ctx == nil {
 		ctx = m.baseCtx
 	}
-	return m.sendOutboundResult(ctx, target, OutboundMessage{
+	result := m.sendOutboundResult(ctx, target, OutboundMessage{
 		Scene: scene, ConversationID: conv, ReplyToMessageID: req.ReplyToMessageID,
 		Text: req.Text, ImageURLs: req.ImageURLs, Envelope: req.Envelope(),
-	}), nil
+	})
+	if result.Sent {
+		return result, nil
+	}
+	switch result.Decision.Reason {
+	case "no_adapter", "policy_error", "transport_failed", "retry_claim_failed":
+		return result, ErrDeliveryFailed
+	default:
+		return result, ErrDeliverySuppressed
+	}
 }
 
 // RunAcceptanceAck confirms that a real Run was accepted for a user. It is

--- a/server/internal/channels/delivery_test.go
+++ b/server/internal/channels/delivery_test.go
@@ -86,13 +86,13 @@ type failingAdapter struct {
 	attempts int
 }
 
-func (f *failingAdapter) Send(ctx context.Context, out OutboundMessage) error {
+func (f *failingAdapter) Send(ctx context.Context, out OutboundMessage) (SendResult, error) {
 	f.mu.Lock()
 	f.attempts++
 	attempt := f.attempts
 	f.mu.Unlock()
 	if attempt <= f.failures {
-		return errors.New("transport down")
+		return SendResult{}, errors.New("transport down")
 	}
 	return f.fakeAdapter.Send(ctx, out)
 }
@@ -189,8 +189,13 @@ func TestSendRunAcceptanceAckOncePerRunAndRejectsMissingRun(t *testing.T) {
 	if _, err := m.SendRunAcceptanceAck(context.Background(), ack); err != nil {
 		t.Fatalf("first ack: %v", err)
 	}
-	if result, err := m.SendRunAcceptanceAck(context.Background(), ack); !errors.Is(err, ErrDeliverySuppressed) || result.Sent {
+	// The second ACK is idempotently suppressed: a structured result, not an error.
+	result, err := m.SendRunAcceptanceAck(context.Background(), ack)
+	if err != nil || result.Sent || !result.Suppressed() {
 		t.Fatalf("second ack should report idempotent suppression: result=%+v err=%v", result, err)
+	}
+	if result.Reason() != "run_acceptance_ack_already_sent" && result.Reason() != "already_sent" {
+		t.Fatalf("second ack reason = %q want an already-sent suppression", result.Reason())
 	}
 	got := sentTexts(fa)
 	if len(got) != 1 {
@@ -234,6 +239,455 @@ func TestTurnProcessingAckIsNotRunScoped(t *testing.T) {
 			t.Fatalf("turn ACK was recorded as a run acceptance ACK: %+v", r)
 		}
 	}
+}
+
+func noticeInbound(messageID string) InboundMessage {
+	in := testInbound(messageID)
+	in.Text = ""
+	in.Safety = &SafetyNotice{
+		Text:   "附件超过 20 MiB 上限，已拒绝：big.zip。请压缩后重试。",
+		Reason: "oversized_attachment", DedupeKey: messageID + ":oversize", Only: true,
+	}
+	return in
+}
+
+func TestSafetyNoticeUsesManagerEgressAndStaysIdempotent(t *testing.T) {
+	fa := &fakeAdapter{}
+	var audits []sendable.AuditEntry
+	m, db := policyManager(t, fa, func(e sendable.AuditEntry) { audits = append(audits, e) })
+	rc := testRunningChannel(fa)
+	m.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
+		t.Fatal("a notice-only inbound must not start a turn")
+		return Reply{}, nil
+	}
+
+	m.dispatch(context.Background(), rc, noticeInbound("m-oversize"))
+	// A gateway reconnect replays the same inbound with the same dedupe key.
+	m.dispatch(context.Background(), rc, noticeInbound("m-oversize"))
+
+	got := sentTexts(fa)
+	if len(got) != 1 || !strings.Contains(got[0], "big.zip") {
+		t.Fatalf("safety notice sends = %v want exactly one tip", got)
+	}
+
+	var receipts []models.SendableDeliveryReceipt
+	if err := db.Find(&receipts).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(receipts) != 1 {
+		t.Fatalf("receipts = %+v want one shared dedupe receipt", receipts)
+	}
+	if receipts[0].DedupeKey != "m-oversize:oversize" {
+		t.Fatalf("dedupe key = %q want the inbound-scoped oversize key", receipts[0].DedupeKey)
+	}
+	if receipts[0].Status != "sent" || receipts[0].Kind != string(sendable.KindSafetyNotice) {
+		t.Fatalf("receipt = %+v want a sent safety_notice", receipts[0])
+	}
+	if receipts[0].RunID != "" {
+		t.Fatalf("safety notice fabricated a run id: %+v", receipts[0])
+	}
+
+	var sent, suppressed int
+	for _, entry := range audits {
+		switch entry.Result {
+		case "sent":
+			sent++
+			if entry.Reason != "oversized_attachment" {
+				t.Fatalf("sent audit reason = %q", entry.Reason)
+			}
+		case "suppressed":
+			suppressed++
+			if entry.Reason != "already_sent" {
+				t.Fatalf("suppressed audit reason = %q want already_sent", entry.Reason)
+			}
+		}
+	}
+	if sent != 1 || suppressed != 1 {
+		t.Fatalf("audit results sent=%d suppressed=%d want 1/1 (%+v)", sent, suppressed, audits)
+	}
+}
+
+func TestSafetyNoticeSendFailureIsRecorded(t *testing.T) {
+	fa := &failingAdapter{failures: 99}
+	var audits []sendable.AuditEntry
+	m, db := policyManager(t, &fa.fakeAdapter, func(e sendable.AuditEntry) { audits = append(audits, e) })
+	rc := testRunningChannel(fa)
+
+	in := noticeInbound("m-fail")
+	result := m.sendSafetyNotice(context.Background(), rc, in, *in.Safety)
+	if result.Sent || !result.Failed() {
+		t.Fatalf("failed notice = %+v want a delivery failure", result)
+	}
+	if fa.attempts != 3 {
+		t.Fatalf("adapter attempts = %d want the bounded 3", fa.attempts)
+	}
+	var receipt models.SendableDeliveryReceipt
+	if err := db.First(&receipt).Error; err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Status != "failed" {
+		t.Fatalf("receipt = %+v want failed", receipt)
+	}
+	failures := 0
+	for _, entry := range audits {
+		if entry.Result == "failed" && entry.Reason == "transport_failed" {
+			failures++
+		}
+	}
+	if failures == 0 {
+		t.Fatalf("no transport failure audited: %+v", audits)
+	}
+}
+
+func TestDeliverSendableSuppressionIsNotAFailure(t *testing.T) {
+	// Every normal policy outcome (dedupe, merge, rate limit, validation gate)
+	// must come back as a structured result so callers do not retry it.
+	cases := []struct {
+		name       string
+		prepare    func(t *testing.T, m *Manager)
+		request    func() SendableRequest
+		wantReason string
+	}{
+		{
+			name: "already sent receipt",
+			prepare: func(t *testing.T, m *Manager) {
+				if _, err := m.DeliverSendable(context.Background(),
+					progressRequest("r1", "user1", "已提交分支", "same")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			request:    func() SendableRequest { return progressRequest("r1", "user1", "已提交分支", "same") },
+			wantReason: "already_sent",
+		},
+		{
+			name: "duplicate content under a new key",
+			prepare: func(t *testing.T, m *Manager) {
+				if _, err := m.DeliverSendable(context.Background(),
+					progressRequest("r1", "user1", "已提交分支", "first")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			request:    func() SendableRequest { return progressRequest("r1", "user1", "已提交分支", "second") },
+			wantReason: "duplicate_content",
+		},
+		{
+			name: "progress rate limited and merged",
+			prepare: func(t *testing.T, m *Manager) {
+				if _, err := m.DeliverSendable(context.Background(),
+					progressRequest("r1", "user1", "已提交分支", "first")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			request:    func() SendableRequest { return progressRequest("r1", "user1", "已开始跑测试", "second") },
+			wantReason: "progress_rate_limited_merged",
+		},
+		{
+			name: "progress without substance",
+			request: func() SendableRequest {
+				req := progressRequest("r1", "user1", "在忙", "")
+				return req
+			},
+			wantReason: "non_substantive_progress",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fa := &fakeAdapter{}
+			m, _ := bindingManager(t, fa)
+			if c.prepare != nil {
+				c.prepare(t, m)
+			}
+			result, err := m.DeliverSendable(context.Background(), c.request())
+			if err != nil {
+				t.Fatalf("suppression returned an error: %v (result=%+v)", err, result)
+			}
+			if result.Sent || !result.Suppressed() || result.Failed() {
+				t.Fatalf("result = %+v want suppressed", result)
+			}
+			if result.Reason() != c.wantReason {
+				t.Fatalf("reason = %q want %q", result.Reason(), c.wantReason)
+			}
+		})
+	}
+}
+
+func TestDeliverSendableRealFailuresReturnErrors(t *testing.T) {
+	t.Run("no target", func(t *testing.T) {
+		m, _ := policyManager(t, &fakeAdapter{}, nil)
+		result, err := m.DeliverSendable(context.Background(), progressRequest("r1", "user1", "已提交分支", "s1"))
+		if !errors.Is(err, ErrNoSendableTarget) || result.Sent {
+			t.Fatalf("no target = %+v err=%v want ErrNoSendableTarget", result, err)
+		}
+	})
+
+	t.Run("empty text", func(t *testing.T) {
+		m, _ := policyManager(t, &fakeAdapter{}, nil)
+		req := progressRequest("r1", "user1", "", "s1")
+		if _, err := m.DeliverSendable(context.Background(), req); err == nil {
+			t.Fatal("empty text must be rejected")
+		}
+	})
+
+	t.Run("transport failure", func(t *testing.T) {
+		fa := &failingAdapter{failures: 99}
+		m, _ := bindingManager(t, &fa.fakeAdapter)
+		m.mu.Lock()
+		for _, rc := range m.running {
+			rc.adapter = fa
+		}
+		m.mu.Unlock()
+
+		// The context ends during the retry backoff, so the delivery stops right
+		// after a transport error: the message did not reach the channel.
+		m.SetRetryBackoff(func(int) time.Duration { return time.Hour })
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+		result, err := m.DeliverSendable(ctx, progressRequest("r1", "user1", "已提交分支", "s1"))
+		if !errors.Is(err, ErrDeliveryFailed) || !result.Failed() || result.Suppressed() {
+			t.Fatalf("transport failure = %+v err=%v want ErrDeliveryFailed", result, err)
+		}
+		if result.Reason() != "transport_failed" {
+			t.Fatalf("reason = %q want transport_failed", result.Reason())
+		}
+	})
+
+	t.Run("retries exhausted", func(t *testing.T) {
+		fa := &failingAdapter{failures: 99}
+		m, _ := bindingManager(t, &fa.fakeAdapter)
+		m.mu.Lock()
+		for _, rc := range m.running {
+			rc.adapter = fa
+		}
+		m.mu.Unlock()
+
+		req := progressRequest("r1", "user1", "已提交分支", "s1")
+		result, err := m.DeliverSendable(context.Background(), req)
+		if !errors.Is(err, ErrDeliveryFailed) || !result.Failed() {
+			t.Fatalf("exhausted attempts = %+v err=%v want ErrDeliveryFailed", result, err)
+		}
+		if result.Reason() != "retry_exhausted" {
+			t.Fatalf("reason = %q want retry_exhausted", result.Reason())
+		}
+		if fa.attempts != 3 {
+			t.Fatalf("adapter attempts = %d want the bounded 3", fa.attempts)
+		}
+		// A later attempt on the same key stays a failure, never a suppression
+		// the agent is told to accept.
+		result, err = m.DeliverSendable(context.Background(), req)
+		if !errors.Is(err, ErrDeliveryFailed) || result.Reason() != "retry_exhausted" {
+			t.Fatalf("second call = %+v err=%v want retry_exhausted failure", result, err)
+		}
+	})
+
+	t.Run("policy evaluation failed closed", func(t *testing.T) {
+		fa := &fakeAdapter{}
+		m, _ := bindingManager(t, fa)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // the policy store cannot be consulted → fail closed
+		result, err := m.DeliverSendable(ctx, progressRequest("r1", "user1", "已提交分支", "s1"))
+		if !errors.Is(err, ErrDeliveryFailed) || result.Reason() != "policy_error" {
+			t.Fatalf("fail-closed policy = %+v err=%v want policy_error failure", result, err)
+		}
+		if got := sentTexts(fa); len(got) != 0 {
+			t.Fatalf("fail-closed policy still sent %v", got)
+		}
+	})
+
+	t.Run("no adapter", func(t *testing.T) {
+		m := NewManager(nil, nil, nil)
+		result := m.sendOutboundResult(context.Background(), &runningChannel{
+			cfg: models.ChannelConfig{ID: "c1", Type: models.ChannelTypeQQ, ProjectID: "proj"},
+		}, OutboundMessage{Scene: SceneC2C, ConversationID: "user1", Text: "x"})
+		if !result.Failed() || result.Reason() != "no_adapter" {
+			t.Fatalf("missing adapter = %+v want a no_adapter failure", result)
+		}
+	})
+}
+
+// bindingManager wires a DB-backed policy plus task context and a started
+// channel for project "proj" bound to conversation "user1".
+func bindingManager(t *testing.T, fa *fakeAdapter) (*Manager, *services.TaskContextService) {
+	t.Helper()
+	m, db := policyManager(t, fa, nil)
+	svc := services.NewTaskContextService(db)
+	m.SetTaskContextService(svc)
+	m.Apply([]models.ChannelConfig{{
+		ID: "c1", Type: models.ChannelTypeQQ, ProjectID: "proj", AppID: "app", Enabled: true,
+		CronDeliver: true, CronDeliverTarget: "c2c:user1",
+	}})
+	t.Cleanup(m.StopAll)
+	return m, svc
+}
+
+func ensureTestIdentity(t *testing.T, svc *services.TaskContextService, runID, projectID, userID, title string) {
+	t.Helper()
+	if _, err := svc.EnsureIdentity(services.EnsureTaskIdentityInput{
+		RunID: runID, ProjectID: projectID, UserID: userID,
+		ShortTitle: title, OriginalRequirement: "实现" + title, Status: "active",
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func progressRequest(runID, userID, text, stage string) SendableRequest {
+	return SendableRequest{
+		ProjectID: "proj", Scene: SceneC2C, ConversationID: "user1", UserID: userID,
+		RunID: runID, Kind: sendable.KindProgress, Reason: "pm_notify_progress",
+		DedupeKey: "test:" + runID + ":" + stage,
+		Progress:  sendable.ProgressFields{Stage: stage},
+		Text:      text,
+	}
+}
+
+func bindings(t *testing.T, svc *services.TaskContextService) []models.MessageBinding {
+	t.Helper()
+	var out []models.MessageBinding
+	if err := svc.DB().Find(&out).Error; err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func TestOutboundSuccessBindsExternalMessageIDAndReplyWins(t *testing.T) {
+	fa := &fakeAdapter{messageIDs: []string{"qq-msg-1"}}
+	m, svc := bindingManager(t, fa)
+	qqUser := "user1"
+	userID := services.SyntheticQQUserID(qqUser)
+	ensureTestIdentity(t, svc, "r1", "proj", userID, "支付登录页")
+	ensureTestIdentity(t, svc, "r2", "proj", userID, "用户登录页")
+
+	result, err := m.ReportRunProgress(context.Background(), progressRequest("r1", qqUser, "已提交分支", "branch_pushed"))
+	if err != nil || !result.Sent {
+		t.Fatalf("progress delivery = %+v err=%v", result, err)
+	}
+	if result.ExternalMessageID != "qq-msg-1" {
+		t.Fatalf("external message id = %q want the id the channel reported", result.ExternalMessageID)
+	}
+
+	all := bindings(t, svc)
+	if len(all) != 1 {
+		t.Fatalf("message bindings = %+v want exactly one", all)
+	}
+	if all[0].MessageID != "qq-msg-1" || all[0].RunID != "r1" ||
+		all[0].UserID != userID || all[0].Channel != models.ChannelTypeQQ ||
+		all[0].ConversationID != "user1" || all[0].ProjectID != "proj" {
+		t.Fatalf("binding = %+v want project/user/channel/conversation scoped r1 binding", all[0])
+	}
+
+	// A reply to that message wins over a query that matches the other task.
+	scope := services.TaskScope{
+		ProjectID: "proj", UserID: userID,
+		Channel: models.ChannelTypeQQ, ConversationID: "user1",
+	}
+	candidates, err := svc.Search(scope, "用户登录页")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := svc.ResolveTask(services.ResolveTaskInput{
+		Scope: scope, Query: "用户登录页", ReplyMessageID: "qq-msg-1", Candidates: candidates,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Identity == nil || res.Identity.RunID != "r1" || res.Reason != "reply_binding" {
+		t.Fatalf("reply reference = %+v want the bound r1 task", res)
+	}
+
+	// Another user in the same conversation must not resolve through it.
+	otherScope := scope
+	otherScope.UserID = services.SyntheticQQUserID("user2")
+	res, err = svc.ResolveTask(services.ResolveTaskInput{Scope: otherScope, ReplyMessageID: "qq-msg-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Identity != nil {
+		t.Fatalf("cross-user reply reference resolved to %+v", res.Identity)
+	}
+	// Same for another project.
+	otherProject := scope
+	otherProject.ProjectID = "other-proj"
+	res, err = svc.ResolveTask(services.ResolveTaskInput{Scope: otherProject, ReplyMessageID: "qq-msg-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Identity != nil {
+		t.Fatalf("cross-project reply reference resolved to %+v", res.Identity)
+	}
+}
+
+func TestOutboundBindingSkippedWithoutRealIDRunOrOwnership(t *testing.T) {
+	qqUser := "user1"
+	userID := services.SyntheticQQUserID(qqUser)
+
+	t.Run("channel reported no message id", func(t *testing.T) {
+		fa := &fakeAdapter{}
+		m, svc := bindingManager(t, fa)
+		ensureTestIdentity(t, svc, "r1", "proj", userID, "支付登录页")
+		result, err := m.ReportRunProgress(context.Background(), progressRequest("r1", qqUser, "已提交分支", "s1"))
+		if err != nil || !result.Sent {
+			t.Fatalf("delivery = %+v err=%v", result, err)
+		}
+		if all := bindings(t, svc); len(all) != 0 {
+			t.Fatalf("bindings without a channel message id = %+v", all)
+		}
+	})
+
+	t.Run("send failed", func(t *testing.T) {
+		fa := &failingAdapter{failures: 99}
+		fa.messageIDs = []string{"qq-msg-fail"}
+		m, svc := bindingManager(t, &fa.fakeAdapter)
+		m.mu.Lock()
+		for _, rc := range m.running {
+			rc.adapter = fa
+		}
+		m.mu.Unlock()
+		ensureTestIdentity(t, svc, "r1", "proj", userID, "支付登录页")
+		result, err := m.ReportRunProgress(context.Background(), progressRequest("r1", qqUser, "已提交分支", "s1"))
+		if !errors.Is(err, ErrDeliveryFailed) || result.Sent {
+			t.Fatalf("failed delivery = %+v err=%v want ErrDeliveryFailed", result, err)
+		}
+		if all := bindings(t, svc); len(all) != 0 {
+			t.Fatalf("bindings after transport failure = %+v", all)
+		}
+	})
+
+	t.Run("turn traffic has no run id", func(t *testing.T) {
+		fa := &fakeAdapter{messageIDs: []string{"qq-msg-turn", "qq-msg-final"}}
+		m, svc := bindingManager(t, fa)
+		m.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
+			return Reply{FinalSummary: "done"}, nil
+		}
+		ensureTestIdentity(t, svc, "r1", "proj", userID, "支付登录页")
+		m.dispatch(context.Background(), testRunningChannel(fa), testInbound("turn-bind"))
+		if all := bindings(t, svc); len(all) != 0 {
+			t.Fatalf("turn deliveries must not bind: %+v", all)
+		}
+	})
+
+	t.Run("run belongs to another user", func(t *testing.T) {
+		fa := &fakeAdapter{messageIDs: []string{"qq-msg-2"}}
+		m, svc := bindingManager(t, fa)
+		ensureTestIdentity(t, svc, "r1", "proj", services.SyntheticQQUserID("owner"), "支付登录页")
+		result, err := m.ReportRunProgress(context.Background(), progressRequest("r1", "intruder", "已提交分支", "s1"))
+		if err != nil || !result.Sent {
+			t.Fatalf("delivery = %+v err=%v", result, err)
+		}
+		if all := bindings(t, svc); len(all) != 0 {
+			t.Fatalf("binding crossed task ownership: %+v", all)
+		}
+	})
+
+	t.Run("run has no task identity", func(t *testing.T) {
+		fa := &fakeAdapter{messageIDs: []string{"qq-msg-3"}}
+		m, svc := bindingManager(t, fa)
+		result, err := m.ReportRunProgress(context.Background(), progressRequest("r-unknown", qqUser, "已提交分支", "s1"))
+		if err != nil || !result.Sent {
+			t.Fatalf("delivery = %+v err=%v", result, err)
+		}
+		if all := bindings(t, svc); len(all) != 0 {
+			t.Fatalf("binding invented an identity: %+v", all)
+		}
+	})
 }
 
 func TestResolveTaskReferenceQQFlow(t *testing.T) {

--- a/server/internal/channels/delivery_test.go
+++ b/server/internal/channels/delivery_test.go
@@ -189,8 +189,8 @@ func TestSendRunAcceptanceAckOncePerRunAndRejectsMissingRun(t *testing.T) {
 	if _, err := m.SendRunAcceptanceAck(context.Background(), ack); err != nil {
 		t.Fatalf("first ack: %v", err)
 	}
-	if _, err := m.SendRunAcceptanceAck(context.Background(), ack); err != nil {
-		t.Fatalf("second ack: %v", err)
+	if result, err := m.SendRunAcceptanceAck(context.Background(), ack); !errors.Is(err, ErrDeliverySuppressed) || result.Sent {
+		t.Fatalf("second ack should report idempotent suppression: result=%+v err=%v", result, err)
 	}
 	got := sentTexts(fa)
 	if len(got) != 1 {

--- a/server/internal/channels/delivery_test.go
+++ b/server/internal/channels/delivery_test.go
@@ -186,10 +186,10 @@ func TestSendRunAcceptanceAckOncePerRunAndRejectsMissingRun(t *testing.T) {
 		ProjectID: "proj", RunID: "run-1", Scene: SceneC2C,
 		ConversationID: "user1", UserID: "u1", ShortTitle: "登录页", Language: "zh-CN",
 	}
-	if err := m.SendRunAcceptanceAck(context.Background(), ack); err != nil {
+	if _, err := m.SendRunAcceptanceAck(context.Background(), ack); err != nil {
 		t.Fatalf("first ack: %v", err)
 	}
-	if err := m.SendRunAcceptanceAck(context.Background(), ack); err != nil {
+	if _, err := m.SendRunAcceptanceAck(context.Background(), ack); err != nil {
 		t.Fatalf("second ack: %v", err)
 	}
 	got := sentTexts(fa)
@@ -201,7 +201,7 @@ func TestSendRunAcceptanceAckOncePerRunAndRejectsMissingRun(t *testing.T) {
 	}
 
 	ack.RunID = ""
-	if err := m.SendRunAcceptanceAck(context.Background(), ack); err == nil {
+	if _, err := m.SendRunAcceptanceAck(context.Background(), ack); err == nil {
 		t.Fatal("run acceptance ACK without a real run id must be rejected")
 	}
 }
@@ -255,9 +255,9 @@ func TestResolveTaskReferenceQQFlow(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	// Another QQ identity in the same project must stay invisible.
+	// Another project's task must stay invisible even with a similar title.
 	if _, err := svc.EnsureIdentity(services.EnsureTaskIdentityInput{
-		RunID: "r3", ProjectID: projectID, UserID: services.SyntheticQQUserID("intruder"),
+		RunID: "r3", ProjectID: "other-proj", UserID: userID,
 		ShortTitle: "登录页", Status: "active",
 	}); err != nil {
 		t.Fatal(err)

--- a/server/internal/channels/delivery_test.go
+++ b/server/internal/channels/delivery_test.go
@@ -1,0 +1,347 @@
+package channels
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/sendable"
+	"github.com/cocofhu/approving/internal/services"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func deliveryDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(
+		sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"),
+		&gorm.Config{Logger: logger.Discard},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	if err := db.AutoMigrate(models.AllModels()...); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+// policyManager builds a Manager with a DB-backed policy and no retry sleeping.
+func policyManager(t *testing.T, fa *fakeAdapter, audit sendable.AuditFunc) (*Manager, *gorm.DB) {
+	t.Helper()
+	db := deliveryDB(t)
+	m := newTestManager(fa)
+	m.SetSendablePolicy(sendable.NewPolicy(db, audit))
+	m.SetRetryBackoff(func(int) time.Duration { return 0 })
+	return m, db
+}
+
+func TestFinalOnlySendsStructuredSummaryNeverRawAssistantText(t *testing.T) {
+	const raw = "内部推理：我先读了配置文件，然后决定改动 auth 模块，密钥是 sk-secret。\n[摘要] 即使带提示词标签也不能外发"
+	fa := &fakeAdapter{}
+	m := NewManager(nil, nil, nil)
+	m.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
+		return Reply{Text: raw}, nil
+	}
+	m.dispatch(context.Background(), testRunningChannel(fa), testInbound("final-raw"))
+
+	got := sentTexts(fa)
+	for _, text := range got {
+		if strings.Contains(text, "内部推理") || strings.Contains(text, "sk-secret") || strings.Contains(text, "提示词标签") {
+			t.Fatalf("raw assistant final leaked: %v", got)
+		}
+	}
+	if countText(got, safeFinalNotice) != 1 {
+		t.Fatalf("expected the safe notice when no structured summary exists, got %v", got)
+	}
+
+	fa2 := &fakeAdapter{}
+	m2 := NewManager(nil, nil, nil)
+	m2.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
+		return Reply{Text: raw, FinalSummary: "已完成 auth 模块改动"}, nil
+	}
+	m2.dispatch(context.Background(), testRunningChannel(fa2), testInbound("final-structured"))
+	got2 := sentTexts(fa2)
+	if countText(got2, "已完成 auth 模块改动") != 1 {
+		t.Fatalf("structured summary missing in %v", got2)
+	}
+	for _, text := range got2 {
+		if strings.Contains(text, "内部推理") {
+			t.Fatalf("raw text leaked alongside summary: %v", got2)
+		}
+	}
+}
+
+// failingAdapter fails the first failures sends, then succeeds.
+type failingAdapter struct {
+	fakeAdapter
+	failures int
+	attempts int
+}
+
+func (f *failingAdapter) Send(ctx context.Context, out OutboundMessage) error {
+	f.mu.Lock()
+	f.attempts++
+	attempt := f.attempts
+	f.mu.Unlock()
+	if attempt <= f.failures {
+		return errors.New("transport down")
+	}
+	return f.fakeAdapter.Send(ctx, out)
+}
+
+func TestSendOutboundRetriesThenSucceedsExactlyOnce(t *testing.T) {
+	fa := &failingAdapter{failures: 2}
+	var audits []sendable.AuditEntry
+	m, db := policyManager(t, &fa.fakeAdapter, func(e sendable.AuditEntry) { audits = append(audits, e) })
+	m.Apply([]models.ChannelConfig{{
+		ID: "c1", Type: "qq", ProjectID: "proj", AppID: "app", Enabled: true,
+		CronDeliver: true, CronDeliverTarget: "c2c:user1",
+	}})
+	defer m.StopAll()
+	// Replace the started adapter with the failing one.
+	m.mu.Lock()
+	for _, rc := range m.running {
+		rc.adapter = fa
+	}
+	m.mu.Unlock()
+
+	if err := m.DeliverCron(cronDelivery("proj", "每小时PR", "changed", "PR 有更新")); err != nil {
+		t.Fatalf("DeliverCron: %v", err)
+	}
+	if fa.attempts != 3 {
+		t.Fatalf("adapter attempts = %d want 3 bounded attempts", fa.attempts)
+	}
+	if got := sentTexts(&fa.fakeAdapter); len(got) != 1 {
+		t.Fatalf("delivered %v want exactly one successful send", got)
+	}
+
+	var receipt models.SendableDeliveryReceipt
+	if err := db.First(&receipt).Error; err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Status != "sent" || receipt.Attempts != 3 {
+		t.Fatalf("receipt = %+v want sent after 3 attempts", receipt)
+	}
+	sent, failed := 0, 0
+	for _, entry := range audits {
+		switch entry.Result {
+		case "sent":
+			sent++
+		case "failed":
+			failed++
+		}
+	}
+	if sent != 1 || failed != 2 {
+		t.Fatalf("audit results sent=%d failed=%d want 1/2", sent, failed)
+	}
+}
+
+func TestSendOutboundStopsAfterExhaustingAttempts(t *testing.T) {
+	fa := &failingAdapter{failures: 99}
+	m, db := policyManager(t, &fa.fakeAdapter, nil)
+	m.Apply([]models.ChannelConfig{{
+		ID: "c1", Type: "qq", ProjectID: "proj", AppID: "app", Enabled: true,
+		CronDeliver: true, CronDeliverTarget: "c2c:user1",
+	}})
+	defer m.StopAll()
+	m.mu.Lock()
+	for _, rc := range m.running {
+		rc.adapter = fa
+	}
+	m.mu.Unlock()
+
+	if err := m.DeliverCron(cronDelivery("proj", "每小时PR", "changed", "PR 有更新")); err != nil {
+		t.Fatalf("DeliverCron: %v", err)
+	}
+	if fa.attempts != 3 {
+		t.Fatalf("adapter attempts = %d want 3", fa.attempts)
+	}
+	var receipt models.SendableDeliveryReceipt
+	if err := db.First(&receipt).Error; err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Status != "failed" || receipt.Attempts != 3 {
+		t.Fatalf("receipt = %+v want failed after 3 attempts", receipt)
+	}
+}
+
+func TestSendRunAcceptanceAckOncePerRunAndRejectsMissingRun(t *testing.T) {
+	fa := &fakeAdapter{}
+	m, _ := policyManager(t, fa, nil)
+	m.Apply([]models.ChannelConfig{{
+		ID: "c1", Type: "qq", ProjectID: "proj", AppID: "app", Enabled: true,
+		CronDeliver: true, CronDeliverTarget: "c2c:user1",
+	}})
+	defer m.StopAll()
+
+	ack := RunAcceptanceAck{
+		ProjectID: "proj", RunID: "run-1", Scene: SceneC2C,
+		ConversationID: "user1", UserID: "u1", ShortTitle: "登录页", Language: "zh-CN",
+	}
+	if err := m.SendRunAcceptanceAck(context.Background(), ack); err != nil {
+		t.Fatalf("first ack: %v", err)
+	}
+	if err := m.SendRunAcceptanceAck(context.Background(), ack); err != nil {
+		t.Fatalf("second ack: %v", err)
+	}
+	got := sentTexts(fa)
+	if len(got) != 1 {
+		t.Fatalf("run acceptance ACK sent %v want exactly once per run", got)
+	}
+	if !strings.HasPrefix(got[0], "【登录页｜已接单】") {
+		t.Fatalf("ack text = %q want short title prefix", got[0])
+	}
+
+	ack.RunID = ""
+	if err := m.SendRunAcceptanceAck(context.Background(), ack); err == nil {
+		t.Fatal("run acceptance ACK without a real run id must be rejected")
+	}
+}
+
+func TestTurnProcessingAckIsNotRunScoped(t *testing.T) {
+	fa := &fakeAdapter{}
+	m, db := policyManager(t, fa, nil)
+	m.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
+		return Reply{FinalSummary: "done-" + in.MessageID}, nil
+	}
+	rc := testRunningChannel(fa)
+	m.dispatch(context.Background(), rc, testInbound("turn-1"))
+	m.dispatch(context.Background(), rc, testInbound("turn-2"))
+
+	if n := hasPrefixCount(sentTexts(fa), ackProcessingPrefix); n != 2 {
+		t.Fatalf("processing ACK count = %d want one per turn", n)
+	}
+	var receipts []models.SendableDeliveryReceipt
+	if err := db.Find(&receipts).Error; err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range receipts {
+		if r.RunID != "" {
+			t.Fatalf("turn delivery carried a fabricated run id: %+v", r)
+		}
+		if r.TaskContext == "" {
+			t.Fatalf("turn delivery has no task scope: %+v", r)
+		}
+		if r.Kind == string(sendable.KindRunAcceptanceAck) {
+			t.Fatalf("turn ACK was recorded as a run acceptance ACK: %+v", r)
+		}
+	}
+}
+
+func TestResolveTaskReferenceQQFlow(t *testing.T) {
+	fa := &fakeAdapter{}
+	m, db := policyManager(t, fa, nil)
+	svc := services.NewTaskContextService(db)
+	m.SetTaskContextService(svc)
+
+	projectID, qqUser := "proj", "u1"
+	userID := services.SyntheticQQUserID(qqUser)
+	for _, spec := range []struct{ run, title string }{
+		{"r1", "支付登录页"},
+		{"r2", "用户登录页"},
+	} {
+		if _, err := svc.EnsureIdentity(services.EnsureTaskIdentityInput{
+			RunID: spec.run, ProjectID: projectID, UserID: userID,
+			ShortTitle: spec.title, OriginalRequirement: "实现" + spec.title, Status: "active",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Another QQ identity in the same project must stay invisible.
+	if _, err := svc.EnsureIdentity(services.EnsureTaskIdentityInput{
+		RunID: "r3", ProjectID: projectID, UserID: services.SyntheticQQUserID("intruder"),
+		ShortTitle: "登录页", Status: "active",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	base := TaskReferenceRequest{
+		ProjectID: projectID, ChannelType: models.ChannelTypeQQ, Scene: SceneC2C,
+		ConversationID: "c1", QQUserID: qqUser,
+	}
+
+	// QQ has no reply reference, so a quoted message id is ignored entirely.
+	ambiguous := base
+	ambiguous.Text = "登录页"
+	ambiguous.ReplyToMessageID = "m-quoted"
+	res, err := m.ResolveTaskReference(ambiguous)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != TaskReferenceAmbiguous || len(res.Options) != 2 {
+		t.Fatalf("ambiguous result = %+v", res)
+	}
+	if res.ReplyRefSupported {
+		t.Fatal("QQ must report reply references as unsupported")
+	}
+	if !strings.Contains(res.Message, "不支持引用回复") || !strings.Contains(res.Message, "1. ") {
+		t.Fatalf("ambiguity prompt = %q", res.Message)
+	}
+
+	// The ordinal selects from exactly the options the user was shown.
+	pick := base
+	pick.Text = "2"
+	res, err = m.ResolveTaskReference(pick)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != TaskReferenceResolved || res.Task == nil {
+		t.Fatalf("ordinal selection = %+v", res)
+	}
+	picked := res.Task.RunID
+
+	// Focus now answers a follow-up with no task words at all.
+	followUp := base
+	followUp.Text = ""
+	res, err = m.ResolveTaskReference(followUp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != TaskReferenceResolved || res.Task.RunID != picked {
+		t.Fatalf("focus follow-up = %+v want %s", res, picked)
+	}
+
+	// A unique short title resolves directly and is formatted for the user.
+	unique := base
+	unique.Text = "支付登录页"
+	res, err = m.ResolveTaskReference(unique)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != TaskReferenceResolved || res.Task.RunID != "r1" {
+		t.Fatalf("unique match = %+v", res)
+	}
+	if !strings.HasPrefix(res.Message, "【支付登录页｜进行中】") {
+		t.Fatalf("resolved message = %q", res.Message)
+	}
+
+	// No match must not guess.
+	missing := base
+	missing.Text = "结算页面"
+	res, err = m.ResolveTaskReference(missing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != TaskReferenceNotFound || res.Task != nil {
+		t.Fatalf("no-match result = %+v", res)
+	}
+
+	// English input switches the copy.
+	english := base
+	english.Text = "unknown checkout task"
+	res, err = m.ResolveTaskReference(english)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Language != "en" || !strings.Contains(res.Message, "No matching task") {
+		t.Fatalf("english fallback = %+v", res)
+	}
+}

--- a/server/internal/channels/manager.go
+++ b/server/internal/channels/manager.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/sendable"
 	"github.com/cocofhu/approving/internal/services"
 
 	"github.com/rs/zerolog/log"
@@ -79,7 +80,15 @@ type Manager struct {
 	pushMu     sync.Mutex
 	pushQueues map[string]*pushQueue
 
-	baseCtx context.Context
+	baseCtx          context.Context
+	policy           *sendable.Policy
+	taskContext      *services.TaskContextService
+	riskConfirmation *services.RiskConfirmationService
+	// retryBackoff overrides the delivery backoff (tests set it to zero).
+	retryBackoff func(attempt int) time.Duration
+
+	ambiguityMu sync.Mutex
+	ambiguity   map[string]ambiguityMemory
 
 	// Test hooks (production leaves these nil/zero):
 	// handleFunc overrides bridge.Handle when set (no progress callback).
@@ -106,7 +115,38 @@ func NewManager(bridge *ChannelBridge, factories map[string]AdapterFactory, decr
 		convQueues: map[string]*convQueue{},
 		pushQueues: map[string]*pushQueue{},
 		baseCtx:    context.Background(),
+		policy:     sendable.NewPolicy(nil, nil),
 	}
+}
+
+// SetSendablePolicy installs the single delivery gate used before Adapter.Send.
+func (m *Manager) SetSendablePolicy(policy *sendable.Policy) {
+	if policy != nil {
+		m.policy = policy
+	}
+}
+
+// SetRetryBackoff overrides the outbound retry backoff schedule.
+func (m *Manager) SetRetryBackoff(backoff func(attempt int) time.Duration) {
+	m.retryBackoff = backoff
+}
+
+// SetTaskContextService exposes DB-backed task identity/focus to orchestration.
+func (m *Manager) SetTaskContextService(service *services.TaskContextService) {
+	m.taskContext = service
+}
+
+// TaskContextService returns the configured task context service.
+func (m *Manager) TaskContextService() *services.TaskContextService { return m.taskContext }
+
+// SetRiskConfirmationService exposes one-shot high-risk confirmation tickets.
+func (m *Manager) SetRiskConfirmationService(service *services.RiskConfirmationService) {
+	m.riskConfirmation = service
+}
+
+// RiskConfirmationService returns the configured ticket service.
+func (m *Manager) RiskConfirmationService() *services.RiskConfirmationService {
+	return m.riskConfirmation
 }
 
 // SetLoader registers the DB-backed config source used by Reload/ApplyOnBoot.
@@ -275,6 +315,7 @@ func (m *Manager) dispatch(ctx context.Context, rc *runningChannel, in InboundMe
 			m.sendOutbound(ctx, rc, OutboundMessage{
 				Scene: in.Scene, ConversationID: in.ConversationID,
 				ReplyToMessageID: in.MessageID, Text: queueFullText,
+				Envelope: turnEnvelope(rc, in, sendable.KindSafetyNotice, "queue_full", sendable.PriorityHigh),
 			})
 			return
 		}
@@ -285,6 +326,7 @@ func (m *Manager) dispatch(ctx context.Context, rc *runningChannel, in InboundMe
 		m.sendOutbound(ctx, rc, OutboundMessage{
 			Scene: in.Scene, ConversationID: in.ConversationID,
 			ReplyToMessageID: in.MessageID, Text: queueAckTextFor(ahead, in.Text),
+			Envelope: turnEnvelope(rc, in, sendable.KindQueueAck, "turn_queued", sendable.PriorityHigh),
 		})
 		return
 	}
@@ -322,6 +364,7 @@ func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMes
 		m.sendOutbound(ctx, rc, OutboundMessage{
 			Scene: in.Scene, ConversationID: in.ConversationID,
 			ReplyToMessageID: in.MessageID, Text: processingAckText(in.Text),
+			Envelope: turnEnvelope(rc, in, sendable.KindTurnProcessingAck, "turn_processing", sendable.PriorityHigh),
 		})
 	}
 
@@ -335,9 +378,12 @@ func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMes
 		if text == "" {
 			return
 		}
+		// Classification-only events stay internal; sendOutbound still runs so
+		// the suppression is audited with a reason instead of vanishing.
 		m.sendOutbound(ctx, rc, OutboundMessage{
 			Scene: in.Scene, ConversationID: in.ConversationID,
 			ReplyToMessageID: in.MessageID, Text: text,
+			Envelope: progressEnvelope(rc, in, ev),
 		})
 	}
 	reply, err := m.handleTurn(ctx, resolved, in, onProgress)
@@ -346,13 +392,38 @@ func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMes
 		m.sendOutbound(ctx, rc, OutboundMessage{
 			Scene: in.Scene, ConversationID: in.ConversationID,
 			ReplyToMessageID: in.MessageID, Text: failReplyPrefix + friendlyErr(err),
+			Envelope: turnEnvelope(rc, in, sendable.KindBlocked, "turn_failed", sendable.PriorityCritical),
 		})
 		return
 	}
+	summary, reason := deliverableFinalText(reply)
+	images := reply.ImageURLs
+	if summary == safeFinalNotice {
+		images = nil // no structured summary → no derived attachments either
+	}
 	m.sendOutbound(ctx, rc, OutboundMessage{
 		Scene: in.Scene, ConversationID: in.ConversationID, ReplyToMessageID: in.MessageID,
-		Text: reply.Text, ImageURLs: reply.ImageURLs,
+		Text: summary, ImageURLs: images,
+		Envelope: func() sendable.DeliveryEnvelope {
+			e := turnEnvelope(rc, in, sendable.KindFinal, reason, sendable.PriorityCritical)
+			e.Structured = true
+			return e
+		}(),
 	})
+}
+
+// safeFinalNotice is sent when Work produced no structured summary. Raw
+// assistant text is never used as a fallback.
+const safeFinalNotice = "本回合已结束，请在 Approving 查看完整结果。"
+
+// deliverableFinalText returns the only text allowed out of a finished turn:
+// the structured FinalSummary, or a fixed safe notice. Reply.Text stays
+// internal regardless of its content.
+func deliverableFinalText(reply Reply) (text, reason string) {
+	if summary := strings.TrimSpace(reply.FinalSummary); summary != "" {
+		return truncateRunes(summary, 240), "structured_turn_final"
+	}
+	return safeFinalNotice, "final_summary_missing_safe_notice"
 }
 
 func (m *Manager) handleTurn(ctx context.Context, rc ResolvedChannel, in InboundMessage, onProgress func(ProgressEvent)) (Reply, error) {
@@ -365,13 +436,115 @@ func (m *Manager) handleTurn(ctx context.Context, rc ResolvedChannel, in Inbound
 	return m.bridge.Handle(ctx, rc, in, onProgress)
 }
 
+// turnScope identifies one conversation turn. A turn is NOT a Run: the inbound
+// platform MessageID may only key turn-level dedupe, never a run_id.
+func turnScope(rc *runningChannel, in InboundMessage) string {
+	if id := strings.TrimSpace(in.MessageID); id != "" {
+		return "turn:" + rc.cfg.ProjectID + "|" + id
+	}
+	return "turn:" + convKey(rc.cfg.ProjectID, in.Scene, in.ConversationID)
+}
+
+// turnEnvelope builds a turn-scoped envelope. RunID stays empty on purpose;
+// Run-scoped delivery must come from ProgressEvent.RunID or an explicit
+// DeliverSendable / SendRunAcceptanceAck call that carries a real Run id.
+func turnEnvelope(rc *runningChannel, in InboundMessage, kind sendable.Kind, reason string, priority sendable.Priority) sendable.DeliveryEnvelope {
+	scope := turnScope(rc, in)
+	e := sendable.DeliveryEnvelope{
+		Priority: priority, TaskContext: scope, ProjectID: rc.cfg.ProjectID,
+		ConversationID: in.ConversationID, UserID: in.UserID,
+		DedupeKey: scope + ":" + string(kind),
+		Reason:    reason, Kind: kind,
+	}
+	return sendable.AppendSendable(e, sendable.ChannelQQ)
+}
+
+// progressEnvelope maps a progress event onto a delivery envelope. Events that
+// are not explicitly deliverable stay internal so a prompt-shaped marker in
+// model output can never reach a channel.
+func progressEnvelope(rc *runningChannel, in InboundMessage, ev ProgressEvent) sendable.DeliveryEnvelope {
+	if !ev.Deliverable() {
+		return sendable.Internal(sendable.KindAgentRaw, "classified_progress_not_sendable")
+	}
+	kind := sendable.KindProgress
+	priority := sendable.PriorityNormal
+	switch {
+	case ev.Blocked || ev.Kind == ProgressBlocker:
+		kind, priority = sendable.KindBlocked, sendable.PriorityCritical
+	case ev.ActionRequired || ev.Kind == ProgressConfirm:
+		kind, priority = sendable.KindActionRequired, sendable.PriorityCritical
+	}
+	e := turnEnvelope(rc, in, kind, strings.TrimSpace(ev.Reason), priority)
+	if runID := strings.TrimSpace(ev.RunID); runID != "" {
+		e.RunID = runID
+		e.TaskContext = ""
+	}
+	if key := strings.TrimSpace(ev.DedupeKey); key != "" {
+		e.DedupeKey = key
+	} else {
+		e.DedupeKey = ""
+	}
+	e.Progress = sendable.ProgressFields{
+		Stage: ev.Stage, Blocked: ev.Blocked || ev.Kind == ProgressBlocker,
+		ActionRequired: ev.ActionRequired || ev.Kind == ProgressConfirm,
+		Conclusion:     ev.Conclusion,
+	}
+	if kind == sendable.KindProgress && strings.TrimSpace(e.Progress.Stage) == "" {
+		e.Progress.Stage = strings.TrimSpace(ev.Summary)
+	}
+	return e
+}
+
 func (m *Manager) sendOutbound(ctx context.Context, rc *runningChannel, out OutboundMessage) {
 	if rc == nil || rc.adapter == nil {
 		return
 	}
-	if err := rc.adapter.Send(ctx, out); err != nil {
-		log.Warn().Err(err).Str("channel", rc.cfg.ID).Str("text", truncateRunes(out.Text, 40)).
+	contentFingerprint := out.Text + "\n" + strings.Join(out.ImageURLs, "\n")
+	decision, err := m.policy.Evaluate(ctx, out.Envelope, sendable.ChannelQQ, contentFingerprint)
+	if err != nil {
+		log.Warn().Err(err).Str("channel", rc.cfg.ID).Msg("channel outbound policy failed closed")
+		return
+	}
+	for decision.Send {
+		sendErr := rc.adapter.Send(ctx, out)
+		if sendErr == nil {
+			_ = m.policy.MarkSent(ctx, decision, out.Envelope, sendable.ChannelQQ)
+			return
+		}
+		_ = m.policy.MarkFailed(ctx, decision, out.Envelope, sendable.ChannelQQ, sendErr)
+		log.Warn().Err(sendErr).Str("channel", rc.cfg.ID).Int("attempt", decision.Attempt).
 			Msg("channel outbound send failed")
+		if !m.waitBackoff(ctx, decision.Attempt) {
+			return
+		}
+		// Retry claims the next bounded attempt for this dedupe key; it returns
+		// Send=false once the receipt is sent elsewhere or attempts are spent.
+		next, err := m.policy.Retry(ctx, decision, out.Envelope, sendable.ChannelQQ)
+		if err != nil {
+			log.Warn().Err(err).Str("channel", rc.cfg.ID).Msg("channel outbound retry claim failed")
+			return
+		}
+		decision = next
+	}
+}
+
+// waitBackoff sleeps the delivery backoff and reports whether the caller may
+// continue (false when the context ended).
+func (m *Manager) waitBackoff(ctx context.Context, attempt int) bool {
+	delay := sendable.RetryDelay(attempt)
+	if m.retryBackoff != nil {
+		delay = m.retryBackoff(attempt)
+	}
+	if delay <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
 	}
 }
 
@@ -410,7 +583,22 @@ func (m *Manager) DeliverCron(d services.CronDelivery) error {
 		Category:  d.Category,
 		Kind:      kind,
 		// Keep raw formatted text (incl. image URLs); flushPushQueue splits on send.
-		Text:     text,
+		Text: text,
+		Envelope: sendable.AppendSendable(sendable.DeliveryEnvelope{
+			Priority: func() sendable.Priority {
+				if kind == CronResultFailed {
+					return sendable.PriorityCritical
+				}
+				return sendable.PriorityLow
+			}(),
+			// Cron jobs are not Runs: they carry a real Run id only when the
+			// scheduler supplied one, otherwise a cron task scope.
+			RunID:       strings.TrimSpace(d.RunID),
+			TaskContext: cronTaskContext(d),
+			ProjectID:   d.ProjectID, ConversationID: conv,
+			DedupeKey: d.DedupeKey, Reason: "cron_delivery", Kind: sendable.KindCron,
+			Structured: true,
+		}, sendable.ChannelQQ),
 		Enqueued: time.Now(),
 	}
 
@@ -444,7 +632,16 @@ func (m *Manager) DeliverRunNotify(projectID, text string) error {
 		Category:  "run_notify",
 		Kind:      CronResultChanged, // priority: treat actionable Run alerts like "changed"
 		Text:      text,
-		Enqueued:  time.Now(),
+		Envelope: sendable.AppendSendable(sendable.DeliveryEnvelope{
+			Priority: sendable.PriorityCritical,
+			// Only a Run id actually present in the notification is used; an
+			// unlinked notification falls back to a conversation task scope.
+			RunID:       runNotifyRunID(text),
+			TaskContext: runNotifyTaskContext(projectID, text),
+			ProjectID:   projectID, ConversationID: conv,
+			Reason: "run_notification", Kind: sendable.KindRunNotify, Structured: true,
+		}, sendable.ChannelQQ),
+		Enqueued: time.Now(),
 	}
 	m.enqueuePush(key, item)
 	m.flushPushQueue(key)
@@ -484,13 +681,48 @@ func (m *Manager) flushPushQueue(key string) {
 		}
 		stripped, urls := splitImageURLs(item.Text)
 		ctx, cancel := context.WithTimeout(m.baseCtx, 60*time.Second)
-		if err := target.adapter.Send(ctx, OutboundMessage{
-			Scene: item.Scene, ConversationID: item.Conv, Text: stripped, ImageURLs: urls,
-		}); err != nil {
-			log.Warn().Err(err).Str("project", item.ProjectID).Msg("cron push flush send failed")
-		}
+		m.sendOutbound(ctx, target, OutboundMessage{
+			Scene: item.Scene, ConversationID: item.Conv, Text: stripped,
+			ImageURLs: urls, Envelope: item.Envelope,
+		})
 		cancel()
 	}
+}
+
+// runNotifyRunID extracts the real Run id from a notification link, or "" when
+// the notification is not linked to a Run. It never fabricates an id.
+func runNotifyRunID(text string) string {
+	const marker = "/runs/"
+	idx := strings.Index(text, marker)
+	if idx < 0 {
+		return ""
+	}
+	value := text[idx+len(marker):]
+	if end := strings.IndexAny(value, " \t\r\n?#"); end >= 0 {
+		value = value[:end]
+	}
+	return strings.TrimSpace(value)
+}
+
+// runNotifyTaskContext scopes an unlinked notification so it still has a
+// delivery bucket without pretending to be a Run.
+func runNotifyTaskContext(projectID, text string) string {
+	if runNotifyRunID(text) != "" {
+		return ""
+	}
+	return "run-notify:" + projectID
+}
+
+// cronTaskContext scopes a cron push that carries no Run id.
+func cronTaskContext(d services.CronDelivery) string {
+	if strings.TrimSpace(d.RunID) != "" {
+		return ""
+	}
+	category := strings.TrimSpace(d.Category)
+	if category == "" {
+		category = "cron"
+	}
+	return "cron:" + d.ProjectID + "|" + category
 }
 
 // requeuePushAll puts remaining flush items back ahead of anything that arrived

--- a/server/internal/channels/manager.go
+++ b/server/internal/channels/manager.go
@@ -307,6 +307,12 @@ func (m *Manager) IsConversationBusy(projectID string, scene Scene, conversation
 // per-message queue ACK (ahead count); dequeue sends another processing ACK.
 // Full queue: reject with a visible reply (never silently drop).
 func (m *Manager) dispatch(ctx context.Context, rc *runningChannel, in InboundMessage) {
+	// A notice-only inbound (e.g. every attachment rejected) has no turn to run;
+	// it still goes out through the single policy/dedupe/audit egress.
+	if in.Safety != nil && in.Safety.Only {
+		m.sendSafetyNotice(ctx, rc, in, *in.Safety)
+		return
+	}
 	key := convKey(rc.cfg.ProjectID, in.Scene, in.ConversationID)
 	q := m.convQueueFor(key)
 
@@ -338,6 +344,28 @@ func (m *Manager) dispatch(ctx context.Context, rc *runningChannel, in InboundMe
 	// This goroutine owns the busy cycle: run the idle-first turn, then drain.
 	m.runTurn(ctx, rc, in, true /* withProcessingAck */)
 	m.drainConvQueue(q, key)
+}
+
+// sendSafetyNotice delivers an adapter-detected notice through the Manager, so a
+// replayed inbound message cannot produce a second notice and the outcome is
+// audited as sent or suppressed like any other outbound.
+func (m *Manager) sendSafetyNotice(ctx context.Context, rc *runningChannel, in InboundMessage, notice SafetyNotice) DeliveryResult {
+	text := strings.TrimSpace(notice.Text)
+	if text == "" {
+		return DeliveryResult{Decision: sendable.Decision{Reason: "empty"}}
+	}
+	reason := strings.TrimSpace(notice.Reason)
+	if reason == "" {
+		reason = "safety_notice"
+	}
+	envelope := turnEnvelope(rc, in, sendable.KindSafetyNotice, reason, sendable.PriorityHigh)
+	if key := strings.TrimSpace(notice.DedupeKey); key != "" {
+		envelope.DedupeKey = key
+	}
+	return m.sendOutboundResult(ctx, rc, OutboundMessage{
+		Scene: in.Scene, ConversationID: in.ConversationID,
+		ReplyToMessageID: in.MessageID, Text: text, Envelope: envelope,
+	})
 }
 
 // drainConvQueue runs pending messages in arrival order until the queue is
@@ -516,10 +544,11 @@ func (m *Manager) sendOutboundResult(ctx context.Context, rc *runningChannel, ou
 		return DeliveryResult{Decision: sendable.Decision{Reason: "policy_error"}}
 	}
 	for decision.Send {
-		sendErr := rc.adapter.Send(ctx, out)
+		sent, sendErr := rc.adapter.Send(ctx, out)
 		if sendErr == nil {
 			_ = m.policy.MarkSent(ctx, decision, out.Envelope, sendable.ChannelQQ)
-			return DeliveryResult{Decision: decision, Sent: true}
+			m.bindOutboundMessage(rc, out, sent.MessageID)
+			return DeliveryResult{Decision: decision, Sent: true, ExternalMessageID: sent.MessageID}
 		}
 		_ = m.policy.MarkFailed(ctx, decision, out.Envelope, sendable.ChannelQQ, sendErr)
 		log.Warn().Err(sendErr).Str("channel", rc.cfg.ID).Int("attempt", decision.Attempt).
@@ -542,6 +571,41 @@ func (m *Manager) sendOutboundResult(ctx context.Context, rc *runningChannel, ou
 		decision.Reason = "suppressed"
 	}
 	return DeliveryResult{Decision: decision}
+}
+
+// bindOutboundMessage records "this channel message belongs to that Run" so a
+// later reply reference resolves to the same task without any guessing. It is
+// best-effort and deliberately narrow: a delivery without a real Run id, without
+// a channel-reported message id, without a sender, or whose Run has no task
+// identity in this user's scope is simply not bound. No id is ever synthesized.
+func (m *Manager) bindOutboundMessage(rc *runningChannel, out OutboundMessage, messageID string) {
+	if m.taskContext == nil || rc == nil {
+		return
+	}
+	runID := strings.TrimSpace(out.Envelope.RunID)
+	messageID = strings.TrimSpace(messageID)
+	qqUserID := strings.TrimSpace(out.Envelope.UserID)
+	if runID == "" || messageID == "" || qqUserID == "" {
+		return
+	}
+	identity, err := m.taskContext.IdentityForRun(runID, rc.cfg.ProjectID)
+	if err != nil {
+		log.Warn().Err(err).Str("run", runID).Msg("outbound message binding: load task identity failed")
+		return
+	}
+	if identity == nil {
+		return
+	}
+	scope := services.TaskScope{
+		ProjectID: rc.cfg.ProjectID, UserID: services.SyntheticQQUserID(qqUserID),
+		Channel: rc.cfg.Type, ConversationID: out.ConversationID,
+	}
+	// BindMessage re-checks project/user ownership, so another user's task can
+	// never be bound to this conversation's message.
+	if err := m.taskContext.BindMessage(scope, messageID, identity); err != nil {
+		log.Warn().Err(err).Str("run", runID).Str("message", messageID).
+			Msg("outbound message binding skipped")
+	}
 }
 
 // waitBackoff sleeps the delivery backoff and reports whether the caller may

--- a/server/internal/channels/manager.go
+++ b/server/internal/channels/manager.go
@@ -90,6 +90,8 @@ type Manager struct {
 	ambiguityMu sync.Mutex
 	ambiguity   map[string]ambiguityMemory
 
+	riskExecutor RiskActionExecutor
+
 	// Test hooks (production leaves these nil/zero):
 	// handleFunc overrides bridge.Handle when set (no progress callback).
 	handleFunc func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error)
@@ -368,6 +370,10 @@ func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMes
 		})
 	}
 
+	if m.handleInboundOrchestration(ctx, rc, &in) {
+		return
+	}
+
 	resolved := ResolvedChannel{
 		ID: rc.cfg.ID, Type: rc.cfg.Type, ProjectID: rc.cfg.ProjectID,
 		TurnTimeout: time.Duration(rc.cfg.TurnTimeoutSeconds) * time.Second,
@@ -496,36 +502,46 @@ func progressEnvelope(rc *runningChannel, in InboundMessage, ev ProgressEvent) s
 }
 
 func (m *Manager) sendOutbound(ctx context.Context, rc *runningChannel, out OutboundMessage) {
+	_ = m.sendOutboundResult(ctx, rc, out)
+}
+
+func (m *Manager) sendOutboundResult(ctx context.Context, rc *runningChannel, out OutboundMessage) DeliveryResult {
 	if rc == nil || rc.adapter == nil {
-		return
+		return DeliveryResult{Decision: sendable.Decision{Reason: "no_adapter"}}
 	}
 	contentFingerprint := out.Text + "\n" + strings.Join(out.ImageURLs, "\n")
 	decision, err := m.policy.Evaluate(ctx, out.Envelope, sendable.ChannelQQ, contentFingerprint)
 	if err != nil {
 		log.Warn().Err(err).Str("channel", rc.cfg.ID).Msg("channel outbound policy failed closed")
-		return
+		return DeliveryResult{Decision: sendable.Decision{Reason: "policy_error"}}
 	}
 	for decision.Send {
 		sendErr := rc.adapter.Send(ctx, out)
 		if sendErr == nil {
 			_ = m.policy.MarkSent(ctx, decision, out.Envelope, sendable.ChannelQQ)
-			return
+			return DeliveryResult{Decision: decision, Sent: true}
 		}
 		_ = m.policy.MarkFailed(ctx, decision, out.Envelope, sendable.ChannelQQ, sendErr)
 		log.Warn().Err(sendErr).Str("channel", rc.cfg.ID).Int("attempt", decision.Attempt).
 			Msg("channel outbound send failed")
 		if !m.waitBackoff(ctx, decision.Attempt) {
-			return
+			decision.Reason = "transport_failed"
+			return DeliveryResult{Decision: decision}
 		}
 		// Retry claims the next bounded attempt for this dedupe key; it returns
 		// Send=false once the receipt is sent elsewhere or attempts are spent.
 		next, err := m.policy.Retry(ctx, decision, out.Envelope, sendable.ChannelQQ)
 		if err != nil {
 			log.Warn().Err(err).Str("channel", rc.cfg.ID).Msg("channel outbound retry claim failed")
-			return
+			decision.Reason = "retry_claim_failed"
+			return DeliveryResult{Decision: decision}
 		}
 		decision = next
 	}
+	if decision.Reason == "" {
+		decision.Reason = "suppressed"
+	}
+	return DeliveryResult{Decision: decision}
 }
 
 // waitBackoff sleeps the delivery backoff and reports whether the caller may

--- a/server/internal/channels/orchestration.go
+++ b/server/internal/channels/orchestration.go
@@ -53,7 +53,7 @@ func (m *Manager) handleInboundOrchestration(ctx context.Context, rc *runningCha
 	if m.taskContext == nil {
 		return false
 	}
-	if !looksLikeTaskAddressing(text) {
+	if !looksLikeTaskAddressing(text) && !m.hasTaskCandidate(rc, *in, text) {
 		return false
 	}
 	resolveText := text
@@ -157,6 +157,25 @@ func (m *Manager) tryCreateRiskConfirmation(ctx context.Context, rc *runningChan
 		}
 		return false
 	}
+	if action == "approve_gate" || action == "reject_gate" {
+		gateAction := "approve"
+		if action == "reject_gate" {
+			gateAction = "reject"
+		}
+		var gate models.Gate
+		err := m.taskContext.DB().Where("run_id = ? AND resolved = ?", res.Task.RunID, false).
+			Order("iteration desc, id desc").First(&gate).Error
+		if err != nil || strings.TrimSpace(gate.NodeID) == "" {
+			kind, body := "需澄清", "未找到该任务当前待处理的门禁，请先确认任务门禁状态。"
+			if language == "en" {
+				kind, body = "Action required", "No pending gate was found for this task. Check its gate status first."
+			}
+			m.sendOrchestrationReply(ctx, rc, in,
+				FormatTaskMessage(res.Task.ShortTitle, kind, body, text, language))
+			return true
+		}
+		action = "resume_gate:" + gate.NodeID + ":" + gateAction
+	}
 	ticket, err := m.riskConfirmation.CreateTicket(services.RiskTicketInput{
 		ProjectID: rc.cfg.ProjectID, UserID: scopeUser,
 		RunID: res.Task.RunID, Action: action, Language: language,
@@ -236,13 +255,28 @@ func looksLikeTaskAddressing(text string) bool {
 	// Short bare titles / keyword mentions are handled when Resolve finds them;
 	// avoid hijacking every casual chat line.
 	lower := strings.ToLower(text)
-	needles := []string{"任务", "怎么样", "进度", "状态", "登录页", "task", "status", "progress", "how is", "what's"}
+	needles := []string{"任务", "怎么样", "进度", "状态", "task", "status", "progress", "how is", "what's"}
 	for _, n := range needles {
 		if strings.Contains(lower, strings.ToLower(n)) {
 			return true
 		}
 	}
 	return false
+}
+
+func (m *Manager) hasTaskCandidate(rc *runningChannel, in InboundMessage, text string) bool {
+	if m == nil || m.taskContext == nil || rc == nil {
+		return false
+	}
+	text = strings.TrimSpace(text)
+	if text == "" || strings.ContainsAny(text, "\r\n") || len([]rune(text)) > 80 {
+		return false
+	}
+	candidates, err := m.taskContext.Search(services.TaskScope{
+		ProjectID: rc.cfg.ProjectID, UserID: services.SyntheticQQUserID(in.UserID),
+		Channel: rc.cfg.Type, ConversationID: in.ConversationID,
+	}, text)
+	return err == nil && len(candidates) > 0
 }
 
 func isContinuation(text string) bool {

--- a/server/internal/channels/orchestration.go
+++ b/server/internal/channels/orchestration.go
@@ -1,0 +1,362 @@
+package channels
+
+import (
+	"context"
+	"strings"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/sendable"
+	"github.com/cocofhu/approving/internal/services"
+
+	"github.com/rs/zerolog/log"
+)
+
+// RiskActionExecutor performs a confirmed high-risk action. Injected from main
+// so channels stay free of engine/pmmcp imports.
+type RiskActionExecutor func(projectID, runID, action string, meta map[string]string) error
+
+// RunLifecycleHooks lets workflow/MCP layers notify IM when a real Run is
+// accepted or when orchestration has a structured progress snapshot.
+type RunLifecycleHooks struct {
+	OnRunAccepted func(ctx context.Context, projectID, runID, userID string) error
+}
+
+func (m *Manager) SetRiskActionExecutor(exec RiskActionExecutor) {
+	m.riskExecutor = exec
+}
+
+// handleInboundOrchestration runs before the PM turn: risk confirmation,
+// high-risk intent tickets, and natural-language task addressing. Returns true
+// when the inbound message was fully handled (do not start a PM turn).
+func (m *Manager) handleInboundOrchestration(ctx context.Context, rc *runningChannel, in *InboundMessage) bool {
+	if in == nil || (m.taskContext == nil && m.riskConfirmation == nil) {
+		return false
+	}
+	text := strings.TrimSpace(in.Text)
+	if text == "" {
+		return false
+	}
+	scopeUser := services.SyntheticQQUserID(in.UserID)
+	language := services.DetectLanguage(text, "")
+
+	if m.riskConfirmation != nil {
+		decision := services.ParseRiskDecisionPublic(text)
+		if decision != "" {
+			if handled := m.tryResolveRiskConfirmation(ctx, rc, *in, scopeUser, text, language); handled {
+				return true
+			}
+		}
+		if handled := m.tryCreateRiskConfirmation(ctx, rc, *in, scopeUser, text, language); handled {
+			return true
+		}
+	}
+	if m.taskContext == nil {
+		return false
+	}
+	if !looksLikeTaskAddressing(text) {
+		return false
+	}
+	resolveText := text
+	if isContinuation(text) {
+		resolveText = "" // force conversation-focus binding
+	} else if isStatusQuery(text) {
+		resolveText = stripStatusQueryNoise(text)
+	}
+	res, err := m.ResolveTaskReference(TaskReferenceRequest{
+		ProjectID: rc.cfg.ProjectID, ChannelType: rc.cfg.Type, Scene: in.Scene,
+		ConversationID: in.ConversationID, QQUserID: in.UserID, Text: resolveText,
+	})
+	if err != nil {
+		log.Warn().Err(err).Str("project", rc.cfg.ProjectID).Msg("task reference resolve failed")
+		return false
+	}
+	switch res.Status {
+	case TaskReferenceAmbiguous, TaskReferenceNotFound, TaskReferenceNoContext:
+		m.sendOrchestrationReply(ctx, rc, *in, res.Message)
+		return true
+	case TaskReferenceResolved:
+		if res.Task == nil {
+			return false
+		}
+		if isContinuation(text) {
+			// Focus already renewed by ResolveTask; continue into the PM turn
+			// with the resolved run context prepended.
+			in.Text = prependFocusContext(text, res.Task)
+			return false
+		}
+		if isStatusQuery(text) || isBareTaskSelection(text, res) || resolveText != text {
+			// Re-render status with the original user wording language.
+			msg := FormatTaskMessage(res.Task.ShortTitle, taskStatusLabel(res.Task.Status, language),
+				"", text, language)
+			m.sendOrchestrationReply(ctx, rc, *in, msg)
+			return true
+		}
+		// Named a task but wants the agent to work — keep focus, continue turn.
+		return false
+	default:
+		return false
+	}
+}
+
+func (m *Manager) tryResolveRiskConfirmation(ctx context.Context, rc *runningChannel, in InboundMessage, scopeUser, text, language string) bool {
+	ticket, err := m.riskConfirmation.LatestPending(scopeUser, rc.cfg.ProjectID)
+	if err != nil {
+		log.Warn().Err(err).Msg("list pending risk ticket failed")
+		return false
+	}
+	if ticket == nil {
+		// Duplicate confirm/cancel against an already settled ticket.
+		ticket, err = m.riskConfirmation.LatestAny(scopeUser, rc.cfg.ProjectID)
+		if err != nil || ticket == nil || ticket.Status == "pending" {
+			return false
+		}
+	}
+	resolved, err := m.riskConfirmation.ResolveTicket(services.RiskTicketInput{
+		ProjectID: rc.cfg.ProjectID, UserID: scopeUser,
+		RunID: ticket.RunID, Action: ticket.Action, Language: language,
+	}, text)
+	if err != nil {
+		log.Warn().Err(err).Msg("risk ticket resolve failed")
+		return false
+	}
+	if resolved.Execute && m.riskExecutor != nil {
+		meta := map[string]string{}
+		if node := riskMetaNode(ticket.Action); node != "" {
+			meta["nodeId"] = node
+		}
+		if action := riskMetaGateAction(ticket.Action); action != "" {
+			meta["gateAction"] = action
+		}
+		if err := m.riskExecutor(rc.cfg.ProjectID, ticket.RunID, riskBaseAction(ticket.Action), meta); err != nil {
+			log.Warn().Err(err).Str("run", ticket.RunID).Str("action", ticket.Action).
+				Msg("confirmed risk action failed")
+			m.sendOrchestrationReply(ctx, rc, in, resolved.Message+" "+friendlyErr(err))
+			return true
+		}
+	}
+	m.sendOrchestrationReply(ctx, rc, in, resolved.Message)
+	return true
+}
+
+func (m *Manager) tryCreateRiskConfirmation(ctx context.Context, rc *runningChannel, in InboundMessage, scopeUser, text, language string) bool {
+	action, query := detectHighRiskIntent(text)
+	if action == "" {
+		return false
+	}
+	res, err := m.ResolveTaskReference(TaskReferenceRequest{
+		ProjectID: rc.cfg.ProjectID, ChannelType: rc.cfg.Type, Scene: in.Scene,
+		ConversationID: in.ConversationID, QQUserID: in.UserID, Text: query,
+	})
+	if err != nil {
+		return false
+	}
+	if res.Status != TaskReferenceResolved || res.Task == nil {
+		if res.Message != "" {
+			m.sendOrchestrationReply(ctx, rc, in, res.Message)
+			return true
+		}
+		return false
+	}
+	ticket, err := m.riskConfirmation.CreateTicket(services.RiskTicketInput{
+		ProjectID: rc.cfg.ProjectID, UserID: scopeUser,
+		RunID: res.Task.RunID, Action: action, Language: language,
+		ShortTitle: res.Task.ShortTitle,
+	})
+	if err != nil {
+		log.Warn().Err(err).Msg("create risk ticket failed")
+		return false
+	}
+	m.sendOrchestrationReply(ctx, rc, in, m.riskConfirmation.ConfirmationPrompt(*ticket))
+	return true
+}
+
+func (m *Manager) sendOrchestrationReply(ctx context.Context, rc *runningChannel, in InboundMessage, text string) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return
+	}
+	m.sendOutbound(ctx, rc, OutboundMessage{
+		Scene: in.Scene, ConversationID: in.ConversationID,
+		ReplyToMessageID: in.MessageID, Text: text,
+		Envelope: turnEnvelope(rc, in, sendable.KindActionRequired, "orchestration_reply", sendable.PriorityCritical),
+	})
+}
+
+// ReportRunProgress is the orchestration-layer explicit progress sendable path.
+func (m *Manager) ReportRunProgress(ctx context.Context, req SendableRequest) (DeliveryResult, error) {
+	if req.Kind == "" {
+		req.Kind = sendable.KindProgress
+	}
+	if req.Reason == "" {
+		req.Reason = "explicit_progress"
+	}
+	if req.Priority == "" {
+		req.Priority = sendable.PriorityNormal
+	}
+	if req.Kind == sendable.KindBlocked || req.Kind == sendable.KindActionRequired {
+		req.Priority = sendable.PriorityCritical
+	}
+	return m.DeliverSendable(ctx, req)
+}
+
+// EnsureRunAccepted materializes task identity and sends the once-per-run ACK.
+func (m *Manager) EnsureRunAccepted(ctx context.Context, projectID, runID, qqUserID, conversationID string, scene Scene, language string) (DeliveryResult, error) {
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return DeliveryResult{}, ErrDeliverySuppressed
+	}
+	shortTitle := runID
+	userID := services.SyntheticQQUserID(qqUserID)
+	if m.taskContext != nil {
+		var run models.Run
+		if err := m.taskContext.DB().Where("id = ?", runID).First(&run).Error; err == nil {
+			identity, err := m.taskContext.EnsureIdentityForRun(run, projectID, userID)
+			if err == nil && identity != nil {
+				shortTitle = identity.ShortTitle
+			}
+		}
+	}
+	if scene == "" {
+		scene = SceneC2C
+	}
+	return m.SendRunAcceptanceAck(ctx, RunAcceptanceAck{
+		ProjectID: projectID, RunID: runID, Scene: scene,
+		ConversationID: conversationID, UserID: qqUserID,
+		ShortTitle: shortTitle, Language: language,
+	})
+}
+
+func looksLikeTaskAddressing(text string) bool {
+	if services.ParseOrdinal(text) > 0 {
+		return true
+	}
+	if isContinuation(text) || isStatusQuery(text) {
+		return true
+	}
+	// Short bare titles / keyword mentions are handled when Resolve finds them;
+	// avoid hijacking every casual chat line.
+	lower := strings.ToLower(text)
+	needles := []string{"任务", "怎么样", "进度", "状态", "登录页", "task", "status", "progress", "how is", "what's"}
+	for _, n := range needles {
+		if strings.Contains(lower, strings.ToLower(n)) {
+			return true
+		}
+	}
+	return false
+}
+
+func isContinuation(text string) bool {
+	t := strings.TrimSpace(strings.ToLower(text))
+	switch t {
+	case "那继续吧", "继续吧", "继续", "接着做", "接着干", "go on", "continue", "keep going", "that continue":
+		return true
+	default:
+		return strings.Contains(t, "继续") && len([]rune(t)) <= 12
+	}
+}
+
+func isStatusQuery(text string) bool {
+	t := strings.TrimSpace(text)
+	if t == "" {
+		return false
+	}
+	needles := []string{"怎么样", "怎么了", "进度", "状态", "如何了", "好了吗", "how is", "how's", "status", "progress", "any update"}
+	lower := strings.ToLower(t)
+	for _, n := range needles {
+		if strings.Contains(lower, strings.ToLower(n)) {
+			return true
+		}
+	}
+	return false
+}
+
+func stripStatusQueryNoise(text string) string {
+	out := text
+	for _, noise := range []string{
+		"的事情怎么样了", "事情怎么样了", "怎么样了", "怎么样", "怎么了",
+		"的进度", "进度如何", "进度", "的状态", "状态", "如何了", "好了吗",
+		"how is", "how's", "status of", "status", "progress on", "progress", "any update",
+		"的事情", "事情",
+	} {
+		out = strings.ReplaceAll(out, noise, " ")
+		out = strings.ReplaceAll(out, strings.ToUpper(noise), " ")
+	}
+	return strings.Join(strings.Fields(strings.TrimSpace(out)), " ")
+}
+
+func isBareTaskSelection(text string, res TaskReferenceResult) bool {
+	if res.Task == nil {
+		return false
+	}
+	t := strings.TrimSpace(text)
+	if services.ParseOrdinal(t) > 0 {
+		return true
+	}
+	return strings.EqualFold(t, res.Task.ShortTitle)
+}
+
+func prependFocusContext(text string, task *models.TaskIdentity) string {
+	if task == nil {
+		return text
+	}
+	return "（当前焦点任务：" + task.ShortTitle + " / run " + task.RunID + "）\n" + text
+}
+
+func detectHighRiskIntent(text string) (action, query string) {
+	t := strings.TrimSpace(text)
+	lower := strings.ToLower(t)
+	type rule struct {
+		action string
+		keys   []string
+	}
+	rules := []rule{
+		{"cancel_run", []string{"取消任务", "取消这个", "取消该", "取消运行", "cancel run", "cancel the task", "取消"}},
+		{"approve_gate", []string{"批准", "同意门禁", "approve", "批准门禁"}},
+		{"reject_gate", []string{"拒绝门禁", "驳回", "reject gate"}},
+		{"delete_run", []string{"删除任务", "删掉", "delete task"}},
+	}
+	for _, r := range rules {
+		for _, key := range r.keys {
+			if strings.Contains(lower, strings.ToLower(key)) {
+				query = strings.TrimSpace(strings.ReplaceAll(t, key, ""))
+				query = strings.TrimSpace(strings.ReplaceAll(query, strings.ToUpper(key), ""))
+				if query == "" {
+					query = t
+				}
+				return r.action, query
+			}
+		}
+	}
+	return "", ""
+}
+
+func riskBaseAction(action string) string {
+	action = strings.TrimSpace(action)
+	if i := strings.IndexByte(action, ':'); i >= 0 {
+		return action[:i]
+	}
+	return action
+}
+
+func riskMetaNode(action string) string {
+	// action form: resume_gate:nodeId:approve
+	parts := strings.Split(action, ":")
+	if len(parts) >= 2 && parts[0] == "resume_gate" {
+		return parts[1]
+	}
+	return ""
+}
+
+func riskMetaGateAction(action string) string {
+	parts := strings.Split(action, ":")
+	if len(parts) >= 3 && parts[0] == "resume_gate" {
+		return parts[2]
+	}
+	if parts[0] == "approve_gate" {
+		return "approve"
+	}
+	if parts[0] == "reject_gate" {
+		return "reject"
+	}
+	return ""
+}

--- a/server/internal/channels/orchestration.go
+++ b/server/internal/channels/orchestration.go
@@ -2,6 +2,7 @@ package channels
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/cocofhu/approving/internal/models"
@@ -222,7 +223,7 @@ func (m *Manager) ReportRunProgress(ctx context.Context, req SendableRequest) (D
 func (m *Manager) EnsureRunAccepted(ctx context.Context, projectID, runID, qqUserID, conversationID string, scene Scene, language string) (DeliveryResult, error) {
 	runID = strings.TrimSpace(runID)
 	if runID == "" {
-		return DeliveryResult{}, ErrDeliverySuppressed
+		return DeliveryResult{}, errors.New("run acceptance requires a real run id")
 	}
 	shortTitle := runID
 	userID := services.SyntheticQQUserID(qqUserID)

--- a/server/internal/channels/orchestration_test.go
+++ b/server/internal/channels/orchestration_test.go
@@ -49,7 +49,7 @@ func TestInboundOrchestrationAmbiguityAndContinuation(t *testing.T) {
 	}
 
 	rc := &runningChannel{
-		cfg: models.ChannelConfig{ID: "c1", Type: models.ChannelTypeQQ, ProjectID: projectID},
+		cfg:     models.ChannelConfig{ID: "c1", Type: models.ChannelTypeQQ, ProjectID: projectID},
 		adapter: fa,
 	}
 	in := InboundMessage{
@@ -119,6 +119,85 @@ func TestInboundOrchestrationAmbiguityAndContinuation(t *testing.T) {
 	}, false)
 	if len(cancelled) != 1 || cancelled[0] != "r1:cancel_run" {
 		t.Fatalf("confirmed cancel = %v", cancelled)
+	}
+}
+
+func TestInboundOrchestrationGenericTitleAndGateConfirmation(t *testing.T) {
+	fa := &fakeAdapter{}
+	m, db := policyManager(t, fa, nil)
+	tasks := services.NewTaskContextService(db)
+	risk := services.NewRiskConfirmationService(db)
+	m.SetTaskContextService(tasks)
+	m.SetRiskConfirmationService(risk)
+
+	const projectID = "proj"
+	if err := db.Create(&models.Run{ID: "r-gate", Status: "waiting_human"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.EnsureIdentity(services.EnsureTaskIdentityInput{
+		RunID: "r-gate", ProjectID: projectID, UserID: services.SyntheticQQUserID("u1"),
+		ShortTitle: "结算页性能", Status: "waiting_human",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&models.Gate{
+		RunID: "r-gate", NodeID: "review-gate", Iteration: 1,
+		Title: "上线审批", Resolved: false,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	turned := 0
+	m.handleFunc = func(context.Context, ResolvedChannel, InboundMessage) (Reply, error) {
+		turned++
+		return Reply{}, nil
+	}
+	rc := &runningChannel{
+		cfg:     models.ChannelConfig{ID: "c1", Type: models.ChannelTypeQQ, ProjectID: projectID},
+		adapter: fa,
+	}
+	m.runTurn(context.Background(), rc, InboundMessage{
+		Scene: SceneC2C, ConversationID: "c1", UserID: "u1",
+		MessageID: "m1", Text: "结算页性能",
+	}, false)
+	if turned != 0 {
+		t.Fatalf("generic exact short title should be handled before PM turn, turned=%d", turned)
+	}
+	if got := sentTexts(fa); len(got) != 1 || !strings.Contains(got[0], "结算页性能") {
+		t.Fatalf("generic title reply = %v", got)
+	}
+
+	fa.mu.Lock()
+	fa.sent = nil
+	fa.mu.Unlock()
+	var executedAction string
+	var executedMeta map[string]string
+	m.SetRiskActionExecutor(func(projectID, runID, action string, meta map[string]string) error {
+		executedAction, executedMeta = action, meta
+		return nil
+	})
+	m.runTurn(context.Background(), rc, InboundMessage{
+		Scene: SceneC2C, ConversationID: "c1", UserID: "u1",
+		MessageID: "m2", Text: "批准结算页性能",
+	}, false)
+	pending, err := risk.LatestPending(services.SyntheticQQUserID("u1"), projectID)
+	if err != nil || pending == nil {
+		t.Fatalf("pending gate ticket = %+v err=%v", pending, err)
+	}
+	if pending.Action != "resume_gate:review-gate:approve" {
+		t.Fatalf("gate ticket action = %q", pending.Action)
+	}
+	if executedAction != "" {
+		t.Fatalf("gate executed before confirmation: %s", executedAction)
+	}
+
+	m.runTurn(context.Background(), rc, InboundMessage{
+		Scene: SceneC2C, ConversationID: "c1", UserID: "u1",
+		MessageID: "m3", Text: "确认",
+	}, false)
+	if executedAction != "resume_gate" ||
+		executedMeta["nodeId"] != "review-gate" || executedMeta["gateAction"] != "approve" {
+		t.Fatalf("confirmed gate action=%q meta=%v", executedAction, executedMeta)
 	}
 }
 

--- a/server/internal/channels/orchestration_test.go
+++ b/server/internal/channels/orchestration_test.go
@@ -1,0 +1,133 @@
+package channels
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/services"
+)
+
+func TestInboundOrchestrationAmbiguityAndContinuation(t *testing.T) {
+	fa := &fakeAdapter{}
+	m, db := policyManager(t, fa, nil)
+	tasks := services.NewTaskContextService(db)
+	risk := services.NewRiskConfirmationService(db)
+	m.SetTaskContextService(tasks)
+	m.SetRiskConfirmationService(risk)
+
+	var cancelled []string
+	m.SetRiskActionExecutor(func(projectID, runID, action string, meta map[string]string) error {
+		cancelled = append(cancelled, runID+":"+action)
+		return nil
+	})
+
+	turned := 0
+	m.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
+		turned++
+		return Reply{FinalSummary: "agent-handled:" + in.Text}, nil
+	}
+
+	projectID := "proj"
+	for _, spec := range []struct{ run, title string }{
+		{"r1", "登录页性能优化"},
+		{"r2", "登录页文案整改"},
+	} {
+		if _, err := tasks.EnsureIdentity(services.EnsureTaskIdentityInput{
+			RunID: spec.run, ProjectID: projectID, UserID: services.SyntheticQQUserID("u1"),
+			ShortTitle: spec.title, Status: "running",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if cands, err := tasks.Search(services.TaskScope{
+		ProjectID: projectID, UserID: services.SyntheticQQUserID("u1"),
+		Channel: "qq", ConversationID: "c1",
+	}, "登录页"); err != nil || len(cands) != 2 {
+		t.Fatalf("precondition search = %d err=%v", len(cands), err)
+	}
+
+	rc := &runningChannel{
+		cfg: models.ChannelConfig{ID: "c1", Type: models.ChannelTypeQQ, ProjectID: projectID},
+		adapter: fa,
+	}
+	in := InboundMessage{
+		Scene: SceneC2C, ConversationID: "c1", UserID: "u1",
+		MessageID: "m1", Text: "登录页怎么样了",
+	}
+	m.runTurn(context.Background(), rc, in, false)
+	got := sentTexts(fa)
+	if turned != 0 {
+		t.Fatalf("ambiguous status query must not start a PM turn, turned=%d", turned)
+	}
+	if len(got) != 1 || !strings.Contains(got[0], "匹配到多个任务") {
+		t.Fatalf("expected ambiguity clarification, got %v", got)
+	}
+
+	fa.mu.Lock()
+	fa.sent = nil
+	fa.mu.Unlock()
+	m.runTurn(context.Background(), rc, InboundMessage{
+		Scene: SceneC2C, ConversationID: "c1", UserID: "u1",
+		MessageID: "m2", Text: "登录页性能优化",
+	}, false)
+	got = sentTexts(fa)
+	if turned != 0 {
+		t.Fatalf("short-title selection should answer without PM turn, turned=%d", turned)
+	}
+	if len(got) != 1 || !strings.Contains(got[0], "登录页性能优化") {
+		t.Fatalf("short-title reply = %v", got)
+	}
+
+	fa.mu.Lock()
+	fa.sent = nil
+	fa.mu.Unlock()
+	m.runTurn(context.Background(), rc, InboundMessage{
+		Scene: SceneC2C, ConversationID: "c1", UserID: "u1",
+		MessageID: "m3", Text: "那继续吧",
+	}, false)
+	if turned != 1 {
+		t.Fatalf("continuation should enter PM turn with focus, turned=%d", turned)
+	}
+	got = sentTexts(fa)
+	if len(got) != 1 || !strings.Contains(got[0], "agent-handled") {
+		t.Fatalf("continuation final = %v", got)
+	}
+
+	fa.mu.Lock()
+	fa.sent = nil
+	fa.mu.Unlock()
+	m.runTurn(context.Background(), rc, InboundMessage{
+		Scene: SceneC2C, ConversationID: "c1", UserID: "u1",
+		MessageID: "m4", Text: "取消登录页性能优化",
+	}, false)
+	got = sentTexts(fa)
+	if len(cancelled) != 0 {
+		t.Fatalf("high-risk action executed before confirmation: %v", cancelled)
+	}
+	if len(got) != 1 || !strings.Contains(got[0], "高风险确认") {
+		t.Fatalf("expected confirmation prompt, got %v", got)
+	}
+
+	fa.mu.Lock()
+	fa.sent = nil
+	fa.mu.Unlock()
+	m.runTurn(context.Background(), rc, InboundMessage{
+		Scene: SceneC2C, ConversationID: "c1", UserID: "u1",
+		MessageID: "m5", Text: "确认",
+	}, false)
+	if len(cancelled) != 1 || cancelled[0] != "r1:cancel_run" {
+		t.Fatalf("confirmed cancel = %v", cancelled)
+	}
+}
+
+func TestExtractStructuredFinalSummary(t *testing.T) {
+	got := extractStructuredFinalSummary("推理一堆\n[摘要] 已完成登录页性能优化\n其它")
+	if got != "已完成登录页性能优化" {
+		t.Fatalf("summary = %q", got)
+	}
+	if extractStructuredFinalSummary("只有普通正文") != "" {
+		t.Fatal("unmarked text must not become FinalSummary")
+	}
+}

--- a/server/internal/channels/preamble.go
+++ b/server/internal/channels/preamble.go
@@ -14,5 +14,6 @@ func ChannelPreamble(channelType string) string {
 		"需要用户可见结论时，用 [摘要] 单独一行写出结构化最终摘要；工具细节与思考过程不要写成用户可见正文。" +
 		"如果需要发送图片，请在回复中用 Markdown 图片语法给出可公网访问的图片直链，例如 ![](https://example.com/x.png)，" +
 		"系统会自动把这些直链作为图片消息发送；请勿发送本地路径或需要鉴权的链接。" +
-		"取消/批准等会改变任务状态的操作必须先短标题二次确认；可用 pm_notify_progress / pm_start_run 等工具显式提交外发进展与接单。"
+		"取消/批准等会改变任务状态的操作必须先短标题二次确认；可用 pm_notify_progress / pm_start_run 等工具显式提交外发进展与接单。" +
+		"pm_notify_progress 返回 status=suppressed 表示被限频/去重/合并等策略正常抑制，属正常结果，不要换措辞重发；只有返回错误才是真实投递失败。"
 }

--- a/server/internal/channels/preamble.go
+++ b/server/internal/channels/preamble.go
@@ -5,12 +5,14 @@ package channels
 // and, critically, instructs it to embed shareable image URLs in markdown so
 // the adapter can extract and re-upload them as native rich-media messages.
 func ChannelPreamble(channelType string) string {
-	return "你正在通过外部 IM 渠道（" + channelType + "）与用户对话，回复会被转发到聊天窗口。" +
+	return "你正在通过外部 IM 渠道（" + channelType + "）与用户对话。" +
 		"请用简洁、可直接阅读的自然语言回答；可使用 Markdown（标题、加粗、斜体、有序/无序列表、块引用、链接、分割线）提升可读性，" +
 		"但不要使用表格（QQ 原生 Markdown 不支持表格）。" +
 		"通过 pm-leader / context-store / memory-store 等 MCP 工具获取项目进度、记忆与历史后再作答，不要编造。" +
-		"长任务执行中，请在实质进展、阻塞/失败风险、或需要用户确认时，用单独一行并以标记开头汇报（系统会按需转发到 QQ，勿刷屏）：" +
-		"[进度] … / [阻塞] … / [确认] …；工具调用细节与思考过程不要写成用户可见进度。" +
+		"长任务执行中，可用单独一行并以标记开头整理内部进展分类（[进度]/[阻塞]/[确认]）；" +
+		"这些标记只作内部分类提示，不会单独决定外发——只有服务端 Sendable 策略或显式提交的结构化摘要才会到达 QQ。" +
+		"需要用户可见结论时，用 [摘要] 单独一行写出结构化最终摘要；工具细节与思考过程不要写成用户可见正文。" +
 		"如果需要发送图片，请在回复中用 Markdown 图片语法给出可公网访问的图片直链，例如 ![](https://example.com/x.png)，" +
-		"系统会自动把这些直链作为图片消息发送；请勿发送本地路径或需要鉴权的链接。"
+		"系统会自动把这些直链作为图片消息发送；请勿发送本地路径或需要鉴权的链接。" +
+		"取消/批准等会改变任务状态的操作必须先短标题二次确认；可用 pm_notify_progress / pm_start_run 等工具显式提交外发进展与接单。"
 }

--- a/server/internal/channels/progress.go
+++ b/server/internal/channels/progress.go
@@ -22,10 +22,40 @@ const (
 
 // ProgressEvent is an internal Work→Reply progress signal. Tool-level / token
 // noise must not become a ProgressEvent.
+// Delivery is opt-in: events produced by text classification are internal by
+// default, because prompt-shaped markers in model output must not be able to
+// drive external sends. Only an orchestration layer that sets Sendable, or the
+// Manager's explicit blocked/action_required promotion (which additionally
+// requires a reliable structured Conclusion), may reach a channel.
+//
+// RunID must be a real Run identifier when set; it is never synthesized from an
+// inbound platform message id.
 type ProgressEvent struct {
-	Kind    ProgressKind
-	Summary string
-	At      time.Time
+	Kind           ProgressKind
+	Summary        string
+	Stage          string
+	Blocked        bool
+	ActionRequired bool
+	Conclusion     string
+	RunID          string
+	DedupeKey      string
+	Reason         string
+	Sendable       bool
+	At             time.Time
+}
+
+// Deliverable reports whether this event may leave the platform. Classified
+// narration alone never qualifies.
+func (ev ProgressEvent) Deliverable() bool {
+	if ev.Sendable {
+		return true
+	}
+	// Manager-side promotion: an orchestration-set blocker / decision request
+	// backed by a reliable structured conclusion.
+	if ev.Blocked || ev.ActionRequired {
+		return strings.TrimSpace(ev.Conclusion) != ""
+	}
+	return false
 }
 
 // TurnFinalReport is the Work turn outcome consumed by Reply for the required

--- a/server/internal/channels/push_queue.go
+++ b/server/internal/channels/push_queue.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cocofhu/approving/internal/sendable"
 	"github.com/cocofhu/approving/internal/services"
 
 	"github.com/rs/zerolog/log"
@@ -39,6 +40,7 @@ type CronPushItem struct {
 	Category  string
 	Kind      CronResultKind
 	Text      string
+	Envelope  sendable.DeliveryEnvelope
 	Enqueued  time.Time
 }
 
@@ -264,7 +266,10 @@ func FormatCronPush(category string, kind CronResultKind, body string) string {
 		if body == "" {
 			return catLabel(cat) + "有变化"
 		}
-		return body
+		if lineEnd := strings.IndexAny(body, "\r\n"); lineEnd >= 0 {
+			body = strings.TrimSpace(body[:lineEnd])
+		}
+		return truncateRunes(body, 120)
 	}
 }
 

--- a/server/internal/channels/qq/adapter.go
+++ b/server/internal/channels/qq/adapter.go
@@ -91,23 +91,33 @@ func (a *Adapter) Stop() error {
 	return nil
 }
 
-// Send implements channels.Adapter.
-func (a *Adapter) Send(ctx context.Context, out channels.OutboundMessage) error {
+// Send implements channels.Adapter. The returned SendResult carries the real QQ
+// message id when the API reported one; it is left empty rather than filled with
+// a locally derived value.
+func (a *Adapter) Send(ctx context.Context, out channels.OutboundMessage) (channels.SendResult, error) {
+	// Second gate: the Manager already evaluated the delivery policy, this
+	// fail-closed check keeps a bypassing caller from reaching QQ.
 	if reason := sendable.GateReason(out.Envelope, sendable.ChannelQQ,
 		out.Text+"\n"+strings.Join(out.ImageURLs, "\n")); reason != "" {
-		return fmt.Errorf("qq: outbound suppressed by delivery policy: %s", reason)
+		return channels.SendResult{}, fmt.Errorf("qq: outbound suppressed by delivery policy: %s", reason)
 	}
 	imgs := filterSendableImages(out.ImageURLs)
+	var messageID string
+	var err error
 	switch out.Scene {
 	case channels.SceneC2C:
-		return a.client.sendC2C(ctx, out.ConversationID, out.ReplyToMessageID, out.Text, imgs)
+		messageID, err = a.client.sendC2C(ctx, out.ConversationID, out.ReplyToMessageID, out.Text, imgs)
 	case channels.SceneGroup:
-		return a.client.sendGroup(ctx, out.ConversationID, out.ReplyToMessageID, out.Text, imgs)
+		messageID, err = a.client.sendGroup(ctx, out.ConversationID, out.ReplyToMessageID, out.Text, imgs)
 	case channels.SceneGuild:
-		return a.client.sendGuild(ctx, out.ConversationID, out.ReplyToMessageID, out.Text, imgs)
+		messageID, err = a.client.sendGuild(ctx, out.ConversationID, out.ReplyToMessageID, out.Text, imgs)
 	default:
-		return fmt.Errorf("qq: 未知会话类型 %q", out.Scene)
+		return channels.SendResult{}, fmt.Errorf("qq: 未知会话类型 %q", out.Scene)
 	}
+	if err != nil {
+		return channels.SendResult{}, err
+	}
+	return channels.SendResult{MessageID: messageID}, nil
 }
 
 func (a *Adapter) handleEvent(ctx context.Context, evtType string, data []byte, onInbound channels.InboundHandler) {
@@ -177,39 +187,40 @@ func (a *Adapter) handleEvent(ctx context.Context, evtType string, data []byte, 
 		}
 		in.Images = append(in.Images, img)
 	}
-	if len(oversized) > 0 {
-		tip := fmt.Sprintf(
-			"附件超过 %d MiB 上限，已拒绝：%s。请压缩后重试。",
-			qqAttachMaxMiB, strings.Join(oversized, ", "),
-		)
-		// Pure oversize with nothing else: reply tip without starting an agent turn.
-		if len(in.Images) == 0 && strings.TrimSpace(in.Text) == "" {
-			if err := a.Send(ctx, channels.OutboundMessage{
-				Scene:            scene,
-				ConversationID:   conversationID,
-				ReplyToMessageID: m.ID,
-				Text:             tip,
-				Envelope: sendable.AppendSendable(sendable.DeliveryEnvelope{
-					Priority: sendable.PriorityHigh, TaskContext: "turn:" + m.ID,
-					ProjectID: a.cfg.ProjectID, ConversationID: conversationID,
-					UserID: userID, DedupeKey: m.ID + ":oversize",
-					Reason: "oversized_attachment", Kind: sendable.KindSafetyNotice,
-				}, sendable.ChannelQQ),
-			}); err != nil {
-				log.Warn().Err(err).Msg("qq: oversized reject reply failed")
-			}
-			return
-		}
-		if in.Text != "" {
-			in.Text = in.Text + "\n" + tip
-		} else {
-			in.Text = tip
-		}
-	}
+	in = applyOversizedNotice(in, oversized)
 
 	// Run the turn asynchronously so the gateway read loop keeps flowing; the
 	// Manager serializes per conversation.
 	go onInbound(ctx, in)
+}
+
+// applyOversizedNotice routes the rejected-attachment tip. An inbound that has
+// nothing but rejected attachments carries the tip as a SafetyNotice, so the
+// Manager delivers it through the single egress (policy, dedupe receipt, retry
+// and audit) instead of the adapter sending it directly. When there is other
+// content, the tip rides along with the user text and the turn runs normally.
+func applyOversizedNotice(in channels.InboundMessage, oversized []string) channels.InboundMessage {
+	if len(oversized) == 0 {
+		return in
+	}
+	tip := fmt.Sprintf(
+		"附件超过 %d MiB 上限，已拒绝：%s。请压缩后重试。",
+		qqAttachMaxMiB, strings.Join(oversized, ", "),
+	)
+	if len(in.Images) == 0 && strings.TrimSpace(in.Text) == "" {
+		in.Safety = &channels.SafetyNotice{
+			Text: tip, Reason: "oversized_attachment",
+			// Same key across gateway reconnects that replay this message.
+			DedupeKey: in.MessageID + ":oversize", Only: true,
+		}
+		return in
+	}
+	if in.Text != "" {
+		in.Text = in.Text + "\n" + tip
+	} else {
+		in.Text = tip
+	}
+	return in
 }
 
 func (a *Adapter) isDuplicate(msgID string) bool {

--- a/server/internal/channels/qq/adapter.go
+++ b/server/internal/channels/qq/adapter.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cocofhu/approving/internal/channels"
+	"github.com/cocofhu/approving/internal/sendable"
 
 	"github.com/rs/zerolog/log"
 )
@@ -92,6 +93,10 @@ func (a *Adapter) Stop() error {
 
 // Send implements channels.Adapter.
 func (a *Adapter) Send(ctx context.Context, out channels.OutboundMessage) error {
+	if reason := sendable.GateReason(out.Envelope, sendable.ChannelQQ,
+		out.Text+"\n"+strings.Join(out.ImageURLs, "\n")); reason != "" {
+		return fmt.Errorf("qq: outbound suppressed by delivery policy: %s", reason)
+	}
 	imgs := filterSendableImages(out.ImageURLs)
 	switch out.Scene {
 	case channels.SceneC2C:
@@ -184,6 +189,12 @@ func (a *Adapter) handleEvent(ctx context.Context, evtType string, data []byte, 
 				ConversationID:   conversationID,
 				ReplyToMessageID: m.ID,
 				Text:             tip,
+				Envelope: sendable.AppendSendable(sendable.DeliveryEnvelope{
+					Priority: sendable.PriorityHigh, TaskContext: "turn:" + m.ID,
+					ProjectID: a.cfg.ProjectID, ConversationID: conversationID,
+					UserID: userID, DedupeKey: m.ID + ":oversize",
+					Reason: "oversized_attachment", Kind: sendable.KindSafetyNotice,
+				}, sendable.ChannelQQ),
 			}); err != nil {
 				log.Warn().Err(err).Msg("qq: oversized reject reply failed")
 			}

--- a/server/internal/channels/qq/client.go
+++ b/server/internal/channels/qq/client.go
@@ -326,27 +326,34 @@ func (c *client) uploadMedia(ctx context.Context, scene, target, imageURL string
 	return out.FileInfo, nil
 }
 
-// sendC2C sends a text and/or images to a user openid.
-func (c *client) sendC2C(ctx context.Context, openid, replyMsgID, text string, imageURLs []string) error {
+// sendC2C sends a text and/or images to a user openid and returns the id of the
+// first message QQ created.
+func (c *client) sendC2C(ctx context.Context, openid, replyMsgID, text string, imageURLs []string) (string, error) {
 	return c.sendUserOrGroup(ctx, "c2c", "/v2/users/"+openid+"/messages", "c2c", openid, replyMsgID, text, imageURLs)
 }
 
-// sendGroup sends a text and/or images to a group openid.
-func (c *client) sendGroup(ctx context.Context, groupOpenID, replyMsgID, text string, imageURLs []string) error {
+// sendGroup sends a text and/or images to a group openid and returns the id of
+// the first message QQ created.
+func (c *client) sendGroup(ctx context.Context, groupOpenID, replyMsgID, text string, imageURLs []string) (string, error) {
 	return c.sendUserOrGroup(ctx, "group", "/v2/groups/"+groupOpenID+"/messages", "group", groupOpenID, replyMsgID, text, imageURLs)
 }
 
-func (c *client) sendUserOrGroup(ctx context.Context, scene, path, uploadScene, target, replyMsgID, text string, imageURLs []string) error {
-	// Text first (if any), then each image as its own media message.
+func (c *client) sendUserOrGroup(ctx context.Context, scene, path, uploadScene, target, replyMsgID, text string, imageURLs []string) (string, error) {
+	// Text first (if any), then each image as its own media message. A
+	// multi-part send is identified by its first message: the text one when
+	// there is text, so later media parts never overwrite it.
+	messageID := ""
 	if strings.TrimSpace(text) != "" {
-		if err := c.sendUserOrGroupText(ctx, scene, path, target, replyMsgID, text); err != nil {
-			return err
+		id, err := c.sendUserOrGroupText(ctx, scene, path, target, replyMsgID, text)
+		if err != nil {
+			return "", err
 		}
+		messageID = id
 	}
 	for _, u := range imageURLs {
 		fileInfo, err := c.uploadMedia(ctx, uploadScene, target, u)
 		if err != nil {
-			return err
+			return messageID, err
 		}
 		payload := map[string]any{
 			"content":  " ",
@@ -357,17 +364,21 @@ func (c *client) sendUserOrGroup(ctx context.Context, scene, path, uploadScene, 
 			payload["msg_id"] = replyMsgID
 			payload["msg_seq"] = c.nextSeq(replyMsgID)
 		}
-		if err := c.doJSON(ctx, http.MethodPost, path, payload, nil); err != nil {
-			return err
+		var out sendMessageResponse
+		if err := c.doJSON(ctx, http.MethodPost, path, payload, &out); err != nil {
+			return messageID, err
+		}
+		if messageID == "" {
+			messageID = strings.TrimSpace(out.ID)
 		}
 	}
-	return nil
+	return messageID, nil
 }
 
 // sendGuildText sends the text body for a guild channel message. Guild Markdown
 // still requires 内邀开通, so a Markdown attempt (markdown.content) falls back to
 // a plain-text content message and caches the target as unsupported.
-func (c *client) sendGuildText(ctx context.Context, path, channelID, replyMsgID, text string) error {
+func (c *client) sendGuildText(ctx context.Context, path, channelID, replyMsgID, text string) (string, error) {
 	capKey := "guild:" + channelID
 	if c.markdownSupported(capKey) {
 		payload := map[string]any{
@@ -376,15 +387,16 @@ func (c *client) sendGuildText(ctx context.Context, path, channelID, replyMsgID,
 		if replyMsgID != "" {
 			payload["msg_id"] = replyMsgID
 		}
-		err := c.doJSON(ctx, http.MethodPost, path, payload, nil)
+		var out sendMessageResponse
+		err := c.doJSON(ctx, http.MethodPost, path, payload, &out)
 		if err == nil {
-			return nil
+			return strings.TrimSpace(out.ID), nil
 		}
 		// Only downgrade on an outright rejection; propagate transient errors so
 		// we neither cache a false negative nor risk double-posting a message
 		// that may have actually been delivered.
 		if !markdownRejected(err) {
-			return err
+			return "", err
 		}
 		c.markMarkdownUnsupported(capKey)
 		log.Warn().Err(err).Str("scene", "guild").Msg("qq: markdown rejected; falling back to plain text")
@@ -393,14 +405,18 @@ func (c *client) sendGuildText(ctx context.Context, path, channelID, replyMsgID,
 	if replyMsgID != "" {
 		payload["msg_id"] = replyMsgID
 	}
-	return c.doJSON(ctx, http.MethodPost, path, payload, nil)
+	var out sendMessageResponse
+	if err := c.doJSON(ctx, http.MethodPost, path, payload, &out); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.ID), nil
 }
 
 // sendUserOrGroupText sends the text body for a C2C/group message. When Markdown
 // is enabled and the target isn't known to reject it, the text is sent as a
 // native Markdown message (msg_type=2); on failure it falls back to plain text
 // (msg_type=0) and remembers the target as Markdown-unsupported.
-func (c *client) sendUserOrGroupText(ctx context.Context, scene, path, target, replyMsgID, text string) error {
+func (c *client) sendUserOrGroupText(ctx context.Context, scene, path, target, replyMsgID, text string) (string, error) {
 	capKey := scene + ":" + target
 	// Reserve a single msg_seq up front and reuse it for both the Markdown
 	// attempt and the plain-text fallback. QQ dedups on (msg_id, msg_seq), so if
@@ -420,13 +436,14 @@ func (c *client) sendUserOrGroupText(ctx context.Context, scene, path, target, r
 			payload["msg_id"] = replyMsgID
 			payload["msg_seq"] = seq
 		}
-		err := c.doJSON(ctx, http.MethodPost, path, payload, nil)
+		var out sendMessageResponse
+		err := c.doJSON(ctx, http.MethodPost, path, payload, &out)
 		if err == nil {
-			return nil
+			return strings.TrimSpace(out.ID), nil
 		}
 		// Only downgrade on an outright rejection; propagate transient errors.
 		if !markdownRejected(err) {
-			return err
+			return "", err
 		}
 		c.markMarkdownUnsupported(capKey)
 		log.Warn().Err(err).Str("scene", scene).Msg("qq: markdown rejected; falling back to plain text")
@@ -439,27 +456,38 @@ func (c *client) sendUserOrGroupText(ctx context.Context, scene, path, target, r
 		payload["msg_id"] = replyMsgID
 		payload["msg_seq"] = seq
 	}
-	return c.doJSON(ctx, http.MethodPost, path, payload, nil)
+	var out sendMessageResponse
+	if err := c.doJSON(ctx, http.MethodPost, path, payload, &out); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.ID), nil
 }
 
 // sendGuild sends to a guild channel. Guild channel messages carry text plus an
 // optional image URL (public-domain guilds cannot receive inbound rich media,
 // but can be sent an image URL).
-func (c *client) sendGuild(ctx context.Context, channelID, replyMsgID, text string, imageURLs []string) error {
+func (c *client) sendGuild(ctx context.Context, channelID, replyMsgID, text string, imageURLs []string) (string, error) {
 	path := "/channels/" + channelID + "/messages"
+	messageID := ""
 	if strings.TrimSpace(text) != "" || len(imageURLs) == 0 {
-		if err := c.sendGuildText(ctx, path, channelID, replyMsgID, text); err != nil {
-			return err
+		id, err := c.sendGuildText(ctx, path, channelID, replyMsgID, text)
+		if err != nil {
+			return "", err
 		}
+		messageID = id
 	}
 	for _, u := range imageURLs {
 		payload := map[string]any{"image": u}
 		if replyMsgID != "" {
 			payload["msg_id"] = replyMsgID
 		}
-		if err := c.doJSON(ctx, http.MethodPost, path, payload, nil); err != nil {
-			return err
+		var out sendMessageResponse
+		if err := c.doJSON(ctx, http.MethodPost, path, payload, &out); err != nil {
+			return messageID, err
+		}
+		if messageID == "" {
+			messageID = strings.TrimSpace(out.ID)
 		}
 	}
-	return nil
+	return messageID, nil
 }

--- a/server/internal/channels/qq/qq_test.go
+++ b/server/internal/channels/qq/qq_test.go
@@ -1,12 +1,17 @@
 package qq
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/cocofhu/approving/internal/channels"
+	"github.com/cocofhu/approving/internal/sendable"
 )
 
 func TestIsImageAttachment(t *testing.T) {
@@ -191,6 +196,158 @@ func TestNewAdapterSandboxBase(t *testing.T) {
 	qa := a.(*Adapter)
 	if qa.client.apiBase != sandboxAPIBase {
 		t.Fatalf("apiBase = %q want sandbox base", qa.client.apiBase)
+	}
+}
+
+// testAdapter builds an adapter talking to srvURL with a pre-primed token so no
+// real QQ endpoint is contacted.
+func testAdapter(t *testing.T, srvURL string) *Adapter {
+	t.Helper()
+	a, err := New(channels.AdapterConfig{
+		Type: "qq", AppID: "app", AppSecret: "sec", ProjectID: "proj",
+		Config: map[string]any{"apiBase": srvURL, "markdown": false},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	qa := a.(*Adapter)
+	qa.client.token = "token"
+	qa.client.tokenExp = time.Now().Add(time.Hour)
+	return qa
+}
+
+func testEnvelope() sendable.DeliveryEnvelope {
+	return sendable.AppendSendable(sendable.DeliveryEnvelope{
+		Priority: sendable.PriorityHigh, RunID: "r1", ProjectID: "proj",
+		ConversationID: "user1", UserID: "user1",
+		Reason: "test", Kind: sendable.KindSafetyNotice,
+	}, sendable.ChannelQQ)
+}
+
+func TestSendReturnsRealMessageID(t *testing.T) {
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/files"):
+			_, _ = w.Write([]byte(`{"file_info":"file-1"}`))
+		default:
+			_, _ = w.Write([]byte(`{"id":"MSG-REAL-1"}`))
+		}
+	}))
+	defer srv.Close()
+	a := testAdapter(t, srv.URL)
+
+	res, err := a.Send(context.Background(), channels.OutboundMessage{
+		Scene: channels.SceneC2C, ConversationID: "user1", Text: "hello",
+		ImageURLs: []string{"https://x.com/a.png"}, Envelope: testEnvelope(),
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	// Text goes first, so the multi-part send is identified by the text message.
+	if res.MessageID != "MSG-REAL-1" {
+		t.Fatalf("MessageID = %q want the id from the QQ response", res.MessageID)
+	}
+	if len(paths) != 3 {
+		t.Fatalf("request paths = %v want text + upload + media", paths)
+	}
+}
+
+func TestSendWithoutResponseIDReportsNoMessageID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+	a := testAdapter(t, srv.URL)
+
+	res, err := a.Send(context.Background(), channels.OutboundMessage{
+		Scene: channels.SceneGroup, ConversationID: "group1", Text: "hello",
+		Envelope: testEnvelope(),
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	// No id in the response means no id at all: nothing local may stand in.
+	if res.MessageID != "" {
+		t.Fatalf("MessageID = %q want empty when QQ reported none", res.MessageID)
+	}
+}
+
+func TestSendGuildReturnsRealMessageID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"GUILD-MSG-1"}`))
+	}))
+	defer srv.Close()
+	a := testAdapter(t, srv.URL)
+
+	res, err := a.Send(context.Background(), channels.OutboundMessage{
+		Scene: channels.SceneGuild, ConversationID: "chan1", Text: "hello",
+		Envelope: testEnvelope(),
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if res.MessageID != "GUILD-MSG-1" {
+		t.Fatalf("MessageID = %q", res.MessageID)
+	}
+}
+
+func TestSendFailClosedOnPolicyGate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("gate must close before any request (%s)", r.URL.Path)
+	}))
+	defer srv.Close()
+	a := testAdapter(t, srv.URL)
+
+	// Internal-only envelope: the adapter's second gate refuses it.
+	if _, err := a.Send(context.Background(), channels.OutboundMessage{
+		Scene: channels.SceneC2C, ConversationID: "user1", Text: "hello",
+		Envelope: sendable.Internal(sendable.KindAgentRaw, "not_sendable"),
+	}); err == nil {
+		t.Fatal("Send must fail closed for a non-sendable envelope")
+	}
+}
+
+func TestApplyOversizedNoticeRoutesThroughManager(t *testing.T) {
+	base := channels.InboundMessage{
+		Scene: channels.SceneC2C, ConversationID: "user1", UserID: "user1", MessageID: "m1",
+	}
+
+	// Nothing but rejected attachments: the tip becomes a notice for the
+	// Manager's single egress, keyed for reconnect idempotency.
+	only := applyOversizedNotice(base, []string{"big.zip"})
+	if only.Safety == nil || !only.Safety.Only {
+		t.Fatalf("pure oversize inbound = %+v want a notice-only safety notice", only)
+	}
+	if only.Safety.DedupeKey != "m1:oversize" || only.Safety.Reason != "oversized_attachment" {
+		t.Fatalf("safety notice = %+v", only.Safety)
+	}
+	if !strings.Contains(only.Safety.Text, "big.zip") ||
+		!strings.Contains(only.Safety.Text, fmt.Sprintf("%d MiB", qqAttachMaxMiB)) {
+		t.Fatalf("safety notice text = %q", only.Safety.Text)
+	}
+	if only.Text != "" {
+		t.Fatalf("pure oversize must not fabricate turn text: %q", only.Text)
+	}
+
+	// With user text the turn still runs and the tip rides along.
+	mixed := base
+	mixed.Text = "看下这个"
+	mixed = applyOversizedNotice(mixed, []string{"big.zip"})
+	if mixed.Safety != nil {
+		t.Fatalf("mixed inbound must not short-circuit the turn: %+v", mixed.Safety)
+	}
+	if !strings.Contains(mixed.Text, "看下这个") || !strings.Contains(mixed.Text, "big.zip") {
+		t.Fatalf("mixed text = %q", mixed.Text)
+	}
+
+	// No rejected attachment changes nothing.
+	if got := applyOversizedNotice(base, nil); got.Safety != nil || got.Text != "" {
+		t.Fatalf("unchanged inbound = %+v", got)
 	}
 }
 

--- a/server/internal/channels/qq/types.go
+++ b/server/internal/channels/qq/types.go
@@ -108,6 +108,13 @@ type gatewayResponse struct {
 	URL string `json:"url"`
 }
 
+// sendMessageResponse is the message-send reply. QQ returns the created
+// message id (the same id used for recall), which is the only acceptable source
+// of an external message id for reply bindings.
+type sendMessageResponse struct {
+	ID string `json:"id"`
+}
+
 // fileInfoResponse is the rich-media upload reply (C2C/group).
 type fileInfoResponse struct {
 	FileUUID string `json:"file_uuid"`

--- a/server/internal/channels/types.go
+++ b/server/internal/channels/types.go
@@ -43,6 +43,21 @@ type Image struct {
 	Filename string
 }
 
+// SafetyNotice is an adapter-detected notice about an inbound message (e.g. a
+// rejected oversized attachment). Adapters must not send it themselves: they
+// attach it to the inbound message so it leaves through the Manager's single
+// egress and shares its dedupe receipt, retries and audit.
+type SafetyNotice struct {
+	Text   string
+	Reason string
+	// DedupeKey keeps the notice idempotent across gateway reconnects that
+	// replay the same inbound message.
+	DedupeKey string
+	// Only marks an inbound message that carries no user content: deliver the
+	// notice and do not start a turn.
+	Only bool
+}
+
 // InboundMessage is a normalized user message received from a channel.
 type InboundMessage struct {
 	Scene          Scene
@@ -53,6 +68,7 @@ type InboundMessage struct {
 	MessageID      string // platform message id (passive reply + dedup)
 	Timestamp      time.Time
 	Raw            map[string]any
+	Safety         *SafetyNotice
 }
 
 // OutboundMessage is a normalized reply/push to a channel conversation.
@@ -68,6 +84,15 @@ type OutboundMessage struct {
 // InboundHandler is invoked by an adapter for each received message.
 type InboundHandler func(ctx context.Context, in InboundMessage)
 
+// SendResult is what a channel reports back about a delivered message.
+// MessageID is the channel's own message identifier and must only be set from a
+// real transport response — it is never derived from an inbound message id, a
+// dedupe key, or any other local value. Channels without such a response leave
+// it empty.
+type SendResult struct {
+	MessageID string
+}
+
 // Adapter is a transport for one external channel account. Implementations are
 // created per ChannelConfig and are responsible only for receiving/sending;
 // PM orchestration lives in ChannelBridge.
@@ -78,8 +103,9 @@ type Adapter interface {
 	// the ctx is cancelled or Stop is called. It should return once the receive
 	// loop is running (non-blocking) or on a fatal startup error.
 	Start(ctx context.Context, onInbound InboundHandler) error
-	// Send delivers an outbound message.
-	Send(ctx context.Context, out OutboundMessage) error
+	// Send delivers an outbound message and reports the channel's message id
+	// when the transport returns one.
+	Send(ctx context.Context, out OutboundMessage) (SendResult, error)
 	// Stop tears down the connection and releases resources.
 	Stop() error
 }

--- a/server/internal/channels/types.go
+++ b/server/internal/channels/types.go
@@ -15,6 +15,8 @@ package channels
 import (
 	"context"
 	"time"
+
+	"github.com/cocofhu/approving/internal/sendable"
 )
 
 // Scene classifies a conversation surface. Adapters map their native scopes
@@ -60,6 +62,7 @@ type OutboundMessage struct {
 	ReplyToMessageID string // passive reply id (empty → active push)
 	Text             string
 	ImageURLs        []string // shareable image URLs to attach
+	Envelope         sendable.DeliveryEnvelope
 }
 
 // InboundHandler is invoked by an adapter for each received message.

--- a/server/internal/models/audit.go
+++ b/server/internal/models/audit.go
@@ -49,6 +49,7 @@ const (
 	AuditActionAuditExport     = "audit.export"
 	AuditActionChannel         = "channel.config"
 	AuditActionCron            = "cron.config"
+	AuditActionDelivery        = "channel.delivery"
 )
 
 // Audit outcome values.

--- a/server/internal/models/models.go
+++ b/server/internal/models/models.go
@@ -686,6 +686,8 @@ func AllModels() []any {
 		&AgentCronJob{}, &AgentCronRun{}, &ChannelConfig{},
 		&ProjectAuditEvent{},
 		&NotifyDeliveryReceipt{},
+		&SendableDeliveryReceipt{},
+		&TaskIdentity{}, &MessageBinding{}, &ConversationFocus{}, &RiskConfirmationTicket{},
 	}
 }
 

--- a/server/internal/models/sendable.go
+++ b/server/internal/models/sendable.go
@@ -3,7 +3,7 @@ package models
 import "time"
 
 // SendableDeliveryReceipt is the durable idempotency record for one external
-// delivery. Content is deliberately not persisted.
+// delivery. Content is deliberately not persisted — only hashes / digests.
 type SendableDeliveryReceipt struct {
 	ID             uint      `gorm:"primaryKey" json:"id"`
 	DedupeKey      string    `gorm:"size:128;uniqueIndex" json:"dedupeKey"`
@@ -14,6 +14,9 @@ type SendableDeliveryReceipt struct {
 	Channel        string    `gorm:"size:32;index:idx_sendable_bucket,priority:4" json:"channel"`
 	Kind           string    `gorm:"size:32" json:"kind"`
 	ContentHash    string    `gorm:"size:64;index" json:"-"`
+	// ProgressDigest fingerprints ProgressFields so a rate-limited window can
+	// still retain and later emit a newer stage/conclusion.
+	ProgressDigest string    `gorm:"size:64" json:"-"`
 	Status         string    `gorm:"size:16;index" json:"status"` // pending | sent | failed
 	Result         string    `gorm:"size:64" json:"result"`
 	Attempts       int       `json:"attempts"`

--- a/server/internal/models/sendable.go
+++ b/server/internal/models/sendable.go
@@ -1,0 +1,24 @@
+package models
+
+import "time"
+
+// SendableDeliveryReceipt is the durable idempotency record for one external
+// delivery. Content is deliberately not persisted.
+type SendableDeliveryReceipt struct {
+	ID             uint      `gorm:"primaryKey" json:"id"`
+	DedupeKey      string    `gorm:"size:128;uniqueIndex" json:"dedupeKey"`
+	ProjectID      string    `gorm:"size:64;index" json:"projectId"`
+	RunID          string    `gorm:"size:64;index:idx_sendable_bucket,priority:1" json:"runId"`
+	TaskContext    string    `gorm:"size:191;index:idx_sendable_bucket,priority:2" json:"taskContext,omitempty"`
+	ConversationID string    `gorm:"size:191;index:idx_sendable_bucket,priority:3" json:"conversationId"`
+	Channel        string    `gorm:"size:32;index:idx_sendable_bucket,priority:4" json:"channel"`
+	Kind           string    `gorm:"size:32" json:"kind"`
+	ContentHash    string    `gorm:"size:64;index" json:"-"`
+	Status         string    `gorm:"size:16;index" json:"status"` // pending | sent | failed
+	Result         string    `gorm:"size:64" json:"result"`
+	Attempts       int       `json:"attempts"`
+	NextAttemptAt  time.Time `json:"nextAttemptAt"`
+	LastAttemptAt  time.Time `json:"lastAttemptAt"`
+	CreatedAt      time.Time `json:"createdAt"`
+	UpdatedAt      time.Time `json:"updatedAt"`
+}

--- a/server/internal/models/task_context.go
+++ b/server/internal/models/task_context.go
@@ -3,16 +3,13 @@ package models
 import "time"
 
 // TaskIdentity is the stable, user-facing identity of a Run.
-// It is project/Run scoped: any QQ identity in the project may search it.
-// Per-sender isolation lives on MessageBinding / ConversationFocus / tickets.
+// Search visibility is bounded by both project and external user identity.
 type TaskIdentity struct {
 	ID                  string     `gorm:"primaryKey;size:64" json:"id"`
 	RunID               string     `gorm:"size:64;uniqueIndex:idx_task_run_project,priority:1" json:"runId"`
-	ProjectID           string     `gorm:"size:64;uniqueIndex:idx_task_run_project,priority:2;index:idx_task_project_title,priority:1" json:"projectId"`
-	// UserID is an optional provenance hint (who first materialized the row).
-	// It is NOT an ownership or search boundary.
-	UserID              string     `gorm:"size:191" json:"userId,omitempty"`
-	ShortTitle          string     `gorm:"size:160;index:idx_task_project_title,priority:2" json:"shortTitle"`
+	ProjectID           string     `gorm:"size:64;uniqueIndex:idx_task_run_project,priority:2;index:idx_task_project_title,priority:1;index:idx_task_scope_title,priority:1" json:"projectId"`
+	UserID              string     `gorm:"size:191;index:idx_task_scope_title,priority:2" json:"userId,omitempty"`
+	ShortTitle          string     `gorm:"size:160;index:idx_task_project_title,priority:2;index:idx_task_scope_title,priority:3" json:"shortTitle"`
 	OriginalRequirement string     `gorm:"type:text" json:"originalRequirement"`
 	Aliases             []string   `gorm:"serializer:json" json:"aliases"`
 	Keywords            []string   `gorm:"serializer:json" json:"keywords"`

--- a/server/internal/models/task_context.go
+++ b/server/internal/models/task_context.go
@@ -3,12 +3,16 @@ package models
 import "time"
 
 // TaskIdentity is the stable, user-facing identity of a Run.
+// It is project/Run scoped: any QQ identity in the project may search it.
+// Per-sender isolation lives on MessageBinding / ConversationFocus / tickets.
 type TaskIdentity struct {
 	ID                  string     `gorm:"primaryKey;size:64" json:"id"`
-	RunID               string     `gorm:"size:64;uniqueIndex" json:"runId"`
-	ProjectID           string     `gorm:"size:64;index:idx_task_scope,priority:1" json:"projectId"`
-	UserID              string     `gorm:"size:191;index:idx_task_scope,priority:2" json:"userId"`
-	ShortTitle          string     `gorm:"size:160;index:idx_task_scope,priority:3" json:"shortTitle"`
+	RunID               string     `gorm:"size:64;uniqueIndex:idx_task_run_project,priority:1" json:"runId"`
+	ProjectID           string     `gorm:"size:64;uniqueIndex:idx_task_run_project,priority:2;index:idx_task_project_title,priority:1" json:"projectId"`
+	// UserID is an optional provenance hint (who first materialized the row).
+	// It is NOT an ownership or search boundary.
+	UserID              string     `gorm:"size:191" json:"userId,omitempty"`
+	ShortTitle          string     `gorm:"size:160;index:idx_task_project_title,priority:2" json:"shortTitle"`
 	OriginalRequirement string     `gorm:"type:text" json:"originalRequirement"`
 	Aliases             []string   `gorm:"serializer:json" json:"aliases"`
 	Keywords            []string   `gorm:"serializer:json" json:"keywords"`

--- a/server/internal/models/task_context.go
+++ b/server/internal/models/task_context.go
@@ -1,0 +1,66 @@
+package models
+
+import "time"
+
+// TaskIdentity is the stable, user-facing identity of a Run.
+type TaskIdentity struct {
+	ID                  string     `gorm:"primaryKey;size:64" json:"id"`
+	RunID               string     `gorm:"size:64;uniqueIndex" json:"runId"`
+	ProjectID           string     `gorm:"size:64;index:idx_task_scope,priority:1" json:"projectId"`
+	UserID              string     `gorm:"size:191;index:idx_task_scope,priority:2" json:"userId"`
+	ShortTitle          string     `gorm:"size:160;index:idx_task_scope,priority:3" json:"shortTitle"`
+	OriginalRequirement string     `gorm:"type:text" json:"originalRequirement"`
+	Aliases             []string   `gorm:"serializer:json" json:"aliases"`
+	Keywords            []string   `gorm:"serializer:json" json:"keywords"`
+	Status              string     `gorm:"size:32;index" json:"status"`
+	TerminalAt          *time.Time `gorm:"index" json:"terminalAt,omitempty"`
+	CreatedAt           time.Time  `json:"createdAt"`
+	UpdatedAt           time.Time  `json:"updatedAt"`
+}
+
+// MessageBinding gives an explicit quoted/replied message precedence over
+// fuzzy title matching.
+type MessageBinding struct {
+	ID             uint      `gorm:"primaryKey" json:"id"`
+	ProjectID      string    `gorm:"size:64;uniqueIndex:idx_message_binding,priority:1" json:"projectId"`
+	UserID         string    `gorm:"size:191;uniqueIndex:idx_message_binding,priority:2" json:"userId"`
+	Channel        string    `gorm:"size:32;uniqueIndex:idx_message_binding,priority:3" json:"channel"`
+	MessageID      string    `gorm:"size:191;uniqueIndex:idx_message_binding,priority:4" json:"messageId"`
+	ConversationID string    `gorm:"size:191;index" json:"conversationId"`
+	TaskIdentityID string    `gorm:"size:64;index" json:"taskIdentityId"`
+	RunID          string    `gorm:"size:64;index" json:"runId"`
+	CreatedAt      time.Time `json:"createdAt"`
+}
+
+// ConversationFocus is a short-lived, renewable conversation→task pointer.
+type ConversationFocus struct {
+	ID             uint      `gorm:"primaryKey" json:"id"`
+	ProjectID      string    `gorm:"size:64;uniqueIndex:idx_conversation_focus,priority:1" json:"projectId"`
+	UserID         string    `gorm:"size:191;uniqueIndex:idx_conversation_focus,priority:2" json:"userId"`
+	Channel        string    `gorm:"size:32;uniqueIndex:idx_conversation_focus,priority:3" json:"channel"`
+	ConversationID string    `gorm:"size:191;uniqueIndex:idx_conversation_focus,priority:4" json:"conversationId"`
+	TaskIdentityID string    `gorm:"size:64;index" json:"taskIdentityId"`
+	RunID          string    `gorm:"size:64;index" json:"runId"`
+	Language       string    `gorm:"size:16" json:"language"`
+	ExpiresAt      time.Time `gorm:"index" json:"expiresAt"`
+	CreatedAt      time.Time `json:"createdAt"`
+	UpdatedAt      time.Time `json:"updatedAt"`
+}
+
+// RiskConfirmationTicket authorizes one high-risk action once.
+type RiskConfirmationTicket struct {
+	ID        string `gorm:"primaryKey;size:64" json:"id"`
+	ProjectID string `gorm:"size:64;index:idx_risk_ticket,priority:1" json:"projectId"`
+	UserID    string `gorm:"size:191;index:idx_risk_ticket,priority:2" json:"userId"`
+	RunID     string `gorm:"size:64;index:idx_risk_ticket,priority:3" json:"runId"`
+	// ShortTitle snapshots the task title at creation time so every prompt and
+	// every later status reply echoes the task the user was actually asked about.
+	ShortTitle string     `gorm:"size:160" json:"shortTitle"`
+	Action     string     `gorm:"size:191;index:idx_risk_ticket,priority:4" json:"action"`
+	Status     string     `gorm:"size:16;index" json:"status"` // pending | confirmed | cancelled | expired
+	Language   string     `gorm:"size:16" json:"language"`
+	ExpiresAt  time.Time  `gorm:"index" json:"expiresAt"`
+	ResolvedAt *time.Time `json:"resolvedAt,omitempty"`
+	CreatedAt  time.Time  `json:"createdAt"`
+	UpdatedAt  time.Time  `json:"updatedAt"`
+}

--- a/server/internal/pmmcp/host.go
+++ b/server/internal/pmmcp/host.go
@@ -84,11 +84,21 @@ type Host struct {
 	notify ExternalIMNotifier
 }
 
+// IMDeliveryOutcome is what an IM egress reports back about one notification.
+// Sent=false with a Reason means the delivery policy withheld the message on
+// purpose (rate limited, deduplicated, merged, already sent); that is a normal
+// outcome and must not be reported to the agent as a tool error. Real failures
+// (no target, transport error, retries exhausted) come back as an error instead.
+type IMDeliveryOutcome struct {
+	Sent   bool
+	Reason string
+}
+
 // ExternalIMNotifier is the minimal IM egress used by PM MCP write tools.
 // Implemented by the channel Manager in main; nil disables explicit IM notify.
 type ExternalIMNotifier interface {
 	NotifyRunAccepted(projectID, runID string, target IMTarget, shortTitle, language string) error
-	NotifyProgress(projectID, runID string, target IMTarget, kind, text, stage, conclusion string, blocked, actionRequired bool) error
+	NotifyProgress(projectID, runID string, target IMTarget, kind, text, stage, conclusion string, blocked, actionRequired bool) (IMDeliveryOutcome, error)
 }
 
 // engineOps covers the run operations exposed through pm-workflow-write
@@ -823,10 +833,23 @@ func (h *Host) callWorkflowWrite(projectID, token, name string, args map[string]
 		if sess, ok := h.SessionFor(projectID, token); ok {
 			target = imTargetForSession(sess)
 		}
-		if err := h.notify.NotifyProgress(projectID, runID, target, kind, text, stage, conclusion, blocked, actionRequired); err != nil {
+		outcome, err := h.notify.NotifyProgress(projectID, runID, target, kind, text, stage, conclusion, blocked, actionRequired)
+		if err != nil {
 			return map[string]any{"error": err.Error()}, true
 		}
-		return map[string]any{"status": "queued", "kind": kind}, false
+		if !outcome.Sent {
+			// A policy suppression is a successful call with a different
+			// outcome. Reporting it as a tool error made agents rephrase and
+			// resend the very message the policy just merged or deduplicated.
+			reason := outcome.Reason
+			if reason == "" {
+				reason = "suppressed"
+			}
+			return map[string]any{
+				"status": "suppressed", "sent": false, "reason": reason, "kind": kind,
+			}, false
+		}
+		return map[string]any{"status": "sent", "sent": true, "kind": kind}, false
 	case "pm_resume_gate":
 		if h.eng == nil {
 			return map[string]any{"error": "engine unavailable"}, true
@@ -964,7 +987,9 @@ func (h *Host) notifyConfirmation(projectID, runID string, sess *Session, prompt
 	if h.notify == nil {
 		return nil
 	}
-	if err := h.notify.NotifyProgress(projectID, runID, imTargetForSession(sess),
+	// A suppressed confirmation prompt (the same ticket already went out) is not
+	// a failure: only a real delivery failure blocks the write.
+	if _, err := h.notify.NotifyProgress(projectID, runID, imTargetForSession(sess),
 		"action_required", prompt, "", "", false, true); err != nil {
 		return fmt.Errorf("send confirmation prompt: %w", err)
 	}
@@ -1110,7 +1135,7 @@ func toolSchemas(mcpID string) []map[string]any {
 			platformmcp.Tool("pm_cancel_run", "取消一次运行中的 Run（需用户短标题二次确认后才会真正取消）。", map[string]any{
 				"runId": map[string]any{"type": "string"},
 			}),
-			platformmcp.Tool("pm_notify_progress", "向外部 IM 显式提交一条 Sendable 进度/阻塞/确认消息（须含 stage/conclusion 等实质字段）。", map[string]any{
+			platformmcp.Tool("pm_notify_progress", "向外部 IM 显式提交一条 Sendable 进度/阻塞/确认消息（须含 stage/conclusion 等实质字段）。返回 status=sent 表示已外发；status=suppressed 表示被限频/去重/合并等策略正常抑制（不是失败，不要改措辞重发）；只有真实投递失败才返回错误。", map[string]any{
 				"runId":          map[string]any{"type": "string"},
 				"kind":           map[string]any{"type": "string", "description": "progress|blocked|action_required|final"},
 				"text":           map[string]any{"type": "string"},

--- a/server/internal/pmmcp/host.go
+++ b/server/internal/pmmcp/host.go
@@ -58,6 +58,17 @@ type Host struct {
 	skill    *services.SkillService
 	eng      engineOps
 	audit    func(services.AuditRecord)
+
+	risk     *services.RiskConfirmationService
+	tasks    *services.TaskContextService
+	notify   ExternalIMNotifier
+}
+
+// ExternalIMNotifier is the minimal IM egress used by PM MCP write tools.
+// Implemented by the channel Manager in main; nil disables explicit IM notify.
+type ExternalIMNotifier interface {
+	NotifyRunAccepted(projectID, runID, userID, shortTitle, language string) error
+	NotifyProgress(projectID, runID, userID, kind, text, stage, conclusion string, blocked, actionRequired bool) error
 }
 
 // engineOps covers the run operations exposed through pm-workflow-write
@@ -97,6 +108,16 @@ func (h *Host) SetOrgAndSkill(org *services.OrgService, skill *services.SkillSer
 func (h *Host) SetAuditRecorder(fn func(services.AuditRecord)) {
 	h.mu.Lock()
 	h.audit = fn
+	h.mu.Unlock()
+}
+
+// SetTaskSafety wires high-risk confirmation and task identity helpers used by
+// write tools and explicit IM progress notifications.
+func (h *Host) SetTaskSafety(risk *services.RiskConfirmationService, tasks *services.TaskContextService, notify ExternalIMNotifier) {
+	h.mu.Lock()
+	h.risk = risk
+	h.tasks = tasks
+	h.notify = notify
 	h.mu.Unlock()
 }
 
@@ -722,7 +743,60 @@ func (h *Host) callWorkflowWrite(projectID, token, name string, args map[string]
 				"runId":      run.ID,
 			},
 		})
-		return map[string]any{"id": run.ID, "status": run.Status}, false
+		shortTitle := run.Title
+		if h.tasks != nil {
+			sessUser := ""
+			if sess, ok := h.SessionFor(projectID, token); ok {
+				sessUser = sess.UserID
+			}
+			if identity, err := h.tasks.EnsureIdentityForRun(*run, projectID, sessUser); err == nil && identity != nil {
+				shortTitle = identity.ShortTitle
+			}
+		}
+		if h.notify != nil {
+			sessUser := ""
+			if sess, ok := h.SessionFor(projectID, token); ok {
+				sessUser = sess.UserID
+			}
+			if err := h.notify.NotifyRunAccepted(projectID, run.ID, sessUser, shortTitle, ""); err != nil {
+				log.Warn().Err(err).Str("run", run.ID).Msg("pm_start_run acceptance ack failed")
+			}
+		}
+		return map[string]any{"id": run.ID, "status": run.Status, "shortTitle": shortTitle}, false
+	case "pm_notify_progress":
+		if h.notify == nil {
+			return map[string]any{"error": "im notifier unavailable"}, true
+		}
+		runID := platformmcp.StrArg(args, "runId")
+		if _, ok := h.runInProject(projectID, runID); !ok {
+			return map[string]any{"error": "run not found"}, true
+		}
+		text := strings.TrimSpace(platformmcp.StrArg(args, "text"))
+		stage := strings.TrimSpace(platformmcp.StrArg(args, "stage"))
+		conclusion := strings.TrimSpace(platformmcp.StrArg(args, "conclusion"))
+		kind := strings.TrimSpace(platformmcp.StrArg(args, "kind"))
+		if kind == "" {
+			kind = "progress"
+		}
+		blocked := platformmcp.BoolArg(args, "blocked")
+		actionRequired := platformmcp.BoolArg(args, "actionRequired")
+		if text == "" {
+			text = stage
+			if text == "" {
+				text = conclusion
+			}
+		}
+		if text == "" {
+			return map[string]any{"error": "text, stage or conclusion required"}, true
+		}
+		sessUser := ""
+		if sess, ok := h.SessionFor(projectID, token); ok {
+			sessUser = sess.UserID
+		}
+		if err := h.notify.NotifyProgress(projectID, runID, sessUser, kind, text, stage, conclusion, blocked, actionRequired); err != nil {
+			return map[string]any{"error": err.Error()}, true
+		}
+		return map[string]any{"status": "queued", "kind": kind}, false
 	case "pm_resume_gate":
 		if h.eng == nil {
 			return map[string]any{"error": "engine unavailable"}, true
@@ -735,6 +809,9 @@ func (h *Host) callWorkflowWrite(projectID, token, name string, args map[string]
 		action := strings.TrimSpace(platformmcp.StrArg(args, "action"))
 		if nodeID == "" || action == "" {
 			return map[string]any{"error": "nodeId and action required"}, true
+		}
+		if blocked, prompt := h.requireRiskConfirmation(projectID, token, runID, "resume_gate:"+nodeID+":"+action); blocked {
+			return map[string]any{"status": "needs_confirmation", "prompt": prompt}, false
 		}
 		if err := h.eng.ResumeGate(runID, nodeID, action, platformmcp.MapArg(args, "form")); err != nil {
 			return map[string]any{"error": err.Error()}, true
@@ -776,6 +853,9 @@ func (h *Host) callWorkflowWrite(projectID, token, name string, args map[string]
 		if !ok {
 			return map[string]any{"error": "run not found"}, true
 		}
+		if blocked, prompt := h.requireRiskConfirmation(projectID, token, runID, "cancel_run"); blocked {
+			return map[string]any{"status": "needs_confirmation", "prompt": prompt, "runId": runID}, false
+		}
 		if err := h.eng.Cancel(runID); err != nil {
 			return map[string]any{"error": err.Error()}, true
 		}
@@ -798,6 +878,41 @@ func (h *Host) callWorkflowWrite(projectID, token, name string, args map[string]
 	default:
 		return map[string]any{"error": "unknown tool: " + name}, true
 	}
+}
+
+// requireRiskConfirmation creates a one-shot ticket and blocks the write until
+// the user confirms via IM. Returns blocked=false when risk service is unset
+// (unit tests without IM wiring) or when a ticket was already confirmed in-band
+// via confirmed=true after the IM path executed the action separately.
+func (h *Host) requireRiskConfirmation(projectID, token, runID, action string) (blocked bool, prompt string) {
+	if h.risk == nil {
+		return false, ""
+	}
+	sess, ok := h.SessionFor(projectID, token)
+	if !ok {
+		return true, "session required for high-risk confirmation"
+	}
+	// If the IM orchestration already confirmed and executed, MCP should not
+	// create another ticket. A fresh pending ticket always blocks.
+	if pending, err := h.risk.LatestPending(sess.UserID, projectID); err == nil && pending != nil &&
+		pending.RunID == runID && pending.Action == action {
+		return true, h.risk.ConfirmationPrompt(*pending)
+	}
+	shortTitle := ""
+	if h.tasks != nil {
+		var identity models.TaskIdentity
+		if err := h.tasks.DB().Where("run_id = ? AND project_id = ?", runID, projectID).First(&identity).Error; err == nil {
+			shortTitle = identity.ShortTitle
+		}
+	}
+	ticket, err := h.risk.CreateTicket(services.RiskTicketInput{
+		ProjectID: projectID, UserID: sess.UserID, RunID: runID,
+		Action: action, ShortTitle: shortTitle, Language: "",
+	})
+	if err != nil {
+		return true, "failed to create confirmation ticket: " + err.Error()
+	}
+	return true, h.risk.ConfirmationPrompt(*ticket)
 }
 
 func toolSchemas(mcpID string) []map[string]any {
@@ -915,8 +1030,17 @@ func toolSchemas(mcpID string) []map[string]any {
 					"description": "可选：精确字段/页面元素标注；首版不支持 images",
 				},
 			}),
-			platformmcp.Tool("pm_cancel_run", "取消一次运行中的 Run。", map[string]any{
+			platformmcp.Tool("pm_cancel_run", "取消一次运行中的 Run（需用户短标题二次确认后才会真正取消）。", map[string]any{
 				"runId": map[string]any{"type": "string"},
+			}),
+			platformmcp.Tool("pm_notify_progress", "向外部 IM 显式提交一条 Sendable 进度/阻塞/确认消息（须含 stage/conclusion 等实质字段）。", map[string]any{
+				"runId":          map[string]any{"type": "string"},
+				"kind":           map[string]any{"type": "string", "description": "progress|blocked|action_required|final"},
+				"text":           map[string]any{"type": "string"},
+				"stage":          map[string]any{"type": "string"},
+				"conclusion":     map[string]any{"type": "string"},
+				"blocked":        map[string]any{"type": "boolean"},
+				"actionRequired": map[string]any{"type": "boolean"},
 			}),
 		}
 	default:

--- a/server/internal/pmmcp/host.go
+++ b/server/internal/pmmcp/host.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/cocofhu/approving/internal/models"
 	"github.com/cocofhu/approving/internal/platformmcp"
@@ -40,7 +41,26 @@ type Session struct {
 	ThreadID  string
 	UserID    string
 	AgentName string
+	Channel   ChannelContext
 	Attached  *models.AttachedContext
+}
+
+// ChannelContext is the concrete external identity/destination for a channel
+// MCP session. UserID on Session remains the conversation-scoped thread key.
+type ChannelContext struct {
+	ChannelType    string
+	Scene          string
+	ConversationID string
+	ExternalUserID string
+}
+
+// IMTarget is passed to the external notifier so lifecycle messages stay bound
+// to the active conversation instead of relying on a configured cron target.
+type IMTarget struct {
+	ChannelType    string
+	Scene          string
+	ConversationID string
+	UserID         string
 }
 
 // Host manages project-scoped PM MCP sessions and tool dispatch.
@@ -59,16 +79,16 @@ type Host struct {
 	eng      engineOps
 	audit    func(services.AuditRecord)
 
-	risk     *services.RiskConfirmationService
-	tasks    *services.TaskContextService
-	notify   ExternalIMNotifier
+	risk   *services.RiskConfirmationService
+	tasks  *services.TaskContextService
+	notify ExternalIMNotifier
 }
 
 // ExternalIMNotifier is the minimal IM egress used by PM MCP write tools.
 // Implemented by the channel Manager in main; nil disables explicit IM notify.
 type ExternalIMNotifier interface {
-	NotifyRunAccepted(projectID, runID, userID, shortTitle, language string) error
-	NotifyProgress(projectID, runID, userID, kind, text, stage, conclusion string, blocked, actionRequired bool) error
+	NotifyRunAccepted(projectID, runID string, target IMTarget, shortTitle, language string) error
+	NotifyProgress(projectID, runID string, target IMTarget, kind, text, stage, conclusion string, blocked, actionRequired bool) error
 }
 
 // engineOps covers the run operations exposed through pm-workflow-write
@@ -192,6 +212,16 @@ func (h *Host) SetAttached(token string, attached *models.AttachedContext) {
 	defer h.mu.Unlock()
 	if s, ok := h.sessions[token]; ok {
 		s.Attached = attached
+	}
+}
+
+// SetChannelContext updates the active external sender and destination after a
+// fresh register or sandbox reuse.
+func (h *Host) SetChannelContext(token string, channel ChannelContext) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if s, ok := h.sessions[token]; ok {
+		s.Channel = channel
 	}
 }
 
@@ -754,11 +784,11 @@ func (h *Host) callWorkflowWrite(projectID, token, name string, args map[string]
 			}
 		}
 		if h.notify != nil {
-			sessUser := ""
+			target := IMTarget{}
 			if sess, ok := h.SessionFor(projectID, token); ok {
-				sessUser = sess.UserID
+				target = imTargetForSession(sess)
 			}
-			if err := h.notify.NotifyRunAccepted(projectID, run.ID, sessUser, shortTitle, ""); err != nil {
+			if err := h.notify.NotifyRunAccepted(projectID, run.ID, target, shortTitle, ""); err != nil {
 				log.Warn().Err(err).Str("run", run.ID).Msg("pm_start_run acceptance ack failed")
 			}
 		}
@@ -789,11 +819,11 @@ func (h *Host) callWorkflowWrite(projectID, token, name string, args map[string]
 		if text == "" {
 			return map[string]any{"error": "text, stage or conclusion required"}, true
 		}
-		sessUser := ""
+		target := IMTarget{}
 		if sess, ok := h.SessionFor(projectID, token); ok {
-			sessUser = sess.UserID
+			target = imTargetForSession(sess)
 		}
-		if err := h.notify.NotifyProgress(projectID, runID, sessUser, kind, text, stage, conclusion, blocked, actionRequired); err != nil {
+		if err := h.notify.NotifyProgress(projectID, runID, target, kind, text, stage, conclusion, blocked, actionRequired); err != nil {
 			return map[string]any{"error": err.Error()}, true
 		}
 		return map[string]any{"status": "queued", "kind": kind}, false
@@ -810,7 +840,9 @@ func (h *Host) callWorkflowWrite(projectID, token, name string, args map[string]
 		if nodeID == "" || action == "" {
 			return map[string]any{"error": "nodeId and action required"}, true
 		}
-		if blocked, prompt := h.requireRiskConfirmation(projectID, token, runID, "resume_gate:"+nodeID+":"+action); blocked {
+		if blocked, completed, prompt := h.requireRiskConfirmation(projectID, token, runID, "resume_gate:"+nodeID+":"+action); completed {
+			return map[string]any{"status": "already_confirmed"}, false
+		} else if blocked {
 			return map[string]any{"status": "needs_confirmation", "prompt": prompt}, false
 		}
 		if err := h.eng.ResumeGate(runID, nodeID, action, platformmcp.MapArg(args, "form")); err != nil {
@@ -853,7 +885,9 @@ func (h *Host) callWorkflowWrite(projectID, token, name string, args map[string]
 		if !ok {
 			return map[string]any{"error": "run not found"}, true
 		}
-		if blocked, prompt := h.requireRiskConfirmation(projectID, token, runID, "cancel_run"); blocked {
+		if blocked, completed, prompt := h.requireRiskConfirmation(projectID, token, runID, "cancel_run"); completed {
+			return map[string]any{"status": "already_confirmed", "runId": runID}, false
+		} else if blocked {
 			return map[string]any{"status": "needs_confirmation", "prompt": prompt, "runId": runID}, false
 		}
 		if err := h.eng.Cancel(runID); err != nil {
@@ -884,19 +918,24 @@ func (h *Host) callWorkflowWrite(projectID, token, name string, args map[string]
 // the user confirms via IM. Returns blocked=false when risk service is unset
 // (unit tests without IM wiring) or when a ticket was already confirmed in-band
 // via confirmed=true after the IM path executed the action separately.
-func (h *Host) requireRiskConfirmation(projectID, token, runID, action string) (blocked bool, prompt string) {
+func (h *Host) requireRiskConfirmation(projectID, token, runID, action string) (blocked, completed bool, prompt string) {
 	if h.risk == nil {
-		return false, ""
+		return false, false, ""
 	}
 	sess, ok := h.SessionFor(projectID, token)
 	if !ok {
-		return true, "session required for high-risk confirmation"
+		return true, false, "session required for high-risk confirmation"
 	}
+	riskUserID := riskUserIDForSession(sess)
 	// If the IM orchestration already confirmed and executed, MCP should not
 	// create another ticket. A fresh pending ticket always blocks.
-	if pending, err := h.risk.LatestPending(sess.UserID, projectID); err == nil && pending != nil &&
+	if pending, err := h.risk.LatestPending(riskUserID, projectID); err == nil && pending != nil &&
 		pending.RunID == runID && pending.Action == action {
-		return true, h.risk.ConfirmationPrompt(*pending)
+		return true, false, h.risk.ConfirmationPrompt(*pending)
+	}
+	if settled, err := h.risk.LatestForAction(riskUserID, projectID, runID, action); err == nil &&
+		settled != nil && settled.Status == "confirmed" && settled.ExpiresAt.After(time.Now()) {
+		return false, true, ""
 	}
 	shortTitle := ""
 	if h.tasks != nil {
@@ -906,13 +945,34 @@ func (h *Host) requireRiskConfirmation(projectID, token, runID, action string) (
 		}
 	}
 	ticket, err := h.risk.CreateTicket(services.RiskTicketInput{
-		ProjectID: projectID, UserID: sess.UserID, RunID: runID,
+		ProjectID: projectID, UserID: riskUserID, RunID: runID,
 		Action: action, ShortTitle: shortTitle, Language: "",
 	})
 	if err != nil {
-		return true, "failed to create confirmation ticket: " + err.Error()
+		return true, false, "failed to create confirmation ticket: " + err.Error()
 	}
-	return true, h.risk.ConfirmationPrompt(*ticket)
+	return true, false, h.risk.ConfirmationPrompt(*ticket)
+}
+
+func riskUserIDForSession(sess *Session) string {
+	if sess == nil {
+		return ""
+	}
+	if strings.EqualFold(strings.TrimSpace(sess.Channel.ChannelType), "qq") &&
+		strings.TrimSpace(sess.Channel.ExternalUserID) != "" {
+		return services.SyntheticQQUserID(sess.Channel.ExternalUserID)
+	}
+	return strings.TrimSpace(sess.UserID)
+}
+
+func imTargetForSession(sess *Session) IMTarget {
+	if sess == nil {
+		return IMTarget{}
+	}
+	return IMTarget{
+		ChannelType: sess.Channel.ChannelType, Scene: sess.Channel.Scene,
+		ConversationID: sess.Channel.ConversationID, UserID: sess.Channel.ExternalUserID,
+	}
 }
 
 func toolSchemas(mcpID string) []map[string]any {

--- a/server/internal/pmmcp/host.go
+++ b/server/internal/pmmcp/host.go
@@ -777,7 +777,7 @@ func (h *Host) callWorkflowWrite(projectID, token, name string, args map[string]
 		if h.tasks != nil {
 			sessUser := ""
 			if sess, ok := h.SessionFor(projectID, token); ok {
-				sessUser = sess.UserID
+				sessUser = riskUserIDForSession(sess)
 			}
 			if identity, err := h.tasks.EnsureIdentityForRun(*run, projectID, sessUser); err == nil && identity != nil {
 				shortTitle = identity.ShortTitle
@@ -840,7 +840,9 @@ func (h *Host) callWorkflowWrite(projectID, token, name string, args map[string]
 		if nodeID == "" || action == "" {
 			return map[string]any{"error": "nodeId and action required"}, true
 		}
-		if blocked, completed, prompt := h.requireRiskConfirmation(projectID, token, runID, "resume_gate:"+nodeID+":"+action); completed {
+		if blocked, completed, prompt, confirmErr := h.requireRiskConfirmation(projectID, token, runID, "resume_gate:"+nodeID+":"+action); confirmErr != nil {
+			return map[string]any{"error": confirmErr.Error()}, true
+		} else if completed {
 			return map[string]any{"status": "already_confirmed"}, false
 		} else if blocked {
 			return map[string]any{"status": "needs_confirmation", "prompt": prompt}, false
@@ -885,7 +887,9 @@ func (h *Host) callWorkflowWrite(projectID, token, name string, args map[string]
 		if !ok {
 			return map[string]any{"error": "run not found"}, true
 		}
-		if blocked, completed, prompt := h.requireRiskConfirmation(projectID, token, runID, "cancel_run"); completed {
+		if blocked, completed, prompt, confirmErr := h.requireRiskConfirmation(projectID, token, runID, "cancel_run"); confirmErr != nil {
+			return map[string]any{"error": confirmErr.Error()}, true
+		} else if completed {
 			return map[string]any{"status": "already_confirmed", "runId": runID}, false
 		} else if blocked {
 			return map[string]any{"status": "needs_confirmation", "prompt": prompt, "runId": runID}, false
@@ -918,24 +922,25 @@ func (h *Host) callWorkflowWrite(projectID, token, name string, args map[string]
 // the user confirms via IM. Returns blocked=false when risk service is unset
 // (unit tests without IM wiring) or when a ticket was already confirmed in-band
 // via confirmed=true after the IM path executed the action separately.
-func (h *Host) requireRiskConfirmation(projectID, token, runID, action string) (blocked, completed bool, prompt string) {
+func (h *Host) requireRiskConfirmation(projectID, token, runID, action string) (blocked, completed bool, prompt string, err error) {
 	if h.risk == nil {
-		return false, false, ""
+		return false, false, "", nil
 	}
 	sess, ok := h.SessionFor(projectID, token)
 	if !ok {
-		return true, false, "session required for high-risk confirmation"
+		return true, false, "session required for high-risk confirmation", nil
 	}
 	riskUserID := riskUserIDForSession(sess)
 	// If the IM orchestration already confirmed and executed, MCP should not
 	// create another ticket. A fresh pending ticket always blocks.
 	if pending, err := h.risk.LatestPending(riskUserID, projectID); err == nil && pending != nil &&
 		pending.RunID == runID && pending.Action == action {
-		return true, false, h.risk.ConfirmationPrompt(*pending)
+		prompt := h.risk.ConfirmationPrompt(*pending)
+		return true, false, prompt, h.notifyConfirmation(projectID, runID, sess, prompt)
 	}
 	if settled, err := h.risk.LatestForAction(riskUserID, projectID, runID, action); err == nil &&
 		settled != nil && settled.Status == "confirmed" && settled.ExpiresAt.After(time.Now()) {
-		return false, true, ""
+		return false, true, "", nil
 	}
 	shortTitle := ""
 	if h.tasks != nil {
@@ -949,9 +954,21 @@ func (h *Host) requireRiskConfirmation(projectID, token, runID, action string) (
 		Action: action, ShortTitle: shortTitle, Language: "",
 	})
 	if err != nil {
-		return true, false, "failed to create confirmation ticket: " + err.Error()
+		return true, false, "failed to create confirmation ticket: " + err.Error(), nil
 	}
-	return true, false, h.risk.ConfirmationPrompt(*ticket)
+	prompt = h.risk.ConfirmationPrompt(*ticket)
+	return true, false, prompt, h.notifyConfirmation(projectID, runID, sess, prompt)
+}
+
+func (h *Host) notifyConfirmation(projectID, runID string, sess *Session, prompt string) error {
+	if h.notify == nil {
+		return nil
+	}
+	if err := h.notify.NotifyProgress(projectID, runID, imTargetForSession(sess),
+		"action_required", prompt, "", "", false, true); err != nil {
+		return fmt.Errorf("send confirmation prompt: %w", err)
+	}
+	return nil
 }
 
 func riskUserIDForSession(sess *Session) string {

--- a/server/internal/pmmcp/host_more_test.go
+++ b/server/internal/pmmcp/host_more_test.go
@@ -20,20 +20,24 @@ type recordingIMNotifier struct {
 		target                       IMTarget
 		actionRequired               bool
 	}
-	err error
+	outcome IMDeliveryOutcome
+	err     error
 }
 
 func (n *recordingIMNotifier) NotifyRunAccepted(string, string, IMTarget, string, string) error {
 	return n.err
 }
 
-func (n *recordingIMNotifier) NotifyProgress(projectID, runID string, target IMTarget, kind, text, stage, conclusion string, blocked, actionRequired bool) error {
+func (n *recordingIMNotifier) NotifyProgress(projectID, runID string, target IMTarget, kind, text, stage, conclusion string, blocked, actionRequired bool) (IMDeliveryOutcome, error) {
 	n.progressCalls = append(n.progressCalls, struct {
 		projectID, runID, kind, text string
 		target                       IMTarget
 		actionRequired               bool
 	}{projectID: projectID, runID: runID, kind: kind, text: text, target: target, actionRequired: actionRequired})
-	return n.err
+	if n.err != nil {
+		return IMDeliveryOutcome{}, n.err
+	}
+	return n.outcome, nil
 }
 
 func setupPmMCPHost(t *testing.T) (*gorm.DB, *services.PmService, *Host, models.Project) {
@@ -182,6 +186,71 @@ func TestPmStartRunUsesExternalQQIdentityForTaskSearch(t *testing.T) {
 	}
 	if candidates[0].Identity.UserID == "qq:group:conversation-1" {
 		t.Fatalf("conversation identity owns task: %+v", candidates[0].Identity)
+	}
+}
+
+func TestPmNotifyProgressSeparatesSuppressionFromFailure(t *testing.T) {
+	db, pm, _, p := setupPmMCPHost(t)
+	wf := services.NewWorkflowService(db)
+	wfDef := &models.WorkflowDef{
+		ID: "wf-notify", ProjectID: p.ID, Name: "Notify WF",
+		Graph: models.Graph{Nodes: []models.Node{{ID: "in", Type: "input"}, {ID: "out", Type: "output"}}},
+	}
+	if err := wf.Save(wfDef); err != nil {
+		t.Fatal(err)
+	}
+	rs := services.NewRunService(db)
+	if err := rs.DB().Create(&models.Run{ID: "run-notify", WorkflowID: wfDef.ID, Status: "running"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	h := NewHost(pm, services.NewPmProgress(pm, rs, nil), wf, rs, services.NewArtifactService(db), &fakePmEngine{})
+	notifier := &recordingIMNotifier{}
+	h.SetTaskSafety(nil, nil, notifier)
+	tok := h.Register(p.ID, "thr-notify", "alice", "agent-a")
+	notify := func() (map[string]any, bool) {
+		out, isErr := h.callTool(p.ID, tok, MCPWorkflowWrite, "pm_notify_progress", map[string]any{
+			"runId": "run-notify", "kind": "progress", "stage": "已提交分支",
+		})
+		payload, ok := out.(map[string]any)
+		if !ok {
+			t.Fatalf("unexpected tool payload %#v", out)
+		}
+		return payload, isErr
+	}
+
+	notifier.outcome = IMDeliveryOutcome{Sent: true}
+	payload, isErr := notify()
+	if isErr || payload["status"] != "sent" || payload["sent"] != true {
+		t.Fatalf("delivered progress = %#v isError=%v", payload, isErr)
+	}
+
+	// A rate-limited / merged progress update is a normal outcome: reporting it
+	// as a tool error made agents rephrase and resend.
+	notifier.outcome = IMDeliveryOutcome{Reason: "progress_rate_limited_merged"}
+	payload, isErr = notify()
+	if isErr {
+		t.Fatalf("suppression must not be a tool error: %#v", payload)
+	}
+	if payload["status"] != "suppressed" || payload["sent"] != false ||
+		payload["reason"] != "progress_rate_limited_merged" {
+		t.Fatalf("suppressed progress = %#v", payload)
+	}
+	if _, hasError := payload["error"]; hasError {
+		t.Fatalf("suppressed progress carried an error field: %#v", payload)
+	}
+
+	// A suppression without a reason still reads as suppressed, not sent.
+	notifier.outcome = IMDeliveryOutcome{}
+	payload, isErr = notify()
+	if isErr || payload["status"] != "suppressed" || payload["reason"] != "suppressed" {
+		t.Fatalf("reasonless suppression = %#v isError=%v", payload, isErr)
+	}
+
+	// Only a real delivery failure is an error the agent should act on.
+	notifier.err = errors.New("项目未配置可用的外发渠道目标")
+	payload, isErr = notify()
+	if !isErr || !strings.Contains(fmt.Sprint(payload["error"]), "未配置可用的外发渠道") {
+		t.Fatalf("delivery failure = %#v isError=%v", payload, isErr)
 	}
 }
 

--- a/server/internal/pmmcp/host_more_test.go
+++ b/server/internal/pmmcp/host_more_test.go
@@ -2,6 +2,7 @@ package pmmcp
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -12,6 +13,28 @@ import (
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
+
+type recordingIMNotifier struct {
+	progressCalls []struct {
+		projectID, runID, kind, text string
+		target                       IMTarget
+		actionRequired               bool
+	}
+	err error
+}
+
+func (n *recordingIMNotifier) NotifyRunAccepted(string, string, IMTarget, string, string) error {
+	return n.err
+}
+
+func (n *recordingIMNotifier) NotifyProgress(projectID, runID string, target IMTarget, kind, text, stage, conclusion string, blocked, actionRequired bool) error {
+	n.progressCalls = append(n.progressCalls, struct {
+		projectID, runID, kind, text string
+		target                       IMTarget
+		actionRequired               bool
+	}{projectID: projectID, runID: runID, kind: kind, text: text, target: target, actionRequired: actionRequired})
+	return n.err
+}
 
 func setupPmMCPHost(t *testing.T) (*gorm.DB, *services.PmService, *Host, models.Project) {
 	t.Helper()
@@ -63,7 +86,8 @@ func TestChannelSessionRiskIdentityAndConfirmedRetry(t *testing.T) {
 	db, _, h, p := setupPmMCPHost(t)
 	risk := services.NewRiskConfirmationService(db)
 	tasks := services.NewTaskContextService(db)
-	h.SetTaskSafety(risk, tasks, nil)
+	notifier := &recordingIMNotifier{}
+	h.SetTaskSafety(risk, tasks, notifier)
 
 	tok := h.Register(p.ID, "thr-channel", "qq:group:conversation-1", "agent-a")
 	h.SetChannelContext(tok, ChannelContext{
@@ -79,9 +103,18 @@ func TestChannelSessionRiskIdentityAndConfirmedRetry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	blocked, completed, prompt := h.requireRiskConfirmation(p.ID, tok, "run-risk", "cancel_run")
-	if !blocked || completed || !strings.Contains(prompt, "结算页性能") {
-		t.Fatalf("first confirmation = blocked:%v completed:%v prompt:%q", blocked, completed, prompt)
+	blocked, completed, prompt, err := h.requireRiskConfirmation(p.ID, tok, "run-risk", "cancel_run")
+	if err != nil || !blocked || completed || !strings.Contains(prompt, "结算页性能") {
+		t.Fatalf("first confirmation = blocked:%v completed:%v prompt:%q err:%v", blocked, completed, prompt, err)
+	}
+	if len(notifier.progressCalls) != 1 {
+		t.Fatalf("confirmation notify calls = %d", len(notifier.progressCalls))
+	}
+	confirmation := notifier.progressCalls[0]
+	if confirmation.kind != "action_required" || !confirmation.actionRequired ||
+		confirmation.runID != "run-risk" || !strings.Contains(confirmation.text, "结算页性能") ||
+		confirmation.target.UserID != "openid-1" {
+		t.Fatalf("confirmation notify = %+v", confirmation)
 	}
 	scopeUser := services.SyntheticQQUserID("openid-1")
 	pending, err := risk.LatestPending(scopeUser, p.ID)
@@ -97,9 +130,9 @@ func TestChannelSessionRiskIdentityAndConfirmedRetry(t *testing.T) {
 	if err != nil || !resolved.Execute {
 		t.Fatalf("QQ confirmation = %+v err=%v", resolved, err)
 	}
-	blocked, completed, _ = h.requireRiskConfirmation(p.ID, tok, "run-risk", "cancel_run")
-	if blocked || !completed {
-		t.Fatalf("confirmed MCP retry must be read-only: blocked=%v completed=%v", blocked, completed)
+	blocked, completed, _, err = h.requireRiskConfirmation(p.ID, tok, "run-risk", "cancel_run")
+	if err != nil || blocked || !completed {
+		t.Fatalf("confirmed MCP retry must be read-only: blocked=%v completed=%v err=%v", blocked, completed, err)
 	}
 	var count int64
 	if err := db.Model(&models.RiskConfirmationTicket{}).Count(&count).Error; err != nil || count != 1 {
@@ -110,6 +143,64 @@ func TestChannelSessionRiskIdentityAndConfirmedRetry(t *testing.T) {
 	target := imTargetForSession(sess)
 	if target.Scene != "group" || target.ConversationID != "conversation-1" || target.UserID != "openid-1" {
 		t.Fatalf("IM target = %+v", target)
+	}
+}
+
+func TestPmStartRunUsesExternalQQIdentityForTaskSearch(t *testing.T) {
+	db, pm, _, p := setupPmMCPHost(t)
+	wf := services.NewWorkflowService(db)
+	wfDef := &models.WorkflowDef{
+		ID: "wf-qq-task", ProjectID: p.ID, Name: "登录页工作",
+		Graph: models.Graph{Nodes: []models.Node{{ID: "in", Type: "input"}, {ID: "out", Type: "output"}}},
+	}
+	if err := wf.Save(wfDef); err != nil {
+		t.Fatal(err)
+	}
+	eng := &fakePmEngine{runTitle: "登录页性能优化"}
+	rs := services.NewRunService(db)
+	h := NewHost(pm, services.NewPmProgress(pm, rs, nil), wf, rs, services.NewArtifactService(db), eng)
+	tasks := services.NewTaskContextService(db)
+	h.SetTaskSafety(nil, tasks, nil)
+	tok := h.Register(p.ID, "thr-qq-task", "qq:group:conversation-1", "agent-a")
+	h.SetChannelContext(tok, ChannelContext{
+		ChannelType: "qq", Scene: "group", ConversationID: "conversation-1", ExternalUserID: "openid-1",
+	})
+
+	if _, isErr := h.callTool(p.ID, tok, MCPWorkflowWrite, "pm_start_run", map[string]any{
+		"workflowId": wfDef.ID, "inputs": map[string]any{"requirement": "优化登录页性能"},
+	}); isErr {
+		t.Fatal("pm_start_run returned an error")
+	}
+
+	scope := services.TaskScope{
+		ProjectID: p.ID, UserID: services.SyntheticQQUserID("openid-1"),
+		Channel: "qq", ConversationID: "conversation-1",
+	}
+	candidates, err := tasks.Search(scope, "登录页")
+	if err != nil || len(candidates) != 1 || candidates[0].Identity.RunID != "run-pm-mcp" {
+		t.Fatalf("QQ sender task search = %+v err=%v", candidates, err)
+	}
+	if candidates[0].Identity.UserID == "qq:group:conversation-1" {
+		t.Fatalf("conversation identity owns task: %+v", candidates[0].Identity)
+	}
+}
+
+func TestRiskConfirmationNotifyFailureIsReturned(t *testing.T) {
+	db, _, h, p := setupPmMCPHost(t)
+	risk := services.NewRiskConfirmationService(db)
+	tasks := services.NewTaskContextService(db)
+	h.SetTaskSafety(risk, tasks, &recordingIMNotifier{err: errors.New("transport down")})
+	tok := h.Register(p.ID, "thr-notify-fail", "qq:group:c1", "agent-a")
+	h.SetChannelContext(tok, ChannelContext{
+		ChannelType: "qq", Scene: "group", ConversationID: "c1", ExternalUserID: "openid-1",
+	})
+	if err := db.Create(&models.Run{ID: "run-notify-fail", Status: "running"}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	blocked, completed, prompt, err := h.requireRiskConfirmation(p.ID, tok, "run-notify-fail", "cancel_run")
+	if !blocked || completed || prompt == "" || err == nil || !strings.Contains(err.Error(), "transport down") {
+		t.Fatalf("confirmation failure = blocked:%v completed:%v prompt:%q err:%v", blocked, completed, prompt, err)
 	}
 }
 
@@ -224,6 +315,7 @@ type fakePmEngine struct {
 	}
 	cancelled   string
 	lastTrigger string
+	runTitle    string
 	startCalls  int
 	waiting     int
 	thinking    bool
@@ -236,7 +328,10 @@ func (f *fakePmEngine) StartRunWithPriority(workflowID string, inputs map[string
 	if len(tags) > 0 {
 		normalized = append([]string{}, tags[0]...)
 	}
-	return &models.Run{ID: "run-pm-mcp", WorkflowID: workflowID, Status: "queued", Trigger: trigger, Tags: normalized}, nil
+	return &models.Run{
+		ID: "run-pm-mcp", WorkflowID: workflowID, Status: "queued",
+		Title: f.runTitle, Trigger: trigger, Tags: normalized, Inputs: inputs,
+	}, nil
 }
 
 func (f *fakePmEngine) ResumeGate(runID, nodeID, action string, form map[string]any) error {

--- a/server/internal/pmmcp/host_more_test.go
+++ b/server/internal/pmmcp/host_more_test.go
@@ -59,6 +59,60 @@ func TestPmMCPSessionHelpers(t *testing.T) {
 	h.Restore(p.ID, "thr-1", "alice", "agent-a", "")
 }
 
+func TestChannelSessionRiskIdentityAndConfirmedRetry(t *testing.T) {
+	db, _, h, p := setupPmMCPHost(t)
+	risk := services.NewRiskConfirmationService(db)
+	tasks := services.NewTaskContextService(db)
+	h.SetTaskSafety(risk, tasks, nil)
+
+	tok := h.Register(p.ID, "thr-channel", "qq:group:conversation-1", "agent-a")
+	h.SetChannelContext(tok, ChannelContext{
+		ChannelType: "qq", Scene: "group",
+		ConversationID: "conversation-1", ExternalUserID: "openid-1",
+	})
+	if err := db.Create(&models.Run{ID: "run-risk", Status: "running"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.EnsureIdentity(services.EnsureTaskIdentityInput{
+		RunID: "run-risk", ProjectID: p.ID, ShortTitle: "结算页性能", Status: "running",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	blocked, completed, prompt := h.requireRiskConfirmation(p.ID, tok, "run-risk", "cancel_run")
+	if !blocked || completed || !strings.Contains(prompt, "结算页性能") {
+		t.Fatalf("first confirmation = blocked:%v completed:%v prompt:%q", blocked, completed, prompt)
+	}
+	scopeUser := services.SyntheticQQUserID("openid-1")
+	pending, err := risk.LatestPending(scopeUser, p.ID)
+	if err != nil || pending == nil {
+		t.Fatalf("QQ sender must see MCP ticket: ticket=%+v err=%v", pending, err)
+	}
+	if pending.UserID == "qq:group:conversation-1" {
+		t.Fatalf("ticket used conversation thread id instead of sender identity: %+v", pending)
+	}
+	resolved, err := risk.ResolveTicket(services.RiskTicketInput{
+		ProjectID: p.ID, UserID: scopeUser, RunID: "run-risk", Action: "cancel_run",
+	}, "确认")
+	if err != nil || !resolved.Execute {
+		t.Fatalf("QQ confirmation = %+v err=%v", resolved, err)
+	}
+	blocked, completed, _ = h.requireRiskConfirmation(p.ID, tok, "run-risk", "cancel_run")
+	if blocked || !completed {
+		t.Fatalf("confirmed MCP retry must be read-only: blocked=%v completed=%v", blocked, completed)
+	}
+	var count int64
+	if err := db.Model(&models.RiskConfirmationTicket{}).Count(&count).Error; err != nil || count != 1 {
+		t.Fatalf("ticket count=%d err=%v", count, err)
+	}
+
+	sess, _ := h.SessionFor(p.ID, tok)
+	target := imTargetForSession(sess)
+	if target.Scene != "group" || target.ConversationID != "conversation-1" || target.UserID != "openid-1" {
+		t.Fatalf("IM target = %+v", target)
+	}
+}
+
 func TestPmMCPServeRPCBranches(t *testing.T) {
 	db, pm, h, p := setupPmMCPHost(t)
 	tok := h.Register(p.ID, "thr-rpc", "alice", "agent-a")

--- a/server/internal/sendable/sendable.go
+++ b/server/internal/sendable/sendable.go
@@ -297,14 +297,12 @@ func (p *Policy) bucketSuppression(ctx context.Context, e DeliveryEnvelope, chan
 		var last models.SendableDeliveryReceipt
 		err := base().Where("kind = ?", string(KindProgress)).Order("last_attempt_at desc").First(&last).Error
 		if err == nil && now.Sub(last.LastAttemptAt) < p.rateWindow {
-			digest := progressDigest(e)
-			// Same stage/conclusion within the window: coalesce & suppress.
-			if digest == "" || digest == last.ProgressDigest {
-				return "progress_rate_limited_merged"
-			}
-			// Substantive field change: immediately retain/deliver the latest
-			// snapshot (still one logical progress update of the newest stage).
-			return ""
+			// Every ordinary progress update shares the same 60-second bucket,
+			// including a changed stage/conclusion. Producers keep reporting
+			// snapshots, so the first snapshot evaluated after the window is the
+			// latest one. Urgent blocked/action_required/final updates use their
+			// dedicated kinds and therefore bypass this progress-only limit.
+			return "progress_rate_limited_merged"
 		}
 	}
 	return ""

--- a/server/internal/sendable/sendable.go
+++ b/server/internal/sendable/sendable.go
@@ -209,11 +209,14 @@ func (p *Policy) Evaluate(ctx context.Context, e DeliveryEnvelope, channel Chann
 			DedupeKey: key, ProjectID: e.ProjectID, RunID: e.RunID,
 			TaskContext:    e.TaskContext,
 			ConversationID: e.ConversationID, Channel: string(channel),
-			Kind: string(e.Kind), ContentHash: contentHash, CreatedAt: now,
+			Kind: string(e.Kind), ContentHash: contentHash,
+			ProgressDigest: progressDigest(e), CreatedAt: now,
 		}
 	}
 	receipt.Status = "pending"
 	receipt.Result = "pending"
+	receipt.ContentHash = contentHash
+	receipt.ProgressDigest = progressDigest(e)
 	receipt.Attempts++
 	receipt.LastAttemptAt = now
 	receipt.UpdatedAt = now
@@ -294,10 +297,40 @@ func (p *Policy) bucketSuppression(ctx context.Context, e DeliveryEnvelope, chan
 		var last models.SendableDeliveryReceipt
 		err := base().Where("kind = ?", string(KindProgress)).Order("last_attempt_at desc").First(&last).Error
 		if err == nil && now.Sub(last.LastAttemptAt) < p.rateWindow {
-			return "progress_rate_limited_merged"
+			digest := progressDigest(e)
+			// Same stage/conclusion within the window: coalesce & suppress.
+			if digest == "" || digest == last.ProgressDigest {
+				return "progress_rate_limited_merged"
+			}
+			// Substantive field change: immediately retain/deliver the latest
+			// snapshot (still one logical progress update of the newest stage).
+			return ""
 		}
 	}
 	return ""
+}
+
+func progressDigest(e DeliveryEnvelope) string {
+	if e.Kind != KindProgress {
+		return ""
+	}
+	raw := strings.Join([]string{
+		strings.TrimSpace(e.Progress.Stage),
+		fmtBool(e.Progress.Blocked),
+		fmtBool(e.Progress.ActionRequired),
+		strings.TrimSpace(e.Progress.Conclusion),
+	}, "\x1f")
+	if strings.TrimSpace(strings.ReplaceAll(raw, "\x1f", "")) == "" {
+		return ""
+	}
+	return digest(raw)
+}
+
+func fmtBool(v bool) string {
+	if v {
+		return "1"
+	}
+	return "0"
 }
 
 // Retry claims the next bounded attempt for a delivery that already failed.

--- a/server/internal/sendable/sendable.go
+++ b/server/internal/sendable/sendable.go
@@ -1,0 +1,426 @@
+// Package sendable owns the explicit external-delivery contract and policy.
+package sendable
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+
+	"gorm.io/gorm"
+)
+
+type Channel string
+type Priority string
+type Kind string
+
+const (
+	ChannelInternal Channel = "internal"
+	ChannelQQ       Channel = "qq"
+
+	PriorityLow      Priority = "low"
+	PriorityNormal   Priority = "normal"
+	PriorityHigh     Priority = "high"
+	PriorityCritical Priority = "critical"
+
+	KindUnknown   Kind = "unknown"
+	KindAgentRaw  Kind = "agent_raw"
+	KindTool      Kind = "tool"
+	KindReasoning Kind = "reasoning"
+	// KindRunAcceptanceAck confirms that a real Run was accepted. It requires a
+	// real RunID and is delivered at most once per run×conversation/user×channel.
+	KindRunAcceptanceAck Kind = "run_acceptance_ack"
+	// KindTurnProcessingAck is the per-turn "received, working on it" reply. It
+	// is scoped to a turn, never to a Run, and must not be treated as a
+	// run acceptance ACK.
+	KindTurnProcessingAck  Kind = "turn_processing_ack"
+	KindQueueAck           Kind = "queue_ack"
+	KindProgress           Kind = "progress"
+	KindBlocked            Kind = "blocked"
+	KindActionRequired     Kind = "action_required"
+	KindFinal              Kind = "final"
+	KindCron               Kind = "cron"
+	KindRunNotify          Kind = "run_notify"
+	KindSafetyNotice       Kind = "safety_notice"
+	KindCapabilityFallback Kind = "capability_fallback"
+)
+
+// requiresRunID marks kinds that are meaningless without a real Run. Other
+// Run-related kinds may fall back to a TaskContext scope when no Run id is
+// available, but must never invent one.
+func (k Kind) requiresRunID() bool {
+	return k == KindRunAcceptanceAck
+}
+
+// ProgressFields are the only fields that make a progress event substantive.
+type ProgressFields struct {
+	Stage          string
+	Blocked        bool
+	ActionRequired bool
+	Conclusion     string
+}
+
+// DeliveryEnvelope must accompany every production outbound message.
+// A zero envelope is internal-only.
+//
+// RunID is the real Run identifier and must never be synthesized from an
+// inbound platform message id. Deliveries that belong to a conversation turn
+// rather than a Run carry TaskContext instead, so per-Run merge/dedupe buckets
+// stay free of turn traffic.
+type DeliveryEnvelope struct {
+	Channels       []Channel
+	Priority       Priority
+	RunID          string
+	TaskContext    string
+	ProjectID      string
+	ConversationID string
+	UserID         string
+	DedupeKey      string
+	Reason         string
+	Kind           Kind
+	Progress       ProgressFields
+	Structured     bool
+}
+
+// Internal returns an explicit non-deliverable envelope.
+func Internal(kind Kind, reason string) DeliveryEnvelope {
+	return DeliveryEnvelope{Channels: []Channel{ChannelInternal}, Kind: kind, Reason: reason}
+}
+
+// AppendSendable explicitly adds an external channel to an envelope.
+func AppendSendable(e DeliveryEnvelope, channels ...Channel) DeliveryEnvelope {
+	for _, channel := range channels {
+		if channel == "" || channel == ChannelInternal || containsChannel(e.Channels, channel) {
+			continue
+		}
+		e.Channels = append(e.Channels, channel)
+	}
+	return e
+}
+
+func (e DeliveryEnvelope) Allows(channel Channel) bool {
+	return containsChannel(e.Channels, channel)
+}
+
+func containsChannel(channels []Channel, want Channel) bool {
+	for _, channel := range channels {
+		if channel == want {
+			return true
+		}
+	}
+	return false
+}
+
+type AuditEntry struct {
+	ProjectID string
+	RunID     string
+	Channel   Channel
+	DedupeKey string
+	Reason    string
+	Result    string
+	Attempt   int
+}
+
+type AuditFunc func(AuditEntry)
+
+type Decision struct {
+	Send      bool
+	Reason    string
+	DedupeKey string
+	Attempt   int
+}
+
+// Policy is a DB-backed delivery gate. It stores hashes and metadata only.
+type Policy struct {
+	db          *gorm.DB
+	audit       AuditFunc
+	now         func() time.Time
+	rateWindow  time.Duration
+	maxAttempts int
+}
+
+func NewPolicy(db *gorm.DB, audit AuditFunc) *Policy {
+	return &Policy{
+		db: db, audit: audit, now: time.Now,
+		rateWindow: 60 * time.Second, maxAttempts: 3,
+	}
+}
+
+func (p *Policy) SetClock(now func() time.Time) {
+	if now != nil {
+		p.now = now
+	}
+}
+
+func (p *Policy) Evaluate(ctx context.Context, e DeliveryEnvelope, channel Channel, content string) (Decision, error) {
+	now := p.now()
+	content = strings.TrimSpace(content)
+	if reason := validate(e, channel, content); reason != "" {
+		p.record(e, channel, e.DedupeKey, reason, "suppressed", 0)
+		return Decision{Reason: reason}, nil
+	}
+
+	contentHash := digest(content)
+	key := strings.TrimSpace(e.DedupeKey)
+	if key == "" {
+		key = stableKey(e, channel, contentHash)
+	}
+	if p.db == nil {
+		return Decision{Send: true, DedupeKey: key, Attempt: 1}, nil
+	}
+
+	var receipt models.SendableDeliveryReceipt
+	err := p.db.WithContext(ctx).Where("dedupe_key = ?", key).First(&receipt).Error
+	if err == nil {
+		switch receipt.Status {
+		case "sent":
+			p.record(e, channel, key, "already_sent", "suppressed", receipt.Attempts)
+			return Decision{Reason: "already_sent", DedupeKey: key, Attempt: receipt.Attempts}, nil
+		case "pending":
+			if now.Sub(receipt.LastAttemptAt) < retryDelay(receipt.Attempts) {
+				p.record(e, channel, key, "pending", "suppressed", receipt.Attempts)
+				return Decision{Reason: "pending", DedupeKey: key, Attempt: receipt.Attempts}, nil
+			}
+		case "failed":
+			if receipt.Attempts >= p.maxAttempts {
+				p.record(e, channel, key, "retry_exhausted", "suppressed", receipt.Attempts)
+				return Decision{Reason: "retry_exhausted", DedupeKey: key, Attempt: receipt.Attempts}, nil
+			}
+			if now.Before(receipt.NextAttemptAt) {
+				p.record(e, channel, key, "retry_backoff", "suppressed", receipt.Attempts)
+				return Decision{Reason: "retry_backoff", DedupeKey: key, Attempt: receipt.Attempts}, nil
+			}
+		}
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return Decision{}, err
+	}
+
+	if reason := p.bucketSuppression(ctx, e, channel, key, contentHash, now); reason != "" {
+		p.record(e, channel, key, reason, "suppressed", 0)
+		return Decision{Reason: reason, DedupeKey: key}, nil
+	}
+
+	if receipt.ID == 0 {
+		receipt = models.SendableDeliveryReceipt{
+			DedupeKey: key, ProjectID: e.ProjectID, RunID: e.RunID,
+			TaskContext:    e.TaskContext,
+			ConversationID: e.ConversationID, Channel: string(channel),
+			Kind: string(e.Kind), ContentHash: contentHash, CreatedAt: now,
+		}
+	}
+	receipt.Status = "pending"
+	receipt.Result = "pending"
+	receipt.Attempts++
+	receipt.LastAttemptAt = now
+	receipt.UpdatedAt = now
+	if receipt.ID == 0 {
+		if err := p.db.WithContext(ctx).Create(&receipt).Error; err != nil {
+			// A concurrent claimant wins; this caller suppresses.
+			if isUniqueConflict(err) {
+				return Decision{Reason: "concurrent_duplicate", DedupeKey: key}, nil
+			}
+			return Decision{}, err
+		}
+	} else if err := p.db.WithContext(ctx).Save(&receipt).Error; err != nil {
+		return Decision{}, err
+	}
+	return Decision{Send: true, DedupeKey: key, Attempt: receipt.Attempts}, nil
+}
+
+// GateReason performs the transport-level fail-closed envelope check.
+func GateReason(e DeliveryEnvelope, channel Channel, content string) string {
+	return validate(e, channel, strings.TrimSpace(content))
+}
+
+func validate(e DeliveryEnvelope, channel Channel, content string) string {
+	if content == "" {
+		return "empty"
+	}
+	if !e.Allows(channel) {
+		return "internal_or_channel_not_allowed"
+	}
+	if strings.TrimSpace(e.RunID) == "" && strings.TrimSpace(e.TaskContext) == "" {
+		return "missing_delivery_scope"
+	}
+	if e.Kind.requiresRunID() && strings.TrimSpace(e.RunID) == "" {
+		return "missing_run_id"
+	}
+	switch e.Kind {
+	case KindUnknown, KindAgentRaw, KindTool, KindReasoning, "":
+		return "unsafe_kind"
+	case KindFinal:
+		if !e.Structured {
+			return "raw_assistant_final"
+		}
+	case KindProgress:
+		if strings.TrimSpace(e.Progress.Stage) == "" &&
+			!e.Progress.Blocked && !e.Progress.ActionRequired &&
+			strings.TrimSpace(e.Progress.Conclusion) == "" {
+			return "non_substantive_progress"
+		}
+	}
+	return ""
+}
+
+func (p *Policy) bucketSuppression(ctx context.Context, e DeliveryEnvelope, channel Channel, key, hash string, now time.Time) string {
+	// The merge bucket is run × task context × conversation × channel, so turn
+	// traffic (no RunID) can never merge with, or suppress, Run events.
+	base := func() *gorm.DB {
+		return p.db.WithContext(ctx).Model(&models.SendableDeliveryReceipt{}).
+			Where("run_id = ? AND task_context = ? AND conversation_id = ? AND channel = ? AND status IN ? AND dedupe_key <> ?",
+				e.RunID, e.TaskContext, e.ConversationID, string(channel),
+				[]string{"pending", "sent"}, key)
+	}
+	var count int64
+	if err := base().Where("content_hash = ?", hash).Count(&count).Error; err == nil && count > 0 {
+		return "duplicate_content"
+	}
+	// Only the Run acceptance ACK is once-per-run×conversation/user×channel.
+	// Per-turn processing/queue ACKs are a different class and stay per turn.
+	if e.Kind == KindRunAcceptanceAck {
+		acked := p.db.WithContext(ctx).Model(&models.SendableDeliveryReceipt{}).
+			Where("run_id = ? AND conversation_id = ? AND channel = ? AND kind = ? AND status IN ? AND dedupe_key <> ?",
+				e.RunID, e.ConversationID, string(channel), string(KindRunAcceptanceAck),
+				[]string{"pending", "sent"}, key)
+		if err := acked.Count(&count).Error; err == nil && count > 0 {
+			return "run_acceptance_ack_already_sent"
+		}
+	}
+	if e.Kind == KindProgress {
+		var last models.SendableDeliveryReceipt
+		err := base().Where("kind = ?", string(KindProgress)).Order("last_attempt_at desc").First(&last).Error
+		if err == nil && now.Sub(last.LastAttemptAt) < p.rateWindow {
+			return "progress_rate_limited_merged"
+		}
+	}
+	return ""
+}
+
+// Retry claims the next bounded attempt for a delivery that already failed.
+// The caller is responsible for waiting RetryDelay first, so this deliberately
+// bypasses the backoff gate that Evaluate applies to fresh callers. Send=false
+// means the delivery is finished: already sent by someone else, or exhausted.
+func (p *Policy) Retry(ctx context.Context, d Decision, e DeliveryEnvelope, channel Channel) (Decision, error) {
+	if strings.TrimSpace(d.DedupeKey) == "" {
+		return Decision{Reason: "missing_dedupe_key"}, nil
+	}
+	now := p.now()
+	if p.db == nil {
+		if d.Attempt >= p.maxAttempts {
+			p.record(e, channel, d.DedupeKey, "retry_exhausted", "suppressed", d.Attempt)
+			return Decision{Reason: "retry_exhausted", DedupeKey: d.DedupeKey, Attempt: d.Attempt}, nil
+		}
+		return Decision{Send: true, DedupeKey: d.DedupeKey, Attempt: d.Attempt + 1}, nil
+	}
+	var receipt models.SendableDeliveryReceipt
+	if err := p.db.WithContext(ctx).Where("dedupe_key = ?", d.DedupeKey).First(&receipt).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return Decision{Reason: "receipt_missing", DedupeKey: d.DedupeKey}, nil
+		}
+		return Decision{}, err
+	}
+	if receipt.Status == "sent" {
+		p.record(e, channel, d.DedupeKey, "already_sent", "suppressed", receipt.Attempts)
+		return Decision{Reason: "already_sent", DedupeKey: d.DedupeKey, Attempt: receipt.Attempts}, nil
+	}
+	if receipt.Attempts >= p.maxAttempts {
+		p.record(e, channel, d.DedupeKey, "retry_exhausted", "suppressed", receipt.Attempts)
+		return Decision{Reason: "retry_exhausted", DedupeKey: d.DedupeKey, Attempt: receipt.Attempts}, nil
+	}
+	receipt.Status = "pending"
+	receipt.Result = "pending"
+	receipt.Attempts++
+	receipt.LastAttemptAt = now
+	receipt.UpdatedAt = now
+	if err := p.db.WithContext(ctx).Save(&receipt).Error; err != nil {
+		return Decision{}, err
+	}
+	return Decision{Send: true, DedupeKey: d.DedupeKey, Attempt: receipt.Attempts}, nil
+}
+
+// MaxAttempts is the bounded delivery attempt ceiling per dedupe key.
+func (p *Policy) MaxAttempts() int { return p.maxAttempts }
+
+func (p *Policy) MarkSent(ctx context.Context, d Decision, e DeliveryEnvelope, channel Channel) error {
+	if !d.Send {
+		return nil
+	}
+	now := p.now()
+	if p.db != nil {
+		if err := p.db.WithContext(ctx).Model(&models.SendableDeliveryReceipt{}).
+			Where("dedupe_key = ?", d.DedupeKey).
+			Updates(map[string]any{"status": "sent", "result": "sent", "updated_at": now}).Error; err != nil {
+			return err
+		}
+	}
+	p.record(e, channel, d.DedupeKey, e.Reason, "sent", d.Attempt)
+	return nil
+}
+
+func (p *Policy) MarkFailed(ctx context.Context, d Decision, e DeliveryEnvelope, channel Channel, sendErr error) error {
+	if !d.Send {
+		return nil
+	}
+	now := p.now()
+	if p.db != nil {
+		if err := p.db.WithContext(ctx).Model(&models.SendableDeliveryReceipt{}).
+			Where("dedupe_key = ?", d.DedupeKey).
+			Updates(map[string]any{
+				"status": "failed", "result": "failed",
+				"next_attempt_at": now.Add(retryDelay(d.Attempt)), "updated_at": now,
+			}).Error; err != nil {
+			return err
+		}
+	}
+	reason := e.Reason
+	if sendErr != nil {
+		reason = "transport_failed"
+	}
+	p.record(e, channel, d.DedupeKey, reason, "failed", d.Attempt)
+	return nil
+}
+
+func (p *Policy) record(e DeliveryEnvelope, channel Channel, key, reason, result string, attempt int) {
+	if p.audit != nil {
+		p.audit(AuditEntry{
+			ProjectID: e.ProjectID, RunID: e.RunID, Channel: channel,
+			DedupeKey: key, Reason: reason, Result: result, Attempt: attempt,
+		})
+	}
+}
+
+func retryDelay(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	d := time.Duration(attempt*attempt) * time.Second
+	if d > 30*time.Second {
+		return 30 * time.Second
+	}
+	return d
+}
+
+// RetryDelay returns the bounded backoff used by delivery callers.
+func RetryDelay(attempt int) time.Duration { return retryDelay(attempt) }
+
+func stableKey(e DeliveryEnvelope, channel Channel, contentHash string) string {
+	raw := strings.Join([]string{
+		e.RunID, e.TaskContext, e.ConversationID, e.UserID,
+		string(channel), string(e.Kind), contentHash,
+	}, "\x1f")
+	return "snd-" + digest(raw)[:32]
+}
+
+func digest(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+func isUniqueConflict(err error) bool {
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "unique") || strings.Contains(s, "duplicate")
+}

--- a/server/internal/sendable/sendable_test.go
+++ b/server/internal/sendable/sendable_test.go
@@ -157,8 +157,20 @@ func TestPolicyRetainsLatestProgressStageWithinWindow(t *testing.T) {
 	}
 	newer := external("r1", string(KindProgress), "p-b")
 	newer.Progress.Stage = "B"
-	if !sendAndMark(t, p, newer, "stage B") {
-		t.Fatal("newer stage within window must still be delivered (retain latest)")
+	if sendAndMark(t, p, newer, "stage B") {
+		t.Fatal("changed stage within window must be merged, not delivered immediately")
+	}
+	*now = now.Add(31 * time.Second)
+	latest := external("r1", string(KindProgress), "p-c")
+	latest.Progress.Stage = "C"
+	if !sendAndMark(t, p, latest, "stage C") {
+		t.Fatal("first latest snapshot after the window must be delivered")
+	}
+
+	blocked := external("r1", string(KindBlocked), "blocked-now")
+	blocked.Progress.Blocked = true
+	if !sendAndMark(t, p, blocked, "blocked now") {
+		t.Fatal("blocked must bypass the ordinary progress window")
 	}
 }
 

--- a/server/internal/sendable/sendable_test.go
+++ b/server/internal/sendable/sendable_test.go
@@ -1,0 +1,242 @@
+package sendable
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func testPolicy(t *testing.T, audit AuditFunc) (*Policy, *gorm.DB, *time.Time) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	if err := db.AutoMigrate(&models.SendableDeliveryReceipt{}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 6, 0, 0, 0, 0, time.UTC)
+	p := NewPolicy(db, audit)
+	p.SetClock(func() time.Time { return now })
+	return p, db, &now
+}
+
+func external(run, kind, key string) DeliveryEnvelope {
+	e := DeliveryEnvelope{
+		RunID: run, ProjectID: "p", ConversationID: "c", UserID: "u",
+		Kind: Kind(kind), DedupeKey: key, Reason: "test",
+	}
+	return AppendSendable(e, ChannelQQ)
+}
+
+func turnScoped(scope, kind, key string) DeliveryEnvelope {
+	e := DeliveryEnvelope{
+		TaskContext: scope, ProjectID: "p", ConversationID: "c", UserID: "u",
+		Kind: Kind(kind), DedupeKey: key, Reason: "test",
+	}
+	return AppendSendable(e, ChannelQQ)
+}
+
+func sendAndMark(t *testing.T, p *Policy, e DeliveryEnvelope, body string) bool {
+	t.Helper()
+	d, err := p.Evaluate(context.Background(), e, ChannelQQ, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Send {
+		if err := p.MarkSent(context.Background(), d, e, ChannelQQ); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return d.Send
+}
+
+func TestPolicyBoundsBackgroundEventsAndKeepsCritical(t *testing.T) {
+	p, _, _ := testPolicy(t, nil)
+	sent := 0
+	if sendAndMark(t, p, external("r1", string(KindRunAcceptanceAck), "ack"), "received") {
+		sent++
+	}
+	for i := 0; i < 128; i++ {
+		e := external("r1", string(KindProgress), "")
+		e.Progress.Stage = "building"
+		if sendAndMark(t, p, e, "building event "+string(rune(i))) {
+			sent++
+		}
+	}
+	blocked := external("r1", string(KindBlocked), "blocked")
+	blocked.Progress.Blocked = true
+	if sendAndMark(t, p, blocked, "blocked by permission") {
+		sent++
+	}
+	final := external("r1", string(KindFinal), "final")
+	final.Structured = true
+	if sendAndMark(t, p, final, "safe structured summary") {
+		sent++
+	}
+	if sent > 5 || sent != 4 {
+		t.Fatalf("sent=%d want ACK + one progress + blocked + final", sent)
+	}
+}
+
+func TestPolicyRunIsolationDefaultsAndRawFinal(t *testing.T) {
+	p, _, _ := testPolicy(t, nil)
+	p1 := external("r1", string(KindProgress), "")
+	p1.Progress.Stage = "build"
+	if !sendAndMark(t, p, p1, "same") {
+		t.Fatal("first run progress suppressed")
+	}
+	p2 := external("r2", string(KindProgress), "")
+	p2.Progress.Stage = "build"
+	if !sendAndMark(t, p, p2, "same") {
+		t.Fatal("progress must not merge across runs")
+	}
+	for _, e := range []DeliveryEnvelope{
+		{},
+		turnScoped("t", string(KindUnknown), ""),
+		turnScoped("t", string(KindAgentRaw), ""),
+		turnScoped("t", string(KindTool), ""),
+		turnScoped("t", string(KindReasoning), ""),
+		turnScoped("t", string(KindFinal), ""),
+		// No Run and no task context: there is no legitimate delivery bucket.
+		AppendSendable(DeliveryEnvelope{Kind: KindProgress, ProjectID: "p"}, ChannelQQ),
+		// Run acceptance ACK without a real Run id must never be sendable.
+		turnScoped("turn:abc", string(KindRunAcceptanceAck), ""),
+	} {
+		d, err := p.Evaluate(context.Background(), e, ChannelQQ, "secret raw body")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d.Send {
+			t.Fatalf("unsafe envelope was sendable: %+v", e)
+		}
+	}
+}
+
+func TestTurnAckIsNotRunAcceptanceAck(t *testing.T) {
+	p, _, _ := testPolicy(t, nil)
+	// Two turns in one conversation each get their own processing ACK.
+	if !sendAndMark(t, p, turnScoped("turn:m1", string(KindTurnProcessingAck), "m1:ack"), "received m1") {
+		t.Fatal("first turn ACK suppressed")
+	}
+	if !sendAndMark(t, p, turnScoped("turn:m2", string(KindTurnProcessingAck), "m2:ack"), "received m2") {
+		t.Fatal("second turn ACK wrongly treated as a run acceptance ACK")
+	}
+	// The run acceptance ACK is once per run × conversation × channel.
+	if !sendAndMark(t, p, external("run-1", string(KindRunAcceptanceAck), "run-ack-1"), "accepted run-1") {
+		t.Fatal("first run acceptance ACK suppressed")
+	}
+	if sendAndMark(t, p, external("run-1", string(KindRunAcceptanceAck), "run-ack-1-again"), "accepted run-1 again") {
+		t.Fatal("run acceptance ACK must be delivered at most once per run")
+	}
+	if !sendAndMark(t, p, external("run-2", string(KindRunAcceptanceAck), "run-ack-2"), "accepted run-2") {
+		t.Fatal("a different run must still get its acceptance ACK")
+	}
+}
+
+func TestRetryClaimsBoundedAttempts(t *testing.T) {
+	var audits []AuditEntry
+	p, _, _ := testPolicy(t, func(entry AuditEntry) { audits = append(audits, entry) })
+	e := external("r", string(KindFinal), "retry-key")
+	e.Structured = true
+
+	d, err := p.Evaluate(context.Background(), e, ChannelQQ, "summary")
+	if err != nil || !d.Send || d.Attempt != 1 {
+		t.Fatalf("initial decision=%+v err=%v", d, err)
+	}
+	attempts := []int{d.Attempt}
+	for {
+		if err := p.MarkFailed(context.Background(), d, e, ChannelQQ, errors.New("network")); err != nil {
+			t.Fatal(err)
+		}
+		next, err := p.Retry(context.Background(), d, e, ChannelQQ)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !next.Send {
+			if next.Reason != "retry_exhausted" {
+				t.Fatalf("final retry reason=%q want retry_exhausted", next.Reason)
+			}
+			break
+		}
+		d = next
+		attempts = append(attempts, d.Attempt)
+	}
+	if len(attempts) != p.MaxAttempts() {
+		t.Fatalf("attempts=%v want %d bounded attempts", attempts, p.MaxAttempts())
+	}
+	if attempts[0] != 1 || attempts[len(attempts)-1] != p.MaxAttempts() {
+		t.Fatalf("attempt numbering=%v", attempts)
+	}
+	if len(audits) == 0 {
+		t.Fatal("retry path produced no audit entries")
+	}
+}
+
+func TestRetryStopsOnceSent(t *testing.T) {
+	p, _, _ := testPolicy(t, nil)
+	e := external("r", string(KindFinal), "sent-key")
+	e.Structured = true
+	d, err := p.Evaluate(context.Background(), e, ChannelQQ, "summary")
+	if err != nil || !d.Send {
+		t.Fatalf("decision=%+v err=%v", d, err)
+	}
+	if err := p.MarkSent(context.Background(), d, e, ChannelQQ); err != nil {
+		t.Fatal(err)
+	}
+	next, err := p.Retry(context.Background(), d, e, ChannelQQ)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next.Send || next.Reason != "already_sent" {
+		t.Fatalf("retry after success=%+v", next)
+	}
+}
+
+func TestPolicyDedupeRetryIdempotencyAndMetadataAudit(t *testing.T) {
+	var audits []AuditEntry
+	p, db, now := testPolicy(t, func(entry AuditEntry) { audits = append(audits, entry) })
+	e := external("r", string(KindFinal), "stable-key")
+	e.Structured = true
+	d, err := p.Evaluate(context.Background(), e, ChannelQQ, "summary")
+	if err != nil || !d.Send || d.Attempt != 1 {
+		t.Fatalf("first decision=%+v err=%v", d, err)
+	}
+	if err := p.MarkFailed(context.Background(), d, e, ChannelQQ, errors.New("network")); err != nil {
+		t.Fatal(err)
+	}
+	d, _ = p.Evaluate(context.Background(), e, ChannelQQ, "summary")
+	if d.Send || d.Reason != "retry_backoff" {
+		t.Fatalf("immediate retry=%+v", d)
+	}
+	*now = now.Add(2 * time.Second)
+	d, err = p.Evaluate(context.Background(), e, ChannelQQ, "summary")
+	if err != nil || !d.Send || d.Attempt != 2 {
+		t.Fatalf("retry decision=%+v err=%v", d, err)
+	}
+	if err := p.MarkSent(context.Background(), d, e, ChannelQQ); err != nil {
+		t.Fatal(err)
+	}
+	d, _ = p.Evaluate(context.Background(), e, ChannelQQ, "summary")
+	if d.Send || d.Reason != "already_sent" {
+		t.Fatalf("sent idempotency=%+v", d)
+	}
+	var receipt models.SendableDeliveryReceipt
+	if err := db.First(&receipt, "dedupe_key = ?", "stable-key").Error; err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Attempts != 2 || receipt.Status != "sent" {
+		t.Fatalf("receipt=%+v", receipt)
+	}
+	if len(audits) == 0 || audits[len(audits)-1].Result != "suppressed" {
+		t.Fatalf("audits=%+v", audits)
+	}
+}

--- a/server/internal/sendable/sendable_test.go
+++ b/server/internal/sendable/sendable_test.go
@@ -142,6 +142,26 @@ func TestTurnAckIsNotRunAcceptanceAck(t *testing.T) {
 	}
 }
 
+func TestPolicyRetainsLatestProgressStageWithinWindow(t *testing.T) {
+	p, _, now := testPolicy(t, nil)
+	first := external("r1", string(KindProgress), "p-a")
+	first.Progress.Stage = "A"
+	if !sendAndMark(t, p, first, "stage A") {
+		t.Fatal("first stage suppressed")
+	}
+	*now = now.Add(30 * time.Second)
+	same := external("r1", string(KindProgress), "p-a2")
+	same.Progress.Stage = "A"
+	if sendAndMark(t, p, same, "stage A again") {
+		t.Fatal("same stage within window must stay rate-limited")
+	}
+	newer := external("r1", string(KindProgress), "p-b")
+	newer.Progress.Stage = "B"
+	if !sendAndMark(t, p, newer, "stage B") {
+		t.Fatal("newer stage within window must still be delivered (retain latest)")
+	}
+}
+
 func TestRetryClaimsBoundedAttempts(t *testing.T) {
 	var audits []AuditEntry
 	p, _, _ := testPolicy(t, func(entry AuditEntry) { audits = append(audits, entry) })

--- a/server/internal/services/cron_scheduler.go
+++ b/server/internal/services/cron_scheduler.go
@@ -24,6 +24,8 @@ type CronTokenHooks struct {
 // egress (changed / unchanged / failed).
 type CronDelivery struct {
 	ProjectID string
+	RunID     string
+	DedupeKey string
 	Category  string // job name / pr / daily — used for minimal templates
 	Kind      string // changed | unchanged | failed (empty → classify from Text)
 	Text      string
@@ -298,6 +300,7 @@ func (s *CronScheduler) deliverCronFailure(job *models.AgentCronJob, reason stri
 	}
 	d := CronDelivery{
 		ProjectID: job.ProjectID,
+		DedupeKey: "cron-failure:" + job.ID + ":" + uuid.NewString(),
 		Category:  category,
 		Kind:      "failed",
 		Text:      text,
@@ -338,6 +341,7 @@ func (s *CronScheduler) maybeDeliver(job *models.AgentCronJob, userMsg models.Ch
 	}
 	d := CronDelivery{
 		ProjectID: job.ProjectID,
+		DedupeKey: "cron-result:" + job.ID + ":" + userMsg.ID,
 		Category:  category,
 		Kind:      kind,
 		Text:      text,

--- a/server/internal/services/risk_confirmation.go
+++ b/server/internal/services/risk_confirmation.go
@@ -224,6 +224,27 @@ func (s *RiskConfirmationService) LatestAny(userID, projectID string) (*models.R
 	return &ticket, nil
 }
 
+// LatestForAction returns the newest ticket for one exact user/project/run/action
+// tuple. MCP retries use it to observe an IM-confirmed action without creating a
+// second ticket or executing the mutation again.
+func (s *RiskConfirmationService) LatestForAction(userID, projectID, runID, action string) (*models.RiskConfirmationTicket, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("risk confirmation database is unavailable")
+	}
+	var ticket models.RiskConfirmationTicket
+	err := s.db.Where("project_id = ? AND user_id = ? AND run_id = ? AND action = ?",
+		strings.TrimSpace(projectID), strings.TrimSpace(userID),
+		strings.TrimSpace(runID), strings.TrimSpace(action)).
+		Order("created_at desc").First(&ticket).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &ticket, nil
+}
+
 func riskPrompt(language string) string {
 	if NormalizeLanguage(language) == "en" {
 		return "Reply “confirm” to proceed or “cancel” to stop."

--- a/server/internal/services/risk_confirmation.go
+++ b/server/internal/services/risk_confirmation.go
@@ -1,0 +1,245 @@
+package services
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const RiskConfirmationTTL = 5 * time.Minute
+
+type RiskConfirmationService struct {
+	db  *gorm.DB
+	now func() time.Time
+}
+
+func NewRiskConfirmationService(db *gorm.DB) *RiskConfirmationService {
+	return &RiskConfirmationService{db: db, now: time.Now}
+}
+
+func (s *RiskConfirmationService) SetClock(now func() time.Time) {
+	if now != nil {
+		s.now = now
+	}
+}
+
+type RiskTicketInput struct {
+	ProjectID, UserID, RunID, Action, Language string
+	// ShortTitle overrides the task title snapshot; empty resolves it from the
+	// Run's task identity so callers do not have to pass it.
+	ShortTitle string
+}
+
+func (s *RiskConfirmationService) CreateTicket(in RiskTicketInput) (*models.RiskConfirmationTicket, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("risk confirmation database is unavailable")
+	}
+	if strings.TrimSpace(in.ProjectID) == "" || strings.TrimSpace(in.UserID) == "" ||
+		strings.TrimSpace(in.RunID) == "" || strings.TrimSpace(in.Action) == "" {
+		return nil, errors.New("project_id, user_id, run_id and action are required")
+	}
+	now := s.now()
+	ticket := models.RiskConfirmationTicket{
+		ID: "risk-" + uuid.NewString()[:12], ProjectID: strings.TrimSpace(in.ProjectID),
+		UserID: strings.TrimSpace(in.UserID), RunID: strings.TrimSpace(in.RunID),
+		ShortTitle: s.resolveShortTitle(in),
+		Action:     strings.TrimSpace(in.Action), Status: "pending",
+		Language: DetectLanguage("", in.Language), ExpiresAt: now.Add(RiskConfirmationTTL),
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := s.db.Create(&ticket).Error; err != nil {
+		return nil, err
+	}
+	return &ticket, nil
+}
+
+// resolveShortTitle prefers the caller's snapshot, then the Run's task identity.
+func (s *RiskConfirmationService) resolveShortTitle(in RiskTicketInput) string {
+	if title := strings.TrimSpace(in.ShortTitle); title != "" {
+		return title
+	}
+	var identity models.TaskIdentity
+	if err := s.db.Where("run_id = ? AND project_id = ? AND user_id = ?",
+		strings.TrimSpace(in.RunID), strings.TrimSpace(in.ProjectID),
+		strings.TrimSpace(in.UserID)).First(&identity).Error; err == nil {
+		return identity.ShortTitle
+	}
+	return ""
+}
+
+// ConfirmationPrompt is the user-facing ask, always echoing the short title.
+func (s *RiskConfirmationService) ConfirmationPrompt(ticket models.RiskConfirmationTicket) string {
+	kind := "高风险确认"
+	if NormalizeLanguage(ticket.Language) == "en" {
+		kind = "High-risk confirmation"
+	}
+	return FormatTaskType(ticket.ShortTitle, kind, ticket.Language) + " " +
+		riskActionLine(ticket.Action, ticket.Language) + riskPrompt(ticket.Language)
+}
+
+type RiskResolution struct {
+	Ticket  models.RiskConfirmationTicket
+	Execute bool
+	Message string
+	// TaskStatus is the latest known task/Run status, so a repeated or expired
+	// decision reports where the task actually stands, not just the ticket.
+	TaskStatus string
+}
+
+// ResolveTicket atomically consumes a pending ticket. Repeated and expired
+// decisions return the persisted latest status and never execute again.
+func (s *RiskConfirmationService) ResolveTicket(in RiskTicketInput, response string) (RiskResolution, error) {
+	var result RiskResolution
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		var ticket models.RiskConfirmationTicket
+		err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("project_id = ? AND user_id = ? AND run_id = ? AND action = ?",
+				strings.TrimSpace(in.ProjectID), strings.TrimSpace(in.UserID),
+				strings.TrimSpace(in.RunID), strings.TrimSpace(in.Action)).
+			Order("created_at desc").First(&ticket).Error
+		if err != nil {
+			return err
+		}
+		now := s.now()
+		if ticket.Status == "pending" && !ticket.ExpiresAt.After(now) {
+			ticket.Status = "expired"
+			ticket.ResolvedAt = &now
+			ticket.UpdatedAt = now
+			if err := tx.Save(&ticket).Error; err != nil {
+				return err
+			}
+		}
+		if ticket.Status != "pending" {
+			result = s.resolutionFor(tx, ticket, false)
+			return nil
+		}
+		decision := parseRiskDecision(response)
+		if decision == "" {
+			result = RiskResolution{
+				Ticket: ticket, Message: s.ConfirmationPrompt(ticket),
+				TaskStatus: s.latestTaskStatus(tx, ticket),
+			}
+			return nil
+		}
+		update := tx.Model(&models.RiskConfirmationTicket{}).
+			Where("id = ? AND status = ? AND expires_at > ?", ticket.ID, "pending", now).
+			Updates(map[string]any{"status": decision, "resolved_at": now, "updated_at": now})
+		if update.Error != nil {
+			return update.Error
+		}
+		if update.RowsAffected == 0 {
+			if err := tx.First(&ticket, "id = ?", ticket.ID).Error; err != nil {
+				return err
+			}
+			result = s.resolutionFor(tx, ticket, false)
+			return nil
+		}
+		if err := tx.First(&ticket, "id = ?", ticket.ID).Error; err != nil {
+			return err
+		}
+		result = s.resolutionFor(tx, ticket, decision == "confirmed")
+		return nil
+	})
+	return result, err
+}
+
+// resolutionFor renders the reply for a settled ticket, echoing the short title
+// and the latest task status.
+func (s *RiskConfirmationService) resolutionFor(tx *gorm.DB, ticket models.RiskConfirmationTicket, execute bool) RiskResolution {
+	taskStatus := s.latestTaskStatus(tx, ticket)
+	return RiskResolution{
+		Ticket: ticket, Execute: execute, TaskStatus: taskStatus,
+		Message: riskStatusMessage(ticket, taskStatus),
+	}
+}
+
+// latestTaskStatus prefers the live Run status and falls back to the task
+// identity snapshot.
+func (s *RiskConfirmationService) latestTaskStatus(tx *gorm.DB, ticket models.RiskConfirmationTicket) string {
+	var run models.Run
+	if err := tx.Select("status").First(&run, "id = ?", ticket.RunID).Error; err == nil {
+		if status := strings.TrimSpace(run.Status); status != "" {
+			return status
+		}
+	}
+	var identity models.TaskIdentity
+	if err := tx.Where("run_id = ? AND project_id = ? AND user_id = ?",
+		ticket.RunID, ticket.ProjectID, ticket.UserID).First(&identity).Error; err == nil {
+		return identity.Status
+	}
+	return ""
+}
+
+func parseRiskDecision(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	switch value {
+	case "确认", "确认执行", "同意", "yes", "y", "confirm", "confirmed", "proceed":
+		return "confirmed"
+	case "取消", "不同意", "否", "no", "n", "cancel", "cancelled", "canceled":
+		return "cancelled"
+	default:
+		return ""
+	}
+}
+
+func riskPrompt(language string) string {
+	if NormalizeLanguage(language) == "en" {
+		return "Reply “confirm” to proceed or “cancel” to stop."
+	}
+	return "请回复“确认”继续，或回复“取消”停止。"
+}
+
+func riskActionLine(action, language string) string {
+	action = strings.TrimSpace(action)
+	if action == "" {
+		return ""
+	}
+	if NormalizeLanguage(language) == "en" {
+		return "Action: " + action + ". "
+	}
+	return "操作：" + action + "。"
+}
+
+// riskStatusMessage renders the settled reply: task title, ticket outcome, and
+// the latest task status.
+func riskStatusMessage(ticket models.RiskConfirmationTicket, taskStatus string) string {
+	en := NormalizeLanguage(ticket.Language) == "en"
+	var outcome, kind string
+	switch ticket.Status {
+	case "confirmed":
+		kind, outcome = "已确认", "已确认，本次授权已使用。"
+		if en {
+			kind, outcome = "Confirmed", "Confirmed. This authorization has already been consumed."
+		}
+	case "cancelled":
+		kind, outcome = "已取消", "已取消，操作未执行。"
+		if en {
+			kind, outcome = "Cancelled", "Cancelled. The action was not executed."
+		}
+	case "expired":
+		kind, outcome = "已过期", "确认已过期，操作未执行。"
+		if en {
+			kind, outcome = "Expired", "This confirmation has expired. The action was not executed."
+		}
+	default:
+		kind, outcome = "待确认", riskPrompt(ticket.Language)
+		if en {
+			kind = "Pending"
+		}
+	}
+	message := FormatTaskType(ticket.ShortTitle, kind, ticket.Language) + " " + outcome
+	if status := strings.TrimSpace(taskStatus); status != "" {
+		if en {
+			message += " Latest task status: " + status + "."
+		} else {
+			message += "当前任务状态：" + status + "。"
+		}
+	}
+	return message
+}

--- a/server/internal/services/risk_confirmation.go
+++ b/server/internal/services/risk_confirmation.go
@@ -65,9 +65,8 @@ func (s *RiskConfirmationService) resolveShortTitle(in RiskTicketInput) string {
 		return title
 	}
 	var identity models.TaskIdentity
-	if err := s.db.Where("run_id = ? AND project_id = ? AND user_id = ?",
-		strings.TrimSpace(in.RunID), strings.TrimSpace(in.ProjectID),
-		strings.TrimSpace(in.UserID)).First(&identity).Error; err == nil {
+	if err := s.db.Where("run_id = ? AND project_id = ?",
+		strings.TrimSpace(in.RunID), strings.TrimSpace(in.ProjectID)).First(&identity).Error; err == nil {
 		return identity.ShortTitle
 	}
 	return ""
@@ -169,8 +168,8 @@ func (s *RiskConfirmationService) latestTaskStatus(tx *gorm.DB, ticket models.Ri
 		}
 	}
 	var identity models.TaskIdentity
-	if err := tx.Where("run_id = ? AND project_id = ? AND user_id = ?",
-		ticket.RunID, ticket.ProjectID, ticket.UserID).First(&identity).Error; err == nil {
+	if err := tx.Where("run_id = ? AND project_id = ?",
+		ticket.RunID, ticket.ProjectID).First(&identity).Error; err == nil {
 		return identity.Status
 	}
 	return ""
@@ -186,6 +185,43 @@ func parseRiskDecision(value string) string {
 	default:
 		return ""
 	}
+}
+
+// ParseRiskDecisionPublic exposes confirmation keyword parsing for IM orchestration.
+func ParseRiskDecisionPublic(value string) string { return parseRiskDecision(value) }
+
+func (s *RiskConfirmationService) LatestPending(userID, projectID string) (*models.RiskConfirmationTicket, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("risk confirmation database is unavailable")
+	}
+	var ticket models.RiskConfirmationTicket
+	err := s.db.Where("project_id = ? AND user_id = ? AND status = ?",
+		strings.TrimSpace(projectID), strings.TrimSpace(userID), "pending").
+		Order("created_at desc").First(&ticket).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &ticket, nil
+}
+
+func (s *RiskConfirmationService) LatestAny(userID, projectID string) (*models.RiskConfirmationTicket, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("risk confirmation database is unavailable")
+	}
+	var ticket models.RiskConfirmationTicket
+	err := s.db.Where("project_id = ? AND user_id = ?",
+		strings.TrimSpace(projectID), strings.TrimSpace(userID)).
+		Order("created_at desc").First(&ticket).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &ticket, nil
 }
 
 func riskPrompt(language string) string {

--- a/server/internal/services/task_context.go
+++ b/server/internal/services/task_context.go
@@ -23,7 +23,7 @@ const (
 )
 
 // ErrTaskIdentityScopeMismatch means the Run already belongs to a different
-// project/user scope. Callers must treat the task as invisible, not re-home it.
+// project. Callers must treat the task as invisible, not re-home it.
 var ErrTaskIdentityScopeMismatch = errors.New("task identity scope mismatch")
 
 type TaskContextService struct {
@@ -46,6 +46,16 @@ func (s *TaskContextService) SetClock(now func() time.Time) {
 	}
 }
 
+// DB exposes the underlying store for orchestration helpers that need to load
+// a Run before EnsureIdentityForRun. Callers must not bypass service methods
+// for task identity mutations.
+func (s *TaskContextService) DB() *gorm.DB {
+	if s == nil {
+		return nil
+	}
+	return s.db
+}
+
 type EnsureTaskIdentityInput struct {
 	RunID, ProjectID, UserID, ShortTitle, OriginalRequirement, Status string
 	Aliases, Keywords                                                 []string
@@ -58,12 +68,12 @@ func (s *TaskContextService) EnsureIdentity(in EnsureTaskIdentityInput) (*models
 	in.RunID = strings.TrimSpace(in.RunID)
 	in.ProjectID = strings.TrimSpace(in.ProjectID)
 	in.UserID = strings.TrimSpace(in.UserID)
-	if in.RunID == "" || in.ProjectID == "" || in.UserID == "" {
-		return nil, errors.New("run_id, project_id and user_id are required")
+	if in.RunID == "" || in.ProjectID == "" {
+		return nil, errors.New("run_id and project_id are required")
 	}
 	now := s.now()
 	var identity models.TaskIdentity
-	err := s.db.Where("run_id = ?", in.RunID).First(&identity).Error
+	err := s.db.Where("run_id = ? AND project_id = ?", in.RunID, in.ProjectID).First(&identity).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		identity = models.TaskIdentity{
 			ID: "task-" + uuid.NewString()[:12], RunID: in.RunID,
@@ -85,9 +95,9 @@ func (s *TaskContextService) EnsureIdentity(in EnsureTaskIdentityInput) (*models
 	if err != nil {
 		return nil, err
 	}
-	// A Run cannot be re-homed across a user/project scope: that is what keeps
-	// one QQ identity from seeing another identity's task in the same project.
-	if identity.ProjectID != in.ProjectID || identity.UserID != in.UserID {
+	// Task metadata is project/Run scoped. A different project's claim is a
+	// hard mismatch; a different QQ identity must never steal or hide the row.
+	if identity.ProjectID != in.ProjectID {
 		return nil, ErrTaskIdentityScopeMismatch
 	}
 	oldTitle := strings.TrimSpace(identity.ShortTitle)
@@ -100,6 +110,9 @@ func (s *TaskContextService) EnsureIdentity(in EnsureTaskIdentityInput) (*models
 	}
 	if req := strings.TrimSpace(in.OriginalRequirement); req != "" && identity.OriginalRequirement == "" {
 		identity.OriginalRequirement = req
+	}
+	if identity.UserID == "" && in.UserID != "" {
+		identity.UserID = in.UserID
 	}
 	identity.Aliases = uniqueStrings(append(identity.Aliases, in.Aliases...))
 	identity.Keywords = uniqueStrings(append(identity.Keywords, in.Keywords...))
@@ -139,17 +152,16 @@ func (s *TaskContextService) EnsureIdentityForRun(run models.Run, projectID, use
 	})
 }
 
-// BackfillProjectRuns lazily materializes identities for a project's Runs under
-// one synthetic identity. It is safe to call repeatedly: EnsureIdentityForRun is
-// idempotent and keeps renamed titles as aliases.
+// BackfillProjectRuns lazily materializes project-scoped identities for a
+// project's Runs. userID is optional provenance only — it never claims exclusive
+// ownership, so a later QQ identity can still search the same Runs.
 func (s *TaskContextService) BackfillProjectRuns(projectID, userID string) error {
 	if s == nil || s.db == nil {
 		return errors.New("task context database is unavailable")
 	}
 	projectID = strings.TrimSpace(projectID)
-	userID = strings.TrimSpace(userID)
-	if projectID == "" || userID == "" {
-		return errors.New("project_id and user_id are required")
+	if projectID == "" {
+		return errors.New("project_id is required")
 	}
 	var runs []models.Run
 	err := s.db.
@@ -161,9 +173,9 @@ func (s *TaskContextService) BackfillProjectRuns(projectID, userID string) error
 		return err
 	}
 	for _, run := range runs {
-		if _, err := s.EnsureIdentityForRun(run, projectID, userID); err != nil {
+		if _, err := s.EnsureIdentityForRun(run, projectID, strings.TrimSpace(userID)); err != nil {
 			if errors.Is(err, ErrTaskIdentityScopeMismatch) {
-				continue // owned by another identity; stays invisible here
+				continue // different project; stay invisible
 			}
 			return err
 		}
@@ -318,8 +330,8 @@ func (s *TaskContextService) ResolveTask(in ResolveTaskInput) (TaskResolution, e
 			in.Scope.ProjectID, in.Scope.UserID, in.Scope.Channel, ref).First(&b).Error
 		if err == nil {
 			var task models.TaskIdentity
-			if err := s.db.Where("id = ? AND project_id = ? AND user_id = ?",
-				b.TaskIdentityID, in.Scope.ProjectID, in.Scope.UserID).First(&task).Error; err != nil {
+			if err := s.db.Where("id = ? AND project_id = ?",
+				b.TaskIdentityID, in.Scope.ProjectID).First(&task).Error; err != nil {
 				return TaskResolution{}, err
 			}
 			return s.resolvedWithFocus(in.Scope, task, in.Query, nil, "reply_binding")
@@ -342,8 +354,8 @@ func (s *TaskContextService) ResolveTask(in ResolveTaskInput) (TaskResolution, e
 			return TaskResolution{}, err
 		}
 		var task models.TaskIdentity
-		if err := s.db.Where("id = ? AND project_id = ? AND user_id = ?",
-			focus.TaskIdentityID, in.Scope.ProjectID, in.Scope.UserID).First(&task).Error; err != nil {
+		if err := s.db.Where("id = ? AND project_id = ?",
+			focus.TaskIdentityID, in.Scope.ProjectID).First(&task).Error; err != nil {
 			return TaskResolution{}, err
 		}
 		return TaskResolution{Identity: &task, Reason: "conversation_focus"}, nil
@@ -383,8 +395,9 @@ func (s *TaskContextService) Search(scope TaskScope, query string) ([]TaskCandid
 	}
 	now := s.now()
 	var tasks []models.TaskIdentity
-	if err := s.db.Where("project_id = ? AND user_id = ? AND (terminal_at IS NULL OR terminal_at >= ?)",
-		scope.ProjectID, scope.UserID, now.Add(-TaskTerminalWindow)).Find(&tasks).Error; err != nil {
+	// Task metadata is project-scoped; focus/bindings remain per QQ identity.
+	if err := s.db.Where("project_id = ? AND (terminal_at IS NULL OR terminal_at >= ?)",
+		scope.ProjectID, now.Add(-TaskTerminalWindow)).Find(&tasks).Error; err != nil {
 		return nil, err
 	}
 	query = normalizeSearchText(query)

--- a/server/internal/services/task_context.go
+++ b/server/internal/services/task_context.go
@@ -208,6 +208,28 @@ type TaskScope struct {
 	ProjectID, UserID, Channel, ConversationID string
 }
 
+// IdentityForRun loads the task identity of a Run inside one project. A Run
+// without an identity yet returns (nil, nil) so callers can skip instead of
+// treating it as a failure.
+func (s *TaskContextService) IdentityForRun(runID, projectID string) (*models.TaskIdentity, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("task context database is unavailable")
+	}
+	runID, projectID = strings.TrimSpace(runID), strings.TrimSpace(projectID)
+	if runID == "" || projectID == "" {
+		return nil, errors.New("run_id and project_id are required")
+	}
+	var identity models.TaskIdentity
+	err := s.db.Where("run_id = ? AND project_id = ?", runID, projectID).First(&identity).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &identity, nil
+}
+
 func (s *TaskContextService) BindMessage(scope TaskScope, messageID string, identity *models.TaskIdentity) error {
 	if identity == nil || strings.TrimSpace(messageID) == "" {
 		return errors.New("message_id and identity are required")

--- a/server/internal/services/task_context.go
+++ b/server/internal/services/task_context.go
@@ -23,7 +23,7 @@ const (
 )
 
 // ErrTaskIdentityScopeMismatch means the Run already belongs to a different
-// project. Callers must treat the task as invisible, not re-home it.
+// project or user scope. Callers must treat the task as invisible, not re-home it.
 var ErrTaskIdentityScopeMismatch = errors.New("task identity scope mismatch")
 
 type TaskContextService struct {
@@ -95,9 +95,10 @@ func (s *TaskContextService) EnsureIdentity(in EnsureTaskIdentityInput) (*models
 	if err != nil {
 		return nil, err
 	}
-	// Task metadata is project/Run scoped. A different project's claim is a
-	// hard mismatch; a different QQ identity must never steal or hide the row.
-	if identity.ProjectID != in.ProjectID {
+	// Task metadata is project/user/Run scoped. A different user must never
+	// update, discover, or re-home another user's task.
+	if identity.ProjectID != in.ProjectID ||
+		(identity.UserID != "" && in.UserID != "" && identity.UserID != in.UserID) {
 		return nil, ErrTaskIdentityScopeMismatch
 	}
 	oldTitle := strings.TrimSpace(identity.ShortTitle)
@@ -152,9 +153,9 @@ func (s *TaskContextService) EnsureIdentityForRun(run models.Run, projectID, use
 	})
 }
 
-// BackfillProjectRuns lazily materializes project-scoped identities for a
-// project's Runs. userID is optional provenance only — it never claims exclusive
-// ownership, so a later QQ identity can still search the same Runs.
+// BackfillProjectRuns lazily materializes identities for a project's Runs in
+// the requesting user scope. Existing identities owned by another user remain
+// invisible and are never re-homed.
 func (s *TaskContextService) BackfillProjectRuns(projectID, userID string) error {
 	if s == nil || s.db == nil {
 		return errors.New("task context database is unavailable")
@@ -248,6 +249,9 @@ func (s *TaskContextService) BindMessage(scope TaskScope, messageID string, iden
 	if identity == nil || strings.TrimSpace(messageID) == "" {
 		return errors.New("message_id and identity are required")
 	}
+	if identity.ProjectID != scope.ProjectID || identity.UserID != scope.UserID {
+		return ErrTaskIdentityScopeMismatch
+	}
 	b := models.MessageBinding{
 		ProjectID: scope.ProjectID, UserID: scope.UserID, Channel: scope.Channel,
 		ConversationID: scope.ConversationID, MessageID: strings.TrimSpace(messageID),
@@ -262,6 +266,9 @@ func (s *TaskContextService) BindMessage(scope TaskScope, messageID string, iden
 func (s *TaskContextService) SetFocus(scope TaskScope, identity *models.TaskIdentity, language string) (*models.ConversationFocus, error) {
 	if identity == nil {
 		return nil, errors.New("identity is required")
+	}
+	if identity.ProjectID != scope.ProjectID || identity.UserID != scope.UserID {
+		return nil, ErrTaskIdentityScopeMismatch
 	}
 	now := s.now()
 	focus := models.ConversationFocus{
@@ -330,8 +337,8 @@ func (s *TaskContextService) ResolveTask(in ResolveTaskInput) (TaskResolution, e
 			in.Scope.ProjectID, in.Scope.UserID, in.Scope.Channel, ref).First(&b).Error
 		if err == nil {
 			var task models.TaskIdentity
-			if err := s.db.Where("id = ? AND project_id = ?",
-				b.TaskIdentityID, in.Scope.ProjectID).First(&task).Error; err != nil {
+			if err := s.db.Where("id = ? AND project_id = ? AND user_id = ?",
+				b.TaskIdentityID, in.Scope.ProjectID, in.Scope.UserID).First(&task).Error; err != nil {
 				return TaskResolution{}, err
 			}
 			return s.resolvedWithFocus(in.Scope, task, in.Query, nil, "reply_binding")
@@ -354,8 +361,8 @@ func (s *TaskContextService) ResolveTask(in ResolveTaskInput) (TaskResolution, e
 			return TaskResolution{}, err
 		}
 		var task models.TaskIdentity
-		if err := s.db.Where("id = ? AND project_id = ?",
-			focus.TaskIdentityID, in.Scope.ProjectID).First(&task).Error; err != nil {
+		if err := s.db.Where("id = ? AND project_id = ? AND user_id = ?",
+			focus.TaskIdentityID, in.Scope.ProjectID, in.Scope.UserID).First(&task).Error; err != nil {
 			return TaskResolution{}, err
 		}
 		return TaskResolution{Identity: &task, Reason: "conversation_focus"}, nil
@@ -395,9 +402,8 @@ func (s *TaskContextService) Search(scope TaskScope, query string) ([]TaskCandid
 	}
 	now := s.now()
 	var tasks []models.TaskIdentity
-	// Task metadata is project-scoped; focus/bindings remain per QQ identity.
-	if err := s.db.Where("project_id = ? AND (terminal_at IS NULL OR terminal_at >= ?)",
-		scope.ProjectID, now.Add(-TaskTerminalWindow)).Find(&tasks).Error; err != nil {
+	if err := s.db.Where("project_id = ? AND user_id = ? AND (terminal_at IS NULL OR terminal_at >= ?)",
+		scope.ProjectID, scope.UserID, now.Add(-TaskTerminalWindow)).Find(&tasks).Error; err != nil {
 		return nil, err
 	}
 	query = normalizeSearchText(query)

--- a/server/internal/services/task_context.go
+++ b/server/internal/services/task_context.go
@@ -1,0 +1,539 @@
+package services
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/cocofhu/approving/internal/models"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const (
+	TaskFocusTTL       = 30 * time.Minute
+	TaskTerminalWindow = 30 * 24 * time.Hour
+)
+
+// ErrTaskIdentityScopeMismatch means the Run already belongs to a different
+// project/user scope. Callers must treat the task as invisible, not re-home it.
+var ErrTaskIdentityScopeMismatch = errors.New("task identity scope mismatch")
+
+type TaskContextService struct {
+	db           *gorm.DB
+	now          func() time.Time
+	autoBackfill bool
+}
+
+func NewTaskContextService(db *gorm.DB) *TaskContextService {
+	return &TaskContextService{db: db, now: time.Now}
+}
+
+// EnableRunBackfill makes Search lazily materialize task identities from the
+// project's real Runs, so IM callers never have to pre-register a task.
+func (s *TaskContextService) EnableRunBackfill() { s.autoBackfill = true }
+
+func (s *TaskContextService) SetClock(now func() time.Time) {
+	if now != nil {
+		s.now = now
+	}
+}
+
+type EnsureTaskIdentityInput struct {
+	RunID, ProjectID, UserID, ShortTitle, OriginalRequirement, Status string
+	Aliases, Keywords                                                 []string
+}
+
+func (s *TaskContextService) EnsureIdentity(in EnsureTaskIdentityInput) (*models.TaskIdentity, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("task context database is unavailable")
+	}
+	in.RunID = strings.TrimSpace(in.RunID)
+	in.ProjectID = strings.TrimSpace(in.ProjectID)
+	in.UserID = strings.TrimSpace(in.UserID)
+	if in.RunID == "" || in.ProjectID == "" || in.UserID == "" {
+		return nil, errors.New("run_id, project_id and user_id are required")
+	}
+	now := s.now()
+	var identity models.TaskIdentity
+	err := s.db.Where("run_id = ?", in.RunID).First(&identity).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		identity = models.TaskIdentity{
+			ID: "task-" + uuid.NewString()[:12], RunID: in.RunID,
+			ProjectID: in.ProjectID, UserID: in.UserID,
+			ShortTitle:          strings.TrimSpace(in.ShortTitle),
+			OriginalRequirement: strings.TrimSpace(in.OriginalRequirement),
+			Aliases:             uniqueStrings(in.Aliases), Keywords: uniqueStrings(in.Keywords),
+			Status: normalizeTaskStatus(in.Status), CreatedAt: now, UpdatedAt: now,
+		}
+		if isTerminalTaskStatus(identity.Status) {
+			t := now
+			identity.TerminalAt = &t
+		}
+		if err := s.db.Create(&identity).Error; err != nil {
+			return nil, err
+		}
+		return &identity, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	// A Run cannot be re-homed across a user/project scope: that is what keeps
+	// one QQ identity from seeing another identity's task in the same project.
+	if identity.ProjectID != in.ProjectID || identity.UserID != in.UserID {
+		return nil, ErrTaskIdentityScopeMismatch
+	}
+	oldTitle := strings.TrimSpace(identity.ShortTitle)
+	newTitle := strings.TrimSpace(in.ShortTitle)
+	if newTitle != "" && oldTitle != "" && newTitle != oldTitle {
+		identity.Aliases = uniqueStrings(append(identity.Aliases, oldTitle))
+	}
+	if newTitle != "" {
+		identity.ShortTitle = newTitle
+	}
+	if req := strings.TrimSpace(in.OriginalRequirement); req != "" && identity.OriginalRequirement == "" {
+		identity.OriginalRequirement = req
+	}
+	identity.Aliases = uniqueStrings(append(identity.Aliases, in.Aliases...))
+	identity.Keywords = uniqueStrings(append(identity.Keywords, in.Keywords...))
+	if strings.TrimSpace(in.Status) != "" {
+		wasTerminal := isTerminalTaskStatus(identity.Status)
+		identity.Status = normalizeTaskStatus(in.Status)
+		if isTerminalTaskStatus(identity.Status) && !wasTerminal {
+			t := now
+			identity.TerminalAt = &t
+		} else if !isTerminalTaskStatus(identity.Status) {
+			identity.TerminalAt = nil
+		}
+	}
+	identity.UpdatedAt = now
+	if err := s.db.Save(&identity).Error; err != nil {
+		return nil, err
+	}
+	return &identity, nil
+}
+
+func (s *TaskContextService) UpdateIdentity(in EnsureTaskIdentityInput) (*models.TaskIdentity, error) {
+	return s.EnsureIdentity(in)
+}
+
+// EnsureIdentityForRun derives a task identity straight from a real Run, so
+// callers never have to hand-assemble titles, requirements or keywords.
+func (s *TaskContextService) EnsureIdentityForRun(run models.Run, projectID, userID string) (*models.TaskIdentity, error) {
+	requirement := runRequirement(run)
+	return s.EnsureIdentity(EnsureTaskIdentityInput{
+		RunID:               run.ID,
+		ProjectID:           projectID,
+		UserID:              userID,
+		ShortTitle:          runShortTitle(run),
+		OriginalRequirement: requirement,
+		Keywords:            runKeywords(run, requirement),
+		Status:              run.Status,
+	})
+}
+
+// BackfillProjectRuns lazily materializes identities for a project's Runs under
+// one synthetic identity. It is safe to call repeatedly: EnsureIdentityForRun is
+// idempotent and keeps renamed titles as aliases.
+func (s *TaskContextService) BackfillProjectRuns(projectID, userID string) error {
+	if s == nil || s.db == nil {
+		return errors.New("task context database is unavailable")
+	}
+	projectID = strings.TrimSpace(projectID)
+	userID = strings.TrimSpace(userID)
+	if projectID == "" || userID == "" {
+		return errors.New("project_id and user_id are required")
+	}
+	var runs []models.Run
+	err := s.db.
+		Where("workflow_id IN (?)",
+			s.db.Model(&models.WorkflowDef{}).Select("id").Where("project_id = ?", projectID)).
+		Where("created_at >= ?", s.now().Add(-TaskTerminalWindow)).
+		Find(&runs).Error
+	if err != nil {
+		return err
+	}
+	for _, run := range runs {
+		if _, err := s.EnsureIdentityForRun(run, projectID, userID); err != nil {
+			if errors.Is(err, ErrTaskIdentityScopeMismatch) {
+				continue // owned by another identity; stays invisible here
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+const runShortTitleRunes = 24
+
+func runShortTitle(run models.Run) string {
+	for _, candidate := range []string{run.Title, run.WorkflowName} {
+		if candidate = strings.TrimSpace(candidate); candidate != "" {
+			return truncateTaskRunes(firstLine(candidate), runShortTitleRunes)
+		}
+	}
+	return truncateTaskRunes("Run "+run.ID, runShortTitleRunes)
+}
+
+// runRequirementKeys are the conventional Run input keys that hold the original
+// human request, most specific first.
+var runRequirementKeys = []string{"requirement", "request", "goal", "task", "prompt", "input", "description"}
+
+func runRequirement(run models.Run) string {
+	for _, key := range runRequirementKeys {
+		if value, ok := run.Inputs[key].(string); ok {
+			if value = strings.TrimSpace(value); value != "" {
+				return value
+			}
+		}
+	}
+	return strings.TrimSpace(run.Title)
+}
+
+func runKeywords(run models.Run, requirement string) []string {
+	keywords := append([]string(nil), run.Tags...)
+	if name := strings.TrimSpace(run.WorkflowName); name != "" {
+		keywords = append(keywords, name)
+	}
+	for _, field := range strings.Fields(normalizeSearchText(firstLine(requirement))) {
+		if len([]rune(field)) >= 2 {
+			keywords = append(keywords, field)
+		}
+	}
+	if len(keywords) > 12 {
+		keywords = keywords[:12]
+	}
+	return uniqueStrings(keywords)
+}
+
+func firstLine(value string) string {
+	if idx := strings.IndexAny(value, "\r\n"); idx >= 0 {
+		return strings.TrimSpace(value[:idx])
+	}
+	return strings.TrimSpace(value)
+}
+
+func truncateTaskRunes(value string, limit int) string {
+	r := []rune(strings.TrimSpace(value))
+	if limit <= 0 || len(r) <= limit {
+		return string(r)
+	}
+	return string(r[:limit])
+}
+
+type TaskScope struct {
+	ProjectID, UserID, Channel, ConversationID string
+}
+
+func (s *TaskContextService) BindMessage(scope TaskScope, messageID string, identity *models.TaskIdentity) error {
+	if identity == nil || strings.TrimSpace(messageID) == "" {
+		return errors.New("message_id and identity are required")
+	}
+	b := models.MessageBinding{
+		ProjectID: scope.ProjectID, UserID: scope.UserID, Channel: scope.Channel,
+		ConversationID: scope.ConversationID, MessageID: strings.TrimSpace(messageID),
+		TaskIdentityID: identity.ID, RunID: identity.RunID, CreatedAt: s.now(),
+	}
+	return s.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "project_id"}, {Name: "user_id"}, {Name: "channel"}, {Name: "message_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"conversation_id", "task_identity_id", "run_id"}),
+	}).Create(&b).Error
+}
+
+func (s *TaskContextService) SetFocus(scope TaskScope, identity *models.TaskIdentity, language string) (*models.ConversationFocus, error) {
+	if identity == nil {
+		return nil, errors.New("identity is required")
+	}
+	now := s.now()
+	focus := models.ConversationFocus{
+		ProjectID: scope.ProjectID, UserID: scope.UserID, Channel: scope.Channel,
+		ConversationID: scope.ConversationID, TaskIdentityID: identity.ID,
+		RunID: identity.RunID, Language: NormalizeLanguage(language),
+		ExpiresAt: now.Add(TaskFocusTTL), CreatedAt: now, UpdatedAt: now,
+	}
+	err := s.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "project_id"}, {Name: "user_id"}, {Name: "channel"}, {Name: "conversation_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"task_identity_id", "run_id", "language", "expires_at", "updated_at"}),
+	}).Create(&focus).Error
+	if err != nil {
+		return nil, err
+	}
+	return &focus, nil
+}
+
+func (s *TaskContextService) GetFocus(scope TaskScope, renew bool) (*models.ConversationFocus, error) {
+	var focus models.ConversationFocus
+	err := s.db.Where("project_id = ? AND user_id = ? AND channel = ? AND conversation_id = ?",
+		scope.ProjectID, scope.UserID, scope.Channel, scope.ConversationID).First(&focus).Error
+	if err != nil {
+		return nil, err
+	}
+	now := s.now()
+	if !focus.ExpiresAt.After(now) {
+		return nil, gorm.ErrRecordNotFound
+	}
+	if renew {
+		focus.ExpiresAt = now.Add(TaskFocusTTL)
+		focus.UpdatedAt = now
+		if err := s.db.Save(&focus).Error; err != nil {
+			return nil, err
+		}
+	}
+	return &focus, nil
+}
+
+type TaskCandidate struct {
+	Identity models.TaskIdentity
+	Score    int
+	Reasons  []string
+}
+
+type TaskResolution struct {
+	Identity   *models.TaskIdentity
+	Candidates []TaskCandidate
+	Ambiguous  bool
+	Reason     string
+}
+
+type ResolveTaskInput struct {
+	Scope          TaskScope
+	Query          string
+	ReplyMessageID string
+	Ordinal        int // 1-based selection from Candidates
+	Candidates     []TaskCandidate
+}
+
+func (s *TaskContextService) ResolveTask(in ResolveTaskInput) (TaskResolution, error) {
+	// Explicit reply binding always wins and is still strictly scoped.
+	if ref := strings.TrimSpace(in.ReplyMessageID); ref != "" {
+		var b models.MessageBinding
+		err := s.db.Where("project_id = ? AND user_id = ? AND channel = ? AND message_id = ?",
+			in.Scope.ProjectID, in.Scope.UserID, in.Scope.Channel, ref).First(&b).Error
+		if err == nil {
+			var task models.TaskIdentity
+			if err := s.db.Where("id = ? AND project_id = ? AND user_id = ?",
+				b.TaskIdentityID, in.Scope.ProjectID, in.Scope.UserID).First(&task).Error; err != nil {
+				return TaskResolution{}, err
+			}
+			return s.resolvedWithFocus(in.Scope, task, in.Query, nil, "reply_binding")
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return TaskResolution{}, err
+		}
+	}
+	if in.Ordinal > 0 && in.Ordinal <= len(in.Candidates) {
+		task := in.Candidates[in.Ordinal-1].Identity
+		return s.resolvedWithFocus(in.Scope, task, in.Query, in.Candidates, "ordinal")
+	}
+	query := strings.TrimSpace(in.Query)
+	if query == "" {
+		focus, err := s.GetFocus(in.Scope, true)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return TaskResolution{Reason: "focus_missing_or_expired"}, nil
+			}
+			return TaskResolution{}, err
+		}
+		var task models.TaskIdentity
+		if err := s.db.Where("id = ? AND project_id = ? AND user_id = ?",
+			focus.TaskIdentityID, in.Scope.ProjectID, in.Scope.UserID).First(&task).Error; err != nil {
+			return TaskResolution{}, err
+		}
+		return TaskResolution{Identity: &task, Reason: "conversation_focus"}, nil
+	}
+	candidates, err := s.Search(in.Scope, query)
+	if err != nil {
+		return TaskResolution{}, err
+	}
+	if len(candidates) == 0 {
+		return TaskResolution{Reason: "no_match"}, nil
+	}
+	if len(candidates) > 1 && candidates[0].Score-candidates[1].Score < 15 {
+		return TaskResolution{Candidates: candidates, Ambiguous: true, Reason: "score_margin"}, nil
+	}
+	task := candidates[0].Identity
+	return s.resolvedWithFocus(in.Scope, task, in.Query, candidates, "unique_score")
+}
+
+func (s *TaskContextService) resolvedWithFocus(scope TaskScope, task models.TaskIdentity, current string, candidates []TaskCandidate, reason string) (TaskResolution, error) {
+	recent := ""
+	if focus, err := s.GetFocus(scope, false); err == nil {
+		recent = focus.Language
+	}
+	if _, err := s.SetFocus(scope, &task, DetectLanguage(current, recent)); err != nil {
+		return TaskResolution{}, err
+	}
+	return TaskResolution{Identity: &task, Candidates: candidates, Reason: reason}, nil
+}
+
+func (s *TaskContextService) Search(scope TaskScope, query string) ([]TaskCandidate, error) {
+	if s.autoBackfill {
+		// Best-effort: a backfill failure must not make addressing unavailable.
+		if err := s.BackfillProjectRuns(scope.ProjectID, scope.UserID); err != nil {
+			log.Warn().Err(err).Str("project", scope.ProjectID).
+				Msg("task identity backfill failed; searching existing identities only")
+		}
+	}
+	now := s.now()
+	var tasks []models.TaskIdentity
+	if err := s.db.Where("project_id = ? AND user_id = ? AND (terminal_at IS NULL OR terminal_at >= ?)",
+		scope.ProjectID, scope.UserID, now.Add(-TaskTerminalWindow)).Find(&tasks).Error; err != nil {
+		return nil, err
+	}
+	query = normalizeSearchText(query)
+	var out []TaskCandidate
+	for _, task := range tasks {
+		score, reasons := scoreTask(task, query)
+		if score > 0 {
+			out = append(out, TaskCandidate{Identity: task, Score: score, Reasons: reasons})
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		return out[i].Identity.UpdatedAt.After(out[j].Identity.UpdatedAt)
+	})
+	return out, nil
+}
+
+func scoreTask(task models.TaskIdentity, query string) (int, []string) {
+	if query == "" {
+		return 0, nil
+	}
+	title := normalizeSearchText(task.ShortTitle)
+	if query == title {
+		return 100, []string{"exact_short_title"}
+	}
+	best := 0
+	var reasons []string
+	for _, alias := range task.Aliases {
+		a := normalizeSearchText(alias)
+		if query == a {
+			return 90, []string{"exact_alias"}
+		}
+		if a != "" && (strings.Contains(a, query) || strings.Contains(query, a)) && best < 55 {
+			best, reasons = 55, []string{"alias_contains"}
+		}
+	}
+	if title != "" && (strings.Contains(title, query) || strings.Contains(query, title)) && best < 60 {
+		best, reasons = 60, []string{"short_title_contains"}
+	}
+	for _, keyword := range task.Keywords {
+		k := normalizeSearchText(keyword)
+		if k != "" && strings.Contains(query, k) {
+			best += 15
+			reasons = append(reasons, "keyword:"+keyword)
+		}
+	}
+	if req := normalizeSearchText(task.OriginalRequirement); strings.Contains(req, query) && best < 35 {
+		best, reasons = 35, []string{"requirement_contains"}
+	}
+	return best, reasons
+}
+
+// ParseOrdinal recognizes a plain 1-based numeric selection.
+func ParseOrdinal(text string) int {
+	n, err := strconv.Atoi(strings.TrimSpace(text))
+	if err != nil || n < 1 {
+		return 0
+	}
+	return n
+}
+
+func SyntheticQQUserID(userID string) string {
+	return "qq:" + strings.TrimSpace(userID)
+}
+
+func DetectLanguage(current, recent string) string {
+	current = strings.TrimSpace(current)
+	if current != "" {
+		for _, r := range current {
+			if unicode.Is(unicode.Han, r) {
+				return "zh-CN"
+			}
+		}
+		for _, r := range current {
+			if unicode.IsLetter(r) {
+				return "en"
+			}
+		}
+	}
+	if normalized := NormalizeLanguage(recent); normalized != "" {
+		return normalized
+	}
+	return "zh-CN"
+}
+
+func NormalizeLanguage(language string) string {
+	switch strings.ToLower(strings.TrimSpace(language)) {
+	case "en", "en-us", "en-gb":
+		return "en"
+	case "zh", "zh-cn", "zh-hans":
+		return "zh-CN"
+	default:
+		return ""
+	}
+}
+
+func FormatTaskType(shortTitle, kind, language string) string {
+	shortTitle = strings.TrimSpace(shortTitle)
+	kind = strings.TrimSpace(kind)
+	if shortTitle == "" {
+		if NormalizeLanguage(language) == "en" {
+			shortTitle = "Task"
+		} else {
+			shortTitle = "任务"
+		}
+	}
+	if kind == "" {
+		if NormalizeLanguage(language) == "en" {
+			kind = "Update"
+		} else {
+			kind = "更新"
+		}
+	}
+	return fmt.Sprintf("【%s｜%s】", shortTitle, kind)
+}
+
+func normalizeTaskStatus(status string) string {
+	status = strings.ToLower(strings.TrimSpace(status))
+	if status == "" {
+		return "active"
+	}
+	return status
+}
+
+func isTerminalTaskStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "completed", "failed", "cancelled", "canceled", "done":
+		return true
+	default:
+		return false
+	}
+}
+
+func uniqueStrings(values []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
+}
+
+func normalizeSearchText(value string) string {
+	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(value)), " "))
+}

--- a/server/internal/services/task_context.go
+++ b/server/internal/services/task_context.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cocofhu/approving/internal/models"
 
 	"github.com/google/uuid"
-	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -27,18 +26,13 @@ const (
 var ErrTaskIdentityScopeMismatch = errors.New("task identity scope mismatch")
 
 type TaskContextService struct {
-	db           *gorm.DB
-	now          func() time.Time
-	autoBackfill bool
+	db  *gorm.DB
+	now func() time.Time
 }
 
 func NewTaskContextService(db *gorm.DB) *TaskContextService {
 	return &TaskContextService{db: db, now: time.Now}
 }
-
-// EnableRunBackfill makes Search lazily materialize task identities from the
-// project's real Runs, so IM callers never have to pre-register a task.
-func (s *TaskContextService) EnableRunBackfill() { s.autoBackfill = true }
 
 func (s *TaskContextService) SetClock(now func() time.Time) {
 	if now != nil {
@@ -151,37 +145,6 @@ func (s *TaskContextService) EnsureIdentityForRun(run models.Run, projectID, use
 		Keywords:            runKeywords(run, requirement),
 		Status:              run.Status,
 	})
-}
-
-// BackfillProjectRuns lazily materializes identities for a project's Runs in
-// the requesting user scope. Existing identities owned by another user remain
-// invisible and are never re-homed.
-func (s *TaskContextService) BackfillProjectRuns(projectID, userID string) error {
-	if s == nil || s.db == nil {
-		return errors.New("task context database is unavailable")
-	}
-	projectID = strings.TrimSpace(projectID)
-	if projectID == "" {
-		return errors.New("project_id is required")
-	}
-	var runs []models.Run
-	err := s.db.
-		Where("workflow_id IN (?)",
-			s.db.Model(&models.WorkflowDef{}).Select("id").Where("project_id = ?", projectID)).
-		Where("created_at >= ?", s.now().Add(-TaskTerminalWindow)).
-		Find(&runs).Error
-	if err != nil {
-		return err
-	}
-	for _, run := range runs {
-		if _, err := s.EnsureIdentityForRun(run, projectID, strings.TrimSpace(userID)); err != nil {
-			if errors.Is(err, ErrTaskIdentityScopeMismatch) {
-				continue // different project; stay invisible
-			}
-			return err
-		}
-	}
-	return nil
 }
 
 const runShortTitleRunes = 24
@@ -393,13 +356,6 @@ func (s *TaskContextService) resolvedWithFocus(scope TaskScope, task models.Task
 }
 
 func (s *TaskContextService) Search(scope TaskScope, query string) ([]TaskCandidate, error) {
-	if s.autoBackfill {
-		// Best-effort: a backfill failure must not make addressing unavailable.
-		if err := s.BackfillProjectRuns(scope.ProjectID, scope.UserID); err != nil {
-			log.Warn().Err(err).Str("project", scope.ProjectID).
-				Msg("task identity backfill failed; searching existing identities only")
-		}
-	}
 	now := s.now()
 	var tasks []models.TaskIdentity
 	if err := s.db.Where("project_id = ? AND user_id = ? AND (terminal_at IS NULL OR terminal_at >= ?)",

--- a/server/internal/services/task_context_test.go
+++ b/server/internal/services/task_context_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -57,8 +58,8 @@ func TestTaskContextMigrationIdentityResolutionAndIsolation(t *testing.T) {
 	}
 	ensureTask(t, svc, "r2", scope.ProjectID, scope.UserID, "用户登录页")
 	ensureTask(t, svc, "r3", "other-project", scope.UserID, "登录页")
-	// Another QQ identity may seed the same project; metadata stays project-scoped
-	// and searchable, while focus/bindings remain per synthetic identity.
+	// Another QQ identity in the same project must remain outside this user's
+	// candidate set.
 	ensureTask(t, svc, "r4", scope.ProjectID, SyntheticQQUserID("other"), "登录页性能优化")
 
 	res, err := svc.ResolveTask(ResolveTaskInput{Scope: scope, Query: "登录页"})
@@ -69,10 +70,13 @@ func TestTaskContextMigrationIdentityResolutionAndIsolation(t *testing.T) {
 		if c.Identity.ProjectID != scope.ProjectID {
 			t.Fatalf("cross-project candidate leaked: %+v", c.Identity)
 		}
+		if c.Identity.UserID != scope.UserID {
+			t.Fatalf("cross-user candidate leaked: %+v", c.Identity)
+		}
 	}
 	otherScope := TaskScope{ProjectID: "p1", UserID: SyntheticQQUserID("other"), Channel: "qq", ConversationID: "c-other"}
-	if _, err := svc.SetFocus(otherScope, &res.Candidates[0].Identity, "zh-CN"); err != nil {
-		t.Fatal(err)
+	if _, err := svc.SetFocus(otherScope, &res.Candidates[0].Identity, "zh-CN"); !errors.Is(err, ErrTaskIdentityScopeMismatch) {
+		t.Fatalf("cross-user focus error = %v", err)
 	}
 	if focus, err := svc.GetFocus(scope, false); err == nil {
 		t.Fatalf("u1 must not see other identity focus: %+v", focus)
@@ -282,26 +286,20 @@ func TestEnsureIdentityForRunDerivesFieldsAndBackfillsScoped(t *testing.T) {
 	if others, err := svc.Search(scope, "结算页"); err != nil || len(others) != 0 {
 		t.Fatalf("cross-project leak: %+v err=%v", others, err)
 	}
-	// A different QQ identity in the same project must still find project-scoped
-	// task metadata; only focus/bindings stay isolated per synthetic identity.
+	// A different QQ identity in the same project must not discover a task
+	// owned by the first identity.
 	intruder := TaskScope{ProjectID: "p1", UserID: SyntheticQQUserID("u2"), Channel: "qq", ConversationID: "c9"}
 	res, err := svc.ResolveTask(ResolveTaskInput{Scope: intruder, Query: "修复登录页跳转"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.Identity == nil || res.Identity.RunID != "r1" {
-		t.Fatalf("same-project QQ identity should resolve project tasks: %+v", res)
+	if res.Identity != nil || len(res.Candidates) != 0 || res.Reason != "no_match" {
+		t.Fatalf("cross-user task leaked: %+v", res)
 	}
-	focusA, err := svc.SetFocus(scope, res.Identity, "zh-CN")
-	if err != nil {
-		t.Fatal(err)
-	}
-	focusB, err := svc.GetFocus(intruder, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if focusA.UserID == focusB.UserID {
-		t.Fatalf("focus must stay isolated per QQ identity: %+v %+v", focusA, focusB)
+	if _, err := svc.EnsureIdentityForRun(models.Run{
+		ID: "r1", Status: "running", Title: "修复登录页跳转",
+	}, "p1", intruder.UserID); !errors.Is(err, ErrTaskIdentityScopeMismatch) {
+		t.Fatalf("cross-user identity update error = %v", err)
 	}
 	var count int64
 	if err := db.Model(&models.TaskIdentity{}).Where("run_id = ?", "r1").Count(&count).Error; err != nil {

--- a/server/internal/services/task_context_test.go
+++ b/server/internal/services/task_context_test.go
@@ -57,12 +57,27 @@ func TestTaskContextMigrationIdentityResolutionAndIsolation(t *testing.T) {
 	}
 	ensureTask(t, svc, "r2", scope.ProjectID, scope.UserID, "用户登录页")
 	ensureTask(t, svc, "r3", "other-project", scope.UserID, "登录页")
-	ensureTask(t, svc, "r4", scope.ProjectID, SyntheticQQUserID("other"), "登录页")
+	// Another QQ identity may seed the same project; metadata stays project-scoped
+	// and searchable, while focus/bindings remain per synthetic identity.
+	ensureTask(t, svc, "r4", scope.ProjectID, SyntheticQQUserID("other"), "登录页性能优化")
 
 	res, err := svc.ResolveTask(ResolveTaskInput{Scope: scope, Query: "登录页"})
-	if err != nil || !res.Ambiguous || len(res.Candidates) != 2 {
+	if err != nil || !res.Ambiguous || len(res.Candidates) < 2 {
 		t.Fatalf("ambiguous resolution=%+v err=%v", res, err)
 	}
+	for _, c := range res.Candidates {
+		if c.Identity.ProjectID != scope.ProjectID {
+			t.Fatalf("cross-project candidate leaked: %+v", c.Identity)
+		}
+	}
+	otherScope := TaskScope{ProjectID: "p1", UserID: SyntheticQQUserID("other"), Channel: "qq", ConversationID: "c-other"}
+	if _, err := svc.SetFocus(otherScope, &res.Candidates[0].Identity, "zh-CN"); err != nil {
+		t.Fatal(err)
+	}
+	if focus, err := svc.GetFocus(scope, false); err == nil {
+		t.Fatalf("u1 must not see other identity focus: %+v", focus)
+	}
+
 	ref, err := svc.ResolveTask(ResolveTaskInput{
 		Scope: scope, Query: "用户登录页", ReplyMessageID: "m1",
 	})
@@ -267,21 +282,32 @@ func TestEnsureIdentityForRunDerivesFieldsAndBackfillsScoped(t *testing.T) {
 	if others, err := svc.Search(scope, "结算页"); err != nil || len(others) != 0 {
 		t.Fatalf("cross-project leak: %+v err=%v", others, err)
 	}
-	// A different QQ identity in the same project must not see the task that
-	// already belongs to u1, and the scope conflict must not break resolution.
+	// A different QQ identity in the same project must still find project-scoped
+	// task metadata; only focus/bindings stay isolated per synthetic identity.
 	intruder := TaskScope{ProjectID: "p1", UserID: SyntheticQQUserID("u2"), Channel: "qq", ConversationID: "c9"}
 	res, err := svc.ResolveTask(ResolveTaskInput{Scope: intruder, Query: "修复登录页跳转"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.Identity != nil {
-		t.Fatalf("another QQ identity saw a task it does not own: %+v", res.Identity)
+	if res.Identity == nil || res.Identity.RunID != "r1" {
+		t.Fatalf("same-project QQ identity should resolve project tasks: %+v", res)
+	}
+	focusA, err := svc.SetFocus(scope, res.Identity, "zh-CN")
+	if err != nil {
+		t.Fatal(err)
+	}
+	focusB, err := svc.GetFocus(intruder, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if focusA.UserID == focusB.UserID {
+		t.Fatalf("focus must stay isolated per QQ identity: %+v %+v", focusA, focusB)
 	}
 	var count int64
 	if err := db.Model(&models.TaskIdentity{}).Where("run_id = ?", "r1").Count(&count).Error; err != nil {
 		t.Fatal(err)
 	}
 	if count != 1 {
-		t.Fatalf("run r1 has %d identities; a Run belongs to one identity scope", count)
+		t.Fatalf("run r1 has %d identities; a Run has one project-scoped identity", count)
 	}
 }

--- a/server/internal/services/task_context_test.go
+++ b/server/internal/services/task_context_test.go
@@ -1,0 +1,287 @@
+package services
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func taskContextDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	if err := db.AutoMigrate(
+		&models.TaskIdentity{}, &models.MessageBinding{}, &models.ConversationFocus{},
+		&models.RiskConfirmationTicket{}, &models.SendableDeliveryReceipt{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func ensureTask(t *testing.T, svc *TaskContextService, run, project, user, title string) *models.TaskIdentity {
+	t.Helper()
+	task, err := svc.EnsureIdentity(EnsureTaskIdentityInput{
+		RunID: run, ProjectID: project, UserID: user, ShortTitle: title,
+		OriginalRequirement: "实现" + title, Status: "active",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return task
+}
+
+func TestTaskContextMigrationIdentityResolutionAndIsolation(t *testing.T) {
+	db := taskContextDB(t)
+	svc := NewTaskContextService(db)
+	scope := TaskScope{ProjectID: "p1", UserID: SyntheticQQUserID("u1"), Channel: "qq", ConversationID: "c"}
+	task := ensureTask(t, svc, "r1", scope.ProjectID, scope.UserID, "支付登录页")
+	renamed, err := svc.UpdateIdentity(EnsureTaskIdentityInput{
+		RunID: "r1", ProjectID: scope.ProjectID, UserID: scope.UserID, ShortTitle: "商户登录页",
+		Status: "active",
+	})
+	if err != nil || len(renamed.Aliases) != 1 || renamed.Aliases[0] != "支付登录页" {
+		t.Fatalf("rename=%+v err=%v", renamed, err)
+	}
+	if err := svc.BindMessage(scope, "m1", task); err != nil {
+		t.Fatal(err)
+	}
+	ensureTask(t, svc, "r2", scope.ProjectID, scope.UserID, "用户登录页")
+	ensureTask(t, svc, "r3", "other-project", scope.UserID, "登录页")
+	ensureTask(t, svc, "r4", scope.ProjectID, SyntheticQQUserID("other"), "登录页")
+
+	res, err := svc.ResolveTask(ResolveTaskInput{Scope: scope, Query: "登录页"})
+	if err != nil || !res.Ambiguous || len(res.Candidates) != 2 {
+		t.Fatalf("ambiguous resolution=%+v err=%v", res, err)
+	}
+	ref, err := svc.ResolveTask(ResolveTaskInput{
+		Scope: scope, Query: "用户登录页", ReplyMessageID: "m1",
+	})
+	if err != nil || ref.Identity == nil || ref.Identity.RunID != "r1" || ref.Reason != "reply_binding" {
+		t.Fatalf("binding precedence=%+v err=%v", ref, err)
+	}
+	ordinal, err := svc.ResolveTask(ResolveTaskInput{
+		Scope: scope, Ordinal: 2, Candidates: res.Candidates,
+	})
+	if err != nil || ordinal.Identity == nil {
+		t.Fatalf("ordinal=%+v err=%v", ordinal, err)
+	}
+}
+
+func TestConversationFocusRenewAndExpireWithoutGuess(t *testing.T) {
+	db := taskContextDB(t)
+	svc := NewTaskContextService(db)
+	now := time.Date(2026, 8, 6, 0, 0, 0, 0, time.UTC)
+	svc.SetClock(func() time.Time { return now })
+	scope := TaskScope{ProjectID: "p", UserID: "qq:u", Channel: "qq", ConversationID: "c"}
+	task := ensureTask(t, svc, "r", "p", "qq:u", "任务")
+	if _, err := svc.SetFocus(scope, task, "en"); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(20 * time.Minute)
+	res, err := svc.ResolveTask(ResolveTaskInput{Scope: scope})
+	if err != nil || res.Identity == nil || res.Reason != "conversation_focus" {
+		t.Fatalf("focused=%+v err=%v", res, err)
+	}
+	var focus models.ConversationFocus
+	if err := db.First(&focus).Error; err != nil || !focus.ExpiresAt.Equal(now.Add(TaskFocusTTL)) {
+		t.Fatalf("focus not renewed: %+v err=%v", focus, err)
+	}
+	now = now.Add(31 * time.Minute)
+	res, err = svc.ResolveTask(ResolveTaskInput{Scope: scope})
+	if err != nil || res.Identity != nil || res.Reason != "focus_missing_or_expired" {
+		t.Fatalf("expired focus guessed: %+v err=%v", res, err)
+	}
+}
+
+func TestRiskConfirmationOneShotDuplicateExpiredAndLanguage(t *testing.T) {
+	db := taskContextDB(t)
+	svc := NewRiskConfirmationService(db)
+	now := time.Date(2026, 8, 6, 0, 0, 0, 0, time.UTC)
+	svc.SetClock(func() time.Time { return now })
+	input := RiskTicketInput{ProjectID: "p", UserID: "qq:u", RunID: "r", Action: "delete", Language: "en"}
+	if _, err := svc.CreateTicket(input); err != nil {
+		t.Fatal(err)
+	}
+	first, err := svc.ResolveTicket(input, "confirm")
+	if err != nil || !first.Execute || first.Ticket.Status != "confirmed" {
+		t.Fatalf("first=%+v err=%v", first, err)
+	}
+	repeated, err := svc.ResolveTicket(input, "确认")
+	if err != nil || repeated.Execute || repeated.Ticket.Status != "confirmed" {
+		t.Fatalf("repeated=%+v err=%v", repeated, err)
+	}
+	expiring := RiskTicketInput{ProjectID: "p", UserID: "qq:u", RunID: "r2", Action: "deploy", Language: "zh-CN"}
+	if _, err := svc.CreateTicket(expiring); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(RiskConfirmationTTL + time.Second)
+	expired, err := svc.ResolveTicket(expiring, "确认")
+	if err != nil || expired.Execute || expired.Ticket.Status != "expired" {
+		t.Fatalf("expired=%+v err=%v", expired, err)
+	}
+	if DetectLanguage("please continue", "zh-CN") != "en" ||
+		DetectLanguage("", "en") != "en" || DetectLanguage("", "") != "zh-CN" {
+		t.Fatal("language fallback order is incorrect")
+	}
+	if got := FormatTaskType("Login", "Risk", "en"); got != "【Login｜Risk】" {
+		t.Fatalf("format=%q", got)
+	}
+}
+
+func TestRiskConfirmationEchoesShortTitleAndLatestTaskStatus(t *testing.T) {
+	db := taskContextDB(t)
+	if err := db.AutoMigrate(&models.Run{}, &models.WorkflowDef{}); err != nil {
+		t.Fatal(err)
+	}
+	tasks := NewTaskContextService(db)
+	risk := NewRiskConfirmationService(db)
+	now := time.Date(2026, 8, 6, 0, 0, 0, 0, time.UTC)
+	tasks.SetClock(func() time.Time { return now })
+	risk.SetClock(func() time.Time { return now })
+
+	if err := db.Create(&models.Run{ID: "r1", Status: "running", Title: "结算页重构"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.EnsureIdentity(EnsureTaskIdentityInput{
+		RunID: "r1", ProjectID: "p", UserID: "qq:u", ShortTitle: "结算页", Status: "active",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The short title is resolved from the task identity, not passed by hand.
+	input := RiskTicketInput{ProjectID: "p", UserID: "qq:u", RunID: "r1", Action: "删除生产分支", Language: "zh-CN"}
+	ticket, err := risk.CreateTicket(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ticket.ShortTitle != "结算页" {
+		t.Fatalf("ticket short title = %q", ticket.ShortTitle)
+	}
+	prompt := risk.ConfirmationPrompt(*ticket)
+	if !strings.HasPrefix(prompt, "【结算页｜高风险确认】") || !strings.Contains(prompt, "删除生产分支") {
+		t.Fatalf("prompt = %q", prompt)
+	}
+
+	confirmed, err := risk.ResolveTicket(input, "确认")
+	if err != nil || !confirmed.Execute {
+		t.Fatalf("confirm = %+v err=%v", confirmed, err)
+	}
+
+	// The Run moves on; a repeated decision reports the latest task status.
+	if err := db.Model(&models.Run{}).Where("id = ?", "r1").
+		Update("status", "completed").Error; err != nil {
+		t.Fatal(err)
+	}
+	repeated, err := risk.ResolveTicket(input, "确认")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repeated.Execute {
+		t.Fatal("repeated confirmation must not execute again")
+	}
+	if repeated.TaskStatus != "completed" {
+		t.Fatalf("latest task status = %q want completed", repeated.TaskStatus)
+	}
+	if !strings.Contains(repeated.Message, "结算页") || !strings.Contains(repeated.Message, "completed") {
+		t.Fatalf("repeat message = %q", repeated.Message)
+	}
+
+	// Expiry also reports the short title and the latest status.
+	expiring := RiskTicketInput{ProjectID: "p", UserID: "qq:u", RunID: "r1", Action: "回滚发布", Language: "zh-CN"}
+	if _, err := risk.CreateTicket(expiring); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(RiskConfirmationTTL + time.Second)
+	expired, err := risk.ResolveTicket(expiring, "确认")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expired.Execute || expired.Ticket.Status != "expired" {
+		t.Fatalf("expired = %+v", expired)
+	}
+	if !strings.Contains(expired.Message, "【结算页｜已过期】") || expired.TaskStatus != "completed" {
+		t.Fatalf("expired message = %q status=%q", expired.Message, expired.TaskStatus)
+	}
+}
+
+func TestEnsureIdentityForRunDerivesFieldsAndBackfillsScoped(t *testing.T) {
+	db := taskContextDB(t)
+	if err := db.AutoMigrate(&models.Run{}, &models.WorkflowDef{}); err != nil {
+		t.Fatal(err)
+	}
+	svc := NewTaskContextService(db)
+	svc.EnableRunBackfill()
+
+	if err := db.Create(&models.WorkflowDef{ID: "wf1", ProjectID: "p1", Name: "登录流程"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&models.WorkflowDef{ID: "wf2", ProjectID: "p2", Name: "结算流程"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&models.Run{
+		ID: "r1", WorkflowID: "wf1", WorkflowName: "登录流程", Status: "running",
+		Title: "修复登录页跳转", Tags: []string{"login"},
+		Inputs:    map[string]any{"requirement": "修复登录页在移动端的跳转问题"},
+		CreatedAt: time.Now(),
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&models.Run{
+		ID: "r2", WorkflowID: "wf2", WorkflowName: "结算流程", Status: "running",
+		Title: "结算页", CreatedAt: time.Now(),
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	scope := TaskScope{ProjectID: "p1", UserID: SyntheticQQUserID("u1"), Channel: "qq", ConversationID: "c1"}
+	// The caller supplies nothing but the query; identities are derived lazily.
+	candidates, err := svc.Search(scope, "登录页")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candidates) != 1 || candidates[0].Identity.RunID != "r1" {
+		t.Fatalf("backfilled candidates = %+v", candidates)
+	}
+	got := candidates[0].Identity
+	if got.ShortTitle != "修复登录页跳转" {
+		t.Fatalf("derived short title = %q", got.ShortTitle)
+	}
+	if got.OriginalRequirement != "修复登录页在移动端的跳转问题" {
+		t.Fatalf("derived requirement = %q", got.OriginalRequirement)
+	}
+	if got.Status != "running" || len(got.Keywords) == 0 {
+		t.Fatalf("derived identity = %+v", got)
+	}
+
+	// A different project's Run is never exposed to this identity.
+	if others, err := svc.Search(scope, "结算页"); err != nil || len(others) != 0 {
+		t.Fatalf("cross-project leak: %+v err=%v", others, err)
+	}
+	// A different QQ identity in the same project must not see the task that
+	// already belongs to u1, and the scope conflict must not break resolution.
+	intruder := TaskScope{ProjectID: "p1", UserID: SyntheticQQUserID("u2"), Channel: "qq", ConversationID: "c9"}
+	res, err := svc.ResolveTask(ResolveTaskInput{Scope: intruder, Query: "修复登录页跳转"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Identity != nil {
+		t.Fatalf("another QQ identity saw a task it does not own: %+v", res.Identity)
+	}
+	var count int64
+	if err := db.Model(&models.TaskIdentity{}).Where("run_id = ?", "r1").Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("run r1 has %d identities; a Run belongs to one identity scope", count)
+	}
+}

--- a/server/internal/services/task_context_test.go
+++ b/server/internal/services/task_context_test.go
@@ -330,3 +330,30 @@ func TestEnsureIdentityForRunDerivesFieldsAndBackfillsScoped(t *testing.T) {
 		t.Fatalf("run r1 has %d identities; a Run has one project-scoped identity", count)
 	}
 }
+
+func TestIdentityForRunIsProjectScopedAndAbsenceIsNotAnError(t *testing.T) {
+	db := taskContextDB(t)
+	svc := NewTaskContextService(db)
+	ensureTask(t, svc, "r1", "p1", SyntheticQQUserID("u1"), "登录页")
+
+	got, err := svc.IdentityForRun("r1", "p1")
+	if err != nil || got == nil || got.UserID != SyntheticQQUserID("u1") {
+		t.Fatalf("identity for run = %+v err=%v", got, err)
+	}
+	// Another project must never see this Run's identity, and a miss is a
+	// nil identity rather than an error so callers can skip binding.
+	for _, miss := range []struct{ run, project string }{
+		{"r1", "p2"},
+		{"missing", "p1"},
+	} {
+		got, err := svc.IdentityForRun(miss.run, miss.project)
+		if err != nil || got != nil {
+			t.Fatalf("IdentityForRun(%q,%q) = %+v err=%v", miss.run, miss.project, got, err)
+		}
+	}
+	for _, bad := range []struct{ run, project string }{{"", "p1"}, {"r1", ""}} {
+		if _, err := svc.IdentityForRun(bad.run, bad.project); err == nil {
+			t.Fatalf("IdentityForRun(%q,%q) must reject empty scope", bad.run, bad.project)
+		}
+	}
+}

--- a/server/internal/services/task_context_test.go
+++ b/server/internal/services/task_context_test.go
@@ -239,7 +239,6 @@ func TestEnsureIdentityForRunDerivesFieldsAndBackfillsScoped(t *testing.T) {
 		t.Fatal(err)
 	}
 	svc := NewTaskContextService(db)
-	svc.EnableRunBackfill()
 
 	if err := db.Create(&models.WorkflowDef{ID: "wf1", ProjectID: "p1", Name: "登录流程"}).Error; err != nil {
 		t.Fatal(err)
@@ -263,13 +262,35 @@ func TestEnsureIdentityForRunDerivesFieldsAndBackfillsScoped(t *testing.T) {
 	}
 
 	scope := TaskScope{ProjectID: "p1", UserID: SyntheticQQUserID("u1"), Channel: "qq", ConversationID: "c1"}
-	// The caller supplies nothing but the query; identities are derived lazily.
+	// Search must not claim project Runs on behalf of the first caller.
 	candidates, err := svc.Search(scope, "登录页")
 	if err != nil {
 		t.Fatal(err)
 	}
+	if len(candidates) != 0 {
+		t.Fatalf("unclaimed run became visible: %+v", candidates)
+	}
+	var unclaimedCount int64
+	if err := db.Model(&models.TaskIdentity{}).Where("run_id = ?", "r1").Count(&unclaimedCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if unclaimedCount != 0 {
+		t.Fatalf("search claimed an unowned run: count=%d", unclaimedCount)
+	}
+
+	var run models.Run
+	if err := db.First(&run, "id = ?", "r1").Error; err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.EnsureIdentityForRun(run, "p1", scope.UserID); err != nil {
+		t.Fatal(err)
+	}
+	candidates, err = svc.Search(scope, "登录页")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(candidates) != 1 || candidates[0].Identity.RunID != "r1" {
-		t.Fatalf("backfilled candidates = %+v", candidates)
+		t.Fatalf("explicitly owned candidates = %+v", candidates)
 	}
 	got := candidates[0].Identity
 	if got.ShortTitle != "修复登录页跳转" {


### PR DESCRIPTION
## Summary
- enforce an explicit, fail-closed Sendable envelope before every QQ/external delivery; raw agent, tool, reasoning, unknown, and prompt-tagged output remain internal
- add run-scoped dedupe receipts, progress throttling, bounded retries, delivery audit, one-time run acceptance acknowledgements, and safe structured final handling
- persist task identities, bindings, 30-minute conversation focus, natural-language task resolution, QQ fallback, bilingual copy, and one-shot high-risk confirmations in SQLite

## Review fixes
- bind MCP risk tickets to the real QQ sender and make confirmed MCP retries read-only/idempotent
- bind natural-language approve/reject confirmations to the current pending gate node
- route MCP ACK/progress to the active QQ scene and conversation, with configured target only as fallback
- support generic exact short-title addressing without demo-specific keywords
- propagate real channel message IDs on successful outbound delivery and persist scoped MessageBindings; failures, missing IDs, missing RunIDs, and ownership mismatches do not create bindings
- return structured `sent=false` suppression outcomes for normal policy, dedupe, rate-limit, and merge decisions; only real delivery failures such as no target, transport failure, and retry exhaustion return errors
- route QQ oversized-attachment SafetyNotices through the Manager egress path so they share dedupe receipts, bounded retries, and ProjectAudit while retaining the adapter policy gate

## Demo acceptance
- 128 background events compress to 4 external messages (ACK, substantive progress, blocked, final), with no cross-run merging
- ambiguous “登录页” requests return natural short-title candidates; ordinal or full-title selection establishes focus
- risky actions echo the short title and require a five-minute, one-use confirmation ticket

## Test plan
- [x] `cd server && golangci-lint run --config ../.golangci.yml ./...`
- [x] `cd server && go vet ./...`
- [x] `cd server && go run ./cmd/gen-configdoc -out CONFIGURATION.md -check`
- [x] `cd server && go test ./...`
- [x] `cd server && ./scripts/cover-check-server.sh 90`
- [x] focused channels/QQ/pmmcp/services and production notifier seam regression tests
- [x] `cd server && go test ./internal/runtime/ -count=1 -run 'TestRunAgent|TestReact'`
- [x] `git diff --check`

## Scope
No Voice/TTS, external vector database, Issue #158 platform workflow changes, or unrelated refactor.

Made with [Cursor](https://cursor.com)