### PR TITLE
fix(channels): 补齐 turn trace 并统一 Voice/Scrub 入口

### DIFF
--- a/server/cmd/server/live_synthesizer.go
+++ b/server/cmd/server/live_synthesizer.go
@@ -33,7 +33,7 @@ const synthesisRetryMaxTokens = 2 * synthesisMaxTokens
 // synthesisSystemPrompt is the reporting voice. It is the same person the user
 // has been talking to all along, which is the whole point of phrasing an
 // outcome instead of pushing a template.
-const synthesisSystemPrompt = `你是这个项目的负责人本人，正在 IM 上和同事聊天。你的回复会原样发给对方。
+const synthesisSystemPrompt = channels.VoicePersonaLead + `
 
 下面会给你一件事的结果。用一两段人话讲给对方听：先结论，再带上 brief 里的关键发现。
 

--- a/server/internal/channels/capabilities.go
+++ b/server/internal/channels/capabilities.go
@@ -31,15 +31,6 @@ func SupportsReplyReference(channelType string) bool {
 	return ReplyCapability(channelType) == ReplyCapabilitySupported
 }
 
-// QQReplyFallback explains that native quote/reply is unavailable and asks the
-// user to select by number or short title.
-func QQReplyFallback(currentMessage, recentLanguage string) string {
-	if services.DetectLanguage(currentMessage, recentLanguage) == "en" {
-		return "QQ reply references are unavailable here. Please choose a task by number or short title."
-	}
-	return "当前 QQ 会话不支持引用回复，请按序号或短标题选择任务。"
-}
-
 // FormatTaskMessage names the task a message is about. Use it only when the
 // name carries information — several tasks are live, or the user named this one
 // — because a reference attached to every line reads like a ticket queue.

--- a/server/internal/channels/capabilities_test.go
+++ b/server/internal/channels/capabilities_test.go
@@ -3,19 +3,16 @@ package channels
 import (
 	"strings"
 	"testing"
+
+	"github.com/cocofhu/approving/internal/models"
 )
 
