### PR TITLE
fix(channels): 接单回执的点名门槛卡掉了几乎所有标题

### DIFF
--- a/server/internal/channels/delivery.go
+++ b/server/internal/channels/delivery.go
@@ -306,20 +306,24 @@ func runAcceptanceText(shortTitle, language string) string {
 	return "好，那事我去弄，完了告诉你。"
 }
 
-// nameableTitleRunes is where a name stops being a name. Past this a title is
-// the request written out, and reading a request back at the person who just
-// made it is the thing every ack prompt here is trying to avoid.
-const nameableTitleRunes = 14
+// placeholderTitles are what the title resolver produces for a run that has no
+// name of its own. Saying one of these out loud is no better than the pronoun.
+var placeholderTitles = map[string]bool{
+	"未命名任务": true, "untitled task": true, "untitled": true,
+}
 
-// nameableTitle returns the title if it can stand in as the name of a task, or
-// empty if it cannot: too long to be anything but the requirement restated, or
-// already marked as cut short.
+// nameableTitle returns the title if it can stand in as the name of a task.
+//
+// Only an absent or placeholder title is refused. There was a length limit
+// here, on the theory that a long short_title is the requirement written out
+// rather than a name — but titles are allowed up to 40 runes and most real ones
+// are longer than the limit was, so nearly every acceptance fell through to
+// 「好，那事我去弄」 anyway, which was the whole complaint. A long name is
+// clumsy; no name at all is unusable, and the completion push that follows has
+// been naming these in full for a while now without anyone minding.
 func nameableTitle(shortTitle string) string {
 	t := strings.TrimSpace(shortTitle)
-	if t == "" || strings.Contains(t, "…") || strings.Contains(t, "...") {
-		return ""
-	}
-	if len([]rune(t)) > nameableTitleRunes {
+	if t == "" || placeholderTitles[strings.ToLower(t)] {
 		return ""
 	}
 	return t

--- a/server/internal/channels/delivery_test.go
+++ b/server/internal/channels/delivery_test.go
@@ -338,14 +338,16 @@ func TestRunAcceptanceSaysWhichTaskItTook(t *testing.T) {
 	}{
 		{name: "short title is a name", title: "PR 179 的 CI", lang: "zh-CN", wantNamed: true},
 		{name: "short title in english", title: "Login perf", lang: "en", wantNamed: true},
-		// Past a certain length a short_title is the request written out, and
-		// reading a request back to the person who just made it is worse than
-		// the pronoun.
-		{name: "a requirement is not a name", lang: "zh-CN", wantNamed: false,
+		// A long title is clumsy to say and still tells the user which task it
+		// is. Refusing to say it is how 「那事」 survived the first fix: titles
+		// run to 40 runes, so a length gate rejected almost all of them.
+		{name: "a long title is still a name", lang: "zh-CN", wantNamed: true,
 			title: "调研 Approving 最近关于快模型和 worker 架构的精简空间"},
-		// A title that was cut short is not a name either.
-		{name: "a cut title is not a name", title: "调研快模型和…", lang: "zh-CN", wantNamed: false},
+		{name: "a cut title still identifies", title: "调研快模型和…", lang: "zh-CN", wantNamed: true},
 		{name: "no title at all", title: "", lang: "zh-CN", wantNamed: false},
+		// The resolver invents this one when a run carries no name; repeating
+		// it says as little as the pronoun does.
+		{name: "placeholder is not a name", title: "未命名任务", lang: "zh-CN", wantNamed: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got := runAcceptanceText(tc.title, tc.lang)


### PR DESCRIPTION
## 起因

[#185](https://github.com/cocofhu/approving/pull/185) 之后,「起一个工作流做一下呢」拿到的还是:

> 好，那事我去弄，完了告诉你。

## 原因

#185 给兜底加了点名,但门槛写成 `nameableTitleRunes = 14`,而标题本身的上限 `runShortTitleRunes` 是 **40**。现实里的短标题大多是 15–40 字的一句话,全部落在门槛外,一律退回代词。

那条门槛的理由是「超过一定长度的 short_title 是需求原文,不是名字」——正是 #185 判定为过期、并从别处删掉的同一条前提。我在改别人的代码时把它删了,又在自己新写的兜底里原样放了回去。

## 改动

只在两种情况下用代词:没有标题,或标题是解析器兜出来的占位名(`runShortTitle` 在拿不到任何名字时返回的「未命名任务」)。其余一律点名。

长标题说起来是啰嗦,但仍然指得明是哪件事;而且完成推送(`completedOutcomeFallback`)早就在整句点名了,没有再加长度限制——两条路径现在一致。

## 效果

    好，PR 179 的 CI，我去弄，完了告诉你。
    好，调研 Approving 最近关于快模型和 worker 架构的精简空间，我去弄，完了告诉你。

## 测试

`TestRunAcceptanceSaysWhichTaskItTook` 增加长标题、截断标题、占位名三种情形,前两种要求点名,占位名维持代词。

Made with [Cursor](https://cursor.com)