### PR TITLE
对话模型在线测试 + 运行状况

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -447,6 +447,7 @@ func main() {
 		Browser:       browserSvc,
 		Audit:         auditSvc,
 		InjectBundles: injectStore,
+		LiveModel:     liveClient,
 		Onboarding:    services.NewOnboardingService(projectSvc, skillSvc, wfSvc),
 	}
 

--- a/server/internal/handlers/handlers.go
+++ b/server/internal/handlers/handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cocofhu/approving/internal/browser"
 	"github.com/cocofhu/approving/internal/contextmcp"
 	"github.com/cocofhu/approving/internal/engine"
+	"github.com/cocofhu/approving/internal/liveagent"
 	"github.com/cocofhu/approving/internal/mcp"
 	"github.com/cocofhu/approving/internal/memorymcp"
 	"github.com/cocofhu/approving/internal/models"
@@ -65,7 +66,11 @@ type Handlers struct {
 	// to simulate a read-only member denial while production keeps the hook nil.
 	CanViewProjectAudit func(username, projectID string) bool
 	// InjectBundles serves ConfigHome .tgz for gateway SANDBOX_INJECT (no session auth).
-	InjectBundles  *sandbox.BundleStore
+	InjectBundles *sandbox.BundleStore
+	// LiveModel is the conversation-model client, held so the settings page can
+	// test an endpoint and read what that layer has actually been doing. nil
+	// disables both, which is what tests that do not wire it get.
+	LiveModel      *liveagent.Client
 	doctorMu       sync.Mutex
 	doctorSessions map[string]doctorArtifactSession
 }
@@ -90,6 +95,46 @@ func (h *Handlers) UpdateSettings(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"items": items})
+}
+
+// TestLiveEndpoint checks a conversation-model endpoint and reports what it
+// found. The body is a settings patch, so the values on screen can be tested
+// before they are saved; a blank or masked key means "use the stored one".
+//
+// A failing endpoint is a successful test with OK=false, not an HTTP error: the
+// caller asked whether it works, and "no, because the key was rejected" is the
+// answer to that question rather than a failure to answer it.
+func (h *Handlers) TestLiveEndpoint(c *gin.Context) {
+	if h.LiveModel == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "conversation model client unavailable"})
+		return
+	}
+	var body map[string]any
+	if err := c.ShouldBindJSON(&body); err != nil {
+		// An empty body is a legitimate "test what is saved".
+		body = map[string]any{}
+	}
+	baseURL, apiKey, model, timeout := h.Settings.LiveEndpointFor(body)
+	report := liveagent.Probe(c.Request.Context(), liveagent.Endpoint{
+		BaseURL: baseURL, APIKey: apiKey, Model: model, Timeout: timeout,
+	})
+	c.JSON(http.StatusOK, report)
+}
+
+// LiveStatus reports what the conversation layer has actually been doing.
+//
+// The test button proves an endpoint can work; this is the other question, and
+// the one that was unanswerable: a configured endpoint with zero calls means
+// messages are not going through this layer at all.
+func (h *Handlers) LiveStatus(c *gin.Context) {
+	if h.LiveModel == nil {
+		c.JSON(http.StatusOK, gin.H{"configured": false, "stats": liveagent.Stats{}})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"configured": h.LiveModel.Configured(),
+		"stats":      h.LiveModel.Stats(),
+	})
 }
 
 // SandboxInject serves a short-lived ConfigHome .tgz for gateway

--- a/server/internal/handlers/handlers_extra_test.go
+++ b/server/internal/handlers/handlers_extra_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cocofhu/approving/internal/auth"
+	"github.com/cocofhu/approving/internal/liveagent"
 	"github.com/cocofhu/approving/internal/models"
 	"github.com/cocofhu/approving/internal/services"
 	"github.com/cocofhu/approving/internal/shutdown"
