### PR TITLE
fix: preserve QQ final answers after #157

### DIFF
--- a/server/internal/channels/bridge.go
+++ b/server/internal/channels/bridge.go
@@ -55,9 +55,9 @@ type ResolvedChannel struct {
 //
 // Text is the raw assistant output and is internal-only: it is persisted and
 // used for orchestration but must never reach an external channel. Only
-// FinalSummary — a structured, explicitly produced summary — is deliverable.
-// When FinalSummary is empty the Manager sends a fixed safe status notice
-// instead of leaking raw model output.
+// FinalSummary — a server-constructed, deliverable kind=final summary — may
+// leave the process. When FinalSummary is empty the Manager takes an
+// observable failure path instead of pretending the turn completed for the user.
 type Reply struct {
 	Text         string
 	FinalSummary string
@@ -184,7 +184,7 @@ func (b *ChannelBridge) Handle(ctx context.Context, rc ResolvedChannel, in Inbou
 	stripped, urls := splitImageURLs(text)
 	return Reply{
 		Text:         stripped,
-		FinalSummary: extractStructuredFinalSummary(stripped),
+		FinalSummary: buildDeliverableFinalSummary(stripped),
 		ImageURLs:    urls,
 	}, nil
 }
@@ -401,9 +401,20 @@ var (
 	finalSummaryMarkers = []string{"[摘要]", "【摘要】", "[最终]", "【最终】", "[Final]", "[Summary]"}
 )
 
+// buildDeliverableFinalSummary constructs the only text allowed into
+// Reply.FinalSummary. Marker lines ([摘要]/…) win; otherwise a constrained
+// conversational summary is derived from user-visible assistant lines.
+// Empty means the Manager must fail observably — never leak Reply.Text whole.
+func buildDeliverableFinalSummary(text string) string {
+	if summary := extractStructuredFinalSummary(text); summary != "" {
+		return summary
+	}
+	return constrainedConversationalSummary(text)
+}
+
 // extractStructuredFinalSummary pulls an orchestration-authored structured
-// summary line. Prompt markers alone never make raw narration sendable; only
-// this explicit extraction populates Reply.FinalSummary for the Manager gate.
+// summary line. Unmarked narration never becomes a FinalSummary here; the
+// conversational fallback lives in constrainedConversationalSummary.
 func extractStructuredFinalSummary(text string) string {
 	for _, line := range strings.Split(text, "\n") {
 		trimmed := strings.TrimSpace(line)
@@ -414,6 +425,54 @@ func extractStructuredFinalSummary(text string) string {
 		}
 	}
 	return ""
+}
+
+// constrainedConversationalSummary builds a short user-facing final from
+// assistant body text: drop tool/reasoning/progress-marker noise, then truncate.
+// It is still a server-owned summary, not a raw Reply.Text passthrough.
+func constrainedConversationalSummary(text string) string {
+	var keep []string
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || isFinalSummaryNoiseLine(trimmed) {
+			continue
+		}
+		keep = append(keep, trimmed)
+	}
+	joined := strings.TrimSpace(strings.Join(keep, "\n"))
+	if joined == "" {
+		return ""
+	}
+	return truncateRunes(joined, 240)
+}
+
+func isFinalSummaryNoiseLine(line string) bool {
+	if isProgressNoise(line) {
+		return true
+	}
+	for _, m := range progressMarkers {
+		if strings.HasPrefix(line, m.prefix) {
+			return true
+		}
+	}
+	for _, marker := range finalSummaryMarkers {
+		if strings.HasPrefix(line, marker) {
+			return true
+		}
+	}
+	lower := strings.ToLower(line)
+	switch {
+	case strings.HasPrefix(line, "内部推理"),
+		strings.HasPrefix(lower, "reasoning:"),
+		strings.HasPrefix(lower, "thinking:"):
+		return true
+	case strings.Contains(lower, "tool_call"),
+		strings.Contains(lower, "tool call"),
+		strings.Contains(lower, "function_call"),
+		strings.Contains(lower, "reasoning_delta"):
+		return true
+	}
+	return false
 }
 
 // splitImageURLs extracts shareable image URLs (markdown or bare) from an

--- a/server/internal/channels/delivery_test.go
+++ b/server/internal/channels/delivery_test.go
@@ -48,6 +48,8 @@ func TestFinalOnlySendsStructuredSummaryNeverRawAssistantText(t *testing.T) {
 	fa := &fakeAdapter{}
 	m := NewManager(nil, nil, nil)
 	m.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
+		// Stub bypasses bridge: empty FinalSummary must fail observably, never
+		// leak Reply.Text or the deprecated #157 safe-notice shell.
 		return Reply{Text: raw}, nil
 	}
 	m.dispatch(context.Background(), testRunningChannel(fa), testInbound("final-raw"))
@@ -57,9 +59,12 @@ func TestFinalOnlySendsStructuredSummaryNeverRawAssistantText(t *testing.T) {
 		if strings.Contains(text, "内部推理") || strings.Contains(text, "sk-secret") || strings.Contains(text, "提示词标签") {
 			t.Fatalf("raw assistant final leaked: %v", got)
 		}
+		if strings.Contains(text, deprecatedSafeFinalNotice) {
+			t.Fatalf("deprecated safe-notice fake completion must not be sent: %v", got)
+		}
 	}
-	if countText(got, safeFinalNotice) != 1 {
-		t.Fatalf("expected the safe notice when no structured summary exists, got %v", got)
+	if countText(got, finalSummaryMissingNotice) != 1 {
+		t.Fatalf("expected observable missing-summary failure notice, got %v", got)
 	}
 
 	fa2 := &fakeAdapter{}
@@ -76,6 +81,79 @@ func TestFinalOnlySendsStructuredSummaryNeverRawAssistantText(t *testing.T) {
 		if strings.Contains(text, "内部推理") {
 			t.Fatalf("raw text leaked alongside summary: %v", got2)
 		}
+	}
+}
+
+// TestNaturalLanguageQQFinalContainsAnswerNotShellNotice is the cross-layer
+// regression for ordinary QQ chat after #157: inbound NL → turn → FinalSummary
+// construction → Sendable policy → fake QQ adapter outbound must carry a real
+// answer, never only the Approving redirect shell.
+func TestNaturalLanguageQQFinalContainsAnswerNotShellNotice(t *testing.T) {
+	const userQ = "回的慢还不好"
+	const assistantBody = "tool_call read_config\n内部推理：先自评再答\n抱歉回复慢了，也认同质量需要改进。我们会优先排查延迟与答复质量。"
+	const wantAnswer = "抱歉回复慢了，也认同质量需要改进"
+
+	fa := &fakeAdapter{}
+	m, _ := policyManager(t, fa, nil)
+	// Mimic ChannelBridge.Handle: FinalSummary is server-built, Text stays internal.
+	m.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
+		return Reply{
+			Text:         assistantBody,
+			FinalSummary: buildDeliverableFinalSummary(assistantBody),
+		}, nil
+	}
+
+	rc := testRunningChannel(fa)
+	rc.cfg.Type = "qq"
+	m.dispatch(context.Background(), rc, testInboundText("nl-slow-bad", userQ))
+
+	got := sentTexts(fa)
+	if hasPrefixCount(got, ackProcessingPrefix) != 1 {
+		t.Fatalf("expected processing ACK, got %v", got)
+	}
+	foundAnswer := false
+	for _, text := range got {
+		if strings.Contains(text, deprecatedSafeFinalNotice) || strings.Contains(text, "本回合已结束") {
+			t.Fatalf("shell/fake-completion must not appear in QQ outbound: %v", got)
+		}
+		if strings.Contains(text, "tool_call") || strings.Contains(text, "内部推理") {
+			t.Fatalf("tool/reasoning must not reach QQ outbound: %v", got)
+		}
+		if strings.Contains(text, wantAnswer) {
+			foundAnswer = true
+		}
+	}
+	if !foundAnswer {
+		t.Fatalf("QQ outbound missing real answer %q; got %v", wantAnswer, got)
+	}
+
+	// Empty FinalSummary (noise-only body) → observable failure, not shell success.
+	faFail := &fakeAdapter{}
+	mFail, _ := policyManager(t, faFail, nil)
+	mFail.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
+		noise := "tool_call x\nthinking: y"
+		return Reply{Text: noise, FinalSummary: buildDeliverableFinalSummary(noise)}, nil
+	}
+	mFail.dispatch(context.Background(), testRunningChannel(faFail), testInboundText("nl-empty", userQ))
+	failGot := sentTexts(faFail)
+	if countText(failGot, finalSummaryMissingNotice) != 1 {
+		t.Fatalf("expected missing-summary failure notice, got %v", failGot)
+	}
+	for _, text := range failGot {
+		if strings.Contains(text, deprecatedSafeFinalNotice) {
+			t.Fatalf("failure path must not send deprecated shell: %v", failGot)
+		}
+	}
+	sawMissingReason := false
+	faFail.mu.Lock()
+	for _, out := range faFail.sent {
+		if out.Envelope.Reason == "final_summary_missing" && out.Envelope.Kind == sendable.KindBlocked {
+			sawMissingReason = true
+		}
+	}
+	faFail.mu.Unlock()
+	if !sawMissingReason {
+		t.Fatalf("expected KindBlocked with reason=final_summary_missing; outbound=%v", failGot)
 	}
 }
 

