### PR TITLE
feat(channels): Live 总监层作为唯一 IM 出口

### DIFF
--- a/server/cmd/server/live_synthesizer.go
+++ b/server/cmd/server/live_synthesizer.go
@@ -7,49 +7,68 @@ import (
 	"time"
 
 	"github.com/cocofhu/approving/internal/channels"
-	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/liveagent"
 )
 
-// synthesisTimeout bounds a reflow synthesis turn. Nobody is waiting on a live
-// conversation for this, but a background event that has been pending for a
-// minute is stale, and the structured fallback is already good enough to send.
-const synthesisTimeout = 20 * time.Second
+// synthesisTimeout bounds one phrasing call. Nobody is waiting on a live
+// conversation for this, but a background event that has been pending for
+// twenty seconds is stale, and the structured fallback is already good enough
+// to send.
+const synthesisTimeout = 12 * time.Second
 
-// newLiveSynthesizer phrases a background event through the conversation's own
-// PM agent, so the result lands as part of that conversation rather than as a
-// notification about it. The agent already knows what was asked and what has
-// been said since; a template does not.
+// synthesisMaxTokens sizes a one-or-two-sentence report plus whatever the model
+// thinks first.
+const synthesisMaxTokens = 512
+
+// synthesisSystemPrompt is the reporting voice. It is the same person the user
+// has been talking to all along, which is the whole point of phrasing an
+// outcome instead of pushing a template.
+const synthesisSystemPrompt = `你是这个项目的负责人本人，正在 IM 上和同事聊天。你的回复会原样发给对方。
+
+下面会给你一件事的结果。用一到两句话把它讲给对方听，就像同事之间当面说一样。
+
+规矩：
+- 只讲给出的事实，不要补充、不要推测、不要展开成报告。
+- 不要出现任务编号、工作流名、执行环境、工具名这些内部说法。
+- 不要说「请前往 Approving 查看」之类把人打发走的话。
+- 结论要能独立看懂，不要只说「已完成」。
+- 只输出要发出去的那句话，不要加前缀、标题或解释。`
+
+// newLiveSynthesizer phrases a background event through the conversation model,
+// so a result lands as part of the conversation rather than as a notification
+// about it.
+//
+// It used to open a sandbox turn for this. That worked, but it spent a
+// container and tens of seconds to reword two sentences the platform already
+// had, and it borrowed the agent that might be busy doing real work. The
+// conversation model is the layer that talks to users; phrasing is exactly its
+// job.
 //
 // Anything that goes wrong here degrades to the caller's structured fallback,
 // which is a complete message in its own right — synthesis improves how an
 // outcome reads, it is not what makes it deliverable.
