### PR TITLE
fix(channels): preserve trace lineage and scrub at egress

### DIFF
--- a/server/internal/channels/copy_guard.go
+++ b/server/internal/channels/copy_guard.go
@@ -96,8 +96,8 @@ var verdictScaffolding = regexp.MustCompile(`(?m)(^|[。；;\n])\s*(最终判定
 var deliveryReceiptLine = regexp.MustCompile(`(?im)^\s*(已发送|已通过\s*QQ\s*回复用户|稍等，?我看一下|Give me a moment on this one|已开始处理|任务已启动|收到，正在处理)\s*[。.!！…]*\s*$`)
 
 // ScrubForOutbound is the single policy entry for user-visible channel text.
-// sendOutboundResult applies it as the final gate; other call sites that still
-// scrub early do so for local hygiene and must stay behavior-equivalent.
+// Channel egress (capture/report/delivery/reflow) passes text through and
+// sendOutboundResult applies this as the final gate before transport.
 func ScrubForOutbound(text string) string {
 	return ScrubInternalTerms(text)
 }

--- a/server/internal/channels/delivery.go
+++ b/server/internal/channels/delivery.go
@@ -158,7 +158,10 @@ type ConversationReply struct {
 // is never forwarded, which keeps reasoning and tool chatter inside the
 // platform without needing to scrape a summary out of the transcript.
 func (m *Manager) DeliverConversationReply(ctx context.Context, reply ConversationReply) (DeliveryResult, error) {
-	text := ScrubForOutbound(reply.Text)
+	// Pass through; sendOutboundResult applies ScrubForOutbound as the final gate.
+	// Whitespace-only replies are rejected here; content that scrubs to empty
+	// surfaces as empty_after_scrub at the gate (same external non-delivery).
+	text := strings.TrimSpace(reply.Text)
 	if text == "" {
 		return DeliveryResult{}, errors.New("conversation reply text is empty")
 	}

--- a/server/internal/channels/director.go
+++ b/server/internal/channels/director.go
@@ -597,6 +597,7 @@ func (m *Manager) ensureTaskIdentity(rc *runningChannel, in InboundMessage, d *W
 		OriginScene:          string(in.Scene),
 		OriginConversationID: in.ConversationID,
 		OriginExternalUserID: in.UserID,
+		OriginTraceID:        strings.TrimSpace(in.TraceID),
 		Language:             services.DetectLanguage(in.Text, ""),
 	})
 	if err != nil || identity == nil {

--- a/server/internal/channels/live.go
+++ b/server/internal/channels/live.go
@@ -744,6 +744,11 @@ func (m *Manager) dispatchWork(ctx context.Context, rc *runningChannel, in Inbou
 		}
 	}
 
+	// Record the tool span before commit so successful dispatch samples carry
+	// the same tool:dispatch_pm semantics as the refusal path.
+	rec.toolReturned(dispatchPMTool, args, encodeToolResult(map[string]any{
+		"accepted": true, "short_title": title, "request": brief,
+	}))
 	return liveOutcome{
 		reason: brief, dispatch: dispatch, sampleID: rec.commit(routeDispatch),
 	}, ""
@@ -933,7 +938,8 @@ func (c *foregroundCapture) take() string {
 	}
 	c.taken = true
 	if c.collect != nil {
-		c.text = strings.TrimSpace(ScrubForOutbound(c.collect()))
+		// Pass through; sendOutboundResult is the sole ScrubForOutbound gate.
+		c.text = strings.TrimSpace(c.collect())
 	}
 	return c.text
 }
@@ -958,11 +964,11 @@ func (c *foregroundCapture) egress(degraded bool) string {
 // This is rephrasing, not rewriting. The facts come from the agent, which is
 // the only layer that checked them; the conversation layer is only allowed to
 // say them the way it says everything else. When it cannot — no model, a slow
-// endpoint, an empty completion — the agent's own words go out scrubbed, which
-// reads slightly off but is true. degraded reports which of the two happened.
+// endpoint, an empty completion — the agent's own words go out and are scrubbed
+// at sendOutboundResult. degraded reports which of the two happened.
 func (m *Manager) reportThroughDirector(ctx context.Context, rc *runningChannel, in InboundMessage,
 	conclusion string) (text string, degraded bool) {
-	plain := strings.TrimSpace(ScrubForOutbound(conclusion))
+	plain := strings.TrimSpace(conclusion)
 	started := time.Now()
 	if m.live == nil || !m.live.Configured() || plain == "" {
 		m.appendTraceSpan(in.TraceID, finishSpan("director_report", "skipped", "degraded", started))

--- a/server/internal/channels/reflow.go
+++ b/server/internal/channels/reflow.go
@@ -90,31 +90,15 @@ func (m *Manager) ReflowTaskOutcome(ctx context.Context, outcome TaskOutcome) er
 	return err
 }
 
-// traceIDForReflow best-effort joins a terminal outcome to the inbound turn that
-// dispatched it. TaskIdentity has no OriginTraceID; matching the newest sample
-// for the origin conversation is enough for observability and matches the
-// existing "sampling may drop" posture. An empty result is fine — delivery still
-// proceeds without a span join.
+// traceIDForReflow joins a terminal outcome to the inbound turn that dispatched
+// it via the write-once OriginTraceID on TaskIdentity. An empty result is fine —
+// delivery still proceeds without a span join (including historical rows that
+// predate OriginTraceID persistence).
 func (m *Manager) traceIDForReflow(identity *models.TaskIdentity) string {
-	if m == nil || m.samples == nil || identity == nil {
+	if identity == nil {
 		return ""
 	}
-	conv := strings.TrimSpace(identity.OriginConversationID)
-	if conv == "" {
-		return ""
-	}
-	listed, err := m.samples.List(services.SampleQuery{
-		ProjectID: identity.ProjectID, ConversationID: conv, Limit: 10,
-	})
-	if err != nil {
-		return ""
-	}
-	for _, s := range listed {
-		if tid := strings.TrimSpace(s.TraceID); tid != "" {
-			return tid
-		}
-	}
-	return ""
+	return strings.TrimSpace(identity.OriginTraceID)
 }
 
 // synthesizeOutcome asks the conversation's agent to phrase the outcome in
@@ -154,9 +138,8 @@ func (m *Manager) synthesizeOutcome(ctx context.Context, identity *models.TaskId
 		}
 	}
 	m.appendTraceSpan(traceID, finishSpan("synthesis", status, detail, started))
-	// Final scrub lives in sendOutboundResult (ScrubForOutbound); keep a thin
-	// pass here so captured/fallback text is already clean if inspected early.
-	return ScrubForOutbound(text)
+	// Pass through; sendOutboundResult is the sole ScrubForOutbound gate.
+	return text
 }
 
 // SynthesisRequest asks the conversation's agent to phrase a background event
@@ -285,8 +268,8 @@ func outcomeFallbackText(identity *models.TaskIdentity, outcome TaskOutcome, lan
 	en := services.NormalizeLanguage(language) == "en"
 	// The digest goes to completedOutcomeFallback unscrubbed on purpose: it
 	// chooses which sentences to quote by asking whether each one is clean, and
-	// a pre-scrubbed digest looks clean everywhere. What it returns is scrubbed
-	// before it leaves.
+	// a pre-scrubbed digest looks clean everywhere. Outbound scrubbing happens
+	// only in sendOutboundResult.
 	facts := strings.TrimSpace(outcome.ResultSummary)
 	switch strings.ToLower(strings.TrimSpace(outcome.Status)) {
 	case "completed":
@@ -335,7 +318,9 @@ func completedOutcomeFallback(title, facts string, en bool) string {
 		link = m[1]
 		facts = deliveryLine.ReplaceAllString(facts, "")
 	}
-	body := ScrubForOutbound(leadingConclusion(facts, outcomeFallbackFactsRunes))
+	// leadingConclusion already drops sentences with internal terms; final
+	// ScrubForOutbound runs in sendOutboundResult.
+	body := leadingConclusion(facts, outcomeFallbackFactsRunes)
 	// The task has to be named, first thing. Several jobs can be in flight at
 	// once, and two pushes that both open with 「弄完了」 are indistinguishable
 	// in a chat window — which is the state this message arrived in.

--- a/server/internal/channels/turn_trace_test.go
+++ b/server/internal/channels/turn_trace_test.go
@@ -93,7 +93,7 @@ func TestNoLiveModelStillRecordsADirectTrace(t *testing.T) {
 
 // TestDispatchReflowOutboundTraceChain covers the observable handoff:
 // live_route → tool:dispatch_pm → sandbox_turn → synthesis → outbound:task_outcome
-// joined by one TraceID (reflow best-effort matches the origin conversation).
+// joined by OriginTraceID on TaskIdentity.
 func TestDispatchReflowOutboundTraceChain(t *testing.T) {
 	g := newGPTLive(t)
 	// handleInbound uses the standalone rc; DeliverSendable resolves via m.running.
@@ -119,6 +119,7 @@ func TestDispatchReflowOutboundTraceChain(t *testing.T) {
 		ShortTitle: "错误处理", Status: "running",
 		OriginChannel: "qq", OriginScene: string(SceneC2C),
 		OriginConversationID: "user1", OriginExternalUserID: "u1",
+		OriginTraceID:       traceID,
 		Language:            "zh-CN",
 		OriginalRequirement: "查错误处理",
 	}); err != nil {
@@ -141,18 +142,105 @@ func TestDispatchReflowOutboundTraceChain(t *testing.T) {
 		t.Fatal(err)
 	}
 	names := spanNames(spans)
-	for _, want := range []string{"live_route", "sandbox_turn", "synthesis", "outbound:task_outcome"} {
+	for _, want := range []string{"live_route", "tool:dispatch_pm", "sandbox_turn", "synthesis", "outbound:task_outcome"} {
 		if !containsString(names, want) {
 			t.Fatalf("missing span %q in %v (raw=%s)", want, names, sample.Spans)
 		}
 	}
-	// Successful dispatch returns before toolReturned; the observable handoff is
-	// the live_ack (and route=dispatch on the sample), not tool:dispatch_pm.
 	if sample.Route != routeDispatch {
 		t.Fatalf("route = %q want dispatch", sample.Route)
 	}
-	if !containsString(names, "outbound:live_ack") && !containsString(names, "tool:dispatch_pm") {
-		t.Fatalf("dispatch handoff missing (want live_ack or tool:dispatch_pm): %v", names)
+}
+
+// TestConcurrentReflowUsesOriginTraceIDNotNewestSample proves two tasks in the
+// same origin conversation keep their own inbound TraceID when both reflow —
+// the old newest-sample best-effort would cross-wire them.
+func TestConcurrentReflowUsesOriginTraceIDNotNewestSample(t *testing.T) {
+	fa := &fakeAdapter{}
+	m, db := policyManager(t, fa, nil)
+	m.Apply([]models.ChannelConfig{{
+		ID: "c1", Type: "qq", ProjectID: "proj", AppID: "app", Enabled: true,
+		CronDeliver: true, CronDeliverTarget: "c2c:cron-target",
+	}})
+	t.Cleanup(m.StopAll)
+	m.mu.Lock()
+	for _, rc := range m.running {
+		rc.adapter = fa
+	}
+	m.mu.Unlock()
+	svc := services.NewLiveSampleService(db)
+	m.SetLiveSampleService(svc)
+	tasks := services.NewTaskContextService(db)
+	m.SetTaskContextService(tasks)
+
+	type job struct {
+		runID, traceID, title, summary string
+	}
+	jobs := []job{
+		{"run-concurrent-a", "tr-concurrent-a", "错误处理", "超时策略已对齐。"},
+		{"run-concurrent-b", "tr-concurrent-b", "登录性能", "首屏降到 1.1s。"},
+	}
+	for _, j := range jobs {
+		if _, err := tasks.EnsureIdentity(services.EnsureTaskIdentityInput{
+			RunID: j.runID, ProjectID: "proj",
+			UserID:     services.SyntheticQQUserID("u1"),
+			ShortTitle: j.title, Status: "running",
+			OriginChannel: "qq", OriginScene: string(SceneC2C),
+			OriginConversationID: "user-shared", OriginExternalUserID: "u1",
+			OriginTraceID: j.traceID, Language: "zh-CN",
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := svc.Record(models.LiveDecisionSample{
+			ProjectID: "proj", Channel: "qq", Scene: string(SceneC2C),
+			ConversationID: "user-shared", TraceID: j.traceID, Route: routeDispatch,
+			Spans: `[{"name":"live_route","status":"ok"},{"name":"tool:dispatch_pm","status":"ok"}]`,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Newest-first sample list would prefer B; A must still join its own OriginTraceID.
+	for _, j := range jobs {
+		if err := m.ReflowTaskOutcome(context.Background(), TaskOutcome{
+			ProjectID: "proj", RunID: j.runID, Status: "completed",
+			ResultSummary: j.summary,
+		}); err != nil {
+			t.Fatalf("reflow %s: %v", j.runID, err)
+		}
+	}
+	for _, j := range jobs {
+		sample, err := svc.GetByTrace("proj", j.traceID)
+		if err != nil || sample == nil {
+			t.Fatalf("sample %s: %+v err=%v", j.traceID, sample, err)
+		}
+		var spans []TraceSpan
+		if err := json.Unmarshal([]byte(sample.Spans), &spans); err != nil {
+			t.Fatal(err)
+		}
+		names := spanNames(spans)
+		for _, want := range []string{"synthesis", "outbound:task_outcome"} {
+			if !containsString(names, want) {
+				t.Fatalf("%s missing %q in %v (would indicate cross-wired reflow)", j.traceID, want, names)
+			}
+		}
+		var outcomeDetail string
+		for _, sp := range spans {
+			if sp.Name == "outbound:task_outcome" {
+				outcomeDetail = sp.Detail
+			}
+		}
+		if outcomeDetail == "" {
+			t.Fatalf("%s has no outbound:task_outcome detail", j.traceID)
+		}
+		for _, other := range jobs {
+			if other.traceID == j.traceID {
+				continue
+			}
+			// Fallback names the task; the other title must not appear on this chain.
+			if strings.Contains(outcomeDetail, other.title) {
+				t.Fatalf("%s outcome cross-wired to %s: %q", j.traceID, other.title, outcomeDetail)
+			}
+		}
 	}
 }
 
@@ -220,4 +308,3 @@ func containsString(list []string, want string) bool {
 	}
 	return false
 }
-

--- a/server/internal/models/task_context.go
+++ b/server/internal/models/task_context.go
@@ -18,16 +18,20 @@ type TaskIdentity struct {
 	// a restart and must not fall back to a project-wide push target.
 	// Scene is stored as a plain string because models must not depend on the
 	// channels package.
-	OriginChannel        string     `gorm:"size:32;index:idx_task_origin,priority:1" json:"originChannel,omitempty"`
-	OriginScene          string     `gorm:"size:32" json:"originScene,omitempty"`
-	OriginConversationID string     `gorm:"size:191;index:idx_task_origin,priority:2" json:"originConversationId,omitempty"`
-	OriginExternalUserID string     `gorm:"size:191" json:"originExternalUserId,omitempty"`
-	Language             string     `gorm:"size:16" json:"language,omitempty"`
-	RecentContext        string     `gorm:"type:text" json:"recentContext,omitempty"`
-	Status               string     `gorm:"size:32;index" json:"status"`
-	TerminalAt           *time.Time `gorm:"index" json:"terminalAt,omitempty"`
-	CreatedAt            time.Time  `json:"createdAt"`
-	UpdatedAt            time.Time  `json:"updatedAt"`
+	OriginChannel        string `gorm:"size:32;index:idx_task_origin,priority:1" json:"originChannel,omitempty"`
+	OriginScene          string `gorm:"size:32" json:"originScene,omitempty"`
+	OriginConversationID string `gorm:"size:191;index:idx_task_origin,priority:2" json:"originConversationId,omitempty"`
+	OriginExternalUserID string `gorm:"size:191" json:"originExternalUserId,omitempty"`
+	// OriginTraceID is the inbound turn that dispatched this task. Persisted
+	// write-once so reflow can join the terminal outcome to that turn without
+	// guessing from the newest sample in the origin conversation.
+	OriginTraceID string     `gorm:"size:64" json:"originTraceId,omitempty"`
+	Language      string     `gorm:"size:16" json:"language,omitempty"`
+	RecentContext string     `gorm:"type:text" json:"recentContext,omitempty"`
+	Status        string     `gorm:"size:32;index" json:"status"`
+	TerminalAt    *time.Time `gorm:"index" json:"terminalAt,omitempty"`
+	CreatedAt     time.Time  `json:"createdAt"`
+	UpdatedAt     time.Time  `json:"updatedAt"`
 }
 
 // MessageBinding gives an explicit quoted/replied message precedence over
@@ -85,10 +89,10 @@ type RiskConfirmationTicket struct {
 	RunID     string `gorm:"size:64;index:idx_risk_ticket,priority:3" json:"runId"`
 	// ShortTitle snapshots the task title at creation time so every prompt and
 	// every later status reply echoes the task the user was actually asked about.
-	ShortTitle string     `gorm:"size:160" json:"shortTitle"`
-	Action   string `gorm:"size:191;index:idx_risk_ticket,priority:4" json:"action"`
-	Status   string `gorm:"size:16;index" json:"status"` // pending | confirmed | cancelled | expired
-	Language string `gorm:"size:16" json:"language"`
+	ShortTitle string `gorm:"size:160" json:"shortTitle"`
+	Action     string `gorm:"size:191;index:idx_risk_ticket,priority:4" json:"action"`
+	Status     string `gorm:"size:16;index" json:"status"` // pending | confirmed | cancelled | expired
+	Language   string `gorm:"size:16" json:"language"`
 	// PromptedAt records when this ticket's question actually reached the user.
 	// Nil means it never did — delivery can be suppressed or fail — and such a
 	// ticket must never be settled by a bare "确认", because the user cannot

--- a/server/internal/pmmcp/host.go
+++ b/server/internal/pmmcp/host.go
@@ -823,6 +823,7 @@ func (h *Host) callWorkflowWrite(projectID, token, name string, args map[string]
 						OriginScene:          sess.Channel.Scene,
 						OriginConversationID: sess.Channel.ConversationID,
 						OriginExternalUserID: sess.Channel.ExternalUserID,
+						OriginTraceID:        strings.TrimSpace(sess.Channel.TraceID),
 						// The task is conducted in the language it was asked
 						// in; later updates follow the task, not whichever
 						// message happens to trigger them.

--- a/server/internal/services/task_context.go
+++ b/server/internal/services/task_context.go
@@ -65,7 +65,10 @@ type EnsureTaskIdentityInput struct {
 	// Origin conversation, recorded once when the task is created from a
 	// channel turn. Empty values never clear an already-recorded origin.
 	OriginChannel, OriginScene, OriginConversationID, OriginExternalUserID string
-	Language, RecentContext                                                string
+	// OriginTraceID is the inbound turn that dispatched this task. Write-once
+	// like OriginConversationID: empty values never clear a stored id.
+	OriginTraceID           string
+	Language, RecentContext string
 }
 
 func (s *TaskContextService) EnsureIdentity(in EnsureTaskIdentityInput) (*models.TaskIdentity, error) {
@@ -92,6 +95,7 @@ func (s *TaskContextService) EnsureIdentity(in EnsureTaskIdentityInput) (*models
 			OriginScene:          strings.TrimSpace(in.OriginScene),
 			OriginConversationID: strings.TrimSpace(in.OriginConversationID),
 			OriginExternalUserID: strings.TrimSpace(in.OriginExternalUserID),
+			OriginTraceID:        strings.TrimSpace(in.OriginTraceID),
 			Language:             NormalizeLanguage(in.Language),
 			RecentContext:        strings.TrimSpace(in.RecentContext),
 			Status:               normalizeTaskStatus(in.Status), CreatedAt: now, UpdatedAt: now,
@@ -136,6 +140,11 @@ func (s *TaskContextService) EnsureIdentity(in EnsureTaskIdentityInput) (*models
 			identity.OriginScene = strings.TrimSpace(in.OriginScene)
 			identity.OriginConversationID = conv
 			identity.OriginExternalUserID = strings.TrimSpace(in.OriginExternalUserID)
+		}
+	}
+	if identity.OriginTraceID == "" {
+		if tid := strings.TrimSpace(in.OriginTraceID); tid != "" {
+			identity.OriginTraceID = tid
 		}
 	}
 	// Callers decide whether a message really represents a language switch (see

--- a/server/internal/services/task_context_test.go
+++ b/server/internal/services/task_context_test.go
@@ -616,3 +616,34 @@ func TestIdentityForRunIsProjectScopedAndAbsenceIsNotAnError(t *testing.T) {
 		}
 	}
 }
+
+// TestOriginTraceIDIsWriteOnce pins the reflow join key: once set, empty or
+// different values must not overwrite it (same posture as OriginConversationID).
+func TestOriginTraceIDIsWriteOnce(t *testing.T) {
+	db := taskContextDB(t)
+	svc := NewTaskContextService(db)
+	first, err := svc.EnsureIdentity(EnsureTaskIdentityInput{
+		RunID: "run-trace", ProjectID: "p1", UserID: SyntheticQQUserID("u1"),
+		ShortTitle: "查主干", Status: "running",
+		OriginConversationID: "c1", OriginTraceID: "tr-first",
+	})
+	if err != nil || first.OriginTraceID != "tr-first" {
+		t.Fatalf("create = %+v err=%v", first, err)
+	}
+	second, err := svc.EnsureIdentity(EnsureTaskIdentityInput{
+		RunID: "run-trace", ProjectID: "p1", UserID: SyntheticQQUserID("u1"),
+		ShortTitle: "查主干", Status: "running",
+		OriginTraceID: "tr-other",
+	})
+	if err != nil || second.OriginTraceID != "tr-first" {
+		t.Fatalf("overwrite attempt = %+v err=%v", second, err)
+	}
+	cleared, err := svc.EnsureIdentity(EnsureTaskIdentityInput{
+		RunID: "run-trace", ProjectID: "p1", UserID: SyntheticQQUserID("u1"),
+		ShortTitle: "查主干", Status: "running",
+		OriginTraceID: "",
+	})
+	if err != nil || cleared.OriginTraceID != "tr-first" {
+		t.Fatalf("empty must not clear = %+v err=%v", cleared, err)
+	}
+}


### PR DESCRIPTION
## Summary
- persist `OriginTraceID` as a write-once task identity field and use it for deterministic reflow trace joins
- record `tool:dispatch_pm` on successful dispatches before committing the trace sample
- remove duplicate scrubbing from capture, report, delivery, and reflow paths so `sendOutboundResult` remains the final egress gate

## Test plan
- [x] `go test ./internal/channels/ ./internal/services/ ./internal/pmmcp/ -count=1`
- [x] `go test ./... -count=1` from `server/`
- [x] Verify concurrent tasks in one conversation retain separate origin trace chains
- [x] Verify successful dispatch traces include `tool:dispatch_pm`
- [x] Verify outbound scrub behavior remains covered by existing golden tests

## Residual risks
- historical `TaskIdentity` rows without `OriginTraceID` still deliver outcomes but cannot join them to an originating trace
- replies containing only internal terms now become `empty_after_scrub` at the final gate instead of failing earlier; external non-delivery behavior is unchanged
- scrub call sites outside the four scoped upstream paths remain unchanged

Task: `task-cc02bcb4-f4d`  
Trace: `tr-f74c6005-6b2`

Made with [Cursor](https://cursor.com)