### PR TITLE
fix(channels): 措辞失败时不再把内部调研报告原样发给用户

### DIFF
--- a/server/cmd/server/live_synthesizer.go
+++ b/server/cmd/server/live_synthesizer.go
@@ -18,6 +18,18 @@ const synthesisFallbackTimeout = 45 * time.Second
 // after a reasoning model spends budget deliberating.
 const synthesisMaxTokens = 2048
 
+// synthesisRetryMaxTokens is the second attempt's cap. A reasoning model can
+// spend the whole first budget thinking and return nothing at all — the
+// endpoint reports finish_reason=length with no content, which the client
+// rejects as ErrBudgetExhausted.
+//
+// That failure is worth one more call here, because the alternative is not a
+// slightly worse sentence: the caller's fallback quotes the raw findings digest,
+// so a model that stays silent is how a working agent's internal report ends up
+// in someone's chat window. Only this one error retries; a refusal, a timeout or
+// a bad endpoint would buy the same answer twice.
+const synthesisRetryMaxTokens = 2 * synthesisMaxTokens
+
 // synthesisSystemPrompt is the reporting voice. It is the same person the user
 // has been talking to all along, which is the whole point of phrasing an
 // outcome instead of pushing a template.
@@ -68,14 +80,24 @@ func newLiveSynthesizer(live *liveagent.Client) channels.SynthesisFunc {
 		callCtx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 
-		res, err := live.Complete(callCtx, liveagent.Request{
-			System:    synthesisSystemPrompt,
-			Messages:  []liveagent.Message{{Role: "user", Content: req.Brief}},
-			MaxTokens: synthesisMaxTokens,
-		})
+		ask := func(maxTokens int) (string, error) {
+			res, err := live.Complete(callCtx, liveagent.Request{
+				System:    synthesisSystemPrompt,
+				Messages:  []liveagent.Message{{Role: "user", Content: req.Brief}},
+				MaxTokens: maxTokens,
+			})
+			if err != nil {
+				return "", err
+			}
+			return strings.TrimSpace(res.Text), nil
+		}
+		text, err := ask(synthesisMaxTokens)
+		if errors.Is(err, liveagent.ErrBudgetExhausted) {
+			text, err = ask(synthesisRetryMaxTokens)
+		}
 		if err != nil {
 			return "", err
 		}
-		return strings.TrimSpace(res.Text), nil
+		return text, nil
 	}
 }

--- a/server/internal/channels/copy_guard.go
+++ b/server/internal/channels/copy_guard.go
@@ -68,6 +68,29 @@ var internalMarkerLines = regexp.MustCompile(`(?m)^\s*(\[(摘要|进度|里程�
 
 var toolNoiseLine = regexp.MustCompile(`(?im)^\s*(tool_call|function_call|tool result|reasoning_delta|input_tokens|output_tokens)\b.*$`)
 
+// repoCoordinates match the way a working agent cites where it looked: a commit
+// hash, a merge commit subject, a HEAD snapshot. They are precise and useful in
+// a report, and meaningless to someone reading QQ — 「对照基线（git: 90713d62
+// Merge #177），之后到 HEAD（652b0d68 Merge #178）」 tells the user nothing about
+// what was decided.
+//
+// Each pattern is anchored on its label (git:, Merge #, HEAD) rather than on the
+// hash alone: a bare hex run also matches ordinary numbers and ids, and deleting
+// those would eat real content.
+var repoCoordinates = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)[（(]\s*git\s*[:：]\s*[0-9a-f]{7,40}[^)）]*[)）]`),
+	regexp.MustCompile(`(?i)\bgit\s*[:：]\s*[0-9a-f]{7,40}\b`),
+	regexp.MustCompile(`(?i)\bHEAD\s*[（(][0-9a-f]{7,40}[^)）]*[)）]`),
+	regexp.MustCompile(`(?i)\bMerge\s*#\s*\d+\b`),
+	regexp.MustCompile(`(?i)\b[0-9a-f]{7,40}\s+Merge\s*#\s*\d+\b`),
+}
+
+// verdictScaffolding matches the headings a working agent puts on a written
+// report. The sentence after the heading is the actual finding and is kept; only
+// the label is dropped, because 「最终判定：需局部修订」 read aloud to a colleague
+// is just 「需局部修订」.
+var verdictScaffolding = regexp.MustCompile(`(?m)(^|[。；;\n])\s*(最终判定|结论状态|判定结果|建议下一步|下一步建议|置信度|证据链)\s*[:：]\s*`)
+
 // deliveryReceiptLine matches whole-line model asides that restate a successful
 // pm_reply / channel delivery. These leaked through FinalSummary after #161.
 var deliveryReceiptLine = regexp.MustCompile(`(?im)^\s*(已发送|已通过\s*QQ\s*回复用户|稍等，?我看一下|Give me a moment on this one|已开始处理|任务已启动|收到，正在处理)\s*[。.!！…]*\s*$`)