-func newLiveSynthesizer(bridge *channels.ChannelBridge) channels.SynthesisFunc {
-	if bridge == nil {
+func newLiveSynthesizer(live *liveagent.Client) channels.SynthesisFunc {
+	if live == nil {
 		return nil
 	}
 	return func(ctx context.Context, req channels.SynthesisRequest) (string, error) {
 		if strings.TrimSpace(req.Brief) == "" {
 			return "", errors.New("synthesis brief is empty")
 		}
-		turnCtx, cancel := context.WithTimeout(ctx, synthesisTimeout)
+		if !live.Configured() {
+			return "", liveagent.ErrNotConfigured
+		}
+		callCtx, cancel := context.WithTimeout(ctx, synthesisTimeout)
 		defer cancel()
 
-		// A synthetic inbound: same conversation, same thread, same agent, so
-		// the turn sees the history it needs. Progress is not forwarded —
-		// intermediate narration from a synthesis turn is not something the
-		// user asked to see. The agent's own pm_reply is captured by the
-		// Manager for the duration of this turn, so returning empty here is
-		// normal and does not mean synthesis failed.
-		reply, err := bridge.Handle(turnCtx, channels.ResolvedChannel{
-			Type: models.ChannelTypeQQ, ProjectID: req.ProjectID,
-			TurnTimeout: synthesisTimeout,
-		}, channels.InboundMessage{
-			Scene: req.Scene, ConversationID: req.ConversationID,
-			UserID: req.ExternalUserID, Text: req.Brief, Timestamp: time.Now(),
-		}, nil)
+		res, err := live.Complete(callCtx, liveagent.Request{
+			System:    synthesisSystemPrompt,
+			Messages:  []liveagent.Message{{Role: "user", Content: req.Brief}},
+			MaxTokens: synthesisMaxTokens,
+		})
 		if err != nil {
 			return "", err
 		}
-		return strings.TrimSpace(reply.FinalSummary), nil
+		return strings.TrimSpace(res.Text), nil
 	}
 }

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -383,6 +383,10 @@ func main() {
 	}
 	taskContextSvc := services.NewTaskContextService(db)
 	channelMgr.SetTaskContextService(taskContextSvc)
+	// Every routing decision is recorded. Earlier rounds of this layer were
+	// tuned by adding banned phrases because nothing captured what the model
+	// was shown and what it chose; with samples, a change can be measured.
+	channelMgr.SetLiveSampleService(services.NewLiveSampleService(db))
 	riskSvc := services.NewRiskConfirmationService(db)
 	channelMgr.SetRiskConfirmationService(riskSvc)
 	channelMgr.SetRiskActionExecutor(func(projectID, runID, action string, meta map[string]string) error {
@@ -406,7 +410,7 @@ func main() {
 	pmMCP.SetTaskSafety(riskSvc, taskContextSvc, channelIMNotifier{mgr: channelMgr})
 	// A finished task reports back to the conversation that asked for it, in
 	// that conversation's own words.
-	channelMgr.SetSynthesizer(newLiveSynthesizer(channelBridge))
+	channelMgr.SetSynthesizer(newLiveSynthesizer(liveClient))
 	eng.SetRunTerminalObserver(runTerminalAdapter{mgr: channelMgr})
 	channelMgr.SetLoader(channelSvc.ListRaw)
 	channelSvc.SetOnChange(channelMgr.Reload)

--- a/server/internal/channels/bridge.go
+++ b/server/internal/channels/bridge.go
@@ -170,21 +170,20 @@ func (b *ChannelBridge) Handle(ctx context.Context, rc ResolvedChannel, in Inbou
 		return Reply{}, err
 	}
 	userText := userMsg.Content
+	// Only what the user just sent travels with the turn. Everything earlier is
+	// reachable through context-store, which is what keeps a prompt the same
+	// size on the hundredth message as on the first.
 	images := userMsg.Images
 
-	// What this sandbox has not seen. A warm container already lived through
-	// everything up to its cursor; a fresh one lived through nothing, so it gets
-	// the bounded baseline instead of an empty delta it would silently accept.
-	handoff := b.buildHandoff(thread, userMsg, in, reused)
-	images = append(images, handoff.images...)
+	brief := b.buildWorkBrief(thread, userMsg, in)
 
 	prompt := userText
 	if !reused {
 		// First turn of this conversation's sandbox: orient the agent.
 		prompt = ChannelPreamble(rc.Type) + "\n\n用户消息：" + userText
 	}
-	if handoff.text != "" {
-		prompt = handoff.text + "\n\n" + prompt
+	if brief != "" {
+		prompt = brief + "\n\n" + prompt
 	}
 	if len(images) > 0 {
 		prompt += fmt.Sprintf("\n（随本次请求附带 %d 个附件，已写入沙箱本地文件，用绝对路径读取）", len(images))
@@ -205,14 +204,6 @@ func (b *ChannelBridge) Handle(ctx context.Context, rc ResolvedChannel, in Inbou
 		return Reply{}, err
 	}
 	progCancel()
-
-	// The agent has now seen everything up to this message, so the next turn
-	// only has to carry what comes after it. Recorded before the reply is read:
-	// the sandbox consumed the context whether or not it produced an answer, and
-	// replaying it would show the agent its own conversation twice.
-	if err := b.pm.SetHandoffCursor(thread.ID, userMsg.ID); err != nil {
-		log.Warn().Err(err).Str("thread", thread.ID).Msg("channel handoff cursor not advanced")
-	}
 
 	text := b.readReply(thread.ID, userMsg.CreatedAt)
 	if strings.TrimSpace(text) == "" {
@@ -309,93 +300,201 @@ func (b *ChannelBridge) currentMessage(threadID string, in InboundMessage) (mode
 		models.MessageSourceChannel, nil, nil, images, nil, nil)
 }
 
-// handoffPayload is the conversation the sandbox has not seen, ready to prepend
-// to the turn's prompt.
-type handoffPayload struct {
-	text   string
-	images []models.PromptImage
+// attachmentManifestLimit caps how many earlier files are named in one brief.
+// The list is a set of pointers, not the files themselves, but a conversation
+// that has traded fifty screenshots should still not spend its prompt listing
+// them: the newest ones are the ones a request refers to.
+const attachmentManifestLimit = 12
+
+// buildWorkBrief states what the agent is being asked to do and where the rest
+// of the context lives. It is deliberately not the conversation.
+//
+// Replaying recent turns into every prompt was the previous answer to "the
+// sandbox has not seen what the conversation layer said". It made each turn
+// carry the whole exchange plus its attachments as base64, which grew without
+// bound, crowded out the actual question, and taught the agent to repeat
+// answers the user had already been given. The agent now reads history through
+// context-store when a request depends on it, and this brief tells it what to
+// look for: the routing reason, the task it belongs to, and the files already
+// in the conversation.
+func (b *ChannelBridge) buildWorkBrief(thread models.ChatThread, current models.ChatMessage,
+	in InboundMessage) string {
+	var lines []string
+	if note := escalationNote(in); note != "" {
+		lines = append(lines, note)
+	}
+	if d := in.Dispatch; d != nil {
+		if brief := strings.TrimSpace(d.Brief); brief != "" && brief != strings.TrimSpace(in.EscalationReason) {
+			lines = append(lines, "会话层转交的要求："+brief)
+		}
+		if title := strings.TrimSpace(d.ShortTitle); title != "" {
+			task := "任务：" + title
+			if id := strings.TrimSpace(d.TaskID); id != "" {
+				task += "（taskId=" + id + "）"
+			}
+			lines = append(lines, task)
+		}
+		if d.Difficulty == DifficultyHeavy {
+			lines = append(lines, "会话层判断这件事要花分钟级以上，用户已经被告知了；请用 pm_start_run 交给后台，不要在这一轮里做完。")
+		}
+	}
+	if id := strings.TrimSpace(current.ID); id != "" {
+		lines = append(lines, "当前这条用户消息的 messageId="+id+"（用 context-store 定位上下文时用得上）。")
+	}
+
+	if refs := b.attachmentPointers(thread.ID, current.ID, in); len(refs) > 0 {
+		lines = append(lines, "这个会话里更早的附件（内容没有随本轮下发，用 context-store 的 get_attachment 按 messageId+index 取回）：")
+		for _, ref := range refs {
+			lines = append(lines, fmt.Sprintf("- %s（%s，%d 字节，messageId=%s，index=%d）",
+				ref.Name, ref.MimeType, ref.Bytes, ref.MessageID, ref.Index))
+		}
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	lines = append(lines, "需要更早说过什么，用 context-store 的 get_messages / search_messages 按需拉取；不要凭印象猜，也不要把已经回过的话再说一遍。")
+	return "<work_brief>\n" + strings.Join(lines, "\n") + "\n</work_brief>"
 }
 
-// handoffAttachmentBudget caps the base64 bytes of replayed history
-// attachments. ACP delivers a turn as one WebSocket JSON frame and base64 adds
-// a third on top of the raw size, so replaying an old 20 MiB upload alongside a
-// new one is how a prompt stops arriving at all. The current message is never
-// charged against this: it is what the user is asking about right now.
-const handoffAttachmentBudget = 8 << 20
-
-// buildHandoff assembles what the sandbox missed: the turns answered without it
-// and, for a container that has just come up, a bounded baseline of the
-// conversation so far.
+// attachmentPointers lists the conversation's earlier files, newest first.
 //
-// It carries the exchange, not the reasoning behind it. An escalation note says
-// why the turn arrived here; it does not hand over the routing model's train of
-// thought, which the agent has no way to verify and every reason to believe.
-func (b *ChannelBridge) buildHandoff(thread models.ChatThread, current models.ChatMessage,
-	in InboundMessage, warm bool) handoffPayload {
-	var entries []models.ChatMessage
-	var err error
-	label := "以下是这个会话最近的往来，用来对齐上下文"
-	if warm {
-		entries, err = b.pm.CanonicalSince(thread.ID, b.pm.HandoffCursor(thread.ID), transcriptWindow)
-		label = "以下是你上次处理之后、你没有看到的往来"
-	} else {
-		entries, err = b.pm.CanonicalWindow(thread.ID, transcriptWindow)
+// The current message's own attachments are excluded: they travel with the turn
+// as real files, and naming them again would send the agent to fetch what it is
+// already holding. Pointers supplied by the director win over what the stored
+// transcript shows, because the director may be pointing at something older
+// than the window.
+func (b *ChannelBridge) attachmentPointers(threadID, currentID string, in InboundMessage) []AttachmentRef {
+	seen := map[string]bool{}
+	var out []AttachmentRef
+	add := func(ref AttachmentRef) {
+		if ref.MessageID == currentID || ref.MessageID == "" {
+			return
+		}
+		key := fmt.Sprintf("%s#%d", ref.MessageID, ref.Index)
+		if seen[key] || len(out) >= attachmentManifestLimit {
+			return
+		}
+		seen[key] = true
+		out = append(out, ref)
 	}
+	if in.Dispatch != nil {
+		for _, ref := range in.Dispatch.Attachments {
+			add(ref)
+		}
+	}
+	for _, ref := range b.recentAttachments(threadID) {
+		add(ref)
+	}
+	return out
+}
+
+// recentAttachments reads the conversation's attachment manifest from storage,
+// newest first. Manifest only — the bytes stay where they are.
+func (b *ChannelBridge) recentAttachments(threadID string) []AttachmentRef {
+	if b.pm == nil {
+		return nil
+	}
+	msgs, err := b.pm.CanonicalWindow(threadID, transcriptWindow)
 	if err != nil {
-		log.Warn().Err(err).Str("thread", thread.ID).Msg("channel handoff history unavailable")
-		return handoffPayload{text: escalationNote(in)}
+		log.Warn().Err(err).Str("thread", threadID).
+			Msg("attachment manifest unavailable; this turn names no earlier files")
+		return nil
 	}
-
-	var lines []string
-	var images []models.PromptImage
-	var deferred []string
-	budget := handoffAttachmentBudget
-	for _, msg := range entries {
-		if msg.ID == current.ID {
-			continue // the request itself, carried by the prompt
-		}
-		speaker := "用户"
-		if msg.Role == "assistant" {
-			speaker = "你（已发给用户）"
-		}
-		line := speaker + "：" + strings.TrimSpace(msg.Content)
-		for i, img := range msg.Images {
-			size := len(img.Data)
-			if size <= budget {
-				budget -= size
-				images = append(images, img)
-				continue
+	var out []AttachmentRef
+	for i := len(msgs) - 1; i >= 0; i-- {
+		msg := msgs[i]
+		for idx, img := range msg.Images {
+			out = append(out, AttachmentRef{
+				MessageID: msg.ID, Index: idx, Name: img.Name,
+				MimeType: img.MimeType, Bytes: len(img.Data), Role: msg.Role,
+			})
+			if len(out) >= attachmentManifestLimit {
+				return out
 			}
-			// Too large to replay. Saying so beats dropping it silently: the
-			// listing is everything get_attachment needs to fetch it.
-			deferred = append(deferred, fmt.Sprintf("%s（%s，%d 字节，messageId=%s，index=%d）",
-				img.Name, img.MimeType, size, msg.ID, i))
 		}
-		if len(msg.Images) > 0 {
-			line += fmt.Sprintf("（附 %d 个附件）", len(msg.Images))
-		}
-		lines = append(lines, line)
 	}
+	return out
+}
 
-	var b2 strings.Builder
-	if len(lines) > 0 {
-		b2.WriteString("<conversation_handoff>\n")
-		b2.WriteString(label)
-		b2.WriteString("：\n")
-		b2.WriteString(strings.Join(lines, "\n"))
-		if len(deferred) > 0 {
-			b2.WriteString("\n未随本次请求携带的历史附件（用 context-store 的 get_attachment 按消息 id 取回）：\n")
-			b2.WriteString(strings.Join(deferred, "\n"))
-		}
-		b2.WriteString("\n</conversation_handoff>")
+// RecentAttachments exposes the conversation's attachment manifest to the
+// conversation layer, which cannot see the files but must be able to tell the
+// agent that they exist.
+func (b *ChannelBridge) RecentAttachments(ref ConversationRef) []AttachmentRef {
+	thread, err := b.threadFor(ref, InboundMessage{Scene: ref.Scene, ConversationID: ref.ConversationID})
+	if err != nil {
+		return nil
 	}
-	if note := escalationNote(in); note != "" {
-		if b2.Len() > 0 {
-			b2.WriteString("\n")
-		}
-		b2.WriteString(note)
+	return b.recentAttachments(thread.ID)
+}
+
+// Warm gets a conversation's sandbox and its MCP servers up before anything is
+// asked of them.
+//
+// Cold start is the cost that used to be hidden by handing the agent the whole
+// conversation: a prompt big enough to answer from was also a prompt that took
+// a container to read. Now that the agent pulls what it needs, its first pull
+// happens while the user is still typing rather than while they are waiting.
+// Failure is not reported: this is an optimisation, and the turn that follows
+// opens the sandbox itself if this did not.
+func (b *ChannelBridge) Warm(ctx context.Context, projectID string, ref ConversationRef, caps SessionCaps) {
+	if b == nil || b.pm == nil || b.sbx == nil {
+		return
 	}
-	return handoffPayload{text: b2.String(), images: images}
+	proj, err := b.pm.RequireEnabled(projectID)
+	if err != nil {
+		return
+	}
+	agent := proj.PmLeaderAgent
+	userID := SyntheticUserID(ref.ChannelType, ref.Scene, ref.ConversationID)
+	thread, err := b.ensureThread(projectID, userID, agent,
+		InboundMessage{Scene: ref.Scene, ConversationID: ref.ConversationID})
+	if err != nil {
+		return
+	}
+	binding, _ := b.pm.GetBinding(projectID)
+	channelCtx := ChannelSessionContext{
+		ChannelType: ref.ChannelType, Scene: ref.Scene, ConversationID: ref.ConversationID,
+	}
+	token, specs := b.hooks.Register(projectID, thread.ID, userID, agent, channelCtx, binding.EnabledMcps, caps)
+	row, reused, err := b.sbx.OpenAgentSandbox(ctx, services.AgentSandboxOpenOpts{
+		Profile: agent, ProjectID: projectID, ThreadID: thread.ID,
+		SharedToken: token, PlatformSpecs: specs, Reuse: true, RunIDPrefix: "agent",
+	})
+	if err != nil {
+		if b.hooks.Unregister != nil {
+			b.hooks.Unregister(token)
+		}
+		log.Debug().Err(err).Str("project", projectID).Msg("sandbox pre-warm skipped")
+		return
+	}
+	if reused {
+		if b.hooks.Unregister != nil {
+			b.hooks.Unregister(token)
+		}
+		if b.hooks.RestoreOnReuse != nil {
+			b.hooks.RestoreOnReuse(projectID, thread.ID, userID, agent, row.Token,
+				channelCtx, binding.EnabledMcps, caps)
+		}
+		return
+	}
+	if err := b.pm.BindSandbox(thread.ID, row.ID); err != nil {
+		log.Debug().Err(err).Str("thread", thread.ID).Msg("sandbox pre-warm did not bind")
+	}
+}
+
+// CancelConversationTurn stops an in-flight agent turn for one conversation and
+// reports whether there was one to stop. "Stop doing that" must act on the work
+// the user can see, not only on background Runs.
+func (b *ChannelBridge) CancelConversationTurn(ref ConversationRef) bool {
+	if b == nil || b.turns == nil {
+		return false
+	}
+	thread, err := b.threadFor(ref, InboundMessage{Scene: ref.Scene, ConversationID: ref.ConversationID})
+	if err != nil || !b.turns.Active(thread.ID) {
+		return false
+	}
+	b.turns.Cancel(thread.ID)
+	return true
 }
 
 // escalationNote states why a turn reached the agent instead of being answered

--- a/server/internal/channels/channels_test.go
+++ b/server/internal/channels/channels_test.go
@@ -903,12 +903,17 @@ func TestDispatchForwardsOnlyExplicitlySendableProgress(t *testing.T) {
 	if countText(got, "卡住了：CI 红了") != 1 {
 		t.Fatalf("missing structured blocker in %v", got)
 	}
-	// Progress already marked the turn replied; FinalSummary must not double-send.
-	if countText(got, "final-ok") != 0 {
-		t.Fatalf("FinalSummary must be suppressed after progress outbound: %v", got)
+	// Progress is not an answer. Suppressing the conclusion because an update
+	// went out first is how "还在跑" became the last thing a user heard about a
+	// task that had already finished.
+	if countText(got, "final-ok") != 1 {
+		t.Fatalf("the conclusion was swallowed by earlier progress: %v", got)
 	}
-	if len(got) != 2 {
-		t.Fatalf("sends = %v want milestone + blocker only", got)
+	if len(got) != 3 {
+		t.Fatalf("sends = %v want milestone + blocker + conclusion", got)
+	}
+	if got[len(got)-1] != "final-ok" {
+		t.Fatalf("the conclusion did not come last: %v", got)
 	}
 }
 

--- a/server/internal/channels/delivery.go
+++ b/server/internal/channels/delivery.go
@@ -230,6 +230,18 @@ func (m *Manager) SendRunAcceptanceAck(ctx context.Context, ack RunAcceptanceAck
 	if runID == "" {
 		return DeliveryResult{}, errors.New("run acceptance ack requires a real run id")
 	}
+	scene := ack.Scene
+	if scene == "" {
+		scene = SceneC2C
+	}
+	// The conversation layer may already have told the user this is being
+	// picked up — that is what a heavy dispatch's acknowledgement is. Adding
+	// the platform's own acceptance notice on top is the "我去看看" + "好的我去看看"
+	// double-send that made delegation feel like the system talking to itself.
+	turn := conversationTurnScope(ack.ProjectID, scene, ack.ConversationID)
+	if m.hasAcknowledged(turn) {
+		return DeliveryResult{Decision: sendable.Decision{Reason: "already_acknowledged"}}, nil
+	}
 	language := services.DetectLanguage("", ack.Language)
 	result, err := m.DeliverSendable(ctx, SendableRequest{
 		ProjectID: ack.ProjectID, Scene: ack.Scene, ConversationID: ack.ConversationID,
@@ -239,15 +251,16 @@ func (m *Manager) SendRunAcceptanceAck(ctx context.Context, ack RunAcceptanceAck
 		DedupeKey: runAcceptanceDedupeKey(runID, ack.ConversationID, ack.UserID),
 		Text:      runAcceptanceText(ack.ShortTitle, language),
 	})
-	// Handing work to the background is this turn's answer. Marking the turn
-	// replied is what lets the conversation move on immediately instead of
-	// waiting for the Run and then appending a second message about it.
+	// Handing work to the background is this turn's answer: the user asked for
+	// something and has been told it is being done. Marking the turn answered
+	// is what lets the conversation move on immediately instead of waiting for
+	// the Run and then appending a second message about it.
+	// The marker deliberately says "answered", not "acknowledged": a repeat of
+	// this notice is caught by its own per-run dedupe, which reports why more
+	// precisely than a turn-level marker could.
 	if result.Sent {
-		scene := ack.Scene
-		if scene == "" {
-			scene = SceneC2C
-		}
 		m.MarkConversationReplied(ack.ProjectID, scene, ack.ConversationID)
+		m.markAnswered(turn)
 	}
 	return result, err
 }

--- a/server/internal/channels/director.go
+++ b/server/internal/channels/director.go
@@ -1,0 +1,461 @@
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cocofhu/approving/internal/services"
+
+	"github.com/rs/zerolog/log"
+)
+
+// The conversation layer is a person reporting to the user, not a switchboard.
+//
+// That distinction decides what it is allowed to know. A reporter who invents a
+// status is worse than one who has none, so everything it says about work in
+// flight comes from here: the task ledger, the progress notes recorded as they
+// arrive, and the tools that read them. The model supplies the wording; this
+// file supplies the facts.
+
+// ledgerLimit bounds how many live tasks the director is shown at once. A
+// conversation with more than a handful in flight has a different problem, and
+// listing them all would push the actual question out of the prompt.
+const ledgerLimit = 5
+
+// maxConcurrentWork caps the tasks one conversation may have running. The limit
+// is the director's to explain, not a silent rejection: past this point it says
+// so and offers to cancel something.
+const maxConcurrentWork = 3
+
+// workNote is the most recent thing the platform actually observed about a
+// task. It is written when progress arrives and read when the user asks, which
+// is what makes "还在跑，现在在查代码" a fact rather than a guess.
+type workNote struct {
+	Stage   string
+	Blocked bool
+	At      time.Time
+}
+
+// ledgerEntry is one task as the director is allowed to describe it.
+type ledgerEntry struct {
+	TaskID       string `json:"task_id"`
+	RunID        string `json:"run_id,omitempty"`
+	ShortTitle   string `json:"short_title"`
+	Status       string `json:"status"`
+	Stage        string `json:"stage,omitempty"`
+	Blocked      bool   `json:"blocked,omitempty"`
+	LastProgress string `json:"last_progress,omitempty"`
+	UpdatedAgo   string `json:"updated_ago,omitempty"`
+}
+
+// directorContext is what the conversation layer knows before it speaks.
+//
+// It is a briefing, not an authority: the model may read it to decide what to
+// do, but a status it reports to the user must come back from get_status. The
+// two are usually the same, and when they are not it is because something
+// finished while the model was thinking — exactly the case where guessing from
+// a snapshot is wrong.
+type directorContext struct {
+	ConversationBusy  bool            `json:"conversation_busy"`
+	FocusTaskID       string          `json:"focus_task_id,omitempty"`
+	Tasks             []ledgerEntry   `json:"tasks,omitempty"`
+	RecentAttachments []AttachmentRef `json:"recent_attachments,omitempty"`
+	LastOutbound      string          `json:"last_outbound,omitempty"`
+	UserMessageID     string          `json:"user_message_id,omitempty"`
+}
+
+// render turns the briefing into the lines the model reads.
+//
+// An empty ledger is stated outright while every other empty section is simply
+// left out. The asymmetry is deliberate: "nothing is running" is the fact that
+// stops the model from reporting progress on work that does not exist, whereas
+// "there are no attachments" is a sentence that only invites it to say so.
+func (dc directorContext) render() string {
+	var b strings.Builder
+	b.WriteString("【当前情况】\n")
+	if len(dc.Tasks) == 0 {
+		b.WriteString("现在没有在跑的任务。\n")
+	} else {
+		b.WriteString("在跑的任务：\n")
+		for _, t := range dc.Tasks {
+			line := fmt.Sprintf("- %s（taskId=%s，状态=%s", t.ShortTitle, t.TaskID, t.Status)
+			if t.Stage != "" {
+				line += "，阶段=" + t.Stage
+			}
+			if t.Blocked {
+				line += "，被阻塞"
+			}
+			if t.UpdatedAgo != "" {
+				line += "，" + t.UpdatedAgo + "有更新"
+			}
+			line += "）"
+			if t.LastProgress != "" {
+				line += "\n  最近进展：" + t.LastProgress
+			}
+			b.WriteString(line + "\n")
+		}
+		if dc.FocusTaskID != "" {
+			b.WriteString("你们刚才在聊的是 taskId=" + dc.FocusTaskID + "。\n")
+		}
+	}
+	if dc.ConversationBusy {
+		b.WriteString("现在有一件事正在前台执行。\n")
+	}
+	if len(dc.RecentAttachments) > 0 {
+		b.WriteString("这个会话里已有的附件（你看不到内容，但可以在 dispatch_pm 时把它们指给干活的人）：\n")
+		for _, ref := range dc.RecentAttachments {
+			b.WriteString(fmt.Sprintf("- %s（%s，messageId=%s，index=%d）\n",
+				ref.Name, ref.MimeType, ref.MessageID, ref.Index))
+		}
+	}
+	if dc.LastOutbound != "" {
+		b.WriteString("你上一条对他说的是：" + dc.LastOutbound + "\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// buildDirectorContext assembles the briefing for one inbound message.
+func (m *Manager) buildDirectorContext(rc *runningChannel, in InboundMessage) directorContext {
+	dc := directorContext{
+		ConversationBusy: m.IsConversationBusy(rc.cfg.ProjectID, in.Scene, in.ConversationID),
+		UserMessageID:    strings.TrimSpace(in.RecordedMessageID),
+		Tasks:            m.taskLedger(rc, in),
+	}
+	if focus := m.focusTaskID(rc, in); focus != "" {
+		dc.FocusTaskID = focus
+	}
+	if b, ok := m.transcript.(*ChannelBridge); ok && b != nil {
+		dc.RecentAttachments = b.RecentAttachments(conversationRefFor(rc, in))
+	}
+	dc.LastOutbound = m.lastOutboundText(rc, in)
+	return dc
+}
+
+// taskLedger lists this conversation's live tasks with whatever the platform
+// has actually observed about them.
+func (m *Manager) taskLedger(rc *runningChannel, in InboundMessage) []ledgerEntry {
+	if m.taskContext == nil {
+		return nil
+	}
+	tasks, err := m.taskContext.ActiveTasksForConversation(m.taskScopeFor(rc, in), ledgerLimit)
+	if err != nil {
+		log.Warn().Err(err).Str("project", rc.cfg.ProjectID).
+			Msg("task ledger unavailable; the conversation layer speaks without it")
+		return nil
+	}
+	out := make([]ledgerEntry, 0, len(tasks))
+	for _, t := range tasks {
+		entry := ledgerEntry{
+			TaskID: t.ID, RunID: t.RunID,
+			ShortTitle: services.SanitizeShortTitle(t.ShortTitle),
+			Status:     t.Status,
+			UpdatedAgo: humanizeAge(time.Since(t.UpdatedAt)),
+		}
+		if note, ok := m.workNoteFor(rc.cfg.ProjectID, t.RunID); ok {
+			entry.Stage, entry.Blocked = note.Stage, note.Blocked
+			entry.LastProgress = note.Stage
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func (m *Manager) focusTaskID(rc *runningChannel, in InboundMessage) string {
+	if m.taskContext == nil {
+		return ""
+	}
+	focus, err := m.taskContext.GetFocus(m.taskScopeFor(rc, in), false)
+	if err != nil || focus == nil {
+		return ""
+	}
+	return focus.TaskIdentityID
+}
+
+func (m *Manager) taskScopeFor(rc *runningChannel, in InboundMessage) services.TaskScope {
+	return services.TaskScope{
+		ProjectID: rc.cfg.ProjectID, UserID: services.SyntheticQQUserID(in.UserID),
+		Channel: rc.cfg.Type, ConversationID: in.ConversationID,
+	}
+}
+
+// lastOutboundText is the most recent thing this conversation was told, so the
+// director does not greet someone it just greeted.
+func (m *Manager) lastOutboundText(rc *runningChannel, in InboundMessage) string {
+	if m.transcript == nil {
+		return ""
+	}
+	entries, err := m.transcript.Window(conversationRefFor(rc, in), 6)
+	if err != nil {
+		return ""
+	}
+	for i := len(entries) - 1; i >= 0; i-- {
+		if entries[i].Role == "assistant" {
+			return truncateRunes(strings.TrimSpace(entries[i].Text), 120)
+		}
+	}
+	return ""
+}
+
+// noteWorkProgress records what was just observed about a task so a later
+// "how's it going" can be answered from fact.
+func (m *Manager) noteWorkProgress(projectID, runID, stage string, blocked bool) {
+	runID = strings.TrimSpace(runID)
+	stage = strings.TrimSpace(ScrubInternalTerms(stage))
+	if runID == "" || stage == "" {
+		return
+	}
+	m.noteMu.Lock()
+	defer m.noteMu.Unlock()
+	if m.workNotes == nil {
+		m.workNotes = map[string]workNote{}
+	}
+	m.workNotes[projectID+"|"+runID] = workNote{
+		Stage: truncateRunes(stage, 120), Blocked: blocked, At: time.Now(),
+	}
+}
+
+func (m *Manager) workNoteFor(projectID, runID string) (workNote, bool) {
+	if strings.TrimSpace(runID) == "" {
+		return workNote{}, false
+	}
+	m.noteMu.Lock()
+	defer m.noteMu.Unlock()
+	note, ok := m.workNotes[projectID+"|"+runID]
+	return note, ok
+}
+
+// labelProgress names which task an update is about, but only when the answer
+// is not obvious.
+//
+// With one task in flight the conversation already says what "还在跑" refers to,
+// and a title in front of it reads like a ticket header. With two, an unlabelled
+// update is genuinely ambiguous — the user has to guess which of the things
+// they asked for just moved.
+func (m *Manager) labelProgress(rc *runningChannel, in InboundMessage, ev ProgressEvent, text string) string {
+	tasks := m.taskLedger(rc, in)
+	if len(tasks) < 2 {
+		return text
+	}
+	runID := strings.TrimSpace(ev.RunID)
+	for _, t := range tasks {
+		if t.RunID == runID && t.ShortTitle != "" {
+			return "「" + t.ShortTitle + "」" + text
+		}
+	}
+	return text
+}
+
+// statusResult is what get_status hands back to the model. It is JSON on
+// purpose: a sentence would invite the model to copy it verbatim, and the point
+// of this layer is that the model does the phrasing.
+type statusResult struct {
+	Tasks []ledgerEntry `json:"tasks"`
+	Note  string        `json:"note,omitempty"`
+}
+
+// runGetStatus answers "where is it" from the ledger, never from memory.
+func (m *Manager) runGetStatus(rc *runningChannel, in InboundMessage, taskID string) string {
+	tasks := m.taskLedger(rc, in)
+	taskID = strings.TrimSpace(taskID)
+	if taskID != "" {
+		for _, t := range tasks {
+			if t.TaskID == taskID || t.RunID == taskID {
+				return encodeToolResult(statusResult{Tasks: []ledgerEntry{t}})
+			}
+		}
+		return encodeToolResult(statusResult{Tasks: tasks, Note: "没有这个 taskId 的在跑任务；下面是目前还在跑的。"})
+	}
+	res := statusResult{Tasks: tasks}
+	if len(tasks) == 0 {
+		res.Note = "现在没有在跑的任务。如果用户问的事情还没开始，就用 dispatch_pm 派下去。"
+	}
+	if m.IsConversationBusy(rc.cfg.ProjectID, in.Scene, in.ConversationID) {
+		res.Note = strings.TrimSpace(res.Note + " 现在有一件事正在前台执行。")
+	}
+	return encodeToolResult(res)
+}
+
+// cancelResult reports what actually stopped.
+type cancelResult struct {
+	Cancelled  []string      `json:"cancelled,omitempty"`
+	Ambiguous  []ledgerEntry `json:"ambiguous,omitempty"`
+	NothingRun bool          `json:"nothing_running,omitempty"`
+	Failed     string        `json:"failed,omitempty"`
+}
+
+// runCancelWork stops work the user has asked to stop.
+//
+// It refuses to guess. With two tasks in flight and no pointer to either, the
+// result says so and the director asks which one — cancelling the wrong task is
+// not a wording mistake that can be apologised for afterwards.
+func (m *Manager) runCancelWork(ctx context.Context, rc *runningChannel, in InboundMessage, taskID string) string {
+	tasks := m.taskLedger(rc, in)
+	taskID = strings.TrimSpace(taskID)
+
+	var target *ledgerEntry
+	switch {
+	case taskID != "":
+		for i := range tasks {
+			if tasks[i].TaskID == taskID || tasks[i].RunID == taskID {
+				target = &tasks[i]
+				break
+			}
+		}
+	case len(tasks) == 1:
+		target = &tasks[0]
+	case len(tasks) > 1:
+		if focus := m.focusTaskID(rc, in); focus != "" {
+			for i := range tasks {
+				if tasks[i].TaskID == focus {
+					target = &tasks[i]
+					break
+				}
+			}
+		}
+		if target == nil {
+			return encodeToolResult(cancelResult{Ambiguous: tasks})
+		}
+	}
+
+	// A foreground turn is work too, and it is the one the user is watching.
+	stoppedForeground := m.cancelForegroundTurn(rc, in)
+
+	if target == nil {
+		if stoppedForeground {
+			return encodeToolResult(cancelResult{Cancelled: []string{"正在处理的这件事"}})
+		}
+		return encodeToolResult(cancelResult{NothingRun: true})
+	}
+	if runID := strings.TrimSpace(target.RunID); runID != "" && m.riskExecutor != nil {
+		if err := m.riskExecutor(rc.cfg.ProjectID, runID, "cancel_run", map[string]string{}); err != nil {
+			log.Warn().Err(err).Str("run", runID).Msg("director cancel_work failed")
+			return encodeToolResult(cancelResult{Failed: "没能停下来，状态没变。"})
+		}
+	}
+	m.clearWorkNote(rc.cfg.ProjectID, target.RunID)
+	m.retireTask(rc, in, target)
+	_ = ctx
+	return encodeToolResult(cancelResult{Cancelled: []string{target.ShortTitle}})
+}
+
+// retireTask writes the cancellation into the ledger and drops the focus if it
+// pointed here.
+//
+// Without this the next "how's it going" reads a task that is still marked
+// running, and the conversation layer — which is required to answer from the
+// ledger — reports progress on work that was stopped minutes ago.
+func (m *Manager) retireTask(rc *runningChannel, in InboundMessage, target *ledgerEntry) {
+	if m.taskContext == nil || target == nil {
+		return
+	}
+	scope := m.taskScopeFor(rc, in)
+	if _, err := m.taskContext.UpdateIdentity(services.EnsureTaskIdentityInput{
+		RunID: target.RunID, ProjectID: rc.cfg.ProjectID, UserID: scope.UserID,
+		Status: "cancelled",
+	}); err != nil {
+		log.Warn().Err(err).Str("task", target.TaskID).
+			Msg("cancelled task still reads as running in the ledger")
+	}
+	if m.focusTaskID(rc, in) == target.TaskID {
+		if err := m.taskContext.ExpireFocus(scope); err != nil {
+			log.Debug().Err(err).Msg("conversation focus still points at a cancelled task")
+		}
+	}
+}
+
+func (m *Manager) clearWorkNote(projectID, runID string) {
+	m.noteMu.Lock()
+	delete(m.workNotes, projectID+"|"+runID)
+	m.noteMu.Unlock()
+}
+
+// cancelForegroundTurn stops an in-flight sandbox turn for this conversation.
+func (m *Manager) cancelForegroundTurn(rc *runningChannel, in InboundMessage) bool {
+	b, ok := m.transcript.(*ChannelBridge)
+	if !ok || b == nil {
+		return false
+	}
+	return b.CancelConversationTurn(conversationRefFor(rc, in))
+}
+
+func encodeToolResult(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return `{"error":"result could not be encoded"}`
+	}
+	return string(b)
+}
+
+// humanizeAge renders an age the way a colleague would say it.
+func humanizeAge(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "刚刚"
+	case d < time.Hour:
+		return fmt.Sprintf("%d 分钟前", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%d 小时前", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%d 天前", int(d.Hours()/24))
+	}
+}
+
+// ensureTaskIdentity records a dispatched task in the ledger so the next "how's
+// it going" has something real to read. A dispatch that cannot be recorded
+// still runs: losing the ledger entry costs context, not the work.
+func (m *Manager) ensureTaskIdentity(rc *runningChannel, in InboundMessage, d *WorkDispatch) {
+	if m.taskContext == nil || d == nil {
+		return
+	}
+	title := strings.TrimSpace(d.ShortTitle)
+	if title == "" {
+		title = truncateRunes(strings.TrimSpace(in.Text), 40)
+	}
+	if title == "" {
+		return
+	}
+	scope := m.taskScopeFor(rc, in)
+	identity, err := m.taskContext.EnsureIdentity(services.EnsureTaskIdentityInput{
+		ProjectID: rc.cfg.ProjectID, UserID: scope.UserID,
+		RunID:                dispatchLedgerRunID(rc, in),
+		ShortTitle:           title,
+		OriginalRequirement:  strings.TrimSpace(in.Text),
+		RecentContext:        strings.TrimSpace(d.Brief),
+		Status:               "running",
+		OriginChannel:        rc.cfg.Type,
+		OriginScene:          string(in.Scene),
+		OriginConversationID: in.ConversationID,
+		OriginExternalUserID: in.UserID,
+		Language:             services.DetectLanguage(in.Text, ""),
+	})
+	if err != nil || identity == nil {
+		log.Debug().Err(err).Str("project", rc.cfg.ProjectID).
+			Msg("dispatched task not recorded in the ledger")
+		return
+	}
+	d.TaskID = identity.ID
+	if _, err := m.taskContext.SetFocus(scope, identity, identity.Language); err != nil {
+		log.Debug().Err(err).Msg("conversation focus not updated for dispatched task")
+	}
+	if msgID := strings.TrimSpace(in.MessageID); msgID != "" {
+		if err := m.taskContext.BindMessage(scope, msgID, identity); err != nil {
+			log.Debug().Err(err).Msg("dispatched task not bound to the inbound message")
+		}
+	}
+}
+
+// dispatchLedgerRunID keys a dispatched task before a Run exists.
+//
+// A ledger row needs an identifier and a real Run id is not available until the
+// agent starts one, so the turn itself is the key. It is replaced by the Run's
+// own identity once pm_start_run creates it.
+func dispatchLedgerRunID(rc *runningChannel, in InboundMessage) string {
+	if id := strings.TrimSpace(in.RecordedMessageID); id != "" {
+		return "dispatch:" + id
+	}
+	return fmt.Sprintf("dispatch:%s:%d",
+		convKey(rc.cfg.ProjectID, in.Scene, in.ConversationID), time.Now().UnixNano())
+}

--- a/server/internal/channels/gptlive_test.go
+++ b/server/internal/channels/gptlive_test.go
@@ -13,20 +13,37 @@ import (
 	"gorm.io/gorm"
 )
 
-// fakeLive stands in for a conversation-model endpoint. Each inbound message
-// consumes one scripted decision; running out means the script and the
-// conversation disagree, which is a test failure worth seeing.
+// fakeLive stands in for a conversation-model endpoint.
+//
+// Routing calls and phrasing calls are told apart by whether tools were
+// offered, because that is the real difference between them: routing decides
+// what to do and needs the tools, phrasing only rewords a conclusion the
+// platform already has. Each routing call consumes one scripted decision;
+// running out means the script and the conversation disagree, which is a test
+// failure worth seeing.
 type fakeLive struct {
 	configured bool
 	decisions  []liveagent.Result
 	err        error
-	seen       [][]liveagent.Message
+	// report answers the phrasing call. nil leaves it unanswered, which is what
+	// production does when the endpoint is slow: the conclusion goes out in the
+	// work layer's own words.
+	report  *liveagent.Result
+	seen    [][]liveagent.Message
+	systems []string
 }
 
 func (f *fakeLive) Configured() bool { return f.configured }
 
 func (f *fakeLive) Complete(_ context.Context, req liveagent.Request) (liveagent.Result, error) {
+	if len(req.Tools) == 0 {
+		if f.report == nil {
+			return liveagent.Result{}, errors.New("fakeLive: no phrasing configured")
+		}
+		return *f.report, nil
+	}
 	f.seen = append(f.seen, req.Messages)
+	f.systems = append(f.systems, req.System)
 	if f.err != nil {
 		return liveagent.Result{}, f.err
 	}
@@ -40,8 +57,29 @@ func (f *fakeLive) Complete(_ context.Context, req liveagent.Request) (liveagent
 
 func liveAnswer(text string) liveagent.Result { return liveagent.Result{Text: text} }
 
-func liveEscalate(request string) liveagent.Result {
-	return liveagent.Result{ToolName: askProjectAgentTool, Args: map[string]string{"request": request}}
+// liveDispatch scripts a delegation. Lookup work with no acknowledgement is the
+// quiet shape: the user hears one message, the conclusion.
+func liveDispatch(request, title string) liveagent.Result {
+	return liveagent.Result{ToolName: dispatchPMTool, Args: map[string]string{
+		"request": request, "difficulty": string(DifficultyLookup),
+		"short_title": title, "wait": "true",
+	}}
+}
+
+// liveHeavyDispatch scripts a delegation that answers the user first.
+func liveHeavyDispatch(request, title, userReply string) liveagent.Result {
+	return liveagent.Result{ToolName: dispatchPMTool, Args: map[string]string{
+		"request": request, "difficulty": string(DifficultyHeavy),
+		"short_title": title, "user_reply": userReply,
+	}}
+}
+
+func liveGetStatus(taskID string) liveagent.Result {
+	return liveagent.Result{ToolName: getStatusTool, Args: map[string]string{"task_id": taskID}}
+}
+
+func liveCancel(taskID string) liveagent.Result {
+	return liveagent.Result{ToolName: cancelWorkTool, Args: map[string]string{"task_id": taskID}}
 }
 
 // gptLive is the inbound pipeline over a real database: DB-backed delivery
@@ -72,6 +110,7 @@ func newGPTLive(t *testing.T) *gptLive {
 	m.SetTranscript(bridge)
 	m.SetRiskConfirmationService(services.NewRiskConfirmationService(db))
 	m.SetTaskContextService(services.NewTaskContextService(db))
+	m.SetLiveSampleService(services.NewLiveSampleService(db))
 
 	rc := testRunningChannel(fa)
 	rc.cfg.ProjectID = "proj"
@@ -113,6 +152,21 @@ func (g *gptLive) transcript() []string {
 	return out
 }
 
+// briefFor renders the work brief the sandbox would receive for the escalated
+// turn, which is where "what does the agent actually get told" is decided.
+func (g *gptLive) briefFor(in InboundMessage) string {
+	g.t.Helper()
+	thread, err := g.pm.GetThreadByID(g.threadID())
+	if err != nil {
+		g.t.Fatal(err)
+	}
+	current, err := g.pm.GetMessage(thread.ID, in.RecordedMessageID)
+	if err != nil {
+		g.t.Fatalf("escalated turn has no transcript row: %v", err)
+	}
+	return g.bridge.buildWorkBrief(thread, current, in)
+}
+
 // A configured conversation model answers chat itself, in one message, without
 // ever opening a sandbox.
 func TestLiveModelAnswersChatWithoutTheAgent(t *testing.T) {
@@ -131,13 +185,13 @@ func TestLiveModelAnswersChatWithoutTheAgent(t *testing.T) {
 	assertNoBannedOutbound(t, sentTexts(g.fa))
 }
 
-// Anything that needs the repository is handed over, and the handover carries
+// Anything that needs the repository is delegated, and the delegation carries
 // the request plus the attachments the user sent with it.
-func TestLiveModelEscalationCarriesTextAndAttachments(t *testing.T) {
+func TestDispatchCarriesTextAndAttachments(t *testing.T) {
 	g := newGPTLive(t)
 	g.m.SetLiveModel(&fakeLive{
 		configured: true,
-		decisions:  []liveagent.Result{liveEscalate("按这张截图修登录页")},
+		decisions:  []liveagent.Result{liveDispatch("按这张截图修登录页", "登录页")},
 	})
 
 	g.say("m1", "按这张图修一下", Image{
@@ -145,7 +199,7 @@ func TestLiveModelEscalationCarriesTextAndAttachments(t *testing.T) {
 	})
 
 	if len(g.agent) != 1 {
-		t.Fatalf("escalation did not reach the agent: %v", g.agent)
+		t.Fatalf("delegation did not reach the agent: %v", g.agent)
 	}
 	got := g.agent[0]
 	if got.Text != "按这张图修一下" {
@@ -154,10 +208,13 @@ func TestLiveModelEscalationCarriesTextAndAttachments(t *testing.T) {
 	if len(got.Images) != 1 || got.Images[0].Filename != "shot.png" {
 		t.Fatalf("attachment did not survive routing: %+v", got.Images)
 	}
-	if !strings.Contains(got.EscalationReason, "登录页") {
-		t.Fatalf("escalation reason = %q, the agent cannot tell why it was called", got.EscalationReason)
+	if got.Dispatch == nil || !strings.Contains(got.Dispatch.Brief, "登录页") {
+		t.Fatalf("agent cannot tell why it was called: %+v", got.Dispatch)
 	}
-	// The bytes are stored too, so a later turn can replay them.
+	if got.Dispatch.ShortTitle != "登录页" {
+		t.Fatalf("task title lost: %+v", got.Dispatch)
+	}
+	// The bytes are stored too, so a later turn can fetch them.
 	msgs, err := g.pm.CanonicalWindow(g.threadID(), 10)
 	if err != nil || len(msgs) == 0 {
 		t.Fatalf("transcript = %v err=%v", msgs, err)
@@ -201,16 +258,18 @@ func TestConversationModelFailureStillAnswersTheUser(t *testing.T) {
 	}
 }
 
-// The two layers must see one conversation. After the model answers twice on
-// its own, the turn it hands over has to arrive with those exchanges attached —
-// otherwise the agent starts from a question with no context and asks the user
-// to repeat what they just said.
-func TestEscalatedTurnCarriesWhatTheOuterLayerAnswered(t *testing.T) {
+// The prompt handed to the agent must not be the conversation.
+//
+// Replaying recent turns into every prompt is what this layer replaced: it grew
+// without bound, crowded out the question, and taught the agent to repeat
+// answers the user already had. What the agent gets instead is a pointer to
+// where the history lives.
+func TestWorkBriefDoesNotReplayTheConversation(t *testing.T) {
 	g := newGPTLive(t)
 	g.m.SetLiveModel(&fakeLive{configured: true, decisions: []liveagent.Result{
 		liveAnswer("我在。"),
 		liveAnswer("登录页那条我记得，你说的是首屏。"),
-		liveEscalate("看仓库确认首屏改动"),
+		liveDispatch("看仓库确认首屏改动", "首屏改动"),
 	}})
 
 	g.say("m1", "在吗")
@@ -218,9 +277,9 @@ func TestEscalatedTurnCarriesWhatTheOuterLayerAnswered(t *testing.T) {
 	g.say("m3", "去仓库确认一下改了没")
 
 	if len(g.agent) != 1 {
-		t.Fatalf("agent turns = %d want exactly the escalated one", len(g.agent))
+		t.Fatalf("agent turns = %d want exactly the delegated one", len(g.agent))
 	}
-	// One record, both layers: two turns the model answered, then the escalated
+	// One record, both layers: two turns the model answered, then the delegated
 	// turn and the agent's reply to it.
 	want := []string{
 		"user: 在吗",
@@ -240,37 +299,31 @@ func TestEscalatedTurnCarriesWhatTheOuterLayerAnswered(t *testing.T) {
 		}
 	}
 
-	// The handoff the sandbox would receive names both earlier turns and the
-	// replies the user actually got.
-	thread, err := g.pm.GetThreadByID(g.threadID())
-	if err != nil {
-		t.Fatal(err)
+	brief := g.briefFor(g.agent[0])
+	if strings.Contains(brief, "conversation_handoff") {
+		t.Fatalf("the removed handoff block came back:\n%s", brief)
 	}
-	current, err := g.pm.GetMessage(thread.ID, g.agent[0].RecordedMessageID)
-	if err != nil {
-		t.Fatalf("escalated turn has no transcript row: %v", err)
-	}
-	payload := g.bridge.buildHandoff(thread, current, g.agent[0], false)
-	for _, must := range []string{"在吗", "我在。", "登录页那个还记得吗", "你说的是首屏"} {
-		if !strings.Contains(payload.text, must) {
-			t.Fatalf("handoff lost %q:\n%s", must, payload.text)
+	for _, replayed := range []string{"在吗", "我在。", "登录页那个还记得吗", "你说的是首屏"} {
+		if strings.Contains(brief, replayed) {
+			t.Fatalf("brief replayed the conversation (%q):\n%s", replayed, brief)
 		}
 	}
-	if strings.Contains(payload.text, "去仓库确认一下改了没") {
-		t.Fatalf("handoff repeated the current request as history:\n%s", payload.text)
+	if !strings.Contains(brief, "看仓库确认首屏改动") {
+		t.Fatalf("brief does not say what the agent was asked for:\n%s", brief)
 	}
-	if !strings.Contains(payload.text, "看仓库确认首屏改动") {
-		t.Fatalf("handoff does not say why the turn arrived:\n%s", payload.text)
+	if !strings.Contains(brief, "get_messages") {
+		t.Fatalf("brief does not tell the agent where the history is:\n%s", brief)
 	}
 }
 
-// A picture sent one turn and referred to the next must still reach the layer
-// that can open it.
-func TestAttachmentFromAnEarlierTurnIsReplayedOnEscalation(t *testing.T) {
+// A picture sent one turn and referred to the next must still be reachable. It
+// is named rather than resent: the pointer is everything get_attachment needs,
+// and the bytes would be carried again on every later turn.
+func TestHistoryAttachmentIsNamedRatherThanReplayed(t *testing.T) {
 	g := newGPTLive(t)
 	g.m.SetLiveModel(&fakeLive{configured: true, decisions: []liveagent.Result{
 		liveAnswer("收到，我看看。"),
-		liveEscalate("按上一条的图改"),
+		liveDispatch("按上一条的图改", "按图修改"),
 	}})
 
 	g.say("m1", "这是报错截图", Image{
@@ -278,101 +331,385 @@ func TestAttachmentFromAnEarlierTurnIsReplayedOnEscalation(t *testing.T) {
 	})
 	g.say("m2", "按刚才那张图修")
 
-	thread, err := g.pm.GetThreadByID(g.threadID())
-	if err != nil {
-		t.Fatal(err)
-	}
-	current, err := g.pm.GetMessage(thread.ID, g.agent[0].RecordedMessageID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	payload := g.bridge.buildHandoff(thread, current, g.agent[0], false)
-	if len(payload.images) != 1 {
-		t.Fatalf("history attachment was not replayed: %+v", payload.images)
-	}
-	if payload.images[0].Name != "err.png" || payload.images[0].MimeType != "image/png" {
-		t.Fatalf("replayed attachment lost its identity: %+v", payload.images[0])
-	}
-	if payload.images[0].Data == "" {
-		t.Fatal("replayed attachment carried no bytes")
-	}
-}
-
-// An attachment too large to replay must be named, not dropped: the agent can
-// fetch it, but only if it knows it exists. The current message's own
-// attachments are never the ones sacrificed.
-func TestOversizeHistoryAttachmentIsListedRatherThanDropped(t *testing.T) {
-	g := newGPTLive(t)
-	g.m.SetLiveModel(&fakeLive{configured: true, decisions: []liveagent.Result{
-		liveAnswer("收到。"),
-		liveEscalate("接着上一张图"),
-	}})
-
-	huge := make([]byte, handoffAttachmentBudget)
-	g.say("m1", "大文件", Image{Data: huge, MimeType: "application/pdf", Filename: "big.pdf"})
-	g.say("m2", "按上面那份改", Image{
-		Data: []byte("SMALL"), MimeType: "image/png", Filename: "now.png",
-	})
-
-	thread, err := g.pm.GetThreadByID(g.threadID())
-	if err != nil {
-		t.Fatal(err)
-	}
-	current, err := g.pm.GetMessage(thread.ID, g.agent[0].RecordedMessageID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(current.Images) != 1 || current.Images[0].Name != "now.png" {
-		t.Fatalf("the current message's attachment was not kept intact: %+v", current.Images)
-	}
-	payload := g.bridge.buildHandoff(thread, current, g.agent[0], false)
-	for _, img := range payload.images {
-		if img.Name == "big.pdf" {
-			t.Fatal("an attachment over budget was replayed anyway")
+	brief := g.briefFor(g.agent[0])
+	for _, must := range []string{"err.png", "image/png", "get_attachment", "index=0"} {
+		if !strings.Contains(brief, must) {
+			t.Fatalf("brief lost the attachment pointer %q:\n%s", must, brief)
 		}
 	}
-	if !strings.Contains(payload.text, "big.pdf") || !strings.Contains(payload.text, "get_attachment") {
-		t.Fatalf("oversize attachment vanished silently:\n%s", payload.text)
+	if strings.Contains(brief, "PNGBYTES") {
+		t.Fatalf("attachment bytes were replayed into the prompt:\n%s", brief)
+	}
+	// The pointer names a message the agent can actually fetch.
+	msgs, err := g.pm.CanonicalWindow(g.threadID(), 10)
+	if err != nil || len(msgs) == 0 {
+		t.Fatalf("window = %v err=%v", msgs, err)
+	}
+	if !strings.Contains(brief, msgs[0].ID) {
+		t.Fatalf("brief does not name the message holding the file:\n%s", brief)
+	}
+	// And the conversation layer knew the file existed, so it could point at it.
+	if refs := g.agent[0].Dispatch.Attachments; len(refs) == 0 || refs[0].Name != "err.png" {
+		t.Fatalf("delegation carried no attachment pointer: %+v", refs)
 	}
 }
 
-// A warm sandbox is caught up with what it missed; a fresh one, which
-// remembers nothing, gets the bounded baseline instead of an empty delta.
-func TestHandoffIsIncrementalForAWarmSandboxAndABaselineForAFreshOne(t *testing.T) {
+// The file the user just sent travels with the turn as a file. Only history is
+// fetched on demand; making the agent fetch what it was handed this second
+// would be a round trip for nothing.
+func TestCurrentAttachmentIsNotDeferredToContextStore(t *testing.T) {
 	g := newGPTLive(t)
 	g.m.SetLiveModel(&fakeLive{configured: true, decisions: []liveagent.Result{
-		liveAnswer("早"), liveAnswer("嗯"), liveEscalate("看仓库"),
+		liveDispatch("看这张图", "看图"),
 	}})
-	g.say("m1", "早上好")
-	g.say("m2", "在忙吗")
-	g.say("m3", "去看下仓库")
 
-	thread, err := g.pm.GetThreadByID(g.threadID())
-	if err != nil {
-		t.Fatal(err)
+	g.say("m1", "看看这个", Image{
+		Data: []byte("NOW"), MimeType: "image/png", Filename: "now.png",
+	})
+
+	if imgs := g.agent[0].Images; len(imgs) != 1 || imgs[0].Filename != "now.png" {
+		t.Fatalf("the current attachment did not travel with the turn: %+v", imgs)
 	}
-	current, err := g.pm.GetMessage(thread.ID, g.agent[0].RecordedMessageID)
-	if err != nil {
-		t.Fatal(err)
+	if brief := g.briefFor(g.agent[0]); strings.Contains(brief, "now.png") {
+		t.Fatalf("the current attachment was listed as history to fetch:\n%s", brief)
+	}
+}
+
+// Minute-scale work is acknowledged before it starts, and the acknowledgement
+// says what is being worked on. The conclusion still follows: an
+// acknowledgement is not an answer.
+func TestHeavyWorkIsAcknowledgedBeforeItStarts(t *testing.T) {
+	g := newGPTLive(t)
+	g.m.SetLiveModel(&fakeLive{configured: true, decisions: []liveagent.Result{
+		liveHeavyDispatch("排查登录页 500", "登录页报错", "我去翻一下登录页那个 500，翻到就回你。"),
+	}})
+
+	g.say("m1", "登录页报 500，看看什么原因")
+
+	got := sentTexts(g.fa)
+	if len(got) != 2 {
+		t.Fatalf("sends = %v want an acknowledgement then the conclusion", got)
+	}
+	if !strings.Contains(got[0], "登录页") {
+		t.Fatalf("acknowledgement says nothing verifiable: %q", got[0])
+	}
+	if got[1] != "agent-answer" {
+		t.Fatalf("the conclusion was withheld after an acknowledgement: %v", got)
+	}
+	assertNoBannedOutbound(t, got)
+}
+
+// An acknowledgement that promises nothing is replaced and counted. Banning the
+// old fixed template is not enough: a model saying the same empty thing in its
+// own words leaves the user exactly as uninformed.
+func TestEmptyAcknowledgementIsReplacedAndFlagged(t *testing.T) {
+	text, flags := gateAcknowledgement("好的，稍等，我看一下", "登录页报错", "登录页报 500")
+	if !strings.Contains(text, "登录页报错") {
+		t.Fatalf("replacement names nothing the user can hold us to: %q", text)
+	}
+	if len(flags) != 1 || flags[0] != "empty_ack" {
+		t.Fatalf("flags = %v want the empty acknowledgement counted", flags)
+	}
+	for _, banned := range bannedOutboundPhrases {
+		if strings.Contains(text, banned) {
+			t.Fatalf("replacement reintroduced banned copy %q: %q", banned, text)
+		}
 	}
 
-	fresh := g.bridge.buildHandoff(thread, current, g.agent[0], false)
-	if !strings.Contains(fresh.text, "早上好") {
-		t.Fatalf("a fresh sandbox got no baseline:\n%s", fresh.text)
+	kept, flags := gateAcknowledgement("我去翻一下登录页那个 500，翻到就回你。", "登录页报错", "")
+	if kept != "我去翻一下登录页那个 500，翻到就回你。" || len(flags) != 0 {
+		t.Fatalf("an informative acknowledgement was rewritten: %q flags=%v", kept, flags)
+	}
+}
+
+// "How's it going" is answered from the ledger, and answering it must not start
+// anything. Opening a sandbox to find out where a task is, is how a progress
+// question used to cost a container.
+func TestProgressQuestionIsAnsweredFromTheLedgerWithoutStartingWork(t *testing.T) {
+	g := newGPTLive(t)
+	identity := g.seedTask("run-1", "登录页报错")
+	g.m.noteWorkProgress("proj", "run-1", "正在查代码", false)
+
+	live := &fakeLive{configured: true, decisions: []liveagent.Result{
+		liveGetStatus(identity.ID),
+		liveAnswer("还在跑，现在在查代码。"),
+	}}
+	g.m.SetLiveModel(live)
+
+	g.say("m1", "好了没")
+
+	if len(g.agent) != 0 {
+		t.Fatalf("a progress question opened a sandbox turn: %v", g.agent)
+	}
+	if got := sentTexts(g.fa); len(got) != 1 || got[0] != "还在跑，现在在查代码。" {
+		t.Fatalf("sends = %v want one status reply", got)
+	}
+	// The status the model answered from was the platform's, not its own idea
+	// of one.
+	last := live.seen[len(live.seen)-1]
+	fed := last[len(last)-1].Content
+	for _, must := range []string{getStatusTool, "登录页报错", "正在查代码"} {
+		if !strings.Contains(fed, must) {
+			t.Fatalf("tool result did not carry %q: %s", must, fed)
+		}
+	}
+}
+
+// Cancelling acts on a real task and reports what actually stopped.
+func TestCancelStopsTheNamedTask(t *testing.T) {
+	g := newGPTLive(t)
+	identity := g.seedTask("run-1", "登录页报错")
+	var cancelled []string
+	g.m.SetRiskActionExecutor(func(_, runID, action string, _ map[string]string) error {
+		cancelled = append(cancelled, action+":"+runID)
+		return nil
+	})
+
+	live := &fakeLive{configured: true, decisions: []liveagent.Result{
+		liveCancel(identity.ID),
+		liveAnswer("好，登录页那个我停了。"),
+	}}
+	g.m.SetLiveModel(live)
+
+	g.say("m1", "算了别弄了")
+
+	if len(cancelled) != 1 || cancelled[0] != "cancel_run:run-1" {
+		t.Fatalf("cancel actions = %v want the named run stopped", cancelled)
+	}
+	if got := sentTexts(g.fa); len(got) != 1 || got[0] != "好，登录页那个我停了。" {
+		t.Fatalf("sends = %v want one confirmation", got)
+	}
+}
+
+// With two tasks in flight and nothing to point at, cancelling must not guess.
+// Stopping the wrong task is not a wording mistake that can be apologised for
+// afterwards.
+func TestAmbiguousCancelAsksInsteadOfGuessing(t *testing.T) {
+	g := newGPTLive(t)
+	g.seedTask("run-1", "登录页报错")
+	g.seedTask("run-2", "导出超时")
+	var cancelled []string
+	g.m.SetRiskActionExecutor(func(_, runID, action string, _ map[string]string) error {
+		cancelled = append(cancelled, action+":"+runID)
+		return nil
+	})
+
+	live := &fakeLive{configured: true, decisions: []liveagent.Result{
+		liveCancel(""),
+		liveAnswer("你是说登录页那个，还是导出那个？"),
+	}}
+	g.m.SetLiveModel(live)
+
+	g.say("m1", "算了别弄了")
+
+	if len(cancelled) != 0 {
+		t.Fatalf("an ambiguous cancel stopped something anyway: %v", cancelled)
+	}
+	last := live.seen[len(live.seen)-1]
+	fed := last[len(last)-1].Content
+	if !strings.Contains(fed, "ambiguous") {
+		t.Fatalf("the model was not told the request was ambiguous: %s", fed)
+	}
+	if got := sentTexts(g.fa); len(got) != 1 || !strings.Contains(got[0], "还是") {
+		t.Fatalf("sends = %v want a question back", got)
+	}
+}
+
+// A quick check the director chose to wait on answers once. Acknowledging and
+// then answering a second later is two notifications for one question.
+func TestWaitedLookupAnswersExactlyOnce(t *testing.T) {
+	g := newGPTLive(t)
+	g.m.SetLiveModel(&fakeLive{configured: true, decisions: []liveagent.Result{
+		liveDispatch("确认登录页那个修好没", "登录页报错"),
+	}})
+
+	g.say("m1", "登录页那个修复了没")
+
+	if got := sentTexts(g.fa); len(got) != 1 || got[0] != "agent-answer" {
+		t.Fatalf("sends = %v want a single conclusion with no acknowledgement first", got)
+	}
+	if len(g.agent) != 1 {
+		t.Fatalf("the check never reached the agent: %v", g.agent)
+	}
+}
+
+// A cancelled task must stop reading as running, or the next status question is
+// answered from the ledger with work nobody is doing.
+func TestCancelUpdatesTheLedger(t *testing.T) {
+	g := newGPTLive(t)
+	identity := g.seedTask("run-1", "登录页报错")
+	g.m.SetRiskActionExecutor(func(string, string, string, map[string]string) error { return nil })
+	g.m.SetLiveModel(&fakeLive{configured: true, decisions: []liveagent.Result{
+		liveCancel(identity.ID),
+		liveAnswer("好，停了。"),
+	}})
+
+	g.say("m1", "算了别弄了")
+
+	var stored models.TaskIdentity
+	if err := g.db.First(&stored, "id = ?", identity.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.Status != "cancelled" || stored.TerminalAt == nil {
+		t.Fatalf("cancelled task still reads as %q (terminal=%v)", stored.Status, stored.TerminalAt)
+	}
+	if focus := g.m.focusTaskID(g.rc, InboundMessage{
+		Scene: SceneC2C, ConversationID: "user1", UserID: "u1",
+	}); focus == identity.ID {
+		t.Fatal("the conversation still points at the task it just cancelled")
+	}
+}
+
+// With two things in flight an update has to say which one moved. With one, the
+// conversation already says it and a title in front reads like a ticket header.
+func TestProgressNamesTheTaskOnlyWhenSeveralAreRunning(t *testing.T) {
+	g := newGPTLive(t)
+	g.seedTask("run-1", "登录页报错")
+	g.m.SetLiveModel(&fakeLive{configured: true, decisions: []liveagent.Result{
+		liveDispatch("查导出超时", "导出超时"),
+	}})
+	g.m.handleFunc = nil
+	g.m.handleFuncWithProgress = func(_ context.Context, _ ResolvedChannel, in InboundMessage,
+		onProgress func(ProgressEvent)) (Reply, error) {
+		g.agent = append(g.agent, in)
+		onProgress(ProgressEvent{
+			Kind: ProgressMilestone, Summary: "已经复现了", Stage: "repro",
+			RunID: "run-1", Sendable: true,
+		})
+		return Reply{FinalSummary: "agent-answer"}, nil
 	}
 
-	// Pretend the sandbox already handled everything up to the second turn.
-	msgs, err := g.pm.CanonicalWindow(thread.ID, 50)
-	if err != nil {
+	g.say("m1", "导出也看看")
+
+	got := sentTexts(g.fa)
+	if len(got) != 2 {
+		t.Fatalf("sends = %v want an update and a conclusion", got)
+	}
+	if !strings.HasPrefix(got[0], "「登录页报错」") {
+		t.Fatalf("update does not say which task moved: %q", got[0])
+	}
+}
+
+// Past the concurrency limit the platform declines and the conversation layer
+// explains. A silent rejection and a platform-worded refusal are both worse:
+// one loses the request, the other puts a template back in the conversation.
+func TestConcurrencyLimitIsExplainedRatherThanImposedSilently(t *testing.T) {
+	g := newGPTLive(t)
+	for i, title := range []string{"登录页", "导出", "搜索"} {
+		g.seedTask(string(rune('a'+i))+"-run", title)
+	}
+	live := &fakeLive{configured: true, decisions: []liveagent.Result{
+		liveHeavyDispatch("再修一个", "订单页", "我去看订单页。"),
+		liveAnswer("我手上还有三件事在跑，先停一个再开新的？"),
+	}}
+	g.m.SetLiveModel(live)
+
+	g.say("m1", "订单页也修一下")
+
+	if len(g.agent) != 0 {
+		t.Fatalf("a rejected delegation reached the agent anyway: %v", g.agent)
+	}
+	last := live.seen[len(live.seen)-1]
+	if !strings.Contains(last[len(last)-1].Content, "rejected") {
+		t.Fatalf("the model was not told the delegation was declined: %s", last[len(last)-1].Content)
+	}
+	if got := sentTexts(g.fa); len(got) != 1 || !strings.Contains(got[0], "三件事") {
+		t.Fatalf("sends = %v want the limit explained in the model's own words", got)
+	}
+}
+
+// The agent's conclusion reaches the user through the conversation layer, in
+// the voice the user has been hearing. Two speakers in one conversation is what
+// made a delegated answer read like a different system replying.
+func TestAgentConclusionIsReportedByTheConversationLayer(t *testing.T) {
+	g := newGPTLive(t)
+	phrased := liveAnswer("查过了，是缓存没刷新导致的。")
+	live := &fakeLive{
+		configured: true,
+		decisions:  []liveagent.Result{liveDispatch("查登录页 500 的根因", "登录页报错")},
+		report:     &phrased,
+	}
+	g.m.SetLiveModel(live)
+	g.m.handleFunc = func(ctx context.Context, _ ResolvedChannel, in InboundMessage) (Reply, error) {
+		g.agent = append(g.agent, in)
+		if _, err := g.m.DeliverConversationReply(ctx, ConversationReply{
+			ProjectID: "proj", Scene: in.Scene, ConversationID: in.ConversationID,
+			UserID: in.UserID, Text: "根因：缓存未刷新，已定位到 CacheWarmer。",
+		}); err != nil {
+			t.Fatalf("pm_reply failed: %v", err)
+		}
+		return Reply{}, nil
+	}
+
+	g.say("m1", "登录页 500 的根因是什么")
+
+	got := sentTexts(g.fa)
+	if len(got) != 1 {
+		t.Fatalf("sends = %v want exactly one message", got)
+	}
+	if got[0] != "查过了，是缓存没刷新导致的。" {
+		t.Fatalf("the work layer spoke to the user directly: %q", got[0])
+	}
+}
+
+// When the conversation layer cannot phrase the conclusion, the conclusion
+// still goes out. Degrading to the work layer's own words reads slightly off;
+// staying silent loses the answer the user waited for.
+func TestConclusionSurvivesAFailedPhrasingCall(t *testing.T) {
+	g := newGPTLive(t)
+	g.m.SetLiveModel(&fakeLive{
+		configured: true,
+		decisions:  []liveagent.Result{liveDispatch("查根因", "根因")},
+		// report left nil: the phrasing call fails.
+	})
+	g.m.handleFunc = func(ctx context.Context, _ ResolvedChannel, in InboundMessage) (Reply, error) {
+		g.agent = append(g.agent, in)
+		if _, err := g.m.DeliverConversationReply(ctx, ConversationReply{
+			ProjectID: "proj", Scene: in.Scene, ConversationID: in.ConversationID,
+			UserID: in.UserID, Text: "缓存没刷新。",
+		}); err != nil {
+			t.Fatalf("pm_reply failed: %v", err)
+		}
+		return Reply{}, nil
+	}
+
+	g.say("m1", "根因是什么")
+
+	if got := sentTexts(g.fa); len(got) != 1 || got[0] != "缓存没刷新。" {
+		t.Fatalf("sends = %v want the conclusion in the work layer's own words", got)
+	}
+}
+
+// Every routing decision is recorded, including what the model was shown and
+// what the user received. Without this, the next change to routing can only be
+// argued about.
+func TestRoutingDecisionsAreRecorded(t *testing.T) {
+	g := newGPTLive(t)
+	g.m.SetLiveModel(&fakeLive{configured: true, decisions: []liveagent.Result{
+		liveAnswer("我在，说吧。"),
+	}})
+
+	g.say("m1", "你好")
+
+	var samples []models.LiveDecisionSample
+	if err := g.db.Find(&samples).Error; err != nil {
 		t.Fatal(err)
 	}
-	if err := g.pm.SetHandoffCursor(thread.ID, msgs[3].ID); err != nil {
-		t.Fatal(err)
+	if len(samples) != 1 {
+		t.Fatalf("samples = %d want one per decision", len(samples))
 	}
-	thread.HandoffCursor = msgs[3].ID
-	warm := g.bridge.buildHandoff(thread, current, g.agent[0], true)
-	if strings.Contains(warm.text, "早上好") {
-		t.Fatalf("a warm sandbox was shown history it already lived through:\n%s", warm.text)
+	s := samples[0]
+	if s.Route != routeReply {
+		t.Fatalf("route = %q want %q", s.Route, routeReply)
+	}
+	if s.UserText != "你好" || !strings.Contains(s.Actions, "live_reply") {
+		t.Fatalf("sample does not hold the exchange: %+v", s)
+	}
+	if !strings.Contains(s.RawCompletion, "我在，说吧。") {
+		t.Fatalf("sample does not hold what the model produced: %s", s.RawCompletion)
+	}
+	if s.DirectorContext == "" || s.Transcript == "" {
+		t.Fatalf("sample does not hold what the model was shown: %+v", s)
 	}
 }
 
@@ -438,6 +775,20 @@ func TestFailedTurnKeepsTheUsersMessageInTheRecord(t *testing.T) {
 	if len(after) == 0 || !strings.Contains(after[0], "记一笔") {
 		t.Fatalf("failed turn lost the user's own words: %v", after)
 	}
+}
+
+// seedTask puts a live task in the ledger, as a dispatch or a Run would.
+func (g *gptLive) seedTask(runID, title string) *models.TaskIdentity {
+	g.t.Helper()
+	identity, err := g.m.taskContext.EnsureIdentity(services.EnsureTaskIdentityInput{
+		ProjectID: "proj", UserID: services.SyntheticQQUserID("u1"),
+		RunID: runID, ShortTitle: title, Status: "running",
+		OriginChannel: "qq", OriginScene: string(SceneC2C), OriginConversationID: "user1",
+	})
+	if err != nil {
+		g.t.Fatal(err)
+	}
+	return identity
 }
 
 // threadFromFirstMessage seeds one recorded user message and returns the thread.

--- a/server/internal/channels/live.go
+++ b/server/internal/channels/live.go
@@ -4,53 +4,77 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/cocofhu/approving/internal/liveagent"
 	"github.com/cocofhu/approving/internal/sendable"
+	"github.com/cocofhu/approving/internal/services"
 
 	"github.com/rs/zerolog/log"
 )
 
-// LiveModel is the conversation model consulted before a message reaches the
-// sandbox. It answers what it can from the conversation alone and hands over
-// everything else.
+// LiveModel is the conversation model. It is the only thing that talks to the
+// user.
 //
-// Splitting the work this way is what makes an IM conversation feel like one:
-// a sandbox turn costs a container and tens of seconds even to say hello, while
-// most of what a colleague sends is chat, clarification, or a question about
-// something already discussed. The model is not a filter in front of the agent
-// — it cannot read the repository and is not asked to pretend otherwise — it
-// just keeps the conversation moving while real work happens behind it.
+// The split is between talking and doing, not between easy and hard. The
+// sandbox agent can read the repository and change it; it cannot hold a
+// conversation, because every sentence it says costs a container and tens of
+// seconds, and it has no way to know what the user was already told. So the
+// model in front does the talking — answering what it can, delegating what it
+// cannot, and reporting back what the work layer found — and the agent works
+// behind it.
+//
+// The model is not a filter. It cannot read the repository and is never asked
+// to pretend otherwise: anything it says about work in flight comes from
+// get_status, and anything requiring facts it does not have goes to dispatch_pm.
 type LiveModel interface {
 	Configured() bool
 	Complete(ctx context.Context, req liveagent.Request) (liveagent.Result, error)
 }
 
-// askProjectAgentTool is the only decision the conversation model can hand
-// back. There is deliberately no "start a task" or "cancel that" tool: acting
-// on the project is the agent's job, and a second place that can trigger it is
-// a second place that can trigger it wrongly.
-const askProjectAgentTool = "ask_project_agent"
+// The three decisions the conversation layer can make about work. They exist as
+// separate tools rather than one "escalate" because the difference matters at
+// the point of the call: delegating starts something, reading status must never
+// start anything, and cancelling stops something. Collapsing them into one verb
+// is what made "好了没" open a second sandbox to find out.
+const (
+	dispatchPMTool = "dispatch_pm"
+	getStatusTool  = "get_status"
+	cancelWorkTool = "cancel_work"
+)
+
+// liveToolLoopLimit bounds one turn's tool calls. Two is enough for the shapes
+// that occur — check status then answer, cancel then confirm — and a model that
+// wants a third is looping rather than working.
+const liveToolLoopLimit = 3
 
 // liveSystemPrompt tells the model who it is and where the line is.
 //
 // The line is drawn by capability, not topic: it may say anything it can
-// support from the conversation in front of it, and must hand over anything
-// that needs the repository, real task state, or an action. Uncertainty
-// resolves toward handing over, because an invented answer is indistinguishable
+// support from the conversation in front of it or from a tool result, and must
+// delegate anything that needs the repository or an action. Uncertainty
+// resolves toward delegating, because an invented answer is indistinguishable
 // from a real one to the person reading it.
 const liveSystemPrompt = `你是这个项目的负责人本人，正在 IM 上和同事聊天。你的回复会原样发给对方。
 
+你手下有人干活。你的职责是接话、判断这件事有多大、派下去，然后把真实的进展和结论讲给对方听。
+
 你可以直接回答：打招呼、闲聊、澄清对方的意思、解释你们刚才聊过的内容、回答你从这段对话里就能确定的事。
 
-你必须调用 ask_project_agent 交给项目 Agent 的：需要看代码或仓库、需要知道任务的真实状态或进度、需要动手改东西、需要跑流程或发起工作、以及任何你不能仅凭这段对话就确定的事。
+需要看代码或仓库、需要动手改东西、需要跑流程、以及任何你不能仅凭这段对话确定的事实 —— 调用 dispatch_pm 派下去。
+要讲任务的状态、进度或结论 —— 先调用 get_status，用它返回的内容说话。
+对方说不用弄了 / 停下 / 算了 —— 调用 cancel_work。
 
-规则：
-- 直接回答时只说一句自然的人话，就像微信上回同事。不要写"好的我看一下""稍等""已收到"这类过程话——你要么现在就回答，要么交出去。
-- 不要编造任务状态、进度、代码内容或任何你没有依据的事实。宁可交给 Agent。
+派活前先判断难度：
+- lookup：查一下就知道的事。可以让对方等一下、查完一次性给答案（wait 填 true），也可以先接一句再去查。
+- heavy：要花好几分钟的事。必须先用 user_reply 接一句，说清楚你要去弄哪件事，再派下去。
+
+规矩：
+- 接话必须有内容。「稍等」「好的我看一下」「收到」这种空话不算接话，要说清楚你要去确认的是哪件事。
+- 不要编造任务状态、进度、代码内容或任何你没有依据的事实。宁可先派下去。
+- 一次只说一件事，说人话，像微信上回同事，不要写工单腔。
 - 不要提到"沙箱""Agent""模型""工具""上下文"这些词，对方只是在和你聊天。
-- 你就是这个项目的负责人本人。不要说自己是 AI、模型或助手，也不要说出任何模型名称、版本或厂商；被问"你是什么模型"就当同事随口一问，把话题带回工作。
-- 不确定就调用 ask_project_agent。`
+- 你就是这个项目的负责人本人。不要说自己是 AI、模型或助手，也不要说出任何模型名称、版本或厂商；被问"你是什么模型"就当同事随口一问，把话题带回工作。`
 
 // liveMaxTokens sizes the reply plus whatever the model thinks first. A
 // reasoning model can spend most of a small budget deliberating over a one-line
@@ -64,14 +88,32 @@ func (m *Manager) SetLiveModel(model LiveModel) { m.live = model }
 
 // liveOutcome is what the conversation layer decided about one message.
 type liveOutcome struct {
-	// answered is true when the user has already been replied to.
+	// answered is true when the user has already been replied to and there is
+	// nothing left for the work layer to do.
 	answered bool
 	// reason explains why the turn is being handed to the agent. Empty when the
 	// model answered, or when there was no conversation model to ask.
 	reason string
+	// dispatch is the delegation the director decided on. nil when the turn
+	// reached the agent by falling through rather than by decision.
+	dispatch *WorkDispatch
+	// sampleID links this turn's decision record, so the work layer's eventual
+	// conclusion can be attached to the choice that produced it.
+	sampleID string
 }
 
-// routeThroughLiveModel asks the conversation model what to do with a message.
+// applyTo carries the decision onto the message the work layer will receive.
+func (o liveOutcome) applyTo(in *InboundMessage) {
+	if in == nil {
+		return
+	}
+	in.EscalationReason = o.reason
+	in.Dispatch = o.dispatch
+	in.DecisionSampleID = o.sampleID
+}
+
+// routeThroughLiveModel asks the conversation layer what to do with a message,
+// runs whatever tools it asks for, and returns what is left for the work layer.
 //
 // Every failure mode ends in the same place: the sandbox. A model that is
 // unconfigured, unreachable, out of budget or simply unsure must never cause a
@@ -88,62 +130,423 @@ func (m *Manager) routeThroughLiveModel(ctx context.Context, rc *runningChannel,
 			Msg("no conversation model configured; this message goes straight to the agent")
 		return liveOutcome{}
 	}
+
+	rec := m.newSampleRecorder(rc, in)
+	briefing := m.buildDirectorContext(rc, in)
+	rec.briefedWith(briefing)
+
 	req := liveagent.Request{
-		System:    liveSystemPrompt,
+		System:    liveSystemPrompt + "\n\n" + briefing.render(),
 		Messages:  m.liveMessages(rc, in),
-		Tools:     []liveagent.ToolSpec{askProjectAgentSpec()},
+		Tools:     directorTools(),
 		MaxTokens: liveMaxTokens,
 	}
-	res, err := m.live.Complete(ctx, req)
-	if err != nil {
-		// Not a user-visible failure: the message still gets answered, by the
-		// agent. Logged so an endpoint that is failing every call is visible
-		// as something other than "the assistant got slow".
-		level := log.Warn()
-		if errors.Is(err, liveagent.ErrNotConfigured) {
-			level = log.Debug()
+	rec.shown(req.Messages)
+
+	for step := 0; step < liveToolLoopLimit; step++ {
+		res, err := m.live.Complete(ctx, req)
+		if err != nil {
+			// Not a user-visible failure: the message still gets answered, by
+			// the agent. Logged so an endpoint failing every call is visible as
+			// something other than "the assistant got slow".
+			level := log.Warn()
+			if errors.Is(err, liveagent.ErrNotConfigured) {
+				level = log.Debug()
+			}
+			level.Err(err).Str("project", rc.cfg.ProjectID).
+				Msg("conversation model unavailable; handing turn to the agent")
+			rec.failed(err)
+			return liveOutcome{reason: "会话层没能给出答复", sampleID: rec.commit(routeFallthrough)}
 		}
-		level.Err(err).Str("project", rc.cfg.ProjectID).Msg("conversation model unavailable; handing turn to the agent")
-		return liveOutcome{reason: "会话层没能给出答复"}
-	}
-	if res.ToolName == askProjectAgentTool {
-		reason := strings.TrimSpace(res.Args["request"])
-		if reason == "" {
-			reason = "需要读仓库或任务真实状态"
+		rec.completed(res)
+
+		switch res.ToolName {
+		case getStatusTool:
+			out := m.runGetStatus(rc, in, res.Args["task_id"])
+			rec.toolReturned(getStatusTool, res.Args, out)
+			req.Messages = append(req.Messages, toolResultMessage(getStatusTool, out))
+		case cancelWorkTool:
+			out := m.runCancelWork(ctx, rc, in, res.Args["task_id"])
+			rec.toolReturned(cancelWorkTool, res.Args, out)
+			req.Messages = append(req.Messages, toolResultMessage(cancelWorkTool, out))
+		case dispatchPMTool:
+			outcome, refused := m.dispatchWork(ctx, rc, in, res.Args, rec)
+			if refused == "" {
+				return outcome
+			}
+			rec.toolReturned(dispatchPMTool, res.Args, refused)
+			req.Messages = append(req.Messages, toolResultMessage(dispatchPMTool, refused))
+		default:
+			return m.deliverDirectorReply(ctx, rc, in, res.Text, rec)
 		}
-		return liveOutcome{reason: reason}
 	}
-	answer := strings.TrimSpace(res.Text)
+
+	// The model kept reaching for tools and never said anything. Handing the
+	// turn on is the only path that still produces a reply.
+	log.Info().Str("project", rc.cfg.ProjectID).
+		Msg("conversation model looped on tools without answering; handing turn to the agent")
+	rec.flag("tool_loop_exhausted")
+	return liveOutcome{reason: "会话层查了状态但没有给出答复", sampleID: rec.commit(routeFallthrough)}
+}
+
+// deliverDirectorReply sends what the model said, as it said it.
+func (m *Manager) deliverDirectorReply(ctx context.Context, rc *runningChannel, in InboundMessage,
+	text string, rec *sampleRecorder) liveOutcome {
+	answer := strings.TrimSpace(text)
 	if answer == "" {
-		return liveOutcome{reason: "会话层没能给出答复"}
+		return liveOutcome{reason: "会话层没能给出答复", sampleID: rec.commit(routeFallthrough)}
 	}
 	sent := m.sendOutboundResult(ctx, rc, OutboundMessage{
 		Scene: in.Scene, ConversationID: in.ConversationID,
 		ReplyToMessageID: in.MessageID, Text: answer,
 		Envelope: turnEnvelope(rc, in, sendable.KindFinal, "live_reply", sendable.PriorityNormal),
 	})
+	rec.acted("live_reply", answer, sent)
 	if !sent.Sent {
 		// The answer never reached anyone, so the turn is still unanswered.
 		// Handing it to the agent is the only path that can still produce a
 		// reply; claiming success here is what leaves a user waiting in silence.
 		log.Warn().Str("project", rc.cfg.ProjectID).Str("reason", sent.Decision.Reason).
 			Msg("conversation model answer was not delivered; handing turn to the agent")
-		return liveOutcome{reason: "会话层的回复没有送达"}
+		return liveOutcome{reason: "会话层的回复没有送达", sampleID: rec.commit(routeFallthrough)}
 	}
-	m.markReplied(conversationTurnScope(rc.cfg.ProjectID, in.Scene, in.ConversationID))
-	return liveOutcome{answered: true}
+	scope := conversationTurnScope(rc.cfg.ProjectID, in.Scene, in.ConversationID)
+	m.markReplied(scope)
+	m.markAnswered(scope)
+	return liveOutcome{answered: true, sampleID: rec.commit(routeReply)}
 }
 
-func askProjectAgentSpec() liveagent.ToolSpec {
-	return liveagent.ToolSpec{
-		Name: askProjectAgentTool,
-		Description: "把这条消息交给能读代码仓库、能查任务真实状态、能动手干活的项目 Agent。" +
-			"任何需要事实依据或需要执行的事情都用它，不要自己猜。",
-		Params: []liveagent.Param{{
-			Name:        "request",
-			Description: "用一句话说清对方要什么，供 Agent 直接接手。",
-			Required:    true,
-		}},
+// dispatchWork turns a delegation into a real task and, when the work will
+// outlive the conversation's patience, answers the user before starting it.
+//
+// A non-empty refusal means the delegation did not happen and the string is a
+// tool result the director must deal with — the platform declines, the director
+// explains. Wording a refusal here is how a fixed template ends up in the
+// conversation again.
+func (m *Manager) dispatchWork(ctx context.Context, rc *runningChannel, in InboundMessage,
+	args map[string]string, rec *sampleRecorder) (outcome liveOutcome, refused string) {
+	brief := strings.TrimSpace(args["request"])
+	if brief == "" {
+		brief = strings.TrimSpace(in.Text)
+	}
+	if brief == "" {
+		brief = "需要读仓库或任务真实状态"
+	}
+	difficulty := parseDifficulty(args["difficulty"])
+	title := services.SanitizeShortTitle(args["short_title"])
+	if title == "" {
+		title = truncateRunes(strings.TrimSpace(in.Text), 40)
+	}
+	// Waiting is only offered for work short enough to wait for. A heavy task
+	// held in the foreground is the blocked conversation this layer exists to
+	// prevent.
+	wait := parseLooseBool(args["wait"]) && difficulty == DifficultyLookup
+
+	if running := m.taskLedger(rc, in); len(running) >= maxConcurrentWork {
+		return liveOutcome{}, encodeToolResult(map[string]any{
+			"rejected": "这个会话同时在跑的任务已经到上限了，没有派下去。",
+			"running":  running,
+			"hint":     "跟对方说清楚现在手上有哪几件事，问他要先停掉哪件，或者要不要排在后面。",
+		})
+	}
+
+	dispatch := &WorkDispatch{
+		Brief: brief, Difficulty: difficulty, ShortTitle: title,
+		Attachments: m.conversationAttachments(rc, in),
+	}
+	m.ensureTaskIdentity(rc, in, dispatch)
+
+	// heavy work is always acknowledged: the user is about to wait minutes and
+	// must know what for. A lookup the director chose to wait on says nothing
+	// now and answers once, which is the better shape for a quick check.
+	if difficulty == DifficultyHeavy || (!wait && strings.TrimSpace(args["user_reply"]) != "") {
+		text, flags := gateAcknowledgement(args["user_reply"], title, in.Text)
+		rec.flag(flags...)
+		sent := m.sendOutboundResult(ctx, rc, OutboundMessage{
+			Scene: in.Scene, ConversationID: in.ConversationID,
+			ReplyToMessageID: in.MessageID, Text: text,
+			// An acknowledgement is not the answer. It marks the turn as having
+			// spoken, never as having answered, so the conclusion that follows
+			// is not suppressed as a duplicate.
+			Envelope: turnEnvelope(rc, in, sendable.KindTurnProcessingAck, "live_ack", sendable.PriorityHigh),
+		})
+		rec.acted("live_ack", text, sent)
+		if sent.Sent {
+			scope := conversationTurnScope(rc.cfg.ProjectID, in.Scene, in.ConversationID)
+			m.markReplied(scope)
+			m.markAcknowledged(scope)
+		}
+	}
+
+	return liveOutcome{
+		reason: brief, dispatch: dispatch, sampleID: rec.commit(routeDispatch),
+	}, ""
+}
+
+// foregroundCapture holds a turn's diverted agent replies.
+//
+// The zero value is a no-op capture that yields nothing, which is exactly what
+// a turn without a conversation layer needs: pm_reply goes straight out as it
+// always did, and this side of the code does not have to know the difference.
+type foregroundCapture struct {
+	collect func() string
+	taken   bool
+	text    string
+	enabled bool
+}
+
+// beginForegroundCapture diverts this turn's pm_reply into the conversation
+// layer, when there is one to divert it into.
+//
+// Without a conversation model there is nobody to do the reporting, so the
+// agent keeps speaking for itself. That is a degradation, not a mode: the user
+// hears the work layer's own register, and the sample says so.
+func (m *Manager) beginForegroundCapture(rc *runningChannel, in InboundMessage) *foregroundCapture {
+	if m.live == nil || !m.live.Configured() {
+		return &foregroundCapture{}
+	}
+	collect, ok := m.captureAgentReplies(rc.cfg.ProjectID, in.Scene, in.ConversationID)
+	if !ok {
+		return &foregroundCapture{}
+	}
+	return &foregroundCapture{collect: collect, enabled: true}
+}
+
+// take ends the capture and returns what the agent submitted. Calling it twice
+// is safe: the second call returns the same text rather than an empty string,
+// so a deferred release cannot erase the answer.
+func (c *foregroundCapture) take() string {
+	if c == nil {
+		return ""
+	}
+	if c.taken {
+		return c.text
+	}
+	c.taken = true
+	if c.collect != nil {
+		c.text = strings.TrimSpace(ScrubInternalTerms(c.collect()))
+	}
+	return c.text
+}
+
+func (c *foregroundCapture) release() {
+	if c != nil {
+		_ = c.take()
+	}
+}
+
+// egress names who ended up speaking, for the decision record.
+func (c *foregroundCapture) egress(degraded bool) string {
+	if c == nil || !c.enabled || degraded {
+		return egressPMDirect
+	}
+	return egressDirector
+}
+
+// reportThroughDirector puts the work layer's conclusion into the voice the
+// user has been hearing all along.
+//
+// This is rephrasing, not rewriting. The facts come from the agent, which is
+// the only layer that checked them; the conversation layer is only allowed to
+// say them the way it says everything else. When it cannot — no model, a slow
+// endpoint, an empty completion — the agent's own words go out scrubbed, which
+// reads slightly off but is true. degraded reports which of the two happened.
+func (m *Manager) reportThroughDirector(ctx context.Context, rc *runningChannel, in InboundMessage,
+	conclusion string) (text string, degraded bool) {
+	plain := strings.TrimSpace(ScrubInternalTerms(conclusion))
+	if m.live == nil || !m.live.Configured() || plain == "" {
+		return plain, true
+	}
+	callCtx, cancel := context.WithTimeout(ctx, directorReportTimeout)
+	defer cancel()
+
+	res, err := m.live.Complete(callCtx, liveagent.Request{
+		System: directorReportPrompt,
+		Messages: []liveagent.Message{
+			{Role: "user", Content: "对方问的是：" + truncateRunes(strings.TrimSpace(in.Text), 200)},
+			{Role: "user", Content: "查到的结果：" + truncateRunes(plain, 1200)},
+		},
+		MaxTokens: directorReportMaxTokens,
+	})
+	if err != nil || strings.TrimSpace(res.Text) == "" {
+		log.Info().Err(err).Str("project", rc.cfg.ProjectID).
+			Msg("conclusion reported in the work layer's own words; the conversation model did not phrase it")
+		return plain, true
+	}
+	return strings.TrimSpace(res.Text), false
+}
+
+// directorReportTimeout bounds the extra hop between having an answer and
+// sending it. The user has already waited for the work; a slow phrasing call
+// must cost them nothing more than this.
+const directorReportTimeout = 3 * time.Second
+
+const directorReportMaxTokens = 800
+
+// directorReportPrompt is deliberately narrow. Anything that invites the model
+// to add, judge, or expand turns a verified conclusion into a partly invented
+// one, which is the exact failure this whole layer exists to prevent.
+const directorReportPrompt = `你是这个项目的负责人本人，正在 IM 上和同事聊天。你的回复会原样发给对方。
+
+下面给你的是查到的结果。把它讲给对方听。
+
+规矩：
+- 只讲给出的事实。不要补充、不要推测、不要下额外结论、不要建议。
+- 结果本身已经说得清楚的，几乎原样转述就行，不要为了改写而改写。
+- 说人话，像同事之间当面说，不要写报告，不要分点罗列（除非结果本身就是几条并列的事）。
+- 不要出现任务编号、工作流名、执行环境、工具名这些内部说法。
+- 只输出要发出去的话，不要加前缀、标题或解释。`
+
+// warmWorkLayer brings the agent's sandbox up in the background.
+//
+// It runs at most once per conversation. Waking a container on every chat
+// message would spend more than it saves, and a conversation that never
+// delegates should not be paying for an agent it does not use.
+func (m *Manager) warmWorkLayer(rc *runningChannel, in InboundMessage) {
+	if m.bridge == nil {
+		return
+	}
+	key := convKey(rc.cfg.ProjectID, in.Scene, in.ConversationID)
+	m.warmMu.Lock()
+	if m.warmed == nil {
+		m.warmed = map[string]bool{}
+	}
+	if m.warmed[key] {
+		m.warmMu.Unlock()
+		return
+	}
+	m.warmed[key] = true
+	m.warmMu.Unlock()
+
+	bridge, ref, caps := m.bridge, conversationRefFor(rc, in), SessionCapsFromConfig(rc.cfg.Config)
+	projectID := rc.cfg.ProjectID
+	go func() {
+		ctx, cancel := context.WithTimeout(m.baseCtx, sandboxOpenBudget)
+		defer cancel()
+		bridge.Warm(ctx, projectID, ref, caps)
+	}()
+}
+
+// conversationAttachments names the files already in this conversation so the
+// delegation can point at them. The conversation layer cannot see their
+// contents; it only has to know they exist and where.
+func (m *Manager) conversationAttachments(rc *runningChannel, in InboundMessage) []AttachmentRef {
+	b, ok := m.transcript.(*ChannelBridge)
+	if !ok || b == nil {
+		return nil
+	}
+	return b.RecentAttachments(conversationRefFor(rc, in))
+}
+
+// gateAcknowledgement keeps an acknowledgement from being a fixed template
+// wearing the model's voice.
+//
+// An earlier version of this platform shipped "稍等，我看一下" as a literal
+// constant before every turn, which is why that phrase is now banned outright.
+// The ban alone is not the fix: a model that says the same empty thing in its
+// own words leaves the user exactly as uninformed. So an acknowledgement has to
+// name what is being checked, and one that does not is replaced by a line that
+// does — and flagged, because the replacement is a symptom worth counting.
+func gateAcknowledgement(reply, shortTitle, userText string) (string, []string) {
+	text := strings.TrimSpace(reply)
+	if informative := stripFiller(text); len([]rune(informative)) >= 6 {
+		return text, nil
+	}
+	title := services.SanitizeShortTitle(shortTitle)
+	if title == "" {
+		title = truncateRunes(strings.TrimSpace(userText), 20)
+	}
+	flags := []string{"empty_ack"}
+	if title == "" {
+		return "我这就去确认，有结果马上回你。", flags
+	}
+	return "「" + title + "」我这就去确认，有结果马上回你。", flags
+}
+
+// ackFiller lists the phrases that carry no information on their own. This is
+// not a routing table — nothing is decided from it. It only measures how much
+// of the platform's own acknowledgement would still be there once the polite
+// noise is removed.
+var ackFiller = []string{
+	"稍等", "等一下", "等等", "好的", "好嘞", "行", "收到", "我看一下", "看一下",
+	"我来看看", "看看", "马上", "这就", "我处理一下", "处理一下", "ok", "okay",
+	"sure", "let me", "one moment", "a moment", "hold on", "on it", "got it",
+}
+
+func stripFiller(s string) string {
+	lower := strings.ToLower(s)
+	for _, f := range ackFiller {
+		lower = strings.ReplaceAll(lower, f, "")
+	}
+	return strings.TrimFunc(lower, func(r rune) bool {
+		return strings.ContainsRune(" \t\n，。！!,.…~、？?", r)
+	})
+}
+
+func parseDifficulty(v string) Difficulty {
+	if strings.EqualFold(strings.TrimSpace(v), string(DifficultyHeavy)) {
+		return DifficultyHeavy
+	}
+	return DifficultyLookup
+}
+
+// parseLooseBool accepts what models actually emit for a boolean argument.
+func parseLooseBool(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "true", "1", "yes", "y", "是":
+		return true
+	}
+	return false
+}
+
+// toolResultMessage feeds a tool result back as conversation.
+//
+// The transport speaks plain chat completions against any OpenAI-compatible
+// endpoint, several of which handle a "tool" role badly or not at all. A
+// labelled user message is understood everywhere and costs nothing in accuracy
+// for results this small.
+func toolResultMessage(tool, result string) liveagent.Message {
+	return liveagent.Message{
+		Role: "user",
+		Content: "[系统] " + tool + " 返回：" + result +
+			"\n用这个结果直接回答对方，不要再调用同一个工具。",
+	}
+}
+
+func directorTools() []liveagent.ToolSpec {
+	return []liveagent.ToolSpec{
+		{
+			Name: dispatchPMTool,
+			Description: "把这件事派给能读代码仓库、能查真实状态、能动手干活的人。" +
+				"任何需要事实依据或需要执行的事情都用它，不要自己猜。",
+			Params: []liveagent.Param{
+				{Name: "request", Description: "用一句话说清对方要什么，供接手的人直接开工。", Required: true},
+				{
+					Name:        "difficulty",
+					Description: "lookup=查一下就知道；heavy=要花好几分钟。",
+					Enum:        []string{string(DifficultyLookup), string(DifficultyHeavy)},
+					Required:    true,
+				},
+				{Name: "short_title", Description: "给这件事起个对方看得懂的短名字，例如「登录页报错」。", Required: true},
+				{Name: "user_reply", Description: "现在就发给对方的一句话。heavy 必填，要说清楚你去确认的是哪件事。"},
+				{Name: "wait", Description: "只有 lookup 能填 true：不先接话，查完一次性回答。"},
+			},
+		},
+		{
+			Name: getStatusTool,
+			Description: "查这个会话里正在跑的任务的真实状态。" +
+				"要跟对方讲进度、状态或结论之前必须先调它，不要凭印象说。",
+			Params: []liveagent.Param{
+				{Name: "task_id", Description: "只查某一件事时填它的 taskId；不填就列出全部。"},
+			},
+		},
+		{
+			Name:        cancelWorkTool,
+			Description: "停掉正在跑的任务。对方说不用弄了、停下、算了的时候用。",
+			Params: []liveagent.Param{
+				{Name: "task_id", Description: "要停的那件事的 taskId。只有一件在跑时可以不填。"},
+			},
+		},
 	}
 }
 

--- a/server/internal/channels/live_sample.go
+++ b/server/internal/channels/live_sample.go
@@ -1,0 +1,167 @@
+package channels
+
+import (
+	"strings"
+
+	"github.com/cocofhu/approving/internal/liveagent"
+	"github.com/cocofhu/approving/internal/models"
+
+	"github.com/rs/zerolog/log"
+)
+
+// Recording what the conversation layer decided is a feature, not telemetry.
+//
+// Four rounds of this design were corrected the same way: someone reported a
+// bad reply, a phrase went on a ban list, and nobody could say whether routing
+// had improved or merely moved. A decision that is not recorded can only be
+// argued about. One that is — with the briefing the model saw, what it
+// produced, what the tools returned, and what the user actually received — can
+// be replayed, counted, and eventually trained on.
+
+// Route names a decision in one word so samples can be counted without parsing.
+const (
+	routeReply       = "reply"
+	routeDispatch    = "dispatch"
+	routeFallthrough = "fallthrough"
+)
+
+// Egress names which layer spoke to the user. The direct case is the
+// degradation path, and it is recorded rather than assumed rare.
+const (
+	egressDirector = "director"
+	egressPMDirect = "pm_direct"
+)
+
+// sampleRecorder accumulates one turn's decision. A nil recorder is usable and
+// does nothing, so call sites do not branch on whether sampling is configured.
+type sampleRecorder struct {
+	m      *Manager
+	sample models.LiveDecisionSample
+
+	completions []map[string]any
+	toolResults []map[string]any
+	actions     []map[string]any
+	flags       []string
+}
+
+func (m *Manager) newSampleRecorder(rc *runningChannel, in InboundMessage) *sampleRecorder {
+	return &sampleRecorder{
+		m: m,
+		sample: models.LiveDecisionSample{
+			ProjectID: rc.cfg.ProjectID, Channel: rc.cfg.Type, Scene: string(in.Scene),
+			ConversationID: in.ConversationID,
+			TurnID:         turnScope(rc, in),
+			UserMessageID:  strings.TrimSpace(in.RecordedMessageID),
+			UserText:       strings.TrimSpace(in.Text),
+			Egress:         egressDirector,
+		},
+	}
+}
+
+func (r *sampleRecorder) briefedWith(dc directorContext) {
+	if r == nil {
+		return
+	}
+	r.sample.DirectorContext = encodeToolResult(dc)
+}
+
+func (r *sampleRecorder) shown(messages []liveagent.Message) {
+	if r == nil {
+		return
+	}
+	window := make([]map[string]any, 0, len(messages))
+	for _, msg := range messages {
+		window = append(window, map[string]any{"role": msg.Role, "content": msg.Content})
+	}
+	r.sample.Transcript = encodeToolResult(window)
+}
+
+func (r *sampleRecorder) completed(res liveagent.Result) {
+	if r == nil {
+		return
+	}
+	r.completions = append(r.completions, map[string]any{
+		"text": res.Text, "tool": res.ToolName, "args": res.Args,
+	})
+}
+
+func (r *sampleRecorder) failed(err error) {
+	if r == nil || err == nil {
+		return
+	}
+	r.completions = append(r.completions, map[string]any{"error": err.Error()})
+	r.flags = append(r.flags, "model_unavailable")
+}
+
+func (r *sampleRecorder) toolReturned(tool string, args map[string]string, result string) {
+	if r == nil {
+		return
+	}
+	r.toolResults = append(r.toolResults, map[string]any{
+		"tool": tool, "args": args, "result": result,
+	})
+}
+
+// acted records something the platform tried to send, delivered or not. A
+// suppressed message is as interesting as a sent one: it is usually where a
+// turn went quiet.
+func (r *sampleRecorder) acted(reason, text string, result DeliveryResult) {
+	if r == nil {
+		return
+	}
+	r.actions = append(r.actions, map[string]any{
+		"reason": reason, "text": text,
+		"sent": result.Sent, "decision": result.Decision.Reason,
+	})
+}
+
+func (r *sampleRecorder) flag(flags ...string) {
+	if r == nil {
+		return
+	}
+	for _, f := range flags {
+		if strings.TrimSpace(f) != "" {
+			r.flags = append(r.flags, f)
+		}
+	}
+}
+
+func (r *sampleRecorder) degraded() {
+	if r == nil {
+		return
+	}
+	r.sample.Degraded = true
+	r.sample.Egress = egressPMDirect
+}
+
+// commit writes the sample and returns its id, which links a decision made now
+// to a conclusion that arrives minutes later.
+func (r *sampleRecorder) commit(route string) string {
+	if r == nil || r.m == nil || r.m.samples == nil {
+		return ""
+	}
+	r.sample.Route = route
+	r.sample.RawCompletion = encodeToolResult(r.completions)
+	r.sample.ToolResults = encodeToolResult(r.toolResults)
+	r.sample.Actions = encodeToolResult(r.actions)
+	r.sample.QualityFlags = r.flags
+	id, err := r.m.samples.Record(r.sample)
+	if err != nil {
+		log.Debug().Err(err).Str("project", r.sample.ProjectID).
+			Msg("conversation decision not recorded")
+		return ""
+	}
+	return id
+}
+
+// attachSampleOutcome completes a delegation's record once the work layer has
+// something to say. Best-effort: a lost sample costs a training example, never
+// a reply.
+func (m *Manager) attachSampleOutcome(sampleID, outcome, egress string) {
+	if m.samples == nil || strings.TrimSpace(sampleID) == "" {
+		return
+	}
+	if err := m.samples.AttachOutcome(sampleID, truncateRunes(outcome, 2000), egress); err != nil {
+		log.Debug().Err(err).Msg("work outcome not attached to its decision sample")
+	}
+}

--- a/server/internal/channels/manager.go
+++ b/server/internal/channels/manager.go
@@ -94,17 +94,27 @@ type Manager struct {
 	convMu     sync.Mutex
 	convQueues map[string]*convQueue
 
+	// busyHintMu guards the per-conversation rate limits: the backlog notice and
+	// the progress floor. Both answer the same question — when may this
+	// conversation be interrupted again — so they share a lock.
 	busyHintMu   sync.Mutex
 	busyHintSent map[string]time.Time
+	progressSent map[string]time.Time
 
 	repliedMu sync.Mutex
 	replied   map[string]bool
 	// answered is the stricter marker: this turn has already delivered an
-	// answer, not merely something user-visible. Progress milestones and run
-	// acknowledgements set replied but not this, because suppressing the actual
-	// answer because a progress line went out first is worse than the double
-	// reply the marker exists to prevent.
+	// answer, not merely something user-visible. Progress milestones set
+	// replied but not this, because suppressing the actual answer because a
+	// progress line went out first is worse than the double reply the marker
+	// exists to prevent.
 	answered map[string]bool
+	// acked records that the conversation layer already told the user this is
+	// being picked up. It is separate from replied because only one thing may
+	// be suppressed by it — the platform's own run acceptance notice — and
+	// suppressing that on the strength of any progress line would lose the only
+	// confirmation some delegations ever send.
+	acked map[string]bool
 
 	// synthesize rewrites background events for the conversation they belong
 	// to. nil means outcomes go out as structured fallbacks.
@@ -112,6 +122,24 @@ type Manager struct {
 
 	captureMu sync.Mutex
 	captured  map[string]*string
+
+	// warmed marks conversations whose sandbox has been brought up ahead of
+	// being needed, so the pre-warm happens once rather than on every message.
+	warmMu sync.Mutex
+	warmed map[string]bool
+
+	// workNotes is the conversation layer's memory of what the work layer last
+	// reported, keyed by project|run. It exists so a progress question is
+	// answered from something observed rather than from the model's impression
+	// of how long ago it delegated.
+	noteMu    sync.Mutex
+	workNotes map[string]workNote
+
+	// samples records what the conversation layer decided and why. Every
+	// previous round of this design was tuned by adding banned phrases, because
+	// nothing recorded the decisions well enough to tell whether routing had
+	// actually improved. nil means sampling is off.
+	samples *services.LiveSampleService
 
 	pushMu     sync.Mutex
 	pushQueues map[string]*pushQueue
@@ -161,8 +189,11 @@ func NewManager(bridge *ChannelBridge, factories map[string]AdapterFactory, decr
 		convQueues:   map[string]*convQueue{},
 		pushQueues:   map[string]*pushQueue{},
 		busyHintSent: map[string]time.Time{},
+		progressSent: map[string]time.Time{},
 		replied:      map[string]bool{},
 		answered:     map[string]bool{},
+		acked:        map[string]bool{},
+		workNotes:    map[string]workNote{},
 		baseCtx:      context.Background(),
 		policy:       sendable.NewPolicy(nil, nil),
 	}
@@ -187,6 +218,13 @@ func (m *Manager) SetSendablePolicy(policy *sendable.Policy) {
 // SetRetryBackoff overrides the outbound retry backoff schedule.
 func (m *Manager) SetRetryBackoff(backoff func(attempt int) time.Duration) {
 	m.retryBackoff = backoff
+}
+
+// SetLiveSampleService installs the decision recorder for the conversation
+// layer. Without it the platform still runs, but nothing can be learned from
+// how it routed.
+func (m *Manager) SetLiveSampleService(service *services.LiveSampleService) {
+	m.samples = service
 }
 
 // SetTaskContextService exposes DB-backed task identity/focus to orchestration.
@@ -386,9 +424,13 @@ func (m *Manager) dispatch(ctx context.Context, rc *runningChannel, in InboundMe
 	// this system used to feel like filing tickets.
 	outcome := m.routeThroughLiveModel(ctx, rc, in)
 	if outcome.answered {
+		// The conversation is moving without the work layer, which is the good
+		// case and also the moment to get it ready: the next message that does
+		// need it should not pay for a container.
+		m.warmWorkLayer(rc, in)
 		return
 	}
-	in.EscalationReason = outcome.reason
+	outcome.applyTo(&in)
 
 	key := convKey(rc.cfg.ProjectID, in.Scene, in.ConversationID)
 	q := m.convQueueFor(key)
@@ -425,7 +467,7 @@ func (m *Manager) handleInbound(ctx context.Context, rc *runningChannel, in Inbo
 	if outcome.answered {
 		return
 	}
-	in.EscalationReason = outcome.reason
+	outcome.applyTo(&in)
 	m.runTurn(ctx, rc, in)
 }
 
@@ -546,20 +588,33 @@ func (m *Manager) drainConvQueue(q *convQueue, key string) {
 	}
 }
 
-// runTurn executes one foreground Live turn.
+// runTurn executes one foreground work turn.
 //
 // The turn is expected to either answer briefly or delegate, and it is bounded
-// so a conversation is never held open by work that belongs in a Run. No
-// acknowledgement precedes it — the reply is the acknowledgement.
+// so a conversation is never held open by work that belongs in a Run. What the
+// agent produces does not go to the user directly: it is captured and reported
+// by the conversation layer, so the user hears one voice for the whole
+// exchange. The capture is dropped when there is no conversation layer to
+// report through, because a silent turn is worse than one in the wrong register.
 func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMessage) {
 	// Keyed by conversation, not by inbound message id: the MCP host marks its
 	// own replies and only knows which conversation it is serving.
 	scope := conversationTurnScope(rc.cfg.ProjectID, in.Scene, in.ConversationID)
 	m.clearReplied(scope)
-	defer m.clearReplied(scope)
+	// An acknowledgement the conversation layer already sent belongs to this
+	// turn: the user has heard from us, even though the turn is only starting
+	// now. Carrying it across is what stops the timeout path from apologising
+	// for silence a moment after promising a result.
+	if m.hasAcknowledged(scope) {
+		m.markReplied(scope)
+	}
+	defer m.clearTurnMarkers(scope)
 
 	pendingID := m.beginPendingTurn(rc, in)
 	defer m.endPendingTurn(pendingID)
+
+	collect := m.beginForegroundCapture(rc, in)
+	defer collect.release()
 
 	timeout := foregroundTurnTimeout
 	if configured := time.Duration(rc.cfg.TurnTimeoutSeconds) * time.Second; configured > 0 {
@@ -577,32 +632,9 @@ func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMes
 		TurnTimeout: timeout,
 		Caps:        SessionCapsFromConfig(rc.cfg.Config),
 	}
-	// Foreground turns stay silent until the single final answer (or a real
-	// RunAcceptanceAck after pm_start_run). Fixed stillWorking templates and
-	// streaming openers are hard-disabled — they caused multi-send UX noise.
-	onProgress := func(ev ProgressEvent) {
-		text := FormatProgressText(ev)
-		if text == "" {
-			return
-		}
-		// live_first_sentence was an early-release opener; never user-visible.
-		if strings.TrimSpace(ev.Reason) == "live_first_sentence" {
-			return
-		}
-		// Classification-only events stay internal; sendOutbound still runs so
-		// the suppression is audited with a reason instead of vanishing.
-		result := m.sendOutboundResult(ctx, rc, OutboundMessage{
-			Scene: in.Scene, ConversationID: in.ConversationID,
-			ReplyToMessageID: in.MessageID, Text: text,
-			Envelope: progressEnvelope(rc, in, ev),
-		})
-		// A delivered milestone is the turn's first meaningful response; the
-		// final summary must not repeat it verbatim.
-		if result.Sent {
-			m.markReplied(scope)
-		}
-	}
+	onProgress := func(ev ProgressEvent) { m.reportProgress(ctx, rc, in, scope, ev) }
 	reply, err := m.handleTurn(turnCtx, resolved, in, onProgress)
+	captured := collect.take()
 	if err != nil {
 		// Running out of time is not a failure, but it is not a delegation
 		// either: nothing was started and nothing is still running. Saying "I'll
@@ -625,7 +657,12 @@ func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMes
 		return
 	}
 
-	summary, reason, ok := deliverableFinalText(reply)
+	// What the agent answered through pm_reply is the conclusion; the turn's
+	// own final summary is the fallback for an agent that ended without one.
+	summary, reason, ok := captured, "pm_reply_captured", captured != ""
+	if !ok {
+		summary, reason, ok = deliverableFinalText(reply)
+	}
 	if !ok {
 		// The agent finished without submitting anything the user can read. If
 		// something substantive already went out this turn, staying quiet is the
@@ -641,21 +678,87 @@ func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMes
 		})
 		return
 	}
-	// Something user-visible already left this turn (pm_reply, RunAcceptanceAck,
-	// or a real progress milestone). Do not append a second FinalSummary — that
-	// is the "answer + wrap-up" double-send the markReplied gate exists to stop.
-	if m.hasReplied(scope) {
+	// An acknowledgement or a progress line is not an answer, so neither may be
+	// the reason a conclusion is withheld. Only a delivered answer is.
+	if m.hasAnswered(scope) {
 		return
 	}
-	m.sendOutbound(ctx, rc, OutboundMessage{
+	final, degraded := m.reportThroughDirector(ctx, rc, in, summary)
+	m.attachSampleOutcome(in.DecisionSampleID, summary, collect.egress(degraded))
+	sent := m.sendOutboundResult(ctx, rc, OutboundMessage{
 		Scene: in.Scene, ConversationID: in.ConversationID, ReplyToMessageID: in.MessageID,
-		Text: summary, ImageURLs: reply.ImageURLs,
+		Text: final, ImageURLs: reply.ImageURLs,
 		Envelope: func() sendable.DeliveryEnvelope {
 			e := turnEnvelope(rc, in, sendable.KindFinal, reason, sendable.PriorityCritical)
 			e.Structured = true
 			return e
 		}(),
 	})
+	if sent.Sent {
+		m.markAnswered(scope)
+	}
+}
+
+// progressReportInterval rate-limits progress lines per conversation.
+//
+// A minute-scale task can emit a dozen classified milestones, and forwarding
+// each one turns an update into a stream the user has to read past to find the
+// answer. Earlier rounds fixed this by banning progress entirely, which traded
+// noise for silence; a floor between reports keeps the update and drops the
+// stream.
+const progressReportInterval = 90 * time.Second
+
+// reportProgress records what the work layer observed and, at most once per
+// interval, says it out loud.
+func (m *Manager) reportProgress(ctx context.Context, rc *runningChannel, in InboundMessage,
+	scope string, ev ProgressEvent) {
+	// live_first_sentence was an early-release opener that raced the answer;
+	// never user-visible.
+	if strings.TrimSpace(ev.Reason) == "live_first_sentence" {
+		return
+	}
+	// The ledger records everything, including events too minor to interrupt
+	// with, so a later "how's it going" can answer from the newest one.
+	m.noteWorkProgress(rc.cfg.ProjectID, ev.RunID, ev.Stage+ev.Summary,
+		ev.Blocked || ev.Kind == ProgressBlocker)
+
+	text := FormatProgressText(ev)
+	if text == "" {
+		return
+	}
+	text = m.labelProgress(rc, in, ev, text)
+	// A blocker or a question needs the user now; ordinary progress waits its
+	// turn. Suppression still goes through sendOutbound so it is audited with a
+	// reason rather than vanishing.
+	urgent := ev.Blocked || ev.ActionRequired ||
+		ev.Kind == ProgressBlocker || ev.Kind == ProgressConfirm
+	if !urgent && !m.progressDue(scope) {
+		return
+	}
+	result := m.sendOutboundResult(ctx, rc, OutboundMessage{
+		Scene: in.Scene, ConversationID: in.ConversationID,
+		ReplyToMessageID: in.MessageID, Text: text,
+		Envelope: progressEnvelope(rc, in, ev),
+	})
+	if result.Sent {
+		// Spoken, but not answered: the conclusion still has to go out.
+		m.markReplied(scope)
+	}
+}
+
+// progressDue claims this conversation's next progress slot.
+func (m *Manager) progressDue(scope string) bool {
+	now := time.Now()
+	m.busyHintMu.Lock()
+	defer m.busyHintMu.Unlock()
+	if last, seen := m.progressSent[scope]; seen && now.Sub(last) < progressReportInterval {
+		return false
+	}
+	if m.progressSent == nil {
+		m.progressSent = map[string]time.Time{}
+	}
+	m.progressSent[scope] = now
+	return true
 }
 
 // sandboxOpenBudget is the cold-start allowance for this Manager.
@@ -1205,6 +1308,34 @@ func (m *Manager) clearReplied(scope string) {
 	m.repliedMu.Lock()
 	delete(m.replied, scope)
 	delete(m.answered, scope)
+	m.repliedMu.Unlock()
+}
+
+// markAcknowledged records that the user has been told this turn's work is
+// being picked up, so the platform does not say it a second time in its own
+// words when the agent starts the Run.
+func (m *Manager) markAcknowledged(scope string) {
+	if strings.TrimSpace(scope) == "" {
+		return
+	}
+	m.repliedMu.Lock()
+	m.acked[scope] = true
+	m.repliedMu.Unlock()
+}
+
+func (m *Manager) hasAcknowledged(scope string) bool {
+	m.repliedMu.Lock()
+	defer m.repliedMu.Unlock()
+	return m.acked[scope]
+}
+
+// clearTurnMarkers ends a turn: nothing it said may suppress anything in the
+// next one.
+func (m *Manager) clearTurnMarkers(scope string) {
+	m.repliedMu.Lock()
+	delete(m.replied, scope)
+	delete(m.answered, scope)
+	delete(m.acked, scope)
 	m.repliedMu.Unlock()
 }
 

--- a/server/internal/channels/preamble.go
+++ b/server/internal/channels/preamble.go
@@ -45,13 +45,16 @@ func ChannelPreamble(channelType string) string {
 			"需要发图片时，在 pm_reply 的 text 里用 Markdown 图片语法给出可公网访问的直链，例如 ![](https://example.com/x.png)；" +
 			"不要给本地路径或需要鉴权的链接。",
 
-		"【上下文交接】提示里如果出现 <conversation_handoff> 段，那是你没有参与的那几轮对话（用户说过什么、" +
-			"平台已经替你回过什么）。它是背景，不是新的请求；真正要你处理的是它后面那条用户消息。" +
-			"不要把已经回过的话再说一遍。",
+		"【上下文自己取】提示里不会再附带这个会话的历史对话。" +
+			"提示里如果出现 <work_brief> 段，那是会话层转交给你的要求、任务名和附件线索，不是用户的新消息。" +
+			"遇到「刚才那个」「上面说的」这类指代，或者需要知道用户之前说过什么、平台已经替你回过什么，" +
+			"先用 context-store 的 get_messages / search_messages 拉取，再回答；不要凭印象猜，也不要把已经回过的话再说一遍。",
 
-		"【附件】用户发的图片和文件已经写成沙箱本地文件，用绝对路径直接读。" +
-			"历史附件如果太大没有随本轮带过来，交接段里会列出文件名和所属消息 id，" +
-			"需要时用 context-store 的 get_attachment 按 id 取回。",
+		"【附件】用户本轮发的图片和文件已经写成沙箱本地文件，用绝对路径直接读。" +
+			"更早的附件不会随本轮下发：<work_brief> 里会列出文件名、messageId 和 index，" +
+			"没列出的用 context-store 的 get_messages 查附件清单，" +
+			"再用 get_attachment 按 messageId+index 取回内容。" +
+			"用户提到「刚才那张图」时，先查清单再取，不要说自己看不到。",
 
 		"【先查再答】通过 pm-leader / context-store / memory-store 等 MCP 工具获取项目进度、记忆与历史后再作答，不要编造。",
 

--- a/server/internal/channels/reflow.go
+++ b/server/internal/channels/reflow.go
@@ -93,18 +93,10 @@ func (m *Manager) synthesizeOutcome(ctx context.Context, identity *models.TaskId
 	if m.synthesize == nil {
 		return fallback
 	}
-	// Synthesis borrows the conversation's agent, which can answer through
-	// pm_reply. Capturing that reply instead of letting it out keeps delivery
-	// in one place, so the outcome is sent exactly once with the dedupe key
-	// that guarantees it. A conversation already running a turn is left alone:
-	// interleaving a synthesis turn there would both fail and risk capturing
-	// the user's own answer.
-	take, ok := m.tryCaptureReply(identity.ProjectID, scene, conv)
-	if !ok {
-		log.Debug().Str("run", identity.RunID).
-			Msg("reflow: conversation is busy, using structured fallback")
-		return fallback
-	}
+	// Phrasing happens in the conversation layer, which is not the layer doing
+	// the work. That is what lets an outcome be reported while the agent is
+	// still busy: synthesis used to borrow the conversation's own agent, so a
+	// conversation with a turn in flight got the template instead of a sentence.
 	req := SynthesisRequest{
 		ProjectID: identity.ProjectID, Scene: scene, ConversationID: conv,
 		ExternalUserID: identity.OriginExternalUserID,
@@ -113,10 +105,6 @@ func (m *Manager) synthesizeOutcome(ctx context.Context, identity *models.TaskId
 		Brief: outcomeBrief(identity, outcome, language),
 	}
 	text, err := m.synthesize(ctx, req)
-	captured := take()
-	if strings.TrimSpace(text) == "" {
-		text = captured
-	}
 	if strings.TrimSpace(text) == "" {
 		log.Info().Err(err).Str("run", identity.RunID).
 			Msg("reflow: natural-language synthesis unavailable, using structured fallback")
@@ -149,20 +137,20 @@ type SynthesisFunc func(ctx context.Context, req SynthesisRequest) (string, erro
 // SetSynthesizer wires natural-language reflow (nil keeps structured fallbacks).
 func (m *Manager) SetSynthesizer(fn SynthesisFunc) { m.synthesize = fn }
 
-// tryCaptureReply diverts this conversation's agent replies into a buffer
+// captureAgentReplies diverts this conversation's agent replies into a buffer
 // instead of the channel, and returns a function that ends the capture and
-// yields whatever was collected. It reports false when a foreground turn is
-// already running, because that turn's replies belong to the user.
-func (m *Manager) tryCaptureReply(projectID string, scene Scene, conv string) (take func() string, ok bool) {
+// yields whatever was collected.
+//
+// This is what makes one voice possible. The agent answers through pm_reply,
+// which used to go straight to the channel — so the user heard the work layer
+// directly, in its own register, sometimes twice in a turn, and the
+// conversation layer had no idea what had been said. Capturing turns that
+// answer into an internal result the conversation layer can report.
+//
+// It reports false when the conversation is already under capture, because two
+// captures would split one answer between them.
+func (m *Manager) captureAgentReplies(projectID string, scene Scene, conv string) (take func() string, ok bool) {
 	key := convKey(projectID, scene, conv)
-	q := m.convQueueFor(key)
-	q.mu.Lock()
-	busy := q.busy
-	q.mu.Unlock()
-	if busy {
-		return nil, false
-	}
-
 	m.captureMu.Lock()
 	if m.captured == nil {
 		m.captured = map[string]*string{}

--- a/server/internal/channels/types.go
+++ b/server/internal/channels/types.go
@@ -76,6 +76,64 @@ type InboundMessage struct {
 	// EscalationReason is why the conversation model handed this turn to the
 	// agent. Empty when no conversation model was involved.
 	EscalationReason string
+	// Dispatch is what the director decided about this turn. Empty when the
+	// turn reached the agent without one (no conversation model, or a failure
+	// that fell through to it).
+	Dispatch *WorkDispatch
+	// DecisionSampleID links this turn back to the recorded routing decision,
+	// so the work layer's eventual conclusion lands on the choice that produced
+	// it rather than in a separate row nothing joins.
+	DecisionSampleID string
+}
+
+// WorkDispatch is the director's delegation: what the agent is being asked to
+// do, and the pointers it needs to find the rest for itself.
+//
+// It deliberately carries no conversation replay. The agent reads history
+// through context-store when it needs it, so a long-running conversation costs
+// a prompt that stays the same size instead of one that grows with every turn.
+type WorkDispatch struct {
+	// Brief is one sentence stating what the user wants, written for the agent.
+	Brief string
+	// Difficulty is the director's estimate: DifficultyLookup for a question
+	// that needs a real check, DifficultyHeavy for work that outlives a chat
+	// turn.
+	Difficulty Difficulty
+	// TaskID / ShortTitle identify this work in the conversation's ledger.
+	TaskID     string
+	ShortTitle string
+	// Attachments are files already in this conversation that the agent may
+	// need. Pointers only: the bytes stay in context-store until it asks.
+	Attachments []AttachmentRef
+}
+
+// Difficulty is how much work the director thinks a turn needs. It decides
+// whether the user is answered now and told later, or simply waited with.
+type Difficulty string
+
+const (
+	// DifficultyLookup is a real check the user can reasonably wait a moment
+	// for. The director may hold the turn briefly and answer once.
+	DifficultyLookup Difficulty = "lookup"
+	// DifficultyHeavy is work measured in minutes. The user is answered first
+	// and the work is delegated behind the conversation.
+	DifficultyHeavy Difficulty = "heavy"
+)
+
+// AttachmentRef points at one file already stored in the conversation.
+//
+// It exists so an attachment can be named without being carried: the bytes of
+// an image sent five turns ago do not belong in every later prompt, but
+// "there is a screenshot, here is where it lives" does.
+type AttachmentRef struct {
+	MessageID string
+	Index     int
+	Name      string
+	MimeType  string
+	Bytes     int
+	// Role is who sent it ("user" / "assistant"), so the agent can tell a file
+	// it was given from one it produced.
+	Role string
 }
 
 // OutboundMessage is a normalized reply/push to a channel conversation.

--- a/server/internal/models/live_sample.go
+++ b/server/internal/models/live_sample.go
@@ -1,0 +1,56 @@
+package models
+
+import "time"
+
+// LiveDecisionSample is one complete record of the conversation layer deciding
+// what to do with a user message.
+//
+// It exists because every earlier attempt at this routing was corrected by
+// guesswork: a bad reply was reported, a phrase was added to a ban list, and
+// nobody could tell whether the next version routed better or merely differently.
+// A sample holds everything needed to replay the decision offline — what the
+// model was shown, what it produced, what the tools returned, and what the user
+// actually received — so the next change can be measured instead of argued.
+//
+// Attachments appear as manifests, never as bytes. A sample that carried images
+// would grow without limit and could not be exported for review.
+type LiveDecisionSample struct {
+	ID             string `gorm:"primaryKey;size:64" json:"id"`
+	ProjectID      string `gorm:"size:64;index:idx_live_sample_scope,priority:1" json:"projectId"`
+	Channel        string `gorm:"size:32" json:"channel,omitempty"`
+	Scene          string `gorm:"size:32" json:"scene,omitempty"`
+	ConversationID string `gorm:"size:191;index:idx_live_sample_scope,priority:2" json:"conversationId"`
+	TurnID         string `gorm:"size:191;index" json:"turnId,omitempty"`
+	UserMessageID  string `gorm:"size:191" json:"userMessageId,omitempty"`
+
+	UserText string `gorm:"type:text" json:"userText"`
+	// DirectorContext is the ledger snapshot the model was briefed with.
+	DirectorContext string `gorm:"type:text" json:"directorContext,omitempty"`
+	// Transcript is the conversation window the model was shown.
+	Transcript string `gorm:"type:text" json:"transcript,omitempty"`
+
+	Model string `gorm:"size:191" json:"model,omitempty"`
+	// RawCompletion is what the model produced, tool calls included, before the
+	// platform decided what to do with it.
+	RawCompletion string `gorm:"type:text" json:"rawCompletion,omitempty"`
+	// ToolResults is what each tool handed back, in call order.
+	ToolResults string `gorm:"type:text" json:"toolResults,omitempty"`
+	// Actions is what actually left the platform: reason and text per message.
+	Actions string `gorm:"type:text" json:"actions,omitempty"`
+	// Route names the decision in one word (reply / dispatch / status /
+	// cancel / fallthrough), so samples can be counted without parsing.
+	Route string `gorm:"size:32;index" json:"route,omitempty"`
+	// PMOutcome is what the work layer eventually concluded, filled in when the
+	// result comes back rather than at decision time.
+	PMOutcome string `gorm:"type:text" json:"pmOutcome,omitempty"`
+	// Egress records which layer spoke to the user, so the direct-send fallback
+	// can be counted rather than assumed rare.
+	Egress string `gorm:"size:32" json:"egress,omitempty"`
+
+	LatencyMs int  `json:"latencyMs"`
+	Degraded  bool `gorm:"index" json:"degraded"`
+	// QualityFlags marks decisions worth looking at, e.g. an acknowledgement
+	// that promised nothing verifiable.
+	QualityFlags []string  `gorm:"serializer:json" json:"qualityFlags,omitempty"`
+	CreatedAt    time.Time `gorm:"index" json:"createdAt"`
+}

--- a/server/internal/models/models.go
+++ b/server/internal/models/models.go
@@ -689,6 +689,7 @@ func AllModels() []any {
 		&SendableDeliveryReceipt{},
 		&TaskIdentity{}, &MessageBinding{}, &ConversationFocus{}, &RiskConfirmationTicket{},
 		&PendingChannelTurn{},
+		&LiveDecisionSample{},
 	}
 }
 

--- a/server/internal/models/pm.go
+++ b/server/internal/models/pm.go
@@ -34,14 +34,9 @@ type ChatThread struct {
 	Title string `json:"title"`
 	// SandboxRef stores the bound models.Sandbox.ID as a decimal string when a
 	// PM consult sandbox is live for this thread. Empty means unbound.
-	SandboxRef string `json:"sandboxRef,omitempty"`
-	// HandoffCursor is the last ChatMessage the sandbox agent has been shown.
-	// It is persisted rather than kept in memory because the alternative is a
-	// sandbox that either forgets the conversation or is handed the whole of it
-	// again every time the process restarts or the container reconnects.
-	HandoffCursor string    `json:"-"`
-	CreatedAt     time.Time `json:"createdAt"`
-	UpdatedAt     time.Time `json:"updatedAt"`
+	SandboxRef string    `json:"sandboxRef,omitempty"`
+	CreatedAt  time.Time `json:"createdAt"`
+	UpdatedAt  time.Time `json:"updatedAt"`
 }
 
 // Chat thread kinds.

--- a/server/internal/services/live_sample.go
+++ b/server/internal/services/live_sample.go
@@ -1,0 +1,106 @@
+package services
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// LiveSampleService persists conversation-layer decisions for later review and
+// tuning.
+//
+// Recording is best-effort by design. A sample that fails to write must never
+// cost the user their reply, so every call site logs and moves on; the dataset
+// is allowed to have holes, the conversation is not.
+type LiveSampleService struct {
+	db  *gorm.DB
+	now func() time.Time
+}
+
+func NewLiveSampleService(db *gorm.DB) *LiveSampleService {
+	return &LiveSampleService{db: db, now: time.Now}
+}
+
+// SetClock overrides the sample timestamp source (tests).
+func (s *LiveSampleService) SetClock(now func() time.Time) {
+	if now != nil {
+		s.now = now
+	}
+}
+
+// Record stores one decision and returns its id.
+func (s *LiveSampleService) Record(sample models.LiveDecisionSample) (string, error) {
+	if s == nil || s.db == nil {
+		return "", errors.New("live sample database is unavailable")
+	}
+	if strings.TrimSpace(sample.ID) == "" {
+		sample.ID = "lds-" + uuid.NewString()[:12]
+	}
+	if sample.CreatedAt.IsZero() {
+		sample.CreatedAt = s.now()
+	}
+	if err := s.db.Create(&sample).Error; err != nil {
+		return "", err
+	}
+	return sample.ID, nil
+}
+
+// AttachOutcome fills in what the work layer concluded for a decision that was
+// recorded before the work finished. The two halves of a delegation are minutes
+// apart, and a dataset that only holds the first half cannot show whether the
+// routing call was right.
+func (s *LiveSampleService) AttachOutcome(id, outcome, egress string) error {
+	if s == nil || s.db == nil {
+		return errors.New("live sample database is unavailable")
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil
+	}
+	updates := map[string]any{}
+	if outcome = strings.TrimSpace(outcome); outcome != "" {
+		updates["pm_outcome"] = outcome
+	}
+	if egress = strings.TrimSpace(egress); egress != "" {
+		updates["egress"] = egress
+	}
+	if len(updates) == 0 {
+		return nil
+	}
+	return s.db.Model(&models.LiveDecisionSample{}).Where("id = ?", id).Updates(updates).Error
+}
+
+// SampleQuery bounds an export.
+type SampleQuery struct {
+	ProjectID string
+	Since     time.Time
+	Limit     int
+}
+
+// List returns samples newest first, for offline review and export.
+func (s *LiveSampleService) List(q SampleQuery) ([]models.LiveDecisionSample, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("live sample database is unavailable")
+	}
+	limit := q.Limit
+	if limit <= 0 || limit > 500 {
+		limit = 200
+	}
+	db := s.db.Model(&models.LiveDecisionSample{})
+	if p := strings.TrimSpace(q.ProjectID); p != "" {
+		db = db.Where("project_id = ?", p)
+	}
+	if !q.Since.IsZero() {
+		db = db.Where("created_at >= ?", q.Since)
+	}
+	var out []models.LiveDecisionSample
+	if err := db.Order("created_at DESC").Limit(limit).Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/server/internal/services/pm.go
+++ b/server/internal/services/pm.go
@@ -877,19 +877,12 @@ func (s *PmService) CanonicalWindow(threadID string, n int) ([]models.ChatMessag
 	return s.canonicalQuery(threadID, n, nil)
 }
 
-// CanonicalSince returns the user-visible turns recorded after afterID, oldest
-// first, so a reader that has already seen everything up to that point can be
-// caught up with only what is new. An empty or unknown afterID yields the
-// bounded window instead, which is the correct answer for a reader starting
-// fresh.
-func (s *PmService) CanonicalSince(threadID, afterID string, n int) ([]models.ChatMessage, error) {
-	anchor, err := s.GetMessage(threadID, strings.TrimSpace(afterID))
-	if err != nil {
-		return s.CanonicalWindow(threadID, n)
-	}
-	return s.canonicalQuery(threadID, n, &anchor)
-}
-
+// A CanonicalSince / HandoffCursor pair used to live here: how far the thread's
+// sandbox had been caught up, so each turn could replay the conversation it had
+// missed. It is gone with the replay itself. The cursor modelled the agent as
+// something that had to be shown the whole conversation to know it, which made
+// every prompt grow with the conversation; the agent now reads what it needs
+// through context-store, so there is nothing to catch up.
 func (s *PmService) canonicalQuery(threadID string, n int, after *models.ChatMessage) ([]models.ChatMessage, error) {
 	if n <= 0 {
 		n = 20
@@ -911,21 +904,6 @@ func (s *PmService) canonicalQuery(threadID string, n int, after *models.ChatMes
 		newestFirst[i], newestFirst[j] = newestFirst[j], newestFirst[i]
 	}
 	return newestFirst, nil
-}
-
-// HandoffCursor reports the last message the thread's sandbox has been shown.
-func (s *PmService) HandoffCursor(threadID string) string {
-	var t models.ChatThread
-	if err := s.db.Select("handoff_cursor").First(&t, "id = ?", threadID).Error; err != nil {
-		return ""
-	}
-	return t.HandoffCursor
-}
-
-// SetHandoffCursor records how far the thread's sandbox has been caught up.
-func (s *PmService) SetHandoffCursor(threadID, messageID string) error {
-	return s.db.Model(&models.ChatThread{}).Where("id = ?", threadID).
-		Update("handoff_cursor", messageID).Error
 }
 
 // ListConversationsForAgent returns threads visible to a context-store session.

--- a/server/internal/services/task_context.go
+++ b/server/internal/services/task_context.go
@@ -411,6 +411,19 @@ func (s *TaskContextService) GetFocus(scope TaskScope, renew bool) (*models.Conv
 	return &focus, nil
 }
 
+// ExpireFocus drops a conversation's task pointer. It is called when the task
+// it points at is no longer something the conversation is about — a cancelled
+// task that stays in focus makes every later "那个" resolve to work nobody is
+// doing.
+func (s *TaskContextService) ExpireFocus(scope TaskScope) error {
+	if s == nil || s.db == nil {
+		return errors.New("task context database is unavailable")
+	}
+	return s.db.Where("project_id = ? AND user_id = ? AND channel = ? AND conversation_id = ?",
+		scope.ProjectID, scope.UserID, scope.Channel, scope.ConversationID).
+		Delete(&models.ConversationFocus{}).Error
+}
+
 type TaskCandidate struct {
 	Identity models.TaskIdentity
 	Score    int


### PR DESCRIPTION
## Summary
- 把 Live 建成会话总监：唯一对用户说话；用 `dispatch_pm` / `get_status` / `cancel_work` 管理任务，不再靠 `ask_project_agent` 二选一或全文 `conversation_handoff` 拼装。
- 沙箱改为 brief + context-store 渐进加载；本轮附件仍直传，历史附件只带指针并按需 `get_attachment`；前台 `pm_reply` 强制 capture 后由总监轻量终态汇报。
- 接入任务账本（Focus/Binding/`recent_attachments`）与 `live_decision_samples` 决策样本落盘，进度限频汇报，取消走消歧与账本更新。

## Test plan
- [x] `go test ./internal/channels/...`
- [x] `go test ./internal/...`
- [ ] IM：「xxx 修复了没」→ 有依据短答或 ack，不干等编造
- [ ] IM：工作中「好了没」→ 读 SoT 进度，不新开无关沙箱
- [ ] IM：上轮截图 +「按刚才那张图修」→ brief 含附件指针，沙箱可 `get_attachment`
- [ ] IM：两任务并行时进度带短标题；「算了别弄了」消歧或反问
- [ ] Live 不可用时 PM 可降级直发，样本标记 `degraded` / `pm_direct`


Made with [Cursor](https://cursor.com)