### PR TITLE
fix(channels): 状态查询同步失败终态，禁止空队列说成「做完了」

### DIFF
--- a/server/internal/channels/director.go
+++ b/server/internal/channels/director.go
@@ -63,10 +63,15 @@ type directorContext struct {
 	ConversationBusy  bool            `json:"conversation_busy"`
 	FocusTaskID       string          `json:"focus_task_id,omitempty"`
 	Tasks             []ledgerEntry   `json:"tasks,omitempty"`
+	RecentTerminal    []ledgerEntry   `json:"recent_terminal,omitempty"`
 	RecentAttachments []AttachmentRef `json:"recent_attachments,omitempty"`
 	LastOutbound      string          `json:"last_outbound,omitempty"`
 	UserMessageID     string          `json:"user_message_id,omitempty"`
 }
+
+// recentTerminalWindow is how far back get_status / briefing still surface
+// finished work so "什么情况了" cannot invent success from an empty active list.
+const recentTerminalWindow = 24 * time.Hour
 
 // render turns the briefing into the lines the model reads.
 //
@@ -78,7 +83,7 @@ func (dc directorContext) render() string {
 	var b strings.Builder
 	b.WriteString("【当前情况】\n")
 	if len(dc.Tasks) == 0 {
-		b.WriteString("现在没有在跑的任务。\n")
+		b.WriteString("现在没有在跑的任务。这不等于「做完了」——先看刚结束的任务状态。\n")
 	} else {
 		b.WriteString("在跑的任务：\n")
 		for _, t := range dc.Tasks {
@@ -103,6 +108,17 @@ func (dc directorContext) render() string {
 			b.WriteString("对方若是补充/收窄这件事，用 refine_work 挂到这个 taskId，不要新开任务，也不要把队列甩给对方选。\n")
 		}
 	}
+	if len(dc.RecentTerminal) > 0 {
+		b.WriteString("刚结束的任务（务必按 status 原样说，failed≠完成）：\n")
+		for _, t := range dc.RecentTerminal {
+			line := fmt.Sprintf("- %s（taskId=%s，状态=%s", t.ShortTitle, t.TaskID, t.Status)
+			if t.UpdatedAgo != "" {
+				line += "，" + t.UpdatedAgo
+			}
+			line += "）"
+			b.WriteString(line + "\n")
+		}
+	}
 	if dc.ConversationBusy {
 		b.WriteString("现在有一件事正在前台执行。\n")
 	}
@@ -125,6 +141,7 @@ func (m *Manager) buildDirectorContext(rc *runningChannel, in InboundMessage) di
 		ConversationBusy: m.IsConversationBusy(rc.cfg.ProjectID, in.Scene, in.ConversationID),
 		UserMessageID:    strings.TrimSpace(in.RecordedMessageID),
 		Tasks:            m.taskLedger(rc, in),
+		RecentTerminal:   m.recentTerminalLedger(rc, in),
 	}
 	if focus := m.focusTaskID(rc, in); focus != "" {
 		dc.FocusTaskID = focus
@@ -148,6 +165,24 @@ func (m *Manager) taskLedger(rc *runningChannel, in InboundMessage) []ledgerEntr
 			Msg("task ledger unavailable; the conversation layer speaks without it")
 		return nil
 	}
+	return m.entriesFromIdentities(rc.cfg.ProjectID, tasks)
+}
+
+func (m *Manager) recentTerminalLedger(rc *runningChannel, in InboundMessage) []ledgerEntry {
+	if m.taskContext == nil {
+		return nil
+	}
+	tasks, err := m.taskContext.RecentTerminalTasksForConversation(
+		m.taskScopeFor(rc, in), ledgerLimit, recentTerminalWindow)
+	if err != nil {
+		log.Debug().Err(err).Str("project", rc.cfg.ProjectID).
+			Msg("recent terminal ledger unavailable")
+		return nil
+	}
+	return m.entriesFromIdentities(rc.cfg.ProjectID, tasks)
+}
+
+func (m *Manager) entriesFromIdentities(projectID string, tasks []models.TaskIdentity) []ledgerEntry {
 	out := make([]ledgerEntry, 0, len(tasks))
 	for _, t := range tasks {
 		entry := ledgerEntry{
@@ -156,7 +191,7 @@ func (m *Manager) taskLedger(rc *runningChannel, in InboundMessage) []ledgerEntr
 			Status:     t.Status,
 			UpdatedAgo: humanizeAge(time.Since(t.UpdatedAt)),
 		}
-		if note, ok := m.workNoteFor(rc.cfg.ProjectID, t.RunID); ok {
+		if note, ok := m.workNoteFor(projectID, t.RunID); ok {
 			entry.Stage, entry.Blocked = note.Stage, note.Blocked
 			entry.LastProgress = note.Stage
 		}
@@ -278,25 +313,41 @@ func (m *Manager) labelProgress(rc *runningChannel, in InboundMessage, ev Progre
 // purpose: a sentence would invite the model to copy it verbatim, and the point
 // of this layer is that the model does the phrasing.
 type statusResult struct {
-	Tasks []ledgerEntry `json:"tasks"`
-	Note  string        `json:"note,omitempty"`
+	Tasks          []ledgerEntry `json:"tasks"`
+	RecentTerminal []ledgerEntry `json:"recent_terminal,omitempty"`
+	Note           string        `json:"note,omitempty"`
 }
 
 // runGetStatus answers "where is it" from the ledger, never from memory.
 func (m *Manager) runGetStatus(rc *runningChannel, in InboundMessage, taskID string) string {
 	tasks := m.taskLedger(rc, in)
+	recent := m.recentTerminalLedger(rc, in)
 	taskID = strings.TrimSpace(taskID)
 	if taskID != "" {
 		for _, t := range tasks {
 			if t.TaskID == taskID || t.RunID == taskID {
-				return encodeToolResult(statusResult{Tasks: []ledgerEntry{t}})
+				return encodeToolResult(statusResult{Tasks: []ledgerEntry{t}, RecentTerminal: recent})
 			}
 		}
-		return encodeToolResult(statusResult{Tasks: tasks, Note: "没有这个 taskId 的在跑任务；下面是目前还在跑的。"})
+		for _, t := range recent {
+			if t.TaskID == taskID || t.RunID == taskID {
+				return encodeToolResult(statusResult{
+					Tasks: nil, RecentTerminal: []ledgerEntry{t},
+					Note: "这个任务已经结束，状态见 recent_terminal，不要说成还在跑或笼统「做完了」。",
+				})
+			}
+		}
+		return encodeToolResult(statusResult{
+			Tasks: tasks, RecentTerminal: recent,
+			Note: "没有这个 taskId；下面是在跑的和刚结束的。",
+		})
 	}
-	res := statusResult{Tasks: tasks}
-	if len(tasks) == 0 {
-		res.Note = "现在没有在跑的任务。如果用户问的事情还没开始，就用 dispatch_pm 派下去。"
+	res := statusResult{Tasks: tasks, RecentTerminal: recent}
+	switch {
+	case len(tasks) == 0 && len(recent) > 0:
+		res.Note = "现在没有在跑的任务。刚结束的在 recent_terminal：必须按每条的 status 说（failed=失败，cancelled=取消，completed=完成）。禁止把空的在跑列表说成「都做完了」。"
+	case len(tasks) == 0:
+		res.Note = "现在没有在跑的任务，也没有刚结束的记录。如果用户问的事情还没开始，用 dispatch_pm 派下去；不要编造完成或失败。"
 	}
 	if m.IsConversationBusy(rc.cfg.ProjectID, in.Scene, in.ConversationID) {
 		res.Note = strings.TrimSpace(res.Note + " 现在有一件事正在前台执行。")

--- a/server/internal/channels/gptlive_test.go
+++ b/server/internal/channels/gptlive_test.go
@@ -269,8 +269,8 @@ func TestGetStatusSurfacesFailedTerminalTasks(t *testing.T) {
 	if !strings.Contains(raw, "recent_terminal") && !strings.Contains(raw, `"status":"failed"`) {
 		t.Fatalf("get_status should expose terminal status explicitly: %s", raw)
 	}
-	if strings.Contains(raw, "都做完了") {
-		t.Fatalf("note must not invent success: %s", raw)
+	if !strings.Contains(raw, "禁止把空的在跑列表说成") {
+		t.Fatalf("note must forbid inventing success from an empty active list: %s", raw)
 	}
 	brief := g.m.buildDirectorContext(g.rc, InboundMessage{UserID: "u1", ConversationID: "user1"}).render()
 	if !strings.Contains(brief, "failed") || !strings.Contains(brief, "不等于") {

--- a/server/internal/channels/gptlive_test.go
+++ b/server/internal/channels/gptlive_test.go
@@ -253,6 +253,31 @@ func TestNoConversationModelSendsEverythingToTheAgent(t *testing.T) {
 	}
 }
 
+func TestGetStatusSurfacesFailedTerminalTasks(t *testing.T) {
+	g := newGPTLive(t)
+	if _, err := g.m.taskContext.EnsureIdentity(services.EnsureTaskIdentityInput{
+		RunID: "run-fail-status", ProjectID: "proj", UserID: services.SyntheticQQUserID("u1"),
+		ShortTitle: "统一错误码", Status: "failed",
+		OriginChannel: "qq", OriginScene: string(SceneC2C), OriginConversationID: "user1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	raw := g.m.runGetStatus(g.rc, InboundMessage{UserID: "u1", ConversationID: "user1"}, "")
+	if !strings.Contains(raw, "failed") || !strings.Contains(raw, "统一错误码") {
+		t.Fatalf("get_status missing failed terminal: %s", raw)
+	}
+	if !strings.Contains(raw, "recent_terminal") && !strings.Contains(raw, `"status":"failed"`) {
+		t.Fatalf("get_status should expose terminal status explicitly: %s", raw)
+	}
+	if strings.Contains(raw, "都做完了") {
+		t.Fatalf("note must not invent success: %s", raw)
+	}
+	brief := g.m.buildDirectorContext(g.rc, InboundMessage{UserID: "u1", ConversationID: "user1"}).render()
+	if !strings.Contains(brief, "failed") || !strings.Contains(brief, "不等于") {
+		t.Fatalf("briefing must warn empty≠done and list failure: %s", brief)
+	}
+}
+
 func TestLiveCallTimeoutFollowsConfiguredLiveTimeout(t *testing.T) {
 	m := &Manager{live: &fakeLive{configured: true, timeout: 300 * time.Second}}
 	if got := m.liveCallTimeout(45 * time.Second); got != 300*time.Second {

--- a/server/internal/channels/live.go
+++ b/server/internal/channels/live.go
@@ -68,7 +68,7 @@ const liveSystemPrompt = `你是这个项目的负责人本人，正在 IM 上�
 意图怎么认（先认意图，再动手）：
 - 对方在补充、收窄、纠正、加重点（例如「重点看 Release 到现在」「别看旧的」「再加上导出」）——只要是挂在已有任务上，调用 refine_work，不要新开任务。
 - 对方要一件和正在跑的事明显不同的新活 —— 调用 dispatch_pm。
-- 要讲进度、状态或结论 —— 先 get_status，用返回内容说话。
+- 要讲进度、状态或结论 —— 先 get_status，用返回内容说话。recent_terminal 里的 status 必须照实说：failed 就是失败，cancelled 就是取消；没有在跑的任务不等于做完了。
 - 对方说不用弄了 / 停下 / 算了 —— 调用 cancel_work。
 
 派活前判断难度：lookup=查一下就知道；heavy=要花好几分钟。
@@ -743,10 +743,11 @@ func directorTools() []liveagent.ToolSpec {
 		},
 		{
 			Name: getStatusTool,
-			Description: "查这个会话里正在跑的任务的真实状态。" +
-				"要跟对方讲进度、状态或结论之前必须先调它，不要凭印象说。",
+			Description: "查这个会话里任务的真实状态（在跑的 + 刚结束的 recent_terminal）。" +
+				"要跟对方讲进度、状态或结论之前必须先调它，不要凭印象说。" +
+				"recent_terminal.status 为 failed/cancelled/completed 时必须照实转述；空的在跑列表不等于都成功了。",
 			Params: []liveagent.Param{
-				{Name: "task_id", Description: "只查某一件事时填它的 taskId；不填就列出全部。"},
+				{Name: "task_id", Description: "只查某一件事时填它的 taskId；不填就列出在跑的和刚结束的。"},
 			},
 		},
 		{

--- a/server/internal/channels/manager.go
+++ b/server/internal/channels/manager.go
@@ -681,6 +681,9 @@ func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMes
 		summary, reason, ok = deliverableFinalText(reply)
 	}
 	if !ok {
+		// No deliverable conclusion — do not mark the ephemeral ledger row
+		// "completed", or the next "什么情况了" invents success from an empty queue.
+		closeStatus = "failed"
 		// The agent finished without submitting anything the user can read. If
 		// something substantive already went out this turn, staying quiet is the
 		// honest outcome. Receipt/process-only bodies also stay quiet (0 sends)

--- a/server/internal/services/task_context.go
+++ b/server/internal/services/task_context.go
@@ -385,13 +385,47 @@ func (s *TaskContextService) reapStaleActiveTask(task *models.TaskIdentity) bool
 		}
 	}
 	if strings.HasPrefix(runID, "dispatch:") && now.Sub(task.UpdatedAt) > StaleDispatchTTL {
+		// Abandoned stub — not a successful finish. Marking these "completed"
+		// taught get_status to report "做完了" when nothing succeeded.
 		_, _ = s.UpdateIdentity(EnsureTaskIdentityInput{
 			RunID: runID, ProjectID: task.ProjectID, UserID: task.UserID,
-			Status: "completed",
+			Status: "cancelled",
 		})
 		return true
 	}
 	return false
+}
+
+// RecentTerminalTasksForConversation lists recently finished tasks in this
+// conversation so status questions can say "失败了 / 取消了 / 做完了" instead of
+// inventing success from an empty active list.
+func (s *TaskContextService) RecentTerminalTasksForConversation(scope TaskScope, limit int, within time.Duration) ([]models.TaskIdentity, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("task context database is unavailable")
+	}
+	if strings.TrimSpace(scope.ProjectID) == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 5
+	}
+	if within <= 0 {
+		within = 24 * time.Hour
+	}
+	since := s.now().Add(-within)
+	q := s.db.Where("project_id = ? AND terminal_at IS NOT NULL AND terminal_at >= ?",
+		scope.ProjectID, since)
+	if uid := strings.TrimSpace(scope.UserID); uid != "" {
+		q = q.Where("user_id = ? OR user_id = ''", uid)
+	}
+	if conv := strings.TrimSpace(scope.ConversationID); conv != "" {
+		q = q.Where("origin_conversation_id = ?", conv)
+	}
+	var rows []models.TaskIdentity
+	if err := q.Order("terminal_at DESC").Limit(limit).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
 }
 
 // ProjectTaskQuery bounds a project-management task list.

--- a/server/internal/services/task_context_test.go
+++ b/server/internal/services/task_context_test.go
@@ -126,6 +126,42 @@ func TestActiveTasksAreScopedToTheConversationAndReapGhosts(t *testing.T) {
 	if len(got) != 1 || got[0].ID != live.ID {
 		t.Fatalf("active = %+v want only the live task in this conversation", got)
 	}
+	var stub models.TaskIdentity
+	if err := db.Where("run_id = ?", "dispatch:old").First(&stub).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stub.Status != "cancelled" || stub.TerminalAt == nil {
+		t.Fatalf("stale dispatch should be cancelled, got status=%q terminal=%v", stub.Status, stub.TerminalAt)
+	}
+}
+
+func TestRecentTerminalTasksSurfaceFailuresForStatus(t *testing.T) {
+	db := taskContextDB(t)
+	svc := NewTaskContextService(db)
+	now := time.Date(2026, 8, 8, 3, 0, 0, 0, time.UTC)
+	svc.SetClock(func() time.Time { return now })
+	scope := TaskScope{ProjectID: "p1", UserID: SyntheticQQUserID("u1"), Channel: "qq", ConversationID: "c1"}
+
+	failed, err := svc.EnsureIdentity(EnsureTaskIdentityInput{
+		RunID: "run-fail", ProjectID: scope.ProjectID, UserID: scope.UserID,
+		ShortTitle: "统一错误码", Status: "failed", OriginConversationID: "c1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.EnsureIdentity(EnsureTaskIdentityInput{
+		RunID: "run-ok", ProjectID: scope.ProjectID, UserID: scope.UserID,
+		ShortTitle: "别的会话成功", Status: "completed", OriginConversationID: "c2",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := svc.RecentTerminalTasksForConversation(scope, 10, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != failed.ID || got[0].Status != "failed" {
+		t.Fatalf("recent = %+v want the failed task in this conversation", got)
+	}
 }
 
 func TestTaskContextMigrationIdentityResolutionAndIsolation(t *testing.T) {


### PR DESCRIPTION
## Summary
- 补上 #171 漏合的状态同步：`get_status` / 会话 briefing 带上近期 `failed` / `cancelled` / `completed`
- 过期 `dispatch:*` 标为 `cancelled`（不再误标 `completed`）
- 无结论的前台回合不再把账本写成 `completed`，避免「什么情况了」被说成都做完了

## Test plan
- [ ] 派活后让 Run 失败，再问「什么情况了」——应说失败，而不是「已经完成了」
- [ ] 调用链 / 任务待办里能看到对应终态
- [ ] `go test ./internal/channels/ ./internal/services/ -run 'GetStatusSurfaces|RecentTerminal|ActiveTasksAreScoped'`


Made with [Cursor](https://cursor.com)