--- a/server/internal/channels/manager.go
+++ b/server/internal/channels/manager.go
@@ -430,14 +430,22 @@ func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMes
 		})
 		return
 	}
-	summary, reason := deliverableFinalText(reply)
-	images := reply.ImageURLs
-	if summary == safeFinalNotice {
-		images = nil // no structured summary → no derived attachments either
+	summary, reason, ok := deliverableFinalText(reply)
+	if !ok {
+		log.Warn().
+			Str("channel", rc.cfg.ID).
+			Str("reason", reason).
+			Msg("channel turn finished without deliverable FinalSummary")
+		m.sendOutbound(ctx, rc, OutboundMessage{
+			Scene: in.Scene, ConversationID: in.ConversationID,
+			ReplyToMessageID: in.MessageID, Text: summary,
+			Envelope: turnEnvelope(rc, in, sendable.KindBlocked, reason, sendable.PriorityCritical),
+		})
+		return
 	}
 	m.sendOutbound(ctx, rc, OutboundMessage{
 		Scene: in.Scene, ConversationID: in.ConversationID, ReplyToMessageID: in.MessageID,
-		Text: summary, ImageURLs: images,
+		Text: summary, ImageURLs: reply.ImageURLs,
 		Envelope: func() sendable.DeliveryEnvelope {
 			e := turnEnvelope(rc, in, sendable.KindFinal, reason, sendable.PriorityCritical)
 			e.Structured = true
@@ -446,18 +454,23 @@ func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMes
 	})
 }
 
-// safeFinalNotice is sent when Work produced no structured summary. Raw
-// assistant text is never used as a fallback.
-const safeFinalNotice = "本回合已结束，请在 Approving 查看完整结果。"
+// deprecatedSafeFinalNotice is the #157 fake-completion string. It must never
+// be sent as a successful turn final (kept only so regressions can assert absence).
+const deprecatedSafeFinalNotice = "本回合已结束，请在 Approving 查看完整结果。"
+
+// finalSummaryMissingNotice is the observable failure/fallback sent when Work
+// produced no deliverable FinalSummary. Raw assistant text is never used.
+const finalSummaryMissingNotice = "未能生成可外发答复，请稍后重试或在 Approving 查看详情。"
 
 // deliverableFinalText returns the only text allowed out of a finished turn:
-// the structured FinalSummary, or a fixed safe notice. Reply.Text stays
-// internal regardless of its content.
-func deliverableFinalText(reply Reply) (text, reason string) {
+// the structured FinalSummary. When empty, ok=false and text is an explicit
+// failure notice — never the deprecated "turn ended, check Approving" shell.
+// Reply.Text stays internal regardless of its content.
+func deliverableFinalText(reply Reply) (text, reason string, ok bool) {
 	if summary := strings.TrimSpace(reply.FinalSummary); summary != "" {
-		return truncateRunes(summary, 240), "structured_turn_final"
+		return truncateRunes(summary, 240), "structured_turn_final", true
 	}
-	return safeFinalNotice, "final_summary_missing_safe_notice"
+	return finalSummaryMissingNotice, "final_summary_missing", false
 }
 
 func (m *Manager) handleTurn(ctx context.Context, rc ResolvedChannel, in InboundMessage, onProgress func(ProgressEvent)) (Reply, error) {

--- a/server/internal/channels/orchestration_test.go
+++ b/server/internal/channels/orchestration_test.go
@@ -207,6 +207,34 @@ func TestExtractStructuredFinalSummary(t *testing.T) {
 		t.Fatalf("summary = %q", got)
 	}
 	if extractStructuredFinalSummary("只有普通正文") != "" {
-		t.Fatal("unmarked text must not become FinalSummary")
+		t.Fatal("unmarked text must not become FinalSummary via marker extraction alone")
+	}
+}
+
+func TestBuildDeliverableFinalSummaryConversationalFallback(t *testing.T) {
+	marked := buildDeliverableFinalSummary("内部推理：先想清楚\n[摘要] 已修好延迟\n其它")
+	if marked != "已修好延迟" {
+		t.Fatalf("marker path = %q", marked)
+	}
+
+	plain := buildDeliverableFinalSummary("抱歉回复慢了，也认同质量需要改进。我们会优先排查延迟与答复质量。")
+	if plain == "" || !strings.Contains(plain, "抱歉回复慢了") {
+		t.Fatalf("conversational fallback missing answer: %q", plain)
+	}
+	if plain == deprecatedSafeFinalNotice || strings.Contains(plain, "本回合已结束") {
+		t.Fatalf("fallback must not be shell notice: %q", plain)
+	}
+
+	noisy := buildDeliverableFinalSummary("tool_call foo\n内部推理：密钥 sk-secret\n[进度] 读文件中\n对用户可见的答复在这里")
+	if !strings.Contains(noisy, "对用户可见的答复在这里") {
+		t.Fatalf("expected user-visible line kept: %q", noisy)
+	}
+	if strings.Contains(noisy, "tool_call") || strings.Contains(noisy, "内部推理") ||
+		strings.Contains(noisy, "sk-secret") || strings.Contains(noisy, "读文件中") {
+		t.Fatalf("noise leaked into summary: %q", noisy)
+	}
+
+	if buildDeliverableFinalSummary("tool_call x\nthinking: y") != "" {
+		t.Fatal("noise-only body must yield empty FinalSummary")
 	}
 }


### PR DESCRIPTION
## Summary
- Build a constrained, user-visible `FinalSummary` for ordinary QQ conversations while preserving marked-summary precedence.
- Replace the empty-summary success shell with an observable blocked fallback (`final_summary_missing`).
- Keep the #157 sendability boundary intact so tool output, reasoning, and unsafe events remain internal.

Fixes the regression introduced around #157.

## Test plan
- [x] `go test ./internal/channels/ -count=1`
- [x] `go test ./internal/sendable/ -count=1`
- [x] NL→QQ adapter regression verifies the outbound message contains the answer and excludes the old shell notice and tool/reasoning noise.
- [ ] After deployment, validate the real QQ flow with a normal conversational prompt; live validation was unavailable in the sandbox because QQ credentials and a running bot were not present.

Made with [Cursor](https://cursor.com)