### PR TITLE
fix(channels): 任务失败时让用户选下一步

### DIFF
--- a/server/internal/channels/director.go
+++ b/server/internal/channels/director.go
@@ -118,6 +118,9 @@ func (dc directorContext) render() string {
 			line += "）"
 			b.WriteString(line + "\n")
 		}
+		if hasFailedOrCancelled(dc.RecentTerminal) {
+			b.WriteString("其中有失败或取消：先说清状况，再让对方选下一步（重试 / 换范围或改方向 / 先搁置）。不要擅自说接着做。\n")
+		}
 	}
 	if dc.ConversationBusy {
 		b.WriteString("现在有一件事正在前台执行。\n")
@@ -331,9 +334,13 @@ func (m *Manager) runGetStatus(rc *runningChannel, in InboundMessage, taskID str
 		}
 		for _, t := range recent {
 			if t.TaskID == taskID || t.RunID == taskID {
+				note := "这个任务已经结束，状态见 recent_terminal，不要说成还在跑或笼统「做完了」。"
+				if isFailedOrCancelledStatus(t.Status) {
+					note += " " + failedStatusChoiceNote
+				}
 				return encodeToolResult(statusResult{
 					Tasks: nil, RecentTerminal: []ledgerEntry{t},
-					Note: "这个任务已经结束，状态见 recent_terminal，不要说成还在跑或笼统「做完了」。",
+					Note: note,
 				})
 			}
 		}
@@ -346,13 +353,42 @@ func (m *Manager) runGetStatus(rc *runningChannel, in InboundMessage, taskID str
 	switch {
 	case len(tasks) == 0 && len(recent) > 0:
 		res.Note = "现在没有在跑的任务。刚结束的在 recent_terminal：必须按每条的 status 说（failed=失败，cancelled=取消，completed=完成）。禁止把空的在跑列表说成「都做完了」。"
+		if hasFailedOrCancelled(recent) {
+			res.Note += " " + failedStatusChoiceNote
+		}
 	case len(tasks) == 0:
 		res.Note = "现在没有在跑的任务，也没有刚结束的记录。如果用户问的事情还没开始，用 dispatch_pm 派下去；不要编造完成或失败。"
+	default:
+		if hasFailedOrCancelled(recent) {
+			res.Note = failedStatusChoiceNote
+		}
 	}
 	if m.IsConversationBusy(rc.cfg.ProjectID, in.Scene, in.ConversationID) {
 		res.Note = strings.TrimSpace(res.Note + " 现在有一件事正在前台执行。")
 	}
 	return encodeToolResult(res)
+}
+
+// failedStatusChoiceNote steers the conversation model away from unilaterally
+// restarting failed work. The user should pick the next step.
+const failedStatusChoiceNote = "有失败或取消时：先如实说状况，再明确让对方选——重试、换范围/改方向、还是先搁置。不要擅自派活或说「我接着做」。"
+
+func hasFailedOrCancelled(entries []ledgerEntry) bool {
+	for _, e := range entries {
+		if isFailedOrCancelledStatus(e.Status) {
+			return true
+		}
+	}
+	return false
+}
+
+func isFailedOrCancelledStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "failed", "cancelled", "canceled":
+		return true
+	default:
+		return false
+	}
 }
 
 // cancelResult reports what actually stopped.

--- a/server/internal/channels/gptlive_test.go
+++ b/server/internal/channels/gptlive_test.go
@@ -253,6 +253,37 @@ func TestNoConversationModelSendsEverythingToTheAgent(t *testing.T) {
 	}
 }
 
