### PR TITLE
fix(channels): Live 超时先 ack，收短工作层 preamble

### DIFF
--- a/server/CONFIGURATION.md
+++ b/server/CONFIGURATION.md
@@ -32,7 +32,7 @@ configured on Agent meta env, not in this platform config table.
 | `APPROVING_LIVE_BASE_URL` | `live.base_url` | URL | `Not set` | Public | OpenAI-compatible endpoint for the conversation model; usually set on the settings page |
 | `APPROVING_LIVE_API_KEY` | `live.api_key` | string | `Not set` | Sensitive | Conversation model API key; usually set on the settings page |
 | `APPROVING_LIVE_MODEL` | `live.model` | string | `Not set` | Public | Conversation model name; usually set on the settings page |
-| `APPROVING_LIVE_TIMEOUT_SEC` | `live.timeout_seconds` | integer | `8` | Public | Timeout for one conversation model call in seconds; escalates to the sandbox on timeout |
+| `APPROVING_LIVE_TIMEOUT_SEC` | `live.timeout_seconds` | integer | `120` | Public | Timeout for one conversation model call in seconds; local reasoning models often need a minute or more, then escalates to the sandbox |
 | `APPROVING_BROWSER_ENABLED` | `browser.enabled` | boolean | `Not set` | Deprecated | Compatibility field; VNC preview is always available |
 | `APPROVING_CURSOR_API_KEY` | `sandbox.cursor_api_key` | string | `Not set` | Sensitive, Deprecated | Deprecated; use agent env |
 | `CURSOR_API_KEY` | `sandbox.cursor_api_key` | string | `Not set` | Sensitive, Deprecated | Deprecated alias; use agent env |

--- a/server/internal/channels/channels_test.go
+++ b/server/internal/channels/channels_test.go
@@ -1321,43 +1321,24 @@ func TestPushQueueProtectsRunNotify(t *testing.T) {
 	}
 }
 
