### PR TITLE
feat(channels): 把 QQ 交互改造成 Live 连续对话与异步任务委派

### DIFF
--- a/server/cmd/server/channel_notify.go
+++ b/server/cmd/server/channel_notify.go
@@ -26,6 +26,21 @@ func (n channelIMNotifier) NotifyRunAccepted(projectID, runID string, target pmm
 	return err
 }
 
+func (n channelIMNotifier) NotifyReply(projectID, runID string, target pmmcp.IMTarget, text, shortTitle string) (pmmcp.IMDeliveryOutcome, error) {
+	if n.mgr == nil {
+		return pmmcp.IMDeliveryOutcome{}, nil
+	}
+	result, err := n.mgr.DeliverConversationReply(context.Background(), channels.ConversationReply{
+		ProjectID: projectID, RunID: runID, Scene: channels.Scene(target.Scene),
+		ConversationID: target.ConversationID, UserID: target.UserID,
+		Text: text, ShortTitle: shortTitle,
+	})
+	if err != nil {
+		return pmmcp.IMDeliveryOutcome{}, err
+	}
+	return pmmcp.IMDeliveryOutcome{Sent: result.Sent, Reason: result.Reason()}, nil
+}
+
 func (n channelIMNotifier) NotifyProgress(projectID, runID string, target pmmcp.IMTarget, kind, text, stage, conclusion string, blocked, actionRequired bool) (pmmcp.IMDeliveryOutcome, error) {
 	if n.mgr == nil {
 		return pmmcp.IMDeliveryOutcome{}, nil

--- a/server/cmd/server/live_synthesizer.go
+++ b/server/cmd/server/live_synthesizer.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/cocofhu/approving/internal/channels"
+	"github.com/cocofhu/approving/internal/models"
+)
+
+// synthesisTimeout bounds a reflow synthesis turn. Nobody is waiting on a live
+// conversation for this, but a background event that has been pending for a
+// minute is stale, and the structured fallback is already good enough to send.
+const synthesisTimeout = 20 * time.Second
+
+// newLiveSynthesizer phrases a background event through the conversation's own
+// PM agent, so the result lands as part of that conversation rather than as a
+// notification about it. The agent already knows what was asked and what has
+// been said since; a template does not.
+//
+// Anything that goes wrong here degrades to the caller's structured fallback,
+// which is a complete message in its own right — synthesis improves how an
+// outcome reads, it is not what makes it deliverable.
+func newLiveSynthesizer(bridge *channels.ChannelBridge) channels.SynthesisFunc {
+	if bridge == nil {
+		return nil
+	}
+	return func(ctx context.Context, req channels.SynthesisRequest) (string, error) {
+		if strings.TrimSpace(req.Brief) == "" {
+			return "", errors.New("synthesis brief is empty")
+		}
+		turnCtx, cancel := context.WithTimeout(ctx, synthesisTimeout)
+		defer cancel()
+
+		// A synthetic inbound: same conversation, same thread, same agent, so
+		// the turn sees the history it needs. Progress is not forwarded —
+		// intermediate narration from a synthesis turn is not something the
+		// user asked to see. The agent's own pm_reply is captured by the
+		// Manager for the duration of this turn, so returning empty here is
+		// normal and does not mean synthesis failed.
+		reply, err := bridge.Handle(turnCtx, channels.ResolvedChannel{
+			Type: models.ChannelTypeQQ, ProjectID: req.ProjectID,
+			TurnTimeout: synthesisTimeout,
+		}, channels.InboundMessage{
+			Scene: req.Scene, ConversationID: req.ConversationID,
+			UserID: req.ExternalUserID, Text: req.Brief, Timestamp: time.Now(),
+		}, nil)
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(reply.FinalSummary), nil
+	}
+}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -389,9 +389,16 @@ func main() {
 		}
 	})
 	pmMCP.SetTaskSafety(riskSvc, taskContextSvc, channelIMNotifier{mgr: channelMgr})
+	// A finished task reports back to the conversation that asked for it, in
+	// that conversation's own words.
+	channelMgr.SetSynthesizer(newLiveSynthesizer(channelBridge))
+	eng.SetRunTerminalObserver(runTerminalAdapter{mgr: channelMgr})
 	channelMgr.SetLoader(channelSvc.ListRaw)
 	channelSvc.SetOnChange(channelMgr.Reload)
 	channelMgr.ApplyOnBoot()
+	// Turns that died with the previous process left users waiting on a reply
+	// that will never arrive; tell them so instead of failing silently.
+	go channelMgr.RecoverInterruptedTurns(sweeperCtx)
 	cronSched.SetChannelDeliverer(channelMgr)
 	runNotifySvc.SetDeliverer(channelMgr)
 	cronSched.Start(sweeperCtx)

--- a/server/cmd/server/run_terminal_adapter.go
+++ b/server/cmd/server/run_terminal_adapter.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+
+	"github.com/cocofhu/approving/internal/channels"
+	"github.com/cocofhu/approving/internal/engine"
+
+	"github.com/rs/zerolog/log"
+)
+
+// runTerminalAdapter brings a finished Run's outcome back to the conversation
+// that started it. It is separate from runNotifyEngineAdapter on purpose: that
+// one is the project-level "a run needs attention" push with its own policy and
+// templates, this one is a reply in an ongoing conversation.
+type runTerminalAdapter struct {
+	mgr *channels.Manager
+}
+
+func (a runTerminalAdapter) OnRunTerminal(ev engine.RunTerminalEvent) {
+	if a.mgr == nil {
+		return
+	}
+	err := a.mgr.ReflowTaskOutcome(context.Background(), channels.TaskOutcome{
+		ProjectID:     ev.ProjectID,
+		RunID:         ev.RunID,
+		Status:        ev.Status,
+		FailureReason: ev.FailureSummary,
+	})
+	if err != nil {
+		log.Warn().Err(err).Str("run", ev.RunID).Str("status", ev.Status).
+			Msg("task outcome did not reach its origin conversation")
+	}
+}

