### PR TITLE
fix(channels): 总监层先 ack、去 240 截断，并加固 Ollama 总结

### DIFF
--- a/server/internal/channels/bridge.go
+++ b/server/internal/channels/bridge.go
@@ -743,16 +743,22 @@ func extractStructuredFinalSummary(text string) string {
 		trimmed := strings.TrimSpace(line)
 		for _, marker := range finalSummaryMarkers {
 			if strings.HasPrefix(trimmed, marker) {
-				return truncateRunes(strings.TrimSpace(strings.TrimPrefix(trimmed, marker)), 240)
+				return truncateRunes(strings.TrimSpace(strings.TrimPrefix(trimmed, marker)), agentConclusionLimit)
 			}
 		}
 	}
 	return ""
 }
 
-// constrainedConversationalSummary builds a short user-facing final from
-// assistant body text: drop tool/reasoning/progress-marker noise, then truncate.
-// It is still a server-owned summary, not a raw Reply.Text passthrough.
+// agentConclusionLimit bounds material kept for the conversation layer to
+// phrase. It is deliberately larger than an IM message: the director turns this
+// into a short reply, and chopping here first is what produced mid-sentence
+// cuts like 「因此目前审…」 before anyone could summarise.
+const agentConclusionLimit = 4000
+
+// constrainedConversationalSummary builds a server-owned conclusion from
+// assistant body text: drop tool/reasoning/progress-marker noise. The length
+// budget is for the director to read, not for the user to receive as-is.
 func constrainedConversationalSummary(text string) string {
 	var keep []string
 	for _, line := range strings.Split(text, "\n") {
@@ -766,7 +772,7 @@ func constrainedConversationalSummary(text string) string {
 	if joined == "" {
 		return ""
 	}
-	return truncateRunes(joined, 240)
+	return truncateRunes(joined, agentConclusionLimit)
 }
 
 func isFinalSummaryNoiseLine(line string) bool {

--- a/server/internal/channels/gptlive_test.go
+++ b/server/internal/channels/gptlive_test.go
@@ -57,12 +57,12 @@ func (f *fakeLive) Complete(_ context.Context, req liveagent.Request) (liveagent
 
 func liveAnswer(text string) liveagent.Result { return liveagent.Result{Text: text} }
 
-// liveDispatch scripts a delegation. Lookup work with no acknowledgement is the
-// quiet shape: the user hears one message, the conclusion.
+// liveDispatch scripts a lookup delegation. The platform always acknowledges
+// sandbox-bound work first; user_reply may be empty so the gate fills one in.
 func liveDispatch(request, title string) liveagent.Result {
 	return liveagent.Result{ToolName: dispatchPMTool, Args: map[string]string{
 		"request": request, "difficulty": string(DifficultyLookup),
-		"short_title": title, "wait": "true",
+		"short_title": title,
 	}}
 }
 
@@ -280,13 +280,14 @@ func TestWorkBriefDoesNotReplayTheConversation(t *testing.T) {
 		t.Fatalf("agent turns = %d want exactly the delegated one", len(g.agent))
 	}
 	// One record, both layers: two turns the model answered, then the delegated
-	// turn and the agent's reply to it.
+	// turn's acknowledgement, then the agent's reply to it.
 	want := []string{
 		"user: 在吗",
 		"assistant: 我在。",
 		"user: 登录页那个还记得吗",
 		"assistant: 登录页那条我记得，你说的是首屏。",
 		"user: 去仓库确认一下改了没",
+		"assistant: 「首屏改动」我这就去确认，有结果马上回你。",
 		"assistant: agent-answer",
 	}
 	got := g.transcript()
@@ -515,9 +516,10 @@ func TestAmbiguousCancelAsksInsteadOfGuessing(t *testing.T) {
 	}
 }
 
-// A quick check the director chose to wait on answers once. Acknowledging and
-// then answering a second later is two notifications for one question.
-func TestWaitedLookupAnswersExactlyOnce(t *testing.T) {
+// A sandbox-bound lookup still acknowledges first. Staying silent until the
+// agent finishes was the "快模型没有先回复" failure: the wait flag assumed a
+// sub-second SoT check that this path does not perform.
+func TestLookupDispatchAcknowledgesBeforeTheAgent(t *testing.T) {
 	g := newGPTLive(t)
 	g.m.SetLiveModel(&fakeLive{configured: true, decisions: []liveagent.Result{
 		liveDispatch("确认登录页那个修好没", "登录页报错"),
@@ -525,8 +527,15 @@ func TestWaitedLookupAnswersExactlyOnce(t *testing.T) {
 
 	g.say("m1", "登录页那个修复了没")
 
-	if got := sentTexts(g.fa); len(got) != 1 || got[0] != "agent-answer" {
-		t.Fatalf("sends = %v want a single conclusion with no acknowledgement first", got)
+	got := sentTexts(g.fa)
+	if len(got) != 2 {
+		t.Fatalf("sends = %v want an acknowledgement then the conclusion", got)
+	}
+	if !strings.Contains(got[0], "登录页报错") {
+		t.Fatalf("acknowledgement names nothing verifiable: %q", got[0])
+	}
+	if got[1] != "agent-answer" {
+		t.Fatalf("conclusion = %q want agent-answer", got[1])
 	}
 	if len(g.agent) != 1 {
 		t.Fatalf("the check never reached the agent: %v", g.agent)
@@ -582,11 +591,14 @@ func TestProgressNamesTheTaskOnlyWhenSeveralAreRunning(t *testing.T) {
 	g.say("m1", "导出也看看")
 
 	got := sentTexts(g.fa)
-	if len(got) != 2 {
-		t.Fatalf("sends = %v want an update and a conclusion", got)
+	if len(got) != 3 {
+		t.Fatalf("sends = %v want ack, labelled update, and conclusion", got)
 	}
-	if !strings.HasPrefix(got[0], "「登录页报错」") {
-		t.Fatalf("update does not say which task moved: %q", got[0])
+	if !strings.Contains(got[0], "导出超时") {
+		t.Fatalf("acknowledgement names nothing verifiable: %q", got[0])
+	}
+	if !strings.HasPrefix(got[1], "「登录页报错」") {
+		t.Fatalf("update does not say which task moved: %q", got[1])
 	}
 }
 
@@ -644,11 +656,11 @@ func TestAgentConclusionIsReportedByTheConversationLayer(t *testing.T) {
 	g.say("m1", "登录页 500 的根因是什么")
 
 	got := sentTexts(g.fa)
-	if len(got) != 1 {
-		t.Fatalf("sends = %v want exactly one message", got)
+	if len(got) != 2 {
+		t.Fatalf("sends = %v want an acknowledgement then the director's conclusion", got)
 	}
-	if got[0] != "查过了，是缓存没刷新导致的。" {
-		t.Fatalf("the work layer spoke to the user directly: %q", got[0])
+	if got[1] != "查过了，是缓存没刷新导致的。" {
+		t.Fatalf("the work layer spoke to the user directly: %q", got[1])
 	}
 }
 
@@ -675,8 +687,40 @@ func TestConclusionSurvivesAFailedPhrasingCall(t *testing.T) {
 
 	g.say("m1", "根因是什么")
 
-	if got := sentTexts(g.fa); len(got) != 1 || got[0] != "缓存没刷新。" {
-		t.Fatalf("sends = %v want the conclusion in the work layer's own words", got)
+	got := sentTexts(g.fa)
+	if len(got) != 2 || got[1] != "缓存没刷新。" {
+		t.Fatalf("sends = %v want ack then the conclusion in the work layer's own words", got)
+	}
+}
+
+// A long agent conclusion must not be chopped mid-sentence at 240 runes before
+// the director can phrase it. That cut is what produced unfinished outbound
+// like 「因此目前审…」.
+func TestLongConclusionIsNotChoppedBeforeTheDirector(t *testing.T) {
+	g := newGPTLive(t)
+	long := strings.Repeat("查过了，审计里没有模型调用事件。", 40) // well over 240 runes
+	phrased := liveAnswer("审计里确实没有快模型调用记录，现在只落在决策样本表里。")
+	g.m.SetLiveModel(&fakeLive{
+		configured: true,
+		decisions:  []liveagent.Result{liveDispatch("查审计里有没有快模型调用", "审计日志")},
+		report:     &phrased,
+	})
+	g.m.handleFunc = func(_ context.Context, _ ResolvedChannel, in InboundMessage) (Reply, error) {
+		g.agent = append(g.agent, in)
+		return Reply{FinalSummary: long}, nil
+	}
+
+	g.say("m1", "审计日志里看不到快模型调用")
+
+	got := sentTexts(g.fa)
+	if len(got) != 2 {
+		t.Fatalf("sends = %v want ack then summarised conclusion", got)
+	}
+	if got[1] != "审计里确实没有快模型调用记录，现在只落在决策样本表里。" {
+		t.Fatalf("director did not get to phrase the long conclusion: %q", got[1])
+	}
+	if strings.Contains(got[1], "因此目前审") || strings.HasSuffix(got[1], "审…") {
+		t.Fatalf("mid-sentence truncation came back: %q", got[1])
 	}
 }
 

--- a/server/internal/channels/live.go
+++ b/server/internal/channels/live.go
@@ -376,11 +376,16 @@ func (m *Manager) reportThroughDirector(ctx context.Context, rc *runningChannel,
 }
 
 // directorReportTimeout bounds the extra hop between having an answer and
-// sending it. The user has already waited for the work; a slow phrasing call
-// must cost them nothing more than this.
-const directorReportTimeout = 4 * time.Second
+// sending it. Local reasoning models routinely need tens of seconds; a 4s
+// budget was what forced every Ollama conclusion down the degraded "paste the
+// whole agent dump" path in live verification.
+const directorReportTimeout = 45 * time.Second
 
-const directorReportMaxTokens = 600
+// Reasoning models on local Ollama often spend most of a small budget on the
+// side-channel "reasoning" field and return empty content with finish_reason
+// length. 2048 is what actually left room for a two-sentence IM reply in live
+// verification against genesis-hermes-v7.
+const directorReportMaxTokens = 2048
 
 // directorReportPrompt is deliberately narrow. Anything that invites the model
 // to add, judge, or expand turns a verified conclusion into a partly invented

--- a/server/internal/channels/live.go
+++ b/server/internal/channels/live.go
@@ -66,8 +66,10 @@ const liveSystemPrompt = `你是这个项目的负责人本人，正在 IM 上�
 对方说不用弄了 / 停下 / 算了 —— 调用 cancel_work。
 
 派活前先判断难度：
-- lookup：查一下就知道的事。可以让对方等一下、查完一次性给答案（wait 填 true），也可以先接一句再去查。
-- heavy：要花好几分钟的事。必须先用 user_reply 接一句，说清楚你要去弄哪件事，再派下去。
+- lookup：查一下就知道的事。
+- heavy：要花好几分钟的事。
+
+派活时必须用 user_reply 先接一句，说清楚你要去确认的是哪件事；平台会先把这句发出去，再去查。
 
 规矩：
 - 接话必须有内容。「稍等」「好的我看一下」「收到」这种空话不算接话，要说清楚你要去确认的是哪件事。
@@ -237,11 +239,6 @@ func (m *Manager) dispatchWork(ctx context.Context, rc *runningChannel, in Inbou
 	if title == "" {
 		title = truncateRunes(strings.TrimSpace(in.Text), 40)
 	}
-	// Waiting is only offered for work short enough to wait for. A heavy task
-	// held in the foreground is the blocked conversation this layer exists to
-	// prevent.
-	wait := parseLooseBool(args["wait"]) && difficulty == DifficultyLookup
-
 	if running := m.taskLedger(rc, in); len(running) >= maxConcurrentWork {
 		return liveOutcome{}, encodeToolResult(map[string]any{
 			"rejected": "这个会话同时在跑的任务已经到上限了，没有派下去。",
@@ -256,26 +253,28 @@ func (m *Manager) dispatchWork(ctx context.Context, rc *runningChannel, in Inbou
 	}
 	m.ensureTaskIdentity(rc, in, dispatch)
 
-	// heavy work is always acknowledged: the user is about to wait minutes and
-	// must know what for. A lookup the director chose to wait on says nothing
-	// now and answers once, which is the better shape for a quick check.
-	if difficulty == DifficultyHeavy || (!wait && strings.TrimSpace(args["user_reply"]) != "") {
-		text, flags := gateAcknowledgement(args["user_reply"], title, in.Text)
-		rec.flag(flags...)
-		sent := m.sendOutboundResult(ctx, rc, OutboundMessage{
-			Scene: in.Scene, ConversationID: in.ConversationID,
-			ReplyToMessageID: in.MessageID, Text: text,
-			// An acknowledgement is not the answer. It marks the turn as having
-			// spoken, never as having answered, so the conclusion that follows
-			// is not suppressed as a duplicate.
-			Envelope: turnEnvelope(rc, in, sendable.KindTurnProcessingAck, "live_ack", sendable.PriorityHigh),
-		})
-		rec.acted("live_ack", text, sent)
-		if sent.Sent {
-			scope := conversationTurnScope(rc.cfg.ProjectID, in.Scene, in.ConversationID)
-			m.markReplied(scope)
-			m.markAcknowledged(scope)
-		}
+	// Every sandbox-bound dispatch is acknowledged first.
+	//
+	// An earlier "wait=true means stay silent until the answer" shape assumed a
+	// short synchronous lookup. What we actually start here is a sandbox turn
+	// that can take tens of seconds — silence for that long is exactly the
+	// "快模型没有先回复" failure. Until a real sub-second SoT path exists,
+	// acknowledging is not optional.
+	text, flags := gateAcknowledgement(args["user_reply"], title, in.Text)
+	rec.flag(flags...)
+	sent := m.sendOutboundResult(ctx, rc, OutboundMessage{
+		Scene: in.Scene, ConversationID: in.ConversationID,
+		ReplyToMessageID: in.MessageID, Text: text,
+		// An acknowledgement is not the answer. It marks the turn as having
+		// spoken, never as having answered, so the conclusion that follows
+		// is not suppressed as a duplicate.
+		Envelope: turnEnvelope(rc, in, sendable.KindTurnProcessingAck, "live_ack", sendable.PriorityHigh),
+	})
+	rec.acted("live_ack", text, sent)
+	if sent.Sent {
+		scope := conversationTurnScope(rc.cfg.ProjectID, in.Scene, in.ConversationID)
+		m.markReplied(scope)
+		m.markAcknowledged(scope)
 	}
 
 	return liveOutcome{
@@ -364,7 +363,7 @@ func (m *Manager) reportThroughDirector(ctx context.Context, rc *runningChannel,
 		System: directorReportPrompt,
 		Messages: []liveagent.Message{
 			{Role: "user", Content: "对方问的是：" + truncateRunes(strings.TrimSpace(in.Text), 200)},
-			{Role: "user", Content: "查到的结果：" + truncateRunes(plain, 1200)},
+			{Role: "user", Content: "查到的结果：" + truncateRunes(plain, 3000)},
 		},
 		MaxTokens: directorReportMaxTokens,
 	})
@@ -379,23 +378,23 @@ func (m *Manager) reportThroughDirector(ctx context.Context, rc *runningChannel,
 // directorReportTimeout bounds the extra hop between having an answer and
 // sending it. The user has already waited for the work; a slow phrasing call
 // must cost them nothing more than this.
-const directorReportTimeout = 3 * time.Second
+const directorReportTimeout = 4 * time.Second
 
-const directorReportMaxTokens = 800
+const directorReportMaxTokens = 600
 
 // directorReportPrompt is deliberately narrow. Anything that invites the model
 // to add, judge, or expand turns a verified conclusion into a partly invented
 // one, which is the exact failure this whole layer exists to prevent.
 const directorReportPrompt = `你是这个项目的负责人本人，正在 IM 上和同事聊天。你的回复会原样发给对方。
 
-下面给你的是查到的结果。把它讲给对方听。
+下面给你的是查到的结果。用一两段人话把结论讲给对方听。
 
 规矩：
 - 只讲给出的事实。不要补充、不要推测、不要下额外结论、不要建议。
-- 结果本身已经说得清楚的，几乎原样转述就行，不要为了改写而改写。
-- 说人话，像同事之间当面说，不要写报告，不要分点罗列（除非结果本身就是几条并列的事）。
+- 先给结论，必要细节最多再补两三句；不要把长报告或分点清单原样贴出去。
+- 说人话，像同事当面说，不要写工单腔。
 - 不要出现任务编号、工作流名、执行环境、工具名这些内部说法。
-- 只输出要发出去的话，不要加前缀、标题或解释。`
+- 只输出要发出去的话，不要加前缀、标题或解释，也不要写到一半截断。`
 
 // warmWorkLayer brings the agent's sandbox up in the background.
 //
@@ -528,8 +527,7 @@ func directorTools() []liveagent.ToolSpec {
 					Required:    true,
 				},
 				{Name: "short_title", Description: "给这件事起个对方看得懂的短名字，例如「登录页报错」。", Required: true},
-				{Name: "user_reply", Description: "现在就发给对方的一句话。heavy 必填，要说清楚你去确认的是哪件事。"},
-				{Name: "wait", Description: "只有 lookup 能填 true：不先接话，查完一次性回答。"},
+				{Name: "user_reply", Description: "现在就发给对方的一句话，必填；要说清楚你去确认的是哪件事。", Required: true},
 			},
 		},
 		{

--- a/server/internal/channels/live_ollama_test.go
+++ b/server/internal/channels/live_ollama_test.go
@@ -1,0 +1,167 @@
+package channels
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/cocofhu/approving/internal/liveagent"
+)
+
+// Against a real Ollama (or any OpenAI-compatible) endpoint, with the sandbox
+// mocked. Skipped unless configured:
+//
+//	LIVE_TEST_BASE_URL=http://192.168.2.20:11434/v1 \
+//	LIVE_TEST_MODEL=genesis-hermes-v7:latest \
+//	go test ./internal/channels/ -run TestOllamaDirector -v -count=1
+//
+// These catch what the fakeLive suite cannot: a real model that thinks before
+// it speaks, fills tool args in its own words, and may spend most of a small
+// token budget on reasoning.
+func ollamaDirector(t *testing.T) (*gptLive, *liveagent.Client) {
+	t.Helper()
+	base := os.Getenv("LIVE_TEST_BASE_URL")
+	model := os.Getenv("LIVE_TEST_MODEL")
+	if base == "" || model == "" {
+		t.Skip("set LIVE_TEST_BASE_URL and LIVE_TEST_MODEL to run against Ollama")
+	}
+	c := liveagent.New()
+	c.SetLiveEndpoint(base, os.Getenv("LIVE_TEST_API_KEY"), model, 3*time.Minute)
+	g := newGPTLive(t)
+	g.m.SetLiveModel(c)
+	return g, c
+}
+
+func TestOllamaDirectorAnswersChitchatWithoutSandbox(t *testing.T) {
+	g, _ := ollamaDirector(t)
+
+	start := time.Now()
+	g.say("m1", "你好，在吗")
+	t.Logf("took %v", time.Since(start))
+
+	if len(g.agent) != 0 {
+		t.Fatalf("a greeting opened the sandbox: %+v", g.agent)
+	}
+	got := sentTexts(g.fa)
+	if len(got) != 1 {
+		t.Fatalf("sends = %v want exactly one reply", got)
+	}
+	t.Logf("reply: %s", got[0])
+	if utf8.RuneCountInString(got[0]) < 2 {
+		t.Fatalf("empty reply: %q", got[0])
+	}
+	assertNoReasoningLeak(t, got[0])
+	assertNoBannedOutbound(t, got)
+}
+
+func TestOllamaDirectorAcksThenSummarisesSandboxWork(t *testing.T) {
+	g, _ := ollamaDirector(t)
+
+	// Long technical dump — the shape that used to be chopped at 240 runes
+	// mid-sentence before the director could phrase it.
+	long := "你说得对，这是代码缺口不是过滤问题。" +
+		"1）项目审计日志没有「模型调用」事件类型，只记配置/Run/门禁/MCP/投递；" +
+		"2）工作流/PM 模型只靠 prompt_done.usage 进 Token 统计，不进审计；" +
+		"3）快模型调用写进了 LiveDecisionSample，但 Model 字段从未赋值，模型名是空的；" +
+		"4）快模型做汇报改写的调用没有单独记，响应里的 token usage 也没解析。" +
+		"因此目前审计页看不到快模型调用记录，要补事件类型并把样本/usage 接到审计出口。" +
+		strings.Repeat("（补充背景：此前几轮路由都靠禁词表打补丁。）", 8)
+
+	g.m.handleFunc = func(ctx context.Context, _ ResolvedChannel, in InboundMessage) (Reply, error) {
+		g.agent = append(g.agent, in)
+		// Prefer pm_reply capture path: that is what production agents use.
+		if _, err := g.m.DeliverConversationReply(ctx, ConversationReply{
+			ProjectID: "proj", Scene: in.Scene, ConversationID: in.ConversationID,
+			UserID: in.UserID, Text: long,
+		}); err != nil {
+			t.Fatalf("pm_reply failed: %v", err)
+		}
+		return Reply{}, nil
+	}
+
+	start := time.Now()
+	g.say("m1", "审计日志里似乎看不到快模型的调用记录，帮我查下根因")
+	t.Logf("took %v", time.Since(start))
+
+	if len(g.agent) != 1 {
+		t.Fatalf("work was not dispatched to the sandbox: agent=%v", g.agent)
+	}
+	if g.agent[0].Dispatch == nil || strings.TrimSpace(g.agent[0].Dispatch.Brief) == "" {
+		t.Fatalf("dispatch carried no brief: %+v", g.agent[0].Dispatch)
+	}
+	t.Logf("brief: %s", g.agent[0].Dispatch.Brief)
+	t.Logf("title: %s", g.agent[0].Dispatch.ShortTitle)
+
+	got := sentTexts(g.fa)
+	if len(got) < 2 {
+		t.Fatalf("sends = %v want acknowledgement then summarised conclusion", got)
+	}
+	ack, final := got[0], got[len(got)-1]
+	t.Logf("ack: %s", ack)
+	t.Logf("final: %s", final)
+
+	if strings.TrimSpace(ack) == "" {
+		t.Fatal("no acknowledgement before sandbox work")
+	}
+	for _, banned := range []string{"稍等，我看一下", "好的我看一下"} {
+		if ack == banned {
+			t.Fatalf("fixed-template ack came back: %q", ack)
+		}
+	}
+	if utf8.RuneCountInString(final) < 8 {
+		t.Fatalf("empty conclusion: %q", final)
+	}
+	// Must not be the unfinished 240-rune chop from the previous bug.
+	if strings.HasSuffix(strings.TrimRight(final, "…."), "审") {
+		t.Fatalf("mid-sentence truncation came back: %q", final)
+	}
+	assertNoReasoningLeak(t, ack)
+	assertNoReasoningLeak(t, final)
+	// Hard contract after the timeout fix: the director must phrase, not paste.
+	if final == long {
+		t.Fatalf("director degraded to the full agent dump instead of summarising")
+	}
+	if utf8.RuneCountInString(final) > 800 {
+		t.Fatalf("conclusion still too long for IM (%d runes): %s", utf8.RuneCountInString(final), final)
+	}
+	assertNoBannedOutbound(t, got)
+}
+
+func assertNoReasoningLeak(t *testing.T, text string) {
+	t.Helper()
+	for _, leak := range []string{"<think", "</think>", "<reasoning", "</reasoning>", "<thinking", "</thinking>"} {
+		if strings.Contains(strings.ToLower(text), leak) {
+			t.Fatalf("reasoning leaked into user-visible text (%q): %s", leak, text)
+		}
+	}
+}
+
+func TestOllamaDirectorReportsStatusFromLedger(t *testing.T) {
+	g, _ := ollamaDirector(t)
+	identity := g.seedTask("run-audit", "审计日志缺口")
+	g.m.noteWorkProgress("proj", "run-audit", "正在查审计事件类型", false)
+
+	start := time.Now()
+	g.say("m1", "好了没")
+	t.Logf("took %v task=%s", time.Since(start), identity.ID)
+
+	if len(g.agent) != 0 {
+		t.Fatalf("a progress question opened a sandbox: %+v", g.agent)
+	}
+	got := sentTexts(g.fa)
+	if len(got) != 1 {
+		t.Fatalf("sends = %v want one status reply", got)
+	}
+	t.Logf("status: %s", got[0])
+	// Soft check: should reflect the ledger somehow. Models vary; if it
+	// fabricates "done", that is a regression worth failing.
+	lower := got[0]
+	for _, bad := range []string{"已经修好了", "已经完成了", "弄完了"} {
+		if strings.Contains(lower, bad) {
+			t.Fatalf("invented a finished status: %q", got[0])
+		}
+	}
+}

--- a/server/internal/channels/manager.go
+++ b/server/internal/channels/manager.go
@@ -684,12 +684,22 @@ func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMes
 		return
 	}
 	final, degraded := m.reportThroughDirector(ctx, rc, in, summary)
+	if degraded {
+		// Director could not phrase it. Soft-cap the work layer's own words so
+		// a long dump still ends on an ellipsis rather than mid-character —
+		// the hard 240-rune cut is what made 「因此目前审」 look like a hang.
+		final = truncateRunes(final, degradedOutboundLimit)
+	}
 	m.attachSampleOutcome(in.DecisionSampleID, summary, collect.egress(degraded))
 	sent := m.sendOutboundResult(ctx, rc, OutboundMessage{
 		Scene: in.Scene, ConversationID: in.ConversationID, ReplyToMessageID: in.MessageID,
 		Text: final, ImageURLs: reply.ImageURLs,
 		Envelope: func() sendable.DeliveryEnvelope {
-			e := turnEnvelope(rc, in, sendable.KindFinal, reason, sendable.PriorityCritical)
+			outReason := reason
+			if !degraded {
+				outReason = "live_reply"
+			}
+			e := turnEnvelope(rc, in, sendable.KindFinal, outReason, sendable.PriorityCritical)
 			e.Structured = true
 			return e
 		}(),
@@ -698,6 +708,11 @@ func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMes
 		m.markAnswered(scope)
 	}
 }
+
+// degradedOutboundLimit is how much of the work layer's own words may reach the
+// user when the conversation model cannot phrase them. Short enough for IM,
+// long enough that a real answer is not chopped into an unfinished sentence.
+const degradedOutboundLimit = 1200
 
 // progressReportInterval rate-limits progress lines per conversation.
 //
@@ -824,7 +839,9 @@ func deliverableFinalText(reply Reply) (text, reason string, ok bool) {
 		if summary == "" {
 			return "", "final_summary_scrubbed_empty", false
 		}
-		return truncateRunes(summary, 240), "structured_turn_final", true
+		// Do not chop here. This text is material for the director to phrase
+		// (or a soft-capped degraded fallback), not the IM payload itself.
+		return summary, "structured_turn_final", true
 	}
 	return "", "final_summary_missing", false
 }

--- a/server/internal/liveagent/client.go
+++ b/server/internal/liveagent/client.go
@@ -312,10 +312,40 @@ var thinkBlock = regexp.MustCompile(`(?is)<(think|thinking|reasoning)>.*?</(thin
 // would otherwise survive as a half-open tag and everything after it.
 var unclosedThink = regexp.MustCompile(`(?is)<(think|thinking|reasoning)>.*\z`)
 
+// orphanCloseThink catches a lone closing tag some local reasoning models put
+// between a draft reply and the same reply again — e.g. "在的。\n</think>\n\n在的。"
+var orphanCloseThink = regexp.MustCompile(`(?is)</(think|thinking|reasoning)>`)
+
 func stripReasoning(s string) string {
 	s = thinkBlock.ReplaceAllString(s, "")
 	s = unclosedThink.ReplaceAllString(s, "")
+	s = orphanCloseThink.ReplaceAllString(s, "")
+	s = collapseDuplicateParagraphs(s)
 	return strings.TrimSpace(s)
+}
+
+// collapseDuplicateParagraphs drops a paragraph that is repeated right after
+// itself. Reasoning models that echo the final answer on both sides of a think
+// tag would otherwise greet the user twice in one bubble.
+func collapseDuplicateParagraphs(s string) string {
+	parts := strings.Split(s, "\n")
+	var out []string
+	var prev string
+	for _, p := range parts {
+		cur := strings.TrimSpace(p)
+		if cur == "" {
+			if len(out) > 0 && out[len(out)-1] != "" {
+				out = append(out, "")
+			}
+			continue
+		}
+		if cur == prev {
+			continue
+		}
+		out = append(out, p)
+		prev = cur
+	}
+	return strings.TrimSpace(strings.Join(out, "\n"))
 }
 
 // decodeContent accepts both the plain string form and the content-parts array

--- a/server/internal/liveagent/client_test.go
+++ b/server/internal/liveagent/client_test.go
@@ -155,6 +155,7 @@ func TestReasoningNeverSurvivesIntoTheAnswer(t *testing.T) {
 		{"alternate tag", "<reasoning>internal</reasoning>好了", "好了"},
 		{"truncated by token cap", "还在跑<think>接下来我应该", "还在跑"},
 		{"multiline", "<think>\nline one\nline two\n</think>\n结果出来了", "结果出来了"},
+		{"orphan close with echo", "在的，有什么事你说。\n</think>\n\n在的，有什么事你说。", "在的，有什么事你说。"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c := serveJSON(t, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- 补上 #167 合并后漏掉的两笔修复：派沙箱前强制 `live_ack`；去掉终态 240 字硬截，改由总监总结后再发。
- 针对本地 Ollama reasoning 模型：清理 orphan `</think>` 泄漏；汇报 `max_tokens` 提到 2048，避免 content 被 reasoning 吃空后整段降级。
- 增加可选 `TestOllamaDirector*`（`LIVE_TEST_BASE_URL` / `LIVE_TEST_MODEL`）用真 Ollama + mock 沙箱验收。

## Test plan
- [x] `go test ./internal/channels/ ./internal/liveagent/`
- [x] `LIVE_TEST_BASE_URL=http://192.168.2.20:11434/v1 LIVE_TEST_MODEL=genesis-hermes-v7:latest go test ./internal/channels/ -run TestOllamaDirector -v -count=1`
- [ ] 部署后 IM：「审计日志看不到快模型」→ 先接话，再短结论，不再半截长文


Made with [Cursor](https://cursor.com)