### PR TITLE
fix(channels): 接单回执要说清是哪件事

### DIFF
--- a/server/internal/channels/delivery.go
+++ b/server/internal/channels/delivery.go
@@ -275,16 +275,51 @@ func (m *Manager) SendRunAcceptanceAck(ctx context.Context, ack RunAcceptanceAck
 }
 
 // runAcceptanceText is the last-resort line when a Run is accepted but the
-// conversation layer did not already speak. Keep it short and free of pasted
-// ledger titles — long short_title values are truncated requirements, not names.
+// conversation layer did not already speak.
+//
+// It says which task it is whenever the title is short enough to read as a
+// name. This line used to drop the title on the grounds that a short_title is
+// a truncated requirement rather than a name, and back then it was: they
+// arrived as 「快模型和 wo」. Now that they are cut at word boundaries the only
+// remaining objection is length, so length is what is actually checked —
+// dropping the name outright produced 「好，那事我去弄」 in reply to 「修复下」,
+// which names nothing at all.
+//
 // Do not append "feel free to keep chatting": the user already knows they can
 // talk, and saying so reads like a helpdesk script.
 func runAcceptanceText(shortTitle, language string) string {
-	_ = shortTitle
+	name := nameableTitle(shortTitle)
 	if services.NormalizeLanguage(language) == "en" {
+		if name != "" {
+			return "Got it, " + name + " — I'll take it and come back when it's done."
+		}
 		return "Got it, I'll take that one and come back when it's done."
 	}
+	if name != "" {
+		// The comma is doing work: a title can end in either script, and it is
+		// the one separator that reads correctly after both.
+		return "好，" + name + "，我去弄，完了告诉你。"
+	}
 	return "好，那事我去弄，完了告诉你。"
+}
+
+// nameableTitleRunes is where a name stops being a name. Past this a title is
+// the request written out, and reading a request back at the person who just
+// made it is the thing every ack prompt here is trying to avoid.
+const nameableTitleRunes = 14
+
+// nameableTitle returns the title if it can stand in as the name of a task, or
+// empty if it cannot: too long to be anything but the requirement restated, or
+// already marked as cut short.
+func nameableTitle(shortTitle string) string {
+	t := strings.TrimSpace(shortTitle)
+	if t == "" || strings.Contains(t, "…") || strings.Contains(t, "...") {
+		return ""
+	}
+	if len([]rune(t)) > nameableTitleRunes {
+		return ""
+	}
+	return t
 }
 
 func runAcceptanceDedupeKey(runID, conversationID, userID string) string {

--- a/server/internal/channels/delivery_test.go
+++ b/server/internal/channels/delivery_test.go
@@ -283,13 +283,17 @@ func TestSendRunAcceptanceAckOncePerRunAndRejectsMissingRun(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("run acceptance ACK sent %v want exactly once per run", got)
 	}
-	// Confirmation hands the conversation back without a ticket header and
-	// without pasting the ledger title (often a truncated requirement).
+	// Confirmation hands the conversation back without a ticket header, and it
+	// says which task it took: several can be in flight, and an ack that names
+	// none of them is indistinguishable from the next one.
 	if !strings.Contains(got[0], "我去弄") {
 		t.Fatalf("ack text = %q want a short acceptance", got[0])
 	}
-	if strings.Contains(got[0], "【") || strings.Contains(got[0], "已接单") || strings.Contains(got[0], "登录页") {
-		t.Fatalf("delegation confirmation still pastes title/ticket copy: %q", got[0])
+	if !strings.Contains(got[0], "登录页") {
+		t.Fatalf("acceptance does not say which task it is: %q", got[0])
+	}
+	if strings.Contains(got[0], "【") || strings.Contains(got[0], "已接单") {
+		t.Fatalf("delegation confirmation still reads like a ticket: %q", got[0])
 	}
 
 	ack.RunID = ""
@@ -321,6 +325,64 @@ func TestRunAcceptanceAckIsPhrasedByTheConversationModel(t *testing.T) {
 	got := sentTexts(fa)
 	if len(got) != 1 || got[0] != "行，那事我这就安排，弄好了喊你。" {
 		t.Fatalf("sends = %v want the model's own line", got)
+	}
+}
+
+// 「修复下」 came back as 「好，那事我去弄，完了告诉你。」 — a reply that would
+// have been equally true of anything the user had ever asked for. The name is
+// the only part of an acceptance that carries information.
+func TestRunAcceptanceSaysWhichTaskItTook(t *testing.T) {
+	for _, tc := range []struct {
+		name, title, lang string
+		wantNamed         bool
+	}{
+		{name: "short title is a name", title: "PR 179 的 CI", lang: "zh-CN", wantNamed: true},
+		{name: "short title in english", title: "Login perf", lang: "en", wantNamed: true},
+		// Past a certain length a short_title is the request written out, and
+		// reading a request back to the person who just made it is worse than
+		// the pronoun.
+		{name: "a requirement is not a name", lang: "zh-CN", wantNamed: false,
+			title: "调研 Approving 最近关于快模型和 worker 架构的精简空间"},
+		// A title that was cut short is not a name either.
+		{name: "a cut title is not a name", title: "调研快模型和…", lang: "zh-CN", wantNamed: false},
+		{name: "no title at all", title: "", lang: "zh-CN", wantNamed: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := runAcceptanceText(tc.title, tc.lang)
+			if named := tc.title != "" && strings.Contains(got, tc.title); named != tc.wantNamed {
+				t.Errorf("names the task = %v, want %v: %q", named, tc.wantNamed, got)
+			}
+			if tc.wantNamed {
+				return
+			}
+			// Without a usable name the line stays as it was; it must at least
+			// still read as an acceptance.
+			if !strings.Contains(got, "我去弄") && !strings.Contains(got, "I'll take") {
+				t.Errorf("not an acceptance: %q", got)
+			}
+		})
+	}
+}
+
+// Naming the task and pasting the requirement are different things, and the
+// guard that rejects the second must not reject the first — that is how the
+// pronoun became the only thing a model was allowed to say.
+func TestNamingATaskIsNotPastingIt(t *testing.T) {
+	const title = "重新执行上次因服务重启而中断的 Approving 架构调研"
+	if !retryAckEchoesBrief("行，"+title+"，我这就让人接着弄。", title, "") {
+		t.Error("a pasted requirement should still be rejected")
+	}
+	if !retryAckEchoesBrief("行，「架构调研」那个我去弄。", title, "") {
+		t.Error("a bracket-quoted title should still be rejected")
+	}
+	for _, ack := range []string{
+		"行，架构调研那块我这就让人接着弄。",
+		"CI 那个我去弄，完了告诉你。",
+		"好，登录页那块我盯着，有结果喊你。",
+	} {
+		if retryAckEchoesBrief(ack, title, "") {
+			t.Errorf("naming the task was rejected as a paste: %q", ack)
+		}
 	}
 }
 

--- a/server/internal/channels/live.go
+++ b/server/internal/channels/live.go
@@ -373,23 +373,38 @@ const statusWhileRunningPhrasePrompt = phrasePromptHeader + `
 // retryAckEchoesBrief is true when the spoken line pastes the ledger title /
 // requirement back — the failure mode behind quoting
 // 「重新执行上次因服务重启而中断的 Approvin」.
+//
+// Naming the task is not pasting it, and the difference is length. This used to
+// reject any line that reused six characters of the title, which ruled out
+// 「CI 那个我去弄」 along with the quoted requirement, and left the pronoun as
+// the only thing a model could say. What it rejects now is a run long enough to
+// be the requirement read back.
 func retryAckEchoesBrief(ack, title, req string) bool {
 	ack = strings.TrimSpace(ack)
 	if ack == "" {
 		return false
 	}
-	if strings.Contains(ack, "「") || strings.Contains(ack, "」") {
+	if strings.ContainsAny(ack, "「」《》") {
 		return true
 	}
 	for _, s := range []string{title, req} {
-		s = strings.TrimSpace(s)
-		if s == "" {
-			continue
-		}
-		if len([]rune(s)) >= 6 && strings.Contains(ack, s) {
+		if pastesSpanOf(ack, strings.TrimSpace(s)) {
 			return true
 		}
-		if r := []rune(s); len(r) >= 10 && strings.Contains(ack, string(r[:10])) {
+	}
+	return false
+}
+
+// pasteSpanRunes is where reusing the source stops being a reference to it.
+const pasteSpanRunes = 14
+
+// pastesSpanOf reports whether ack quotes any pasteSpanRunes-long run of s.
+// Any run, not just the opening one: a model that skips the first few words of
+// a requirement and reads back the rest has still read it back.
+func pastesSpanOf(ack, s string) bool {
+	r := []rune(s)
+	for i := 0; i+pasteSpanRunes <= len(r); i++ {
+		if strings.Contains(ack, string(r[i:i+pasteSpanRunes])) {
 			return true
 		}
 	}
@@ -430,6 +445,13 @@ const (
 	phraseAckRuleColloquial = `- 像同事当面说，不要工单腔，不要「我这就去确认」「收到」「稍等」。`
 	phraseAckRuleNoInternal = `- 不要提优先级、任务编号、工作流、沙箱、跟进页面、Approving。`
 	phraseAckRuleOneLine    = `- 只输出要发给对方的那句话。`
+
+	// phraseAckRuleNameIt is what keeps two acks apart in a chat window. The
+	// old rule said the opposite — 「用「那事」「那块」指代即可」 — on the
+	// assumption that the user had just named the thing themselves. They often
+	// have not: 「修复下」 got back 「好，那事我去弄」, which could have been
+	// about anything. A handle costs three characters and settles it.
+	phraseAckRuleNameIt = `- 一句话里要能看出是哪件事：从事情本身取两三个字的自然说法（「CI 那个」「登录页那块」）。不要照抄完整标题，不要用书名号或引号把标题括回去，也不要只说「那事」「那块」——对方手上可能同时有好几件。`
 )
 
 // buildPhraseAckPrompt joins header + event body + ordered rule bullets.
@@ -453,7 +475,7 @@ func buildPhraseAckPrompt(eventBody string, rules ...string) string {
 var retryAckPhrasePrompt = buildPhraseAckPrompt(
 	`对方刚明确说要重跑/再试一件刚失败的事。用一两句人话告诉对方：你正派人重新去做那件事——时态是正在重试，不是已经做完。`,
 	phraseAckRuleColloquial,
-	`- 不要复述任务标题或原要求，也不要用书名号/引号把标题括回去——对方刚说了重试，知道是哪件；用「那事」「那块」指代即可。`,
+	phraseAckRuleNameIt,
 	phraseAckRuleNoInternal,
 	`- 禁止「已经重新跑过了 / 已经重试过了 / 重新重试过了 / 已经进到队列」——现在才刚开干，还在进行中。`,
 	phraseAckRuleOneLine,
@@ -471,7 +493,7 @@ var fallthroughAckPhrasePrompt = buildPhraseAckPrompt(
 var dispatchAckPhrasePrompt = buildPhraseAckPrompt(
 	`你刚把一件事派人去干了。用一两句人话告诉对方你正让人做这件事——时态是正在做，不是做完了。`,
 	phraseAckRuleColloquial,
-	`- 不要复述完整任务标题或原要求；用「那事」「那块」或极短口语指代即可。`,
+	phraseAckRuleNameIt,
 	phraseAckRuleNoInternal,
 	`- 禁止「已经重试过了 / 已经跑完了 / 已经进到队列」。`,
 	phraseAckRuleOneLine,
@@ -480,7 +502,7 @@ var dispatchAckPhrasePrompt = buildPhraseAckPrompt(
 var refineAckPhrasePrompt = buildPhraseAckPrompt(
 	`对方刚补充/收窄了正在做的事。用一两句人话告诉对方你会按新重点继续——时态是接着做，不是做完了。`,
 	phraseAckRuleColloquial,
-	`- 不要复述完整任务标题；不要用书名号把标题括回去。`,
+	phraseAckRuleNameIt,
 	phraseAckRuleNoInternal,
 	phraseAckRuleOneLine,
 )
@@ -500,7 +522,8 @@ type operationalLine struct {
 	Situation string
 	// Facts are internal details the model may use but must not quote back.
 	Facts string
-	// Avoid is a title or requirement the reply must not paste back at the user.
+	// Avoid is a title or requirement the reply may name but must not paste
+	// back wholesale.
 	Avoid    string
 	Language string
 	Fallback string
@@ -513,7 +536,7 @@ const operationalLineRules = `
 
 规矩：
 - 像同事当面说，不要工单腔，不要「收到」「稍等」「我这就去确认」。
-- 不要复述任务标题或原要求；用「那事」「那块」指代即可。
+- 内部参考里给了是哪件事的，就用两三个字的自然说法点出来（「CI 那个」「登录页那块」）；不要照抄完整标题，不要用书名号或引号括回去，也不要只说「那事」「那块」——对方手上可能同时有好几件。
 - 不要交代对方可以做什么（「你可以接着问别的」「有事随时叫我」这类都不要）——他本来就知道。
 - 不要提优先级、任务编号、工作流、执行环境、跟进页面、Approving。
 - 不要说已经做完、已经跑完、已经处理好。

--- a/server/internal/channels/live_test.go
+++ b/server/internal/channels/live_test.go
@@ -662,6 +662,23 @@ func TestPhrasePromptSharedFragmentsLock(t *testing.T) {
 		t.Fatal("statusWhileRunning must keep its own body, not the ack「规矩」block")
 	}
 
+	// The three acks that follow a specific task have to say which one. The
+	// fallthrough ack does not: nothing has been dispatched yet, and the only
+	// thing it could name is the question the user just asked.
+	for i, p := range []string{retryAckPhrasePrompt, dispatchAckPhrasePrompt, refineAckPhrasePrompt} {
+		if strings.Count(p, phraseAckRuleNameIt) != 1 {
+			t.Fatalf("task ack %d must carry the naming rule exactly once", i)
+		}
+	}
+	if strings.Contains(fallthroughAckPhrasePrompt, phraseAckRuleNameIt) {
+		t.Fatal("fallthrough has no dispatched task to name")
+	}
+	for i, p := range acks {
+		if strings.Contains(p, "用「那事」「那块」指代即可") {
+			t.Fatalf("ack %d still tells the model to name nothing", i)
+		}
+	}
+
 	mustContain := func(name, prompt string, needles ...string) {
 		t.Helper()
 		for _, n := range needles {
@@ -673,13 +690,13 @@ func TestPhrasePromptSharedFragmentsLock(t *testing.T) {
 	mustContain("statusWhileRunning", statusWhileRunningPhrasePrompt,
 		"禁止说已经做完", "标题截断写法", "只输出要发出去的话。")
 	mustContain("retry", retryAckPhrasePrompt,
-		"正在重试", "已经重新跑过了", "不要复述任务标题或原要求")
+		"正在重试", "已经重新跑过了", "要能看出是哪件事")
 	mustContain("fallthrough", fallthroughAckPhrasePrompt,
 		"还要再查", "正在查/正在弄", "已经查完", "不要复述对方原话")
 	mustContain("dispatch", dispatchAckPhrasePrompt,
-		"刚把一件事派人", "正在做", "不要复述完整任务标题或原要求")
+		"刚把一件事派人", "正在做", "要能看出是哪件事")
 	mustContain("refine", refineAckPhrasePrompt,
-		"按新重点继续", "不要复述完整任务标题；不要用书名号")
+		"按新重点继续", "不要照抄完整标题")
 }
 
 func TestOutcomeBriefForbidsHollowArchitectureConclusion(t *testing.T) {


### PR DESCRIPTION
## 起因

「修复下」换来的回执是:

> 好，那事我去弄，完了告诉你。

这句话放在任何一件事后面都成立,等于什么都没说。

## 为什么会这样

不是模型犯懒,是三处写死的规则合起来把「点名」这条路堵死了:

1. `runAcceptanceText` 收到标题后 `_ = shortTitle` 直接丢弃;
2. 四条 ack 提示词和 `operationalLineRules` 明文要求「不要复述任务标题或原要求;用「那事」「那块」指代即可」——连词都替模型选好了;
3. `retryAckEchoesBrief` 只要回复里出现标题 6 个字就判废,于是即便模型想点名也发不出去,代词成了唯一合法答案。

三处的理由写在同一条注释里,而且已经过期:「long short_title values are truncated requirements, not names」——标题当年确实是 `快模型和 wo` 那种半截残渣,宁可不提。本系列已经把标题按词边界切干净了,剩下的唯一顾虑只是长度,那就只按长度判断。

## 改动

- **提示词**:改为要求从事情本身取两三个字的自然说法点出是哪件(「CI 那个」「登录页那块」),仍然禁止照抄完整标题和书名号括回。三条任务类 ack(retry / dispatch / refine)统一用同一条规则;`fallthrough` 不加——它还没派单,能点的只有对方刚说的话。
- **判废**:从「出现标题 6 个字」改为「照抄了连续 14 字的片段」。短标题当名字用不再误伤,把需求整段念回去照旧拦下。
- **兜底**:标题短到能当名字(≤14 字且没被截断)时点名,否则维持代词——把需求原样念回给刚提需求的人,比代词更糟。

## 效果

    好，登录页性能，我去弄，完了告诉你。
    好，PR 179 的 CI，我去弄，完了告诉你。

## 测试

- `TestRunAcceptanceSaysWhichTaskItTook`:短标题点名,长需求和截断标题维持代词。
- `TestNamingATaskIsNotPastingIt`:点名与照抄的边界,两侧都断言。
- `TestPhrasePromptSharedFragmentsLock`:锁住四条 ack 里不再出现「用「那事」「那块」指代即可」。

Made with [Cursor](https://cursor.com)