@@ -95,6 +118,10 @@ func ScrubInternalTerms(text string) string {
 	for _, p := range internalIDPatterns {
 		out = p.ReplaceAllString(out, "")
 	}
+	for _, p := range repoCoordinates {
+		out = p.ReplaceAllString(out, "")
+	}
+	out = verdictScaffolding.ReplaceAllString(out, "$1")
 	for _, r := range internalTermReplacements {
 		out = r.pattern.ReplaceAllString(out, r.with)
 	}
@@ -113,6 +140,14 @@ func ContainsInternalTerms(text string) bool {
 		if p.MatchString(text) {
 			return true
 		}
+	}
+	for _, p := range repoCoordinates {
+		if p.MatchString(text) {
+			return true
+		}
+	}
+	if verdictScaffolding.MatchString(text) {
+		return true
 	}
 	for _, r := range internalTermReplacements {
 		if r.pattern.MatchString(text) {

--- a/server/internal/channels/live_test.go
+++ b/server/internal/channels/live_test.go
@@ -607,8 +607,11 @@ func TestCompletedOutcomeFallbackIncludesResultSummary(t *testing.T) {
 	if !strings.Contains(got, "fallthrough") || !strings.Contains(got, "8s") {
 		t.Fatalf("fallback dropped findings: %q", got)
 	}
-	if strings.Contains(got, "直接检查") {
-		t.Fatalf("findings path should not glue short title: %q", got)
+	// The task has to be named. An unattributed 「弄完了」 lands in a
+	// conversation where other jobs were handed over since, and reads as an
+	// answer to whichever was asked for last.
+	if !strings.Contains(got, "直接检查") {
+		t.Fatalf("completed fallback does not say which task finished: %q", got)
 	}
 	broken := outcomeFallbackText(&models.TaskIdentity{
 		ShortTitle: "调研 Approving 最近关于快模型和 wo", Language: "zh-CN",
@@ -627,6 +630,81 @@ func TestCompletedOutcomeFallbackIncludesResultSummary(t *testing.T) {
 	}
 	if !strings.Contains(empty, "可读结论") {
 		t.Fatalf("empty fallback should admit missing summary: %q", empty)
+	}
+}
+
+// The digest a working agent writes is addressed to the platform, not to the
+// user. When the conversation model cannot phrase an outcome, the degraded path
+// used to paste that digest verbatim, which is how this arrived in QQ:
+//
+//	弄完了。对照 2026-08-08 09:55 UTC 前次「快模型与 worker 架构精简」调研基线
+//	（git: 90713d62 Merge #177），之后到 HEAD（652b0d68 Merge #178）…
+//	最终判定：需局部修订…结论状态：部分成立。建议下一步：仅观察…
+//
+// Commit hashes, merge subjects and report headings are not something a
+// colleague says out loud, and the message never said which task it was about.
+func TestDegradedOutcomeDoesNotPasteTheWorkingAgentsReport(t *testing.T) {
+	digest := "对照 2026-08-08 09:55 UTC 前次「快模型与 worker 架构精简」调研基线" +
+		"（git: 90713d62 Merge #177），之后到 HEAD（652b0d68 Merge #178）只有文案质量与" +
+		"出口守卫改动。原架构判断大体仍成立，但清单需要局部修订。" +
+		"最终判定：需局部修订。结论状态：部分成立。建议下一步：仅观察。"
+
+	got := outcomeFallbackText(&models.TaskIdentity{
+		ShortTitle: "快模型与 worker 架构精简调研", Language: "zh-CN",
+	}, TaskOutcome{Status: "completed", ResultSummary: digest}, "zh-CN")
+
+	// Names the task, keeps the one sentence that was a conclusion, and leaves
+	// the baseline/heading sentences behind — they were written for the
+	// platform, and half-scrubbing them would only produce broken prose.
+	want := "快模型与 worker 架构精简调研跑完了：原架构判断大体仍成立，但清单需要局部修订。"
+	if got != want {
+		t.Errorf("degraded outcome =\n  %q\nwant\n  %q", got, want)
+	}
+	for _, debris := range []string{"90713d62", "652b0d68", "Merge #177", "Merge #178",
+		"git:", "HEAD", "最终判定", "结论状态", "建议下一步"} {
+		if strings.Contains(got, debris) {
+			t.Errorf("degraded outcome leaked %q: %q", debris, got)
+		}
+	}
+	if ContainsInternalTerms(got) {
+		t.Errorf("degraded outcome still reads as an internal report: %q", got)
+	}
+}
+
+// A digest that was already conversational is quoted as it stands — the
+// sentence filter exists to drop report debris, not to shorten real answers.
+func TestDegradedOutcomeKeepsAConversationalDigestWhole(t *testing.T) {
+	got := outcomeFallbackText(&models.TaskIdentity{
+		ShortTitle: "登录页性能优化", Language: "zh-CN",
+	}, TaskOutcome{
+		Status:        "completed",
+		ResultSummary: "首屏从 3.2s 降到 1.1s。改动已提，链接：https://github.com/org/repo/pull/9",
+	}, "zh-CN")
+
+	for _, keep := range []string{"登录页性能优化", "3.2s 降到 1.1s", "pull/9"} {
+		if !strings.Contains(got, keep) {
+			t.Errorf("degraded outcome dropped %q: %q", keep, got)
+		}
+	}
+}
+
+// Sentences are kept whole so the shortened digest still reads as a finished
+// thought, and a single over-long sentence is soft-cut rather than dropped.
+func TestLeadingConclusionKeepsWholeSentences(t *testing.T) {
+	facts := "结论是可以合并。证据来自三处调用点。第三段是方法论，用户不关心。"
+	got := leadingConclusion(facts, 10)
+	if got != "结论是可以合并。" {
+		t.Fatalf("leadingConclusion = %q, want the first whole sentence", got)
+	}
+	if got := leadingConclusion(facts, 400); got != facts {
+		t.Fatalf("short-enough digest was altered: %q", got)
+	}
+	// A single sentence past the budget is soft-cut (which appends an ellipsis)
+	// rather than dropped — a shortened conclusion beats no conclusion.
+	long := strings.Repeat("很长的一句话没有句号", 20)
+	got = leadingConclusion(long, 30)
+	if got == "" || len([]rune(got)) > 31 {
+		t.Fatalf("over-long single sentence = %q (%d runes)", got, len([]rune(got)))
 	}
 }
 

--- a/server/internal/channels/reflow.go
+++ b/server/internal/channels/reflow.go
@@ -241,10 +241,11 @@ func outcomeBrief(identity *models.TaskIdentity, outcome TaskOutcome, language s
 func outcomeFallbackText(identity *models.TaskIdentity, outcome TaskOutcome, language string) string {
 	title := services.SanitizeShortTitle(identity.ShortTitle)
 	en := services.NormalizeLanguage(language) == "en"
-	facts := ScrubInternalTerms(strings.TrimSpace(outcome.ResultSummary))
-	// Keep the same budget as fireRunTerminal's digest — a second hard cut at
-	// 400 is what produced mid-word endings like「findi…」in IM.
-	facts = truncateRunes(facts, 800)
+	// The digest goes to completedOutcomeFallback unscrubbed on purpose: it
+	// chooses which sentences to quote by asking whether each one is clean, and
+	// a pre-scrubbed digest looks clean everywhere. What it returns is scrubbed
+	// before it leaves.
+	facts := strings.TrimSpace(outcome.ResultSummary)
 	switch strings.ToLower(strings.TrimSpace(outcome.Status)) {
 	case "completed":
 		return completedOutcomeFallback(title, facts, en)
@@ -274,15 +275,29 @@ func outcomeFallbackText(identity *models.TaskIdentity, outcome TaskOutcome, lan
 	}
 }
 
+// outcomeFallbackFactsRunes bounds what the degraded path is allowed to quote.
+// ResultSummary is written by the working agent for the platform, not for the
+// user: a full one is a report with commit hashes, module names and headings.
+// Quoting its opening conclusion is useful; pasting the whole thing is how a
+// finished task arrived in QQ as 「弄完了。对照…基线（git: 90713d62 Merge #177）…」.
+const outcomeFallbackFactsRunes = 160
+
 func completedOutcomeFallback(title, facts string, en bool) string {
-	facts = strings.TrimSpace(facts)
+	facts = ScrubInternalTerms(leadingConclusion(facts, outcomeFallbackFactsRunes))
 	if facts != "" {
-		// Findings already carry the substance. Gluing ShortTitle produced
-		// 「调研 … 和 wo弄完了」when the ledger title had been mid-token cut.
+		// The task has to be named. Two other jobs may have been handed over
+		// since this one started, and an unattributed 「弄完了」 reads as an
+		// answer to whichever was asked for last.
 		if en {
-			return "Done. " + facts
+			if title == "" {
+				return "That one's done: " + facts
+			}
+			return "\"" + title + "\" is done: " + facts
 		}
-		return "弄完了。" + facts
+		if title == "" {
+			return "刚才那件事跑完了：" + facts
+		}
+		return title + "跑完了：" + facts
 	}
 	if en {
 		if title == "" {
@@ -294,6 +309,64 @@ func completedOutcomeFallback(title, facts string, en bool) string {
 		return "刚才那个弄完了，但这一轮没留下可读结论。要我接着补查可以说。"
 	}
 	return title + "弄完了，但这一轮没留下可读结论。要我接着补查可以说。"
+}
+
+// leadingConclusion picks the part of a findings digest that can be said out
+// loud, up to limit runes.
+//
+// Selection is per sentence, and a sentence that carries internal vocabulary is
+// dropped whole rather than cleaned. Scrubbing words out of it leaves a hole —
+// 「对照基线（git: 90713d62 Merge #177），之后到 HEAD（652b0d68）只有文案改动」
+// becomes 「对照基线，之后到 只有文案改动」, which is not better, just broken.
+// The sentence next to it — 「原架构判断大体仍成立，但清单需要局部修订」— is the
+// conclusion, and it was already fine.
+//
+// Everything clean is dropped only for length, and then whole sentences at a
+// time, because the point of this path is that it still reads like a finished
+// thought. An empty result is honest: this digest was written for the platform,
+// and the caller says so instead of quoting it.
+func leadingConclusion(facts string, limit int) string {
+	facts = strings.TrimSpace(facts)
+	if facts == "" || limit <= 0 {
+		return ""
+	}
+	var kept strings.Builder
+	for _, sentence := range splitSentences(facts) {
+		if ContainsInternalTerms(sentence) {
+			continue
+		}
+		if kept.Len() == 0 && len([]rune(sentence)) > limit {
+			// A single clean sentence past the budget: shortened beats absent.
+			return services.SoftTruncateRunes(strings.TrimSpace(sentence), limit)
+		}
+		if kept.Len() > 0 && len([]rune(kept.String()))+len([]rune(sentence)) > limit {
+			break
+		}
+		kept.WriteString(sentence)
+	}
+	return strings.TrimSpace(kept.String())
+}
+
+// splitSentences cuts after CJK/latin sentence enders and newlines, keeping the
+// terminator (and any spacing that follows) with the sentence it ends, so the
+// pieces can be re-joined without losing the gaps between them.
+func splitSentences(text string) []string {
+	var out []string
+	var cur strings.Builder
+	for _, r := range text {
+		cur.WriteRune(r)
+		switch r {
+		case '。', '！', '？', '\n', '.', '!', '?', ';', '；':
+			if strings.TrimSpace(cur.String()) != "" {
+				out = append(out, cur.String())
+			}
+			cur.Reset()
+		}
+	}
+	if strings.TrimSpace(cur.String()) != "" {
+		out = append(out, cur.String())
+	}
+	return out
 }
 
 // humanizeFailureReason turns an aggregated failure cause into something a user


### PR DESCRIPTION
## 现象

用户在 QQ 收到这么一条，完全不知道在说什么：

> 弄完了。对照 2026-08-08 09:55 UTC 前次「快模型与 worker 架构精简」调研基线（git: 90713d62 Merge #177），之后到 HEAD（652b0d68 Merge #178）只有文案质量与出口守卫改动，没有动会话 FIFO、stillWorking 退役…最终判定：需局部修订。结论状态：部分成立。建议下一步：仅观察。

## 根因

日志（20:45:35）：

```
"error":"liveagent: token budget exhausted before a reply"
"run":"run-a28d736b"
"msg":"reflow: natural-language synthesis unavailable, using structured fallback"
```

会话模型 `finish_reason=length` 没吐出正文（推理把 2048 额度烧光），`synthesizeOutcome`
降级到兜底。而兜底是 `"弄完了。" + ResultSummary` 这一句拼接——ResultSummary 是
**worker 写给平台看的**调研报告，不是给人读的话。`ScrubInternalTerms` 的词表里没有
commit hash、`Merge #N`、报告小标题，于是整篇原样出去了。

同时它连是哪件事都没说：用户刚派了 PR 179 和 181 两件活，一句无主的「弄完了」自然
被当成那两件的答复。

## 改动

| 改动 | 为什么 |
|------|--------|
| 兜底重新点名任务 | 之前为躲「…和 wo弄完了」这类半词标题才不带标题；软截断 + 标题修复落地后顾虑已消，不点名才是真问题 |
| 引用按**句子**筛，脏句整句丢 | 只删词会留下「对照基线，之后到 只有文案改动」这种破句，比留着 jargon 更糟 |
| 出口守卫补两类碎屑 | 仓库坐标（`git: <sha>` / `Merge #N` / `HEAD(<sha>)`）与报告标题（最终判定 / 结论状态 / 建议下一步…） |
| 措辞失败重试一次 | 只针对 `ErrBudgetExhausted` 换 2 倍上限；拒答 / 超时 / 端点不对重试都只是买同一个答案 |

关键取舍是**整句丢弃而不是逐词清洗**。截图那段里，被丢掉的是基线对照句和三行小标题，
留下的是它旁边本来就干净的那句结论。全脏则不引用，如实说这轮没整理出要点——空一点，
但不会莫名其妙。

## 效果

同样输入，现在发出去的是：

> 快模型与 worker 架构精简调研跑完了：原架构判断大体仍成立，但清单需要局部修订。

## 测试

- 拿截图原文当输入，断言完整输出（不是 contains，是等值）。
- 本来就是人话的摘要必须原样保留，链接不能丢——筛子是用来丢报告碎屑的，不是用来砍真答案的。
- 半词标题仍不得泄漏；`ContainsInternalTerms` 对新碎屑同步生效。
- `go test ./...` 全绿。

Made with [Cursor](https://cursor.com)