-// The preamble is the only thing telling the agent how a Live turn ends, so it
-// has to name both endings, say that long work goes to the background, and rule
-// out the ticket phrasing this work removed.
+// The work-layer preamble is an operational contract, not a second persona.
+// Voice, identity, and filler bans live on the conversation layer; this text
+// only has to name the two endings, the capture handoff, and confirmation.
 func TestChannelPreambleStatesTheLiveTurnContract(t *testing.T) {
 	p := ChannelPreamble("qq")
-	for _, required := range []string{"pm_reply", "pm_start_run", "pm_notify_progress", "优先"} {
+	for _, required := range []string{
+		"pm_reply", "pm_start_run", "pm_notify_progress",
+		"会话层", "already_replied", "needs_confirmation", "不能代替用户确认", "兜底",
+	} {
 		if !strings.Contains(p, required) {
 			t.Fatalf("preamble never mentions %s: %s", required, p)
 		}
 	}
-	for _, banned := range []string{"收到，正在处理", "本回合已结束", "请前往 Approving 查看", "已发送", "稍等，我看一下"} {
-		if !strings.Contains(p, banned) {
-			t.Fatalf("preamble does not forbid %q: %s", banned, p)
-		}
-	}
-	// Must not claim body text can never be delivered (contradicts #161 fallback).
-	if strings.Contains(p, "正文不会外发") && !strings.Contains(p, "兜底") {
-		t.Fatalf("preamble still claims absolute non-delivery of body without fallback caveat: %s", p)
-	}
-	// The platform withholds a second answer; the agent has to know that before
-	// it tries, or it spends the turn rewording something that will not be sent.
-	if !strings.Contains(p, "already_replied") {
-		t.Fatalf("preamble does not tell the agent one turn gets one answer: %s", p)
-	}
-	// A colleague does not answer 「你是什么模型」 with a model name. This leaked
-	// in production as 「我是 GPT-5.6 Sol」.
-	for _, required := range []string{"你是什么模型", "厂商"} {
-		if !strings.Contains(p, required) {
-			t.Fatalf("preamble does not close the identity question (%s): %s", required, p)
-		}
-	}
-	// The platform sends the confirmation question itself. An agent that asks
-	// again in its own words puts a second question on screen that cannot
-	// settle anything, and it may not confirm on the user's behalf either.
-	for _, required := range []string{"needs_confirmation", "不能代替用户确认"} {
-		if !strings.Contains(p, required) {
-			t.Fatalf("preamble does not fix the confirmation handoff (%s): %s", required, p)
+	// Style/persona belong on liveSystemPrompt — repeating them here is what
+	// made sandbox sessions look like a second director prompt.
+	for _, voiceOnly := range []string{"你是什么模型", "厂商", "稍等，我看一下", "收到，正在处理"} {
+		if strings.Contains(p, voiceOnly) {
+			t.Fatalf("work-layer preamble still carries conversation-layer voice rule %q: %s", voiceOnly, p)
 		}
 	}
 }

--- a/server/internal/channels/gptlive_test.go
+++ b/server/internal/channels/gptlive_test.go
@@ -243,7 +243,9 @@ func TestNoConversationModelSendsEverythingToTheAgent(t *testing.T) {
 	}
 }
 
-// A model that fails must cost latency, not the reply.
+// A model that fails must cost latency, not the reply. The fallthrough used to
+// be silent until the sandbox answered, which is how a timed-out Live call
+// looked like the platform ignored the user — so we ack first, then the agent.
 func TestConversationModelFailureStillAnswersTheUser(t *testing.T) {
 	g := newGPTLive(t)
 	g.m.SetLiveModel(&fakeLive{configured: true, err: liveagent.ErrBudgetExhausted})
@@ -253,8 +255,9 @@ func TestConversationModelFailureStillAnswersTheUser(t *testing.T) {
 	if len(g.agent) != 1 {
 		t.Fatalf("a failed model call swallowed the message: %v", g.agent)
 	}
-	if got := sentTexts(g.fa); len(got) != 1 || got[0] != "agent-answer" {
-		t.Fatalf("sends = %v want the agent's answer", got)
+	got := sentTexts(g.fa)
+	if len(got) != 2 || !strings.Contains(got[0], "什么进度了") || got[1] != "agent-answer" {
+		t.Fatalf("sends = %v want fallthrough ack then the agent's answer", got)
 	}
 }
 

--- a/server/internal/channels/live.go
+++ b/server/internal/channels/live.go
@@ -158,6 +158,11 @@ func (m *Manager) routeThroughLiveModel(ctx context.Context, rc *runningChannel,
 			level.Err(err).Str("project", rc.cfg.ProjectID).
 				Msg("conversation model unavailable; handing turn to the agent")
 			rec.failed(err)
+			// The sandbox still answers, but it can take a minute to come up.
+			// Saying nothing until then is how "项目的错误处理完整吗" sat on
+			// screen with a running timer and no bubble — the model timed out
+			// and the fallthrough used to be silent.
+			m.ackFallthrough(ctx, rc, in, rec)
 			return liveOutcome{reason: "会话层没能给出答复", sampleID: rec.commit(routeFallthrough)}
 		}
 		rec.completed(res)
@@ -188,7 +193,29 @@ func (m *Manager) routeThroughLiveModel(ctx context.Context, rc *runningChannel,
 	log.Info().Str("project", rc.cfg.ProjectID).
 		Msg("conversation model looped on tools without answering; handing turn to the agent")
 	rec.flag("tool_loop_exhausted")
+	m.ackFallthrough(ctx, rc, in, rec)
 	return liveOutcome{reason: "会话层查了状态但没有给出答复", sampleID: rec.commit(routeFallthrough)}
+}
+
+// ackFallthrough tells the user something is happening when the conversation
+// layer could not finish and the sandbox is about to take over. Without it a
+// timed-out Live call looks like the platform ignored the message.
+func (m *Manager) ackFallthrough(ctx context.Context, rc *runningChannel, in InboundMessage, rec *sampleRecorder) {
+	title := truncateRunes(strings.TrimSpace(in.Text), 20)
+	text, flags := gateAcknowledgement("", title, in.Text)
+	rec.flag(flags...)
+	rec.flag("fallthrough_ack")
+	sent := m.sendOutboundResult(ctx, rc, OutboundMessage{
+		Scene: in.Scene, ConversationID: in.ConversationID,
+		ReplyToMessageID: in.MessageID, Text: text,
+		Envelope: turnEnvelope(rc, in, sendable.KindTurnProcessingAck, "live_ack", sendable.PriorityHigh),
+	})
+	rec.acted("live_ack", text, sent)
+	if sent.Sent {
+		scope := conversationTurnScope(rc.cfg.ProjectID, in.Scene, in.ConversationID)
+		m.markReplied(scope)
+		m.markAcknowledged(scope)
+	}
 }
 
 // deliverDirectorReply sends what the model said, as it said it.
@@ -196,6 +223,7 @@ func (m *Manager) deliverDirectorReply(ctx context.Context, rc *runningChannel, 
 	text string, rec *sampleRecorder) liveOutcome {
 	answer := strings.TrimSpace(text)
 	if answer == "" {
+		m.ackFallthrough(ctx, rc, in, rec)
 		return liveOutcome{reason: "会话层没能给出答复", sampleID: rec.commit(routeFallthrough)}
 	}
 	sent := m.sendOutboundResult(ctx, rc, OutboundMessage{
@@ -210,6 +238,7 @@ func (m *Manager) deliverDirectorReply(ctx context.Context, rc *runningChannel, 
 		// reply; claiming success here is what leaves a user waiting in silence.
 		log.Warn().Str("project", rc.cfg.ProjectID).Str("reason", sent.Decision.Reason).
 			Msg("conversation model answer was not delivered; handing turn to the agent")
+		m.ackFallthrough(ctx, rc, in, rec)
 		return liveOutcome{reason: "会话层的回复没有送达", sampleID: rec.commit(routeFallthrough)}
 	}
 	scope := conversationTurnScope(rc.cfg.ProjectID, in.Scene, in.ConversationID)

--- a/server/internal/channels/preamble.go
+++ b/server/internal/channels/preamble.go
@@ -5,65 +5,29 @@ import "strings"
 // ChannelPreamble is the session preamble injected on the first turn of a
 // channel conversation's sandbox.
 //
-// It establishes the Live turn contract: a foreground turn either answers the
-// user or hands the work to a background Run, and it always ends by calling a
-// tool. Long work must not be attempted inline, because the user is waiting in a
-// live conversation while it happens.
+// Keep it short. The conversation layer owns voice, persona, and IM phrasing;
+// this text only tells the work agent how a foreground turn ends and where
+// facts come from. Style rules here just burn tokens the synthesizer rewrites.
 func ChannelPreamble(channelType string) string {
+	_ = channelType
 	return strings.Join([]string{
-		"你正在通过外部 IM 渠道（" + channelType + "）和用户实时聊天。这是一场连续对话，不是工单系统。",
+		"你是工作层：查事实、干活。IM 上的统一口径由会话层（快模型）说，你交结论即可。",
 
-		"【这一轮怎么收尾】每一轮你只做两件事之一，并且必须以对应的工具调用收尾：",
-		"1) 能当场答的（提问、闲聊、解释、查状态）→ 直接调用 pm_reply 把答案发出去，不要建任务。",
-		"2) 需要真正干活的（写代码、调研、改配置、跑流程等要花分钟级以上的事）→ 调用 pm_start_run 交给后台，" +
-			"系统会自动告诉用户已经接手，你不用再重复说一遍，也不要等它跑完。",
+		"【收尾】每轮二选一，必须用工具结束：",
+		"1) 能当场答 → pm_reply 交一条结论；status=already_replied 就停。",
+		"2) 分钟级以上 → pm_start_run，不要前台硬扛，也不要等跑完。",
 
-		"【用户可见答复】优先通过 pm_reply 的 text 发给用户。" +
-			"你写在回复正文里的内容默认不会外发；仅当本回合还没有任何用户可见外发时，" +
-			"平台才可能把经清洗的最终摘要作为兜底发出去。" +
-			"所以想让用户看到的话，优先放进 pm_reply。" +
-			"不要复述投递回执或内部过程语句（例如「已发送」「已通过 QQ 回复用户」「稍等，我看一下」）。",
+		"【结论】pm_reply / pm_notify_progress 是交给会话层转述的事实，不是直发 IM。" +
+			"写清结论与依据；不要 Run ID、工作流名、沙箱、工具名、推理过程。" +
+			"正文默认不外发；无外发时平台可能用清洗摘要兜底，所以结论优先放进 pm_reply。",
 
-		"【一轮只回一条】一次 pm_reply 就把这一轮要说的话说完。" +
-			"不要先发一句招呼再发一句正文——用户看到的是两条消息，像是有两个人在同时回他。" +
-			"如果 pm_reply 返回 status=already_replied，说明这一轮已经回过了，直接结束，不要改措辞重发。",
+		"【查】提示不带完整历史；<work_brief> 是转交要求与附件线索。" +
+			"指代不清用 context-store；本轮附件在本地路径，更早的用 brief 的 messageId+index / get_attachment。" +
+			"进度与记忆先查工具，不要编造。",
 
-		"【你是谁】你就是这个项目的负责人，用户当你是同事。" +
-			"不要说自己是 AI、模型、助手，也不要说出任何模型名称、版本或厂商——" +
-			"被问「你是什么模型」时，就当同事随口一问，把话题带回工作，不要报身份。",
+		"【确认】取消/批准/删除等须二次确认；status=needs_confirmation 时平台已问过用户，" +
+			"本轮结束，不要再问，也不能代替用户确认。",
 
-		"【怎么说话】像同事之间聊天那样说人话，一次说清一件事。" +
-			"不要说「收到，正在处理」「本回合已结束」「请前往 Approving 查看」「已开始处理」「任务已启动」这类话；" +
-			"不要出现 Run ID、工作流名、沙箱、工具名、内部事件名、错误堆栈；" +
-			"不要复述推理过程。用户关心的是结论和下一步。" +
-			"用户用中文你就用中文，用英文就用英文。",
-
-		"【别在前台硬扛】如果一件事你判断要花很久，不要在这一轮里慢慢做完再回答——" +
-			"先 pm_start_run 交给后台，用户可以接着跟你聊别的。前台每一轮都有硬性时间上限，超时这一轮的回答就丢了。",
-
-		"【格式】可以用 Markdown（加粗、列表、链接等）提升可读性，但不要用表格（QQ 不支持）。" +
-			"需要发图片时，在 pm_reply 的 text 里用 Markdown 图片语法给出可公网访问的直链，例如 ![](https://example.com/x.png)；" +
-			"不要给本地路径或需要鉴权的链接。",
-
-		"【上下文自己取】提示里不会再附带这个会话的历史对话。" +
-			"提示里如果出现 <work_brief> 段，那是会话层转交给你的要求、任务名和附件线索，不是用户的新消息。" +
-			"遇到「刚才那个」「上面说的」这类指代，或者需要知道用户之前说过什么、平台已经替你回过什么，" +
-			"先用 context-store 的 get_messages / search_messages 拉取，再回答；不要凭印象猜，也不要把已经回过的话再说一遍。",
-
-		"【附件】用户本轮发的图片和文件已经写成沙箱本地文件，用绝对路径直接读。" +
-			"更早的附件不会随本轮下发：<work_brief> 里会列出文件名、messageId 和 index，" +
-			"没列出的用 context-store 的 get_messages 查附件清单，" +
-			"再用 get_attachment 按 messageId+index 取回内容。" +
-			"用户提到「刚才那张图」时，先查清单再取，不要说自己看不到。",
-
-		"【先查再答】通过 pm-leader / context-store / memory-store 等 MCP 工具获取项目进度、记忆与历史后再作答，不要编造。",
-
-		"【危险操作】取消、批准、删除等会改变任务状态的操作，必须先用短标题向用户二次确认，确认后才执行。" +
-			"工具返回 status=needs_confirmation 时，平台已经把确认问句原样发给用户了——" +
-			"这一轮就此结束，不要自己再问一遍、不要复述、也不要解释确认机制。" +
-			"只有用户回「确认」或「取消」才能结束这次确认，你不能代替用户确认。",
-
-		"【后台进展】任务在后台跑的过程中，有实质进展、被阻塞或需要用户决策时，用 pm_notify_progress 同步；" +
-			"它返回 status=suppressed 表示被限频/去重/合并等策略正常抑制，属正常结果，不要换措辞重发；只有返回错误才是真实投递失败。",
+		"【进展】实质进展、阻塞或要用户决策 → pm_notify_progress；status=suppressed 属限频正常，勿重交。",
 	}, "\n")
 }

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -495,7 +495,7 @@ func setDefaults(c *Config) {
 		c.Engine.NodeAutoRetryMax = 3
 	}
 	if c.Live.TimeoutSeconds == 0 {
-		c.Live.TimeoutSeconds = 8
+		c.Live.TimeoutSeconds = 120
 	}
 	// Image intentionally has no default: empty means per-backend Images /
 	// DefaultSandboxImage. Set sandbox.image / APPROVING_SANDBOX_IMAGE only to

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -279,8 +279,8 @@ func TestLiveTimeoutFallsBackToAShortDefault(t *testing.T) {
 	// mean "wait forever".
 	c := &Config{}
 	setDefaults(c)
-	if c.Live.TimeoutSeconds != 8 {
-		t.Fatalf("default live timeout = %d, want 8", c.Live.TimeoutSeconds)
+	if c.Live.TimeoutSeconds != 120 {
+		t.Fatalf("default live timeout = %d, want 120", c.Live.TimeoutSeconds)
 	}
 
 	c2 := &Config{}

--- a/server/internal/config/descriptor.go
+++ b/server/internal/config/descriptor.go
@@ -38,7 +38,7 @@ func OptionDescriptors() []OptionDescriptor {
 		{Env: "APPROVING_LIVE_BASE_URL", YAML: "live.base_url", Type: "URL", Default: "", ZH: "对话层快模型的 OpenAI 兼容接口地址；通常在设置页配置", EN: "OpenAI-compatible endpoint for the conversation model; usually set on the settings page"},
 		{Env: "APPROVING_LIVE_API_KEY", YAML: "live.api_key", Type: "string", Sensitive: true, ZH: "对话层快模型密钥；通常在设置页配置", EN: "Conversation model API key; usually set on the settings page"},
 		{Env: "APPROVING_LIVE_MODEL", YAML: "live.model", Type: "string", Default: "", ZH: "对话层快模型名称；通常在设置页配置", EN: "Conversation model name; usually set on the settings page"},
-		{Env: "APPROVING_LIVE_TIMEOUT_SEC", YAML: "live.timeout_seconds", Type: "integer", Default: "8", ZH: "单次对话模型调用超时秒数；超时则升级到沙箱", EN: "Timeout for one conversation model call in seconds; escalates to the sandbox on timeout"},
+		{Env: "APPROVING_LIVE_TIMEOUT_SEC", YAML: "live.timeout_seconds", Type: "integer", Default: "120", ZH: "单次对话模型调用超时秒数；本地 reasoning 模型通常需要一分钟以上，超时则升级到沙箱", EN: "Timeout for one conversation model call in seconds; local reasoning models often need a minute or more, then escalates to the sandbox"},
 		{Env: "APPROVING_BROWSER_ENABLED", YAML: "browser.enabled", Type: "boolean", Deprecated: true, ZH: "兼容字段；VNC 预览始终可用", EN: "Compatibility field; VNC preview is always available"},
 		{Env: "APPROVING_CURSOR_API_KEY", YAML: "sandbox.cursor_api_key", Type: "string", Sensitive: true, Deprecated: true, ZH: "已弃用；改用 Agent env", EN: "Deprecated; use agent env"},
 		{Env: "CURSOR_API_KEY", YAML: "sandbox.cursor_api_key", Type: "string", Sensitive: true, Deprecated: true, ZH: "已弃用别名；改用 Agent env", EN: "Deprecated alias; use agent env"},

--- a/server/internal/pmmcp/host.go
+++ b/server/internal/pmmcp/host.go
@@ -1238,15 +1238,16 @@ func toolSchemas(mcpID string) []map[string]any {
 			platformmcp.Tool("pm_cancel_run", "取消一次运行中的 Run（需用户短标题二次确认后才会真正取消）。", map[string]any{
 				"runId": map[string]any{"type": "string"},
 			}),
-			platformmcp.Tool("pm_reply", "把这一轮对话的回答发给用户。这是回答外发的唯一通道——你在正文里写的内容不会被发出去，只有这里提交的 text 会。"+
-				"text 必须是用户直接能读懂的人话：不要出现 Run ID、工作流名、沙箱/工具/内部事件等实现细节，也不要写推理过程。"+
-				"一轮只发一条：把想说的话一次写完，不要拆成多条。返回 status=already_replied 表示这一轮已经回过了，"+
-				"此时不要改措辞重发，直接结束这一轮。", map[string]any{
-				"text":       map[string]any{"type": "string", "description": "发给用户的回答，人话，直接可读"},
-				"runId":      map[string]any{"type": "string", "description": "可选：这条回答关联的 Run"},
+			platformmcp.Tool("pm_reply", "把这一轮查到的结论交给会话层。会话层（快模型）会用人话转述后再发到 IM；"+
+				"有会话层时你提交的 text 不会原样直发。你在正文里写的内容默认不会外发，只有这里提交的 text 会进入转述。"+
+				"text 必须是事实清楚、用户能读懂的人话：不要出现 Run ID、工作流名、沙箱/工具/内部事件等实现细节，也不要写推理过程。"+
+				"一轮只交一条：把结论一次写完，不要拆成多条。返回 status=already_replied 表示这一轮已经收过结论了，"+
+				"此时不要改措辞重交，直接结束这一轮。", map[string]any{
+				"text":       map[string]any{"type": "string", "description": "交给会话层转述的结论，人话，事实清楚"},
+				"runId":      map[string]any{"type": "string", "description": "可选：这条结论关联的 Run"},
 				"shortTitle": map[string]any{"type": "string", "description": "可选：关联任务的短标题（人话，禁止填 Run ID）"},
 			}),
-			platformmcp.Tool("pm_notify_progress", "向外部 IM 显式提交一条 Sendable 进度/阻塞/确认消息（须含 stage/conclusion 等实质字段）。返回 status=sent 表示已外发；status=suppressed 表示被限频/去重/合并等策略正常抑制（不是失败，不要改措辞重发）；只有真实投递失败才返回错误。", map[string]any{
+			platformmcp.Tool("pm_notify_progress", "向会话层提交一条进度/阻塞/确认事实（须含 stage/conclusion 等实质字段），由会话层转述后再发到 IM。返回 status=sent 表示已外发；status=suppressed 表示被限频/去重/合并等策略正常抑制（不是失败，不要改措辞重交）；只有真实投递失败才返回错误。", map[string]any{
 				"runId":          map[string]any{"type": "string"},
 				"kind":           map[string]any{"type": "string", "description": "progress|blocked|action_required|final"},
 				"text":           map[string]any{"type": "string"},


### PR DESCRIPTION
## Summary
- Live 超时/空回复/投递失败降级沙箱时，先发 fallthrough ack，避免 IM 长时间无气泡（线上「项目的错误处理完整吗」复现）
- 默认 `APPROVING_LIVE_TIMEOUT_SEC` 从 8s 提到 120s，适配本地 reasoning 模型
- 工作层 `ChannelPreamble` / `pm_reply` 文案改为「交结论给会话层」短合同；人设与口径仍由快模型统一开口

## Test plan
- [x] `go test ./internal/channels/ ./internal/config/ ./internal/pmmcp/`
- [ ] 设置页确认 Live 超时 ≥120（库里若已存 8 需手动改）
- [ ] QQ 发一条需查仓库的问题：超时降级时应先收到 ack，再收到结论
- [ ] 新开会话后沙箱 preamble 应为短版「工作层」合同


Made with [Cursor](https://cursor.com)