### PR TITLE
fix(channels): 用户可见文案一律交给会话模型措辞

### DIFF
--- a/server/internal/channels/delivery.go
+++ b/server/internal/channels/delivery.go
@@ -246,13 +246,19 @@ func (m *Manager) SendRunAcceptanceAck(ctx context.Context, ack RunAcceptanceAck
 		return DeliveryResult{Decision: sendable.Decision{Reason: "already_acknowledged"}}, nil
 	}
 	language := services.DetectLanguage("", ack.Language)
+	// Phrased by the conversation model like every other acknowledgement; the
+	// fixed line below is only what a missing or slow model falls back to.
+	text := m.phraseRunAccepted(ctx, ack.ShortTitle, language)
+	if text == "" {
+		text = runAcceptanceText(ack.ShortTitle, language)
+	}
 	result, err := m.DeliverSendable(ctx, SendableRequest{
 		ProjectID: ack.ProjectID, Scene: ack.Scene, ConversationID: ack.ConversationID,
 		UserID: ack.UserID, RunID: runID,
 		Kind: sendable.KindRunAcceptanceAck, Reason: "run_accepted",
 		Priority:  sendable.PriorityHigh,
 		DedupeKey: runAcceptanceDedupeKey(runID, ack.ConversationID, ack.UserID),
-		Text:      runAcceptanceText(ack.ShortTitle, language),
+		Text:      text,
 	})
 	// Handing work to the background is this turn's answer: the user asked for
 	// something and has been told it is being done. Marking the turn answered

