### PR TITLE
fix(ci): remove security workflow runtime warnings

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+          dependency-caching: false
       - name: Manual Go build (fallback when autobuild is skipped)
         if: matrix.build-mode == 'manual'
         env:
@@ -87,6 +88,6 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- upgrade `gitleaks/gitleaks-action` to v3 for the Node.js 24 runtime
- disable CodeQL dependency caching because Go modules live below the repository root

## Test plan
- [x] Run `git diff --check`
- [ ] Confirm the security workflow completes without the Node.js 20 and missing root `go.mod` warnings

Made with [Cursor](https://cursor.com)