+func TestRetryAffirmationAfterFailureRedispatchesInsteadOfConfirmAck(t *testing.T) {
+	g := newGPTLive(t)
+	if _, err := g.m.taskContext.EnsureIdentity(services.EnsureTaskIdentityInput{
+		RunID: "run-fail-retry", ProjectID: "proj", UserID: services.SyntheticQQUserID("u1"),
+		ShortTitle: "错误处理与日志", Status: "failed",
+		OriginalRequirement: "修复 Approving 错误处理与日志链路",
+		OriginChannel:       "qq", OriginScene: string(SceneC2C), OriginConversationID: "user1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Live times out — the platform must still redispatch, not stamp 「确认」.
+	g.m.SetLiveModel(&fakeLive{configured: true, err: liveagent.ErrBudgetExhausted})
+	g.say("m-retry", "重跑啊")
+	got := sentTexts(g.fa)
+	if len(got) < 1 {
+		t.Fatalf("sends = %v", got)
+	}
+	if strings.Contains(got[0], "确认") {
+		t.Fatalf("retry affirmation must not use confirm ack: %q", got[0])
+	}
+	if !strings.Contains(got[0], "重新") {
+		t.Fatalf("retry ack should say work is redispatched: %q", got[0])
+	}
+	if len(g.agent) != 1 {
+		t.Fatalf("retry must reach the sandbox agent, got %d turns", len(g.agent))
+	}
+	if d := g.agent[0].Dispatch; d == nil || !strings.Contains(d.Brief, "错误处理") {
+		t.Fatalf("sandbox brief missing original requirement: %+v", g.agent[0].Dispatch)
+	}
+}
+
 func TestGetStatusSurfacesFailedTerminalTasks(t *testing.T) {
 	g := newGPTLive(t)
 	if _, err := g.m.taskContext.EnsureIdentity(services.EnsureTaskIdentityInput{

--- a/server/internal/channels/gptlive_test.go
+++ b/server/internal/channels/gptlive_test.go
@@ -272,9 +272,15 @@ func TestGetStatusSurfacesFailedTerminalTasks(t *testing.T) {
 	if !strings.Contains(raw, "禁止把空的在跑列表说成") {
 		t.Fatalf("note must forbid inventing success from an empty active list: %s", raw)
 	}
+	if !strings.Contains(raw, "重试") || !strings.Contains(raw, "搁置") {
+		t.Fatalf("failed status must ask the user to choose next step: %s", raw)
+	}
 	brief := g.m.buildDirectorContext(g.rc, InboundMessage{UserID: "u1", ConversationID: "user1"}).render()
 	if !strings.Contains(brief, "failed") || !strings.Contains(brief, "不等于") {
 		t.Fatalf("briefing must warn empty≠done and list failure: %s", brief)
+	}
+	if !strings.Contains(brief, "让对方选") {
+		t.Fatalf("briefing must require offering choices on failure: %s", brief)
 	}
 }
 

--- a/server/internal/channels/gptlive_test.go
+++ b/server/internal/channels/gptlive_test.go
@@ -41,6 +41,9 @@ func (f *fakeLive) Timeout() time.Duration { return f.timeout }
 
 func (f *fakeLive) Complete(_ context.Context, req liveagent.Request) (liveagent.Result, error) {
 	if len(req.Tools) == 0 {
+		if f.err != nil {
+			return liveagent.Result{}, f.err
+		}
 		if f.report == nil {
 			return liveagent.Result{}, errors.New("fakeLive: no phrasing configured")
 		}
@@ -263,24 +266,46 @@ func TestRetryAffirmationAfterFailureRedispatchesInsteadOfConfirmAck(t *testing.
 	}); err != nil {
 		t.Fatal(err)
 	}
-	// Live times out — the platform must still redispatch, not stamp 「确认」.
-	g.m.SetLiveModel(&fakeLive{configured: true, err: liveagent.ErrBudgetExhausted})
+	// Live can phrase the ack (no tools ⇒ report path) then we dispatch.
+	ack := "行，那块错误处理我让人重新开干，有进展回你。"
+	g.m.SetLiveModel(&fakeLive{configured: true, report: &liveagent.Result{Text: ack}})
 	g.say("m-retry", "重跑啊")
 	got := sentTexts(g.fa)
 	if len(got) < 1 {
 		t.Fatalf("sends = %v", got)
 	}
-	if strings.Contains(got[0], "确认") {
-		t.Fatalf("retry affirmation must not use confirm ack: %q", got[0])
+	if got[0] != ack {
+		t.Fatalf("retry ack should be Live-phrased GM voice, got %q want %q", got[0], ack)
 	}
-	if !strings.Contains(got[0], "重新") {
-		t.Fatalf("retry ack should say work is redispatched: %q", got[0])
+	if strings.Contains(got[0], "确认") || strings.Contains(got[0], "优先级") {
+		t.Fatalf("retry ack still sounds like a ticket: %q", got[0])
 	}
 	if len(g.agent) != 1 {
 		t.Fatalf("retry must reach the sandbox agent, got %d turns", len(g.agent))
 	}
 	if d := g.agent[0].Dispatch; d == nil || !strings.Contains(d.Brief, "错误处理") {
 		t.Fatalf("sandbox brief missing original requirement: %+v", g.agent[0].Dispatch)
+	}
+}
+
+func TestRetryAffirmationUsesGMTemplateWhenLiveCannotPhrase(t *testing.T) {
+	g := newGPTLive(t)
+	if _, err := g.m.taskContext.EnsureIdentity(services.EnsureTaskIdentityInput{
+		RunID: "run-fail-retry2", ProjectID: "proj", UserID: services.SyntheticQQUserID("u1"),
+		ShortTitle: "错误处理与日志", Status: "failed",
+		OriginalRequirement: "修复 Approving 错误处理与日志链路",
+		OriginChannel:       "qq", OriginScene: string(SceneC2C), OriginConversationID: "user1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	g.m.SetLiveModel(&fakeLive{configured: true, err: liveagent.ErrBudgetExhausted})
+	g.say("m-retry2", "重跑啊")
+	got := sentTexts(g.fa)
+	if len(got) < 1 || strings.Contains(got[0], "确认") {
+		t.Fatalf("want GM retry template without 确认, got %v", got)
+	}
+	if !strings.Contains(got[0], "重新开干") {
+		t.Fatalf("template should sound like a GM restarting work: %q", got[0])
 	}
 }
 

--- a/server/internal/channels/live.go
+++ b/server/internal/channels/live.go
@@ -139,10 +139,20 @@ func (m *Manager) routeThroughLiveModel(ctx context.Context, rc *runningChannel,
 			Msg("no conversation model configured; this message goes straight to the agent")
 		rec := m.newSampleRecorder(rc, in)
 		rec.flag("live_not_configured")
+		if outcome, ok := m.dispatchRetryFromLedger(ctx, rc, in, rec, ""); ok {
+			return outcome
+		}
 		return liveOutcome{sampleID: rec.commit(routeDirect)}
 	}
 
 	rec := m.newSampleRecorder(rc, in)
+	// "重跑啊" must not enter the full tool-routing loop: that is what timed
+	// out into 「我这就去确认」. Phrase the ack with the fast model (tiny
+	// prompt), then dispatch from the ledger.
+	if outcome, ok := m.routeRetryAffirmation(ctx, rc, in, rec); ok {
+		return outcome
+	}
+
 	briefing := m.buildDirectorContext(rc, in)
 	rec.briefedWith(briefing)
 
@@ -167,11 +177,6 @@ func (m *Manager) routeThroughLiveModel(ctx context.Context, rc *runningChannel,
 			level.Err(err).Str("project", rc.cfg.ProjectID).Str("trace", in.TraceID).
 				Msg("conversation model unavailable; handing turn to the agent")
 			rec.failed(err)
-			// Explicit "重跑啊" after a failed task must not become the empty
-			// 「我这就去确认」stamp — rebuild the dispatch from the ledger.
-			if outcome, ok := m.fallbackRetryDispatch(ctx, rc, in, rec); ok {
-				return outcome
-			}
 			// The sandbox still answers, but it can take a minute to come up.
 			// Saying nothing until then is how "项目的错误处理完整吗" sat on
 			// screen with a running timer and no bubble — the model timed out
@@ -242,10 +247,39 @@ func (m *Manager) ackFallthrough(ctx context.Context, rc *runningChannel, in Inb
 	}
 }
 
-// fallbackRetryDispatch runs when Live timed out but the user clearly affirmed
-// a retry of recently failed/cancelled work. It re-dispatches from the ledger
-// so "重跑啊" becomes a real sandbox turn instead of a hollow 确认 ack.
-func (m *Manager) fallbackRetryDispatch(ctx context.Context, rc *runningChannel, in InboundMessage, rec *sampleRecorder) (liveOutcome, bool) {
+// routeRetryAffirmation handles "重跑啊" before the slow full Live tool loop.
+// The user-facing line is phrased by the fast model; the ledger supplies the
+// work brief. That is what keeps the voice GM-like when Ollama would otherwise
+// burn the whole timeout on routing tools and fall back to 「确认」.
+func (m *Manager) routeRetryAffirmation(ctx context.Context, rc *runningChannel, in InboundMessage, rec *sampleRecorder) (liveOutcome, bool) {
+	if !looksLikeRetryAffirmation(in.Text) {
+		return liveOutcome{}, false
+	}
+	failed := m.latestRetryableTerminal(rc, in)
+	if failed == nil {
+		return liveOutcome{}, false
+	}
+	title := services.SanitizeShortTitle(failed.ShortTitle)
+	userContent := "对方说：" + strings.TrimSpace(in.Text) + "\n"
+	if title != "" {
+		userContent += "要重跑的事：" + title + "\n"
+	}
+	if req := strings.TrimSpace(failed.OriginalRequirement); req != "" {
+		userContent += "原来的要求：" + truncateRunes(req, 200) + "\n"
+	}
+	ack := strings.TrimSpace(m.phraseThroughLive(ctx, retryAckPhrasePrompt, userContent))
+	if ack != "" {
+		rec.flag("retry_ack_live")
+	} else {
+		ack = gmRetryAck(title)
+		rec.flag("retry_ack_template")
+	}
+	return m.dispatchRetryFromLedger(ctx, rc, in, rec, ack)
+}
+
+// dispatchRetryFromLedger rebuilds a dispatch from a recently failed/cancelled
+// task. preferredAck is the user-facing line (preferably Live-phrased).
+func (m *Manager) dispatchRetryFromLedger(ctx context.Context, rc *runningChannel, in InboundMessage, rec *sampleRecorder, preferredAck string) (liveOutcome, bool) {
 	if !looksLikeRetryAffirmation(in.Text) {
 		return liveOutcome{}, false
 	}
@@ -261,9 +295,9 @@ func (m *Manager) fallbackRetryDispatch(ctx context.Context, rc *runningChannel,
 		return liveOutcome{}, false
 	}
 	title := services.SanitizeShortTitle(failed.ShortTitle)
-	userReply := "好，重新派下去了，有进展回你。"
-	if title != "" {
-		userReply = "好，「" + title + "」重新派下去了，有进展回你。"
+	userReply := strings.TrimSpace(preferredAck)
+	if userReply == "" {
+		userReply = gmRetryAck(title)
 	}
 	outcome, refused := m.dispatchWork(ctx, rc, in, map[string]string{
 		"request": brief, "short_title": title,
@@ -272,12 +306,62 @@ func (m *Manager) fallbackRetryDispatch(ctx context.Context, rc *runningChannel,
 	}, rec)
 	if refused != "" {
 		log.Info().Str("project", rc.cfg.ProjectID).Str("trace", in.TraceID).
-			Str("detail", refused).Msg("retry dispatch fallback refused; using generic fallthrough")
+			Str("detail", refused).Msg("retry dispatch refused; using generic fallthrough")
 		return liveOutcome{}, false
 	}
-	rec.flag("retry_dispatch_fallback")
+	rec.flag("retry_dispatch")
 	return outcome, true
 }
+
+func gmRetryAck(title string) string {
+	title = services.SanitizeShortTitle(title)
+	if title != "" {
+		return "行，「" + title + "」我让人重新开干，有进展回你。"
+	}
+	return "行，那事我让人重新开干，有进展回你。"
+}
+
+// phraseThroughLive asks the fast model for one short IM line. Empty means the
+// caller should use a GM-toned template — never the hollow 「确认」 stamp.
+func (m *Manager) phraseThroughLive(ctx context.Context, system, user string) string {
+	if m == nil || m.live == nil || !m.live.Configured() {
+		return ""
+	}
+	system, user = strings.TrimSpace(system), strings.TrimSpace(user)
+	if system == "" || user == "" {
+		return ""
+	}
+	// Keep this hop short: it is only one sentence. A stuck Ollama must not
+	// burn the full live_timeout before we fall back to the GM template.
+	timeout := 20 * time.Second
+	if d := m.live.Timeout(); d > 0 && d < timeout {
+		timeout = d
+	}
+	callCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	res, err := m.live.Complete(callCtx, liveagent.Request{
+		System: system, Messages: []liveagent.Message{{Role: "user", Content: user}},
+		MaxTokens: 256,
+	})
+	if err != nil {
+		return ""
+	}
+	out := strings.TrimSpace(res.Text)
+	if out == "" || strings.Contains(out, "确认") {
+		return ""
+	}
+	return out
+}
+
+const retryAckPhrasePrompt = `你是这个项目的负责人本人，正在 IM 上和同事聊天。你的回复会原样发给对方。
+
+对方刚明确说要重跑/再试一件刚失败的事。用一两句人话告诉对方：你已经按那件事重新安排人去干了。
+
+规矩：
+- 像同事当面说，不要工单腔，不要「我这就去确认」「收到」「稍等」。
+- 不要提优先级、任务编号、工作流、沙箱、跟进页面、Approving。
+- 不要说「已经跑完了 / 已经重新跑过了」——现在只是重新开跑。
+- 只输出要发给对方的那句话。`
 
 func (m *Manager) latestRetryableTerminal(rc *runningChannel, in InboundMessage) *models.TaskIdentity {
 	if m.taskContext == nil {
@@ -677,7 +761,9 @@ const directorReportPrompt = `你是这个项目的负责人本人，正在 IM �
 - 只讲给出的事实。不要补充、不要推测、不要下额外结论、不要建议。
 - 先给结论，必要细节最多再补两三句；不要把长报告或分点清单原样贴出去。
 - 说人话，像同事当面说，不要写工单腔。
-- 不要出现任务编号、工作流名、执行环境、工具名这些内部说法。
+- 不要出现任务编号、工作流名、执行环境、工具名、优先级这些内部说法。
+- 不要说「你那边跟进看看」「请前往 Approving」这类把人打发走的话。
+- 若事实只是「重新开跑了」而不是做完了，就说重新开跑了，不要说得像已经收工。
 - 只输出要发出去的话，不要加前缀、标题或解释，也不要写到一半截断。`
 
 // warmWorkLayer brings the agent's sandbox up in the background.

--- a/server/internal/channels/live.go
+++ b/server/internal/channels/live.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cocofhu/approving/internal/liveagent"
+	"github.com/cocofhu/approving/internal/models"
 	"github.com/cocofhu/approving/internal/sendable"
 	"github.com/cocofhu/approving/internal/services"
 
@@ -70,13 +71,14 @@ const liveSystemPrompt = `你是这个项目的负责人本人，正在 IM 上�
 - 对方要一件和正在跑的事明显不同的新活 —— 调用 dispatch_pm。
 - 要讲进度、状态或结论 —— 先 get_status，用返回内容说话。recent_terminal 里的 status 必须照实说：failed 就是失败，cancelled 就是取消；没有在跑的任务不等于做完了。
 - 对方说不用弄了 / 停下 / 算了 —— 调用 cancel_work。
+- 对方明确说重跑 / 再试 / 继续做刚才失败或取消的那件 —— 立刻 dispatch_pm（request 用原要求，short_title 沿用原标题），user_reply 写成「好，重新派下去了」；不要只回「我这就去确认」，也不要再问一遍。
 
 派活前判断难度：lookup=查一下就知道；heavy=要花好几分钟。
 dispatch_pm / refine_work 都要用 user_reply 先接一句；平台会先发出去再去查。
 
 规矩：
 - 接话必须有内容。「稍等」「好的我看一下」「收到」这种空话不算接话。
-- 任务 failed / cancelled 时：先如实说原因（有依据才说），然后让对方选下一步，例如重试、换范围/改方向、或先搁置；不要擅自说「我接着跑」「后面重新做」就开干，除非对方刚明确要你继续。
+- 任务 failed / cancelled 时：先如实说原因（有依据才说），然后让对方选下一步，例如重试、换范围/改方向、或先搁置；不要擅自说「我接着跑」「后面重新做」就开干，除非对方刚明确要你继续（重跑/再试等）。
 - 任务已满时：若对方是在补充你们正在聊的那件，用 refine_work，不要把队列甩给对方让他挑停哪件。
 - 只有对方明确要另开一件完全不同的新事、且确实满了，才简短说明手上忙、问要先停哪件。
 - 不要编造任务状态、进度、代码内容或任何你没有依据的事实。
@@ -165,6 +167,11 @@ func (m *Manager) routeThroughLiveModel(ctx context.Context, rc *runningChannel,
 			level.Err(err).Str("project", rc.cfg.ProjectID).Str("trace", in.TraceID).
 				Msg("conversation model unavailable; handing turn to the agent")
 			rec.failed(err)
+			// Explicit "重跑啊" after a failed task must not become the empty
+			// 「我这就去确认」stamp — rebuild the dispatch from the ledger.
+			if outcome, ok := m.fallbackRetryDispatch(ctx, rc, in, rec); ok {
+				return outcome
+			}
 			// The sandbox still answers, but it can take a minute to come up.
 			// Saying nothing until then is how "项目的错误处理完整吗" sat on
 			// screen with a running timer and no bubble — the model timed out
@@ -233,6 +240,94 @@ func (m *Manager) ackFallthrough(ctx context.Context, rc *runningChannel, in Inb
 		m.markReplied(scope)
 		m.markAcknowledged(scope)
 	}
+}
+
+// fallbackRetryDispatch runs when Live timed out but the user clearly affirmed
+// a retry of recently failed/cancelled work. It re-dispatches from the ledger
+// so "重跑啊" becomes a real sandbox turn instead of a hollow 确认 ack.
+func (m *Manager) fallbackRetryDispatch(ctx context.Context, rc *runningChannel, in InboundMessage, rec *sampleRecorder) (liveOutcome, bool) {
+	if !looksLikeRetryAffirmation(in.Text) {
+		return liveOutcome{}, false
+	}
+	failed := m.latestRetryableTerminal(rc, in)
+	if failed == nil {
+		return liveOutcome{}, false
+	}
+	brief := strings.TrimSpace(failed.OriginalRequirement)
+	if brief == "" {
+		brief = strings.TrimSpace(failed.ShortTitle)
+	}
+	if brief == "" {
+		return liveOutcome{}, false
+	}
+	title := services.SanitizeShortTitle(failed.ShortTitle)
+	userReply := "好，重新派下去了，有进展回你。"
+	if title != "" {
+		userReply = "好，「" + title + "」重新派下去了，有进展回你。"
+	}
+	outcome, refused := m.dispatchWork(ctx, rc, in, map[string]string{
+		"request": brief, "short_title": title,
+		"difficulty": string(DifficultyHeavy),
+		"user_reply": userReply,
+	}, rec)
+	if refused != "" {
+		log.Info().Str("project", rc.cfg.ProjectID).Str("trace", in.TraceID).
+			Str("detail", refused).Msg("retry dispatch fallback refused; using generic fallthrough")
+		return liveOutcome{}, false
+	}
+	rec.flag("retry_dispatch_fallback")
+	return outcome, true
+}
+
+func (m *Manager) latestRetryableTerminal(rc *runningChannel, in InboundMessage) *models.TaskIdentity {
+	if m.taskContext == nil {
+		return nil
+	}
+	rows, err := m.taskContext.RecentTerminalTasksForConversation(
+		m.taskScopeFor(rc, in), ledgerLimit, recentTerminalWindow)
+	if err != nil || len(rows) == 0 {
+		return nil
+	}
+	var cancelled *models.TaskIdentity
+	for i := range rows {
+		switch strings.ToLower(strings.TrimSpace(rows[i].Status)) {
+		case "failed":
+			return &rows[i]
+		case "cancelled", "canceled":
+			if cancelled == nil {
+				cancelled = &rows[i]
+			}
+		}
+	}
+	return cancelled
+}
+
+// looksLikeRetryAffirmation detects short "yes, retry that" replies. Negations
+// ("不要重跑") never match. Longer free-form messages stay with the model.
+func looksLikeRetryAffirmation(text string) bool {
+	t := strings.TrimSpace(text)
+	if t == "" {
+		return false
+	}
+	lower := strings.ToLower(t)
+	for _, neg := range []string{"不要", "别", "不用", "别再", "don't", "do not", "no "} {
+		if strings.Contains(lower, neg) {
+			return false
+		}
+	}
+	if len([]rune(t)) > 24 {
+		return false
+	}
+	for _, a := range []string{
+		"重跑", "再跑", "重试", "再试", "再来一次", "重新做", "重新派", "再弄",
+		"继续做", "接着做", "接着干", "继续",
+		"retry", "try again", "run again", "do it again",
+	} {
+		if lower == a || strings.Contains(lower, a) {
+			return true
+		}
+	}
+	return false
 }
 
 // deliverDirectorReply sends what the model said, as it said it.
@@ -642,6 +737,14 @@ func gateAcknowledgement(reply, shortTitle, userText string) (string, []string) 
 	}
 	title := services.SanitizeShortTitle(shortTitle)
 	flags := []string{"empty_ack"}
+	// A retry affirmation must never read as a vague "确认" — the user already
+	// chose. Name the work when we can.
+	if looksLikeRetryAffirmation(userText) {
+		if title != "" && !echoesUserText(title, userText) {
+			return "好，「" + title + "」我重新安排，有进展回你。", flags
+		}
+		return "好，我重新安排，有进展回你。", flags
+	}
 	// Quoting a real short title ("登录页报错") names the work. Quoting the
 	// user's own question — or a truncation of it — just mirrors them.
 	if title == "" || echoesUserText(title, userText) {

--- a/server/internal/channels/live.go
+++ b/server/internal/channels/live.go
@@ -76,6 +76,7 @@ dispatch_pm / refine_work 都要用 user_reply 先接一句；平台会先发出
 
 规矩：
 - 接话必须有内容。「稍等」「好的我看一下」「收到」这种空话不算接话。
+- 任务 failed / cancelled 时：先如实说原因（有依据才说），然后让对方选下一步，例如重试、换范围/改方向、或先搁置；不要擅自说「我接着跑」「后面重新做」就开干，除非对方刚明确要你继续。
 - 任务已满时：若对方是在补充你们正在聊的那件，用 refine_work，不要把队列甩给对方让他挑停哪件。
 - 只有对方明确要另开一件完全不同的新事、且确实满了，才简短说明手上忙、问要先停哪件。
 - 不要编造任务状态、进度、代码内容或任何你没有依据的事实。
@@ -745,7 +746,8 @@ func directorTools() []liveagent.ToolSpec {
 			Name: getStatusTool,
 			Description: "查这个会话里任务的真实状态（在跑的 + 刚结束的 recent_terminal）。" +
 				"要跟对方讲进度、状态或结论之前必须先调它，不要凭印象说。" +
-				"recent_terminal.status 为 failed/cancelled/completed 时必须照实转述；空的在跑列表不等于都成功了。",
+				"recent_terminal.status 为 failed/cancelled/completed 时必须照实转述；空的在跑列表不等于都成功了。" +
+				"若有 failed/cancelled：回复里要让对方选下一步（重试 / 换做法 / 先搁置），不要擅自继续派活。",
 			Params: []liveagent.Param{
 				{Name: "task_id", Description: "只查某一件事时填它的 taskId；不填就列出在跑的和刚结束的。"},
 			},

--- a/server/internal/channels/live_test.go
+++ b/server/internal/channels/live_test.go
@@ -636,6 +636,9 @@ func TestFailedTaskOutcomeExplainsWithoutDiagnostics(t *testing.T) {
 	if strings.Contains(got[0], "build-1") || ContainsInternalTerms(got[0]) {
 		t.Fatalf("failure quoted the diagnostic: %q", got[0])
 	}
+	if !strings.Contains(got[0], "重试") || !strings.Contains(got[0], "搁置") {
+		t.Fatalf("failure fallback should let the user choose next step: %q", got[0])
+	}
 }
 
 // A restart loses the sandbox but must not lose the user's message in silence.

--- a/server/internal/channels/preamble.go
+++ b/server/internal/channels/preamble.go
@@ -18,7 +18,8 @@ func ChannelPreamble(channelType string) string {
 		"2) 分钟级以上 → pm_start_run，不要前台硬扛，也不要等跑完。",
 
 		"【结论】pm_reply / pm_notify_progress 是交给会话层转述的事实，不是直发 IM。" +
-			"写清结论与依据；不要 Run ID、工作流名、沙箱、工具名、推理过程。" +
+			"写清结论与依据；不要 Run ID、工作流名、沙箱、工具名、优先级、推理过程。" +
+			"重新开跑时写「重新开跑了」，不要写成「已经跑完了」。" +
 			"正文默认不外发；无外发时平台可能用清洗摘要兜底，所以结论优先放进 pm_reply。",
 
 		"【查】提示不带完整历史；<work_brief> 是转交要求与附件线索。" +

--- a/server/internal/channels/reflow.go
+++ b/server/internal/channels/reflow.go
@@ -257,14 +257,14 @@ func outcomeFallbackText(identity *models.TaskIdentity, outcome TaskOutcome, lan
 		reason := humanizeFailureReason(outcome.FailureReason, en)
 		if en {
 			if title == "" {
-				return "That one didn't go through: " + reason + " Want me to try again?"
+				return "That one didn't go through: " + reason + " Want me to retry, change the approach, or leave it for now?"
 			}
-			return "\"" + title + "\" didn't go through: " + reason + " Want me to try again?"
+			return "\"" + title + "\" didn't go through: " + reason + " Want me to retry, change the approach, or leave it for now?"
 		}
 		if title == "" {
-			return "刚才那个没做成：" + reason + "要我再试一次吗？"
+			return "刚才那个没做成：" + reason + "你看是重试、换个做法，还是先搁置？"
 		}
-		return title + "没做成：" + reason + "要我再试一次吗？"
+		return title + "没做成：" + reason + "你看是重试、换个做法，还是先搁置？"
 	}
 }
 


### PR DESCRIPTION
## Summary
- 失败/取消状态回复必须让用户选：重试、换范围/改方向、或先搁置
- 禁止模型擅自说「我接着跑 / 后面重新做」就继续派活
- 覆盖 Live 系统提示、`get_status` note、会话 briefing，以及后台失败收尾兜底文案

## Test plan
- [ ] 任务 failed 后问「什么情况了」——应说明失败，并给出选项，而不是直接说接着做
- [ ] 后台 Run 失败推送应类似「……你看是重试、换个做法，还是先搁置？」
- [ ] `go test ./internal/channels/ -run 'GetStatusSurfaces|FailedTaskOutcome'`


Made with [Cursor](https://cursor.com)