--- a/server/internal/channels/delivery.go
+++ b/server/internal/channels/delivery.go
@@ -271,12 +271,14 @@ func (m *Manager) SendRunAcceptanceAck(ctx context.Context, ack RunAcceptanceAck
 // runAcceptanceText is the last-resort line when a Run is accepted but the
 // conversation layer did not already speak. Keep it short and free of pasted
 // ledger titles — long short_title values are truncated requirements, not names.
+// Do not append "feel free to keep chatting": the user already knows they can
+// talk, and saying so reads like a helpdesk script.
 func runAcceptanceText(shortTitle, language string) string {
 	_ = shortTitle
 	if services.NormalizeLanguage(language) == "en" {
-		return "Got it, I'll take that one and come back when it's done. Feel free to keep chatting in the meantime."
+		return "Got it, I'll take that one and come back when it's done."
 	}
-	return "好，那事我去弄，完了告诉你。你可以接着问别的。"
+	return "好，那事我去弄，完了告诉你。"
 }
 
 func runAcceptanceDedupeKey(runID, conversationID, userID string) string {

--- a/server/internal/channels/delivery_test.go
+++ b/server/internal/channels/delivery_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cocofhu/approving/internal/liveagent"
 	"github.com/cocofhu/approving/internal/models"
 	"github.com/cocofhu/approving/internal/sendable"
 	"github.com/cocofhu/approving/internal/services"
@@ -294,6 +295,45 @@ func TestSendRunAcceptanceAckOncePerRunAndRejectsMissingRun(t *testing.T) {
 	ack.RunID = ""
 	if _, err := m.SendRunAcceptanceAck(context.Background(), ack); err == nil {
 		t.Fatal("run acceptance ACK without a real run id must be rejected")
+	}
+}
+
+// The acceptance line is the model's to write, like every other
+// acknowledgement. Leaving it as a platform template is what produced
+// 「你可以接着问别的」— copy nobody chose, in a voice nobody picked.
+func TestRunAcceptanceAckIsPhrasedByTheConversationModel(t *testing.T) {
+	fa := &fakeAdapter{}
+	m, _ := policyManager(t, fa, nil)
+	live := &fakeLive{configured: true, report: &liveagent.Result{Text: "行，那事我这就安排，弄好了喊你。"}}
+	m.SetLiveModel(live)
+	m.Apply([]models.ChannelConfig{{
+		ID: "c1", Type: "qq", ProjectID: "proj", AppID: "app", Enabled: true,
+		CronDeliver: true, CronDeliverTarget: "c2c:user1",
+	}})
+	defer m.StopAll()
+
+	if _, err := m.SendRunAcceptanceAck(context.Background(), RunAcceptanceAck{
+		ProjectID: "proj", RunID: "run-9", Scene: SceneC2C,
+		ConversationID: "user1", UserID: "u1", ShortTitle: "登录页", Language: "zh-CN",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got := sentTexts(fa)
+	if len(got) != 1 || got[0] != "行，那事我这就安排，弄好了喊你。" {
+		t.Fatalf("sends = %v want the model's own line", got)
+	}
+}
+
+// Whatever the fallback says, it must not narrate what the user is allowed to
+// do next; they already know they can keep talking.
+func TestRunAcceptanceFallbackDoesNotCoachTheUser(t *testing.T) {
+	for _, lang := range []string{"zh-CN", "en"} {
+		text := runAcceptanceText("登录页", lang)
+		for _, banned := range []string{"接着问", "别的", "keep chatting", "Feel free"} {
+			if strings.Contains(text, banned) {
+				t.Errorf("%s fallback still coaches the user (%q): %q", lang, banned, text)
+			}
+		}
 	}
 }
 

--- a/server/internal/channels/live.go
+++ b/server/internal/channels/live.go
@@ -447,38 +447,74 @@ const fallthroughAckPhrasePrompt = `你是这个项目的负责人本人，正�
 - 不要提优先级、任务编号、工作流、沙箱、跟进页面、Approving。
 - 只输出要发给对方的那句话。`
 
-const runAcceptedAckPhrasePrompt = `你是这个项目的负责人本人，正在 IM 上和同事聊天。你的回复会原样发给对方。
+// operationalLine is a situation the platform has to tell the user about that
+// no model decided: the backlog is full, a turn ran out of time, a confirmed
+// action did not go through, the process restarted mid-turn.
+//
+// Each of these used to be a fixed string, and a fixed string is how copy
+// nobody chose ends up in someone's chat window — 「你可以接着问别的」 was one
+// of them. The situation is a fact the platform owns; the wording is the
+// conversation model's job, exactly as it is for every other line it speaks.
+// Fallback is what a missing or slow model falls back to, and nothing else.
+type operationalLine struct {
+	// Situation describes what happened, addressed to the model as the person
+	// who has to say it.
+	Situation string
+	// Facts are internal details the model may use but must not quote back.
+	Facts string
+	// Avoid is a title or requirement the reply must not paste back at the user.
+	Avoid    string
+	Language string
+	Fallback string
+}
 
-对方要的事你已经安排下去了，现在只需要接一句。用一两句人话说你去弄、完了回他。
+// operationalLineRules are the constraints every spoken platform line shares.
+// They live in one place because they are one policy: the reasons a line reads
+// as a template do not change with the situation that produced it.
+const operationalLineRules = `
 
 规矩：
 - 像同事当面说，不要工单腔，不要「收到」「稍等」「我这就去确认」。
 - 不要复述任务标题或原要求；用「那事」「那块」指代即可。
-- 时态是正在做，不是做完了。
 - 不要交代对方可以做什么（「你可以接着问别的」「有事随时叫我」这类都不要）——他本来就知道。
-- 不要提优先级、任务编号、工作流、沙箱、跟进页面、Approving。
+- 不要提优先级、任务编号、工作流、执行环境、跟进页面、Approving。
+- 不要说已经做完、已经跑完、已经处理好。
 - 只输出要发给对方的那句话。`
 
-// phraseRunAccepted asks the conversation model for the acceptance line.
-//
-// Every other acknowledgement in this file is phrased by the model; this one
-// was the last template, and a template is exactly what produced the
-// helpdesk-sounding 「你可以接着问别的」. Empty means the caller falls back to
-// the fixed line, which is now only reached when the model is unconfigured or
-// slow.
-func (m *Manager) phraseRunAccepted(ctx context.Context, shortTitle, language string) string {
-	user := "对方刚要的事已经安排下去了。用一两句人话接住他。"
-	if title := strings.TrimSpace(shortTitle); title != "" {
-		user = "（内部参考，勿原样复述）安排下去的事：" + truncateRunes(title, 60) + "\n" + user
+const operationalLinePersona = `你是这个项目的负责人本人，正在 IM 上和同事聊天。你的回复会原样发给对方。
+
+`
+
+// speakOperationalLine phrases one platform notice, falling back to fixed copy.
+func (m *Manager) speakOperationalLine(ctx context.Context, line operationalLine) string {
+	fallback := strings.TrimSpace(line.Fallback)
+	situation := strings.TrimSpace(line.Situation)
+	if situation == "" {
+		return fallback
 	}
-	if services.NormalizeLanguage(language) == "en" {
+	user := "用一两句人话把这个情况告诉对方。"
+	if facts := strings.TrimSpace(line.Facts); facts != "" {
+		user = "（内部参考，勿原样复述）" + truncateRunes(facts, 160) + "\n" + user
+	}
+	if services.NormalizeLanguage(line.Language) == "en" {
 		user += "\n对方说英文，用英文回一句。"
 	}
-	out := strings.TrimSpace(m.phraseThroughLive(ctx, runAcceptedAckPhrasePrompt, user))
-	if out == "" || spokenLineSoundsFinished(out) || retryAckEchoesBrief(out, shortTitle, "") {
-		return ""
+	out := strings.TrimSpace(m.phraseThroughLive(ctx,
+		operationalLinePersona+situation+operationalLineRules, user))
+	if out == "" || spokenLineSoundsFinished(out) || retryAckEchoesBrief(out, line.Avoid, "") {
+		return fallback
 	}
 	return out
+}
+
+// phraseRunAccepted asks the conversation model for the acceptance line.
+func (m *Manager) phraseRunAccepted(ctx context.Context, shortTitle, language string) string {
+	return m.speakOperationalLine(ctx, operationalLine{
+		Situation: "对方要的事你已经安排下去了，现在只需要接一句：你去弄，完了回他。时态是正在做，不是做完了。",
+		Facts:     shortTitle,
+		Avoid:     shortTitle,
+		Language:  language,
+	})
 }
 
 const dispatchAckPhrasePrompt = `你是这个项目的负责人本人，正在 IM 上和同事聊天。你的回复会原样发给对方。

--- a/server/internal/channels/live.go
+++ b/server/internal/channels/live.go
@@ -447,6 +447,40 @@ const fallthroughAckPhrasePrompt = `你是这个项目的负责人本人，正�
 - 不要提优先级、任务编号、工作流、沙箱、跟进页面、Approving。
 - 只输出要发给对方的那句话。`
 
+const runAcceptedAckPhrasePrompt = `你是这个项目的负责人本人，正在 IM 上和同事聊天。你的回复会原样发给对方。
+
+对方要的事你已经安排下去了，现在只需要接一句。用一两句人话说你去弄、完了回他。
+
+规矩：
+- 像同事当面说，不要工单腔，不要「收到」「稍等」「我这就去确认」。
+- 不要复述任务标题或原要求；用「那事」「那块」指代即可。
+- 时态是正在做，不是做完了。
+- 不要交代对方可以做什么（「你可以接着问别的」「有事随时叫我」这类都不要）——他本来就知道。
+- 不要提优先级、任务编号、工作流、沙箱、跟进页面、Approving。
+- 只输出要发给对方的那句话。`
+
+// phraseRunAccepted asks the conversation model for the acceptance line.
+//
+// Every other acknowledgement in this file is phrased by the model; this one
+// was the last template, and a template is exactly what produced the
+// helpdesk-sounding 「你可以接着问别的」. Empty means the caller falls back to
+// the fixed line, which is now only reached when the model is unconfigured or
+// slow.
+func (m *Manager) phraseRunAccepted(ctx context.Context, shortTitle, language string) string {
+	user := "对方刚要的事已经安排下去了。用一两句人话接住他。"
+	if title := strings.TrimSpace(shortTitle); title != "" {
+		user = "（内部参考，勿原样复述）安排下去的事：" + truncateRunes(title, 60) + "\n" + user
+	}
+	if services.NormalizeLanguage(language) == "en" {
+		user += "\n对方说英文，用英文回一句。"
+	}
+	out := strings.TrimSpace(m.phraseThroughLive(ctx, runAcceptedAckPhrasePrompt, user))
+	if out == "" || spokenLineSoundsFinished(out) || retryAckEchoesBrief(out, shortTitle, "") {
+		return ""
+	}
+	return out
+}
+
 const dispatchAckPhrasePrompt = `你是这个项目的负责人本人，正在 IM 上和同事聊天。你的回复会原样发给对方。
 
 你刚把一件事派人去干了。用一两句人话告诉对方你正让人做这件事——时态是正在做，不是做完了。

--- a/server/internal/channels/manager.go
+++ b/server/internal/channels/manager.go
@@ -545,7 +545,12 @@ func (m *Manager) sendBusyHint(ctx context.Context, rc *runningChannel, in Inbou
 		Msg("live: inbound dropped, queue full")
 	m.sendOutbound(ctx, rc, OutboundMessage{
 		Scene: in.Scene, ConversationID: in.ConversationID,
-		ReplyToMessageID: in.MessageID, Text: busyHintText,
+		ReplyToMessageID: in.MessageID,
+		Text: m.speakOperationalLine(ctx, operationalLine{
+			Situation: "你手上还压着对方前面几条没回完，这条一时顾不上。跟他说一声让他等等。",
+			Language:  services.DetectLanguage(in.Text, ""),
+			Fallback:  busyHintText,
+		}),
 		Envelope: turnEnvelope(rc, in, sendable.KindSafetyNotice, "queue_full", sendable.PriorityHigh),
 	})
 }
@@ -661,9 +666,15 @@ func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMes
 				Msg("live: foreground turn exceeded its budget without an answer")
 			closeStatus = "failed"
 			if !m.hasReplied(scope) {
+				language := services.DetectLanguage(in.Text, "")
 				m.sendOutbound(ctx, rc, OutboundMessage{
 					Scene: in.Scene, ConversationID: in.ConversationID, ReplyToMessageID: in.MessageID,
-					Text:     turnTooSlowText(services.DetectLanguage(in.Text, "")),
+					Text: m.speakOperationalLine(ctx, operationalLine{
+						Situation: "这件事没法在聊天里当场弄完。问对方要不要你当成后台任务去做、做完回他。" +
+							"注意：现在还没开始做，所以别说已经在跑了，是在征求他同意。",
+						Language: language,
+						Fallback: turnTooSlowText(language),
+					}),
 					Envelope: turnEnvelope(rc, in, sendable.KindFinal, "turn_budget_exceeded", sendable.PriorityHigh),
 				})
 			}
@@ -693,7 +704,7 @@ func (m *Manager) runTurn(ctx context.Context, rc *runningChannel, in InboundMes
 		}
 		m.sendOutbound(ctx, rc, OutboundMessage{
 			Scene: in.Scene, ConversationID: in.ConversationID, ReplyToMessageID: in.MessageID,
-			Text:     m.noAnswerFallback(rc, in),
+			Text:     m.sayNoAnswer(ctx, rc, in),
 			Envelope: turnEnvelope(rc, in, sendable.KindFinal, "final_missing_fallback", sendable.PriorityCritical),
 		})
 		return
@@ -1409,6 +1420,26 @@ func (m *Manager) hasAnswered(scope string) bool {
 // the conversation's current turn.
 func (m *Manager) MarkConversationReplied(projectID string, scene Scene, conversationID string) {
 	m.markReplied(conversationTurnScope(projectID, scene, conversationID))
+}
+
+// sayNoAnswer reports a turn that ended without the agent submitting anything.
+// The model words it; noAnswerFallback is the fixed line behind it. Letting the
+// model speak also stops the fallback's 「」+ShortTitle gluing, which is how a
+// mid-token ledger title got pasted into an apology.
+func (m *Manager) sayNoAnswer(ctx context.Context, rc *runningChannel, in InboundMessage) string {
+	situation := "这一轮你没能拿出可用的结论。如实说这个情况，再问对方要不要换个说法、或者告诉你他最关心哪部分。"
+	var title string
+	if task := m.activeTaskFor(rc, in); task != nil {
+		title = task.ShortTitle
+		situation = "那件事你还在弄，这一轮暂时没有可用的结论。如实说还在做、有实质进展再回他。"
+	}
+	return m.speakOperationalLine(ctx, operationalLine{
+		Situation: situation,
+		Facts:     title,
+		Avoid:     title,
+		Language:  services.DetectLanguage(in.Text, ""),
+		Fallback:  m.noAnswerFallback(rc, in),
+	})
 }
 
 // noAnswerFallback is what the user hears when a turn ends without the agent

--- a/server/internal/channels/operational_line_test.go
+++ b/server/internal/channels/operational_line_test.go
@@ -1,0 +1,125 @@
+package channels
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cocofhu/approving/internal/liveagent"
+	"github.com/cocofhu/approving/internal/models"
+)
+
+// The platform owns the fact; the model owns the wording. A fixed string is
+// what put 「你可以接着问别的」 in someone's chat window, so the fixed strings
+// are demoted to what an unreachable model falls back to.
+func TestOperationalLinePrefersTheModelAndFallsBackOnlyWhenItCannotSpeak(t *testing.T) {
+	const fallback = "我这边还在处理前面几条，稍等一下。"
+
+	t.Run("model speaks", func(t *testing.T) {
+		m := NewManager(nil, nil, nil)
+		m.SetLiveModel(&fakeLive{configured: true, report: &liveagent.Result{Text: "前面还压着几条，等我一下。"}})
+		got := m.speakOperationalLine(context.Background(), operationalLine{
+			Situation: "你手上还压着几条没回完。", Fallback: fallback,
+		})
+		if got != "前面还压着几条，等我一下。" {
+			t.Fatalf("got %q want the model's line", got)
+		}
+	})
+
+	t.Run("no model configured", func(t *testing.T) {
+		m := NewManager(nil, nil, nil)
+		got := m.speakOperationalLine(context.Background(), operationalLine{
+			Situation: "你手上还压着几条没回完。", Fallback: fallback,
+		})
+		if got != fallback {
+			t.Fatalf("got %q want the fallback", got)
+		}
+	})
+
+	t.Run("model call fails", func(t *testing.T) {
+		m := NewManager(nil, nil, nil)
+		m.SetLiveModel(&fakeLive{configured: true})
+		got := m.speakOperationalLine(context.Background(), operationalLine{
+			Situation: "你手上还压着几条没回完。", Fallback: fallback,
+		})
+		if got != fallback {
+			t.Fatalf("got %q want the fallback", got)
+		}
+	})
+}
+
+// The model is not trusted blindly: a line that claims the work is done, or
+// pastes the ledger title back at the user, is worse than the template.
+func TestOperationalLineRejectsUnusableModelOutput(t *testing.T) {
+	for name, reply := range map[string]string{
+		"claims finished": "那事已经跑完了，结果我发你。",
+		"pastes title":    "「调研快模型和 worker 架构」这事我先放着。",
+	} {
+		t.Run(name, func(t *testing.T) {
+			m := NewManager(nil, nil, nil)
+			m.SetLiveModel(&fakeLive{configured: true, report: &liveagent.Result{Text: reply}})
+			got := m.speakOperationalLine(context.Background(), operationalLine{
+				Situation: "这一轮没拿出结论。",
+				Avoid:     "调研快模型和 worker 架构",
+				Fallback:  "这条我没能给出结论。",
+			})
+			if got != "这条我没能给出结论。" {
+				t.Fatalf("got %q want the fallback", got)
+			}
+		})
+	}
+}
+
+// Wiring check on a real path: with a model configured, the queue-full notice
+// is the model's sentence, not the constant.
+func TestQueueFullNoticeIsPhrasedByTheModel(t *testing.T) {
+	fa := &fakeAdapter{}
+	m := NewManager(nil, nil, nil)
+	m.SetLiveModel(&fakeLive{configured: true, report: &liveagent.Result{Text: "前面几条还没弄完，稍等我一下。"}})
+	rc := testRunningChannel(fa)
+
+	m.sendBusyHint(context.Background(), rc, testInbound("overflow"), "conv-key")
+
+	got := sentTexts(fa)
+	if countText(got, busyHintText) != 0 {
+		t.Fatalf("the fixed queue-full template still went out: %v", got)
+	}
+	if countText(got, "前面几条还没弄完，稍等我一下。") != 1 {
+		t.Fatalf("sends = %v want the model's queue-full line exactly once", got)
+	}
+}
+
+// The same path with no model reachable still says something: the notice is
+// the point, the wording is the improvement.
+func TestQueueFullNoticeStillGoesOutWithoutAModel(t *testing.T) {
+	fa := &fakeAdapter{}
+	m := NewManager(nil, nil, nil)
+	rc := testRunningChannel(fa)
+
+	m.sendBusyHint(context.Background(), rc, testInbound("overflow"), "conv-key")
+
+	if got := sentTexts(fa); countText(got, busyHintText) != 1 {
+		t.Fatalf("sends = %v want the fallback notice exactly once", got)
+	}
+}
+
+// Whatever any of these lines say, none of them may narrate what the user is
+// allowed to do next. That is the shape of the original complaint.
+func TestNoOperationalCopyCoachesTheUser(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	copies := []string{
+		busyHintText,
+		turnTooSlowText("zh-CN"), turnTooSlowText("en"),
+		riskExecutionFailedText("zh-CN"), riskExecutionFailedText("en"),
+		interruptedTurnText("zh-CN"), interruptedTurnText("en"),
+		runAcceptanceText("登录页", "zh-CN"), runAcceptanceText("登录页", "en"),
+		m.noAnswerFallback(&runningChannel{cfg: models.ChannelConfig{ProjectID: "p"}}, InboundMessage{}),
+	}
+	for _, text := range copies {
+		for _, banned := range []string{"接着问", "keep chatting", "Feel free", "随时叫我", "随时找我"} {
+			if strings.Contains(text, banned) {
+				t.Errorf("copy %q coaches the user with %q", text, banned)
+			}
+		}
+	}
+}

--- a/server/internal/channels/orchestration.go
+++ b/server/internal/channels/orchestration.go
@@ -95,7 +95,11 @@ func (m *Manager) tryResolveRiskConfirmation(ctx context.Context, rc *runningCha
 				Msg("confirmed risk action failed")
 			// The user confirmed and it still did not happen. Say that plainly;
 			// the underlying error is a diagnostic, not an answer.
-			m.sendOrchestrationReply(ctx, rc, in, riskExecutionFailedText(language))
+			m.sendOrchestrationReply(ctx, rc, in, m.speakOperationalLine(ctx, operationalLine{
+				Situation: "对方确认要做的那个操作没执行成功，状态一点没变。如实说清楚，再问他要不要你再试一次。",
+				Language:  language,
+				Fallback:  riskExecutionFailedText(language),
+			}))
 			return true
 		}
 		// Re-render now that the action has run. The text ResolveTicket returned

--- a/server/internal/channels/recovery.go
+++ b/server/internal/channels/recovery.go
@@ -77,7 +77,12 @@ func (m *Manager) RecoverInterruptedTurns(ctx context.Context) {
 			Kind:        sendable.KindFinal, Reason: "turn_interrupted_recovery",
 			Priority:  sendable.PriorityHigh,
 			DedupeKey: "turn-recovery:" + row.ID,
-			Text:      interruptedTurnText(row.Language),
+			Text: m.speakOperationalLine(ctx, operationalLine{
+				Situation: "你这边刚重启过，对方上一条消息没处理完就断了。跟他说一声，请他再发一次。" +
+					"别把重启说成是他的问题，也别解释是什么坏了。",
+				Language: row.Language,
+				Fallback: interruptedTurnText(row.Language),
+			}),
 		})
 		if err != nil {
 			log.Warn().Err(err).Str("conversation", row.ConversationID).


### PR DESCRIPTION
## 背景

用户看到派活后的回复是「好，那事我去弄，完了告诉你。**你可以接着问别的。**」，
后半句既没必要又像客服话术。

根因不是 Live prompt，而是这些出口在**拼字符串**。查下来会话层里还有 6 处同样
的固定文案会直接发给用户，其中 1 处（`QQReplyFallback`）是死代码，其余 5 处
在模型可用时也照样发模板。

## 改动

新增 `speakOperationalLine`：平台只提供**事实**（发生了什么），**措辞归模型**。
护栏与规矩集中在 `operationalLineRules` 一处，不再每个场景写一段 const —— 
「不要交代对方可以做什么」这类规则只写一遍，对所有出口生效。

改走模型的出口：

| 出口 | 场景 |
|------|------|
| `SendRunAcceptanceAck` | 派活确认（本次问题） |
| `sendBusyHint` | 队列满 |
| 前台超预算 | 问是否转后台 |
| `sayNoAnswer` | 这一轮没结论 |
| `riskExecutionFailed` | 确认的操作没执行成功 |
| 重启恢复 | 上一条消息中断 |

`sayNoAnswer` 顺带解决了兜底里 `「」+ShortTitle` 的拼接——那正是之前把半词截断
标题贴进道歉句的来源。

固定文案降级为兜底，只在三种情况下出现：模型没配置、调用失败、或模型输出被护栏
判为不可用（谎报完成 / 复述标题）。

## 测试

- `speakOperationalLine`：模型可用时用模型的话；未配置 / 调用失败 / 输出谎报完成 /
  输出复述标题 → 落兜底。
- 队列满这条真实路径：配了模型发模型的话且不含模板；没模型仍然照发兜底（通知本身不能丢）。
- 所有兜底文案不得包含「接着问 / keep chatting / 随时叫我」等教用户做什么的话。
- `go test ./...` 全绿。