@@ -42,6 +43,89 @@ func TestSettingsAndLiveEndpoints(t *testing.T) {
 	h.h.Shutdown.BeginDraining()
 	if w := h.do("GET", "/api/health", nil); w.Code != 503 {
 		t.Fatalf("health draining: %d %s", w.Code, w.Body)
+	}
+}
+
+// The settings page has to be able to answer two different questions: can this
+// endpoint work, and is it being used. Neither may fail loudly — an endpoint
+// that is misconfigured is a finding, not a server error.
+func TestConversationModelTestAndStatusEndpoints(t *testing.T) {
+	h := newHarness(t)
+	h.h.Settings = services.NewSettingsService(h.db, h.h.Eng, h.h.Sbx)
+
+	// Without a client wired, the test is unavailable but status still answers,
+	// because "not configured" is exactly what the page needs to render.
+	if w := h.do("POST", "/api/settings/live/test", map[string]any{}); w.Code != 503 {
+		t.Fatalf("probe without a client: %d %s", w.Code, w.Body)
+	}
+	w := h.do("GET", "/api/settings/live/status", nil)
+	if w.Code != 200 {
+		t.Fatalf("status without a client: %d %s", w.Code, w.Body)
+	}
+	var status struct {
+		Configured bool `json:"configured"`
+		Stats      struct {
+			Calls int `json:"calls"`
+		} `json:"stats"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &status); err != nil {
+		t.Fatal(err)
+	}
+	if status.Configured || status.Stats.Calls != 0 {
+		t.Fatalf("status = %+v", status)
+	}
+
+	h.h.LiveModel = liveagent.New()
+	// An incomplete form is reported as a failed check rather than a 400: the
+	// page shows why, in the same place every other result appears.
+	w = h.do("POST", "/api/settings/live/test", map[string]any{
+		services.KeyLiveBaseURL: "", services.KeyLiveModel: "",
+	})
+	if w.Code != 200 {
+		t.Fatalf("probe with an empty form: %d %s", w.Code, w.Body)
+	}
+	var report struct {
+		Configured bool `json:"configured"`
+		OK         bool `json:"ok"`
+		Checks     []struct {
+			Name   string `json:"name"`
+			OK     bool   `json:"ok"`
+			Reason string `json:"reason"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.Configured || report.OK {
+		t.Fatalf("empty form reported as working: %+v", report)
+	}
+	if len(report.Checks) == 0 || report.Checks[0].Reason == "" {
+		t.Fatalf("empty form gave no reason: %+v", report)
+	}
+
+	// An unreachable address is also a finding, not an error.
+	w = h.do("POST", "/api/settings/live/test", map[string]any{
+		services.KeyLiveBaseURL:        "http://127.0.0.1:1/v1",
+		services.KeyLiveModel:          "m",
+		services.KeyLiveTimeoutSeconds: 1,
+	})
+	if w.Code != 200 {
+		t.Fatalf("probe of an unreachable endpoint: %d %s", w.Code, w.Body)
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if !report.Configured || report.OK {
+		t.Fatalf("unreachable endpoint reported as working: %+v", report)
+	}
+	// And the manual test must not show up as traffic, or the status panel stops
+	// answering whether real messages are going through this layer.
+	w = h.do("GET", "/api/settings/live/status", nil)
+	if err := json.Unmarshal(w.Body.Bytes(), &status); err != nil {
+		t.Fatal(err)
+	}
+	if status.Stats.Calls != 0 {
+		t.Fatalf("a probe counted as traffic: %+v", status)
 	}
 }
 

--- a/server/internal/liveagent/client.go
+++ b/server/internal/liveagent/client.go
@@ -21,6 +21,27 @@ var ErrNotConfigured = errors.New("liveagent: endpoint not configured")
 // reply or a tool call. Callers treat it like any other failure and escalate.
 var ErrBudgetExhausted = errors.New("liveagent: token budget exhausted before a reply")
 
+// ErrEmptyResponse means the endpoint answered with neither text nor a tool
+// call. ErrBadResponse means the answer could not be read as a completion at
+// all, which usually means the address does not point at an OpenAI-compatible
+// API. They are distinct sentinels because they send you to different places:
+// one is the model, the other is the URL.
+var (
+	ErrEmptyResponse = errors.New("liveagent: response was empty")
+	ErrBadResponse   = errors.New("liveagent: response was not a completion")
+)
+
+// StatusError reports a non-2xx response.
+//
+// The body is deliberately not carried. It can echo request fields — including
+// the conversation — so nothing from it is safe to surface; the status code
+// alone is enough to say which part of the configuration to look at.
+type StatusError struct{ StatusCode int }
+
+func (e *StatusError) Error() string {
+	return fmt.Sprintf("liveagent: endpoint returned %d", e.StatusCode)
+}
+
 // Message is one turn of conversation sent to the model.
 type Message struct {
 	// Role is "user" or "assistant". The system prompt travels in Request.
@@ -74,8 +95,9 @@ type Result struct {
 
 // Client calls an OpenAI-compatible chat/completions endpoint.
 type Client struct {
-	cur  current
-	http *http.Client
+	cur   current
+	http  *http.Client
+	stats stats
 }
 
 // New returns a client with no endpoint set; it stays unconfigured until
@@ -119,10 +141,12 @@ func (c *Client) Complete(ctx context.Context, req Request) (Result, error) {
 		allowed[t.Name] = true
 	}
 
+	started := time.Now()
 	var lastErr error
 	for attempt := 0; attempt < 2; attempt++ {
 		res, retryable, err := c.call(callCtx, ep, body, allowed)
 		if err == nil {
+			c.stats.record(time.Since(started), time.Now(), "")
 			return res, nil
 		}
 		lastErr = err
@@ -130,6 +154,10 @@ func (c *Client) Complete(ctx context.Context, req Request) (Result, error) {
 			break
 		}
 	}
+	// The recorded reason is the operator-facing one rather than the transport
+	// error, so what shows up on the settings page after a real failure reads
+	// the same as what the test button says.
+	c.stats.record(time.Since(started), time.Now(), describeFailure(lastErr, ep.Timeout))
 	return Result{}, lastErr
 }
 
@@ -157,18 +185,15 @@ func (c *Client) call(ctx context.Context, ep Endpoint, body []byte, allowed map
 		return Result{}, true, fmt.Errorf("liveagent: read response: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		// The body can echo request fields, so it is summarised rather than
-		// propagated; nothing from here is ever shown to a user.
-		return Result{}, resp.StatusCode >= 500,
-			fmt.Errorf("liveagent: endpoint returned %d", resp.StatusCode)
+		return Result{}, resp.StatusCode >= 500, &StatusError{StatusCode: resp.StatusCode}
 	}
 
 	var parsed completionResponse
 	if err := json.Unmarshal(raw, &parsed); err != nil {
-		return Result{}, false, fmt.Errorf("liveagent: decode response: %w", err)
+		return Result{}, false, fmt.Errorf("%w: decode: %w", ErrBadResponse, err)
 	}
 	if len(parsed.Choices) == 0 {
-		return Result{}, false, errors.New("liveagent: response had no choices")
+		return Result{}, false, fmt.Errorf("%w: no choices", ErrBadResponse)
 	}
 
 	msg := parsed.Choices[0].Message
@@ -192,7 +217,7 @@ func (c *Client) call(ctx context.Context, ep Endpoint, body []byte, allowed map
 		if parsed.Choices[0].FinishReason == "length" {
 			return Result{}, false, ErrBudgetExhausted
 		}
-		return Result{}, false, errors.New("liveagent: response was empty")
+		return Result{}, false, ErrEmptyResponse
 	}
 	return out, false, nil
 }

--- a/server/internal/liveagent/probe.go
+++ b/server/internal/liveagent/probe.go
@@ -1,0 +1,192 @@
+package liveagent
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// ProbeCheck is one property of an endpoint that either holds or does not.
+// Reason is written for whoever is filling in the settings form, so it names
+// what to go and change rather than what the transport reported.
+type ProbeCheck struct {
+	Name   string `json:"name"`
+	OK     bool   `json:"ok"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// Probe check names. They are stable identifiers the UI translates; the Reason
+// text is already human-readable and is shown as-is.
+const (
+	// CheckReachable is a real completion round trip. It is the one check that
+	// gates the others: nothing else is worth asking if the endpoint is silent.
+	CheckReachable = "reachable"
+	// CheckToolCalls is whether the model can return a tool call. The routing
+	// layer decides to escalate by calling a tool, so a model that cannot do
+	// this answers everything itself and never hands work to the project — a
+	// failure that looks like normal operation from the outside, which is
+	// exactly why it is worth a check of its own.
+	CheckToolCalls = "tool_calls"
+)
+
+// ProbeReport is the outcome of testing one endpoint.
+type ProbeReport struct {
+	Configured bool         `json:"configured"`
+	OK         bool         `json:"ok"`
+	Checks     []ProbeCheck `json:"checks"`
+	// LatencyMS is the round trip of the reachability call. This layer is only
+	// worth having while it is fast, so the number is the point of the test as
+	// much as the pass/fail is: it is what a sensible timeout is chosen from.
+	LatencyMS int64 `json:"latencyMs"`
+	// Sample is a short excerpt of what the model actually said, so an operator
+	// can confirm it is the model they think they configured.
+	Sample string `json:"sample,omitempty"`
+}
+
+// probeTool is deliberately trivial. The check is whether the endpoint supports
+// tool calling at all, not whether the model is any good at choosing.
+var probeTool = ToolSpec{
+	Name:        "report_ready",
+	Description: "Report that you are ready. Call this tool instead of writing a reply.",
+	Params: []Param{{
+		Name: "status", Description: `Always the word "ready".`,
+		Enum: []string{"ready"}, Required: true,
+	}},
+}
+
+// Probe tests one endpoint without disturbing the configured one.
+//
+// It runs against a throwaway client so an operator can check a form they have
+// not saved yet, and so a test never counts as traffic in the runtime stats.
+func Probe(ctx context.Context, ep Endpoint) ProbeReport {
+	report := ProbeReport{Configured: ep.Configured()}
+	if !report.Configured {
+		report.Checks = []ProbeCheck{{
+			Name: CheckReachable, OK: false,
+			Reason: "接口地址和模型名称都填了才能测试。",
+		}}
+		return report
+	}
+
+	c := New()
+	c.cur.store(ep)
+	timeout := c.cur.load().Timeout
+
+	started := time.Now()
+	res, err := c.Complete(ctx, Request{
+		System:    "You are a health check. Reply with the single word: ok",
+		Messages:  []Message{{Role: "user", Content: "ok?"}},
+		MaxTokens: 512,
+	})
+	report.LatencyMS = time.Since(started).Milliseconds()
+	if err != nil {
+		report.Checks = []ProbeCheck{{
+			Name: CheckReachable, OK: false, Reason: describeFailure(err, timeout),
+		}}
+		return report
+	}
+	report.Checks = append(report.Checks, ProbeCheck{Name: CheckReachable, OK: true})
+	report.Sample = excerpt(res.Text, 120)
+
+	// Only worth asking once we know the endpoint answers, and skipping it on
+	// failure also keeps a broken endpoint from costing two full timeouts.
+	tool, err := c.Complete(ctx, Request{
+		System: "You are being checked for tool-calling support. " +
+			"Call the report_ready tool with status=ready. Do not write a reply.",
+		Messages:  []Message{{Role: "user", Content: "Are you ready?"}},
+		Tools:     []ToolSpec{probeTool},
+		MaxTokens: 512,
+	})
+	switch {
+	case err != nil:
+		report.Checks = append(report.Checks, ProbeCheck{
+			Name: CheckToolCalls, OK: false, Reason: describeFailure(err, timeout),
+		})
+	case tool.ToolName != probeTool.Name:
+		report.Checks = append(report.Checks, ProbeCheck{
+			Name: CheckToolCalls, OK: false,
+			Reason: "这个模型没有发出工具调用，只回了文字。它可以直接答话，" +
+				"但不会把需要动手的活儿转交给项目——建议换一个支持 function calling 的模型。",
+		})
+	default:
+		report.Checks = append(report.Checks, ProbeCheck{Name: CheckToolCalls, OK: true})
+	}
+
+	report.OK = true
+	for _, ch := range report.Checks {
+		if !ch.OK {
+			report.OK = false
+			break
+		}
+	}
+	return report
+}
+
+// describeFailure turns a call error into something worth acting on.
+//
+// It never carries the response body: that can echo request fields, including
+// the conversation, and none of it is safe to put on a settings page. What it
+// does carry is which part of the form is likely wrong.
+func describeFailure(err error, timeout time.Duration) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, ErrNotConfigured):
+		return "接口地址和模型名称都填了才能测试。"
+	case errors.Is(err, context.DeadlineExceeded), errors.Is(err, context.Canceled):
+		return "等了 " + strconv.Itoa(int(timeout.Seconds())) + " 秒没有响应。" +
+			"端点可能太慢或卡住了；这一层只有快才有意义，慢的话不如直接交给沙箱。"
+	case errors.Is(err, ErrBudgetExhausted):
+		return "模型把额度都花在思考上，没有产出回答。换一个不那么爱推理的模型会更合适。"
+	case errors.Is(err, ErrEmptyResponse):
+		return "端点接受了请求但没有返回内容。"
+	case errors.Is(err, ErrBadResponse):
+		return "端点返回的内容看不懂，可能不是 OpenAI 兼容接口。检查地址是不是少了 /v1。"
+	}
+
+	var statusErr *StatusError
+	if errors.As(err, &statusErr) {
+		return describeStatus(statusErr.StatusCode)
+	}
+
+	var dnsErr *net.DNSError
+	switch {
+	case errors.As(err, &dnsErr):
+		return "域名解析不了，检查接口地址里的主机名。"
+	case errors.Is(err, syscall.ECONNREFUSED):
+		return "连接被拒绝，检查地址和端口，以及端点是不是在跑。"
+	case errors.Is(err, syscall.EHOSTUNREACH), errors.Is(err, syscall.ENETUNREACH):
+		return "网络到不了这个地址，检查它是否在本机能访问的网段里。"
+	}
+	return "连不上这个端点，检查接口地址。"
+}
+
+// describeStatus maps a rejection to the field that most likely caused it.
+func describeStatus(code int) string {
+	switch {
+	case code == 401 || code == 403:
+		return "端点拒绝了密钥（HTTP " + strconv.Itoa(code) + "）。检查密钥，本机内网模型通常留空即可。"
+	case code == 404:
+		return "地址不对（HTTP 404）。OpenAI 兼容地址一般以 /v1 结尾，" +
+			"系统会自己拼上 /chat/completions。也可能是模型名称不存在。"
+	case code == 400 || code == 422:
+		return "请求被拒绝（HTTP " + strconv.Itoa(code) + "）。最常见的原因是模型名称写错了。"
+	case code == 429:
+		return "被限流了（HTTP 429）。稍后再试，或换一个额度更宽的端点。"
+	case code >= 500:
+		return "端点自己出错了（HTTP " + strconv.Itoa(code) + "）。这是端点侧的问题，不是这里的配置。"
+	}
+	return "端点返回了 HTTP " + strconv.Itoa(code) + "。"
+}
+
+func excerpt(s string, max int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	if len([]rune(s)) <= max {
+		return s
+	}
+	return string([]rune(s)[:max]) + "…"
+}

--- a/server/internal/liveagent/probe_test.go
+++ b/server/internal/liveagent/probe_test.go
@@ -1,0 +1,159 @@
+package liveagent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// probeServer answers the reachability call and then the tool-call call, so a
+// test can decide each independently.
+func probeServer(t *testing.T, handler func(w http.ResponseWriter, hasTools bool)) Endpoint {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Tools []any `json:"tools"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.Header().Set("Content-Type", "application/json")
+		handler(w, len(body.Tools) > 0)
+	}))
+	t.Cleanup(srv.Close)
+	return Endpoint{BaseURL: srv.URL + "/v1", Model: "m", Timeout: 5 * time.Second}
+}
+
+func checkByName(t *testing.T, report ProbeReport, name string) ProbeCheck {
+	t.Helper()
+	for _, c := range report.Checks {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("report has no %q check: %+v", name, report.Checks)
+	return ProbeCheck{}
+}
+
+func TestProbePassesWhenTheEndpointAnswersAndCallsTools(t *testing.T) {
+	ep := probeServer(t, func(w http.ResponseWriter, hasTools bool) {
+		if hasTools {
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"tool_calls":[
+				{"function":{"name":"report_ready","arguments":"{\"status\":\"ready\"}"}}]}}]}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+	})
+
+	report := Probe(context.Background(), ep)
+	if !report.Configured || !report.OK {
+		t.Fatalf("report = %+v", report)
+	}
+	if !checkByName(t, report, CheckReachable).OK || !checkByName(t, report, CheckToolCalls).OK {
+		t.Fatalf("checks = %+v", report.Checks)
+	}
+	if report.Sample != "ok" {
+		t.Fatalf("sample = %q want what the model actually said", report.Sample)
+	}
+}
+
+// A model that answers but cannot call tools is the failure worth catching:
+// it looks healthy and silently never escalates anything to the project.
+func TestProbeReportsAModelThatCannotCallTools(t *testing.T) {
+	ep := probeServer(t, func(w http.ResponseWriter, _ bool) {
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"我不会调工具"}}]}`))
+	})
+
+	report := Probe(context.Background(), ep)
+	if !checkByName(t, report, CheckReachable).OK {
+		t.Fatalf("a reachable endpoint was reported unreachable: %+v", report.Checks)
+	}
+	tools := checkByName(t, report, CheckToolCalls)
+	if tools.OK {
+		t.Fatal("a text-only answer counted as tool-call support")
+	}
+	if !strings.Contains(tools.Reason, "function calling") {
+		t.Fatalf("tool-call failure does not say what to do: %q", tools.Reason)
+	}
+	if report.OK {
+		t.Fatal("report is OK despite a failed check")
+	}
+}
+
+// Each rejection points at the field that most likely caused it. A settings
+// page that only says "it failed" leaves the operator guessing between the
+// address, the key and the model name.
+func TestProbeBlamesTheFieldBehindEachRejection(t *testing.T) {
+	cases := []struct {
+		status int
+		expect string
+	}{
+		{http.StatusUnauthorized, "密钥"},
+		{http.StatusForbidden, "密钥"},
+		{http.StatusNotFound, "/v1"},
+		{http.StatusBadRequest, "模型名称"},
+		{http.StatusTooManyRequests, "限流"},
+		{http.StatusInternalServerError, "端点自己出错"},
+	}
+	for _, tc := range cases {
+		ep := probeServer(t, func(w http.ResponseWriter, _ bool) {
+			// The body is deliberately something that must never be shown.
+			w.WriteHeader(tc.status)
+			_, _ = w.Write([]byte(`{"error":"echo of the prompt: sk-secret"}`))
+		})
+		report := Probe(context.Background(), ep)
+		reason := checkByName(t, report, CheckReachable).Reason
+		if !strings.Contains(reason, tc.expect) {
+			t.Fatalf("HTTP %d reason = %q want it to mention %q", tc.status, reason, tc.expect)
+		}
+		if strings.Contains(reason, "sk-secret") || strings.Contains(reason, "echo") {
+			t.Fatalf("HTTP %d leaked the response body: %q", tc.status, reason)
+		}
+	}
+}
+
+func TestProbeRefusesAnIncompleteForm(t *testing.T) {
+	report := Probe(context.Background(), Endpoint{BaseURL: "http://x/v1"})
+	if report.Configured || report.OK {
+		t.Fatalf("a form with no model was probed anyway: %+v", report)
+	}
+	if len(report.Checks) != 1 || checkByName(t, report, CheckReachable).OK {
+		t.Fatalf("checks = %+v", report.Checks)
+	}
+}
+
+func TestProbeReportsAnUnreachableAddress(t *testing.T) {
+	// Port 0 is never listening, so this exercises the connection-error path
+	// rather than any HTTP status.
+	report := Probe(context.Background(), Endpoint{
+		BaseURL: "http://127.0.0.1:1/v1", Model: "m", Timeout: 2 * time.Second,
+	})
+	if report.OK {
+		t.Fatal("an unreachable endpoint passed")
+	}
+	if reason := checkByName(t, report, CheckReachable).Reason; reason == "" {
+		t.Fatal("an unreachable endpoint gave no reason at all")
+	}
+	// The tool-call check must be skipped: asking twice would cost a second
+	// full timeout for no new information.
+	if len(report.Checks) != 1 {
+		t.Fatalf("checks = %+v want only reachability", report.Checks)
+	}
+}
+
+// A probe must not look like traffic, or the runtime stats stop answering
+// "is this layer actually being used" — which is the one thing they exist for.
+func TestProbeDoesNotCountAsTraffic(t *testing.T) {
+	ep := probeServer(t, func(w http.ResponseWriter, _ bool) {
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+	})
+	c := New()
+	c.SetLiveEndpoint(ep.BaseURL, "", ep.Model, ep.Timeout)
+
+	Probe(context.Background(), ep)
+	if got := c.Stats(); got.Calls != 0 {
+		t.Fatalf("stats after a probe = %+v want no recorded calls", got)
+	}
+}

--- a/server/internal/liveagent/stats.go
+++ b/server/internal/liveagent/stats.go
@@ -1,0 +1,85 @@
+package liveagent
+
+import (
+	"sync"
+	"time"
+)
+
+// Stats is what the conversation layer has actually been doing.
+//
+// A test button proves a configuration can work; this proves whether it is
+// being used. The two are not the same question, and only having the first is
+// how a saved, working endpoint went unnoticed for a day while every message
+// quietly went to a sandbox instead: from the outside an escalation looks like
+// an ordinary answer, only slower. Calls=0 on a configured endpoint is the
+// signal that was missing.
+type Stats struct {
+	Calls  int `json:"calls"`
+	Failed int `json:"failed"`
+	// AvgLatencyMS averages the successful calls. Failures are excluded because
+	// a timeout would otherwise dominate the number and hide how fast the
+	// endpoint is when it does answer.
+	AvgLatencyMS  int64      `json:"avgLatencyMs"`
+	LastLatencyMS int64      `json:"lastLatencyMs"`
+	LastSuccessAt *time.Time `json:"lastSuccessAt,omitempty"`
+	LastFailureAt *time.Time `json:"lastFailureAt,omitempty"`
+	// LastFailure is the same operator-facing explanation the test button
+	// gives, so a failure seen in production reads the same as one reproduced
+	// by hand.
+	LastFailure string `json:"lastFailure,omitempty"`
+}
+
+type stats struct {
+	mu            sync.Mutex
+	calls         int
+	failed        int
+	successes     int
+	latencySumMS  int64
+	lastLatencyMS int64
+	lastSuccessAt time.Time
+	lastFailureAt time.Time
+	lastFailure   string
+}
+
+func (s *stats) record(latency time.Duration, at time.Time, failure string) {
+	ms := latency.Milliseconds()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	s.lastLatencyMS = ms
+	if failure != "" {
+		s.failed++
+		s.lastFailureAt = at
+		s.lastFailure = failure
+		return
+	}
+	s.successes++
+	s.latencySumMS += ms
+	s.lastSuccessAt = at
+}
+
+func (s *stats) snapshot() Stats {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := Stats{
+		Calls: s.calls, Failed: s.failed,
+		LastLatencyMS: s.lastLatencyMS, LastFailure: s.lastFailure,
+	}
+	if s.successes > 0 {
+		out.AvgLatencyMS = s.latencySumMS / int64(s.successes)
+	}
+	if !s.lastSuccessAt.IsZero() {
+		at := s.lastSuccessAt
+		out.LastSuccessAt = &at
+	}
+	if !s.lastFailureAt.IsZero() {
+		at := s.lastFailureAt
+		out.LastFailureAt = &at
+	}
+	return out
+}
+
+// Stats reports the calls made since this process started. A probe does not
+// appear here: it runs on a throwaway client so a manual test is never mistaken
+// for traffic.
+func (c *Client) Stats() Stats { return c.stats.snapshot() }

--- a/server/internal/liveagent/stats_test.go
+++ b/server/internal/liveagent/stats_test.go
@@ -1,0 +1,68 @@
+package liveagent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Zero calls on a configured endpoint is the signal that was missing: it is how
+// a working configuration can sit there for a day while every message quietly
+// goes to a sandbox instead.
+func TestStatsStartEmptySoNoTrafficIsVisible(t *testing.T) {
+	c := New()
+	c.SetLiveEndpoint("http://127.0.0.1:9/v1", "", "m", time.Second)
+	if !c.Configured() {
+		t.Fatal("endpoint should be configured")
+	}
+	if got := c.Stats(); got.Calls != 0 || got.Failed != 0 || got.LastFailure != "" {
+		t.Fatalf("stats before any call = %+v", got)
+	}
+}
+
+func TestStatsRecordSuccessesAndFailuresSeparately(t *testing.T) {
+	var fail bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if fail {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+	}))
+	defer srv.Close()
+
+	c := New()
+	c.SetLiveEndpoint(srv.URL+"/v1", "", "m", 5*time.Second)
+	req := Request{Messages: []Message{{Role: "user", Content: "hi"}}}
+
+	if _, err := c.Complete(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	got := c.Stats()
+	if got.Calls != 1 || got.Failed != 0 || got.LastSuccessAt == nil {
+		t.Fatalf("stats after one success = %+v", got)
+	}
+
+	fail = true
+	if _, err := c.Complete(context.Background(), req); err == nil {
+		t.Fatal("expected the rejection to surface")
+	}
+	got = c.Stats()
+	if got.Calls != 2 || got.Failed != 1 || got.LastFailureAt == nil {
+		t.Fatalf("stats after one failure = %+v", got)
+	}
+	// The recorded reason is the operator-facing one, so a production failure
+	// reads the same as one reproduced with the test button.
+	if !strings.Contains(got.LastFailure, "密钥") {
+		t.Fatalf("last failure = %q want the same explanation the probe gives", got.LastFailure)
+	}
+	// A timeout must not drag the average down and hide how fast the endpoint
+	// is when it does answer.
+	if got.AvgLatencyMS < 0 {
+		t.Fatalf("avg latency = %d", got.AvgLatencyMS)
+	}
+}

--- a/server/internal/router/router.go
+++ b/server/internal/router/router.go
@@ -56,6 +56,8 @@ func New(h *handlers.Handlers) *gin.Engine {
 
 		api.GET("/settings", h.GetSettings)
 		api.PUT("/settings", h.UpdateSettings)
+		api.POST("/settings/live/test", h.TestLiveEndpoint)
+		api.GET("/settings/live/status", h.LiveStatus)
 
 		api.GET("/platform-rules", h.ListPlatformRules)
 		api.GET("/platform-rules/:file/embed", h.GetPlatformRuleEmbed)

--- a/server/internal/services/settings.go
+++ b/server/internal/services/settings.go
@@ -258,6 +258,57 @@ func (s *SettingsService) Update(patch map[string]any) ([]SettingItem, error) {
 	return s.Effective(), nil
 }
 
+// LiveEndpointFor resolves the conversation-model endpoint a patch describes,
+// without saving anything.
+//
+// It exists so the settings page can test what is on screen rather than what is
+// stored: a base URL you have not saved yet is exactly the one you want to
+// check. Two rules make that safe. A blank or masked key falls back to the
+// stored one, because the form never holds the real key to send back. An
+// env-locked knob ignores the form entirely, because the environment is
+// authoritative and testing a value that cannot take effect would be a lie.
+//
+// The key comes back in plaintext and must not be logged or returned to a
+// client.
+func (s *SettingsService) LiveEndpointFor(patch map[string]any) (baseURL, apiKey, model string, timeout time.Duration) {
+	cfg := config.GetConfig()
+	pick := func(k knob) string {
+		stored, _, _ := s.resolveStr(k, cfg)
+		raw, ok := patch[k.key]
+		if !ok || k.envLocked() {
+			return stored
+		}
+		v, isStr := raw.(string)
+		if !isStr {
+			return stored
+		}
+		v = strings.TrimSpace(v)
+		if k.kind == KindSecret && isSecretPlaceholder(v) {
+			return stored
+		}
+		return v
+	}
+	seconds := 0
+	for _, k := range knobs() {
+		switch k.key {
+		case KeyLiveBaseURL:
+			baseURL = pick(k)
+		case KeyLiveModel:
+			model = pick(k)
+		case KeyLiveAPIKey:
+			apiKey = pick(k)
+		case KeyLiveTimeoutSeconds:
+			seconds, _, _ = s.resolveInt(k, cfg)
+			if raw, ok := patch[k.key]; ok && !k.envLocked() {
+				if v, err := coerceInt(raw); err == nil && v >= k.min {
+					seconds = v
+				}
+			}
+		}
+	}
+	return baseURL, apiKey, model, time.Duration(seconds) * time.Second
+}
+
 // coerceInt accepts the shapes an int can take after a JSON round-trip.
 func coerceInt(raw any) (int, error) {
 	switch v := raw.(type) {

--- a/server/internal/services/settings_test.go
+++ b/server/internal/services/settings_test.go
@@ -165,6 +165,68 @@ func TestSettingsCarryStringsAndSecrets(t *testing.T) {
 	}
 }
 
+// The settings page tests what is on screen, not what is stored, so an address
+// can be corrected and checked before it is committed. Two things have to hold
+// for that to be safe: the form never holds the real key, and the environment
+// stays authoritative over anything typed into a locked field.
+func TestLiveEndpointForTestsTheFormNotTheStoredValues(t *testing.T) {
+	db, err := database.OpenSQLite(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(crypto.SecretsKeyEnv, base64.StdEncoding.EncodeToString(make([]byte, 32)))
+	config.StoreConfig(&config.Config{Live: config.LiveConfig{TimeoutSeconds: 8}})
+	svc := NewSettingsService(db, nil, nil)
+	if _, err := svc.Update(map[string]any{
+		KeyLiveBaseURL: "https://saved.example.com/v1",
+		KeyLiveModel:   "saved-model",
+		KeyLiveAPIKey:  "sk-stored",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Unsaved edits are what get tested.
+	baseURL, apiKey, model, timeout := svc.LiveEndpointFor(map[string]any{
+		KeyLiveBaseURL:        "http://192.168.2.20:8080/v1",
+		KeyLiveModel:          "typed-model",
+		KeyLiveAPIKey:         "",
+		KeyLiveTimeoutSeconds: 30,
+	})
+	if baseURL != "http://192.168.2.20:8080/v1" || model != "typed-model" {
+		t.Fatalf("form values ignored: %s %s", baseURL, model)
+	}
+	// A blank field is the UI's resting state for a secret, not a cleared key.
+	if apiKey != "sk-stored" {
+		t.Fatalf("api key = %q want the stored one", apiKey)
+	}
+	if timeout != 30*time.Second {
+		t.Fatalf("timeout = %v", timeout)
+	}
+
+	// The mask means the same thing as blank.
+	if _, apiKey, _, _ = svc.LiveEndpointFor(map[string]any{KeyLiveAPIKey: SecretMask}); apiKey != "sk-stored" {
+		t.Fatalf("masked key = %q want the stored one", apiKey)
+	}
+	// A typed key is used as-is, which is the whole point of testing before saving.
+	if _, apiKey, _, _ = svc.LiveEndpointFor(map[string]any{KeyLiveAPIKey: "sk-typed"}); apiKey != "sk-typed" {
+		t.Fatalf("typed key = %q", apiKey)
+	}
+
+	// An omitted key falls back to what is saved.
+	baseURL, _, model, _ = svc.LiveEndpointFor(map[string]any{})
+	if baseURL != "https://saved.example.com/v1" || model != "saved-model" {
+		t.Fatalf("empty patch = %s %s want the saved values", baseURL, model)
+	}
+
+	// An env-locked field cannot take effect, so testing a typed value there
+	// would report on a configuration that will never run.
+	t.Setenv("APPROVING_LIVE_MODEL", "env-model")
+	config.StoreConfig(&config.Config{Live: config.LiveConfig{Model: "env-model", TimeoutSeconds: 8}})
+	if _, _, model, _ = svc.LiveEndpointFor(map[string]any{KeyLiveModel: "typed-model"}); model != "env-model" {
+		t.Fatalf("model = %q want the env-locked value", model)
+	}
+}
+
 // A stored secret that no longer decrypts (rotated master key) must not reach
 // the model client as ciphertext.
 func TestUndecryptableSecretFallsBackToConfig(t *testing.T) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -269,6 +269,43 @@ export interface SettingItem {
   locked: boolean
 }
 
+// LiveProbeCheck is one property of a conversation-model endpoint that either
+// holds or does not. `reason` is already operator-facing prose from the server
+// and is shown as-is; `name` is the stable identifier the UI labels.
+export interface LiveProbeCheck {
+  name: 'reachable' | 'tool_calls' | string
+  ok: boolean
+  reason?: string
+}
+
+// LiveProbeReport is the outcome of testing an endpoint. An endpoint that does
+// not work is `ok: false` on a successful request, not a thrown error.
+export interface LiveProbeReport {
+  configured: boolean
+  ok: boolean
+  checks: LiveProbeCheck[]
+  latencyMs: number
+  sample?: string
+}
+
+// LiveStats is what the conversation layer has actually done since the server
+// started. `calls: 0` while configured is the signal that inbound messages are
+// not going through this layer at all.
+export interface LiveStats {
+  calls: number
+  failed: number
+  avgLatencyMs: number
+  lastLatencyMs: number
+  lastSuccessAt?: string
+  lastFailureAt?: string
+  lastFailure?: string
+}
+
+export interface LiveStatus {
+  configured: boolean
+  stats: LiveStats
+}
+
 export type PlatformRuleSource = 'override' | 'global' | 'embed'
 
 export interface PlatformRuleMeta {
@@ -1033,6 +1070,15 @@ export const api = {
       method: 'PUT',
       body: JSON.stringify(patch),
     }),
+  // Tests the values in the form rather than the saved ones, so a corrected
+  // address can be checked before committing it. A blank secret means the
+  // server uses the stored key.
+  testLiveEndpoint: (patch: Record<string, number | string>) =>
+    req<LiveProbeReport>('/settings/live/test', {
+      method: 'POST',
+      body: JSON.stringify(patch),
+    }),
+  liveStatus: () => req<LiveStatus>('/settings/live/status'),
 
   listPlatformRules: () => req<{ items: PlatformRuleMeta[] }>('/platform-rules'),
   getPlatformRule: (file: string) => req<PlatformRuleContent>(`/platform-rules/${encodeURIComponent(file)}`),

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -965,6 +965,29 @@
       "liveUnconfigured": "Not configured: every IM message currently goes to a sandbox, which works but takes tens of seconds each. Fill in the endpoint and model to enable; a local or LAN model usually needs no key.",
       "liveSecretStored": "Stored — leave blank to keep",
       "liveSecretEmpty": "Not configured",
+      "liveTest": {
+        "title": "Test endpoint",
+        "desc": "Tests the values in the form, so there is no need to save first. Besides reachability it checks whether the model can return a tool call — one that cannot will answer everything itself and never hand work to the project.",
+        "action": "Test",
+        "running": "Testing…",
+        "pass": "Working",
+        "fail": "Not working",
+        "latency": "{ms} ms round trip",
+        "sample": "The model said:",
+        "failed": "The test request could not be sent",
+        "checks": {
+          "reachable": "Reachable",
+          "toolCalls": "Tool calls"
+        }
+      },
+      "liveRuntime": {
+        "title": "Runtime",
+        "desc": "What this layer has actually handled since the server started. The test button proves a configuration can work; this is what shows whether it is being used.",
+        "neverCalled": "The configuration works, but this layer has not been called once since startup. The IM channel may not be running, or messages are not reaching it — in which case every message goes straight to a sandbox: nothing is missing, everything is slow.",
+        "counts": "{calls} calls, {failed} failed",
+        "avgLatency": "{ms} ms average on success",
+        "lastFailure": "Most recent failure:"
+      },
       "sourceLabels": {
         "env": "Environment",
         "db": "Customized",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -965,6 +965,29 @@
       "liveUnconfigured": "尚未配置：当前每条 IM 消息都会交给沙箱，功能完整但每条都要等几十秒。填好地址和模型即可启用，本机或内网模型通常不需要密钥。",
       "liveSecretStored": "已保存，留空则不修改",
       "liveSecretEmpty": "尚未配置",
+      "liveTest": {
+        "title": "在线测试",
+        "desc": "测的是当前表单里的值，不用先保存。除了连通性，还会看这个模型能不能发出工具调用——不能的话它会把所有消息都自己答掉，永远不转交给项目。",
+        "action": "测试",
+        "running": "测试中…",
+        "pass": "可用",
+        "fail": "不可用",
+        "latency": "往返 {ms} ms",
+        "sample": "模型回了：",
+        "failed": "测试请求没发出去",
+        "checks": {
+          "reachable": "连通",
+          "toolCalls": "工具调用"
+        }
+      },
+      "liveRuntime": {
+        "title": "运行状况",
+        "desc": "自本次启动以来这一层真实处理的消息。测试按钮只能证明配置可用，这里才能看出线上有没有在走。",
+        "neverCalled": "配置可用，但启动至今这一层一次都没被调用过。IM 渠道可能没在跑，或者消息没走到这里——此时每条消息都直接交给沙箱，功能不缺但都慢。",
+        "counts": "调用 {calls} 次，失败 {failed} 次",
+        "avgLatency": "成功调用平均 {ms} ms",
+        "lastFailure": "最近一次失败："
+      },
       "sourceLabels": {
         "env": "环境变量",
         "db": "已自定义",

--- a/web/src/views/SettingsView.liveTest.test.ts
+++ b/web/src/views/SettingsView.liveTest.test.ts
@@ -1,0 +1,205 @@
+// @vitest-environment happy-dom
+import { createI18n } from 'vue-i18n'
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import common from '@/locales/zh-CN/common.json'
+import pages from '@/locales/zh-CN/pages.json'
+import type { LiveProbeReport, LiveStatus, SettingItem } from '@/lib/api'
+
+const mocks = vi.hoisted(() => ({
+  getSettings: vi.fn(),
+  updateSettings: vi.fn(),
+  testLiveEndpoint: vi.fn(),
+  liveStatus: vi.fn(),
+  listSandboxes: vi.fn(),
+  dashboard: vi.fn(),
+}))
+
+vi.mock('@/lib/api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/api')>('@/lib/api')
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getSettings: mocks.getSettings,
+      updateSettings: mocks.updateSettings,
+      testLiveEndpoint: mocks.testLiveEndpoint,
+      liveStatus: mocks.liveStatus,
+      listSandboxes: mocks.listSandboxes,
+      dashboard: mocks.dashboard,
+    },
+  }
+})
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ query: {} }),
+}))
+
+vi.mock('@/lib/useAuth', () => ({
+  useAuth: () => ({ user: { value: { isAdmin: true } } }),
+}))
+
+function settingsFixture(): SettingItem[] {
+  const str = (key: string, value: string): SettingItem => ({
+    key,
+    label: key,
+    kind: 'string',
+    value,
+    min: 0,
+    source: 'db',
+    locked: false,
+  })
+  return [
+    { key: 'max_concurrent_runs', label: '', kind: 'int', value: 5, min: 1, source: 'config', locked: false },
+    { key: 'run_sandbox_ttl_minutes', label: '', kind: 'int', value: 30, min: 1, source: 'config', locked: false },
+    { key: 'test_sandbox_ttl_minutes', label: '', kind: 'int', value: 10, min: 1, source: 'config', locked: false },
+    { key: 'max_test_sandboxes', label: '', kind: 'int', value: 2, min: 1, source: 'config', locked: false },
+    str('live_base_url', 'http://192.168.2.20:8080/v1'),
+    str('live_model', 'holo-3.1-35b-a3b'),
+    { key: 'live_api_key', label: '', kind: 'secret', value: '****', min: 0, source: 'db', locked: false },
+    { key: 'live_timeout_seconds', label: '', kind: 'int', value: 30, min: 1, source: 'db', locked: false },
+  ]
+}
+
+function liveStatusFixture(over: Partial<LiveStatus['stats']> = {}, configured = true): LiveStatus {
+  return {
+    configured,
+    stats: { calls: 0, failed: 0, avgLatencyMs: 0, lastLatencyMs: 0, ...over },
+  }
+}
+
+async function mountSettings() {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common, ...pages } },
+  })
+  const SettingsView = (await import('@/views/SettingsView.vue')).default
+  const wrapper = mount(SettingsView, {
+    global: { plugins: [i18n], stubs: { RouterLink: true } },
+  })
+  await flushPromises()
+  return wrapper
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.getSettings.mockResolvedValue({ items: settingsFixture() })
+  mocks.updateSettings.mockResolvedValue({ items: settingsFixture() })
+  mocks.liveStatus.mockResolvedValue(liveStatusFixture())
+  mocks.listSandboxes.mockResolvedValue([])
+  mocks.dashboard.mockResolvedValue({ running: 0 })
+})
+
+describe('conversation model endpoint test', () => {
+  it('tests the values in the form so a fix can be checked before saving', async () => {
+    mocks.testLiveEndpoint.mockResolvedValue({
+      configured: true,
+      ok: true,
+      latencyMs: 420,
+      checks: [
+        { name: 'reachable', ok: true },
+        { name: 'tool_calls', ok: true },
+      ],
+      sample: 'ok',
+    } satisfies LiveProbeReport)
+
+    const wrapper = await mountSettings()
+    const input = wrapper.findAll('input[type="text"]')[0]
+    await input.setValue('http://10.0.0.9:8080/v1')
+
+    const button = wrapper.findAll('button').find((b) => b.text().includes('测试'))!
+    await button.trigger('click')
+    await flushPromises()
+
+    // The edited value is what got tested, and a blank secret is omitted so the
+    // server falls back to the stored key.
+    const patch = mocks.testLiveEndpoint.mock.calls[0][0]
+    expect(patch.live_base_url).toBe('http://10.0.0.9:8080/v1')
+    expect(patch.live_api_key).toBe('')
+
+    expect(wrapper.text()).toContain('可用')
+    expect(wrapper.text()).toContain('420')
+  })
+
+  it('names the failing check and shows the reason the server gave', async () => {
+    mocks.testLiveEndpoint.mockResolvedValue({
+      configured: true,
+      ok: false,
+      latencyMs: 310,
+      checks: [
+        { name: 'reachable', ok: true },
+        { name: 'tool_calls', ok: false, reason: '这个模型没有发出工具调用，只回了文字。' },
+      ],
+    } satisfies LiveProbeReport)
+
+    const wrapper = await mountSettings()
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('测试'))!
+      .trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('不可用')
+    expect(wrapper.text()).toContain('工具调用')
+    expect(wrapper.text()).toContain('没有发出工具调用')
+  })
+
+  // A pass that outlives the values it was measured against reads as a pass for
+  // whatever is on screen now, which is worse than showing nothing.
+  it('drops a stale result when the endpoint is edited again', async () => {
+    mocks.testLiveEndpoint.mockResolvedValue({
+      configured: true,
+      ok: true,
+      latencyMs: 100,
+      checks: [{ name: 'reachable', ok: true }],
+    } satisfies LiveProbeReport)
+
+    const wrapper = await mountSettings()
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('测试'))!
+      .trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).toContain('可用')
+
+    await wrapper.findAll('input[type="text"]')[0].setValue('http://changed/v1')
+    await flushPromises()
+    expect(wrapper.text()).not.toContain('往返')
+  })
+})
+
+describe('conversation model runtime status', () => {
+  // This is the question the test button cannot answer, and the one that went
+  // unanswered while every message quietly went to a sandbox instead.
+  it('warns when a working configuration has never actually been called', async () => {
+    mocks.liveStatus.mockResolvedValue(liveStatusFixture({ calls: 0 }))
+    const wrapper = await mountSettings()
+    expect(wrapper.text()).toContain('一次都没被调用过')
+  })
+
+  it('reports call counts and the most recent failure once there is traffic', async () => {
+    mocks.liveStatus.mockResolvedValue(
+      liveStatusFixture({
+        calls: 42,
+        failed: 3,
+        avgLatencyMs: 380,
+        lastFailure: '端点拒绝了密钥（HTTP 401）。',
+      }),
+    )
+    const wrapper = await mountSettings()
+    const text = wrapper.text()
+    expect(text).not.toContain('一次都没被调用过')
+    expect(text).toContain('42')
+    expect(text).toContain('380')
+    expect(text).toContain('HTTP 401')
+  })
+
+  it('stays silent rather than erroring when status is unavailable', async () => {
+    mocks.liveStatus.mockRejectedValue(new Error('boom'))
+    const wrapper = await mountSettings()
+    expect(wrapper.text()).not.toContain('boom')
+    expect(wrapper.text()).toContain('运行状况')
+  })
+})

--- a/web/src/views/SettingsView.vue
+++ b/web/src/views/SettingsView.vue
@@ -1,8 +1,15 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
-import { api, type DashboardStats, type SandboxView, type SettingItem } from '@/lib/api'
+import {
+  api,
+  type DashboardStats,
+  type LiveProbeReport,
+  type LiveStatus,
+  type SandboxView,
+  type SettingItem,
+} from '@/lib/api'
 import { useAuth } from '@/lib/useAuth'
 import AppButton from '@/components/ui/AppButton.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
@@ -105,6 +112,59 @@ const liveConfigured = computed(() =>
   }),
 )
 
+const probe = ref<LiveProbeReport | null>(null)
+const probing = ref(false)
+const probeError = ref('')
+const liveStatus = ref<LiveStatus | null>(null)
+
+function probeCheckLabel(name: string): string {
+  const known: Record<string, string> = {
+    reachable: 'pages.settings.liveTest.checks.reachable',
+    tool_calls: 'pages.settings.liveTest.checks.toolCalls',
+  }
+  return known[name] ? t(known[name]) : name
+}
+
+// The probe is sent the same patch save() would send, so what is tested is what
+// is on screen. Editing the form clears a stale result rather than leaving a
+// pass sitting next to a changed address.
+function livePatch(): Record<string, number | string> {
+  const patch: Record<string, number | string> = {}
+  for (const key of ['live_base_url', 'live_model', 'live_api_key', 'live_timeout_seconds']) {
+    const it = itemOf(key)
+    if (!it || it.locked) continue
+    if (it.kind === 'int') {
+      patch[key] = Number(form[key])
+      continue
+    }
+    patch[key] = String(form[key] ?? '').trim()
+  }
+  return patch
+}
+
+async function runLiveTest() {
+  probing.value = true
+  probeError.value = ''
+  probe.value = null
+  try {
+    probe.value = await api.testLiveEndpoint(livePatch())
+  } catch (e: any) {
+    probeError.value = e?.message || t('pages.settings.liveTest.failed')
+  } finally {
+    probing.value = false
+    loadLiveStatus()
+  }
+}
+
+async function loadLiveStatus() {
+  try {
+    liveStatus.value = await api.liveStatus()
+  } catch {
+    // Runtime stats are supplementary; a failure here must not disturb the page.
+    liveStatus.value = null
+  }
+}
+
 function secretPlaceholder(key: string): string {
   const it = itemOf(key)
   const stored = !!it && String(it.value ?? '').trim() !== ''
@@ -196,6 +256,7 @@ async function save() {
     const res = await api.updateSettings(patch)
     hydrate(res.items)
     savedAt.value = Date.now()
+    loadLiveStatus()
   } catch (e: any) {
     error.value = e?.message || t('pages.settings.saveFailed')
   } finally {
@@ -214,8 +275,19 @@ const dirty = () =>
     return v !== String(it.value ?? '')
   })
 
+// A result that outlives the values it was measured against is worse than no
+// result: it reads as a pass for whatever is on screen now.
+watch(
+  () => ['live_base_url', 'live_model', 'live_api_key', 'live_timeout_seconds'].map((k) => form[k]).join('\u0000'),
+  () => {
+    probe.value = null
+    probeError.value = ''
+  },
+)
+
 onMounted(() => {
   loadSettings()
+  loadLiveStatus()
   pollSandboxes()
   poll = window.setInterval(pollSandboxes, 5000)
 })
@@ -411,11 +483,96 @@ onBeforeUnmount(() => {
           </template>
         </div>
 
-        <div v-if="group.id === 'live' && !liveConfigured" class="px-4 py-3">
-          <p class="border border-warn/30 bg-warn/10 px-3 py-2 text-xs leading-relaxed text-warn">
-            {{ t('pages.settings.liveUnconfigured') }}
-          </p>
-        </div>
+        <template v-if="group.id === 'live'">
+          <div v-if="!liveConfigured" class="px-4 py-3">
+            <p class="border border-warn/30 bg-warn/10 px-3 py-2 text-xs leading-relaxed text-warn">
+              {{ t('pages.settings.liveUnconfigured') }}
+            </p>
+          </div>
+
+          <div class="border-t border-line px-4 py-3.5">
+            <div class="flex flex-wrap items-center justify-between gap-2">
+              <div class="min-w-0">
+                <span class="text-sm font-medium text-txt">{{ t('pages.settings.liveTest.title') }}</span>
+                <p class="mt-1 text-xs leading-relaxed text-txt3">{{ t('pages.settings.liveTest.desc') }}</p>
+              </div>
+              <AppButton
+                variant="ghost"
+                size="sm"
+                icon="flask"
+                :disabled="probing || saving || !liveConfigured"
+                @click="runLiveTest"
+              >
+                {{ probing ? t('pages.settings.liveTest.running') : t('pages.settings.liveTest.action') }}
+              </AppButton>
+            </div>
+
+            <p v-if="probeError" class="mt-2.5 text-[11px] text-err">{{ probeError }}</p>
+
+            <div v-if="probe" class="mt-2.5 border border-line bg-elevated px-3 py-2.5">
+              <div class="flex flex-wrap items-center gap-2 text-xs">
+                <span
+                  class="inline-flex items-center gap-1 font-medium"
+                  :class="probe.ok ? 'text-ok' : 'text-err'"
+                >
+                  <Icon :name="probe.ok ? 'check' : 'close'" :size="12" />
+                  {{ probe.ok ? t('pages.settings.liveTest.pass') : t('pages.settings.liveTest.fail') }}
+                </span>
+                <span v-if="probe.latencyMs > 0" class="text-txt3 tabular-nums">
+                  {{ t('pages.settings.liveTest.latency', { ms: probe.latencyMs }) }}
+                </span>
+              </div>
+
+              <ul class="mt-2 space-y-1.5">
+                <li v-for="check in probe.checks" :key="check.name" class="flex items-start gap-1.5 text-[11px]">
+                  <Icon
+                    :name="check.ok ? 'check' : 'close'"
+                    :size="11"
+                    :class="check.ok ? 'mt-0.5 shrink-0 text-ok' : 'mt-0.5 shrink-0 text-err'"
+                  />
+                  <span class="min-w-0">
+                    <span class="text-txt2">{{ probeCheckLabel(check.name) }}</span>
+                    <span v-if="check.reason" class="text-txt3"> — {{ check.reason }}</span>
+                  </span>
+                </li>
+              </ul>
+
+              <p v-if="probe.sample" class="mt-2 border-t border-line pt-2 text-[11px] text-txt3">
+                {{ t('pages.settings.liveTest.sample') }}
+                <span class="font-mono text-txt2">{{ probe.sample }}</span>
+              </p>
+            </div>
+          </div>
+
+          <div class="border-t border-line px-4 py-3.5">
+            <span class="text-sm font-medium text-txt">{{ t('pages.settings.liveRuntime.title') }}</span>
+            <p class="mt-1 text-xs leading-relaxed text-txt3">{{ t('pages.settings.liveRuntime.desc') }}</p>
+
+            <p
+              v-if="liveStatus && liveStatus.configured && liveStatus.stats.calls === 0"
+              class="mt-2.5 border border-warn/30 bg-warn/10 px-3 py-2 text-[11px] leading-relaxed text-warn"
+            >
+              {{ t('pages.settings.liveRuntime.neverCalled') }}
+            </p>
+
+            <div v-if="liveStatus && liveStatus.stats.calls > 0" class="mt-2.5 space-y-1.5 text-[11px]">
+              <div class="text-txt2 tabular-nums">
+                {{
+                  t('pages.settings.liveRuntime.counts', {
+                    calls: liveStatus.stats.calls,
+                    failed: liveStatus.stats.failed,
+                  })
+                }}
+              </div>
+              <div v-if="liveStatus.stats.avgLatencyMs > 0" class="text-txt3 tabular-nums">
+                {{ t('pages.settings.liveRuntime.avgLatency', { ms: liveStatus.stats.avgLatencyMs }) }}
+              </div>
+              <div v-if="liveStatus.stats.lastFailure" class="text-err">
+                {{ t('pages.settings.liveRuntime.lastFailure') }} {{ liveStatus.stats.lastFailure }}
+              </div>
+            </div>
+          </div>
+        </template>
       </div>
     </template>
 


### PR DESCRIPTION
## 为什么

配置填好了也没法知道它到底能不能用。调用失败时这一层只留一条 Warn 日志，然后把消息交给沙箱——用户照样收到回答，只是慢。**从外面看，坏的端点和好的端点长得一模一样。** 结果是线上跑了一整天全走沙箱，没人发现。

`Configured()` 只要求地址和模型名非空，所以「填了」和「能用」完全是两件事。

## 做了什么

两个问题，两块东西。

### 在线测试：这份配置能用吗

测的是**表单里的当前值，不用先保存**，所以改完地址可以直接验。两条规则保证这样做是安全的：密钥留空回退到已存的（表单里从来没有真密钥），env 锁定的字段忽略表单（环境变量才是权威，测一个不会生效的值等于骗人）。

查两项，不是一项：

- **连通** — 一次真实的 completion 往返，附带实测延迟。这个数字和通不通一样重要：这一层的价值就在于快，超时该设多少全靠它。
- **工具调用** — 转交项目靠的就是发工具调用。不支持 function calling 的模型会把所有消息都自己答掉，**永远不转交**，而这看起来跟正常运转毫无区别。

失败信息指向该改的那个字段（401→密钥，404→地址少了 /v1，400→模型名，连接被拒→地址端口），**不透传响应体**——它可能把对话内容回显出来。

### 运行状况：它到底有没有在用

测试按钮证明不了这个。**配置可用但调用次数为 0**，就说明消息根本没走到这一层，而这正是之前完全看不见的状态。探针跑在一次性客户端上，所以手动测试不会被算成流量；真实失败记录的是和按钮一样的那句解释，线上失败和手里复现读起来一致。

## 变更

| 位置 | 内容 |
|---|---|
| `liveagent/probe.go` | `Probe()` + 错误分类 |
| `liveagent/stats.go` | 每次调用的成败/延迟/最后失败原因 |
| `liveagent/client.go` | `StatusError` / `ErrEmptyResponse` / `ErrBadResponse` 三个可分类的错误；`Complete` 记录统计 |
| `services/settings.go` | `LiveEndpointFor(patch)` — 掩码回退与 env 锁定 |
| `POST /api/settings/live/test`<br>`GET /api/settings/live/status` | 端点不可用是 `ok:false` 的成功响应，不是 HTTP 错误 |
| `SettingsView.vue` | 测试按钮、分项结果、运行状况；改动表单会清掉过期结果 |

## 门禁

- `ci-server`：golangci-lint 0 issues、vet、gen-configdoc、`go test ./...`、**覆盖率 90.1%**（阈值 90）
- `ci-web`：eslint、vue-tsc、build 全绿；新增 6 个挂载测试通过

`go test ./...` 有 8 个 `TestPmFS*` / `TestWorkspaceFS*` 失败，`npm test` 有 18 个文件报 `localStorage.clear is not a function`。两者都在干净 main 上同样失败，是本机环境问题（macOS `/tmp` symlink；本机 Node 25 vs CI Node 24），与本次改动无关。

## 怎么验

设置页 → 对话模型 → 点「测试」。`liveagent/live_endpoint_test.go` 里还有一组 env 门控的真机测试，可以直接打你那台：

```bash
cd server
LIVE_TEST_BASE_URL=http://192.168.2.20:8080/v1 LIVE_TEST_MODEL=holo-3.1-35b-a3b \
  go test ./internal/liveagent/ -run TestAgainstARealEndpoint -v
```

> 顺带一提：当前超时设的是 30 秒，代码默认 8 秒。这个值是**每条消息在转给沙箱之前的最长阻塞时间**——端点卡住时每句话都要先等 30 秒。测试按钮报出的实测延迟可以用来把它调到合理值。

基于 #165（已合并）。

Made with [Cursor](https://cursor.com)