--- a/server/internal/channels/bridge.go
+++ b/server/internal/channels/bridge.go
@@ -44,11 +44,19 @@ type ChannelSessionContext struct {
 
 // ResolvedChannel is the per-turn channel context passed to the bridge.
 type ResolvedChannel struct {
-	ID          string
-	Type        string
-	ProjectID   string
-	TurnTimeout time.Duration // 0 → runner default
-	Caps        SessionCaps   // from latest ChannelConfig; applied each turn
+	ID        string
+	Type      string
+	ProjectID string
+	// OpenTimeout bounds getting a sandbox ready. It is separate from
+	// TurnTimeout because provisioning a container and thinking about a
+	// question are different kinds of waiting: charging cold start to the
+	// answer budget means the first message of a conversation can time out
+	// before the agent has read it. 0 → fold into TurnTimeout.
+	OpenTimeout time.Duration
+	// TurnTimeout bounds the agent's own work once the sandbox is ready.
+	// 0 → runner default.
+	TurnTimeout time.Duration
+	Caps        SessionCaps // from latest ChannelConfig; applied each turn
 }
 
 // Reply is the bridge's produced answer for one inbound message.
@@ -111,8 +119,18 @@ func (b *ChannelBridge) Handle(ctx context.Context, rc ResolvedChannel, in Inbou
 		ChannelType: rc.Type, Scene: in.Scene,
 		ConversationID: in.ConversationID, ExternalUserID: in.UserID,
 	}
+	// Getting the sandbox up runs on its own clock. A warm conversation passes
+	// through here in milliseconds; the first message of a conversation waits
+	// for a container, and that wait must not be deducted from the time the
+	// agent gets to answer.
+	openCtx, closeOpen := ctx, context.CancelFunc(func() {})
+	if rc.OpenTimeout > 0 {
+		openCtx, closeOpen = context.WithTimeout(ctx, rc.OpenTimeout)
+	}
+	defer closeOpen()
+
 	token, specs := b.hooks.Register(rc.ProjectID, thread.ID, userID, agent, channelCtx, binding.EnabledMcps, rc.Caps)
-	row, reused, err := b.sbx.OpenAgentSandbox(ctx, services.AgentSandboxOpenOpts{
+	row, reused, err := b.sbx.OpenAgentSandbox(openCtx, services.AgentSandboxOpenOpts{
 		Profile:       agent,
 		ProjectID:     rc.ProjectID,
 		ThreadID:      thread.ID,
@@ -141,9 +159,10 @@ func (b *ChannelBridge) Handle(ctx context.Context, rc ResolvedChannel, in Inbou
 			Msg("channel bind sandbox failed")
 	}
 
-	if _, err := b.waitReady(ctx, row.ID); err != nil {
+	if _, err := b.waitReady(openCtx, row.ID); err != nil {
 		return Reply{}, err
 	}
+	closeOpen()
 
 	images := toPromptImages(in.Images)
 	userText := formatChannelUserText(in, len(images) > 0)

--- a/server/internal/channels/bridge.go
+++ b/server/internal/channels/bridge.go
@@ -218,10 +218,34 @@ func (b *ChannelBridge) forwardProgress(ctx context.Context, threadID string, on
 	defer unsub()
 
 	acc := newProgressAccumulator()
+	sentAnything := false
 	emit := func(events []ProgressEvent) {
 		for _, pe := range events {
+			sentAnything = true
 			onProgress(pe)
 		}
+	}
+	started := time.Now()
+	openerSent := false
+	// Say something real while a slow turn is still thinking. This only fires
+	// after firstSentenceDelay, so a turn that answers quickly still produces
+	// exactly one message — the answer. Past that point the alternative is
+	// silence, and a substantive opening sentence beats both silence and a
+	// content-free "working on it".
+	maybeOpener := func() {
+		if openerSent || sentAnything || time.Since(started) < firstSentenceDelay {
+			return
+		}
+		sentence, ok := acc.FirstCompleteSentence()
+		if !ok {
+			return
+		}
+		openerSent = true
+		sentAnything = true
+		onProgress(ProgressEvent{
+			Kind: ProgressMilestone, Summary: sentence, Stage: sentence,
+			Sendable: true, Reason: "live_first_sentence", At: time.Now(),
+		})
 	}
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
@@ -234,6 +258,7 @@ func (b *ChannelBridge) forwardProgress(ctx context.Context, threadID string, on
 			if _, _, partial, _, _ := b.turns.Status(threadID); partial != "" {
 				emit(acc.FeedSnapshot(partial))
 			}
+			maybeOpener()
 		case ev, open := <-ch:
 			if !open {
 				return
@@ -246,6 +271,7 @@ func (b *ChannelBridge) forwardProgress(ctx context.Context, threadID string, on
 				continue // tool / non-message frames suppressed
 			}
 			emit(acc.Feed(delta))
+			maybeOpener()
 		}
 	}
 }

--- a/server/internal/channels/capabilities.go
+++ b/server/internal/channels/capabilities.go
@@ -40,13 +40,18 @@ func QQReplyFallback(currentMessage, recentLanguage string) string {
 	return "当前 QQ 会话不支持引用回复，请按序号或短标题选择任务。"
 }
 
-// FormatTaskMessage applies the stable user-facing task/type prefix.
+// FormatTaskMessage names the task a message is about. Use it only when the
+// name carries information — several tasks are live, or the user named this one
+// — because a reference attached to every line reads like a ticket queue.
 func FormatTaskMessage(shortTitle, kind, body, currentMessage, recentLanguage string) string {
 	language := services.DetectLanguage(currentMessage, recentLanguage)
-	prefix := services.FormatTaskType(shortTitle, kind, language)
 	body = strings.TrimSpace(body)
 	if body == "" {
-		return prefix
+		return services.TaskStatusSentence(shortTitle, kind, language)
 	}
-	return prefix + " " + body
+	prefix := services.FormatTaskType(shortTitle, kind, language)
+	if prefix == "" {
+		return body
+	}
+	return prefix + body
 }

--- a/server/internal/channels/capabilities_test.go
+++ b/server/internal/channels/capabilities_test.go
@@ -17,10 +17,19 @@ func TestQQReplyCapabilityFallbackAndBilingualFormatting(t *testing.T) {
 	if !strings.Contains(en, "unavailable") || !strings.Contains(en, "number") {
 		t.Fatalf("en fallback=%q", en)
 	}
-	if got := FormatTaskMessage("登录页", "阻塞", "需要权限", "继续", ""); got != "【登录页｜阻塞】 需要权限" {
+	// Naming the task reads as a reference in a sentence, not as a ticket header.
+	if got := FormatTaskMessage("登录页", "阻塞", "需要权限", "继续", ""); got != "登录页那个：需要权限" {
 		t.Fatalf("zh task message=%q", got)
 	}
-	if got := FormatTaskMessage("Login", "Blocked", "Need access", "continue", ""); got != "【Login｜Blocked】 Need access" {
+	if got := FormatTaskMessage("Login", "Blocked", "Need access", "continue", ""); got != "On \"Login\" — Need access" {
 		t.Fatalf("en task message=%q", got)
+	}
+	for _, got := range []string{
+		FormatTaskMessage("登录页", "阻塞", "需要权限", "继续", ""),
+		FormatTaskMessage("Login", "Blocked", "Need access", "continue", ""),
+	} {
+		if strings.ContainsAny(got, "【｜】") {
+			t.Fatalf("task message still wears a ticket header: %q", got)
+		}
 	}
 }

--- a/server/internal/channels/channels_test.go
+++ b/server/internal/channels/channels_test.go
@@ -310,16 +310,6 @@ func testInboundText(id, text string) InboundMessage {
 	return in
 }
 
-func hasPrefixCount(ss []string, prefix string) int {
-	n := 0
-	for _, s := range ss {
-		if strings.HasPrefix(s, prefix) {
-			n++
-		}
-	}
-	return n
-}
-
 func sentTexts(fa *fakeAdapter) []string {
 	fa.mu.Lock()
 	defer fa.mu.Unlock()
@@ -359,63 +349,65 @@ func TestDispatchPassesSessionCapsFromConfig(t *testing.T) {
 	}
 }
 
-func TestDispatchImmediateAckWithSummary(t *testing.T) {
-	// plan g1.1: ≤1s ACK with ~40-rune original summary; short turns still ACK.
-	fa := &fakeAdapter{}
-	m := NewManager(nil, nil, nil)
-	m.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
-		return Reply{FinalSummary: "final-ok"}, nil
-	}
-	long := strings.Repeat("处理下PR与相关检查项", 5) // >40 runes
-	m.dispatch(context.Background(), testRunningChannel(fa), testInboundText("m1", long))
-	got := sentTexts(fa)
-	if len(got) != 2 {
-		t.Fatalf("sends = %v want [ack, final]", got)
-	}
-	if !strings.HasPrefix(got[0], ackProcessingPrefix) {
-		t.Fatalf("ack = %q want prefix %q", got[0], ackProcessingPrefix)
-	}
-	summary := strings.TrimPrefix(got[0], ackProcessingPrefix)
-	if utf8.RuneCountInString(summary) > ackSummaryRunes+1 { // +1 for ellipsis
-		t.Fatalf("summary rune count = %d want <= %d+ellipsis", utf8.RuneCountInString(summary), ackSummaryRunes)
-	}
-	if got[1] != "final-ok" {
-		t.Fatalf("final = %q", got[1])
-	}
-}
-
-func TestDispatchSuccessAckThenFinal(t *testing.T) {
+// One user message produces one bot message. The reply is the acknowledgement;
+// a separate "received, working on it" only pushes the answer further down the
+// screen.
+func TestDispatchAnswersOnceWithNoAcknowledgement(t *testing.T) {
 	fa := &fakeAdapter{}
 	m := NewManager(nil, nil, nil)
 	m.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
 		time.Sleep(30 * time.Millisecond)
-		return Reply{FinalSummary: "final-ok"}, nil
+		return Reply{FinalSummary: "首屏从 3.2s 降到 1.1s"}, nil
 	}
 	m.dispatch(context.Background(), testRunningChannel(fa), testInbound("m2"))
 	got := sentTexts(fa)
-	wantAck := processingAckText("hello")
-	if len(got) != 2 || got[0] != wantAck || got[1] != "final-ok" {
-		t.Fatalf("success sends = %v want [%q final-ok]", got, wantAck)
+	if len(got) != 1 || got[0] != "首屏从 3.2s 降到 1.1s" {
+		t.Fatalf("sends = %v want exactly the answer", got)
 	}
 }
 
-func TestDispatchFailureAckThenFailPrefix(t *testing.T) {
+// An internal error is never quoted back at the user; they get a cause they can
+// act on instead.
+func TestDispatchFailureExplainsInUserTerms(t *testing.T) {
 	fa := &fakeAdapter{}
 	m := NewManager(nil, nil, nil)
 	m.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
-		return Reply{}, errors.New("沙箱未就绪")
+		return Reply{}, errors.New("assistant produced no reply")
 	}
 	m.dispatch(context.Background(), testRunningChannel(fa), testInbound("m3"))
 	got := sentTexts(fa)
-	wantAck := processingAckText("hello")
-	wantFail := failReplyPrefix + "沙箱未就绪"
-	if len(got) != 2 || got[0] != wantAck || got[1] != wantFail {
-		t.Fatalf("failure sends = %v want [%q %q]", got, wantAck, wantFail)
+	if len(got) != 1 {
+		t.Fatalf("failure sends = %v want exactly one message", got)
+	}
+	if strings.Contains(got[0], "assistant produced no reply") {
+		t.Fatalf("internal error text leaked to the user: %q", got[0])
+	}
+	if ContainsInternalTerms(got[0]) {
+		t.Fatalf("failure message exposes internals: %q", got[0])
 	}
 }
 
-func TestDispatchBusyEnqueuePerMessageAckAndDequeueAck(t *testing.T) {
-	// plan g1.2: every queued msg gets queue ACK with ahead count; dequeue ACK.
+// A turn that produced nothing sendable must not emit a placeholder telling the
+// user to go look elsewhere.
+func TestDispatchMissingSummaryFallsBackWithoutPlaceholder(t *testing.T) {
+	fa := &fakeAdapter{}
+	m := NewManager(nil, nil, nil)
+	m.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
+		return Reply{Text: "内部推理，不应外发"}, nil
+	}
+	m.dispatch(context.Background(), testRunningChannel(fa), testInbound("m4"))
+	got := sentTexts(fa)
+	if len(got) != 1 {
+		t.Fatalf("sends = %v want one fallback message", got)
+	}
+	if strings.Contains(got[0], "Approving") || strings.Contains(got[0], "内部推理") {
+		t.Fatalf("fallback leaked raw output or punted to another surface: %q", got[0])
+	}
+}
+
+// Queueing is invisible: messages that arrive during a turn wait their turn and
+// are answered, with no queue-position narration.
+func TestDispatchBusyQueuesSilentlyAndAnswersInOrder(t *testing.T) {
 	fa := &fakeAdapter{}
 	m := NewManager(nil, nil, nil)
 	started := make(chan struct{})
@@ -437,14 +429,8 @@ func TestDispatchBusyEnqueuePerMessageAckAndDequeueAck(t *testing.T) {
 	<-done
 
 	got := sentTexts(fa)
-	if hasPrefixCount(got, ackProcessingPrefix) < 3 {
-		t.Fatalf("expected processing ACK for idle + each dequeue, got %v", got)
-	}
-	if countText(got, queueAckTextFor(1, "hello")) != 1 {
-		t.Fatalf("expected queue ACK ahead=1 with summary, got %v", got)
-	}
-	if countText(got, queueAckTextFor(2, "hello")) != 1 {
-		t.Fatalf("expected queue ACK ahead=2 with summary, got %v", got)
+	if len(got) != 3 {
+		t.Fatalf("sends = %v want one answer per message and nothing else", got)
 	}
 	if countText(got, "final-m5a") != 1 || countText(got, "final-m5b") != 1 || countText(got, "final-m5c") != 1 {
 		t.Fatalf("missing finals in %v", got)
@@ -510,14 +496,8 @@ func TestDispatchFIFOOrderMultipleQueued(t *testing.T) {
 		t.Fatalf("handle order = %v want %v", gotOrder, wantOrder)
 	}
 	got := sentTexts(fa)
-	queueAcks := 0
-	for _, s := range got {
-		if strings.HasPrefix(s, queueAckPrefix) {
-			queueAcks++
-		}
-	}
-	if queueAcks != 3 {
-		t.Fatalf("queue ACK count = %d want 3 in %v", queueAcks, got)
+	if len(got) != len(wantOrder) {
+		t.Fatalf("sends = %v want one answer per message, no queue narration", got)
 	}
 	for _, id := range wantOrder {
 		if countText(got, "final-"+id) != 1 {
@@ -527,7 +507,7 @@ func TestDispatchFIFOOrderMultipleQueued(t *testing.T) {
 }
 
 func TestDispatchQueueFullVisibleReject(t *testing.T) {
-	// depth 16 pending; next inbound gets queueFullText, not silent drop.
+	// depth 16 pending; the next inbound is dropped but never silently.
 	fa := &fakeAdapter{}
 	m := NewManager(nil, nil, nil)
 	gate := make(chan struct{})
@@ -554,8 +534,8 @@ func TestDispatchQueueFullVisibleReject(t *testing.T) {
 	<-done
 
 	got := sentTexts(fa)
-	if countText(got, queueFullText) != 1 {
-		t.Fatalf("full-queue sends = %v want exactly one %q", got, queueFullText)
+	if countText(got, busyHintText) != 1 {
+		t.Fatalf("full-queue sends = %v want exactly one %q", got, busyHintText)
 	}
 	if countText(got, "final-overflow") != 0 {
 		t.Fatalf("overflow message must not be processed, got %v", got)
@@ -565,8 +545,9 @@ func TestDispatchQueueFullVisibleReject(t *testing.T) {
 	}
 }
 
-func TestDispatchPerMessageQueueAckAcrossBusyCycles(t *testing.T) {
-	// Each enqueued message gets its own queue ACK (no throttle).
+// Across repeated busy cycles the conversation stays one-in one-out: five user
+// messages, five answers, nothing else.
+func TestDispatchOneReplyPerMessageAcrossBusyCycles(t *testing.T) {
 	fa := &fakeAdapter{}
 	m := NewManager(nil, nil, nil)
 	rc := testRunningChannel(fa)
@@ -592,15 +573,8 @@ func TestDispatchPerMessageQueueAckAcrossBusyCycles(t *testing.T) {
 	close(release1)
 	<-done1
 
-	got1 := sentTexts(fa)
-	q1 := 0
-	for _, s := range got1 {
-		if strings.HasPrefix(s, queueAckPrefix) {
-			q1++
-		}
-	}
-	if q1 != 2 {
-		t.Fatalf("first busy cycle queue ACK count = %d want 2 in %v", q1, got1)
+	if got := sentTexts(fa); len(got) != 3 {
+		t.Fatalf("first busy cycle sends = %v want exactly 3 answers", got)
 	}
 
 	release2 := make(chan struct{})
@@ -623,15 +597,14 @@ func TestDispatchPerMessageQueueAckAcrossBusyCycles(t *testing.T) {
 	close(release2)
 	<-done2
 
-	got2 := sentTexts(fa)
-	q2 := 0
-	for _, s := range got2 {
-		if strings.HasPrefix(s, queueAckPrefix) {
-			q2++
-		}
+	got := sentTexts(fa)
+	if len(got) != 5 {
+		t.Fatalf("sends = %v want exactly 5 answers for 5 messages", got)
 	}
-	if q2 != 3 {
-		t.Fatalf("after second busy cycle queue ACK total = %d want 3 in %v", q2, got2)
+	for _, id := range []string{"p0", "p1", "p2", "p3", "p4"} {
+		if countText(got, "final-"+id) != 1 {
+			t.Fatalf("missing exactly one answer for %s in %v", id, got)
+		}
 	}
 }
 
@@ -660,7 +633,7 @@ func TestDispatchFailureContinuesDrain(t *testing.T) {
 	<-done
 
 	got := sentTexts(fa)
-	if countText(got, failReplyPrefix+"boom") != 1 {
+	if countText(got, turnFailureText(errors.New("boom"))) != 1 {
 		t.Fatalf("expected failure reply in %v", got)
 	}
 	if countText(got, "final-after-fail") != 1 {
@@ -722,7 +695,7 @@ func TestDispatchCrossConversationIndependent(t *testing.T) {
 	}
 }
 
-func TestDispatchIdleSingleImmediateAckNoQueueAck(t *testing.T) {
+func TestDispatchIdleSendsOnlyTheAnswer(t *testing.T) {
 	fa := &fakeAdapter{}
 	m := NewManager(nil, nil, nil)
 	m.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
@@ -731,32 +704,33 @@ func TestDispatchIdleSingleImmediateAckNoQueueAck(t *testing.T) {
 	}
 	m.dispatch(context.Background(), testRunningChannel(fa), testInbound("idle-1"))
 	got := sentTexts(fa)
-	for _, s := range got {
-		if strings.HasPrefix(s, queueAckPrefix) {
-			t.Fatalf("idle path must not send queue ACK, got %v", got)
-		}
-	}
-	wantAck := processingAckText("hello")
-	if len(got) != 2 || got[0] != wantAck || got[1] != "final-ok" {
-		t.Fatalf("idle ACK path sends = %v want [%q final-ok]", got, wantAck)
+	if len(got) != 1 || got[0] != "final-ok" {
+		t.Fatalf("idle path sends = %v want [final-ok]", got)
 	}
 }
 
-func TestFriendlyErrRuneTruncation(t *testing.T) {
-	long := strings.Repeat("错", 250)
-	got := friendlyErr(errors.New(long))
-	if !utf8.ValidString(got) {
-		t.Fatal("friendlyErr produced invalid UTF-8")
-	}
-	runes := []rune(got)
-	// 200 runes + ellipsis
-	if len(runes) != 201 || string(runes[:200]) != strings.Repeat("错", 200) || runes[200] != '…' {
-		t.Fatalf("friendlyErr truncation = %q (rune len %d)", got, len(runes))
-	}
-	// Fail prefix composition stays short and stack-free.
-	full := failReplyPrefix + got
-	if !strings.HasPrefix(full, failReplyPrefix) || strings.Contains(full, "goroutine") {
-		t.Fatalf("fail reply unexpected: %q", full)
+// Whatever an internal error says, the user gets a short, actionable sentence
+// with no stack, no internals and no raw error text.
+func TestTurnFailureTextIsUserFacing(t *testing.T) {
+	for _, err := range []error{
+		errors.New(strings.Repeat("错", 250)),
+		errors.New("assistant produced no reply"),
+		errors.New("context deadline exceeded"),
+		errors.New("goroutine 1 [running]: sandbox boom"),
+	} {
+		got := turnFailureText(err)
+		if !utf8.ValidString(got) || strings.TrimSpace(got) == "" {
+			t.Fatalf("turnFailureText(%v) = %q", err, got)
+		}
+		if utf8.RuneCountInString(got) > 80 {
+			t.Fatalf("failure text is too long to read in chat: %q", got)
+		}
+		if strings.Contains(got, "goroutine") || ContainsInternalTerms(got) {
+			t.Fatalf("failure text exposes internals: %q", got)
+		}
+		if strings.Contains(got, err.Error()) {
+			t.Fatalf("failure text quotes the raw error: %q", got)
+		}
 	}
 }
 
@@ -922,10 +896,11 @@ func TestDispatchForwardsOnlyExplicitlySendableProgress(t *testing.T) {
 	}
 	m.dispatch(context.Background(), testRunningChannel(fa), testInbound("prog-1"))
 	got := sentTexts(fa)
-	if countText(got, "进度：已提交分支") != 1 {
+	// A milestone is stated plainly; only a blocker is worth flagging as one.
+	if countText(got, "已提交分支") != 1 {
 		t.Fatalf("missing sendable milestone in %v", got)
 	}
-	if countText(got, "阻塞：CI 红了") != 1 {
+	if countText(got, "卡住了：CI 红了") != 1 {
 		t.Fatalf("missing structured blocker in %v", got)
 	}
 	if countText(got, "final-ok") != 1 {
@@ -1337,11 +1312,19 @@ func TestPushQueueProtectsRunNotify(t *testing.T) {
 	}
 }
 
-func TestChannelPreambleRequiresProgressMarkers(t *testing.T) {
+// The preamble is the only thing telling the agent how a Live turn ends, so it
+// has to name both endings, say that long work goes to the background, and rule
+// out the ticket phrasing this work removed.
+func TestChannelPreambleStatesTheLiveTurnContract(t *testing.T) {
 	p := ChannelPreamble("qq")
-	for _, marker := range []string{"[进度]", "[阻塞]", "[确认]"} {
-		if !strings.Contains(p, marker) {
-			t.Fatalf("preamble missing %s: %s", marker, p)
+	for _, required := range []string{"pm_reply", "pm_start_run", "pm_notify_progress"} {
+		if !strings.Contains(p, required) {
+			t.Fatalf("preamble never mentions %s: %s", required, p)
+		}
+	}
+	for _, banned := range []string{"收到，正在处理", "本回合已结束", "请前往 Approving 查看"} {
+		if !strings.Contains(p, banned) {
+			t.Fatalf("preamble does not forbid %q: %s", banned, p)
 		}
 	}
 }

--- a/server/internal/channels/copy_guard.go
+++ b/server/internal/channels/copy_guard.go
@@ -1,0 +1,145 @@
+package channels
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Everything in this file exists for one reason: a user reading a QQ message
+// should never have to know that Approving has Runs, sandboxes, turns or an ACP
+// transport. Those words are how the platform talks to itself. The web client
+// already enforces the same rule for its copy (see userFacingCopy.test.ts); this
+// is the equivalent gate for the channel egress, applied at runtime rather than
+// only in tests because outbound text is partly composed by a model.
+
+// identifierToken matches anything shaped like a run or task id. Matching the
+// shape rather than a fixed alphabet matters: ids are uuid-derived today, but a
+// guard that only knows today's alphabet stops guarding the moment that
+// changes.
+var identifierToken = regexp.MustCompile(`(?i)\b(?:run|task)[-_ ]?#?[0-9a-z]{4,}\b`)
+
+// internalIDPatterns match identifier spellings that are unambiguous on their
+// own, without the digit test isIdentifier applies.
+var internalIDPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\brun\s+id\s*[:：]?\s*[0-9a-z-]{4,}\b`),
+}
+
+// isIdentifier separates "run-1ca1876f" from "run-optimization": a generated id
+// carries a digit, an English phrase usually does not. Erring toward keeping
+// real words is deliberate — deleting a word out of a sentence is a worse
+// outcome than leaving one that merely looks technical.
+func isIdentifier(token string) bool {
+	for _, r := range token {
+		if r >= '0' && r <= '9' {
+			return true
+		}
+	}
+	return false
+}
+
+// internalTermReplacements rewrite platform vocabulary into plain language
+// rather than deleting it, because a sentence with a hole in it reads worse than
+// the jargon did.
+var internalTermReplacements = []struct {
+	pattern *regexp.Regexp
+	with    string
+}{
+	{regexp.MustCompile(`(?i)\bassistant produced no reply\b`), "暂时没有结论"},
+	{regexp.MustCompile(`(?i)\bnode_complete\b`), "阶段完成"},
+	{regexp.MustCompile(`(?i)\bsuppressed\b`), "已合并"},
+	{regexp.MustCompile(`(?i)\bsendable\b`), "消息"},
+	{regexp.MustCompile(`(?i)\bsandbox\b`), "执行环境"},
+	{regexp.MustCompile(`沙箱`), "执行环境"},
+	{regexp.MustCompile(`(?i)\bacp\b`), "执行环境"},
+	{regexp.MustCompile(`(?i)\bworkflow\s+run\b`), "任务"},
+	{regexp.MustCompile(`(?i)\bthis turn\b`), "这一轮"},
+	{regexp.MustCompile(`本回合`), "这一轮"},
+}
+
+// internalMarkerLines are whole lines of machine scaffolding: streaming markers
+// and tool traces that were never meant to be read.
+var internalMarkerLines = regexp.MustCompile(`(?m)^\s*(\[(摘要|进度|里程碑|阻塞|确认|需确认|失败)\]|【(摘要|进度|里程碑|阻塞|确认|需确认|失败)】)\s*`)
+
+var toolNoiseLine = regexp.MustCompile(`(?im)^\s*(tool_call|function_call|tool result|reasoning_delta|input_tokens|output_tokens)\b.*$`)
+
+// ScrubInternalTerms makes outbound text safe to show a user: internal
+// identifiers are removed, platform vocabulary is rewritten in plain language,
+// and machine scaffolding lines are dropped. It is deliberately applied to every
+// egress path rather than trusted to the composer, because part of that text
+// comes from a model.
+func ScrubInternalTerms(text string) string {
+	out := strings.TrimSpace(text)
+	if out == "" {
+		return ""
+	}
+	original := out
+	out = toolNoiseLine.ReplaceAllString(out, "")
+	out = internalMarkerLines.ReplaceAllString(out, "")
+	out = identifierToken.ReplaceAllStringFunc(out, func(token string) string {
+		if isIdentifier(token) {
+			return ""
+		}
+		return token
+	})
+	for _, p := range internalIDPatterns {
+		out = p.ReplaceAllString(out, "")
+	}
+	for _, r := range internalTermReplacements {
+		out = r.pattern.ReplaceAllString(out, r.with)
+	}
+	return tidyWhitespace(out, out != original)
+}
+
+// ContainsInternalTerms reports whether text still exposes platform internals.
+// Used by tests and by delivery logging to catch regressions at the source.
+func ContainsInternalTerms(text string) bool {
+	for _, token := range identifierToken.FindAllString(text, -1) {
+		if isIdentifier(token) {
+			return true
+		}
+	}
+	for _, p := range internalIDPatterns {
+		if p.MatchString(text) {
+			return true
+		}
+	}
+	for _, r := range internalTermReplacements {
+		if r.pattern.MatchString(text) {
+			return true
+		}
+	}
+	return internalMarkerLines.MatchString(text) || toolNoiseLine.MatchString(text)
+}
+
+// cjkGap matches a space between two Han characters. Chinese does not space its
+// characters, so one appearing there is a hole left by a substitution.
+var cjkGap = regexp.MustCompile(`(\p{Han})[ \t]+(\p{Han})`)
+
+// tidyWhitespace collapses the gaps scrubbing leaves behind so the result reads
+// like it was written that way. changed says whether anything was actually
+// removed; when nothing was, the author's own spacing is left alone.
+func tidyWhitespace(text string, changed bool) string {
+	if changed {
+		// Twice: overlapping matches ("字 X 字" leaves "字 字" on the first pass).
+		text = cjkGap.ReplaceAllString(text, "$1$2")
+		text = cjkGap.ReplaceAllString(text, "$1$2")
+	}
+	lines := strings.Split(text, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		for strings.Contains(line, "  ") {
+			line = strings.ReplaceAll(line, "  ", " ")
+		}
+		// Scrubbing an id out of 「取消 run-1ca 吧」 leaves a space before the
+		// punctuation that follows it.
+		for _, punct := range []string{"，", "。", "：", "、", "；", "！", "？"} {
+			line = strings.ReplaceAll(line, " "+punct, punct)
+		}
+		line = strings.TrimSpace(line)
+		if line == "" && (len(kept) == 0 || kept[len(kept)-1] == "") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.TrimSpace(strings.Join(kept, "\n"))
+}

--- a/server/internal/channels/copy_guard.go
+++ b/server/internal/channels/copy_guard.go
@@ -12,15 +12,19 @@ import (
 // is the equivalent gate for the channel egress, applied at runtime rather than
 // only in tests because outbound text is partly composed by a model.
 
-// identifierToken matches anything shaped like a run or task id. Matching the
-// shape rather than a fixed alphabet matters: ids are uuid-derived today, but a
-// guard that only knows today's alphabet stops guarding the moment that
-// changes.
-var identifierToken = regexp.MustCompile(`(?i)\b(?:run|task)[-_ ]?#?[0-9a-z]{4,}\b`)
+// identifierToken matches anything shaped like a run or task id. It matches the
+// shape rather than a fixed alphabet on purpose: ids are uuid-derived today, so
+// a guard that only knows hex would stop guarding the moment that changes.
+//
+// The separator must be "-" or "_", which is how an id is always written. An
+// earlier version also accepted a space, and that swallowed ordinary prose:
+// "we run 5000 iterations" matched as a whole and left " iterations" behind.
+var identifierToken = regexp.MustCompile(`(?i)\b(?:run|task)[-_][0-9a-z]{4,}\b`)
 
 // internalIDPatterns match identifier spellings that are unambiguous on their
 // own, without the digit test isIdentifier applies.
 var internalIDPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\brun\s*#\s*[0-9a-z]{4,}\b`),
 	regexp.MustCompile(`(?i)\brun\s+id\s*[:：]?\s*[0-9a-z-]{4,}\b`),
 }
 

--- a/server/internal/channels/delivery.go
+++ b/server/internal/channels/delivery.go
@@ -133,6 +133,67 @@ func (m *Manager) DeliverSendable(ctx context.Context, req SendableRequest) (Del
 	return result, nil
 }
 
+// ConversationReply is an answer the agent explicitly submitted for the current
+// conversation turn.
+type ConversationReply struct {
+	ProjectID      string
+	RunID          string
+	Scene          Scene
+	ConversationID string
+	UserID         string
+	Text           string
+	ShortTitle     string
+}
+
+// DeliverConversationReply sends the agent's answer and records that this turn
+// has been answered, so the turn's own wrap-up does not append a second message.
+// This is the single egress for conversational answers: the model's raw output
+// is never forwarded, which keeps reasoning and tool chatter inside the
+// platform without needing to scrape a summary out of the transcript.
+func (m *Manager) DeliverConversationReply(ctx context.Context, reply ConversationReply) (DeliveryResult, error) {
+	text := ScrubInternalTerms(reply.Text)
+	if text == "" {
+		return DeliveryResult{}, errors.New("conversation reply text is empty")
+	}
+	scene := reply.Scene
+	if scene == "" {
+		scene = SceneC2C
+	}
+	// A synthesis turn borrows this conversation's agent to phrase a background
+	// event. Its answer belongs to the reflow that asked for it, which delivers
+	// it once with the right dedupe key, so it is collected here rather than
+	// sent from under the agent.
+	if m.captureReply(reply.ProjectID, scene, reply.ConversationID, text) {
+		return DeliveryResult{Decision: sendable.Decision{Reason: "captured_for_reflow"}}, nil
+	}
+	// Most conversational answers belong to no Run at all — chat, an
+	// explanation, a clarifying question — so the delivery scope falls back to
+	// the conversation itself. Without it the answer carries no scope and the
+	// policy drops it, which would silently mute ordinary conversation.
+	scope := strings.TrimSpace(reply.ShortTitle)
+	if scope == "" && strings.TrimSpace(reply.RunID) == "" {
+		scope = conversationTurnScope(reply.ProjectID, scene, reply.ConversationID)
+	}
+	result, err := m.DeliverSendable(ctx, SendableRequest{
+		ProjectID: reply.ProjectID, Scene: scene, ConversationID: reply.ConversationID,
+		UserID: reply.UserID, RunID: strings.TrimSpace(reply.RunID),
+		TaskContext: scope,
+		Kind:        sendable.KindFinal, Reason: "pm_reply",
+		Priority: sendable.PriorityCritical,
+		// No explicit dedupe key: the policy derives one from the content, so a
+		// retry of the same answer collapses while two different answers in the
+		// same conversation both go out.
+		Text: text,
+	})
+	if err != nil {
+		return result, err
+	}
+	if result.Sent {
+		m.MarkConversationReplied(reply.ProjectID, scene, reply.ConversationID)
+	}
+	return result, nil
+}
+
 // RunAcceptanceAck confirms that a real Run was accepted for a user. It is
 // distinct from the per-turn processing ACK and is delivered at most once per
 // run × conversation/user × channel.
@@ -153,19 +214,42 @@ func (m *Manager) SendRunAcceptanceAck(ctx context.Context, ack RunAcceptanceAck
 		return DeliveryResult{}, errors.New("run acceptance ack requires a real run id")
 	}
 	language := services.DetectLanguage("", ack.Language)
-	kindLabel := "已接单"
-	body := "任务已接单，我会在有实质进展时同步。"
-	if language == "en" {
-		kindLabel, body = "Accepted", "Task accepted. I will report substantive progress."
-	}
-	return m.DeliverSendable(ctx, SendableRequest{
+	result, err := m.DeliverSendable(ctx, SendableRequest{
 		ProjectID: ack.ProjectID, Scene: ack.Scene, ConversationID: ack.ConversationID,
 		UserID: ack.UserID, RunID: runID,
 		Kind: sendable.KindRunAcceptanceAck, Reason: "run_accepted",
 		Priority:  sendable.PriorityHigh,
 		DedupeKey: runAcceptanceDedupeKey(runID, ack.ConversationID, ack.UserID),
-		Text:      services.FormatTaskType(ack.ShortTitle, kindLabel, language) + " " + body,
+		Text:      runAcceptanceText(ack.ShortTitle, language),
 	})
+	// Handing work to the background is this turn's answer. Marking the turn
+	// replied is what lets the conversation move on immediately instead of
+	// waiting for the Run and then appending a second message about it.
+	if result.Sent {
+		scene := ack.Scene
+		if scene == "" {
+			scene = SceneC2C
+		}
+		m.MarkConversationReplied(ack.ProjectID, scene, ack.ConversationID)
+	}
+	return result, err
+}
+
+// runAcceptanceText confirms a delegation the way a colleague would: what was
+// picked up, and that the user is free to keep talking. No ticket header, no
+// promise to "report substantive progress".
+func runAcceptanceText(shortTitle, language string) string {
+	title := services.SanitizeShortTitle(shortTitle)
+	if services.NormalizeLanguage(language) == "en" {
+		if title == "" {
+			return "Got it, I'll take that one and come back when it's done. Feel free to keep chatting in the meantime."
+		}
+		return "Got it — I'll go work on \"" + title + "\" and tell you when it's done. Feel free to keep chatting in the meantime."
+	}
+	if title == "" {
+		return "好，我去弄，完了告诉你。你可以接着问别的。"
+	}
+	return "好，" + title + "这块我去弄，完了告诉你。你可以接着问别的。"
 }
 
 func runAcceptanceDedupeKey(runID, conversationID, userID string) string {
@@ -174,26 +258,57 @@ func runAcceptanceDedupeKey(runID, conversationID, userID string) string {
 	}, ":")
 }
 
+// resolveSendableTarget decides which conversation a message goes to.
+//
+// Precedence is deliberate: an explicit conversation wins, then the task's own
+// origin conversation, and only then the project's push target. Falling back to
+// the project target for Run traffic is what sent one user's results into an
+// unrelated cron session, so it is the last resort rather than the default.
 func (m *Manager) resolveSendableTarget(req SendableRequest) (*runningChannel, Scene, string, error) {
-	if strings.TrimSpace(req.ConversationID) != "" {
+	scene, conv := req.Scene, strings.TrimSpace(req.ConversationID)
+	if conv == "" {
+		if s, c, ok := m.originConversationForRun(req.ProjectID, req.RunID); ok {
+			scene, conv = s, c
+		}
+	}
+	if conv != "" {
 		m.mu.Lock()
 		defer m.mu.Unlock()
 		for _, rc := range m.running {
 			if rc.cfg.ProjectID == req.ProjectID {
-				scene := req.Scene
 				if scene == "" {
 					scene = SceneC2C
 				}
-				return rc, scene, req.ConversationID, nil
+				return rc, scene, conv, nil
 			}
 		}
 		return nil, "", "", ErrNoSendableTarget
 	}
-	target, scene, conv, err := m.lookupRunNotifyTarget(req.ProjectID)
+	target, fallbackScene, fallbackConv, err := m.lookupRunNotifyTarget(req.ProjectID)
 	if err != nil {
 		return nil, "", "", ErrNoSendableTarget
 	}
-	return target, scene, conv, nil
+	return target, fallbackScene, fallbackConv, nil
+}
+
+// originConversationForRun looks up where a Run's task was created.
+func (m *Manager) originConversationForRun(projectID, runID string) (Scene, string, bool) {
+	if m.taskContext == nil || strings.TrimSpace(runID) == "" || strings.TrimSpace(projectID) == "" {
+		return "", "", false
+	}
+	identity, err := m.taskContext.IdentityForRun(runID, projectID)
+	if err != nil || identity == nil {
+		return "", "", false
+	}
+	conv := strings.TrimSpace(identity.OriginConversationID)
+	if conv == "" {
+		return "", "", false
+	}
+	scene := Scene(strings.TrimSpace(identity.OriginScene))
+	if scene == "" {
+		scene = SceneC2C
+	}
+	return scene, conv, true
 }
 
 // TaskReferenceStatus is the outcome of resolving which task a user meant.
@@ -346,28 +461,57 @@ func shortTitles(candidates []services.TaskCandidate) []string {
 	return out
 }
 
+// taskStatusLabel states a task's state the way a person would say it, as a
+// predicate that reads naturally after the task's name.
 func taskStatusLabel(status, language string) string {
 	if services.NormalizeLanguage(language) == "en" {
 		switch strings.ToLower(strings.TrimSpace(status)) {
 		case "completed", "done":
-			return "Completed"
+			return "is done."
 		case "failed":
-			return "Failed"
+			return "didn't go through."
 		case "cancelled", "canceled":
-			return "Cancelled"
+			return "was cancelled."
 		default:
-			return "In progress"
+			return "is still running."
 		}
 	}
 	switch strings.ToLower(strings.TrimSpace(status)) {
 	case "completed", "done":
-		return "已完成"
+		return "弄完了。"
 	case "failed":
-		return "已失败"
+		return "没做成。"
 	case "cancelled", "canceled":
-		return "已取消"
+		return "取消了。"
 	default:
-		return "进行中"
+		return "还在做。"
+	}
+}
+
+// soloTaskStatusText is the same state stated without naming the task, for a
+// conversation where only one task could possibly be meant.
+func soloTaskStatusText(status, language string) string {
+	if services.NormalizeLanguage(language) == "en" {
+		switch strings.ToLower(strings.TrimSpace(status)) {
+		case "completed", "done":
+			return "It's done."
+		case "failed":
+			return "It didn't go through."
+		case "cancelled", "canceled":
+			return "It was cancelled."
+		default:
+			return "Still running."
+		}
+	}
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "completed", "done":
+		return "弄完了。"
+	case "failed":
+		return "没做成。"
+	case "cancelled", "canceled":
+		return "取消了。"
+	default:
+		return "还在做呢。"
 	}
 }
 

--- a/server/internal/channels/delivery_test.go
+++ b/server/internal/channels/delivery_test.go
@@ -58,8 +58,13 @@ func TestFinalOnlySendsStructuredSummaryNeverRawAssistantText(t *testing.T) {
 			t.Fatalf("raw assistant final leaked: %v", got)
 		}
 	}
-	if countText(got, safeFinalNotice) != 1 {
-		t.Fatalf("expected the safe notice when no structured summary exists, got %v", got)
+	// Without a structured summary the user still gets one message, and it says
+	// something about their situation rather than pointing them elsewhere.
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one fallback message, got %v", got)
+	}
+	if strings.Contains(got[0], "Approving") {
+		t.Fatalf("fallback told the user to go look somewhere else: %q", got[0])
 	}
 
 	fa2 := &fakeAdapter{}
@@ -201,8 +206,13 @@ func TestSendRunAcceptanceAckOncePerRunAndRejectsMissingRun(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("run acceptance ACK sent %v want exactly once per run", got)
 	}
-	if !strings.HasPrefix(got[0], "【登录页｜已接单】") {
-		t.Fatalf("ack text = %q want short title prefix", got[0])
+	// The confirmation names the task and hands the conversation back, without
+	// a ticket header and without promising a progress feed.
+	if !strings.Contains(got[0], "登录页") {
+		t.Fatalf("ack text = %q want the task named", got[0])
+	}
+	if strings.Contains(got[0], "【") || strings.Contains(got[0], "已接单") {
+		t.Fatalf("delegation confirmation still reads like a ticket: %q", got[0])
 	}
 
 	ack.RunID = ""
@@ -211,7 +221,9 @@ func TestSendRunAcceptanceAckOncePerRunAndRejectsMissingRun(t *testing.T) {
 	}
 }
 
-func TestTurnProcessingAckIsNotRunScoped(t *testing.T) {
+// Turn traffic is scoped to the turn, never to a fabricated Run: an inbound
+// platform message id must not be able to masquerade as a run_id.
+func TestTurnDeliveryIsNotRunScoped(t *testing.T) {
 	fa := &fakeAdapter{}
 	m, db := policyManager(t, fa, nil)
 	m.handleFunc = func(ctx context.Context, rc ResolvedChannel, in InboundMessage) (Reply, error) {
@@ -221,8 +233,8 @@ func TestTurnProcessingAckIsNotRunScoped(t *testing.T) {
 	m.dispatch(context.Background(), rc, testInbound("turn-1"))
 	m.dispatch(context.Background(), rc, testInbound("turn-2"))
 
-	if n := hasPrefixCount(sentTexts(fa), ackProcessingPrefix); n != 2 {
-		t.Fatalf("processing ACK count = %d want one per turn", n)
+	if got := sentTexts(fa); len(got) != 2 {
+		t.Fatalf("sends = %v want exactly one answer per turn", got)
 	}
 	var receipts []models.SendableDeliveryReceipt
 	if err := db.Find(&receipts).Error; err != nil {
@@ -773,8 +785,11 @@ func TestResolveTaskReferenceQQFlow(t *testing.T) {
 	if res.Status != TaskReferenceResolved || res.Task.RunID != "r1" {
 		t.Fatalf("unique match = %+v", res)
 	}
-	if !strings.HasPrefix(res.Message, "【支付登录页｜进行中】") {
+	if !strings.Contains(res.Message, "支付登录页") || !strings.Contains(res.Message, "还在做") {
 		t.Fatalf("resolved message = %q", res.Message)
+	}
+	if strings.ContainsAny(res.Message, "【｜】") {
+		t.Fatalf("resolved message still wears a ticket header: %q", res.Message)
 	}
 
 	// No match must not guess.

--- a/server/internal/channels/live_router.go
+++ b/server/internal/channels/live_router.go
@@ -1,0 +1,167 @@
+package channels
+
+import (
+	"strings"
+
+	"github.com/cocofhu/approving/internal/services"
+)
+
+// LiveIntent is the Live conversation layer's classification of one inbound
+// message.
+//
+// conversation and delegation both need the agent — deciding whether a request
+// deserves a background Run is a judgement call, not a keyword match, so the
+// router deliberately does not try to separate them. The other three are
+// answered from stored task state without opening a sandbox turn, which is what
+// keeps the conversation responsive while Runs execute.
+type LiveIntent string
+
+const (
+	// IntentConversation is ordinary chat: answer directly, never start a Run.
+	IntentConversation LiveIntent = "conversation"
+	// IntentDelegation is work that belongs in a background Run.
+	IntentDelegation LiveIntent = "delegation"
+	// IntentTaskQuery asks about an existing task's state.
+	IntentTaskQuery LiveIntent = "task_query"
+	// IntentTaskControl continues, amends, cancels or approves an existing task.
+	IntentTaskControl LiveIntent = "task_control"
+	// IntentClarificationReply answers a question the background asked.
+	IntentClarificationReply LiveIntent = "clarification_reply"
+)
+
+// FastPath reports whether the intent can be served from stored state alone.
+func (i LiveIntent) FastPath() bool {
+	switch i {
+	case IntentTaskQuery, IntentTaskControl, IntentClarificationReply:
+		return true
+	default:
+		return false
+	}
+}
+
+// highRiskRules map an explicit action verb onto the action it authorizes.
+// Order matters: the most specific phrase for an action wins.
+var highRiskRules = []struct {
+	action string
+	verbs  []string
+}{
+	{"cancel_run", []string{"取消任务", "取消运行", "停止任务", "终止任务", "取消", "停止", "终止",
+		"cancel run", "cancel the task", "cancel this task", "cancel", "stop task", "abort"}},
+	{"approve_gate", []string{"批准门禁", "同意门禁", "批准", "同意", "通过", "approve gate", "approve"}},
+	{"reject_gate", []string{"拒绝门禁", "驳回", "拒绝", "reject gate", "reject"}},
+	{"delete_run", []string{"删除任务", "删除", "删掉", "delete task", "delete"}},
+}
+
+// negationCues mark a message as commentary rather than a command. A user who
+// says 「不要这样啊」 or 「没有实现」 is complaining about what happened, not asking
+// to cancel anything — treating that as a destructive intent is how a complaint
+// turned into a cancel_run confirmation prompt.
+var negationCues = []string{
+	"不要这样", "不是这样", "别这样", "不用取消", "不要取消", "别取消", "不想取消",
+	"没有实现", "没实现", "没做", "不对", "怎么回事", "为什么", "why", "not implemented",
+}
+
+// detectHighRiskIntent returns the destructive action a message explicitly
+// authorizes, plus the remaining text used to address a task.
+//
+// Two conditions must hold, because a bare keyword scan over free-form chat
+// produces false positives on ordinary complaints:
+//
+//  1. the action verb leads the message (a verb buried mid-sentence is
+//     commentary, e.g. 「我不想取消」), and
+//  2. the message carries no negation cue.
+//
+// Callers must still resolve the remainder to a real task before acting.
+func detectHighRiskIntent(text string) (action, query string) {
+	t := strings.TrimSpace(text)
+	if t == "" || looksLikeComplaint(t) {
+		return "", ""
+	}
+	lower := strings.ToLower(t)
+	for _, rule := range highRiskRules {
+		for _, verb := range rule.verbs {
+			rest, ok := cutLeadingVerb(lower, t, strings.ToLower(verb))
+			if !ok {
+				continue
+			}
+			if rest == "" {
+				rest = t
+			}
+			return rule.action, rest
+		}
+	}
+	return "", ""
+}
+
+// cutLeadingVerb reports whether the message opens with verb and returns the
+// remainder with connective particles removed.
+func cutLeadingVerb(lower, original, verb string) (string, bool) {
+	if verb == "" || !strings.HasPrefix(lower, verb) {
+		return "", false
+	}
+	rest := strings.TrimSpace(string([]rune(original)[len([]rune(verb)):]))
+	rest = strings.TrimLeft(rest, " \t:：,，。.、")
+	for _, particle := range []string{"掉", "了", "吧", "一下", "这个", "那个", "该"} {
+		rest = strings.TrimSpace(strings.TrimPrefix(rest, particle))
+	}
+	return strings.TrimSpace(rest), true
+}
+
+func looksLikeComplaint(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	for _, cue := range negationCues {
+		if strings.Contains(lower, strings.ToLower(cue)) {
+			return true
+		}
+	}
+	return false
+}
+
+// amendmentCues introduce a change to an in-flight task's requirements.
+var amendmentCues = []string{
+	"改成", "改为", "换成", "再加", "追加", "补充", "顺便", "另外还要", "还要加",
+	"instead", "also add", "change it to", "make it",
+}
+
+// looksLikeAmendment reports whether the user is revising an existing task
+// rather than asking for a new one. FR-3 requires these to reach the addressed
+// Run instead of silently becoming a fresh delegation.
+func looksLikeAmendment(text string) bool {
+	t := strings.TrimSpace(text)
+	if t == "" {
+		return false
+	}
+	lower := strings.ToLower(t)
+	for _, cue := range amendmentCues {
+		if strings.Contains(lower, strings.ToLower(cue)) {
+			return true
+		}
+	}
+	return false
+}
+
+// classifyIntent assigns the Live intent for an inbound message. hasPendingRisk
+// and taskResolvable are supplied by the Manager because they need database
+// state the router itself does not own.
+func classifyIntent(text string, hasPendingRisk, taskResolvable bool) LiveIntent {
+	t := strings.TrimSpace(text)
+	if t == "" {
+		return IntentConversation
+	}
+	if hasPendingRisk && services.ParseRiskDecisionPublic(t) != "" {
+		return IntentClarificationReply
+	}
+	if action, _ := detectHighRiskIntent(t); action != "" && taskResolvable {
+		return IntentTaskControl
+	}
+	if taskResolvable && (isContinuation(t) || looksLikeAmendment(t)) {
+		return IntentTaskControl
+	}
+	if isStatusQuery(t) && taskResolvable {
+		return IntentTaskQuery
+	}
+	// Everything else needs the agent's judgement. Ambiguity resolves toward
+	// conversation on purpose: a wrongly created Run is far more disruptive
+	// than a clarifying question.
+	return IntentConversation
+}

--- a/server/internal/channels/live_test.go
+++ b/server/internal/channels/live_test.go
@@ -167,6 +167,43 @@ func TestScrubInternalTermsCleansModelComposedText(t *testing.T) {
 	}
 }
 
+// The identifier guard has to cut both ways. Deleting a real id is the point;
+// deleting a chunk of an ordinary sentence is a worse failure than the jargon
+// would have been, because the user cannot even tell something went missing.
+func TestIdentifierScrubbingLeavesOrdinaryProseAlone(t *testing.T) {
+	mustStrip := []string{
+		"run-1ca1876f", "run_1ca1876f", "task-9f8e7d6c5b",
+		"Run ID: 1ca1876f", "run #1ca1876f",
+	}
+	for _, text := range mustStrip {
+		if !ContainsInternalTerms(text) {
+			t.Errorf("%q was not recognised as an identifier", text)
+		}
+		if got := ScrubInternalTerms("结果在 " + text + " 里"); strings.Contains(got, "1ca1876f") ||
+			strings.Contains(got, "9f8e7d6c5b") {
+			t.Errorf("scrubbing %q left the identifier: %q", text, got)
+		}
+	}
+
+	keep := []struct{ text, mustSurvive string }{
+		{"we run 5000 iterations before merging", "5000 iterations"},
+		{"跑了 run 5000 次迭代", "5000"},
+		{"run 3 times and compare", "3 times"},
+		{"这个 task 2 天就能做完", "2 天"},
+		{"run-optimization 那个分支", "run-optimization"},
+		{"the long-run tradeoff here", "long-run tradeoff"},
+		{"overrun2024 is a variable name", "overrun2024"},
+	}
+	for _, c := range keep {
+		if ContainsInternalTerms(c.text) {
+			t.Errorf("%q was wrongly flagged as containing an identifier", c.text)
+		}
+		if got := ScrubInternalTerms(c.text); !strings.Contains(got, c.mustSurvive) {
+			t.Errorf("ScrubInternalTerms(%q) = %q, lost %q", c.text, got, c.mustSurvive)
+		}
+	}
+}
+
 // One message in, one message out. No acknowledgement, no queue narration, no
 // trailing wrap-up alongside the answer.
 func TestOneUserMessageProducesOneReply(t *testing.T) {

--- a/server/internal/channels/live_test.go
+++ b/server/internal/channels/live_test.go
@@ -88,7 +88,8 @@ func TestDetectHighRiskIntentRequiresAnExplicitCommand(t *testing.T) {
 func TestOutboundCopyNeverExposesInternals(t *testing.T) {
 	copies := []string{
 		busyHintText,
-		turnHandoffText("zh-CN"), turnHandoffText("en"),
+		turnTooSlowText("zh-CN"), turnTooSlowText("en"),
+		stillWorkingText("zh-CN"), stillWorkingText("en"),
 		interruptedTurnText("zh-CN"), interruptedTurnText("en"),
 		runAcceptanceText("登录页性能", "zh-CN"), runAcceptanceText("Login perf", "en"),
 		taskStatusLabel("completed", "zh-CN"), taskStatusLabel("failed", "en"),
@@ -209,9 +210,9 @@ func TestExplicitReplySuppressesTheTurnWrapUp(t *testing.T) {
 	}
 }
 
-// A turn that overruns is work that belongs in the background. The user is told
-// that, once, instead of being held on the line or handed an error.
-func TestForegroundTurnTimeoutReadsAsAHandoff(t *testing.T) {
+// A turn that overruns has started nothing and is running nothing, so the user
+// is offered the delegation rather than told it already happened.
+func TestForegroundTurnTimeoutOffersDelegationInsteadOfPromising(t *testing.T) {
 	fa := &fakeAdapter{}
 	m := NewManager(nil, nil, nil)
 	m.handleFunc = func(ctx context.Context, _ ResolvedChannel, _ InboundMessage) (Reply, error) {
@@ -220,6 +221,7 @@ func TestForegroundTurnTimeoutReadsAsAHandoff(t *testing.T) {
 	}
 	rc := testRunningChannel(fa)
 	rc.cfg.TurnTimeoutSeconds = 1
+	m.openBudget = -1 // no cold-start allowance; this turn is pure thinking time
 
 	done := make(chan struct{})
 	go func() {
@@ -228,19 +230,69 @@ func TestForegroundTurnTimeoutReadsAsAHandoff(t *testing.T) {
 	}()
 	select {
 	case <-done:
-	case <-time.After(5 * time.Second):
+	case <-time.After(20 * time.Second):
 		t.Fatal("a foreground turn held the conversation past its budget")
 	}
 
 	got := sentTexts(fa)
 	if len(got) != 1 {
-		t.Fatalf("sends = %v want one handoff message", got)
+		t.Fatalf("sends = %v want one message", got)
 	}
-	if got[0] != turnHandoffText("zh-CN") {
-		t.Fatalf("timeout message = %q want the background handoff wording", got[0])
+	if got[0] != turnTooSlowText("zh-CN") {
+		t.Fatalf("timeout message = %q want the delegation offer", got[0])
 	}
 	if strings.Contains(got[0], "失败") || strings.Contains(got[0], "错误") {
 		t.Fatalf("timeout was reported as a failure: %q", got[0])
+	}
+	// The offer must not claim work is already under way; nothing is running.
+	for _, promise := range []string{"放到后台接着弄", "有结果就来说", "正在处理"} {
+		if strings.Contains(got[0], promise) {
+			t.Fatalf("timeout message promises work nobody is doing: %q", got[0])
+		}
+	}
+}
+
+// Cold start is the one wait the streaming opener cannot cover: there is no
+// sandbox yet, so there is no text to release early. The user hears something
+// once — and a turn that answers quickly still produces only the answer.
+func TestLongSilenceGetsOneNoticeAndFastTurnsGetNone(t *testing.T) {
+	fa := &fakeAdapter{}
+	m := NewManager(nil, nil, nil)
+	m.handleFunc = func(context.Context, ResolvedChannel, InboundMessage) (Reply, error) {
+		return Reply{FinalSummary: "不是 BUG。"}, nil
+	}
+	m.dispatch(context.Background(), testRunningChannel(fa), testInboundText("fast", "那这个是 BUG 吗"))
+	if got := sentTexts(fa); len(got) != 1 || got[0] != "不是 BUG。" {
+		t.Fatalf("fast turn sends = %v want only the answer", got)
+	}
+
+	slow := &fakeAdapter{}
+	m2 := NewManager(nil, nil, nil)
+	rc := testRunningChannel(slow)
+	release := make(chan struct{})
+	m2.handleFunc = func(context.Context, ResolvedChannel, InboundMessage) (Reply, error) {
+		<-release
+		return Reply{FinalSummary: "查完了，是缓存。"}, nil
+	}
+	scope := conversationTurnScope(rc.cfg.ProjectID, SceneC2C, "user1")
+	m2.stillWorkingAfter = 20 * time.Millisecond
+	slowIn := testInboundText("slow", "帮我查一下登录页为什么慢")
+	stop := m2.sayStillWorking(context.Background(), rc, slowIn, scope)
+	deadline := time.Now().Add(5 * time.Second)
+	for len(sentTexts(slow)) == 0 && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	stop()
+	close(release)
+
+	got := sentTexts(slow)
+	if len(got) != 1 || got[0] != stillWorkingText("zh-CN") {
+		t.Fatalf("long silence sends = %v want one waiting notice", got)
+	}
+	// Stopping is idempotent and must not emit a second notice.
+	stop()
+	if n := len(sentTexts(slow)); n != 1 {
+		t.Fatalf("waiting notice repeated: %d sends", n)
 	}
 }
 

--- a/server/internal/channels/live_test.go
+++ b/server/internal/channels/live_test.go
@@ -1,0 +1,496 @@
+package channels
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/services"
+)
+
+// liveManager builds a Manager wired end to end: a policy over a real database,
+// a task-context service, and one running QQ channel whose adapter is fa.
+func liveManager(t *testing.T, fa *fakeAdapter) (*Manager, *services.TaskContextService) {
+	t.Helper()
+	m, db := policyManager(t, fa, nil)
+	tasks := services.NewTaskContextService(db)
+	m.SetTaskContextService(tasks)
+	m.Apply([]models.ChannelConfig{{
+		ID: "c1", Type: "qq", ProjectID: "proj", AppID: "app", Enabled: true,
+		CronDeliver: true, CronDeliverTarget: "c2c:cron-target",
+	}})
+	t.Cleanup(m.StopAll)
+	m.mu.Lock()
+	for _, rc := range m.running {
+		rc.adapter = fa
+	}
+	m.mu.Unlock()
+	return m, tasks
+}
+
+// A question is a question. The router must not turn one into a Run, and it
+// must not read a complaint as a command — both were real failures: 「那这个是
+// BUG 吗」 opened a background task, and 「不要这样啊」 asked to confirm a cancel.
+func TestClassifyIntentKeepsConversationsConversational(t *testing.T) {
+	cases := []struct {
+		text           string
+		pendingRisk    bool
+		taskResolvable bool
+		want           LiveIntent
+	}{
+		{text: "那这个是 BUG 吗", taskResolvable: true, want: IntentConversation},
+		{text: "不要这样啊", taskResolvable: true, want: IntentConversation},
+		{text: "没有实现啊，怎么回事", taskResolvable: true, want: IntentConversation},
+		{text: "我不想取消", taskResolvable: true, want: IntentConversation},
+		{text: "帮我调研并实现登录页性能优化", taskResolvable: false, want: IntentConversation},
+		{text: "现在什么进展了", taskResolvable: true, want: IntentTaskQuery},
+		{text: "现在什么进展了", taskResolvable: false, want: IntentConversation},
+		{text: "取消登录页性能优化", taskResolvable: true, want: IntentTaskControl},
+		{text: "改成只优化首屏", taskResolvable: true, want: IntentTaskControl},
+		{text: "确认", pendingRisk: true, taskResolvable: true, want: IntentClarificationReply},
+	}
+	for _, c := range cases {
+		got := classifyIntent(c.text, c.pendingRisk, c.taskResolvable)
+		if got != c.want {
+			t.Errorf("classifyIntent(%q, risk=%v, resolvable=%v) = %q want %q",
+				c.text, c.pendingRisk, c.taskResolvable, got, c.want)
+		}
+	}
+}
+
+// A destructive action needs the user to have asked for it, in those words, at
+// the front of the message.
+func TestDetectHighRiskIntentRequiresAnExplicitCommand(t *testing.T) {
+	for _, text := range []string{
+		"取消登录页性能优化", "停止任务", "批准结算页性能", "delete task foo",
+	} {
+		if action, _ := detectHighRiskIntent(text); action == "" {
+			t.Errorf("detectHighRiskIntent(%q) found no action", text)
+		}
+	}
+	for _, text := range []string{
+		"不要这样啊", "我不想取消这个", "为什么会取消", "这个功能没实现，不对吧",
+		"顺便问一下批准流程是怎么走的",
+	} {
+		if action, _ := detectHighRiskIntent(text); action != "" {
+			t.Errorf("detectHighRiskIntent(%q) = %q, commentary must not authorize anything", text, action)
+		}
+	}
+}
+
+// The outbound vocabulary guard, mirroring the web client's userFacingCopy
+// test: nothing the platform says to a user may mention how the platform is
+// built. This covers the static copy; ScrubInternalTerms covers text a model
+// composed.
+func TestOutboundCopyNeverExposesInternals(t *testing.T) {
+	copies := []string{
+		busyHintText,
+		turnHandoffText("zh-CN"), turnHandoffText("en"),
+		interruptedTurnText("zh-CN"), interruptedTurnText("en"),
+		runAcceptanceText("登录页性能", "zh-CN"), runAcceptanceText("Login perf", "en"),
+		taskStatusLabel("completed", "zh-CN"), taskStatusLabel("failed", "en"),
+		soloTaskStatusText("active", "zh-CN"), soloTaskStatusText("cancelled", "en"),
+		FormatProgressText(ProgressEvent{Kind: ProgressMilestone, Summary: "已提交分支"}),
+	}
+	for _, err := range []error{
+		errNoReply(), context.DeadlineExceeded,
+	} {
+		copies = append(copies, turnFailureText(err))
+	}
+	for _, text := range copies {
+		if strings.TrimSpace(text) == "" {
+			continue
+		}
+		if ContainsInternalTerms(text) {
+			t.Errorf("user-facing copy exposes internals: %q", text)
+		}
+		for _, banned := range []string{
+			"Run ID", "run_id", "Sendable", "sandbox", "ACP", "node_complete",
+			"suppressed", "assistant produced no reply", "请前往 Approving",
+		} {
+			if strings.Contains(strings.ToLower(text), strings.ToLower(banned)) {
+				t.Errorf("user-facing copy contains %q: %q", banned, text)
+			}
+		}
+	}
+}
+
+func errNoReply() error { return errNoReplyErr{} }
+
+type errNoReplyErr struct{}
+
+func (errNoReplyErr) Error() string { return "assistant produced no reply" }
+
+// ScrubInternalTerms is the last line of defence on text a model wrote. It has
+// to remove the internals and still leave a readable sentence.
+func TestScrubInternalTermsCleansModelComposedText(t *testing.T) {
+	cases := []struct {
+		in       string
+		mustDrop []string
+		mustKeep []string
+	}{
+		{
+			in:       "我已经在 run-1ca1876f 这个 sandbox 里跑完了，本回合已结束。",
+			mustDrop: []string{"run-1ca1876f", "sandbox", "本回合"},
+			mustKeep: []string{"跑完了"},
+		},
+		{
+			in:       "tool_call gh pr view\n[摘要] 登录页首屏从 3.2s 降到 1.1s",
+			mustDrop: []string{"tool_call", "[摘要]"},
+			mustKeep: []string{"登录页首屏从 3.2s 降到 1.1s"},
+		},
+		{
+			in:       "node_complete: 构建完成，delivery suppressed",
+			mustDrop: []string{"node_complete", "suppressed"},
+			mustKeep: []string{"构建完成"},
+		},
+	}
+	for _, c := range cases {
+		got := ScrubInternalTerms(c.in)
+		for _, drop := range c.mustDrop {
+			if strings.Contains(got, drop) {
+				t.Errorf("ScrubInternalTerms(%q) still contains %q: %q", c.in, drop, got)
+			}
+		}
+		for _, keep := range c.mustKeep {
+			if !strings.Contains(got, keep) {
+				t.Errorf("ScrubInternalTerms(%q) lost %q: %q", c.in, keep, got)
+			}
+		}
+		if strings.Contains(got, "  ") || strings.HasPrefix(got, " ") {
+			t.Errorf("ScrubInternalTerms(%q) left ragged spacing: %q", c.in, got)
+		}
+	}
+}
+
+// One message in, one message out. No acknowledgement, no queue narration, no
+// trailing wrap-up alongside the answer.
+func TestOneUserMessageProducesOneReply(t *testing.T) {
+	fa := &fakeAdapter{}
+	m := NewManager(nil, nil, nil)
+	m.handleFunc = func(context.Context, ResolvedChannel, InboundMessage) (Reply, error) {
+		return Reply{Text: "内部推理若干", FinalSummary: "不是 BUG，是缓存没刷新。"}, nil
+	}
+	rc := testRunningChannel(fa)
+	m.dispatch(context.Background(), rc, testInboundText("q1", "那这个是 BUG 吗"))
+
+	got := sentTexts(fa)
+	if len(got) != 1 || got[0] != "不是 BUG，是缓存没刷新。" {
+		t.Fatalf("sends = %v want exactly the answer", got)
+	}
+}
+
+// An answer the agent submitted through pm_reply is the turn's answer. The
+// wrap-up must not append a second message on top of it.
+func TestExplicitReplySuppressesTheTurnWrapUp(t *testing.T) {
+	fa := &fakeAdapter{}
+	m, _ := liveManager(t, fa)
+	rc := testRunningChannel(fa)
+	rc.cfg.ProjectID = "proj"
+	m.handleFunc = func(ctx context.Context, _ ResolvedChannel, in InboundMessage) (Reply, error) {
+		// What pm_reply does, through the same egress the MCP host uses.
+		_, err := m.DeliverConversationReply(ctx, ConversationReply{
+			ProjectID: "proj", Scene: in.Scene, ConversationID: in.ConversationID,
+			UserID: in.UserID, Text: "缓存没刷新而已。",
+		})
+		return Reply{}, err
+	}
+	m.handleInbound(context.Background(), rc, InboundMessage{
+		Scene: SceneC2C, ConversationID: "user1", UserID: "u1",
+		MessageID: "q1", Text: "那这个是 BUG 吗",
+	})
+
+	got := sentTexts(fa)
+	if len(got) != 1 || got[0] != "缓存没刷新而已。" {
+		t.Fatalf("sends = %v want only the agent's own reply", got)
+	}
+}
+
+// A turn that overruns is work that belongs in the background. The user is told
+// that, once, instead of being held on the line or handed an error.
+func TestForegroundTurnTimeoutReadsAsAHandoff(t *testing.T) {
+	fa := &fakeAdapter{}
+	m := NewManager(nil, nil, nil)
+	m.handleFunc = func(ctx context.Context, _ ResolvedChannel, _ InboundMessage) (Reply, error) {
+		<-ctx.Done()
+		return Reply{}, ctx.Err()
+	}
+	rc := testRunningChannel(fa)
+	rc.cfg.TurnTimeoutSeconds = 1
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		m.dispatch(context.Background(), rc, testInboundText("slow", "帮我把整个仓库重构一遍"))
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a foreground turn held the conversation past its budget")
+	}
+
+	got := sentTexts(fa)
+	if len(got) != 1 {
+		t.Fatalf("sends = %v want one handoff message", got)
+	}
+	if got[0] != turnHandoffText("zh-CN") {
+		t.Fatalf("timeout message = %q want the background handoff wording", got[0])
+	}
+	if strings.Contains(got[0], "失败") || strings.Contains(got[0], "错误") {
+		t.Fatalf("timeout was reported as a failure: %q", got[0])
+	}
+}
+
+// A full backlog must not swallow messages, and must not answer each rejected
+// one either: the user hears about it once per cooldown.
+func TestQueueFullHintIsSentOnceAndNotSilent(t *testing.T) {
+	fa := &fakeAdapter{}
+	m := NewManager(nil, nil, nil)
+	release := make(chan struct{})
+	var once sync.Once
+	m.handleFunc = func(context.Context, ResolvedChannel, InboundMessage) (Reply, error) {
+		<-release
+		return Reply{FinalSummary: "done"}, nil
+	}
+	rc := testRunningChannel(fa)
+
+	go m.dispatch(context.Background(), rc, testInbound("head"))
+	// Wait for the head turn to occupy the conversation.
+	deadline := time.Now().Add(2 * time.Second)
+	key := convKey(rc.cfg.ProjectID, SceneC2C, "user1")
+	for {
+		q := m.convQueueFor(key)
+		q.mu.Lock()
+		busy := q.busy
+		q.mu.Unlock()
+		if busy {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("head turn never started")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	// Fill the pending FIFO, then overflow it several times.
+	for i := 0; i < convQueueDepth+5; i++ {
+		m.dispatch(context.Background(), rc, testInbound(string(rune('a'+i%26))+"-fill"))
+	}
+	if n := countText(sentTexts(fa), busyHintText); n != 1 {
+		t.Fatalf("busy hint sent %d times, want exactly one per cooldown", n)
+	}
+	once.Do(func() { close(release) })
+}
+
+// A finished Run reports back to the conversation that asked for it, exactly
+// once, and the task stops answering "still running" afterwards.
+func TestTaskOutcomeReturnsToTheOriginConversation(t *testing.T) {
+	fa := &fakeAdapter{}
+	m, tasks := liveManager(t, fa)
+
+	if _, err := tasks.EnsureIdentity(services.EnsureTaskIdentityInput{
+		RunID: "run-abc123def456", ProjectID: "proj",
+		UserID:     services.SyntheticQQUserID("u1"),
+		ShortTitle: "登录页性能优化", Status: "running",
+		OriginChannel: "qq", OriginScene: string(SceneC2C),
+		OriginConversationID: "user1", OriginExternalUserID: "u1",
+		Language:            "zh-CN",
+		OriginalRequirement: "调研并实现登录页性能优化",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	outcome := TaskOutcome{ProjectID: "proj", RunID: "run-abc123def456", Status: "completed"}
+	if err := m.ReflowTaskOutcome(context.Background(), outcome); err != nil {
+		t.Fatalf("ReflowTaskOutcome: %v", err)
+	}
+	// A duplicate terminal event must not produce a second message.
+	if err := m.ReflowTaskOutcome(context.Background(), outcome); err != nil {
+		t.Fatalf("ReflowTaskOutcome (repeat): %v", err)
+	}
+
+	got := sentTexts(fa)
+	if len(got) != 1 {
+		t.Fatalf("outcome sends = %v want exactly one conclusion", got)
+	}
+	if !strings.Contains(got[0], "登录页性能优化") {
+		t.Fatalf("conclusion does not say which task it is about: %q", got[0])
+	}
+	if strings.Contains(got[0], "Approving") || ContainsInternalTerms(got[0]) {
+		t.Fatalf("conclusion is not self-contained: %q", got[0])
+	}
+	// It went to the conversation that started the task, not the cron target.
+	fa.mu.Lock()
+	conv := fa.sent[0].ConversationID
+	fa.mu.Unlock()
+	if conv != "user1" {
+		t.Fatalf("conclusion delivered to %q want the origin conversation", conv)
+	}
+
+	identity, err := tasks.IdentityForRun("run-abc123def456", "proj")
+	if err != nil || identity == nil {
+		t.Fatalf("identity after reflow = %+v err=%v", identity, err)
+	}
+	if !services.IsTerminalTaskStatus(identity.Status) {
+		t.Fatalf("task status = %q, a finished task must not still read as running", identity.Status)
+	}
+}
+
+// A failed Run explains itself in terms the user can act on, without quoting
+// the diagnostic that caused it.
+func TestFailedTaskOutcomeExplainsWithoutDiagnostics(t *testing.T) {
+	fa := &fakeAdapter{}
+	m, tasks := liveManager(t, fa)
+	if _, err := tasks.EnsureIdentity(services.EnsureTaskIdentityInput{
+		RunID: "run-fail0001", ProjectID: "proj",
+		UserID:     services.SyntheticQQUserID("u1"),
+		ShortTitle: "结算页重构", Status: "running",
+		OriginChannel: "qq", OriginScene: string(SceneC2C),
+		OriginConversationID: "user1", OriginExternalUserID: "u1", Language: "zh-CN",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	err := m.ReflowTaskOutcome(context.Background(), TaskOutcome{
+		ProjectID: "proj", RunID: "run-fail0001", Status: "failed",
+		FailureReason: "node build-1 exited: context deadline exceeded in sandbox",
+	})
+	if err != nil {
+		t.Fatalf("ReflowTaskOutcome: %v", err)
+	}
+	got := sentTexts(fa)
+	if len(got) != 1 {
+		t.Fatalf("sends = %v want one explanation", got)
+	}
+	if !strings.Contains(got[0], "超时") {
+		t.Fatalf("failure was not translated into a cause: %q", got[0])
+	}
+	if strings.Contains(got[0], "build-1") || ContainsInternalTerms(got[0]) {
+		t.Fatalf("failure quoted the diagnostic: %q", got[0])
+	}
+}
+
+// A restart loses the sandbox but must not lose the user's message in silence.
+func TestRecoverInterruptedTurnsTellsTheUser(t *testing.T) {
+	fa := &fakeAdapter{}
+	m, tasks := liveManager(t, fa)
+	if err := tasks.DB().Create(&models.PendingChannelTurn{
+		ID: "turn:proj|m9", ProjectID: "proj", Channel: "qq",
+		Scene: string(SceneC2C), ConversationID: "user1", ExternalUserID: "u1",
+		MessageID: "m9", Language: "zh-CN", StartedAt: time.Now().Add(-time.Minute),
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	m.RecoverInterruptedTurns(context.Background())
+	got := sentTexts(fa)
+	if len(got) != 1 || got[0] != interruptedTurnText("zh-CN") {
+		t.Fatalf("recovery sends = %v want one plain explanation", got)
+	}
+
+	// The record is cleared, so a second boot stays quiet.
+	m.RecoverInterruptedTurns(context.Background())
+	if n := len(sentTexts(fa)); n != 1 {
+		t.Fatalf("recovery repeated itself: %d sends", n)
+	}
+}
+
+// Two live tasks make a bare "how's that one going?" ambiguous; the answer must
+// name the task rather than guess silently.
+func TestParallelTasksAnswerByShortTitle(t *testing.T) {
+	fa := &fakeAdapter{}
+	m, tasks := liveManager(t, fa)
+	for _, task := range []struct{ run, title string }{
+		{"run-aaa111222333", "登录页性能优化"},
+		{"run-bbb444555666", "结算页重构"},
+	} {
+		if _, err := tasks.EnsureIdentity(services.EnsureTaskIdentityInput{
+			RunID: task.run, ProjectID: "proj",
+			UserID:     services.SyntheticQQUserID("u1"),
+			ShortTitle: task.title, Status: "running",
+			OriginChannel: "qq", OriginScene: string(SceneC2C),
+			OriginConversationID: "user1", OriginExternalUserID: "u1", Language: "zh-CN",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	turned := 0
+	m.handleFunc = func(context.Context, ResolvedChannel, InboundMessage) (Reply, error) {
+		turned++
+		return Reply{}, nil
+	}
+	rc := testRunningChannel(fa)
+	rc.cfg.ProjectID = "proj"
+	m.handleInbound(context.Background(), rc, InboundMessage{
+		Scene: SceneC2C, ConversationID: "user1", UserID: "u1",
+		MessageID: "m1", Text: "登录页性能优化怎么样了",
+	})
+	if turned != 0 {
+		t.Fatalf("a status question opened a sandbox turn (%d)", turned)
+	}
+	got := sentTexts(fa)
+	if len(got) != 1 || !strings.Contains(got[0], "登录页性能优化") {
+		t.Fatalf("status answer = %v want the named task", got)
+	}
+	if strings.Contains(got[0], "结算页重构") {
+		t.Fatalf("status answer mixed in the other task: %q", got[0])
+	}
+}
+
+// Synthesis lets a model phrase a background result, which means model output
+// reaches the channel. Anything it drags along with it is scrubbed on the way
+// out; the user still gets the conclusion.
+func TestSynthesizedOutcomeIsScrubbedBeforeItLeaves(t *testing.T) {
+	fa := &fakeAdapter{}
+	m, tasks := liveManager(t, fa)
+	if _, err := tasks.EnsureIdentity(services.EnsureTaskIdentityInput{
+		RunID: "run-leak000001", ProjectID: "proj",
+		UserID:     services.SyntheticQQUserID("u1"),
+		ShortTitle: "登录页性能优化", Status: "running",
+		OriginChannel: "qq", OriginScene: string(SceneC2C),
+		OriginConversationID: "user1", OriginExternalUserID: "u1", Language: "zh-CN",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	m.SetSynthesizer(func(context.Context, SynthesisRequest) (string, error) {
+		return "tool_call gh pr view --json\n" +
+			"[摘要] 登录页首屏从 3.2s 降到 1.1s，run-leak000001 在 sandbox 里跑完了。", nil
+	})
+
+	if err := m.ReflowTaskOutcome(context.Background(), TaskOutcome{
+		ProjectID: "proj", RunID: "run-leak000001", Status: "completed",
+	}); err != nil {
+		t.Fatalf("ReflowTaskOutcome: %v", err)
+	}
+	got := sentTexts(fa)
+	if len(got) != 1 {
+		t.Fatalf("sends = %v want one conclusion", got)
+	}
+	if !strings.Contains(got[0], "3.2s 降到 1.1s") {
+		t.Fatalf("scrubbing removed the conclusion: %q", got[0])
+	}
+	for _, leak := range []string{"tool_call", "[摘要]", "run-leak000001", "sandbox"} {
+		if strings.Contains(got[0], leak) {
+			t.Fatalf("synthesized text leaked %q: %q", leak, got[0])
+		}
+	}
+}
+
+// Short titles are how a user refers to a task, so they must be readable. A
+// Run identifier is neither readable nor stable vocabulary for a conversation.
+func TestShortTitlesNeverCarryRunIdentifiers(t *testing.T) {
+	for _, in := range []string{
+		"Run run-1ca1876f", "run-1ca1876f", "修复 Run run-1ca1876f / PR",
+		"task-9f8e7d6c5b", "Run",
+	} {
+		got := services.SanitizeShortTitle(in)
+		if ContainsInternalTerms(got) {
+			t.Errorf("SanitizeShortTitle(%q) = %q still carries an identifier", in, got)
+		}
+		if strings.EqualFold(strings.TrimSpace(got), "run") {
+			t.Errorf("SanitizeShortTitle(%q) = %q is not a title", in, got)
+		}
+	}
+}

--- a/server/internal/channels/manager.go
+++ b/server/internal/channels/manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -24,24 +23,36 @@ var ErrNoDeliveryChannel = errors.New("项目未配置定时任务推送渠道")
 // has a usable QQ target session for the project (CronDeliver flag not required).
 var ErrNoRunNotifyTarget = errors.New("项目未配置可用的 QQ 推送目标")
 
-// Reply/Work equivalent orchestration (physical dual sandbox NOT required):
+// The conversation layer and the work layer are separate on purpose, and only
+// the conversation layer talks to the user:
 //
-//   - Manager (= Reply): the unique QQ egress — immediate ACK, queue ACK,
-//     on-demand progress, terminal reports, and cron push coordination.
-//   - ChannelBridge / PmTurnRunner / cron sandbox (= Work): execute turns and
-//     emit internal progress/results; must not bypass Manager to Send on QQ.
+//   - Manager is the sole QQ egress. It answers, relays background events into
+//     the conversation that asked for them, and coordinates cron pushes.
+//   - ChannelBridge / PmTurnRunner / cron sandbox execute turns and emit
+//     internal progress and results. They must never Send on QQ directly.
 //
-// Speak priority: user ACK/final > on-demand progress > cron push > unchanged.
+// A foreground turn either answers or delegates; it never waits for a Run, so
+// the user can keep talking while work happens. Speak priority when several
+// things want the channel at once: the user's own answer, then background
+// progress, then cron pushes.
 
 const (
-	ackProcessingPrefix = "收到，正在处理："
-	ackSummaryRunes     = 40
-	queueAckPrefix      = "已收到，排队中"
-	queueFullText       = "队列已满，请稍候"
-	failReplyPrefix     = "处理失败："
+	// busyHintText is the only thing a user hears about queueing, and only when
+	// the backlog is genuinely full. Live conversations do not narrate their own
+	// plumbing: there is no per-message "received, working on it" and no queue
+	// position, because those crowd out the answer without informing anyone.
+	busyHintText = "我这边还在处理前面几条，稍等一下。"
+	// busyHintCooldown rate-limits busyHintText per conversation so a burst
+	// produces one hint instead of one per rejected message.
+	busyHintCooldown = 2 * time.Minute
 	// convQueueDepth is the per-conversation pending FIFO capacity (in-flight
 	// turn is not counted). The next inbound after 16 pending is rejected.
 	convQueueDepth = 16
+	// foregroundTurnTimeout caps a Live turn. The foreground contract is "answer
+	// briefly or delegate", so exceeding this means the agent tried to do the
+	// work inline; we stop waiting and tell the user it moved to the background
+	// rather than holding the conversation hostage.
+	foregroundTurnTimeout = 25 * time.Second
 )
 
 // queuedInbound is a message waiting behind an in-flight turn for the same
@@ -77,6 +88,19 @@ type Manager struct {
 	convMu     sync.Mutex
 	convQueues map[string]*convQueue
 
+	busyHintMu   sync.Mutex
+	busyHintSent map[string]time.Time
+
+	repliedMu sync.Mutex
+	replied   map[string]bool
+
+	// synthesize rewrites background events for the conversation they belong
+	// to. nil means outcomes go out as structured fallbacks.
+	synthesize SynthesisFunc
+
+	captureMu sync.Mutex
+	captured  map[string]*string
+
 	pushMu     sync.Mutex
 	pushQueues map[string]*pushQueue
 
@@ -110,14 +134,16 @@ type runningChannel struct {
 // decrypt reverses the stored app secret.
 func NewManager(bridge *ChannelBridge, factories map[string]AdapterFactory, decrypt func(string) (string, error)) *Manager {
 	return &Manager{
-		bridge:     bridge,
-		factories:  factories,
-		decrypt:    decrypt,
-		running:    map[string]*runningChannel{},
-		convQueues: map[string]*convQueue{},
-		pushQueues: map[string]*pushQueue{},
-		baseCtx:    context.Background(),
-		policy:     sendable.NewPolicy(nil, nil),
+		bridge:       bridge,
+		factories:    factories,
+		decrypt:      decrypt,
+		running:      map[string]*runningChannel{},
+		convQueues:   map[string]*convQueue{},
+		pushQueues:   map[string]*pushQueue{},
+		busyHintSent: map[string]time.Time{},
+		replied:      map[string]bool{},
+		baseCtx:      context.Background(),
+		policy:       sendable.NewPolicy(nil, nil),
 	}
 }
 
@@ -302,10 +328,13 @@ func (m *Manager) IsConversationBusy(projectID string, scene Scene, conversation
 	return q.busy || len(q.pending) > 0
 }
 
-// dispatch serializes messages per conversation via a bounded in-process FIFO.
-// Idle + empty queue: immediate processing ACK then Work. Busy: enqueue with a
-// per-message queue ACK (ahead count); dequeue sends another processing ACK.
-// Full queue: reject with a visible reply (never silently drop).
+// dispatch is the Live inbound pipeline.
+//
+// Order matters and is the heart of the Live model: messages that can be
+// answered from stored task state are served before the queue is ever
+// consulted, so asking "how's that going?" stays instant no matter how many
+// Runs are executing or how long the agent has been thinking. Only messages
+// that genuinely need the agent contend for the single per-conversation turn.
 func (m *Manager) dispatch(ctx context.Context, rc *runningChannel, in InboundMessage) {
 	// A notice-only inbound (e.g. every attachment rejected) has no turn to run;
 	// it still goes out through the single policy/dedupe/audit egress.
@@ -313,6 +342,12 @@ func (m *Manager) dispatch(ctx context.Context, rc *runningChannel, in InboundMe
 		m.sendSafetyNotice(ctx, rc, in, *in.Safety)
 		return
 	}
+
+	// Fast path: answered from the database, never queued, never sandboxed.
+	if m.handleFastPath(ctx, rc, &in) {
+		return
+	}
+
 	key := convKey(rc.cfg.ProjectID, in.Scene, in.ConversationID)
 	q := m.convQueueFor(key)
 
@@ -320,30 +355,53 @@ func (m *Manager) dispatch(ctx context.Context, rc *runningChannel, in InboundMe
 	if q.busy {
 		if len(q.pending) >= convQueueDepth {
 			q.mu.Unlock()
-			m.sendOutbound(ctx, rc, OutboundMessage{
-				Scene: in.Scene, ConversationID: in.ConversationID,
-				ReplyToMessageID: in.MessageID, Text: queueFullText,
-				Envelope: turnEnvelope(rc, in, sendable.KindSafetyNotice, "queue_full", sendable.PriorityHigh),
-			})
+			// Full queue must never drop silently, but it also must not emit one
+			// notice per rejected message — that is how a burst turns into spam.
+			m.sendBusyHint(ctx, rc, in, key)
 			return
 		}
-		// Ahead = in-flight turn + already-queued messages.
-		ahead := 1 + len(q.pending)
 		q.pending = append(q.pending, queuedInbound{ctx: ctx, rc: rc, in: in})
 		q.mu.Unlock()
-		m.sendOutbound(ctx, rc, OutboundMessage{
-			Scene: in.Scene, ConversationID: in.ConversationID,
-			ReplyToMessageID: in.MessageID, Text: queueAckTextFor(ahead, in.Text),
-			Envelope: turnEnvelope(rc, in, sendable.KindQueueAck, "turn_queued", sendable.PriorityHigh),
-		})
 		return
 	}
 	q.busy = true
 	q.mu.Unlock()
 
 	// This goroutine owns the busy cycle: run the idle-first turn, then drain.
-	m.runTurn(ctx, rc, in, true /* withProcessingAck */)
+	m.runTurn(ctx, rc, in)
 	m.drainConvQueue(q, key)
+}
+
+// handleInbound is the complete Live pipeline for one message, used by callers
+// that are not going through the per-conversation queue.
+func (m *Manager) handleInbound(ctx context.Context, rc *runningChannel, in InboundMessage) {
+	if m.handleFastPath(ctx, rc, &in) {
+		return
+	}
+	m.runTurn(ctx, rc, in)
+}
+
+// sendBusyHint emits at most one backlog notice per conversation per cooldown.
+func (m *Manager) sendBusyHint(ctx context.Context, rc *runningChannel, in InboundMessage, key string) {
+	now := time.Now()
+	m.busyHintMu.Lock()
+	last, seen := m.busyHintSent[key]
+	if seen && now.Sub(last) < busyHintCooldown {
+		m.busyHintMu.Unlock()
+		log.Warn().Str("conversation", in.ConversationID).Str("project", rc.cfg.ProjectID).
+			Msg("live: inbound dropped, queue full within busy-hint cooldown")
+		return
+	}
+	m.busyHintSent[key] = now
+	m.busyHintMu.Unlock()
+
+	log.Warn().Str("conversation", in.ConversationID).Str("project", rc.cfg.ProjectID).
+		Msg("live: inbound dropped, queue full")
+	m.sendOutbound(ctx, rc, OutboundMessage{
+		Scene: in.Scene, ConversationID: in.ConversationID,
+		ReplyToMessageID: in.MessageID, Text: busyHintText,
+		Envelope: turnEnvelope(rc, in, sendable.KindSafetyNotice, "queue_full", sendable.PriorityHigh),
+	})
 }
 
 // sendSafetyNotice delivers an adapter-detected notice through the Manager, so a
@@ -382,29 +440,36 @@ func (m *Manager) drainConvQueue(q *convQueue, key string) {
 		next := q.pending[0]
 		q.pending = q.pending[1:]
 		q.mu.Unlock()
-		// Dequeue: another processing ACK before Work.
-		m.runTurn(next.ctx, next.rc, next.in, true /* withProcessingAck */)
+		m.runTurn(next.ctx, next.rc, next.in)
 	}
 }
 
-// runTurn executes one PM turn and sends the final or failure reply.
-// withProcessingAck emits the required ≤1s ACK before dispatching Work.
-func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMessage, withProcessingAck bool) {
-	if withProcessingAck {
-		m.sendOutbound(ctx, rc, OutboundMessage{
-			Scene: in.Scene, ConversationID: in.ConversationID,
-			ReplyToMessageID: in.MessageID, Text: processingAckText(in.Text),
-			Envelope: turnEnvelope(rc, in, sendable.KindTurnProcessingAck, "turn_processing", sendable.PriorityHigh),
-		})
-	}
+// runTurn executes one foreground Live turn.
+//
+// The turn is expected to either answer briefly or delegate; it is bounded by
+// foregroundTurnTimeout so a conversation is never held open by work that
+// belongs in a Run. No acknowledgement precedes it — the reply is the
+// acknowledgement.
+func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMessage) {
+	// Keyed by conversation, not by inbound message id: the MCP host marks its
+	// own replies and only knows which conversation it is serving.
+	scope := conversationTurnScope(rc.cfg.ProjectID, in.Scene, in.ConversationID)
+	m.clearReplied(scope)
+	defer m.clearReplied(scope)
 
-	if m.handleInboundOrchestration(ctx, rc, &in) {
-		return
+	pendingID := m.beginPendingTurn(rc, in)
+	defer m.endPendingTurn(pendingID)
+
+	timeout := foregroundTurnTimeout
+	if configured := time.Duration(rc.cfg.TurnTimeoutSeconds) * time.Second; configured > 0 {
+		timeout = configured
 	}
+	turnCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
 	resolved := ResolvedChannel{
 		ID: rc.cfg.ID, Type: rc.cfg.Type, ProjectID: rc.cfg.ProjectID,
-		TurnTimeout: time.Duration(rc.cfg.TurnTimeoutSeconds) * time.Second,
+		TurnTimeout: timeout,
 		Caps:        SessionCapsFromConfig(rc.cfg.Config),
 	}
 	onProgress := func(ev ProgressEvent) {
@@ -414,30 +479,56 @@ func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMes
 		}
 		// Classification-only events stay internal; sendOutbound still runs so
 		// the suppression is audited with a reason instead of vanishing.
-		m.sendOutbound(ctx, rc, OutboundMessage{
+		result := m.sendOutboundResult(ctx, rc, OutboundMessage{
 			Scene: in.Scene, ConversationID: in.ConversationID,
 			ReplyToMessageID: in.MessageID, Text: text,
 			Envelope: progressEnvelope(rc, in, ev),
 		})
+		// A delivered milestone is the turn's first meaningful response; the
+		// final summary must not repeat it verbatim.
+		if result.Sent {
+			m.markReplied(scope)
+		}
 	}
-	reply, err := m.handleTurn(ctx, resolved, in, onProgress)
+	reply, err := m.handleTurn(turnCtx, resolved, in, onProgress)
 	if err != nil {
-		log.Warn().Err(err).Str("channel", rc.cfg.ID).Msg("channel turn failed")
+		// A turn that ran out of time is not a failure: the agent took on
+		// something that belongs in the background. Say that, rather than
+		// reporting an error for work that is still going to happen.
+		if turnCtx.Err() != nil && ctx.Err() == nil {
+			log.Info().Str("channel", rc.cfg.ID).Dur("timeout", timeout).
+				Msg("live: foreground turn exceeded its budget, handed to background")
+			if !m.hasReplied(scope) {
+				m.sendOutbound(ctx, rc, OutboundMessage{
+					Scene: in.Scene, ConversationID: in.ConversationID, ReplyToMessageID: in.MessageID,
+					Text:     turnHandoffText(services.DetectLanguage(in.Text, "")),
+					Envelope: turnEnvelope(rc, in, sendable.KindFinal, "turn_handed_to_background", sendable.PriorityHigh),
+				})
+			}
+			return
+		}
+		m.sendTurnFailure(ctx, rc, in, scope, err)
+		return
+	}
+
+	summary, reason, ok := deliverableFinalText(reply)
+	if !ok {
+		// The agent finished without submitting anything the user can read. If
+		// something substantive already went out this turn, staying quiet is the
+		// honest outcome; otherwise say so in terms the user can act on.
+		if m.hasReplied(scope) {
+			return
+		}
 		m.sendOutbound(ctx, rc, OutboundMessage{
-			Scene: in.Scene, ConversationID: in.ConversationID,
-			ReplyToMessageID: in.MessageID, Text: failReplyPrefix + friendlyErr(err),
-			Envelope: turnEnvelope(rc, in, sendable.KindBlocked, "turn_failed", sendable.PriorityCritical),
+			Scene: in.Scene, ConversationID: in.ConversationID, ReplyToMessageID: in.MessageID,
+			Text:     m.noAnswerFallback(rc, in),
+			Envelope: turnEnvelope(rc, in, sendable.KindFinal, "final_missing_fallback", sendable.PriorityCritical),
 		})
 		return
 	}
-	summary, reason := deliverableFinalText(reply)
-	images := reply.ImageURLs
-	if summary == safeFinalNotice {
-		images = nil // no structured summary → no derived attachments either
-	}
 	m.sendOutbound(ctx, rc, OutboundMessage{
 		Scene: in.Scene, ConversationID: in.ConversationID, ReplyToMessageID: in.MessageID,
-		Text: summary, ImageURLs: images,
+		Text: summary, ImageURLs: reply.ImageURLs,
 		Envelope: func() sendable.DeliveryEnvelope {
 			e := turnEnvelope(rc, in, sendable.KindFinal, reason, sendable.PriorityCritical)
 			e.Structured = true
@@ -446,18 +537,30 @@ func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMes
 	})
 }
 
-// safeFinalNotice is sent when Work produced no structured summary. Raw
-// assistant text is never used as a fallback.
-const safeFinalNotice = "本回合已结束，请在 Approving 查看完整结果。"
-
-// deliverableFinalText returns the only text allowed out of a finished turn:
-// the structured FinalSummary, or a fixed safe notice. Reply.Text stays
-// internal regardless of its content.
-func deliverableFinalText(reply Reply) (text, reason string) {
-	if summary := strings.TrimSpace(reply.FinalSummary); summary != "" {
-		return truncateRunes(summary, 240), "structured_turn_final"
+// sendTurnFailure reports a failed turn in the user's terms. Internal error
+// strings ("assistant produced no reply", sandbox/ACP plumbing) never leave the
+// platform; they are logged and mapped to a cause plus a next step.
+func (m *Manager) sendTurnFailure(ctx context.Context, rc *runningChannel, in InboundMessage, scope string, err error) {
+	log.Warn().Err(err).Str("channel", rc.cfg.ID).Msg("channel turn failed")
+	if m.hasReplied(scope) {
+		return
 	}
-	return safeFinalNotice, "final_summary_missing_safe_notice"
+	m.sendOutbound(ctx, rc, OutboundMessage{
+		Scene: in.Scene, ConversationID: in.ConversationID,
+		ReplyToMessageID: in.MessageID, Text: turnFailureText(err),
+		Envelope: turnEnvelope(rc, in, sendable.KindBlocked, "turn_failed", sendable.PriorityCritical),
+	})
+}
+
+// deliverableFinalText returns the text allowed out of a finished turn. Only an
+// explicitly submitted summary qualifies; Reply.Text stays internal regardless
+// of its content. ok=false means the turn produced nothing sendable and the
+// caller must fall back rather than emit a placeholder.
+func deliverableFinalText(reply Reply) (text, reason string, ok bool) {
+	if summary := strings.TrimSpace(reply.FinalSummary); summary != "" {
+		return truncateRunes(summary, 240), "structured_turn_final", true
+	}
+	return "", "final_summary_missing", false
 }
 
 func (m *Manager) handleTurn(ctx context.Context, rc ResolvedChannel, in InboundMessage, onProgress func(ProgressEvent)) (Reply, error) {
@@ -476,7 +579,15 @@ func turnScope(rc *runningChannel, in InboundMessage) string {
 	if id := strings.TrimSpace(in.MessageID); id != "" {
 		return "turn:" + rc.cfg.ProjectID + "|" + id
 	}
-	return "turn:" + convKey(rc.cfg.ProjectID, in.Scene, in.ConversationID)
+	return conversationTurnScope(rc.cfg.ProjectID, in.Scene, in.ConversationID)
+}
+
+// conversationTurnScope keys the in-flight turn by conversation. The MCP host
+// knows which conversation it is serving but not which inbound message id
+// started the turn, so the "already replied" marker is tracked per conversation
+// and both spellings resolve to the same live turn.
+func conversationTurnScope(projectID string, scene Scene, conversationID string) string {
+	return "turn:" + convKey(projectID, scene, conversationID)
 }
 
 // turnEnvelope builds a turn-scoped envelope. RunID stays empty on purpose;
@@ -489,6 +600,10 @@ func turnEnvelope(rc *runningChannel, in InboundMessage, kind sendable.Kind, rea
 		ConversationID: in.ConversationID, UserID: in.UserID,
 		DedupeKey: scope + ":" + string(kind),
 		Reason:    reason, Kind: kind,
+		// Turn-level text is composed by the platform (or extracted through an
+		// explicit structured path), never copied from raw model output, which
+		// is what the transport's Structured gate is checking for.
+		Structured: true,
 	}
 	return sendable.AppendSendable(e, sendable.ChannelQQ)
 }
@@ -536,6 +651,17 @@ func (m *Manager) sendOutbound(ctx context.Context, rc *runningChannel, out Outb
 func (m *Manager) sendOutboundResult(ctx context.Context, rc *runningChannel, out OutboundMessage) DeliveryResult {
 	if rc == nil || rc.adapter == nil {
 		return DeliveryResult{Decision: sendable.Decision{Reason: "no_adapter"}}
+	}
+	// Last gate before the transport. Every outbound path converges here, so
+	// scrubbing once here is what makes "internals never leak" a property of the
+	// system rather than a rule each call site has to remember.
+	if scrubbed := ScrubInternalTerms(out.Text); scrubbed != out.Text {
+		log.Debug().Str("channel", rc.cfg.ID).Str("reason", out.Envelope.Reason).
+			Msg("outbound text scrubbed of internal terms")
+		out.Text = scrubbed
+	}
+	if strings.TrimSpace(out.Text) == "" && len(out.ImageURLs) == 0 {
+		return DeliveryResult{Decision: sendable.Decision{Reason: "empty_after_scrub"}}
 	}
 	contentFingerprint := out.Text + "\n" + strings.Join(out.ImageURLs, "\n")
 	decision, err := m.policy.Evaluate(ctx, out.Envelope, sendable.ChannelQQ, contentFingerprint)
@@ -890,16 +1016,98 @@ func (m *Manager) convQueueFor(key string) *convQueue {
 	return q
 }
 
-func processingAckText(userText string) string {
-	return ackProcessingPrefix + truncateRunes(userText, ackSummaryRunes)
+// markReplied records that something substantive already reached the user in
+// this turn. pm_reply runs in the MCP host and the final summary runs here, so
+// without a shared marker a turn can answer twice.
+func (m *Manager) markReplied(scope string) {
+	if strings.TrimSpace(scope) == "" {
+		return
+	}
+	m.repliedMu.Lock()
+	m.replied[scope] = true
+	m.repliedMu.Unlock()
 }
 
-func queueAckTextFor(ahead int, userText string) string {
-	summary := truncateRunes(userText, ackSummaryRunes)
-	if ahead > 0 {
-		return fmt.Sprintf("%s（前方 %d 条）：%s", queueAckPrefix, ahead, summary)
+func (m *Manager) hasReplied(scope string) bool {
+	m.repliedMu.Lock()
+	defer m.repliedMu.Unlock()
+	return m.replied[scope]
+}
+
+func (m *Manager) clearReplied(scope string) {
+	m.repliedMu.Lock()
+	delete(m.replied, scope)
+	m.repliedMu.Unlock()
+}
+
+// MarkConversationReplied lets the MCP host record an explicit agent reply for
+// the conversation's current turn.
+func (m *Manager) MarkConversationReplied(projectID string, scene Scene, conversationID string) {
+	m.markReplied(conversationTurnScope(projectID, scene, conversationID))
+}
+
+// noAnswerFallback is what the user hears when a turn ends without the agent
+// submitting an answer. It names the task in flight and the next step, because
+// "go look somewhere else" is not an answer.
+func (m *Manager) noAnswerFallback(rc *runningChannel, in InboundMessage) string {
+	language := services.DetectLanguage(in.Text, "")
+	if task := m.activeTaskFor(rc, in); task != nil {
+		if language == "en" {
+			return "I'm still on \"" + task.ShortTitle + "\" and don't have a usable answer yet. I'll come back as soon as there's something concrete."
+		}
+		return "「" + task.ShortTitle + "」我还在弄，暂时没有可用的结论。有实质进展我就回来说。"
 	}
-	return fmt.Sprintf("%s：%s", queueAckPrefix, summary)
+	if language == "en" {
+		return "I couldn't put together an answer for that one. Could you rephrase it, or tell me which part matters most?"
+	}
+	return "这条我没能给出结论。你可以换个说法，或者告诉我最关心哪部分。"
+}
+
+// activeTaskFor returns the conversation's focused task, if any.
+func (m *Manager) activeTaskFor(rc *runningChannel, in InboundMessage) *models.TaskIdentity {
+	if m.taskContext == nil || rc == nil {
+		return nil
+	}
+	res, err := m.taskContext.ResolveTask(services.ResolveTaskInput{
+		Scope: services.TaskScope{
+			ProjectID: rc.cfg.ProjectID, UserID: services.SyntheticQQUserID(in.UserID),
+			Channel: rc.cfg.Type, ConversationID: in.ConversationID,
+		},
+	})
+	if err != nil {
+		return nil
+	}
+	return res.Identity
+}
+
+// turnHandoffText is what the user hears when a foreground turn outlives its
+// budget: the work continues, the conversation does not wait for it.
+func turnHandoffText(language string) string {
+	if services.NormalizeLanguage(language) == "en" {
+		return "This one needs more digging, so I'll keep at it in the background and come back with what I find. You can keep chatting in the meantime."
+	}
+	return "这个得多花点时间，我放到后台接着弄，有结果就来说。你可以接着问别的。"
+}
+
+// turnFailureText maps an internal turn error onto a cause the user can act on.
+func turnFailureText(err error) string {
+	if err == nil {
+		return "这条我没处理成功，你再发一次试试。"
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "context deadline exceeded"), strings.Contains(msg, "超时"),
+		strings.Contains(msg, "timeout"):
+		return "这条想得有点久，我先放到后台继续，有结果告诉你。"
+	case strings.Contains(msg, "沙箱"), strings.Contains(msg, "sandbox"):
+		return "我的执行环境暂时起不来，稍后再试一次；一直不行就需要管理员看一下。"
+	case strings.Contains(msg, "no reply"), strings.Contains(msg, "empty"):
+		return "这条我没能给出结论。换个说法我再试试。"
+	case strings.Contains(msg, "未启用"), strings.Contains(msg, "disabled"):
+		return "这个项目还没开启对话能力，需要管理员在后台启用。"
+	default:
+		return "这条我没处理成功。你可以再说一次，或者换个问法。"
+	}
 }
 
 func parseTarget(target string) (Scene, string) {
@@ -922,14 +1130,4 @@ func fingerprint(c models.ChannelConfig) string {
 		TurnTimeoutSeconds: c.TurnTimeoutSeconds, Config: c.Config,
 	})
 	return string(b)
-}
-
-func friendlyErr(err error) string {
-	msg := err.Error()
-	// Truncate on runes so a multi-byte (e.g. Chinese) message is never cut
-	// mid-character into invalid UTF-8.
-	if r := []rune(msg); len(r) > 200 {
-		msg = string(r[:200]) + "…"
-	}
-	return msg
 }

--- a/server/internal/channels/manager.go
+++ b/server/internal/channels/manager.go
@@ -48,11 +48,22 @@ const (
 	// convQueueDepth is the per-conversation pending FIFO capacity (in-flight
 	// turn is not counted). The next inbound after 16 pending is rejected.
 	convQueueDepth = 16
-	// foregroundTurnTimeout caps a Live turn. The foreground contract is "answer
-	// briefly or delegate", so exceeding this means the agent tried to do the
-	// work inline; we stop waiting and tell the user it moved to the background
-	// rather than holding the conversation hostage.
+	// foregroundTurnTimeout caps the agent's own work in a Live turn. The
+	// foreground contract is "answer briefly or delegate", so exceeding this
+	// means the agent tried to do the work inline.
 	foregroundTurnTimeout = 25 * time.Second
+	// sandboxOpenBudget is allowed on top, for getting a sandbox ready. It is
+	// separate because the two waits are not comparable: a warm conversation
+	// spends none of it, while the first message of a conversation waits for a
+	// container. Folding it into the answer budget is how a plain question
+	// times out before the agent has read it.
+	sandboxOpenBudget = 45 * time.Second
+	// stillWorkingDelay is how long a turn may leave the user with nothing at
+	// all before saying so. The streaming opener (firstSentenceDelay) covers
+	// any turn that has produced text; this only fires when there is genuinely
+	// nothing yet, which in practice means a cold start. It is deliberately
+	// later than the opener so a real sentence always wins the race.
+	stillWorkingDelay = 8 * time.Second
 )
 
 // queuedInbound is a message waiting behind an in-flight turn for the same
@@ -110,6 +121,10 @@ type Manager struct {
 	riskConfirmation *services.RiskConfirmationService
 	// retryBackoff overrides the delivery backoff (tests set it to zero).
 	retryBackoff func(attempt int) time.Duration
+	// openBudget overrides sandboxOpenBudget; a negative value means none.
+	openBudget time.Duration
+	// stillWorkingAfter overrides stillWorkingDelay (tests shorten it).
+	stillWorkingAfter time.Duration
 
 	ambiguityMu sync.Mutex
 	ambiguity   map[string]ambiguityMemory
@@ -446,10 +461,9 @@ func (m *Manager) drainConvQueue(q *convQueue, key string) {
 
 // runTurn executes one foreground Live turn.
 //
-// The turn is expected to either answer briefly or delegate; it is bounded by
-// foregroundTurnTimeout so a conversation is never held open by work that
-// belongs in a Run. No acknowledgement precedes it — the reply is the
-// acknowledgement.
+// The turn is expected to either answer briefly or delegate, and it is bounded
+// so a conversation is never held open by work that belongs in a Run. No
+// acknowledgement precedes it — the reply is the acknowledgement.
 func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMessage) {
 	// Keyed by conversation, not by inbound message id: the MCP host marks its
 	// own replies and only knows which conversation it is serving.
@@ -464,14 +478,20 @@ func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMes
 	if configured := time.Duration(rc.cfg.TurnTimeoutSeconds) * time.Second; configured > 0 {
 		timeout = configured
 	}
-	turnCtx, cancel := context.WithTimeout(ctx, timeout)
+	open := m.sandboxOpenBudget()
+	// The outer deadline is a backstop covering both phases; the bridge bounds
+	// each one separately so cold start cannot consume the answer budget.
+	turnCtx, cancel := context.WithTimeout(ctx, timeout+open)
 	defer cancel()
 
 	resolved := ResolvedChannel{
 		ID: rc.cfg.ID, Type: rc.cfg.Type, ProjectID: rc.cfg.ProjectID,
+		OpenTimeout: open,
 		TurnTimeout: timeout,
 		Caps:        SessionCapsFromConfig(rc.cfg.Config),
 	}
+	stopWaiting := m.sayStillWorking(turnCtx, rc, in, scope)
+	defer stopWaiting()
 	onProgress := func(ev ProgressEvent) {
 		text := FormatProgressText(ev)
 		if text == "" {
@@ -491,18 +511,21 @@ func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMes
 		}
 	}
 	reply, err := m.handleTurn(turnCtx, resolved, in, onProgress)
+	stopWaiting()
 	if err != nil {
-		// A turn that ran out of time is not a failure: the agent took on
-		// something that belongs in the background. Say that, rather than
-		// reporting an error for work that is still going to happen.
+		// Running out of time is not a failure, but it is not a delegation
+		// either: nothing was started and nothing is still running. Saying "I'll
+		// keep at it in the background" here would be a promise the platform
+		// cannot keep, so the user is offered the delegation instead — their
+		// next message turns it into a real Run.
 		if turnCtx.Err() != nil && ctx.Err() == nil {
 			log.Info().Str("channel", rc.cfg.ID).Dur("timeout", timeout).
-				Msg("live: foreground turn exceeded its budget, handed to background")
+				Msg("live: foreground turn exceeded its budget without an answer")
 			if !m.hasReplied(scope) {
 				m.sendOutbound(ctx, rc, OutboundMessage{
 					Scene: in.Scene, ConversationID: in.ConversationID, ReplyToMessageID: in.MessageID,
-					Text:     turnHandoffText(services.DetectLanguage(in.Text, "")),
-					Envelope: turnEnvelope(rc, in, sendable.KindFinal, "turn_handed_to_background", sendable.PriorityHigh),
+					Text:     turnTooSlowText(services.DetectLanguage(in.Text, "")),
+					Envelope: turnEnvelope(rc, in, sendable.KindFinal, "turn_budget_exceeded", sendable.PriorityHigh),
 				})
 			}
 			return
@@ -535,6 +558,69 @@ func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMes
 			return e
 		}(),
 	})
+}
+
+// sandboxOpenBudget is the cold-start allowance for this Manager.
+func (m *Manager) sandboxOpenBudget() time.Duration {
+	if m.openBudget < 0 {
+		return 0
+	}
+	if m.openBudget > 0 {
+		return m.openBudget
+	}
+	return sandboxOpenBudget
+}
+
+// sayStillWorking breaks a long silence once, and returns a function that
+// cancels it.
+//
+// It exists for the one case the streaming opener cannot cover: a cold start,
+// where there is no sandbox yet and therefore no text to release early. Leaving
+// the user staring at nothing for the length of a container boot is its own
+// kind of bad. This is not the mechanical acknowledgement that was removed —
+// that one preceded every message including instant ones; this fires only after
+// a genuinely long wait, at most once, and never when anything has been said.
+func (m *Manager) sayStillWorking(ctx context.Context, rc *runningChannel, in InboundMessage, scope string) (stop func()) {
+	done := make(chan struct{})
+	var once sync.Once
+	stop = func() { once.Do(func() { close(done) }) }
+	delay := stillWorkingDelay
+	if m.stillWorkingAfter > 0 {
+		delay = m.stillWorkingAfter
+	}
+	go func() {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		select {
+		case <-done:
+			return
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+		if m.hasReplied(scope) {
+			return
+		}
+		envelope := turnEnvelope(rc, in, sendable.KindProgress, "live_still_working", sendable.PriorityNormal)
+		envelope.Progress = sendable.ProgressFields{Stage: "live_still_working"}
+		result := m.sendOutboundResult(ctx, rc, OutboundMessage{
+			Scene: in.Scene, ConversationID: in.ConversationID, ReplyToMessageID: in.MessageID,
+			Text:     stillWorkingText(services.DetectLanguage(in.Text, "")),
+			Envelope: envelope,
+		})
+		if result.Sent {
+			m.markReplied(scope)
+		}
+	}()
+	return stop
+}
+
+// stillWorkingText admits the wait without pretending to report progress.
+func stillWorkingText(language string) string {
+	if services.NormalizeLanguage(language) == "en" {
+		return "Give me a moment on this one."
+	}
+	return "稍等，我看一下。"
 }
 
 // sendTurnFailure reports a failed turn in the user's terms. Internal error
@@ -1082,11 +1168,18 @@ func (m *Manager) activeTaskFor(rc *runningChannel, in InboundMessage) *models.T
 
 // turnHandoffText is what the user hears when a foreground turn outlives its
 // budget: the work continues, the conversation does not wait for it.
-func turnHandoffText(language string) string {
+// turnTooSlowText handles a turn that ran out of time without answering.
+//
+// It offers to delegate rather than claiming to have done so. Nothing is
+// running at this point, and a message that says otherwise leaves the user
+// waiting for a result that will never arrive — worse than the mechanical
+// acknowledgement it would have replaced. Answering yes makes it a real Run on
+// the next turn.
+func turnTooSlowText(language string) string {
 	if services.NormalizeLanguage(language) == "en" {
-		return "This one needs more digging, so I'll keep at it in the background and come back with what I find. You can keep chatting in the meantime."
+		return "This is more than I can work out while we're talking. Want me to take it on as a background task and come back with the result?"
 	}
-	return "这个得多花点时间，我放到后台接着弄，有结果就来说。你可以接着问别的。"
+	return "这个我一时半会儿聊不完。要不要我当成一个后台任务来做，做完了告诉你？"
 }
 
 // turnFailureText maps an internal turn error onto a cause the user can act on.

--- a/server/internal/channels/orchestration.go
+++ b/server/internal/channels/orchestration.go
@@ -26,10 +26,14 @@ func (m *Manager) SetRiskActionExecutor(exec RiskActionExecutor) {
 	m.riskExecutor = exec
 }
 
-// handleInboundOrchestration runs before the PM turn: risk confirmation,
-// high-risk intent tickets, and natural-language task addressing. Returns true
-// when the inbound message was fully handled (do not start a PM turn).
-func (m *Manager) handleInboundOrchestration(ctx context.Context, rc *runningChannel, in *InboundMessage) bool {
+// handleFastPath answers the deterministic Live intents — task_query,
+// task_control and clarification_reply — straight from stored task state.
+//
+// It runs before the per-conversation queue, so these messages are never
+// blocked by an in-flight agent turn. Returns true when the message was fully
+// handled; returns false (possibly after enriching in.Text with task context)
+// when the agent still needs to see it.
+func (m *Manager) handleFastPath(ctx context.Context, rc *runningChannel, in *InboundMessage) bool {
 	if in == nil || (m.taskContext == nil && m.riskConfirmation == nil) {
 		return false
 	}
@@ -58,7 +62,8 @@ func (m *Manager) handleInboundOrchestration(ctx context.Context, rc *runningCha
 		return false
 	}
 	resolveText := text
-	if isContinuation(text) {
+	amendment := looksLikeAmendment(text)
+	if isContinuation(text) || amendment {
 		resolveText = "" // force conversation-focus binding
 	} else if isStatusQuery(text) {
 		resolveText = stripStatusQueryNoise(text)
@@ -79,16 +84,29 @@ func (m *Manager) handleInboundOrchestration(ctx context.Context, rc *runningCha
 		if res.Task == nil {
 			return false
 		}
+		if amendment {
+			// FR-3: revising an in-flight task must reach that Run instead of
+			// silently becoming a new delegation. A finished task cannot absorb
+			// the change, so say so rather than dropping it.
+			if services.IsTerminalTaskStatus(res.Task.Status) {
+				m.sendOrchestrationReply(ctx, rc, *in,
+					amendAfterTerminalText(res.Task.ShortTitle, taskStatusLabel(res.Task.Status, language), language))
+				return true
+			}
+			m.recordTaskContext(rc, res.Task, text)
+			in.Text = prependAmendmentContext(text, res.Task)
+			return false
+		}
 		if isContinuation(text) {
 			// Focus already renewed by ResolveTask; continue into the PM turn
 			// with the resolved run context prepended.
+			m.recordTaskContext(rc, res.Task, text)
 			in.Text = prependFocusContext(text, res.Task)
 			return false
 		}
 		if isStatusQuery(text) || isBareTaskSelection(text, res) || resolveText != text {
 			// Re-render status with the original user wording language.
-			msg := FormatTaskMessage(res.Task.ShortTitle, taskStatusLabel(res.Task.Status, language),
-				"", text, language)
+			msg := m.formatTaskStatusReply(rc, *in, res.Task, text, language)
 			m.sendOrchestrationReply(ctx, rc, *in, msg)
 			return true
 		}
@@ -131,12 +149,24 @@ func (m *Manager) tryResolveRiskConfirmation(ctx context.Context, rc *runningCha
 		if err := m.riskExecutor(rc.cfg.ProjectID, ticket.RunID, riskBaseAction(ticket.Action), meta); err != nil {
 			log.Warn().Err(err).Str("run", ticket.RunID).Str("action", ticket.Action).
 				Msg("confirmed risk action failed")
-			m.sendOrchestrationReply(ctx, rc, in, resolved.Message+" "+friendlyErr(err))
+			// The user confirmed and it still did not happen. Say that plainly;
+			// the underlying error is a diagnostic, not an answer.
+			m.sendOrchestrationReply(ctx, rc, in, riskExecutionFailedText(language))
 			return true
 		}
 	}
 	m.sendOrchestrationReply(ctx, rc, in, resolved.Message)
 	return true
+}
+
+// riskExecutionFailedText reports a confirmed action that did not go through.
+// It says what the user needs to know — it did not happen, and nothing changed
+// — without repeating the internal error that explains why.
+func riskExecutionFailedText(language string) string {
+	if services.NormalizeLanguage(language) == "en" {
+		return "I couldn't carry that out just now, so nothing has changed. Want me to try again?"
+	}
+	return "这个操作没执行成功，状态没变。要我再试一次吗？"
 }
 
 func (m *Manager) tryCreateRiskConfirmation(ctx context.Context, rc *runningChannel, in InboundMessage, scopeUser, text, language string) bool {
@@ -295,7 +325,11 @@ func isStatusQuery(text string) bool {
 	if t == "" {
 		return false
 	}
-	needles := []string{"怎么样", "怎么了", "进度", "状态", "如何了", "好了吗", "how is", "how's", "status", "progress", "any update"}
+	needles := []string{
+		"怎么样", "怎么了", "什么情况", "到哪了", "到哪一步",
+		"进度", "进展", "状态", "如何了", "好了吗", "完了吗", "完了没", "有结果了吗",
+		"how is", "how's", "status", "progress", "any update", "done yet",
+	}
 	lower := strings.ToLower(t)
 	for _, n := range needles {
 		if strings.Contains(lower, strings.ToLower(n)) {
@@ -309,8 +343,11 @@ func stripStatusQueryNoise(text string) string {
 	out := text
 	for _, noise := range []string{
 		"的事情怎么样了", "事情怎么样了", "怎么样了", "怎么样", "怎么了",
-		"的进度", "进度如何", "进度", "的状态", "状态", "如何了", "好了吗",
-		"how is", "how's", "status of", "status", "progress on", "progress", "any update",
+		"现在什么进展了", "什么进展了", "什么情况", "到哪一步了", "到哪了",
+		"的进度", "进度如何", "进度", "进展", "的状态", "状态", "如何了",
+		"好了吗", "完了吗", "完了没", "有结果了吗",
+		"how is", "how's", "status of", "status", "progress on", "progress",
+		"any update", "done yet",
 		"的事情", "事情",
 	} {
 		out = strings.ReplaceAll(out, noise, " ")
@@ -337,32 +374,96 @@ func prependFocusContext(text string, task *models.TaskIdentity) string {
 	return "（当前焦点任务：" + task.ShortTitle + " / run " + task.RunID + "）\n" + text
 }
 
-func detectHighRiskIntent(text string) (action, query string) {
-	t := strings.TrimSpace(text)
-	lower := strings.ToLower(t)
-	type rule struct {
-		action string
-		keys   []string
+// prependAmendmentContext tells the agent the user is revising an existing
+// task, so it amends that Run instead of starting another one.
+func prependAmendmentContext(text string, task *models.TaskIdentity) string {
+	if task == nil {
+		return text
 	}
-	rules := []rule{
-		{"cancel_run", []string{"取消任务", "取消这个", "取消该", "取消运行", "cancel run", "cancel the task", "取消"}},
-		{"approve_gate", []string{"批准", "同意门禁", "approve", "批准门禁"}},
-		{"reject_gate", []string{"拒绝门禁", "驳回", "reject gate"}},
-		{"delete_run", []string{"删除任务", "删掉", "delete task"}},
+	return "（用户在修改已有任务的要求：" + task.ShortTitle + " / run " + task.RunID +
+		"。请把下面的补充要求并入该任务，不要新建任务。）\n" + text
+}
+
+func amendAfterTerminalText(shortTitle, statusLabel, language string) string {
+	if services.NormalizeLanguage(language) == "en" {
+		return "\"" + shortTitle + "\" is already " + statusLabel +
+			", so I can't fold that into it. Want me to start a new task for it?"
 	}
-	for _, r := range rules {
-		for _, key := range r.keys {
-			if strings.Contains(lower, strings.ToLower(key)) {
-				query = strings.TrimSpace(strings.ReplaceAll(t, key, ""))
-				query = strings.TrimSpace(strings.ReplaceAll(query, strings.ToUpper(key), ""))
-				if query == "" {
-					query = t
-				}
-				return r.action, query
-			}
-		}
+	return "「" + shortTitle + "」已经" + statusLabel + "了，改不进去。要我按这个新开一个任务吗？"
+}
+
+// recordTaskContext keeps the task's most recent conversational context fresh
+// so later status answers and background reflow can reference what the user
+// actually said (FR-6).
+func (m *Manager) recordTaskContext(rc *runningChannel, task *models.TaskIdentity, text string) {
+	if m.taskContext == nil || task == nil || rc == nil {
+		return
 	}
-	return "", ""
+	if _, err := m.taskContext.UpdateIdentity(services.EnsureTaskIdentityInput{
+		RunID: task.RunID, ProjectID: rc.cfg.ProjectID, UserID: task.UserID,
+		RecentContext: strings.TrimSpace(text),
+		Language:      services.TaskLanguageFor(task.Language, text),
+	}); err != nil {
+		log.Warn().Err(err).Str("run", task.RunID).Msg("record task recent context failed")
+	}
+}
+
+// formatTaskReply renders a task-scoped reply, naming the task only when the
+// name carries information.
+//
+// It carries information in two cases: several tasks are live, so the answer
+// would otherwise be ambiguous; or the user named the task themselves, where
+// repeating it confirms which one was understood. Everywhere else the name is
+// noise — a single-task conversation is already unambiguous, and stamping a
+// label on every line is what made the old output read like a ticket queue.
+func (m *Manager) formatTaskStatusReply(rc *runningChannel, in InboundMessage,
+	task *models.TaskIdentity, currentMessage, recentLanguage string) string {
+	if task == nil {
+		return ""
+	}
+	if m.shouldNameTask(rc, in, task, currentMessage) {
+		return FormatTaskMessage(task.ShortTitle,
+			taskStatusLabel(task.Status, recentLanguage), "", currentMessage, recentLanguage)
+	}
+	return soloTaskStatusText(task.Status, recentLanguage)
+}
+
+func (m *Manager) shouldNameTask(rc *runningChannel, in InboundMessage,
+	task *models.TaskIdentity, currentMessage string) bool {
+	return m.liveTaskCount(rc, in) > 1 || mentionsTask(currentMessage, task.ShortTitle)
+}
+
+// mentionsTask reports whether the user's own words picked out this task, so a
+// reply that repeats the name is confirming rather than labelling.
+func mentionsTask(message, shortTitle string) bool {
+	title := services.SanitizeShortTitle(shortTitle)
+	msg := strings.ToLower(strings.TrimSpace(message))
+	if title == "" || msg == "" {
+		return false
+	}
+	lower := strings.ToLower(title)
+	if strings.Contains(msg, lower) {
+		return true
+	}
+	// A bare selection may be a prefix of the stored title ("结算页" for
+	// "结算页性能"); short fragments are too weak to count as a reference.
+	return len([]rune(msg)) >= 3 && strings.Contains(lower, msg)
+}
+
+// liveTaskCount counts this user's non-terminal tasks in the conversation.
+func (m *Manager) liveTaskCount(rc *runningChannel, in InboundMessage) int {
+	if m.taskContext == nil || rc == nil {
+		return 0
+	}
+	n, err := m.taskContext.CountActive(services.TaskScope{
+		ProjectID: rc.cfg.ProjectID, UserID: services.SyntheticQQUserID(in.UserID),
+		Channel: rc.cfg.Type, ConversationID: in.ConversationID,
+	})
+	if err != nil {
+		log.Warn().Err(err).Str("project", rc.cfg.ProjectID).Msg("count active tasks failed")
+		return 0
+	}
+	return n
 }
 
 func riskBaseAction(action string) string {

--- a/server/internal/channels/orchestration.go
+++ b/server/internal/channels/orchestration.go
@@ -77,9 +77,18 @@ func (m *Manager) handleFastPath(ctx context.Context, rc *runningChannel, in *In
 		return false
 	}
 	switch res.Status {
-	case TaskReferenceAmbiguous, TaskReferenceNotFound, TaskReferenceNoContext:
+	case TaskReferenceAmbiguous:
+		// Several tasks match, so the user has to pick. Asking is the answer.
 		m.sendOrchestrationReply(ctx, rc, *in, res.Message)
 		return true
+	case TaskReferenceNotFound, TaskReferenceNoContext:
+		// Nothing matched. The keywords that got us here are weak — 「怎么样」
+		// appears in "这个功能怎么样" as readily as in "那个任务怎么样" — so a
+		// miss is better evidence that this was never about a task than that
+		// the user named one that does not exist. Answering "no matching task"
+		// would end an ordinary question with a canned line the agent could
+		// have answered properly.
+		return false
 	case TaskReferenceResolved:
 		if res.Task == nil {
 			return false

--- a/server/internal/channels/orchestration_test.go
+++ b/server/internal/channels/orchestration_test.go
@@ -56,7 +56,7 @@ func TestInboundOrchestrationAmbiguityAndContinuation(t *testing.T) {
 		Scene: SceneC2C, ConversationID: "c1", UserID: "u1",
 		MessageID: "m1", Text: "登录页怎么样了",
 	}
-	m.runTurn(context.Background(), rc, in, false)
+	m.handleInbound(context.Background(), rc, in)
 	got := sentTexts(fa)
 	if turned != 0 {
 		t.Fatalf("ambiguous status query must not start a PM turn, turned=%d", turned)
@@ -68,10 +68,10 @@ func TestInboundOrchestrationAmbiguityAndContinuation(t *testing.T) {
 	fa.mu.Lock()
 	fa.sent = nil
 	fa.mu.Unlock()
-	m.runTurn(context.Background(), rc, InboundMessage{
+	m.handleInbound(context.Background(), rc, InboundMessage{
 		Scene: SceneC2C, ConversationID: "c1", UserID: "u1",
 		MessageID: "m2", Text: "登录页性能优化",
-	}, false)
+	})
 	got = sentTexts(fa)
 	if turned != 0 {
 		t.Fatalf("short-title selection should answer without PM turn, turned=%d", turned)
@@ -83,10 +83,10 @@ func TestInboundOrchestrationAmbiguityAndContinuation(t *testing.T) {
 	fa.mu.Lock()
 	fa.sent = nil
 	fa.mu.Unlock()
-	m.runTurn(context.Background(), rc, InboundMessage{
+	m.handleInbound(context.Background(), rc, InboundMessage{
 		Scene: SceneC2C, ConversationID: "c1", UserID: "u1",
 		MessageID: "m3", Text: "那继续吧",
-	}, false)
+	})
 	if turned != 1 {
 		t.Fatalf("continuation should enter PM turn with focus, turned=%d", turned)
 	}
@@ -98,25 +98,30 @@ func TestInboundOrchestrationAmbiguityAndContinuation(t *testing.T) {
 	fa.mu.Lock()
 	fa.sent = nil
 	fa.mu.Unlock()
-	m.runTurn(context.Background(), rc, InboundMessage{
+	m.handleInbound(context.Background(), rc, InboundMessage{
 		Scene: SceneC2C, ConversationID: "c1", UserID: "u1",
 		MessageID: "m4", Text: "取消登录页性能优化",
-	}, false)
+	})
 	got = sentTexts(fa)
 	if len(cancelled) != 0 {
 		t.Fatalf("high-risk action executed before confirmation: %v", cancelled)
 	}
-	if len(got) != 1 || !strings.Contains(got[0], "高风险确认") {
+	// The prompt asks in plain words, names the task and says how to answer.
+	if len(got) != 1 || !strings.Contains(got[0], "登录页性能优化") ||
+		!strings.Contains(got[0], "确认") {
 		t.Fatalf("expected confirmation prompt, got %v", got)
+	}
+	if ContainsInternalTerms(got[0]) {
+		t.Fatalf("confirmation prompt exposes internals: %q", got[0])
 	}
 
 	fa.mu.Lock()
 	fa.sent = nil
 	fa.mu.Unlock()
-	m.runTurn(context.Background(), rc, InboundMessage{
+	m.handleInbound(context.Background(), rc, InboundMessage{
 		Scene: SceneC2C, ConversationID: "c1", UserID: "u1",
 		MessageID: "m5", Text: "确认",
-	}, false)
+	})
 	if len(cancelled) != 1 || cancelled[0] != "r1:cancel_run" {
 		t.Fatalf("confirmed cancel = %v", cancelled)
 	}
@@ -156,10 +161,10 @@ func TestInboundOrchestrationGenericTitleAndGateConfirmation(t *testing.T) {
 		cfg:     models.ChannelConfig{ID: "c1", Type: models.ChannelTypeQQ, ProjectID: projectID},
 		adapter: fa,
 	}
-	m.runTurn(context.Background(), rc, InboundMessage{
+	m.handleInbound(context.Background(), rc, InboundMessage{
 		Scene: SceneC2C, ConversationID: "c1", UserID: "u1",
 		MessageID: "m1", Text: "结算页性能",
-	}, false)
+	})
 	if turned != 0 {
 		t.Fatalf("generic exact short title should be handled before PM turn, turned=%d", turned)
 	}
@@ -176,10 +181,10 @@ func TestInboundOrchestrationGenericTitleAndGateConfirmation(t *testing.T) {
 		executedAction, executedMeta = action, meta
 		return nil
 	})
-	m.runTurn(context.Background(), rc, InboundMessage{
+	m.handleInbound(context.Background(), rc, InboundMessage{
 		Scene: SceneC2C, ConversationID: "c1", UserID: "u1",
 		MessageID: "m2", Text: "批准结算页性能",
-	}, false)
+	})
 	pending, err := risk.LatestPending(services.SyntheticQQUserID("u1"), projectID)
 	if err != nil || pending == nil {
 		t.Fatalf("pending gate ticket = %+v err=%v", pending, err)
@@ -191,10 +196,10 @@ func TestInboundOrchestrationGenericTitleAndGateConfirmation(t *testing.T) {
 		t.Fatalf("gate executed before confirmation: %s", executedAction)
 	}
 
-	m.runTurn(context.Background(), rc, InboundMessage{
+	m.handleInbound(context.Background(), rc, InboundMessage{
 		Scene: SceneC2C, ConversationID: "c1", UserID: "u1",
 		MessageID: "m3", Text: "确认",
-	}, false)
+	})
 	if executedAction != "resume_gate" ||
 		executedMeta["nodeId"] != "review-gate" || executedMeta["gateAction"] != "approve" {
 		t.Fatalf("confirmed gate action=%q meta=%v", executedAction, executedMeta)

--- a/server/internal/channels/preamble.go
+++ b/server/internal/channels/preamble.go
@@ -1,19 +1,44 @@
 package channels
 
-// ChannelPreamble is a short session preamble injected on the first turn of a
-// channel conversation's sandbox. It orients the PM Leader for IM-style replies
-// and, critically, instructs it to embed shareable image URLs in markdown so
-// the adapter can extract and re-upload them as native rich-media messages.
+import "strings"
+
+// ChannelPreamble is the session preamble injected on the first turn of a
+// channel conversation's sandbox.
+//
+// It establishes the Live turn contract: a foreground turn either answers the
+// user or hands the work to a background Run, and it always ends by calling a
+// tool. Long work must not be attempted inline, because the user is waiting in a
+// live conversation while it happens.
 func ChannelPreamble(channelType string) string {
-	return "你正在通过外部 IM 渠道（" + channelType + "）与用户对话。" +
-		"请用简洁、可直接阅读的自然语言回答；可使用 Markdown（标题、加粗、斜体、有序/无序列表、块引用、链接、分割线）提升可读性，" +
-		"但不要使用表格（QQ 原生 Markdown 不支持表格）。" +
-		"通过 pm-leader / context-store / memory-store 等 MCP 工具获取项目进度、记忆与历史后再作答，不要编造。" +
-		"长任务执行中，可用单独一行并以标记开头整理内部进展分类（[进度]/[阻塞]/[确认]）；" +
-		"这些标记只作内部分类提示，不会单独决定外发——只有服务端 Sendable 策略或显式提交的结构化摘要才会到达 QQ。" +
-		"需要用户可见结论时，用 [摘要] 单独一行写出结构化最终摘要；工具细节与思考过程不要写成用户可见正文。" +
-		"如果需要发送图片，请在回复中用 Markdown 图片语法给出可公网访问的图片直链，例如 ![](https://example.com/x.png)，" +
-		"系统会自动把这些直链作为图片消息发送；请勿发送本地路径或需要鉴权的链接。" +
-		"取消/批准等会改变任务状态的操作必须先短标题二次确认；可用 pm_notify_progress / pm_start_run 等工具显式提交外发进展与接单。" +
-		"pm_notify_progress 返回 status=suppressed 表示被限频/去重/合并等策略正常抑制，属正常结果，不要换措辞重发；只有返回错误才是真实投递失败。"
+	return strings.Join([]string{
+		"你正在通过外部 IM 渠道（" + channelType + "）和用户实时聊天。这是一场连续对话，不是工单系统。",
+
+		"【这一轮怎么收尾】每一轮你只做两件事之一，并且必须以对应的工具调用收尾：",
+		"1) 能当场答的（提问、闲聊、解释、查状态）→ 直接调用 pm_reply 把答案发出去，不要建任务。",
+		"2) 需要真正干活的（写代码、调研、改配置、跑流程等要花分钟级以上的事）→ 调用 pm_start_run 交给后台，" +
+			"系统会自动告诉用户已经接手，你不用再重复说一遍，也不要等它跑完。",
+
+		"【正文不会外发】你写在回复正文里的内容用户看不到——只有 pm_reply 提交的 text 会真正发给用户。" +
+			"所以想让用户看到的每一句话，都必须放进 pm_reply。",
+
+		"【怎么说话】像同事之间聊天那样说人话，一次说清一件事。" +
+			"不要说「收到，正在处理」「本回合已结束」「请前往 Approving 查看」这类话；" +
+			"不要出现 Run ID、工作流名、沙箱、工具名、内部事件名、错误堆栈；" +
+			"不要复述推理过程。用户关心的是结论和下一步。" +
+			"用户用中文你就用中文，用英文就用英文。",
+
+		"【别在前台硬扛】如果一件事你判断要花很久，不要在这一轮里慢慢做完再回答——" +
+			"先 pm_start_run 交给后台，用户可以接着跟你聊别的。前台每一轮都有硬性时间上限，超时这一轮的回答就丢了。",
+
+		"【格式】可以用 Markdown（加粗、列表、链接等）提升可读性，但不要用表格（QQ 不支持）。" +
+			"需要发图片时，在 pm_reply 的 text 里用 Markdown 图片语法给出可公网访问的直链，例如 ![](https://example.com/x.png)；" +
+			"不要给本地路径或需要鉴权的链接。",
+
+		"【先查再答】通过 pm-leader / context-store / memory-store 等 MCP 工具获取项目进度、记忆与历史后再作答，不要编造。",
+
+		"【危险操作】取消、批准、删除等会改变任务状态的操作，必须先用短标题向用户二次确认，确认后才执行。",
+
+		"【后台进展】任务在后台跑的过程中，有实质进展、被阻塞或需要用户决策时，用 pm_notify_progress 同步；" +
+			"它返回 status=suppressed 表示被限频/去重/合并等策略正常抑制，属正常结果，不要换措辞重发；只有返回错误才是真实投递失败。",
+	}, "\n")
 }

--- a/server/internal/channels/progress.go
+++ b/server/internal/channels/progress.go
@@ -44,8 +44,13 @@ type ProgressEvent struct {
 	At             time.Time
 }
 
-// Deliverable reports whether this event may leave the platform. Classified
-// narration alone never qualifies.
+// Deliverable reports whether this event may leave the platform.
+//
+// Milestones with a substantive Stage are allowed out: suppressing them at the
+// source meant users heard nothing for the entire life of a Run, and rate
+// limiting is the policy layer's job, not a blanket veto here. What stays
+// internal is raw narration with nothing substantive in it — an event whose only
+// content is a fragment of model output.
 func (ev ProgressEvent) Deliverable() bool {
 	if ev.Sendable {
 		return true
@@ -55,7 +60,24 @@ func (ev ProgressEvent) Deliverable() bool {
 	if ev.Blocked || ev.ActionRequired {
 		return strings.TrimSpace(ev.Conclusion) != ""
 	}
+	if ev.Kind == ProgressMilestone {
+		return isSubstantiveStage(ev.Stage)
+	}
 	return false
+}
+
+// substantiveStageRunes is the length below which a stage is a fragment rather
+// than a milestone worth interrupting the conversation for.
+const substantiveStageRunes = 8
+
+// isSubstantiveStage reports whether a milestone's stage says something a user
+// can act on, as opposed to a token fragment or tool noise.
+func isSubstantiveStage(stage string) bool {
+	stage = strings.TrimSpace(stage)
+	if utf8.RuneCountInString(stage) < substantiveStageRunes {
+		return false
+	}
+	return !isProgressNoise(stage)
 }
 
 // TurnFinalReport is the Work turn outcome consumed by Reply for the required
@@ -301,6 +323,56 @@ func (a *progressAccumulator) emitKeywordLines() []ProgressEvent {
 	return out
 }
 
+const (
+	// firstSentenceDelay is how long a turn may stay silent before its opening
+	// sentence is released early.
+	firstSentenceDelay = 3 * time.Second
+	// firstSentenceMinRunes keeps half-formed openings from going out.
+	firstSentenceMinRunes = 10
+	// firstSentenceMaxRunes bounds an opening that never terminates.
+	firstSentenceMaxRunes = 120
+)
+
+var sentenceTerminators = []rune{'。', '！', '？', '\n', '.', '!', '?'}
+
+// FirstCompleteSentence returns the buffer's opening sentence once it is
+// complete and long enough to be worth sending on its own.
+func (a *progressAccumulator) FirstCompleteSentence() (string, bool) {
+	if a == nil {
+		return "", false
+	}
+	text := strings.TrimSpace(a.buf)
+	if text == "" || isProgressNoise(text) {
+		return "", false
+	}
+	// A marker line is internal scaffolding, not something to read aloud.
+	if _, ok := classifyProgressMarker(text); ok {
+		return "", false
+	}
+	runes := []rune(text)
+	end := -1
+	for i, r := range runes {
+		for _, term := range sentenceTerminators {
+			if r == term {
+				end = i
+				break
+			}
+		}
+		if end >= 0 {
+			break
+		}
+	}
+	if end < 0 {
+		return "", false
+	}
+	sentence := strings.TrimSpace(string(runes[:end+1]))
+	sentence = strings.Trim(sentence, "\n")
+	if utf8.RuneCountInString(sentence) < firstSentenceMinRunes {
+		return "", false
+	}
+	return truncateRunes(sentence, firstSentenceMaxRunes), true
+}
+
 func FormatProgressText(ev ProgressEvent) string {
 	sum := strings.TrimSpace(ev.Summary)
 	if sum == "" {
@@ -308,11 +380,14 @@ func FormatProgressText(ev ProgressEvent) string {
 	}
 	switch ev.Kind {
 	case ProgressBlocker:
-		return "阻塞：" + sum
+		return "卡住了：" + sum
 	case ProgressConfirm:
-		return "需确认：" + sum
+		return "需要你定一下：" + sum
 	default:
-		return "进度：" + sum
+		// Milestones carry no label. The old "进度：" prefix turned the agent's
+		// own words into a machine relaying them, and the content already says
+		// it is progress.
+		return sum
 	}
 }
 

--- a/server/internal/channels/recovery.go
+++ b/server/internal/channels/recovery.go
@@ -1,0 +1,107 @@
+package channels
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/sendable"
+	"github.com/cocofhu/approving/internal/services"
+
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+)
+
+// A foreground turn lives entirely in memory: a restart takes the sandbox with
+// it and the user's message is simply never answered. Recording the turn while
+// it runs, and sweeping what is left at boot, is what turns that silent loss
+// into a sentence the user can act on.
+
+func (m *Manager) beginPendingTurn(rc *runningChannel, in InboundMessage) string {
+	db := m.taskContextDB()
+	if db == nil || rc == nil {
+		return ""
+	}
+	id := turnScope(rc, in)
+	row := models.PendingChannelTurn{
+		ID: id, ProjectID: rc.cfg.ProjectID, Channel: rc.cfg.Type,
+		Scene: string(in.Scene), ConversationID: in.ConversationID,
+		ExternalUserID: in.UserID, MessageID: in.MessageID,
+		Language:  services.DetectLanguage(in.Text, ""),
+		StartedAt: time.Now(),
+	}
+	if err := db.Save(&row).Error; err != nil {
+		log.Warn().Err(err).Str("conversation", in.ConversationID).
+			Msg("recording in-flight turn failed; a restart would lose this message silently")
+		return ""
+	}
+	return id
+}
+
+func (m *Manager) endPendingTurn(id string) {
+	db := m.taskContextDB()
+	if db == nil || strings.TrimSpace(id) == "" {
+		return
+	}
+	if err := db.Delete(&models.PendingChannelTurn{}, "id = ?", id).Error; err != nil {
+		log.Warn().Err(err).Str("turn", id).Msg("clearing in-flight turn record failed")
+	}
+}
+
+// RecoverInterruptedTurns tells anyone whose turn died in a restart what
+// happened, and clears the records. Called once after adapters are up.
+func (m *Manager) RecoverInterruptedTurns(ctx context.Context) {
+	db := m.taskContextDB()
+	if db == nil {
+		return
+	}
+	var rows []models.PendingChannelTurn
+	if err := db.Find(&rows).Error; err != nil {
+		log.Warn().Err(err).Msg("scanning interrupted turns failed")
+		return
+	}
+	if len(rows) == 0 {
+		return
+	}
+	if ctx == nil {
+		ctx = m.baseCtx
+	}
+	for _, row := range rows {
+		log.Info().Str("conversation", row.ConversationID).Str("project", row.ProjectID).
+			Time("started", row.StartedAt).Msg("recovering a turn interrupted by restart")
+		_, err := m.DeliverSendable(ctx, SendableRequest{
+			ProjectID: row.ProjectID, Scene: Scene(row.Scene), ConversationID: row.ConversationID,
+			UserID: row.ExternalUserID, ReplyToMessageID: row.MessageID,
+			TaskContext: "recovered:" + row.ID,
+			Kind:        sendable.KindFinal, Reason: "turn_interrupted_recovery",
+			Priority:  sendable.PriorityHigh,
+			DedupeKey: "turn-recovery:" + row.ID,
+			Text:      interruptedTurnText(row.Language),
+		})
+		if err != nil {
+			log.Warn().Err(err).Str("conversation", row.ConversationID).
+				Msg("notifying about an interrupted turn failed")
+			continue
+		}
+		m.endPendingTurn(row.ID)
+	}
+}
+
+// interruptedTurnText explains the gap without blaming the user or exposing
+// what actually broke, and asks for the one thing that resolves it.
+func interruptedTurnText(language string) string {
+	if services.NormalizeLanguage(language) == "en" {
+		return "Sorry — I got restarted while working on your last message and lost it. Could you send it again?"
+	}
+	return "抱歉，我这边刚重启了一下，你上一条消息没处理完就断了。麻烦再发一次。"
+}
+
+// taskContextDB exposes the shared database handle. Recovery deliberately
+// piggybacks on the task-context connection rather than taking its own.
+func (m *Manager) taskContextDB() *gorm.DB {
+	if m.taskContext == nil {
+		return nil
+	}
+	return m.taskContext.DB()
+}

--- a/server/internal/channels/reflow.go
+++ b/server/internal/channels/reflow.go
@@ -1,0 +1,353 @@
+package channels
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/sendable"
+	"github.com/cocofhu/approving/internal/services"
+
+	"github.com/rs/zerolog/log"
+)
+
+// This file brings a background task's outcome back into the conversation that
+// asked for it.
+//
+// The important part is that the outcome is *rewritten for that conversation*
+// before it is sent. Pushing the raw event out as a template is what produced
+// 「本回合已结束，请在 Approving 查看完整结果。」— technically a notification, but
+// it tells the user nothing and makes them go somewhere else to find out what
+// happened. So the event goes to the conversation's own agent first, which
+// already holds the context of what was asked, and it answers in that context.
+//
+// When the agent cannot be reached the message still goes out, as a plain
+// statement of what happened and what to do next. Degrading is acceptable;
+// dropping the outcome is not, because the user is waiting for it.
+
+// TaskOutcome is a terminal Run result on its way back to a conversation.
+type TaskOutcome struct {
+	ProjectID string
+	RunID     string
+	// Status is completed / failed / cancelled.
+	Status string
+	// FailureReason is the aggregated cause for a failed run.
+	FailureReason string
+}
+
+// ReflowTaskOutcome delivers a finished task's outcome to its origin
+// conversation and records the terminal status on the task, so later questions
+// like "how's that one going?" stop answering "in progress".
+func (m *Manager) ReflowTaskOutcome(ctx context.Context, outcome TaskOutcome) error {
+	runID := strings.TrimSpace(outcome.RunID)
+	if runID == "" {
+		return errors.New("task outcome requires a real run id")
+	}
+	if ctx == nil {
+		ctx = m.baseCtx
+	}
+	identity := m.identityForRun(runID, outcome.ProjectID)
+	if identity == nil {
+		// No task identity means this Run was never started from a
+		// conversation; there is nobody waiting on it here.
+		return nil
+	}
+	m.syncTerminalStatus(identity, outcome)
+
+	conv := strings.TrimSpace(identity.OriginConversationID)
+	if conv == "" {
+		log.Debug().Str("run", runID).Msg("reflow: task has no origin conversation, skipping")
+		return nil
+	}
+	scene := Scene(strings.TrimSpace(identity.OriginScene))
+	if scene == "" {
+		scene = SceneC2C
+	}
+
+	text := m.synthesizeOutcome(ctx, identity, outcome, scene, conv)
+	if strings.TrimSpace(text) == "" {
+		return nil
+	}
+	_, err := m.DeliverSendable(ctx, SendableRequest{
+		ProjectID: identity.ProjectID, Scene: scene, ConversationID: conv,
+		UserID: identity.OriginExternalUserID, RunID: runID,
+		Kind: sendable.KindFinal, Reason: "task_outcome",
+		Priority: sendable.PriorityCritical,
+		// One conclusion per run per conversation, whatever path produced it.
+		DedupeKey: strings.Join([]string{"task-outcome", runID, conv}, ":"),
+		Text:      text,
+	})
+	return err
+}
+
+// synthesizeOutcome asks the conversation's agent to phrase the outcome in
+// context, and falls back to a self-contained statement if that is not
+// possible. The fallback is written to be a real answer on its own — it names
+// the task, says what happened, and says what comes next — because it is what
+// the user actually receives whenever the agent is busy or unavailable.
+func (m *Manager) synthesizeOutcome(ctx context.Context, identity *models.TaskIdentity,
+	outcome TaskOutcome, scene Scene, conv string) string {
+	language := taskLanguage(identity)
+	fallback := outcomeFallbackText(identity, outcome, language)
+	if m.synthesize == nil {
+		return fallback
+	}
+	// Synthesis borrows the conversation's agent, which can answer through
+	// pm_reply. Capturing that reply instead of letting it out keeps delivery
+	// in one place, so the outcome is sent exactly once with the dedupe key
+	// that guarantees it. A conversation already running a turn is left alone:
+	// interleaving a synthesis turn there would both fail and risk capturing
+	// the user's own answer.
+	take, ok := m.tryCaptureReply(identity.ProjectID, scene, conv)
+	if !ok {
+		log.Debug().Str("run", identity.RunID).
+			Msg("reflow: conversation is busy, using structured fallback")
+		return fallback
+	}
+	req := SynthesisRequest{
+		ProjectID: identity.ProjectID, Scene: scene, ConversationID: conv,
+		ExternalUserID: identity.OriginExternalUserID,
+		RunID:          identity.RunID, ShortTitle: identity.ShortTitle,
+		Language: language, Fallback: fallback,
+		Brief: outcomeBrief(identity, outcome, language),
+	}
+	text, err := m.synthesize(ctx, req)
+	captured := take()
+	if strings.TrimSpace(text) == "" {
+		text = captured
+	}
+	if strings.TrimSpace(text) == "" {
+		log.Info().Err(err).Str("run", identity.RunID).
+			Msg("reflow: natural-language synthesis unavailable, using structured fallback")
+		return fallback
+	}
+	return ScrubInternalTerms(text)
+}
+
+// SynthesisRequest asks the conversation's agent to phrase a background event
+// for that conversation. Only structured fields are provided — never raw tool
+// output or reasoning text — so synthesis cannot become a channel for internal
+// content to escape.
+type SynthesisRequest struct {
+	ProjectID      string
+	Scene          Scene
+	ConversationID string
+	ExternalUserID string
+	RunID          string
+	ShortTitle     string
+	Language       string
+	// Brief is the structured description of what happened.
+	Brief string
+	// Fallback is what will be sent if synthesis does not produce anything.
+	Fallback string
+}
+
+// SynthesisFunc rewrites a background event as conversational text.
+type SynthesisFunc func(ctx context.Context, req SynthesisRequest) (string, error)
+
+// SetSynthesizer wires natural-language reflow (nil keeps structured fallbacks).
+func (m *Manager) SetSynthesizer(fn SynthesisFunc) { m.synthesize = fn }
+
+// tryCaptureReply diverts this conversation's agent replies into a buffer
+// instead of the channel, and returns a function that ends the capture and
+// yields whatever was collected. It reports false when a foreground turn is
+// already running, because that turn's replies belong to the user.
+func (m *Manager) tryCaptureReply(projectID string, scene Scene, conv string) (take func() string, ok bool) {
+	key := convKey(projectID, scene, conv)
+	q := m.convQueueFor(key)
+	q.mu.Lock()
+	busy := q.busy
+	q.mu.Unlock()
+	if busy {
+		return nil, false
+	}
+
+	m.captureMu.Lock()
+	if m.captured == nil {
+		m.captured = map[string]*string{}
+	}
+	if _, exists := m.captured[key]; exists {
+		m.captureMu.Unlock()
+		return nil, false
+	}
+	buf := new(string)
+	m.captured[key] = buf
+	m.captureMu.Unlock()
+
+	return func() string {
+		m.captureMu.Lock()
+		defer m.captureMu.Unlock()
+		delete(m.captured, key)
+		return *buf
+	}, true
+}
+
+// captureReply records an agent reply when the conversation is under capture.
+func (m *Manager) captureReply(projectID string, scene Scene, conv, text string) bool {
+	m.captureMu.Lock()
+	defer m.captureMu.Unlock()
+	buf, ok := m.captured[convKey(projectID, scene, conv)]
+	if !ok {
+		return false
+	}
+	if *buf == "" {
+		*buf = text
+	} else {
+		*buf += "\n" + text
+	}
+	return true
+}
+
+// outcomeBrief states the facts the agent may use. It is deliberately terse and
+// structured: the agent's job is to phrase it for this conversation, not to
+// discover new information.
+func outcomeBrief(identity *models.TaskIdentity, outcome TaskOutcome, language string) string {
+	var b strings.Builder
+	b.WriteString("后台任务已结束，请用一到两句话把结果告诉用户。\n")
+	b.WriteString("任务：" + identity.ShortTitle + "\n")
+	if req := strings.TrimSpace(identity.OriginalRequirement); req != "" {
+		b.WriteString("用户当初的要求：" + truncateRunes(req, 200) + "\n")
+	}
+	if recent := strings.TrimSpace(identity.RecentContext); recent != "" {
+		b.WriteString("最近一次相关对话：" + truncateRunes(recent, 200) + "\n")
+	}
+	switch strings.ToLower(strings.TrimSpace(outcome.Status)) {
+	case "completed":
+		b.WriteString("结果：做完了。请说清楚做完了什么，不要只说「已完成」。\n")
+	case "cancelled":
+		b.WriteString("结果：被取消了。\n")
+	default:
+		b.WriteString("结果：没做成。\n")
+		if reason := strings.TrimSpace(outcome.FailureReason); reason != "" {
+			b.WriteString("原因（请翻译成用户能懂的话，不要照抄）：" + truncateRunes(reason, 200) + "\n")
+		}
+	}
+	b.WriteString("要求：说人话，像同事汇报一样；不要出现任务编号、工作流名、执行环境、工具名；")
+	b.WriteString("不要说「请前往 Approving 查看」；结论要能独立看懂。")
+	if services.NormalizeLanguage(language) == "en" {
+		b.WriteString("\n用英文回答。")
+	}
+	return b.String()
+}
+
+// outcomeFallbackText is the self-contained version sent when synthesis is
+// unavailable. It never tells the user to go look somewhere else.
+func outcomeFallbackText(identity *models.TaskIdentity, outcome TaskOutcome, language string) string {
+	title := services.SanitizeShortTitle(identity.ShortTitle)
+	en := services.NormalizeLanguage(language) == "en"
+	switch strings.ToLower(strings.TrimSpace(outcome.Status)) {
+	case "completed":
+		if en {
+			if title == "" {
+				return "That one's done. Ask me if you want the details."
+			}
+			return "\"" + title + "\" is done. Ask me if you want the details."
+		}
+		if title == "" {
+			return "刚才那个弄完了。想看细节的话跟我说。"
+		}
+		return title + "弄完了。想看细节的话跟我说。"
+	case "cancelled":
+		if en {
+			if title == "" {
+				return "That one's been cancelled, so I've stopped work on it. Tell me if you want it picked back up."
+			}
+			return "\"" + title + "\" has been cancelled, so I've stopped work on it. Tell me if you want it picked back up."
+		}
+		if title == "" {
+			return "刚才那个取消了，我停下了。要重新做的话说一声。"
+		}
+		return title + "取消了，我停下了。要重新做的话说一声。"
+	default:
+		reason := humanizeFailureReason(outcome.FailureReason, en)
+		if en {
+			if title == "" {
+				return "That one didn't go through: " + reason + " Want me to try again?"
+			}
+			return "\"" + title + "\" didn't go through: " + reason + " Want me to try again?"
+		}
+		if title == "" {
+			return "刚才那个没做成：" + reason + "要我再试一次吗？"
+		}
+		return title + "没做成：" + reason + "要我再试一次吗？"
+	}
+}
+
+// humanizeFailureReason turns an aggregated failure cause into something a user
+// can act on. The raw reason is diagnostic text and often mentions internals.
+func humanizeFailureReason(reason string, en bool) string {
+	lower := strings.ToLower(strings.TrimSpace(reason))
+	switch {
+	case lower == "":
+	case strings.Contains(lower, "timeout"), strings.Contains(lower, "超时"),
+		strings.Contains(lower, "deadline exceeded"), strings.Contains(lower, "timed out"):
+		if en {
+			return "it ran out of time."
+		}
+		return "跑太久超时了。"
+	case strings.Contains(lower, "permission"), strings.Contains(lower, "权限"),
+		strings.Contains(lower, "unauthorized"), strings.Contains(lower, "forbidden"):
+		if en {
+			return "it didn't have the access it needed."
+		}
+		return "权限不够。"
+	case strings.Contains(lower, "sandbox"), strings.Contains(lower, "沙箱"):
+		if en {
+			return "the execution environment couldn't start."
+		}
+		return "执行环境没起来。"
+	case strings.Contains(lower, "network"), strings.Contains(lower, "connection"),
+		strings.Contains(lower, "网络"):
+		if en {
+			return "a network call kept failing."
+		}
+		return "网络一直连不上。"
+	}
+	if en {
+		return "something went wrong partway through."
+	}
+	return "中途出了问题。"
+}
+
+// syncTerminalStatus writes the outcome onto the task so status questions stop
+// answering "in progress" forever. Without this the task table is the only
+// place a user's question is answered from, and it would never be updated.
+func (m *Manager) syncTerminalStatus(identity *models.TaskIdentity, outcome TaskOutcome) {
+	if m.taskContext == nil || identity == nil {
+		return
+	}
+	if _, err := m.taskContext.UpdateIdentity(services.EnsureTaskIdentityInput{
+		RunID: identity.RunID, ProjectID: identity.ProjectID, UserID: identity.UserID,
+		Status: strings.TrimSpace(outcome.Status),
+	}); err != nil {
+		log.Warn().Err(err).Str("run", identity.RunID).
+			Msg("reflow: writing terminal task status failed")
+	}
+}
+
+func (m *Manager) identityForRun(runID, projectID string) *models.TaskIdentity {
+	if m.taskContext == nil {
+		return nil
+	}
+	identity, err := m.taskContext.IdentityForRun(runID, projectID)
+	if err != nil {
+		log.Warn().Err(err).Str("run", runID).Msg("reflow: loading task identity failed")
+		return nil
+	}
+	return identity
+}
+
+// taskLanguage returns the language the task has been conducted in. Following
+// the task rather than the individual message keeps a conversation from
+// switching languages mid-task just because one update happened to be phrased
+// differently.
+func taskLanguage(identity *models.TaskIdentity) string {
+	if identity == nil {
+		return ""
+	}
+	if lang := services.NormalizeLanguage(identity.Language); lang != "" {
+		return lang
+	}
+	return services.DetectLanguage(identity.OriginalRequirement, "")
+}

--- a/server/internal/engine/engine.go
+++ b/server/internal/engine/engine.go
@@ -102,6 +102,11 @@ type Engine struct {
 	// node-scoped failed transitions (QQ Run notify). Engine never blocks on it.
 	runNotify RunNotifier
 
+	// runTerminal is an optional async observer for completed / failed /
+	// cancelled transitions, used to bring a task's outcome back to the
+	// conversation that started it. Engine never blocks on it.
+	runTerminal RunTerminalObserver
+
 	// reviewMu guards reviewSess: per parked producer session FIFO + single
 	// worker for node-inline review and gate hot-revise (SandboxChat-aligned).
 	reviewMu   sync.Mutex
@@ -1430,6 +1435,9 @@ func (e *Engine) finish(runID, status string) bool {
 				Payload:      map[string]any{"status": status, "trigger": "engine", "runId": runID},
 			})
 		}
+	}
+	if status == "completed" || status == "failed" || status == "cancelled" {
+		e.fireRunTerminal(runID, status)
 	}
 	msg, _ := json.Marshal(map[string]any{"type": "status", "runId": runID, "status": status})
 	e.broker.Publish(runID, msg)

--- a/server/internal/engine/run_terminal.go
+++ b/server/internal/engine/run_terminal.go
@@ -1,0 +1,89 @@
+package engine
+
+import (
+	"strings"
+
+	"github.com/cocofhu/approving/internal/services"
+
+	"github.com/rs/zerolog/log"
+)
+
+// RunTerminalEvent describes a Run that has reached a state it will not leave.
+//
+// It is deliberately separate from RunNotifyEvent. RunNotify is a project-level
+// template push ("a run needs attention, here's a link"); this is the
+// conversational counterpart — the answer to a question a specific user asked in
+// a specific conversation, and it must read as such. Sharing the path would mean
+// sharing the templates, which is the behaviour this replaces.
+type RunTerminalEvent struct {
+	ProjectID    string
+	RunID        string
+	WorkflowID   string
+	WorkflowName string
+	RunTitle     string
+	// Status is one of completed / failed / cancelled.
+	Status string
+	// FailureSummary carries the aggregated reason for a failed run so the
+	// observer can explain the outcome without reading raw logs.
+	FailureSummary string
+}
+
+// RunTerminalObserver receives terminal Run transitions. Implementations must
+// not block meaningfully; Engine invokes them in a goroutine.
+type RunTerminalObserver interface {
+	OnRunTerminal(ev RunTerminalEvent)
+}
+
+// SetRunTerminalObserver wires the terminal-state hook (nil disables).
+func (e *Engine) SetRunTerminalObserver(o RunTerminalObserver) {
+	e.runTerminal = o
+}
+
+// fireRunTerminal reports a confirmed terminal transition. finish() is the sole
+// writer of completed / failed / cancelled, which is why the hook lives there:
+// every path that ends a Run passes through it exactly once.
+func (e *Engine) fireRunTerminal(runID, status string) {
+	observer := e.runTerminal
+	if observer == nil {
+		return
+	}
+	status = strings.TrimSpace(status)
+	switch status {
+	case "completed", "failed", "cancelled":
+	default:
+		return
+	}
+	projectID := services.ResolveProjectIDForRun(e.db, runID)
+	if projectID == "" {
+		return
+	}
+	ev := RunTerminalEvent{ProjectID: projectID, RunID: runID, Status: status}
+	var run modelsRun
+	if err := e.db.Table("runs").
+		Select("workflow_id", "workflow_name", "title").
+		Where("id = ?", runID).Take(&run).Error; err == nil {
+		ev.WorkflowID, ev.WorkflowName, ev.RunTitle = run.WorkflowID, run.WorkflowName, run.Title
+	}
+	if status == "failed" {
+		// Reason only. Node ids and log tails are diagnostics for the platform,
+		// not something to read out in a chat.
+		info := services.NewRunService(e.db).AggregateRunFailure(runID)
+		ev.FailureSummary = strings.TrimSpace(info.Reason)
+	}
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error().Str("run_id", ev.RunID).Interface("panic", r).
+					Msg("run-terminal: observer panic")
+			}
+		}()
+		observer.OnRunTerminal(ev)
+	}()
+}
+
+// modelsRun is a narrow projection of the columns fireRunTerminal reads.
+type modelsRun struct {
+	WorkflowID   string
+	WorkflowName string
+	Title        string
+}

--- a/server/internal/engine/run_terminal_test.go
+++ b/server/internal/engine/run_terminal_test.go
@@ -1,0 +1,145 @@
+package engine
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+)
+
+type recordingRunTerminal struct {
+	mu  sync.Mutex
+	evs []RunTerminalEvent
+}
+
+func (r *recordingRunTerminal) OnRunTerminal(ev RunTerminalEvent) {
+	r.mu.Lock()
+	r.evs = append(r.evs, ev)
+	r.mu.Unlock()
+}
+
+func (r *recordingRunTerminal) wait(t *testing.T, n int) []RunTerminalEvent {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		r.mu.Lock()
+		if len(r.evs) >= n {
+			out := append([]RunTerminalEvent(nil), r.evs...)
+			r.mu.Unlock()
+			return out
+		}
+		r.mu.Unlock()
+		time.Sleep(15 * time.Millisecond)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	t.Fatalf("want >=%d terminal events, got %d", n, len(r.evs))
+	return nil
+}
+
+func (r *recordingRunTerminal) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.evs)
+}
+
+// A run that succeeds is the case the old notification path never covered — it
+// only knew about waiting_human and failed, so a user who delegated work was
+// never told it had finished.
+func TestRunTerminalFiresOnceOnSuccess(t *testing.T) {
+	eng, db, _ := setupEngineGraphP(t, models.Graph{
+		Nodes: []models.Node{
+			{ID: "input", Type: "input", Label: "输入"},
+			{ID: "output", Type: "output"},
+		},
+		Edges: []models.Edge{{ID: "e1", Source: "input", Target: "output"}},
+	})
+	proj := models.Project{ID: "proj-terminal", Name: "T", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	if err := db.Create(&proj).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Model(&models.WorkflowDef{}).Where("id = ?", "wf").
+		Update("project_id", proj.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	rec := &recordingRunTerminal{}
+	eng.SetRunTerminalObserver(rec)
+	run, err := eng.StartRun("wf", nil, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitRunStatus(t, db, run.ID, "completed")
+
+	evs := rec.wait(t, 1)
+	if evs[0].Status != "completed" || evs[0].RunID != run.ID || evs[0].ProjectID != proj.ID {
+		t.Fatalf("terminal event = %+v", evs[0])
+	}
+	// finish() is the only writer of a terminal status, so the conclusion must
+	// reach the conversation exactly once.
+	time.Sleep(50 * time.Millisecond)
+	if rec.count() != 1 {
+		t.Fatalf("terminal event count = %d want 1", rec.count())
+	}
+}
+
+// A failure carries the reason so the conversation can explain the outcome
+// without anyone reading logs.
+func TestRunTerminalCarriesFailureReason(t *testing.T) {
+	eng, db, prov := setupEngineGraphP(t, models.Graph{
+		Nodes: []models.Node{
+			{ID: "input", Type: "input", Label: "输入"},
+			{ID: "boom", Type: "agent", Label: "实现", Config: map[string]any{
+				"prompt": "x", "produces": "out.md",
+			}},
+			{ID: "output", Type: "output"},
+		},
+		Edges: []models.Edge{
+			{ID: "e1", Source: "input", Target: "boom"},
+			{ID: "e2", Source: "boom", Target: "output"},
+		},
+	})
+	prov.failLeft = map[string]int{"boom": 99}
+	proj := models.Project{ID: "proj-terminal-fail", Name: "TF", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	if err := db.Create(&proj).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Model(&models.WorkflowDef{}).Where("id = ?", "wf").
+		Update("project_id", proj.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	rec := &recordingRunTerminal{}
+	eng.SetRunTerminalObserver(rec)
+	run, err := eng.StartRun("wf", nil, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitRunStatus(t, db, run.ID, "failed")
+
+	evs := rec.wait(t, 1)
+	if evs[0].Status != "failed" || strings.TrimSpace(evs[0].FailureSummary) == "" {
+		t.Fatalf("failed terminal event = %+v want a reason", evs[0])
+	}
+}
+
+// Not every status change is an ending. A non-terminal status must not be
+// announced as one, and a run the engine cannot place in a project has no
+// conversation to report to.
+func TestRunTerminalIgnoresNonTerminalAndUnknownRuns(t *testing.T) {
+	eng, _, _ := setupEngineGraphP(t, models.Graph{
+		Nodes: []models.Node{{ID: "input", Type: "input"}},
+	})
+	rec := &recordingRunTerminal{}
+	eng.SetRunTerminalObserver(rec)
+	for _, status := range []string{"running", "waiting_human", "paused", ""} {
+		eng.fireRunTerminal("run-anything", status)
+	}
+	eng.fireRunTerminal("run-does-not-exist", "completed")
+	time.Sleep(80 * time.Millisecond)
+	if rec.count() != 0 {
+		t.Fatalf("observer fired %d times for non-endings", rec.count())
+	}
+}

--- a/server/internal/models/models.go
+++ b/server/internal/models/models.go
@@ -688,6 +688,7 @@ func AllModels() []any {
 		&NotifyDeliveryReceipt{},
 		&SendableDeliveryReceipt{},
 		&TaskIdentity{}, &MessageBinding{}, &ConversationFocus{}, &RiskConfirmationTicket{},
+		&PendingChannelTurn{},
 	}
 }
 

--- a/server/internal/models/notify.go
+++ b/server/internal/models/notify.go
@@ -84,4 +84,9 @@ type NotifyDeliveryReceipt struct {
 	Iteration int       `gorm:"uniqueIndex:idx_notify_receipt" json:"iteration"`
 	Kind      string    `gorm:"size:32;uniqueIndex:idx_notify_receipt" json:"kind"`
 	CreatedAt time.Time `json:"createdAt"`
+	// DeliveryStatus records what became of the claimed notification:
+	// delivered | no_target | failed. The claim is taken before the send, so
+	// without this a delivery failure is indistinguishable from a delivery.
+	DeliveryStatus string `gorm:"size:32;index" json:"deliveryStatus,omitempty"`
+	DeliveryError  string `gorm:"size:512" json:"deliveryError,omitempty"`
 }

--- a/server/internal/models/task_context.go
+++ b/server/internal/models/task_context.go
@@ -5,18 +5,29 @@ import "time"
 // TaskIdentity is the stable, user-facing identity of a Run.
 // Search visibility is bounded by both project and external user identity.
 type TaskIdentity struct {
-	ID                  string     `gorm:"primaryKey;size:64" json:"id"`
-	RunID               string     `gorm:"size:64;uniqueIndex:idx_task_run_project,priority:1" json:"runId"`
-	ProjectID           string     `gorm:"size:64;uniqueIndex:idx_task_run_project,priority:2;index:idx_task_project_title,priority:1;index:idx_task_scope_title,priority:1" json:"projectId"`
-	UserID              string     `gorm:"size:191;index:idx_task_scope_title,priority:2" json:"userId,omitempty"`
-	ShortTitle          string     `gorm:"size:160;index:idx_task_project_title,priority:2;index:idx_task_scope_title,priority:3" json:"shortTitle"`
-	OriginalRequirement string     `gorm:"type:text" json:"originalRequirement"`
-	Aliases             []string   `gorm:"serializer:json" json:"aliases"`
-	Keywords            []string   `gorm:"serializer:json" json:"keywords"`
-	Status              string     `gorm:"size:32;index" json:"status"`
-	TerminalAt          *time.Time `gorm:"index" json:"terminalAt,omitempty"`
-	CreatedAt           time.Time  `json:"createdAt"`
-	UpdatedAt           time.Time  `json:"updatedAt"`
+	ID                  string   `gorm:"primaryKey;size:64" json:"id"`
+	RunID               string   `gorm:"size:64;uniqueIndex:idx_task_run_project,priority:1" json:"runId"`
+	ProjectID           string   `gorm:"size:64;uniqueIndex:idx_task_run_project,priority:2;index:idx_task_project_title,priority:1;index:idx_task_scope_title,priority:1" json:"projectId"`
+	UserID              string   `gorm:"size:191;index:idx_task_scope_title,priority:2" json:"userId,omitempty"`
+	ShortTitle          string   `gorm:"size:160;index:idx_task_project_title,priority:2;index:idx_task_scope_title,priority:3" json:"shortTitle"`
+	OriginalRequirement string   `gorm:"type:text" json:"originalRequirement"`
+	Aliases             []string `gorm:"serializer:json" json:"aliases"`
+	Keywords            []string `gorm:"serializer:json" json:"keywords"`
+	// Origin conversation. A task's results belong in the conversation that
+	// asked for them, so this is persisted rather than derived: it must survive
+	// a restart and must not fall back to a project-wide push target.
+	// Scene is stored as a plain string because models must not depend on the
+	// channels package.
+	OriginChannel        string     `gorm:"size:32;index:idx_task_origin,priority:1" json:"originChannel,omitempty"`
+	OriginScene          string     `gorm:"size:32" json:"originScene,omitempty"`
+	OriginConversationID string     `gorm:"size:191;index:idx_task_origin,priority:2" json:"originConversationId,omitempty"`
+	OriginExternalUserID string     `gorm:"size:191" json:"originExternalUserId,omitempty"`
+	Language             string     `gorm:"size:16" json:"language,omitempty"`
+	RecentContext        string     `gorm:"type:text" json:"recentContext,omitempty"`
+	Status               string     `gorm:"size:32;index" json:"status"`
+	TerminalAt           *time.Time `gorm:"index" json:"terminalAt,omitempty"`
+	CreatedAt            time.Time  `json:"createdAt"`
+	UpdatedAt            time.Time  `json:"updatedAt"`
 }
 
 // MessageBinding gives an explicit quoted/replied message precedence over
@@ -46,6 +57,24 @@ type ConversationFocus struct {
 	ExpiresAt      time.Time `gorm:"index" json:"expiresAt"`
 	CreatedAt      time.Time `json:"createdAt"`
 	UpdatedAt      time.Time `json:"updatedAt"`
+}
+
+// PendingChannelTurn records a foreground turn that is currently running.
+//
+// A restart kills the sandbox turn in flight, and without this row the user's
+// message simply disappears — they asked something and nothing ever came back.
+// The row is written when the turn starts and deleted when it ends, so anything
+// still present at boot is a turn that died with the process.
+type PendingChannelTurn struct {
+	ID             string    `gorm:"primaryKey;size:191" json:"id"`
+	ProjectID      string    `gorm:"size:64;index" json:"projectId"`
+	Channel        string    `gorm:"size:32" json:"channel"`
+	Scene          string    `gorm:"size:32" json:"scene"`
+	ConversationID string    `gorm:"size:191;index" json:"conversationId"`
+	ExternalUserID string    `gorm:"size:191" json:"externalUserId"`
+	MessageID      string    `gorm:"size:191" json:"messageId"`
+	Language       string    `gorm:"size:16" json:"language"`
+	StartedAt      time.Time `json:"startedAt"`
 }
 
 // RiskConfirmationTicket authorizes one high-risk action once.

--- a/server/internal/pmmcp/host.go
+++ b/server/internal/pmmcp/host.go
@@ -99,6 +99,10 @@ type IMDeliveryOutcome struct {
 type ExternalIMNotifier interface {
 	NotifyRunAccepted(projectID, runID string, target IMTarget, shortTitle, language string) error
 	NotifyProgress(projectID, runID string, target IMTarget, kind, text, stage, conclusion string, blocked, actionRequired bool) (IMDeliveryOutcome, error)
+	// NotifyReply delivers the agent's answer for the current conversation turn.
+	// This is the only way a conversational answer reaches the user: raw model
+	// output is never forwarded, so an answer has to be submitted deliberately.
+	NotifyReply(projectID, runID string, target IMTarget, text, shortTitle string) (IMDeliveryOutcome, error)
 }
 
 // engineOps covers the run operations exposed through pm-workflow-write
@@ -784,18 +788,39 @@ func (h *Host) callWorkflowWrite(projectID, token, name string, args map[string]
 			},
 		})
 		shortTitle := run.Title
+		sess, hasSess := h.SessionFor(projectID, token)
 		if h.tasks != nil {
 			sessUser := ""
-			if sess, ok := h.SessionFor(projectID, token); ok {
+			if hasSess {
 				sessUser = riskUserIDForSession(sess)
 			}
 			if identity, err := h.tasks.EnsureIdentityForRun(*run, projectID, sessUser); err == nil && identity != nil {
 				shortTitle = identity.ShortTitle
+				// Bind the task to the conversation that asked for it. Results
+				// have to come back here, and a project-wide push target is not
+				// the same place — this is the only record of where "here" is,
+				// and it must survive a restart.
+				if hasSess && strings.TrimSpace(sess.Channel.ConversationID) != "" {
+					if _, err := h.tasks.UpdateIdentity(services.EnsureTaskIdentityInput{
+						RunID: run.ID, ProjectID: projectID, UserID: sessUser,
+						OriginChannel:        sess.Channel.ChannelType,
+						OriginScene:          sess.Channel.Scene,
+						OriginConversationID: sess.Channel.ConversationID,
+						OriginExternalUserID: sess.Channel.ExternalUserID,
+						// The task is conducted in the language it was asked
+						// in; later updates follow the task, not whichever
+						// message happens to trigger them.
+						Language: services.DetectLanguage(identity.OriginalRequirement, ""),
+					}); err != nil {
+						log.Warn().Err(err).Str("run", run.ID).
+							Msg("pm_start_run: binding task to origin conversation failed")
+					}
+				}
 			}
 		}
 		if h.notify != nil {
 			target := IMTarget{}
-			if sess, ok := h.SessionFor(projectID, token); ok {
+			if hasSess {
 				target = imTargetForSession(sess)
 			}
 			if err := h.notify.NotifyRunAccepted(projectID, run.ID, target, shortTitle, ""); err != nil {
@@ -803,6 +828,42 @@ func (h *Host) callWorkflowWrite(projectID, token, name string, args map[string]
 			}
 		}
 		return map[string]any{"id": run.ID, "status": run.Status, "shortTitle": shortTitle}, false
+	case "pm_reply":
+		if h.notify == nil {
+			return map[string]any{"error": "im notifier unavailable"}, true
+		}
+		text := strings.TrimSpace(platformmcp.StrArg(args, "text"))
+		if text == "" {
+			return map[string]any{"error": "text is required"}, true
+		}
+		// A runId is optional, but when given it must be this project's Run —
+		// an answer must never be attributed to another project's task.
+		runID := strings.TrimSpace(platformmcp.StrArg(args, "runId"))
+		if runID != "" {
+			if _, ok := h.runInProject(projectID, runID); !ok {
+				return map[string]any{"error": "run not found"}, true
+			}
+		}
+		target := IMTarget{}
+		if sess, ok := h.SessionFor(projectID, token); ok {
+			target = imTargetForSession(sess)
+		}
+		if strings.TrimSpace(target.ConversationID) == "" {
+			return map[string]any{"error": "no external conversation bound to this session"}, true
+		}
+		outcome, err := h.notify.NotifyReply(projectID, runID, target, text,
+			strings.TrimSpace(platformmcp.StrArg(args, "shortTitle")))
+		if err != nil {
+			return map[string]any{"error": err.Error()}, true
+		}
+		if !outcome.Sent {
+			reason := outcome.Reason
+			if reason == "" {
+				reason = "suppressed"
+			}
+			return map[string]any{"status": "suppressed", "sent": false, "reason": reason}, false
+		}
+		return map[string]any{"status": "sent", "sent": true}, false
 	case "pm_notify_progress":
 		if h.notify == nil {
 			return map[string]any{"error": "im notifier unavailable"}, true
@@ -1134,6 +1195,11 @@ func toolSchemas(mcpID string) []map[string]any {
 			}),
 			platformmcp.Tool("pm_cancel_run", "取消一次运行中的 Run（需用户短标题二次确认后才会真正取消）。", map[string]any{
 				"runId": map[string]any{"type": "string"},
+			}),
+			platformmcp.Tool("pm_reply", "把这一轮对话的回答发给用户。这是回答外发的唯一通道——你在正文里写的内容不会被发出去，只有这里提交的 text 会。text 必须是用户直接能读懂的人话：不要出现 Run ID、工作流名、沙箱/工具/内部事件等实现细节，也不要写推理过程。", map[string]any{
+				"text":       map[string]any{"type": "string", "description": "发给用户的回答，人话，直接可读"},
+				"runId":      map[string]any{"type": "string", "description": "可选：这条回答关联的 Run"},
+				"shortTitle": map[string]any{"type": "string", "description": "可选：关联任务的短标题（人话，禁止填 Run ID）"},
 			}),
 			platformmcp.Tool("pm_notify_progress", "向外部 IM 显式提交一条 Sendable 进度/阻塞/确认消息（须含 stage/conclusion 等实质字段）。返回 status=sent 表示已外发；status=suppressed 表示被限频/去重/合并等策略正常抑制（不是失败，不要改措辞重发）；只有真实投递失败才返回错误。", map[string]any{
 				"runId":          map[string]any{"type": "string"},

--- a/server/internal/pmmcp/host_more_test.go
+++ b/server/internal/pmmcp/host_more_test.go
@@ -20,12 +20,27 @@ type recordingIMNotifier struct {
 		target                       IMTarget
 		actionRequired               bool
 	}
+	replyCalls []struct {
+		projectID, runID, text, shortTitle string
+		target                             IMTarget
+	}
 	outcome IMDeliveryOutcome
 	err     error
 }
 
 func (n *recordingIMNotifier) NotifyRunAccepted(string, string, IMTarget, string, string) error {
 	return n.err
+}
+
+func (n *recordingIMNotifier) NotifyReply(projectID, runID string, target IMTarget, text, shortTitle string) (IMDeliveryOutcome, error) {
+	n.replyCalls = append(n.replyCalls, struct {
+		projectID, runID, text, shortTitle string
+		target                             IMTarget
+	}{projectID: projectID, runID: runID, text: text, shortTitle: shortTitle, target: target})
+	if n.err != nil {
+		return IMDeliveryOutcome{}, n.err
+	}
+	return n.outcome, nil
 }
 
 func (n *recordingIMNotifier) NotifyProgress(projectID, runID string, target IMTarget, kind, text, stage, conclusion string, blocked, actionRequired bool) (IMDeliveryOutcome, error) {
@@ -270,6 +285,84 @@ func TestRiskConfirmationNotifyFailureIsReturned(t *testing.T) {
 	blocked, completed, prompt, err := h.requireRiskConfirmation(p.ID, tok, "run-notify-fail", "cancel_run")
 	if !blocked || completed || prompt == "" || err == nil || !strings.Contains(err.Error(), "transport down") {
 		t.Fatalf("confirmation failure = blocked:%v completed:%v prompt:%q err:%v", blocked, completed, prompt, err)
+	}
+}
+
+// pm_reply is the only way an agent's answer reaches the user, so it has to
+// refuse everything that would put an answer in the wrong place: no text, no
+// bound conversation, or a Run belonging to a different project.
+func TestPmReplyIsTheGuardedAnswerChannel(t *testing.T) {
+	db, _, h, p := setupPmMCPHost(t)
+	notifier := &recordingIMNotifier{outcome: IMDeliveryOutcome{Sent: true}}
+	h.SetTaskSafety(nil, nil, notifier)
+
+	tok := h.Register(p.ID, "thr-reply", "qq:c2c:user1", "agent-a")
+	reply := func(args map[string]any) (map[string]any, bool) {
+		out, isErr := h.callTool(p.ID, tok, MCPWorkflowWrite, "pm_reply", args)
+		payload, ok := out.(map[string]any)
+		if !ok {
+			t.Fatalf("unexpected tool payload %#v", out)
+		}
+		return payload, isErr
+	}
+
+	// No conversation is bound yet: an answer has nowhere to go and must not
+	// be reported as delivered.
+	if payload, isErr := reply(map[string]any{"text": "缓存没刷新。"}); !isErr {
+		t.Fatalf("reply without a bound conversation = %#v", payload)
+	}
+
+	h.SetChannelContext(tok, ChannelContext{
+		ChannelType: "qq", Scene: "c2c",
+		ConversationID: "user1", ExternalUserID: "openid-1",
+	})
+
+	if payload, isErr := reply(map[string]any{"text": "   "}); !isErr {
+		t.Fatalf("empty reply = %#v", payload)
+	}
+	if payload, isErr := reply(map[string]any{
+		"text": "缓存没刷新。", "runId": "run-from-another-project",
+	}); !isErr {
+		t.Fatalf("reply attributed to an unknown run = %#v", payload)
+	}
+	if len(notifier.replyCalls) != 0 {
+		t.Fatalf("a rejected reply still reached the channel: %+v", notifier.replyCalls)
+	}
+
+	wfDef := &models.WorkflowDef{
+		ID: "wf-reply", ProjectID: p.ID, Name: "Reply WF",
+		Graph: models.Graph{Nodes: []models.Node{{ID: "in", Type: "input"}, {ID: "out", Type: "output"}}},
+	}
+	if err := services.NewWorkflowService(db).Save(wfDef); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&models.Run{
+		ID: "run-reply", WorkflowID: wfDef.ID, Status: "running",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	payload, isErr := reply(map[string]any{
+		"text": "缓存没刷新，我已经清掉了。", "runId": "run-reply", "shortTitle": "登录页性能",
+	})
+	if isErr || payload["status"] != "sent" || payload["sent"] != true {
+		t.Fatalf("delivered reply = %#v isError=%v", payload, isErr)
+	}
+	if len(notifier.replyCalls) != 1 {
+		t.Fatalf("reply calls = %+v want exactly one", notifier.replyCalls)
+	}
+	call := notifier.replyCalls[0]
+	if call.text != "缓存没刷新，我已经清掉了。" || call.runID != "run-reply" ||
+		call.shortTitle != "登录页性能" || call.target.ConversationID != "user1" ||
+		call.target.UserID != "openid-1" {
+		t.Fatalf("reply call = %+v", call)
+	}
+
+	// Suppression is a normal outcome, not a tool error: reporting it as one is
+	// what made agents rephrase and send the same answer again.
+	notifier.outcome = IMDeliveryOutcome{Reason: "already_sent"}
+	payload, isErr = reply(map[string]any{"text": "缓存没刷新，我已经清掉了。"})
+	if isErr || payload["status"] != "suppressed" || payload["reason"] != "already_sent" {
+		t.Fatalf("suppressed reply = %#v isError=%v", payload, isErr)
 	}
 }
 

--- a/server/internal/sendable/sendable.go
+++ b/server/internal/sendable/sendable.go
@@ -304,6 +304,36 @@ func (p *Policy) bucketSuppression(ctx context.Context, e DeliveryEnvelope, chan
 			// dedicated kinds and therefore bypass this progress-only limit.
 			return "progress_rate_limited_merged"
 		}
+		// The per-run bucket above says nothing about how many runs are talking.
+		// Several tasks running in parallel each stay within their own limit and
+		// still bury the conversation, so the conversation has a budget of its
+		// own. Blocked / action_required / final are separate kinds and are not
+		// counted here — a decision the user has to make must never be dropped
+		// because other tasks were chatty.
+		if reason := p.conversationQuota(ctx, e, channel, key, now); reason != "" {
+			return reason
+		}
+	}
+	return ""
+}
+
+// conversationProgressQuota is how many ordinary progress messages one
+// conversation may receive per rate window, across all of its Runs.
+const conversationProgressQuota = 3
+
+func (p *Policy) conversationQuota(ctx context.Context, e DeliveryEnvelope, channel Channel, key string, now time.Time) string {
+	conv := strings.TrimSpace(e.ConversationID)
+	if conv == "" || e.Priority == PriorityCritical {
+		return ""
+	}
+	var count int64
+	err := p.db.WithContext(ctx).Model(&models.SendableDeliveryReceipt{}).
+		Where("conversation_id = ? AND channel = ? AND kind = ? AND status IN ? AND dedupe_key <> ? AND last_attempt_at > ?",
+			conv, string(channel), string(KindProgress),
+			[]string{"pending", "sent"}, key, now.Add(-p.rateWindow)).
+		Count(&count).Error
+	if err == nil && count >= conversationProgressQuota {
+		return "conversation_rate_limited"
 	}
 	return ""
 }

--- a/server/internal/sendable/sendable_test.go
+++ b/server/internal/sendable/sendable_test.go
@@ -87,6 +87,35 @@ func TestPolicyBoundsBackgroundEventsAndKeepsCritical(t *testing.T) {
 	}
 }
 
+// Several Runs each stay inside their own progress budget and still bury the
+// conversation between them, so the conversation has a budget of its own. What
+// must never be dropped is something the user has to act on.
+func TestPolicyBudgetsProgressPerConversationNotOnlyPerRun(t *testing.T) {
+	p, _, _ := testPolicy(t, nil)
+	sent := 0
+	for i := 0; i < 8; i++ {
+		e := external("run-"+string(rune('a'+i)), string(KindProgress), "")
+		e.Progress.Stage = "stage-" + string(rune('a'+i))
+		if sendAndMark(t, p, e, "parallel run update "+string(rune('a'+i))) {
+			sent++
+		}
+	}
+	if sent > conversationProgressQuota {
+		t.Fatalf("%d parallel progress messages reached one conversation, budget is %d",
+			sent, conversationProgressQuota)
+	}
+	if sent == 0 {
+		t.Fatal("the conversation budget silenced progress entirely")
+	}
+
+	blocked := external("run-z", string(KindBlocked), "needs-you")
+	blocked.Priority = PriorityCritical
+	blocked.Progress.Blocked = true
+	if !sendAndMark(t, p, blocked, "CI is red, need a decision") {
+		t.Fatal("a decision the user has to make was dropped by the progress budget")
+	}
+}
+
 func TestPolicyRunIsolationDefaultsAndRawFinal(t *testing.T) {
 	p, _, _ := testPolicy(t, nil)
 	p1 := external("r1", string(KindProgress), "")

--- a/server/internal/services/risk_confirmation.go
+++ b/server/internal/services/risk_confirmation.go
@@ -72,14 +72,65 @@ func (s *RiskConfirmationService) resolveShortTitle(in RiskTicketInput) string {
 	return ""
 }
 
-// ConfirmationPrompt is the user-facing ask, always echoing the short title.
+// ConfirmationPrompt asks the user to authorize a destructive action. It always
+// names the task, because "confirm?" with no subject is how the wrong thing gets
+// cancelled — but it asks the way a person would.
 func (s *RiskConfirmationService) ConfirmationPrompt(ticket models.RiskConfirmationTicket) string {
-	kind := "高风险确认"
+	title := SanitizeShortTitle(ticket.ShortTitle)
+	action := riskActionPhrase(ticket.Action, ticket.Language)
 	if NormalizeLanguage(ticket.Language) == "en" {
-		kind = "High-risk confirmation"
+		subject := "that task"
+		if title != "" {
+			subject = "\"" + title + "\""
+		}
+		return "Just to be sure — you want me to " + action + " " + subject + "? " + riskPrompt(ticket.Language)
 	}
-	return FormatTaskType(ticket.ShortTitle, kind, ticket.Language) + " " +
-		riskActionLine(ticket.Action, ticket.Language) + riskPrompt(ticket.Language)
+	subject := "这个任务"
+	if title != "" {
+		subject = "「" + title + "」"
+	}
+	return "确认一下，你是要" + action + subject + "吗？" + riskPrompt(ticket.Language)
+}
+
+// riskActionPhrase names a destructive action as a verb rather than an action
+// code. Callers may also pass a plain-language description, which is used as-is;
+// only the internal codes need translating.
+func riskActionPhrase(action, language string) string {
+	en := NormalizeLanguage(language) == "en"
+	action = strings.TrimSpace(action)
+	base, _, _ := strings.Cut(action, ":")
+	switch base {
+	case "cancel_run":
+		if en {
+			return "cancel"
+		}
+		return "取消"
+	case "delete_run":
+		if en {
+			return "delete"
+		}
+		return "删除"
+	case "approve_gate", "resume_gate":
+		if en {
+			return "approve"
+		}
+		return "批准"
+	case "reject_gate":
+		if en {
+			return "reject"
+		}
+		return "驳回"
+	default:
+		// Not a known code. Anything with code punctuation is internal and must
+		// not be read out; anything else is already a human description.
+		if action != "" && !strings.ContainsAny(action, "_:") {
+			return action
+		}
+		if en {
+			return "run that action on"
+		}
+		return "操作"
+	}
 }
 
 type RiskResolution struct {
@@ -247,56 +298,77 @@ func (s *RiskConfirmationService) LatestForAction(userID, projectID, runID, acti
 
 func riskPrompt(language string) string {
 	if NormalizeLanguage(language) == "en" {
-		return "Reply “confirm” to proceed or “cancel” to stop."
+		return "Say “confirm” and I'll do it, or “cancel” to leave it alone."
 	}
-	return "请回复“确认”继续，或回复“取消”停止。"
+	return "回「确认」我就做，回「取消」就算了。"
 }
 
-func riskActionLine(action, language string) string {
-	action = strings.TrimSpace(action)
-	if action == "" {
-		return ""
-	}
-	if NormalizeLanguage(language) == "en" {
-		return "Action: " + action + ". "
-	}
-	return "操作：" + action + "。"
-}
-
-// riskStatusMessage renders the settled reply: task title, ticket outcome, and
-// the latest task status.
+// riskStatusMessage reports how a confirmation settled. It names the task only
+// when the outcome would otherwise be ambiguous, and states what happened rather
+// than the ticket's internal state.
 func riskStatusMessage(ticket models.RiskConfirmationTicket, taskStatus string) string {
 	en := NormalizeLanguage(ticket.Language) == "en"
-	var outcome, kind string
-	switch ticket.Status {
-	case "confirmed":
-		kind, outcome = "已确认", "已确认，本次授权已使用。"
-		if en {
-			kind, outcome = "Confirmed", "Confirmed. This authorization has already been consumed."
+	title := SanitizeShortTitle(ticket.ShortTitle)
+	action := riskActionPhrase(ticket.Action, ticket.Language)
+
+	var subject string
+	if en {
+		subject = "that one"
+		if title != "" {
+			subject = "\"" + title + "\""
 		}
-	case "cancelled":
-		kind, outcome = "已取消", "已取消，操作未执行。"
-		if en {
-			kind, outcome = "Cancelled", "Cancelled. The action was not executed."
-		}
-	case "expired":
-		kind, outcome = "已过期", "确认已过期，操作未执行。"
-		if en {
-			kind, outcome = "Expired", "This confirmation has expired. The action was not executed."
-		}
-	default:
-		kind, outcome = "待确认", riskPrompt(ticket.Language)
-		if en {
-			kind = "Pending"
+	} else {
+		subject = "那个"
+		if title != "" {
+			subject = "「" + title + "」"
 		}
 	}
-	message := FormatTaskType(ticket.ShortTitle, kind, ticket.Language) + " " + outcome
+
+	var message string
+	switch ticket.Status {
+	case "confirmed":
+		if en {
+			message = "Already done — " + subject + " was " + pastTense(action) + "."
+		} else {
+			message = subject + "已经" + action + "了。"
+		}
+	case "cancelled":
+		if en {
+			message = "OK, I left " + subject + " alone."
+		} else {
+			message = "好，" + subject + "我没动。"
+		}
+	case "expired":
+		if en {
+			message = "That confirmation timed out, so I didn't touch " + subject + ". Tell me again if you still want it."
+		} else {
+			message = "刚才那个确认过期了，" + subject + "我没动。还要的话再说一次。"
+		}
+	default:
+		return riskPrompt(ticket.Language)
+	}
 	if status := strings.TrimSpace(taskStatus); status != "" {
 		if en {
-			message += " Latest task status: " + status + "."
+			message += " It's now " + status + "."
 		} else {
-			message += "当前任务状态：" + status + "。"
+			message += "现在是" + status + "。"
 		}
 	}
 	return message
+}
+
+// pastTense renders an action verb for an outcome sentence.
+func pastTense(verb string) string {
+	switch verb {
+	case "cancel":
+		return "cancelled"
+	case "delete":
+		return "deleted"
+	case "approve":
+		return "approved"
+	case "reject":
+		return "rejected"
+	default:
+		return "handled"
+	}
 }

--- a/server/internal/services/run_notify.go
+++ b/server/internal/services/run_notify.go
@@ -40,6 +40,9 @@ type RunNotifyService struct {
 	db       *gorm.DB
 	deliver  RunNotifyDeliverer
 	deepLink string
+	// retryDelays is overridable so tests do not have to wait out the real
+	// backoff.
+	retryDelays []time.Duration
 }
 
 // NewRunNotifyService builds the service. deliver may be nil (always no-op send).
@@ -48,6 +51,13 @@ func NewRunNotifyService(db *gorm.DB, deliver RunNotifyDeliverer, publicAdvertis
 		db:       db,
 		deliver:  deliver,
 		deepLink: strings.TrimRight(strings.TrimSpace(publicAdvertise), "/"),
+	}
+}
+
+// SetRetryDelays overrides the delivery backoff schedule (tests).
+func (s *RunNotifyService) SetRetryDelays(delays []time.Duration) {
+	if s != nil {
+		s.retryDelays = delays
 	}
 }
 
@@ -121,15 +131,64 @@ func (s *RunNotifyService) AttemptDeliver(ev RunNotifyEvent) {
 			Msg("run-notify: no deliverer — no-op after claim")
 		return
 	}
-	if err := s.deliver.DeliverRunNotify(project.ID, text); err != nil {
-		// P0: claim already held; log and do not retry.
-		if errors.Is(err, ErrRunNotifyNoTarget) {
-			log.Info().Str("run_id", ev.RunID).Str("project", project.ID).
-				Msg("run-notify: no channel target — no-op after claim")
+	s.deliverWithRetry(ev, project.ID, text, kind)
+}
+
+// runNotifyRetryDelays bound how long a failed delivery is retried. The receipt
+// is claimed before the send, so a transport error used to consume the claim and
+// lose the notification permanently. Retrying inside the claim closes that hole
+// without weakening the once-only guarantee; when the attempts are spent the
+// outcome is recorded on the receipt instead of vanishing into a log line.
+var runNotifyRetryDelays = []time.Duration{time.Second, 3 * time.Second, 8 * time.Second}
+
+func (s *RunNotifyService) deliverWithRetry(ev RunNotifyEvent, projectID, text, kind string) {
+	delays := s.retryDelays
+	if delays == nil {
+		delays = runNotifyRetryDelays
+	}
+	var lastErr error
+	for attempt := 0; ; attempt++ {
+		err := s.deliver.DeliverRunNotify(projectID, text)
+		if err == nil {
+			s.markReceipt(ev, kind, "delivered", "")
 			return
 		}
-		log.Warn().Err(err).Str("run_id", ev.RunID).Str("project", project.ID).
-			Msg("run-notify: send failed after claim (no retry)")
+		// A project with no bound channel is a configuration state, not a
+		// failure to retry against.
+		if errors.Is(err, ErrRunNotifyNoTarget) {
+			log.Info().Str("run_id", ev.RunID).Str("project", projectID).
+				Msg("run-notify: no channel target — no-op after claim")
+			s.markReceipt(ev, kind, "no_target", "")
+			return
+		}
+		lastErr = err
+		if attempt >= len(delays) {
+			break
+		}
+		log.Warn().Err(err).Str("run_id", ev.RunID).Str("project", projectID).
+			Int("attempt", attempt+1).Msg("run-notify: send failed, retrying")
+		time.Sleep(delays[attempt])
+	}
+	log.Error().Err(lastErr).Str("run_id", ev.RunID).Str("project", projectID).
+		Msg("run-notify: send failed after retries")
+	s.markReceipt(ev, kind, "failed", lastErr.Error())
+}
+
+// markReceipt records the delivery outcome on the claimed receipt so a failed
+// notification is visible in the data, not only in the logs.
+func (s *RunNotifyService) markReceipt(ev RunNotifyEvent, kind, status, detail string) {
+	if s.db == nil {
+		return
+	}
+	if len(detail) > 500 {
+		detail = detail[:500]
+	}
+	err := s.db.Model(&models.NotifyDeliveryReceipt{}).
+		Where("run_id = ? AND node_id = ? AND iteration = ? AND kind = ?",
+			ev.RunID, ev.NodeID, ev.Iteration, kind).
+		Updates(map[string]any{"delivery_status": status, "delivery_error": detail}).Error
+	if err != nil {
+		log.Warn().Err(err).Str("run_id", ev.RunID).Msg("run-notify: recording delivery status failed")
 	}
 }
 

--- a/server/internal/services/run_notify_test.go
+++ b/server/internal/services/run_notify_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/cocofhu/approving/internal/models"
 
@@ -150,19 +151,57 @@ func TestAttemptDeliver_noTargetStillClaims(t *testing.T) {
 	}
 }
 
-func TestAttemptDeliver_sendFailNoRetry(t *testing.T) {
+// A transport failure must be retried inside the claim: the receipt is taken
+// before the send, so giving up on the first error loses the notification for
+// good. The claim still bounds the whole thing to one notification.
+func TestAttemptDeliver_sendFailRetriesThenRecordsFailure(t *testing.T) {
 	db := setupRunNotifyDB(t)
 	seedNotifyProject(t, db, true, []string{"failed"}, "inherit", nil)
 	d := &fakeRunDeliverer{err: errors.New("qq down")}
 	svc := NewRunNotifyService(db, d, "")
+	svc.SetRetryDelays([]time.Duration{0, 0, 0})
 	ev := RunNotifyEvent{
 		ProjectID: "proj-n1", RunID: "run-5", WorkflowID: "wf-n1",
 		NodeID: "x", Iteration: 1, Kind: "failed",
 	}
 	svc.AttemptDeliver(ev)
+	if d.count() != 4 {
+		t.Fatalf("attempts=%d want 1 initial + 3 retries", d.count())
+	}
+
+	var receipt models.NotifyDeliveryReceipt
+	if err := db.Where("run_id = ? AND node_id = ? AND iteration = ? AND kind = ?",
+		"run-5", "x", 1, "failed").First(&receipt).Error; err != nil {
+		t.Fatal(err)
+	}
+	if receipt.DeliveryStatus != "failed" {
+		t.Fatalf("delivery status = %q; an exhausted delivery must be visible in the data",
+			receipt.DeliveryStatus)
+	}
+
+	// The claim still holds: a second event does not produce a second notification.
+	before := d.count()
 	svc.AttemptDeliver(ev)
-	if d.count() != 1 {
-		t.Fatalf("calls=%d want 1", d.count())
+	if d.count() != before {
+		t.Fatalf("claim did not hold: calls went %d → %d", before, d.count())
+	}
+}
+
+func TestAttemptDeliver_successRecordsDelivered(t *testing.T) {
+	db := setupRunNotifyDB(t)
+	seedNotifyProject(t, db, true, []string{"failed"}, "inherit", nil)
+	d := &fakeRunDeliverer{}
+	svc := NewRunNotifyService(db, d, "")
+	svc.AttemptDeliver(RunNotifyEvent{
+		ProjectID: "proj-n1", RunID: "run-5b", WorkflowID: "wf-n1",
+		NodeID: "x", Iteration: 1, Kind: "failed",
+	})
+	var receipt models.NotifyDeliveryReceipt
+	if err := db.Where("run_id = ?", "run-5b").First(&receipt).Error; err != nil {
+		t.Fatal(err)
+	}
+	if receipt.DeliveryStatus != "delivered" {
+		t.Fatalf("delivery status = %q want delivered", receipt.DeliveryStatus)
 	}
 }
 

--- a/server/internal/services/task_context.go
+++ b/server/internal/services/task_context.go
@@ -3,11 +3,13 @@ package services
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/cocofhu/approving/internal/models"
 
@@ -53,6 +55,11 @@ func (s *TaskContextService) DB() *gorm.DB {
 type EnsureTaskIdentityInput struct {
 	RunID, ProjectID, UserID, ShortTitle, OriginalRequirement, Status string
 	Aliases, Keywords                                                 []string
+
+	// Origin conversation, recorded once when the task is created from a
+	// channel turn. Empty values never clear an already-recorded origin.
+	OriginChannel, OriginScene, OriginConversationID, OriginExternalUserID string
+	Language, RecentContext                                                string
 }
 
 func (s *TaskContextService) EnsureIdentity(in EnsureTaskIdentityInput) (*models.TaskIdentity, error) {
@@ -72,10 +79,16 @@ func (s *TaskContextService) EnsureIdentity(in EnsureTaskIdentityInput) (*models
 		identity = models.TaskIdentity{
 			ID: "task-" + uuid.NewString()[:12], RunID: in.RunID,
 			ProjectID: in.ProjectID, UserID: in.UserID,
-			ShortTitle:          strings.TrimSpace(in.ShortTitle),
+			ShortTitle:          SanitizeShortTitle(in.ShortTitle),
 			OriginalRequirement: strings.TrimSpace(in.OriginalRequirement),
 			Aliases:             uniqueStrings(in.Aliases), Keywords: uniqueStrings(in.Keywords),
-			Status: normalizeTaskStatus(in.Status), CreatedAt: now, UpdatedAt: now,
+			OriginChannel:        strings.TrimSpace(in.OriginChannel),
+			OriginScene:          strings.TrimSpace(in.OriginScene),
+			OriginConversationID: strings.TrimSpace(in.OriginConversationID),
+			OriginExternalUserID: strings.TrimSpace(in.OriginExternalUserID),
+			Language:             NormalizeLanguage(in.Language),
+			RecentContext:        strings.TrimSpace(in.RecentContext),
+			Status:               normalizeTaskStatus(in.Status), CreatedAt: now, UpdatedAt: now,
 		}
 		if isTerminalTaskStatus(identity.Status) {
 			t := now
@@ -96,7 +109,7 @@ func (s *TaskContextService) EnsureIdentity(in EnsureTaskIdentityInput) (*models
 		return nil, ErrTaskIdentityScopeMismatch
 	}
 	oldTitle := strings.TrimSpace(identity.ShortTitle)
-	newTitle := strings.TrimSpace(in.ShortTitle)
+	newTitle := SanitizeShortTitle(in.ShortTitle)
 	if newTitle != "" && oldTitle != "" && newTitle != oldTitle {
 		identity.Aliases = uniqueStrings(append(identity.Aliases, oldTitle))
 	}
@@ -108,6 +121,24 @@ func (s *TaskContextService) EnsureIdentity(in EnsureTaskIdentityInput) (*models
 	}
 	if identity.UserID == "" && in.UserID != "" {
 		identity.UserID = in.UserID
+	}
+	// Origin is write-once: whoever created the task owns where its results go.
+	// A later update from another surface must not re-home an existing task.
+	if identity.OriginConversationID == "" {
+		if conv := strings.TrimSpace(in.OriginConversationID); conv != "" {
+			identity.OriginChannel = strings.TrimSpace(in.OriginChannel)
+			identity.OriginScene = strings.TrimSpace(in.OriginScene)
+			identity.OriginConversationID = conv
+			identity.OriginExternalUserID = strings.TrimSpace(in.OriginExternalUserID)
+		}
+	}
+	// Callers decide whether a message really represents a language switch (see
+	// TaskLanguageFor); this just records the decision.
+	if lang := NormalizeLanguage(in.Language); lang != "" {
+		identity.Language = lang
+	}
+	if recent := strings.TrimSpace(in.RecentContext); recent != "" {
+		identity.RecentContext = recent
 	}
 	identity.Aliases = uniqueStrings(append(identity.Aliases, in.Aliases...))
 	identity.Keywords = uniqueStrings(append(identity.Keywords, in.Keywords...))
@@ -149,13 +180,58 @@ func (s *TaskContextService) EnsureIdentityForRun(run models.Run, projectID, use
 
 const runShortTitleRunes = 24
 
+// internalIDPattern matches the internal Run / task identifier shapes in any
+// casing. Short titles are shown to users, who have no idea what a Run id is;
+// letting one through produced titles like 「修复 Run run-1ca1876f」.
+var internalIDPattern = regexp.MustCompile(`(?i)\b(run|task)[-_ ]?[0-9a-f]{6,}\b`)
+
+// genericTitleWords are placeholders that carry no meaning on their own.
+var genericTitleWords = map[string]bool{
+	"run": true, "task": true, "job": true, "workflow": true, "任务": true, "运行": true,
+}
+
+// SanitizeShortTitle strips internal identifiers from a user-facing task title
+// and reports the empty string when nothing meaningful survives, so callers can
+// fall back to real words instead of persisting a leaked id.
+func SanitizeShortTitle(title string) string {
+	cleaned := internalIDPattern.ReplaceAllString(strings.TrimSpace(title), " ")
+	words := strings.Fields(cleaned)
+	// Removing the identifier from 「修复 Run run-1ca1876f」 leaves a dangling
+	// "Run" that means nothing on its own.
+	for len(words) > 0 && genericTitleWords[strings.ToLower(words[len(words)-1])] {
+		words = words[:len(words)-1]
+	}
+	for len(words) > 0 && genericTitleWords[strings.ToLower(words[0])] {
+		words = words[1:]
+	}
+	cleaned = strings.Trim(strings.Join(words, " "), " -_/|:：、,，")
+	if cleaned == "" || genericTitleWords[strings.ToLower(cleaned)] {
+		return ""
+	}
+	return truncateTaskRunes(cleaned, runShortTitleRunes)
+}
+
+// runShortTitle derives a human-readable label for a Run. It prefers the Run's
+// own title, then the workflow name, then the first sentence of the original
+// request — and never falls back to the Run id.
 func runShortTitle(run models.Run) string {
-	for _, candidate := range []string{run.Title, run.WorkflowName} {
-		if candidate = strings.TrimSpace(candidate); candidate != "" {
-			return truncateTaskRunes(firstLine(candidate), runShortTitleRunes)
+	candidates := []string{run.Title, run.WorkflowName, firstSentence(runRequirement(run))}
+	for _, candidate := range candidates {
+		if title := SanitizeShortTitle(firstLine(candidate)); title != "" {
+			return title
 		}
 	}
-	return truncateTaskRunes("Run "+run.ID, runShortTitleRunes)
+	return "未命名任务"
+}
+
+// firstSentence returns the leading sentence of a free-form request, which is
+// usually the request itself in one line.
+func firstSentence(value string) string {
+	value = firstLine(value)
+	if idx := strings.IndexAny(value, "。！？!?;；\n"); idx > 0 {
+		return strings.TrimSpace(value[:idx])
+	}
+	return strings.TrimSpace(value)
 }
 
 // runRequirementKeys are the conventional Run input keys that hold the original
@@ -228,6 +304,48 @@ func (s *TaskContextService) IdentityForRun(runID, projectID string) (*models.Ta
 		return nil, err
 	}
 	return &identity, nil
+}
+
+// CountActive counts the user's non-terminal tasks in one conversation. Reply
+// formatting uses it to decide whether a task label is needed at all: with a
+// single task in flight the context is already unambiguous.
+func (s *TaskContextService) CountActive(scope TaskScope) (int, error) {
+	if s == nil || s.db == nil {
+		return 0, errors.New("task context database is unavailable")
+	}
+	if strings.TrimSpace(scope.ProjectID) == "" {
+		return 0, nil
+	}
+	q := s.db.Model(&models.TaskIdentity{}).
+		Where("project_id = ? AND terminal_at IS NULL", scope.ProjectID)
+	if strings.TrimSpace(scope.UserID) != "" {
+		q = q.Where("user_id = ? OR user_id = ''", scope.UserID)
+	}
+	var n int64
+	if err := q.Count(&n).Error; err != nil {
+		return 0, err
+	}
+	return int(n), nil
+}
+
+// ActiveTasksForConversation lists this conversation's live tasks, most
+// recently updated first, for disambiguation prompts.
+func (s *TaskContextService) ActiveTasksForConversation(scope TaskScope, limit int) ([]models.TaskIdentity, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("task context database is unavailable")
+	}
+	if limit <= 0 {
+		limit = 5
+	}
+	var out []models.TaskIdentity
+	q := s.db.Where("project_id = ? AND terminal_at IS NULL", scope.ProjectID)
+	if strings.TrimSpace(scope.UserID) != "" {
+		q = q.Where("user_id = ? OR user_id = ''", scope.UserID)
+	}
+	if err := q.Order("updated_at DESC").Limit(limit).Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (s *TaskContextService) BindMessage(scope TaskScope, messageID string, identity *models.TaskIdentity) error {
@@ -469,6 +587,31 @@ func DetectLanguage(current, recent string) string {
 	return "zh-CN"
 }
 
+// languageSwitchRunes is how much of a message must be in the other language
+// before it counts as the user switching rather than quoting.
+const languageSwitchRunes = 12
+
+// TaskLanguageFor decides which language to answer a task in.
+//
+// Per-message detection makes a conversation flip languages whenever someone
+// pastes an English identifier or a Chinese label, so an established task
+// language wins unless the user clearly switched: a message long enough to be a
+// real sentence, entirely in the other language.
+func TaskLanguageFor(established, message string) string {
+	established = NormalizeLanguage(established)
+	if established == "" {
+		return DetectLanguage(message, "")
+	}
+	message = strings.TrimSpace(message)
+	if utf8.RuneCountInString(message) < languageSwitchRunes {
+		return established
+	}
+	if detected := DetectLanguage(message, ""); detected != established {
+		return detected
+	}
+	return established
+}
+
 func NormalizeLanguage(language string) string {
 	switch strings.ToLower(strings.TrimSpace(language)) {
 	case "en", "en-us", "en-gb":
@@ -480,24 +623,37 @@ func NormalizeLanguage(language string) string {
 	}
 }
 
+// FormatTaskType names which task a message is about, in the way a person
+// would. The old bracketed 【title｜kind】 header made every message read like a
+// ticket update; a reference only earns its place when more than one task could
+// be meant, and then it should sound like speech.
 func FormatTaskType(shortTitle, kind, language string) string {
-	shortTitle = strings.TrimSpace(shortTitle)
+	shortTitle = SanitizeShortTitle(shortTitle)
 	kind = strings.TrimSpace(kind)
+	if NormalizeLanguage(language) == "en" {
+		if shortTitle == "" {
+			return ""
+		}
+		return fmt.Sprintf("On \"%s\" — ", shortTitle)
+	}
 	if shortTitle == "" {
-		if NormalizeLanguage(language) == "en" {
-			shortTitle = "Task"
-		} else {
-			shortTitle = "任务"
-		}
+		return ""
 	}
-	if kind == "" {
-		if NormalizeLanguage(language) == "en" {
-			kind = "Update"
-		} else {
-			kind = "更新"
-		}
+	return fmt.Sprintf("%s那个：", shortTitle)
+}
+
+// TaskStatusSentence names a task and states what is true of it. statusLabel is
+// the predicate ("is done." / "还在做。"), so the two read as one sentence.
+func TaskStatusSentence(shortTitle, statusLabel, language string) string {
+	shortTitle = SanitizeShortTitle(shortTitle)
+	statusLabel = strings.TrimSpace(statusLabel)
+	if shortTitle == "" {
+		return statusLabel
 	}
-	return fmt.Sprintf("【%s｜%s】", shortTitle, kind)
+	if NormalizeLanguage(language) == "en" {
+		return fmt.Sprintf("\"%s\" %s", shortTitle, statusLabel)
+	}
+	return fmt.Sprintf("「%s」%s", shortTitle, statusLabel)
 }
 
 func normalizeTaskStatus(status string) string {
@@ -508,7 +664,9 @@ func normalizeTaskStatus(status string) string {
 	return status
 }
 
-func isTerminalTaskStatus(status string) bool {
+// IsTerminalTaskStatus reports whether a task has reached a state it can no
+// longer leave.
+func IsTerminalTaskStatus(status string) bool {
 	switch strings.ToLower(strings.TrimSpace(status)) {
 	case "completed", "failed", "cancelled", "canceled", "done":
 		return true
@@ -516,6 +674,8 @@ func isTerminalTaskStatus(status string) bool {
 		return false
 	}
 }
+
+func isTerminalTaskStatus(status string) bool { return IsTerminalTaskStatus(status) }
 
 func uniqueStrings(values []string) []string {
 	seen := map[string]bool{}

--- a/server/internal/services/task_context_test.go
+++ b/server/internal/services/task_context_test.go
@@ -152,8 +152,58 @@ func TestRiskConfirmationOneShotDuplicateExpiredAndLanguage(t *testing.T) {
 		DetectLanguage("", "en") != "en" || DetectLanguage("", "") != "zh-CN" {
 		t.Fatal("language fallback order is incorrect")
 	}
-	if got := FormatTaskType("Login", "Risk", "en"); got != "【Login｜Risk】" {
+	// A task reference reads like speech, not like a ticket header, and is
+	// omitted entirely when there is no task to name.
+	if got := FormatTaskType("Login", "Risk", "en"); !strings.Contains(got, "Login") ||
+		strings.Contains(got, "【") || strings.Contains(got, "｜") {
 		t.Fatalf("format=%q", got)
+	}
+	if got := FormatTaskType("登录页", "阻塞", "zh-CN"); got != "登录页那个：" {
+		t.Fatalf("zh format=%q", got)
+	}
+	if got := FormatTaskType("", "阻塞", "zh-CN"); got != "" {
+		t.Fatalf("a missing title must not become a placeholder prefix: %q", got)
+	}
+}
+
+func TestSanitizeShortTitleStripsRunIdentifiers(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"修复 Run run-1ca1876f", "修复"},
+		{"run-1ca1876f", ""},
+		{"Run", ""},
+		{"task-9f8e7d6c5b4a", ""},
+		{"登录页性能优化", "登录页性能优化"},
+	} {
+		if got := SanitizeShortTitle(tc.in); got != tc.want {
+			t.Fatalf("SanitizeShortTitle(%q) = %q want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRunShortTitleNeverExposesRunID(t *testing.T) {
+	got := runShortTitle(models.Run{
+		ID:     "run-1ca1876f",
+		Inputs: map[string]any{"requirement": "把登录页首屏时间降下来。顺便看看埋点。"},
+	})
+	if got != "把登录页首屏时间降下来" {
+		t.Fatalf("short title = %q", got)
+	}
+	if strings.Contains(runShortTitle(models.Run{ID: "run-1ca1876f"}), "run-") {
+		t.Fatal("a run with no usable text must not fall back to its id")
+	}
+}
+
+func TestTaskLanguageFollowsTaskNotMessage(t *testing.T) {
+	// A short foreign-language fragment inside an established task does not
+	// flip the language; a full sentence does.
+	if got := TaskLanguageFor("zh-CN", "PR #12"); got != "zh-CN" {
+		t.Fatalf("short fragment switched language: %q", got)
+	}
+	if got := TaskLanguageFor("zh-CN", "Could you also check the login page performance?"); got != "en" {
+		t.Fatalf("a clear switch was ignored: %q", got)
+	}
+	if got := TaskLanguageFor("", "怎么样了"); got != "zh-CN" {
+		t.Fatalf("no established language should fall back to detection: %q", got)
 	}
 }
 
@@ -186,9 +236,14 @@ func TestRiskConfirmationEchoesShortTitleAndLatestTaskStatus(t *testing.T) {
 	if ticket.ShortTitle != "结算页" {
 		t.Fatalf("ticket short title = %q", ticket.ShortTitle)
 	}
+	// The prompt names the task and the action so the wrong thing cannot be
+	// confirmed by accident, but it asks the way a person would.
 	prompt := risk.ConfirmationPrompt(*ticket)
-	if !strings.HasPrefix(prompt, "【结算页｜高风险确认】") || !strings.Contains(prompt, "删除生产分支") {
+	if !strings.Contains(prompt, "结算页") || !strings.Contains(prompt, "删除生产分支") {
 		t.Fatalf("prompt = %q", prompt)
+	}
+	if strings.Contains(prompt, "【") || strings.Contains(prompt, "｜") {
+		t.Fatalf("confirmation prompt still uses the ticket header form: %q", prompt)
 	}
 
 	confirmed, err := risk.ResolveTicket(input, "确认")
@@ -228,8 +283,13 @@ func TestRiskConfirmationEchoesShortTitleAndLatestTaskStatus(t *testing.T) {
 	if expired.Execute || expired.Ticket.Status != "expired" {
 		t.Fatalf("expired = %+v", expired)
 	}
-	if !strings.Contains(expired.Message, "【结算页｜已过期】") || expired.TaskStatus != "completed" {
+	// An expired confirmation still names the task and says the action did not
+	// happen, so the user is never left guessing what state things are in.
+	if !strings.Contains(expired.Message, "结算页") || expired.TaskStatus != "completed" {
 		t.Fatalf("expired message = %q status=%q", expired.Message, expired.TaskStatus)
+	}
+	if !strings.Contains(expired.Message, "过期") || strings.Contains(expired.Message, "【") {
+		t.Fatalf("expired message should explain the timeout in plain language: %q", expired.Message)
 	}
 }
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3875,9 +3875,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## 背景

现在一条 QQ 消息等于一次阻塞式工单：先回一句「收到，正在处理：<回显>」，然后同步等整个沙箱回合跑完，很多时候结尾还是「本回合已结束，请在 Approving 查看完整结果。」。用户没法边等边聊，平台自己的黑话（Run ID、沙箱、回合）还会直接漏进聊天框。

这个 PR 把对话层和干活层拆开：前台回合只做「答一句」或「委派一次」，长活一律进后台 Run，用户可以接着聊。

## 主要改动

**对话不再自我播报。** `dispatch` 顺序改为「安全提示 → 数据库快路径 → 前台短回合」，删掉 processing/queue ACK 与 `safeFinalNotice` 空壳。能从任务状态直接答的消息不进队列、不开沙箱。队满不静默丢弃，改为按会话冷却的一条限频提示。

**前台回合有硬超时。** 默认 25s（渠道可配）。超时按「已转后台」处理而不是报错——事实就是如此。委派成功后前台立刻释放，不等 Run 状态。

**回答有唯一外发口。** 新增 `pm_reply` MCP 工具，模型正文永不直接外发；配套按会话键控的「已回复」标记，消除「Agent 答一句 + 系统补一条终态」的双发。渠道 preamble 相应重写。

**结果回到发起会话。** `TaskIdentity` 持久化发起会话（channel / scene / conversation / user）与最近上下文；`Engine.finish` 上挂独立终态钩子（不复用 RunNotify），completed / failed / cancelled 都回流，由该会话自己的 Agent 组织成自然语言，Agent 不可用时降级为可独立看懂的结构化兜底，并回写 `TaskIdentity.Status`。

**意图路由与话术。** 新增 `live_router.go` 做五类意图分类；重写 `detectHighRiskIntent`，要求动作词位于句首且无否定线索，抱怨句不再触发 cancel 确认。短标题清洗掉 Run ID，去掉 `【短标题｜类型】` 工单头改为自然指代，委派确认 / 结果回流 / 失败三处话术改成对话腔。

**可靠性。** 放宽 `Deliverable()`；在 run 级限频之上加会话级进度配额（关键消息按 critical 豁免）；run-notify 投递失败有界重试并落库记录；重启时扫描在途回合，给原会话补一句可理解的说明。

## 顺带修掉的两个 bug

- `DeliverConversationReply` 在回答不关联任何 Run 时没有投递作用域，会被策略层静默丢弃——也就是普通闲聊的回答根本发不出去。
- `humanizeFailureReason` 把 `context deadline exceeded` 归类成「执行环境没起来」而不是超时，会给用户错误的失败原因。

## 测试

- 新增外发文案守卫（对标 web 端 `userFacingCopy.test.ts`），覆盖全部静态外发文案 + `ScrubInternalTerms` 对模型生成文本的清洗。写这个测试时发现原 ID 正则只认十六进制，非十六进制 Run ID 会漏出去；改为匹配标识符形态 + 含数字判定，避免误伤 `run-optimization` 这类正常词。
- 新增：五类意图路由（「那这个是 BUG 吗」不建 Run、「不要这样啊」不触发取消）、一问一答、超时读作交接、队满提示限频且不静默丢弃、终态回流幂等且回写状态、失败原因不外泄诊断信息、重启在途回合收尾、并行 Run 会话级限频、`pm_reply` 各条拒绝路径、`Engine` 终态钩子只触发一次。
- 回归：重写了 `channels_test.go` / `delivery_test.go` / `orchestration_test.go` / `capabilities_test.go` 中断言旧 ACK 与空壳文案的用例。
- `go build ./...`、`go vet ./...`、`go test ./...` 全绿。

## 复核建议

- [ ] 前台 25s 硬超时的取值是否合适（冷启动场景）
- [ ] 会话级进度配额 `conversationProgressQuota = 3` 是否偏紧
- [ ] `copy_guard.go` 里「含数字即视为标识符」的启发式是否有误伤风险

Made with [Cursor](https://cursor.com)