-func TestQQReplyCapabilityFallbackAndBilingualFormatting(t *testing.T) {
+func TestQQReplyCapabilityAndBilingualFormatting(t *testing.T) {
 	if QQReplyCapability != "unsupported" {
 		t.Fatalf("QQ reply capability=%q", QQReplyCapability)
 	}
-	zh := QQReplyFallback("请继续", "en")
-	if !strings.Contains(zh, "不支持引用回复") || !strings.Contains(zh, "序号") {
-		t.Fatalf("zh fallback=%q", zh)
-	}
-	en := QQReplyFallback("please continue", "zh-CN")
-	if !strings.Contains(en, "unavailable") || !strings.Contains(en, "number") {
-		t.Fatalf("en fallback=%q", en)
+	if SupportsReplyReference(models.ChannelTypeQQ) {
+		t.Fatal("QQ must not claim reply references")
 	}
 	// Naming the task reads as a reference in a sentence, not as a ticket header.
 	if got := FormatTaskMessage("登录页", "阻塞", "需要权限", "继续", ""); got != "登录页那个：需要权限" {

--- a/server/internal/channels/copy_guard.go
+++ b/server/internal/channels/copy_guard.go
@@ -95,6 +95,13 @@ var verdictScaffolding = regexp.MustCompile(`(?m)(^|[。；;\n])\s*(最终判定
 // pm_reply / channel delivery. These leaked through FinalSummary after #161.
 var deliveryReceiptLine = regexp.MustCompile(`(?im)^\s*(已发送|已通过\s*QQ\s*回复用户|稍等，?我看一下|Give me a moment on this one|已开始处理|任务已启动|收到，正在处理)\s*[。.!！…]*\s*$`)
 
+// ScrubForOutbound is the single policy entry for user-visible channel text.
+// sendOutboundResult applies it as the final gate; other call sites that still
+// scrub early do so for local hygiene and must stay behavior-equivalent.
+func ScrubForOutbound(text string) string {
+	return ScrubInternalTerms(text)
+}
+
 // ScrubInternalTerms makes outbound text safe to show a user: internal
 // identifiers are removed, platform vocabulary is rewritten in plain language,
 // and machine scaffolding lines are dropped. It is deliberately applied to every

--- a/server/internal/channels/delivery.go
+++ b/server/internal/channels/delivery.go
@@ -158,7 +158,7 @@ type ConversationReply struct {
 // is never forwarded, which keeps reasoning and tool chatter inside the
 // platform without needing to scrape a summary out of the transcript.
 func (m *Manager) DeliverConversationReply(ctx context.Context, reply ConversationReply) (DeliveryResult, error) {
-	text := ScrubInternalTerms(reply.Text)
+	text := ScrubForOutbound(reply.Text)
 	if text == "" {
 		return DeliveryResult{}, errors.New("conversation reply text is empty")
 	}

--- a/server/internal/channels/delivery_test.go
+++ b/server/internal/channels/delivery_test.go
@@ -825,7 +825,6 @@ func TestOutboundBindingSkippedWithoutRealIDRunOrOwnership(t *testing.T) {
 func TestNoOutboundCopyOffersATaskMenu(t *testing.T) {
 	for _, text := range []string{
 		busyHintText,
-		QQReplyFallback("", "zh-CN"), QQReplyFallback("", "en"),
 		FormatTaskMessage("登录页性能优化", "还在做。", "", "登录页怎么样了", "zh-CN"),
 		runAcceptanceText("登录页性能优化", "zh-CN"),
 	} {

--- a/server/internal/channels/director.go
+++ b/server/internal/channels/director.go
@@ -268,7 +268,7 @@ func (m *Manager) lastOutboundText(rc *runningChannel, in InboundMessage) string
 // "how's it going" can be answered from fact.
 func (m *Manager) noteWorkProgress(projectID, runID, stage string, blocked bool) {
 	runID = strings.TrimSpace(runID)
-	stage = strings.TrimSpace(ScrubInternalTerms(stage))
+	stage = strings.TrimSpace(ScrubForOutbound(stage))
 	if runID == "" || stage == "" {
 		return
 	}

--- a/server/internal/channels/live.go
+++ b/server/internal/channels/live.go
@@ -48,6 +48,11 @@ const (
 	cancelWorkTool = "cancel_work"
 )
 
+// VoicePersonaLead is the single shared opening for every spoken prompt and
+// system instruction that addresses the user as the project owner on IM.
+// Prompt bodies differ; this lead must not be re-copied elsewhere.
+const VoicePersonaLead = `你是这个项目的负责人本人，正在 IM 上和同事聊天。你的回复会原样发给对方。`
+
 // liveSystemPrompt tells the model who it is and where the line is.
 //
 // The line is drawn by capability, not topic: it may say anything it can
@@ -55,7 +60,7 @@ const (
 // delegate anything that needs the repository or an action. Uncertainty
 // resolves toward delegating, because an invented answer is indistinguishable
 // from a real one to the person reading it.
-const liveSystemPrompt = `你是这个项目的负责人本人，正在 IM 上和同事聊天。你的回复会原样发给对方。
+const liveSystemPrompt = VoicePersonaLead + `
 
 你手下有人干活。你的职责是接话、判断意图、派活或收窄已有任务，然后把真实进展和结论讲给对方听。
 
@@ -354,7 +359,7 @@ func containsAnyFold(text string, needles ...string) bool {
 
 // phrasePromptHeader is the shared role/delivery lead-in for every spoken
 // phrase prompt (status + the four acks).
-const phrasePromptHeader = `你是这个项目的负责人本人，正在 IM 上和同事聊天。你的回复会原样发给对方。`
+const phrasePromptHeader = VoicePersonaLead
 
 // statusWhileRunningPhrasePrompt rewrites a premature "done" claim against the
 // live ledger so the user hears what is still in flight. Reuses only the shared
@@ -514,7 +519,7 @@ const operationalLineRules = `
 - 不要说已经做完、已经跑完、已经处理好。
 - 只输出要发给对方的那句话。`
 
-const operationalLinePersona = `你是这个项目的负责人本人，正在 IM 上和同事聊天。你的回复会原样发给对方。
+const operationalLinePersona = VoicePersonaLead + `
 
 `
 
@@ -591,7 +596,7 @@ func looksLikeRetryAffirmation(text string) bool {
 	}
 	for _, a := range []string{
 		"重跑", "再跑", "重试", "再试", "再来一次", "重新做", "重新派", "再弄",
-		"继续做", "接着做", "接着干", "继续",
+		"继续做", "接着做", "接着干",
 		"retry", "try again", "run again", "do it again",
 	} {
 		if lower == a || strings.Contains(lower, a) {
@@ -905,7 +910,7 @@ func (c *foregroundCapture) take() string {
 	}
 	c.taken = true
 	if c.collect != nil {
-		c.text = strings.TrimSpace(ScrubInternalTerms(c.collect()))
+		c.text = strings.TrimSpace(ScrubForOutbound(c.collect()))
 	}
 	return c.text
 }
@@ -934,7 +939,7 @@ func (c *foregroundCapture) egress(degraded bool) string {
 // reads slightly off but is true. degraded reports which of the two happened.
 func (m *Manager) reportThroughDirector(ctx context.Context, rc *runningChannel, in InboundMessage,
 	conclusion string) (text string, degraded bool) {
-	plain := strings.TrimSpace(ScrubInternalTerms(conclusion))
+	plain := strings.TrimSpace(ScrubForOutbound(conclusion))
 	started := time.Now()
 	if m.live == nil || !m.live.Configured() || plain == "" {
 		m.appendTraceSpan(in.TraceID, finishSpan("director_report", "skipped", "degraded", started))
@@ -993,7 +998,7 @@ const directorReportMaxTokens = 2048
 // directorReportPrompt is deliberately narrow. Anything that invites the model
 // to add, judge, or expand turns a verified conclusion into a partly invented
 // one, which is the exact failure this whole layer exists to prevent.
-const directorReportPrompt = `你是这个项目的负责人本人，正在 IM 上和同事聊天。你的回复会原样发给对方。
+const directorReportPrompt = VoicePersonaLead + `
 
 下面给你的是查到的结果。用一两段人话把结论讲给对方听。
 

--- a/server/internal/channels/live_test.go
+++ b/server/internal/channels/live_test.go
@@ -178,6 +178,24 @@ func TestScrubInternalTermsCleansModelComposedText(t *testing.T) {
 		if strings.Contains(got, "  ") || strings.HasPrefix(got, " ") {
 			t.Errorf("ScrubInternalTerms(%q) left ragged spacing: %q", c.in, got)
 		}
+		if via := ScrubForOutbound(c.in); via != got {
+			t.Errorf("ScrubForOutbound drifted from ScrubInternalTerms:\n  %q\n  %q", via, got)
+		}
+	}
+}
+
+// Bare「继续」is casual chatter ("那继续吧"), not a retry affirmation. Explicit
+// retry verbs and「继续做」still short-circuit.
+func TestLooksLikeRetryAffirmationNarrowContinue(t *testing.T) {
+	for _, text := range []string{"继续做", "接着做", "重跑", "再试一次", "retry", "try again"} {
+		if !looksLikeRetryAffirmation(text) {
+			t.Errorf("%q should count as retry affirmation", text)
+		}
+	}
+	for _, text := range []string{"继续", "那继续吧", "好的继续", "继续聊", "不要重跑"} {
+		if looksLikeRetryAffirmation(text) {
+			t.Errorf("%q must not count as retry affirmation", text)
+		}
 	}
 }
 
@@ -586,6 +604,18 @@ func TestClaimsActiveWorkFinished(t *testing.T) {
 // header for all five spoken prompts, three shared ack rule lines reused by
 // the four acks only, and each event's distinctive semantics kept in place.
 func TestPhrasePromptSharedFragmentsLock(t *testing.T) {
+	if VoicePersonaLead == "" || phrasePromptHeader != VoicePersonaLead {
+		t.Fatal("phrasePromptHeader must alias VoicePersonaLead exactly once")
+	}
+	if !strings.HasPrefix(liveSystemPrompt, VoicePersonaLead) {
+		t.Fatal("liveSystemPrompt must open with VoicePersonaLead")
+	}
+	if !strings.HasPrefix(directorReportPrompt, VoicePersonaLead) {
+		t.Fatal("directorReportPrompt must open with VoicePersonaLead")
+	}
+	if !strings.HasPrefix(operationalLinePersona, VoicePersonaLead) {
+		t.Fatal("operationalLinePersona must open with VoicePersonaLead")
+	}
 	if phrasePromptHeader == "" {
 		t.Fatal("phrasePromptHeader must be defined once")
 	}

--- a/server/internal/channels/manager.go
+++ b/server/internal/channels/manager.go
@@ -876,7 +876,7 @@ const deprecatedSafeFinalNotice = "本回合已结束，请在 Approving 查看�
 // delivery-receipt asides that slipped into FinalSummary construction.
 func deliverableFinalText(reply Reply) (text, reason string, ok bool) {
 	if summary := strings.TrimSpace(reply.FinalSummary); summary != "" {
-		summary = ScrubInternalTerms(summary)
+		summary = ScrubForOutbound(summary)
 		if summary == "" {
 			return "", "final_summary_scrubbed_empty", false
 		}
@@ -980,7 +980,7 @@ func (m *Manager) sendOutboundResult(ctx context.Context, rc *runningChannel, ou
 	// Last gate before the transport. Every outbound path converges here, so
 	// scrubbing once here is what makes "internals never leak" a property of the
 	// system rather than a rule each call site has to remember.
-	if scrubbed := ScrubInternalTerms(out.Text); scrubbed != out.Text {
+	if scrubbed := ScrubForOutbound(out.Text); scrubbed != out.Text {
 		log.Debug().Str("channel", rc.cfg.ID).Str("reason", out.Envelope.Reason).
 			Msg("outbound text scrubbed of internal terms")
 		out.Text = scrubbed
@@ -994,13 +994,13 @@ func (m *Manager) sendOutboundResult(ctx context.Context, rc *runningChannel, ou
 		out.Text = repaired
 	}
 	if strings.TrimSpace(out.Text) == "" && len(out.ImageURLs) == 0 {
-		return DeliveryResult{Decision: sendable.Decision{Reason: "empty_after_scrub"}}
+		return m.traceOutbound(out, DeliveryResult{Decision: sendable.Decision{Reason: "empty_after_scrub"}})
 	}
 	contentFingerprint := out.Text + "\n" + strings.Join(out.ImageURLs, "\n")
 	decision, err := m.policy.Evaluate(ctx, out.Envelope, sendable.ChannelQQ, contentFingerprint)
 	if err != nil {
 		log.Warn().Err(err).Str("channel", rc.cfg.ID).Msg("channel outbound policy failed closed")
-		return DeliveryResult{Decision: sendable.Decision{Reason: "policy_error"}}
+		return m.traceOutbound(out, DeliveryResult{Decision: sendable.Decision{Reason: "policy_error"}})
 	}
 	for decision.Send {
 		sent, sendErr := rc.adapter.Send(ctx, out)
@@ -1011,14 +1011,14 @@ func (m *Manager) sendOutboundResult(ctx context.Context, rc *runningChannel, ou
 			// Recording here rather than at each call site is what keeps the
 			// transcript honest: an answer that failed to send is not in it.
 			m.recordOutbound(rc, out)
-			return DeliveryResult{Decision: decision, Sent: true, ExternalMessageID: sent.MessageID}
+			return m.traceOutbound(out, DeliveryResult{Decision: decision, Sent: true, ExternalMessageID: sent.MessageID})
 		}
 		_ = m.policy.MarkFailed(ctx, decision, out.Envelope, sendable.ChannelQQ, sendErr)
 		log.Warn().Err(sendErr).Str("channel", rc.cfg.ID).Int("attempt", decision.Attempt).
 			Msg("channel outbound send failed")
 		if !m.waitBackoff(ctx, decision.Attempt) {
 			decision.Reason = "transport_failed"
-			return DeliveryResult{Decision: decision}
+			return m.traceOutbound(out, DeliveryResult{Decision: decision})
 		}
 		// Retry claims the next bounded attempt for this dedupe key; it returns
 		// Send=false once the receipt is sent elsewhere or attempts are spent.
@@ -1026,14 +1026,35 @@ func (m *Manager) sendOutboundResult(ctx context.Context, rc *runningChannel, ou
 		if err != nil {
 			log.Warn().Err(err).Str("channel", rc.cfg.ID).Msg("channel outbound retry claim failed")
 			decision.Reason = "retry_claim_failed"
-			return DeliveryResult{Decision: decision}
+			return m.traceOutbound(out, DeliveryResult{Decision: decision})
 		}
 		decision = next
 	}
 	if decision.Reason == "" {
 		decision.Reason = "suppressed"
 	}
-	return DeliveryResult{Decision: decision}
+	return m.traceOutbound(out, DeliveryResult{Decision: decision})
+}
+
+// traceOutbound records a late outbound step when Envelope.TraceID is set.
+// Before the decision sample is committed, AppendSpanByTrace finds no row and
+// no-ops — those early ACK/reply paths still get their outbound:* span from
+// sampleRecorder.acted at commit time, so this does not double-count.
+func (m *Manager) traceOutbound(out OutboundMessage, result DeliveryResult) DeliveryResult {
+	tid := strings.TrimSpace(out.Envelope.TraceID)
+	if tid == "" {
+		return result
+	}
+	status := "ok"
+	if !result.Sent {
+		status = "suppressed"
+	}
+	reason := strings.TrimSpace(out.Envelope.Reason)
+	if reason == "" {
+		reason = "outbound"
+	}
+	m.appendTraceSpan(tid, finishSpan("outbound:"+reason, status, truncateRunes(out.Text, 120), time.Now()))
+	return result
 }
 
 // bindOutboundMessage records "this channel message belongs to that Run" so a

--- a/server/internal/channels/reflow.go
+++ b/server/internal/channels/reflow.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"regexp"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/cocofhu/approving/internal/models"
@@ -71,14 +72,16 @@ func (m *Manager) ReflowTaskOutcome(ctx context.Context, outcome TaskOutcome) er
 		scene = SceneC2C
 	}
 
-	text := m.synthesizeOutcome(ctx, identity, outcome, scene, conv)
+	traceID := m.traceIDForReflow(identity)
+	text := m.synthesizeOutcome(ctx, identity, outcome, scene, conv, traceID)
 	if strings.TrimSpace(text) == "" {
 		return nil
 	}
 	_, err := m.DeliverSendable(ctx, SendableRequest{
 		ProjectID: identity.ProjectID, Scene: scene, ConversationID: conv,
 		UserID: identity.OriginExternalUserID, RunID: runID,
-		Kind: sendable.KindFinal, Reason: "task_outcome",
+		TraceID: traceID,
+		Kind:    sendable.KindFinal, Reason: "task_outcome",
 		Priority: sendable.PriorityCritical,
 		// One conclusion per run per conversation, whatever path produced it.
 		DedupeKey: strings.Join([]string{"task-outcome", runID, conv}, ":"),
@@ -87,36 +90,73 @@ func (m *Manager) ReflowTaskOutcome(ctx context.Context, outcome TaskOutcome) er
 	return err
 }
 
+// traceIDForReflow best-effort joins a terminal outcome to the inbound turn that
+// dispatched it. TaskIdentity has no OriginTraceID; matching the newest sample
+// for the origin conversation is enough for observability and matches the
+// existing "sampling may drop" posture. An empty result is fine — delivery still
+// proceeds without a span join.
+func (m *Manager) traceIDForReflow(identity *models.TaskIdentity) string {
+	if m == nil || m.samples == nil || identity == nil {
+		return ""
+	}
+	conv := strings.TrimSpace(identity.OriginConversationID)
+	if conv == "" {
+		return ""
+	}
+	listed, err := m.samples.List(services.SampleQuery{
+		ProjectID: identity.ProjectID, ConversationID: conv, Limit: 10,
+	})
+	if err != nil {
+		return ""
+	}
+	for _, s := range listed {
+		if tid := strings.TrimSpace(s.TraceID); tid != "" {
+			return tid
+		}
+	}
+	return ""
+}
+
 // synthesizeOutcome asks the conversation's agent to phrase the outcome in
 // context, and falls back to a self-contained statement if that is not
 // possible. The fallback is written to be a real answer on its own — it names
 // the task, says what happened, and says what comes next — because it is what
 // the user actually receives whenever the agent is busy or unavailable.
 func (m *Manager) synthesizeOutcome(ctx context.Context, identity *models.TaskIdentity,
-	outcome TaskOutcome, scene Scene, conv string) string {
+	outcome TaskOutcome, scene Scene, conv, traceID string) string {
+	started := time.Now()
 	language := taskLanguage(identity)
 	fallback := outcomeFallbackText(identity, outcome, language)
+	status, detail := "ok", "synthesized"
+	text := ""
 	if m.synthesize == nil {
-		return fallback
+		status, detail = "fallback", "no_synthesizer"
+		text = fallback
+	} else {
+		// Phrasing happens in the conversation layer, which is not the layer doing
+		// the work. That is what lets an outcome be reported while the agent is
+		// still busy: synthesis used to borrow the conversation's own agent, so a
+		// conversation with a turn in flight got the template instead of a sentence.
+		req := SynthesisRequest{
+			ProjectID: identity.ProjectID, Scene: scene, ConversationID: conv,
+			ExternalUserID: identity.OriginExternalUserID,
+			RunID:          identity.RunID, ShortTitle: identity.ShortTitle,
+			Language: language, Fallback: fallback,
+			Brief: outcomeBrief(identity, outcome, language),
+		}
+		var err error
+		text, err = m.synthesize(ctx, req)
+		if strings.TrimSpace(text) == "" {
+			log.Info().Err(err).Str("run", identity.RunID).
+				Msg("reflow: natural-language synthesis unavailable, using structured fallback")
+			status, detail = "fallback", "unavailable"
+			text = fallback
+		}
 	}
-	// Phrasing happens in the conversation layer, which is not the layer doing
-	// the work. That is what lets an outcome be reported while the agent is
-	// still busy: synthesis used to borrow the conversation's own agent, so a
-	// conversation with a turn in flight got the template instead of a sentence.
-	req := SynthesisRequest{
-		ProjectID: identity.ProjectID, Scene: scene, ConversationID: conv,
-		ExternalUserID: identity.OriginExternalUserID,
-		RunID:          identity.RunID, ShortTitle: identity.ShortTitle,
-		Language: language, Fallback: fallback,
-		Brief: outcomeBrief(identity, outcome, language),
-	}
-	text, err := m.synthesize(ctx, req)
-	if strings.TrimSpace(text) == "" {
-		log.Info().Err(err).Str("run", identity.RunID).
-			Msg("reflow: natural-language synthesis unavailable, using structured fallback")
-		return fallback
-	}
-	return ScrubInternalTerms(text)
+	m.appendTraceSpan(traceID, finishSpan("synthesis", status, detail, started))
+	// Final scrub lives in sendOutboundResult (ScrubForOutbound); keep a thin
+	// pass here so captured/fallback text is already clean if inspected early.
+	return ScrubForOutbound(text)
 }
 
 // SynthesisRequest asks the conversation's agent to phrase a background event
@@ -295,7 +335,7 @@ func completedOutcomeFallback(title, facts string, en bool) string {
 		link = m[1]
 		facts = deliveryLine.ReplaceAllString(facts, "")
 	}
-	body := ScrubInternalTerms(leadingConclusion(facts, outcomeFallbackFactsRunes))
+	body := ScrubForOutbound(leadingConclusion(facts, outcomeFallbackFactsRunes))
 	// The task has to be named, first thing. Several jobs can be in flight at
 	// once, and two pushes that both open with 「弄完了」 are indistinguishable
 	// in a chat window — which is the state this message arrived in.

--- a/server/internal/channels/turn_trace_test.go
+++ b/server/internal/channels/turn_trace_test.go
@@ -90,3 +90,134 @@ func TestNoLiveModelStillRecordsADirectTrace(t *testing.T) {
 	}
 	_ = context.Background()
 }
+
+// TestDispatchReflowOutboundTraceChain covers the observable handoff:
+// live_route → tool:dispatch_pm → sandbox_turn → synthesis → outbound:task_outcome
+// joined by one TraceID (reflow best-effort matches the origin conversation).
+func TestDispatchReflowOutboundTraceChain(t *testing.T) {
+	g := newGPTLive(t)
+	// handleInbound uses the standalone rc; DeliverSendable resolves via m.running.
+	g.m.mu.Lock()
+	if g.m.running == nil {
+		g.m.running = map[string]*runningChannel{}
+	}
+	g.m.running[g.rc.cfg.ID] = g.rc
+	g.m.mu.Unlock()
+
+	g.m.SetLiveModel(&fakeLive{configured: true, decisions: []liveagent.Result{
+		liveDispatch("查错误处理", "错误处理"),
+	}})
+	g.say("m1", "项目的错误处理完整吗")
+	if len(g.agent) != 1 || strings.TrimSpace(g.agent[0].TraceID) == "" {
+		t.Fatalf("dispatch lost the trace: %+v", g.agent)
+	}
+	traceID := g.agent[0].TraceID
+
+	if _, err := g.m.taskContext.EnsureIdentity(services.EnsureTaskIdentityInput{
+		RunID: "run-trace-reflow1", ProjectID: "proj",
+		UserID:     services.SyntheticQQUserID("u1"),
+		ShortTitle: "错误处理", Status: "running",
+		OriginChannel: "qq", OriginScene: string(SceneC2C),
+		OriginConversationID: "user1", OriginExternalUserID: "u1",
+		Language:            "zh-CN",
+		OriginalRequirement: "查错误处理",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := g.m.ReflowTaskOutcome(context.Background(), TaskOutcome{
+		ProjectID: "proj", RunID: "run-trace-reflow1", Status: "completed",
+		ResultSummary: "超时与重试策略已对齐。\n交付链接：https://github.com/org/repo/pull/42",
+	}); err != nil {
+		t.Fatalf("reflow: %v", err)
+	}
+
+	sample, err := g.m.samples.GetByTrace("proj", traceID)
+	if err != nil || sample == nil {
+		t.Fatalf("sample by trace: %+v err=%v", sample, err)
+	}
+	var spans []TraceSpan
+	if err := json.Unmarshal([]byte(sample.Spans), &spans); err != nil {
+		t.Fatal(err)
+	}
+	names := spanNames(spans)
+	for _, want := range []string{"live_route", "sandbox_turn", "synthesis", "outbound:task_outcome"} {
+		if !containsString(names, want) {
+			t.Fatalf("missing span %q in %v (raw=%s)", want, names, sample.Spans)
+		}
+	}
+	// Successful dispatch returns before toolReturned; the observable handoff is
+	// the live_ack (and route=dispatch on the sample), not tool:dispatch_pm.
+	if sample.Route != routeDispatch {
+		t.Fatalf("route = %q want dispatch", sample.Route)
+	}
+	if !containsString(names, "outbound:live_ack") && !containsString(names, "tool:dispatch_pm") {
+		t.Fatalf("dispatch handoff missing (want live_ack or tool:dispatch_pm): %v", names)
+	}
+}
+
+// TestLateOutboundWithTraceIDAppendsSpan covers external/late delivery (e.g.
+// pm_reply via DeliverConversationReply) when Envelope.TraceID is present.
+func TestLateOutboundWithTraceIDAppendsSpan(t *testing.T) {
+	fa := &fakeAdapter{}
+	m, db := policyManager(t, fa, nil)
+	m.Apply([]models.ChannelConfig{{
+		ID: "c1", Type: "qq", ProjectID: "proj", AppID: "app", Enabled: true,
+		CronDeliver: true, CronDeliverTarget: "c2c:cron-target",
+	}})
+	t.Cleanup(m.StopAll)
+	m.mu.Lock()
+	for _, rc := range m.running {
+		rc.adapter = fa
+	}
+	m.mu.Unlock()
+	svc := services.NewLiveSampleService(db)
+	m.SetLiveSampleService(svc)
+
+	traceID := "tr-lateoutbound1"
+	if _, err := svc.Record(models.LiveDecisionSample{
+		ProjectID: "proj", Channel: "qq", Scene: string(SceneC2C),
+		ConversationID: "user-late", TraceID: traceID, Route: routeDirect,
+		Spans: `[{"name":"live_route","status":"ok"}]`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := m.DeliverConversationReply(context.Background(), ConversationReply{
+		ProjectID: "proj", Scene: SceneC2C, ConversationID: "user-late",
+		UserID: "u1", TraceID: traceID, Text: "这边看完了，超时策略没问题。",
+	})
+	if err != nil || !result.Sent {
+		t.Fatalf("deliver = %+v err=%v", result, err)
+	}
+
+	sample, err := svc.GetByTrace("proj", traceID)
+	if err != nil || sample == nil {
+		t.Fatalf("sample = %+v err=%v", sample, err)
+	}
+	var spans []TraceSpan
+	if err := json.Unmarshal([]byte(sample.Spans), &spans); err != nil {
+		t.Fatal(err)
+	}
+	if !containsString(spanNames(spans), "outbound:pm_reply") {
+		t.Fatalf("outbound:pm_reply missing: %v", spanNames(spans))
+	}
+}
+
+func spanNames(spans []TraceSpan) []string {
+	out := make([]string, 0, len(spans))
+	for _, sp := range spans {
+		out = append(out, sp.Name)
+	}
+	return out
+}
+
+func containsString(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+


### PR DESCRIPTION
## Summary
- 补齐结果润色、回流与晚出站的 turn trace，按同一 TraceID 覆盖接话、派活、worker、synthesis 和 outbound 链路
- 将重复人格文案收敛到 `VoicePersonaLead`，并以 `ScrubForOutbound` 保持最终出站过滤闸门
- 收窄裸「继续」的重试误判，并删除未使用的 `QQReplyFallback`

## Capability preservation
- 快模型仍是唯一用户发言方，worker 仍只执行并回流
- 外部可见 scrub 行为由既有金样锁定；未扩大 copy_guard 词表或重写编排

## Risks
- 回流 TraceID 采用按项目与会话查找最新 sample 的 best-effort 关联，并发派活时可能偶发关联偏差
- 人格常量抽取会重组 prompt 字节，但回归测试验证共享片段与外部行为保持一致
- 成功 dispatch 仍可能没有 `tool:dispatch_pm` span；链路可由 `outbound:live_ack` 观测

## Test plan
- [x] `go test ./internal/channels/ ./internal/liveagent/ ./internal/sendable/ ./internal/textutil/`
- [x] `go test ./internal/models/ ./internal/services/ -count=1`
- [x] `go build ./cmd/server/`
- [x] 关键 trace、Voice/Scrub 与「继续」边界用例复验通过
- [ ] 未运行 `go test ./...`：改动集中在上述包，指定包与支撑包已覆盖改动面

Made with [Cursor](https://cursor.com)