### PR TITLE
fix(notify): 停下等人时会话里一声不吭

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -416,6 +416,7 @@ func main() {
 	// that conversation's own words.
 	channelMgr.SetSynthesizer(newLiveSynthesizer(liveClient))
 	eng.SetRunTerminalObserver(runTerminalAdapter{mgr: channelMgr})
+	eng.SetRunPausedObserver(runPausedAdapter{mgr: channelMgr})
 	channelMgr.SetLoader(channelSvc.ListRaw)
 	channelSvc.SetOnChange(channelMgr.Reload)
 	channelMgr.ApplyOnBoot()
@@ -424,6 +425,11 @@ func main() {
 	go channelMgr.RecoverInterruptedTurns(sweeperCtx)
 	cronSched.SetChannelDeliverer(channelMgr)
 	runNotifySvc.SetDeliverer(channelMgr)
+	channelMgr.SetPushSentObserver(runNotifySvc.SettlePushSent)
+	// A push parked behind a busy conversation used to move only when some
+	// unrelated event happened to touch the same conversation. Sweep it on a
+	// timer so "等待人工" reaches the user even if nothing else ever happens.
+	go runPushQueueSweeper(sweeperCtx, channelMgr)
 	cronSched.Start(sweeperCtx)
 
 	h := &handlers.Handlers{

--- a/server/cmd/server/push_sweeper.go
+++ b/server/cmd/server/push_sweeper.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/cocofhu/approving/internal/channels"
+)
+
+// pushQueueSweepInterval is deliberately slow. The queue's normal drain paths
+// (a cron push, a run notification, the end of a user turn) still do the work
+// promptly; this only exists so a message never waits on an event that may
+// never come. Slower would leave a user staring at nothing for minutes, faster
+// would mean re-checking busy conversations for no reason.
+const pushQueueSweepInterval = 30 * time.Second
+
+func runPushQueueSweeper(ctx context.Context, mgr *channels.Manager) {
+	if mgr == nil {
+		return
+	}
+	ticker := time.NewTicker(pushQueueSweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			mgr.SweepPushQueues()
+		}
+	}
+}

--- a/server/cmd/server/run_terminal_adapter.go
+++ b/server/cmd/server/run_terminal_adapter.go
@@ -33,3 +33,28 @@ func (a runTerminalAdapter) OnRunTerminal(ev engine.RunTerminalEvent) {
 			Msg("task outcome did not reach its origin conversation")
 	}
 }
+
+// runPausedAdapter tells the conversation that dispatched a task that the task
+// is now waiting on them. Same reasoning as above, one step earlier in the
+// run's life: a pause is news the person who asked needs, and it is not what
+// the project-level notify template is for.
+type runPausedAdapter struct {
+	mgr *channels.Manager
+}
+
+func (a runPausedAdapter) OnRunPaused(ev engine.RunPausedEvent) {
+	if a.mgr == nil {
+		return
+	}
+	err := a.mgr.ReflowTaskPaused(context.Background(), channels.TaskPause{
+		ProjectID: ev.ProjectID,
+		RunID:     ev.RunID,
+		NodeID:    ev.NodeID,
+		Iteration: ev.Iteration,
+		Ask:       ev.Ask,
+	})
+	if err != nil {
+		log.Warn().Err(err).Str("run", ev.RunID).Str("node", ev.NodeID).
+			Msg("task pause did not reach its origin conversation")
+	}
+}

--- a/server/internal/channels/live_test.go
+++ b/server/internal/channels/live_test.go
@@ -957,6 +957,99 @@ func TestTaskOutcomeReturnsToTheOriginConversation(t *testing.T) {
 	}
 }
 
+// A run that stops for a human is news the person who asked for it needs. It
+// used to produce nothing at all in the conversation, and the ledger kept
+// reporting the status the task had when it was created.
+func TestPausedTaskTellsTheOriginConversationAndUpdatesTheLedger(t *testing.T) {
+	fa := &fakeAdapter{}
+	m, tasks := liveManager(t, fa)
+
+	if _, err := tasks.EnsureIdentity(services.EnsureTaskIdentityInput{
+		RunID: "run-paused0001", ProjectID: "proj",
+		UserID:     services.SyntheticQQUserID("u1"),
+		ShortTitle: "登录页性能优化", Status: "queued",
+		OriginChannel: "qq", OriginScene: string(SceneC2C),
+		OriginConversationID: "user1", OriginExternalUserID: "u1",
+		Language:            "zh-CN",
+		OriginalRequirement: "调研并实现登录页性能优化",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	pause := TaskPause{
+		ProjectID: "proj", RunID: "run-paused0001", NodeID: "visual_bqc5", Iteration: 1,
+		Ask: "两版首屏方案都能达标，选哪一版继续做？",
+	}
+	if err := m.ReflowTaskPaused(context.Background(), pause); err != nil {
+		t.Fatalf("ReflowTaskPaused: %v", err)
+	}
+	// The engine can re-announce the same pause; the user must be asked once.
+	if err := m.ReflowTaskPaused(context.Background(), pause); err != nil {
+		t.Fatalf("ReflowTaskPaused (repeat): %v", err)
+	}
+
+	got := sentTexts(fa)
+	if len(got) != 1 {
+		t.Fatalf("pause sends = %v want exactly one nudge", got)
+	}
+	if !strings.Contains(got[0], "选哪一版") {
+		t.Fatalf("nudge dropped what the run is waiting on: %q", got[0])
+	}
+	if strings.Contains(got[0], "Approving") || ContainsInternalTerms(got[0]) {
+		t.Fatalf("nudge is not self-contained: %q", got[0])
+	}
+	fa.mu.Lock()
+	conv := fa.sent[0].ConversationID
+	fa.mu.Unlock()
+	if conv != "user1" {
+		t.Fatalf("nudge delivered to %q want the origin conversation", conv)
+	}
+
+	identity, err := tasks.IdentityForRun("run-paused0001", "proj")
+	if err != nil || identity == nil {
+		t.Fatalf("identity after pause = %+v err=%v", identity, err)
+	}
+	if identity.Status != "waiting_human" {
+		t.Fatalf("task status = %q want waiting_human", identity.Status)
+	}
+	if identity.TerminalAt != nil {
+		t.Fatal("a paused task has not ended and must stay active")
+	}
+}
+
+// A pause event that arrives after the run already ended must not reopen a
+// settled task or ask about work that is over.
+func TestStalePauseAfterTerminalIsIgnored(t *testing.T) {
+	fa := &fakeAdapter{}
+	m, tasks := liveManager(t, fa)
+	if _, err := tasks.EnsureIdentity(services.EnsureTaskIdentityInput{
+		RunID: "run-paused0002", ProjectID: "proj",
+		UserID:     services.SyntheticQQUserID("u1"),
+		ShortTitle: "结算页重构", Status: "completed",
+		OriginChannel: "qq", OriginScene: string(SceneC2C),
+		OriginConversationID: "user1", OriginExternalUserID: "u1", Language: "zh-CN",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := m.ReflowTaskPaused(context.Background(), TaskPause{
+		ProjectID: "proj", RunID: "run-paused0002", NodeID: "gate", Iteration: 1,
+	}); err != nil {
+		t.Fatalf("ReflowTaskPaused: %v", err)
+	}
+
+	if got := sentTexts(fa); len(got) != 0 {
+		t.Fatalf("stale pause produced %v", got)
+	}
+	identity, err := tasks.IdentityForRun("run-paused0002", "proj")
+	if err != nil || identity == nil {
+		t.Fatalf("identity = %+v err=%v", identity, err)
+	}
+	if !services.IsTerminalTaskStatus(identity.Status) {
+		t.Fatalf("task status = %q, a finished task must stay finished", identity.Status)
+	}
+}
+
 // After a completed delivery, briefing / get_status must surface the digest so
 // clarifying follow-ups answer from stored facts — not glossary definitions.
 func TestCompletedDigestSurfacesForFollowup(t *testing.T) {

--- a/server/internal/channels/manager.go
+++ b/server/internal/channels/manager.go
@@ -144,6 +144,7 @@ type Manager struct {
 
 	pushMu     sync.Mutex
 	pushQueues map[string]*pushQueue
+	pushSent   func(id string)
 
 	baseCtx          context.Context
 	policy           *sendable.Policy
@@ -1136,6 +1137,16 @@ func (m *Manager) DeliverCron(d services.CronDelivery) error {
 // Text is sent as-is (no FormatCronPush). Implements services.RunNotifyDeliverer.
 // Missing target returns services.ErrRunNotifyNoTarget (caller treats as no-op).
 func (m *Manager) DeliverRunNotify(projectID, text string) error {
+	return m.DeliverRunNotifyTracked(projectID, text, "")
+}
+
+// DeliverRunNotifyTracked is DeliverRunNotify with an outcome the caller can
+// act on. When the conversation is mid-turn the push is queued rather than
+// sent, and this reports services.ErrRunNotifyDeferred so the caller does not
+// record a delivery that has not happened yet. Passing a non-empty trackID also
+// subscribes the item to the push-sent observer, which is how a deferred
+// receipt eventually settles. Implements services.RunNotifyTrackingDeliverer.
+func (m *Manager) DeliverRunNotifyTracked(projectID, text, trackID string) error {
 	_, scene, conv, err := m.lookupRunNotifyTarget(projectID)
 	if err != nil {
 		if errors.Is(err, ErrNoRunNotifyTarget) || errors.Is(err, ErrNoDeliveryChannel) {
@@ -1145,10 +1156,11 @@ func (m *Manager) DeliverRunNotify(projectID, text string) error {
 	}
 	key := convKey(projectID, scene, conv)
 	item := CronPushItem{
+		ID:        trackID,
 		ProjectID: projectID,
 		Scene:     scene,
 		Conv:      conv,
-		Category:  "run_notify",
+		Category:  runNotifyCategory,
 		Kind:      CronResultChanged, // priority: treat actionable Run alerts like "changed"
 		Text:      text,
 		Envelope: sendable.AppendSendable(sendable.DeliveryEnvelope{
@@ -1163,8 +1175,19 @@ func (m *Manager) DeliverRunNotify(projectID, text string) error {
 		Enqueued: time.Now(),
 	}
 	m.enqueuePush(key, item)
-	m.flushPushQueue(key)
-	return nil
+	outcome := m.flushPushQueue(key)
+	if trackID == "" {
+		return nil
+	}
+	sent, resolved := outcome[trackID]
+	switch {
+	case resolved && sent:
+		return nil
+	case resolved:
+		return errors.New("run notify send failed at transport")
+	default:
+		return services.ErrRunNotifyDeferred
+	}
 }
 
 // HasRunNotifyTarget reports whether an Enabled channel exposes a usable QQ
@@ -1174,21 +1197,26 @@ func (m *Manager) HasRunNotifyTarget(projectID string) bool {
 	return err == nil
 }
 
-func (m *Manager) flushPushQueue(key string) {
+// flushPushQueue drains the conversation's queue and reports, per tracked item
+// id, whether that item actually reached the transport. Items without an id are
+// fire-and-forget and absent from the result. An id missing from the result was
+// neither sent nor dropped — it is still queued, waiting for a later flush.
+func (m *Manager) flushPushQueue(key string) map[string]bool {
 	items := m.takePushQueue(key)
 	if len(items) == 0 {
-		return
+		return nil
 	}
+	outcome := map[string]bool{}
 	for i, item := range items {
 		// Re-check busy: a new user message may have arrived.
 		// Re-queue current AND all remaining — never drop the tail.
 		if m.IsConversationBusy(item.ProjectID, item.Scene, item.Conv) {
 			m.requeuePushAll(key, items[i:])
-			return
+			return outcome
 		}
 		var target *runningChannel
 		var err error
-		if item.Category == "run_notify" {
+		if item.Category == runNotifyCategory {
 			target, _, _, err = m.lookupRunNotifyTarget(item.ProjectID)
 		} else {
 			target, _, _, err = m.lookupDeliveryTarget(item.ProjectID)
@@ -1196,15 +1224,54 @@ func (m *Manager) flushPushQueue(key string) {
 		if err != nil {
 			log.Warn().Err(err).Str("project", item.ProjectID).Str("category", item.Category).
 				Msg("push flush: no delivery channel")
+			if item.ID != "" {
+				outcome[item.ID] = false
+			}
 			continue
 		}
 		stripped, urls := splitImageURLs(item.Text)
 		ctx, cancel := context.WithTimeout(m.baseCtx, 60*time.Second)
-		m.sendOutbound(ctx, target, OutboundMessage{
+		res := m.sendOutboundResult(ctx, target, OutboundMessage{
 			Scene: item.Scene, ConversationID: item.Conv, Text: stripped,
 			ImageURLs: urls, Envelope: item.Envelope,
 		})
 		cancel()
+		if item.ID == "" {
+			continue
+		}
+		outcome[item.ID] = res.Sent
+		if res.Sent {
+			m.notifyPushSent(item.ID)
+		}
+	}
+	return outcome
+}
+
+func (m *Manager) notifyPushSent(id string) {
+	m.pushMu.Lock()
+	observer := m.pushSent
+	m.pushMu.Unlock()
+	if observer != nil {
+		observer(id)
+	}
+}
+
+// SetPushSentObserver registers the callback invoked once a tracked push item
+// leaves the queue for real. It is what lets a deferred notification receipt
+// settle to delivered instead of staying deferred forever.
+func (m *Manager) SetPushSentObserver(fn func(id string)) {
+	m.pushMu.Lock()
+	m.pushSent = fn
+	m.pushMu.Unlock()
+}
+
+// SweepPushQueues re-attempts every conversation that still holds queued
+// pushes. Without this the queue only moves when some other event happens to
+// touch the same conversation, so a notification enqueued while the user was
+// mid-turn could sit in memory indefinitely.
+func (m *Manager) SweepPushQueues() {
+	for _, key := range m.pendingPushKeys() {
+		m.flushPushQueue(key)
 	}
 }
 

--- a/server/internal/channels/push_queue.go
+++ b/server/internal/channels/push_queue.go
@@ -34,6 +34,11 @@ func isProtectedPush(p CronPushItem) bool {
 
 // CronPushItem is a timed push waiting for a conversation idle slot.
 type CronPushItem struct {
+	// ID identifies this item across an enqueue/flush round trip so the caller
+	// can learn whether its own push actually went out or was deferred. Only
+	// set by callers that report a delivery outcome (run_notify); empty for
+	// fire-and-forget cron pushes.
+	ID        string
 	ProjectID string
 	Scene     Scene
 	Conv      string
@@ -191,6 +196,27 @@ func indexOldestNonProtected(items []CronPushItem) int {
 		}
 	}
 	return -1
+}
+
+// pendingPushKeys lists conversation keys that still hold queued pushes, so a
+// compensation sweep can find work without walking every conversation.
+func (m *Manager) pendingPushKeys() []string {
+	m.pushMu.Lock()
+	queues := make(map[string]*pushQueue, len(m.pushQueues))
+	for k, q := range m.pushQueues {
+		queues[k] = q
+	}
+	m.pushMu.Unlock()
+	keys := make([]string, 0, len(queues))
+	for k, q := range queues {
+		q.mu.Lock()
+		pending := len(q.pending)
+		q.mu.Unlock()
+		if pending > 0 {
+			keys = append(keys, k)
+		}
+	}
+	return keys
 }
 
 func (m *Manager) takePushQueue(key string) []CronPushItem {

--- a/server/internal/channels/reflow.go
+++ b/server/internal/channels/reflow.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -90,6 +91,167 @@ func (m *Manager) ReflowTaskOutcome(ctx context.Context, outcome TaskOutcome) er
 	return err
 }
 
+// TaskPause is a Run that has stopped and cannot continue without a person, on
+// its way back to the conversation that asked for the work.
+type TaskPause struct {
+	ProjectID string
+	RunID     string
+	NodeID    string
+	Iteration int
+	// Ask is what the run stopped to hear, as the node phrased it. It is raw
+	// working-layer output, so it is filtered before any of it is quoted.
+	Ask string
+}
+
+// ReflowTaskPaused tells the origin conversation that its task has stopped and
+// is waiting on a person, and records that state on the task itself.
+//
+// Both halves matter. Without the message the user hears nothing at all between
+// dispatch and completion, so a run that stops for input is indistinguishable
+// from one that hung. Without the status write the ledger keeps reporting the
+// status the task had when it was created, which is how a run that had been
+// waiting for a human for half an hour still read as queued.
+func (m *Manager) ReflowTaskPaused(ctx context.Context, pause TaskPause) error {
+	runID := strings.TrimSpace(pause.RunID)
+	if runID == "" {
+		return errors.New("task pause requires a real run id")
+	}
+	if ctx == nil {
+		ctx = m.baseCtx
+	}
+	identity := m.identityForRun(runID, pause.ProjectID)
+	if identity == nil {
+		// Nobody dispatched this from a conversation; the project-level notify
+		// is the only audience it has.
+		return nil
+	}
+	// A pause event that arrives after the run already ended is stale. Acting
+	// on it would reopen a settled task and ask the user about work that is
+	// over.
+	if services.IsTerminalTaskStatus(identity.Status) {
+		return nil
+	}
+	m.markTaskWaitingHuman(identity)
+
+	conv := strings.TrimSpace(identity.OriginConversationID)
+	if conv == "" {
+		log.Debug().Str("run", runID).Msg("reflow: paused task has no origin conversation, skipping")
+		return nil
+	}
+	scene := Scene(strings.TrimSpace(identity.OriginScene))
+	if scene == "" {
+		scene = SceneC2C
+	}
+
+	traceID := m.traceIDForReflow(identity)
+	language := taskLanguage(identity)
+	text := m.synthesizeForTask(ctx, identity, scene, conv, traceID,
+		pauseBrief(identity, pause, language),
+		pauseFallbackText(identity, pause, language))
+	if strings.TrimSpace(text) == "" {
+		return nil
+	}
+	_, err := m.DeliverSendable(ctx, SendableRequest{
+		ProjectID: identity.ProjectID, Scene: scene, ConversationID: conv,
+		UserID: identity.OriginExternalUserID, RunID: runID,
+		TraceID: traceID,
+		Kind:    sendable.KindActionRequired, Reason: "task_paused",
+		Priority: sendable.PriorityCritical,
+		// One nudge per pause. A run can stop at several nodes, and the same
+		// node can pause again on a later iteration, so both are in the key —
+		// otherwise the second stop would be silently deduped away.
+		DedupeKey: strings.Join([]string{
+			"task-paused", runID, pause.NodeID, strconv.Itoa(pause.Iteration), conv,
+		}, ":"),
+		Text: text,
+	})
+	return err
+}
+
+// markTaskWaitingHuman records the pause on the task ledger so status questions
+// stop answering with whatever the run's status happened to be at creation.
+func (m *Manager) markTaskWaitingHuman(identity *models.TaskIdentity) {
+	if m.taskContext == nil || identity == nil {
+		return
+	}
+	if strings.EqualFold(strings.TrimSpace(identity.Status), taskStatusWaitingHuman) {
+		return
+	}
+	_, err := m.taskContext.UpdateIdentity(services.EnsureTaskIdentityInput{
+		RunID: identity.RunID, ProjectID: identity.ProjectID, UserID: identity.UserID,
+		Status: taskStatusWaitingHuman,
+	})
+	if err != nil {
+		log.Warn().Err(err).Str("run", identity.RunID).
+			Msg("reflow: writing waiting_human task status failed")
+	}
+}
+
+// taskStatusWaitingHuman matches the Run status vocabulary so the ledger and
+// the run list read the same way.
+const taskStatusWaitingHuman = "waiting_human"
+
+// pauseAskRunes bounds how much of the node's own words may be quoted. The
+// pause detail is written by the working agent for the platform, so the same
+// per-sentence filter as a findings digest applies: quote the part that is a
+// question to the user, drop the part that is a work log.
+const pauseAskRunes = 160
+
+// pauseBrief states what the conversation's agent may say. The task has not
+// ended, so the one thing the message must do is make clear that it is the
+// user's turn now.
+func pauseBrief(identity *models.TaskIdentity, pause TaskPause, language string) string {
+	var b strings.Builder
+	b.WriteString("后台任务停下来了，需要用户拍板才能继续，请用一到两句话说清楚。\n")
+	if title := services.SanitizeShortTitle(identity.ShortTitle); title != "" {
+		b.WriteString("任务：" + title + "\n")
+	}
+	if req := strings.TrimSpace(identity.OriginalRequirement); req != "" {
+		b.WriteString("用户当初的要求：" + truncateRunes(req, 200) + "\n")
+	}
+	if ask := leadingConclusion(pause.Ask, pauseAskRunes); ask != "" {
+		b.WriteString("停下来是想问：" + ask + "\n")
+	} else {
+		b.WriteString("这一轮没有留下可读的提问内容。如实说需要对方确认才能继续，问对方要怎么走；禁止编造具体选项。\n")
+	}
+	b.WriteString("要求：说人话，像同事当面问一句；先说卡在哪需要什么，再问对方怎么定；")
+	b.WriteString("不要出现任务编号、工作流名、节点名、执行环境、工具名；不要说「请前往 Approving 查看」；")
+	b.WriteString("不要说任务已经完成或失败——它还在等。")
+	if services.NormalizeLanguage(language) == "en" {
+		b.WriteString("\n用英文回答。")
+	}
+	return b.String()
+}
+
+// pauseFallbackText is what goes out when phrasing is unavailable. Like the
+// outcome fallback it has to stand on its own, and it must not send the user
+// somewhere else to find out what is being asked.
+func pauseFallbackText(identity *models.TaskIdentity, pause TaskPause, language string) string {
+	en := services.NormalizeLanguage(language) == "en"
+	title := services.SanitizeShortTitle(identity.ShortTitle)
+	subject := title
+	if subject == "" {
+		if en {
+			subject = "That one"
+		} else {
+			subject = "刚才那件事"
+		}
+	} else if en {
+		subject = "\"" + title + "\""
+	}
+	ask := leadingConclusion(pause.Ask, pauseAskRunes)
+	if ask != "" {
+		if en {
+			return subject + " is waiting on you: " + ask + " Tell me how you want to go and I'll carry on."
+		}
+		return subject + "停下来等你拿主意：" + ask + "你说怎么走，我就接着做。"
+	}
+	if en {
+		return subject + " has stopped and needs your call before it can go further. Tell me how you want to handle it."
+	}
+	return subject + "做到一半停下了，得你确认才能往下走。你说说想怎么处理。"
+}
+
 // traceIDForReflow joins a terminal outcome to the inbound turn that dispatched
 // it via the write-once OriginTraceID on TaskIdentity. An empty result is fine —
 // delivery still proceeds without a span join (including historical rows that
@@ -108,9 +270,18 @@ func (m *Manager) traceIDForReflow(identity *models.TaskIdentity) string {
 // the user actually receives whenever the agent is busy or unavailable.
 func (m *Manager) synthesizeOutcome(ctx context.Context, identity *models.TaskIdentity,
 	outcome TaskOutcome, scene Scene, conv, traceID string) string {
+	language := taskLanguage(identity)
+	return m.synthesizeForTask(ctx, identity, scene, conv, traceID,
+		outcomeBrief(identity, outcome, language),
+		outcomeFallbackText(identity, outcome, language))
+}
+
+// synthesizeForTask is the shared phrasing path: hand the conversation layer a
+// structured brief and the message that goes out if phrasing is unavailable.
+func (m *Manager) synthesizeForTask(ctx context.Context, identity *models.TaskIdentity,
+	scene Scene, conv, traceID, brief, fallback string) string {
 	started := time.Now()
 	language := taskLanguage(identity)
-	fallback := outcomeFallbackText(identity, outcome, language)
 	status, detail := "ok", "synthesized"
 	text := ""
 	if m.synthesize == nil {
@@ -126,7 +297,7 @@ func (m *Manager) synthesizeOutcome(ctx context.Context, identity *models.TaskId
 			ExternalUserID: identity.OriginExternalUserID,
 			RunID:          identity.RunID, ShortTitle: identity.ShortTitle,
 			Language: language, Fallback: fallback,
-			Brief: outcomeBrief(identity, outcome, language),
+			Brief: brief,
 		}
 		var err error
 		text, err = m.synthesize(ctx, req)

--- a/server/internal/channels/run_notify_deferred_test.go
+++ b/server/internal/channels/run_notify_deferred_test.go
@@ -1,0 +1,85 @@
+package channels
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/services"
+)
+
+func runNotifyManager(t *testing.T) (*Manager, *fakeAdapter) {
+	t.Helper()
+	fa := &fakeAdapter{}
+	m := NewManager(nil, nil, nil)
+	m.mu.Lock()
+	m.running["c1"] = &runningChannel{
+		cfg: models.ChannelConfig{
+			ID: "c1", Type: "qq", ProjectID: "proj", Enabled: true,
+			CronDeliverTarget: "c2c:user1",
+		},
+		adapter: fa,
+	}
+	m.mu.Unlock()
+	return m, fa
+}
+
+func setConvBusy(m *Manager, key string, busy bool) {
+	q := m.convQueueFor(key)
+	q.mu.Lock()
+	q.busy = busy
+	q.mu.Unlock()
+}
+
+// The bug this covers: the push was queued behind a live user turn, but the
+// caller was told it had been delivered, so the receipt was consumed and the
+// notification was never sent again.
+func TestDeliverRunNotifyTrackedReportsDeferredWhileBusy(t *testing.T) {
+	m, fa := runNotifyManager(t)
+	key := convKey("proj", SceneC2C, "user1")
+	setConvBusy(m, key, true)
+
+	err := m.DeliverRunNotifyTracked("proj", "【Approving】等待人工处理", "track-1")
+	if !errors.Is(err, services.ErrRunNotifyDeferred) {
+		t.Fatalf("err = %v, want ErrRunNotifyDeferred", err)
+	}
+	if got := sentTexts(fa); len(got) != 0 {
+		t.Fatalf("nothing should have been sent while busy, got %v", got)
+	}
+}
+
+func TestSweepPushQueuesDeliversDeferredNotify(t *testing.T) {
+	m, fa := runNotifyManager(t)
+	key := convKey("proj", SceneC2C, "user1")
+	setConvBusy(m, key, true)
+
+	var settled []string
+	m.SetPushSentObserver(func(id string) { settled = append(settled, id) })
+
+	if err := m.DeliverRunNotifyTracked("proj", "【Approving】等待人工处理", "track-2"); err == nil {
+		t.Fatal("expected the busy conversation to defer the push")
+	}
+
+	// The turn ends; nothing else touches this conversation. Only the sweeper
+	// is left to notice.
+	setConvBusy(m, key, false)
+	m.SweepPushQueues()
+
+	if got := sentTexts(fa); countText(got, "【Approving】等待人工处理") != 1 {
+		t.Fatalf("sweeper should have delivered the queued notification, got %v", got)
+	}
+	if len(settled) != 1 || settled[0] != "track-2" {
+		t.Fatalf("push-sent observer = %v, want one call for track-2", settled)
+	}
+}
+
+func TestDeliverRunNotifyTrackedReportsSent(t *testing.T) {
+	m, fa := runNotifyManager(t)
+
+	if err := m.DeliverRunNotifyTracked("proj", "【Approving】运行失败", "track-3"); err != nil {
+		t.Fatalf("idle conversation should deliver immediately: %v", err)
+	}
+	if got := sentTexts(fa); countText(got, "【Approving】运行失败") != 1 {
+		t.Fatalf("expected one send, got %v", got)
+	}
+}

--- a/server/internal/engine/engine.go
+++ b/server/internal/engine/engine.go
@@ -114,6 +114,11 @@ type Engine struct {
 	// conversation that started it. Engine never blocks on it.
 	runTerminal RunTerminalObserver
 
+	// runPaused is an optional async observer for confirmed waiting_human
+	// transitions, used to tell the originating conversation that the work has
+	// stopped and needs a person. Engine never blocks on it.
+	runPaused RunPausedObserver
+
 	// reviewMu guards reviewSess: per parked producer session FIFO + single
 	// worker for node-inline review and gate hot-revise (SandboxChat-aligned).
 	reviewMu   sync.Mutex
@@ -1039,7 +1044,17 @@ func (e *Engine) execute(runID, fromNodeID string) {
 					// Must not block the FSM driver; failures are the invoker's concern.
 					e.fireGateAutoInvoke(c, node)
 					e.fireRunNotify(c, node, models.NotifyKindWaitingHuman)
+					// The project-level notify above is a templated alert with
+					// a link; this tells whoever asked for the work, where they
+					// asked for it, that it is now waiting on them.
+					e.fireRunPaused(c, node, outcome.outputMd)
+				} else {
+					log.Info().Str("run_id", runID).Str("node_id", node.ID).
+						Msg("pause not recorded: run is no longer running; no waiting_human notification")
 				}
+			} else {
+				log.Info().Str("run_id", runID).Str("node_id", node.ID).
+					Msg("pause already resolved concurrently; no waiting_human notification")
 			}
 			return
 		case "failed":

--- a/server/internal/engine/run_paused.go
+++ b/server/internal/engine/run_paused.go
@@ -1,0 +1,79 @@
+package engine
+
+import (
+	"strings"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/services"
+
+	"github.com/rs/zerolog/log"
+)
+
+// RunPausedEvent describes a Run that has stopped and will not move again until
+// a person acts on it.
+//
+// It is a third channel on purpose. RunTerminalEvent settles a task and closes
+// the conversation on it, which would be a lie about work that is still open.
+// RunNotifyEvent is the project-level templated alert with a deep link,
+// addressed to whoever watches the project. Neither one answers the person who
+// asked for this particular piece of work, in the conversation where they asked
+// for it — and that silence is what makes a paused run look like a stuck one.
+type RunPausedEvent struct {
+	ProjectID string
+	RunID     string
+	NodeID    string
+	NodeLabel string
+	Iteration int
+	// Ask is what the run stopped to hear, carried over from the node output
+	// that accompanied the pause. Empty when the node paused without saying.
+	Ask string
+}
+
+// RunPausedObserver receives waiting-for-a-human transitions. Implementations
+// must not block meaningfully; Engine invokes them in a goroutine.
+type RunPausedObserver interface {
+	OnRunPaused(ev RunPausedEvent)
+}
+
+// SetRunPausedObserver wires the paused-state hook (nil disables).
+func (e *Engine) SetRunPausedObserver(o RunPausedObserver) {
+	e.runPaused = o
+}
+
+// fireRunPaused reports a confirmed pause. It is called from the same branch as
+// fireRunNotify — after finish(waiting_human) succeeded and the gate is still
+// pending — so the two never disagree about whether the run really stopped.
+func (e *Engine) fireRunPaused(c *execCtx, node *models.Node, ask string) {
+	observer := e.runPaused
+	if observer == nil || c == nil || c.run == nil || node == nil {
+		return
+	}
+	iter := 0
+	if c.iter != nil {
+		iter = c.iter[node.ID]
+	}
+	if iter < 1 {
+		return
+	}
+	projectID := services.ResolveProjectIDForRun(e.db, c.run.ID)
+	if projectID == "" {
+		return
+	}
+	ev := RunPausedEvent{
+		ProjectID: projectID,
+		RunID:     c.run.ID,
+		NodeID:    node.ID,
+		NodeLabel: node.Label,
+		Iteration: iter,
+		Ask:       strings.TrimSpace(ask),
+	}
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error().Str("run_id", ev.RunID).Str("node_id", ev.NodeID).
+					Interface("panic", r).Msg("run-paused: observer panic")
+			}
+		}()
+		observer.OnRunPaused(ev)
+	}()
+}

--- a/server/internal/engine/run_paused_test.go
+++ b/server/internal/engine/run_paused_test.go
@@ -1,0 +1,125 @@
+package engine
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+)
+
+type recordingRunPaused struct {
+	mu  sync.Mutex
+	evs []RunPausedEvent
+}
+
+func (r *recordingRunPaused) OnRunPaused(ev RunPausedEvent) {
+	r.mu.Lock()
+	r.evs = append(r.evs, ev)
+	r.mu.Unlock()
+}
+
+func (r *recordingRunPaused) wait(t *testing.T, n int) []RunPausedEvent {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		r.mu.Lock()
+		if len(r.evs) >= n {
+			out := append([]RunPausedEvent(nil), r.evs...)
+			r.mu.Unlock()
+			return out
+		}
+		r.mu.Unlock()
+		time.Sleep(15 * time.Millisecond)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	t.Fatalf("want >=%d run-paused events, got %d", n, len(r.evs))
+	return nil
+}
+
+func (r *recordingRunPaused) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.evs)
+}
+
+// A run that stops at a gate has to announce it on both channels: the
+// project-level notify and the conversation that dispatched the work. Only the
+// first one existed, so a task waiting on a human looked like a task that had
+// gone quiet.
+func TestRunPausedFiresAlongsideRunNotify(t *testing.T) {
+	g := models.Graph{
+		Nodes: []models.Node{
+			{ID: "input", Type: "input", Label: "输入"},
+			{ID: "gate", Type: "human_gate", Label: "评审", Config: map[string]any{
+				"title": "设计评审",
+				"actions": []any{
+					map[string]any{"id": "approve", "label": "批准"},
+				},
+			}},
+			{ID: "output", Type: "output"},
+		},
+		Edges: []models.Edge{
+			{ID: "e1", Source: "input", Target: "gate"},
+			{ID: "e2", Source: "gate", Target: "output", When: "action == 'approve'"},
+		},
+	}
+	eng, db, _ := setupEngineGraphP(t, g)
+	proj := models.Project{ID: "proj-run-paused", Name: "Paused", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	if err := db.Create(&proj).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Model(&models.WorkflowDef{}).Where("id = ?", "wf").
+		Update("project_id", proj.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	notify := &recordingRunNotify{}
+	paused := &recordingRunPaused{}
+	eng.SetRunNotifier(notify)
+	eng.SetRunPausedObserver(paused)
+
+	run, err := eng.StartRun("wf", nil, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitRunStatus(t, db, run.ID, "waiting_human")
+
+	evs := paused.wait(t, 1)
+	if evs[0].RunID != run.ID || evs[0].NodeID != "gate" || evs[0].Iteration < 1 {
+		t.Fatalf("unexpected event: %+v", evs[0])
+	}
+	if evs[0].ProjectID != proj.ID {
+		t.Fatalf("project = %q want %q", evs[0].ProjectID, proj.ID)
+	}
+	notify.wait(t, 1)
+
+	time.Sleep(50 * time.Millisecond)
+	if paused.count() != 1 {
+		t.Fatalf("paused count=%d want 1", paused.count())
+	}
+}
+
+// The observer is optional; a run must pause identically without one.
+func TestRunPausedWithoutObserver(t *testing.T) {
+	eng, db, _ := setupEngineGraphP(t, models.Graph{
+		Nodes: []models.Node{
+			{ID: "input", Type: "input"},
+			{ID: "gate", Type: "human_gate", Label: "G", Config: map[string]any{
+				"title":   "确认",
+				"actions": []any{map[string]any{"id": "approve", "label": "批准"}},
+			}},
+			{ID: "output", Type: "output"},
+		},
+		Edges: []models.Edge{
+			{ID: "e1", Source: "input", Target: "gate"},
+			{ID: "e2", Source: "gate", Target: "output", When: "action == 'approve'"},
+		},
+	})
+	run, err := eng.StartRun("wf", nil, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitRunStatus(t, db, run.ID, "waiting_human")
+}

--- a/server/internal/handlers/dto.go
+++ b/server/internal/handlers/dto.go
@@ -109,7 +109,7 @@ func artifactMetaDTO(a models.Artifact) gin.H {
 	return out
 }
 
-func runSummaryDTO(r models.Run, currentNodeLabel string) gin.H {
+func runSummaryDTO(r models.Run, currentNodeLabel string, origin services.RunOrigin) gin.H {
 	out := gin.H{
 		"id": r.ID, "workflowId": r.WorkflowID, "workflowName": r.WorkflowName,
 		"workflowVersion": r.WorkflowVersion,
@@ -122,6 +122,15 @@ func runSummaryDTO(r models.Run, currentNodeLabel string) gin.H {
 	}
 	if currentNodeLabel != "" {
 		out["currentNodeLabel"] = currentNodeLabel
+	}
+	// Absent for web-triggered runs, following the currentNodeLabel convention:
+	// the list only says where a run came from when that is actually somewhere.
+	if origin.ConversationID != "" {
+		out["origin"] = gin.H{
+			"channel": origin.Channel, "scene": origin.Scene,
+			"conversationId": origin.ConversationID,
+			"externalUserId": origin.ExternalUserID,
+		}
 	}
 	return out
 }

--- a/server/internal/handlers/handlers.go
+++ b/server/internal/handlers/handlers.go
@@ -618,18 +618,20 @@ func (h *Handlers) ListRuns(c *gin.Context) {
 	if !pg.Active {
 		runs := h.Runs.ListByTags(statuses, wf, projectID, tags, sort, order)
 		labels := h.Runs.CurrentNodeLabels(runs)
+		origins := h.Runs.RunOrigins(runs)
 		out := make([]gin.H, 0, len(runs))
 		for _, r := range runs {
-			out = append(out, runSummaryDTO(r, labels[r.ID]))
+			out = append(out, runSummaryDTO(r, labels[r.ID], origins[r.ID]))
 		}
 		c.JSON(http.StatusOK, out)
 		return
 	}
 	runs, total := h.Runs.ListPageByTags(statuses, wf, projectID, tags, pg.Page, pg.PageSize, sort, order)
 	labels := h.Runs.CurrentNodeLabels(runs)
+	origins := h.Runs.RunOrigins(runs)
 	items := make([]gin.H, 0, len(runs))
 	for _, r := range runs {
-		items = append(items, runSummaryDTO(r, labels[r.ID]))
+		items = append(items, runSummaryDTO(r, labels[r.ID], origins[r.ID]))
 	}
 	c.JSON(http.StatusOK, paginatedResponse(items, int(total), pg.Page, pg.PageSize))
 }

--- a/server/internal/handlers/handlers_test.go
+++ b/server/internal/handlers/handlers_test.go
@@ -1224,6 +1224,50 @@ func TestListRunsCurrentNodeLabel(t *testing.T) {
 	assertLabel("run-queued", "")
 }
 
+// The run list has to say which rows came in from a chat. Without it there is
+// no way to tell a run somebody dispatched from QQ — and is waiting on an
+// answer in QQ — from one started in the web UI.
+func TestListRunsOrigin(t *testing.T) {
+	h := newHarness(t)
+	h.h.Eng.Halt()
+	h.db.Create(&models.Run{ID: "run-from-qq", Status: "waiting_human", WorkflowID: "wf-1"})
+	h.db.Create(&models.Run{ID: "run-from-web", Status: "waiting_human", WorkflowID: "wf-1"})
+	h.db.Create(&models.TaskIdentity{
+		ID: "task-qq", RunID: "run-from-qq", ProjectID: "proj-1", Status: "waiting_human",
+		OriginChannel: "qq", OriginScene: "c2c",
+		OriginConversationID: "conv-1", OriginExternalUserID: "u1",
+	})
+	// A task row with no origin conversation is not an origin: the run list
+	// must stay silent rather than render an empty chip.
+	h.db.Create(&models.TaskIdentity{
+		ID: "task-web", RunID: "run-from-web", ProjectID: "proj-1", Status: "waiting_human",
+	})
+
+	w := h.do("GET", "/api/runs", nil)
+	if w.Code != 200 {
+		t.Fatalf("list runs: %d %s", w.Code, w.Body)
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &rows); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	byID := map[string]map[string]any{}
+	for _, row := range rows {
+		byID[row["id"].(string)] = row
+	}
+
+	origin, ok := byID["run-from-qq"]["origin"].(map[string]any)
+	if !ok {
+		t.Fatalf("run dispatched from a conversation has no origin: %v", byID["run-from-qq"])
+	}
+	if origin["channel"] != "qq" || origin["externalUserId"] != "u1" {
+		t.Fatalf("origin = %v", origin)
+	}
+	if _, present := byID["run-from-web"]["origin"]; present {
+		t.Fatalf("web-triggered run carries an origin: %v", byID["run-from-web"])
+	}
+}
+
 func TestListRunsStatusFilter(t *testing.T) {
 	h := newHarness(t)
 	base := time.Date(2026, 7, 4, 18, 30, 0, 0, time.UTC)

--- a/server/internal/services/run_labels.go
+++ b/server/internal/services/run_labels.go
@@ -138,6 +138,48 @@ func (s *RunService) CurrentNodeIDs(runs []models.Run) map[string]string {
 	return ids
 }
 
+// RunOrigin says where a Run was dispatched from, for the runs that came in
+// through a conversation rather than the web UI.
+type RunOrigin struct {
+	Channel        string `json:"channel,omitempty"`
+	Scene          string `json:"scene,omitempty"`
+	ConversationID string `json:"conversationId,omitempty"`
+	ExternalUserID string `json:"externalUserId,omitempty"`
+}
+
+// RunOrigins resolves dispatch origins for a page of runs in one query. Runs
+// started from the web UI have no task identity and are simply absent from the
+// result, which is what lets the caller render nothing for them.
+func (s *RunService) RunOrigins(runs []models.Run) map[string]RunOrigin {
+	if len(runs) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(runs))
+	for _, r := range runs {
+		ids = append(ids, r.ID)
+	}
+	var rows []models.TaskIdentity
+	if err := s.db.
+		Select("run_id", "origin_channel", "origin_scene", "origin_conversation_id", "origin_external_user_id").
+		Where("run_id IN ? AND origin_conversation_id <> ''", ids).
+		Find(&rows).Error; err != nil {
+		return nil
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	out := make(map[string]RunOrigin, len(rows))
+	for _, row := range rows {
+		out[row.RunID] = RunOrigin{
+			Channel:        row.OriginChannel,
+			Scene:          row.OriginScene,
+			ConversationID: row.OriginConversationID,
+			ExternalUserID: row.OriginExternalUserID,
+		}
+	}
+	return out
+}
+
 // RunFailedError returns the latest error message from failed StateRuns for a
 // failed run, or "" when none.
 func (s *RunService) RunFailedError(runID string) string {

--- a/server/internal/services/run_notify.go
+++ b/server/internal/services/run_notify.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,8 +19,22 @@ type RunNotifyDeliverer interface {
 	DeliverRunNotify(projectID, text string) error
 }
 
+// RunNotifyTrackingDeliverer is the richer egress: the caller hands over a
+// token identifying the receipt, and the deliverer reports whether the message
+// actually went out. Without it a push parked behind a busy conversation is
+// indistinguishable from one that reached the user.
+type RunNotifyTrackingDeliverer interface {
+	DeliverRunNotifyTracked(projectID, text, trackID string) error
+}
+
 // ErrRunNotifyNoTarget is returned (and swallowed) when no QQ target is bound.
 var ErrRunNotifyNoTarget = errors.New("no run-notify delivery target")
+
+// ErrRunNotifyDeferred means the message is queued behind an in-flight user
+// turn. Like ErrRunNotifyNoTarget this is a state rather than a fault: retrying
+// here would only stack duplicates behind the same queue, so the receipt is
+// parked and the egress reports back when the queue drains.
+var ErrRunNotifyDeferred = errors.New("run notify deferred behind a busy conversation")
 
 // RunNotifyEvent is the Engine → service payload for a lifecycle side-effect.
 type RunNotifyEvent struct {
@@ -93,7 +108,9 @@ func (s *RunNotifyService) AttemptDeliver(ev RunNotifyEvent) {
 	}
 	events := ResolveNotifyEvents(project.NotifyPolicy, workflow.NotifyPolicy)
 	if !NotifyEventAllowed(events, kind) {
-		log.Debug().Str("run_id", ev.RunID).Str("kind", kind).
+		// Info, not debug: "the user was never told" is the exact symptom
+		// operators report, and at debug this path is invisible in production.
+		log.Info().Str("run_id", ev.RunID).Str("kind", kind).
 			Strs("resolved", events).Msg("run-notify: policy miss")
 		return
 	}
@@ -146,9 +163,10 @@ func (s *RunNotifyService) deliverWithRetry(ev RunNotifyEvent, projectID, text, 
 	if delays == nil {
 		delays = runNotifyRetryDelays
 	}
+	track := receiptTrackID(ev.RunID, ev.NodeID, ev.Iteration, kind)
 	var lastErr error
 	for attempt := 0; ; attempt++ {
-		err := s.deliver.DeliverRunNotify(projectID, text)
+		err := s.deliverOnce(projectID, text, track)
 		if err == nil {
 			s.markReceipt(ev, kind, "delivered", "")
 			return
@@ -159,6 +177,15 @@ func (s *RunNotifyService) deliverWithRetry(ev RunNotifyEvent, projectID, text, 
 			log.Info().Str("run_id", ev.RunID).Str("project", projectID).
 				Msg("run-notify: no channel target — no-op after claim")
 			s.markReceipt(ev, kind, "no_target", "")
+			return
+		}
+		// The message is queued, not lost. Recording it as deferred keeps the
+		// claim intact and lets the push sweeper settle it once the
+		// conversation frees up.
+		if errors.Is(err, ErrRunNotifyDeferred) {
+			log.Info().Str("run_id", ev.RunID).Str("project", projectID).Str("kind", kind).
+				Msg("run-notify: conversation busy — queued, awaiting flush")
+			s.markReceipt(ev, kind, "deferred", "")
 			return
 		}
 		lastErr = err
@@ -172,6 +199,51 @@ func (s *RunNotifyService) deliverWithRetry(ev RunNotifyEvent, projectID, text, 
 	log.Error().Err(lastErr).Str("run_id", ev.RunID).Str("project", projectID).
 		Msg("run-notify: send failed after retries")
 	s.markReceipt(ev, kind, "failed", lastErr.Error())
+}
+
+func (s *RunNotifyService) deliverOnce(projectID, text, trackID string) error {
+	if tracking, ok := s.deliver.(RunNotifyTrackingDeliverer); ok {
+		return tracking.DeliverRunNotifyTracked(projectID, text, trackID)
+	}
+	return s.deliver.DeliverRunNotify(projectID, text)
+}
+
+// receiptTrackID packs the receipt key into the token handed to the egress, so
+// a late delivery can be matched back to its row without keeping in-memory
+// state that a restart would lose.
+func receiptTrackID(runID, nodeID string, iteration int, kind string) string {
+	return strings.Join([]string{runID, nodeID, strconv.Itoa(iteration), kind}, "|")
+}
+
+// SettlePushSent flips a deferred receipt to delivered once the egress reports
+// the queued message finally went out. Rows in any other state are left alone:
+// a receipt that already reads delivered, failed or no_target has a settled
+// story that a late queue drain should not rewrite.
+func (s *RunNotifyService) SettlePushSent(trackID string) {
+	if s == nil || s.db == nil {
+		return
+	}
+	parts := strings.Split(trackID, "|")
+	if len(parts) != 4 {
+		return
+	}
+	iteration, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return
+	}
+	res := s.db.Model(&models.NotifyDeliveryReceipt{}).
+		Where("run_id = ? AND node_id = ? AND iteration = ? AND kind = ? AND delivery_status = ?",
+			parts[0], parts[1], iteration, parts[3], "deferred").
+		Updates(map[string]any{"delivery_status": "delivered", "delivery_error": ""})
+	if res.Error != nil {
+		log.Warn().Err(res.Error).Str("run_id", parts[0]).
+			Msg("run-notify: settling deferred receipt failed")
+		return
+	}
+	if res.RowsAffected > 0 {
+		log.Info().Str("run_id", parts[0]).Str("kind", parts[3]).
+			Msg("run-notify: deferred notification delivered on flush")
+	}
 }
 
 // markReceipt records the delivery outcome on the claimed receipt so a failed

--- a/server/internal/services/run_notify_deferred_test.go
+++ b/server/internal/services/run_notify_deferred_test.go
@@ -1,0 +1,112 @@
+package services
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+)
+
+// fakeTrackingDeliverer stands in for the channel manager: it can report that a
+// push was queued rather than sent, and it remembers the token it was handed so
+// the test can settle the receipt the way a later flush would.
+type fakeTrackingDeliverer struct {
+	mu     sync.Mutex
+	tracks []string
+	err    error
+}
+
+func (f *fakeTrackingDeliverer) DeliverRunNotify(projectID, text string) error {
+	return f.DeliverRunNotifyTracked(projectID, text, "")
+}
+
+func (f *fakeTrackingDeliverer) DeliverRunNotifyTracked(projectID, text, trackID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.tracks = append(f.tracks, trackID)
+	return f.err
+}
+
+func (f *fakeTrackingDeliverer) lastTrack() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.tracks) == 0 {
+		return ""
+	}
+	return f.tracks[len(f.tracks)-1]
+}
+
+func receiptFor(t *testing.T, svc *RunNotifyService, runID string) models.NotifyDeliveryReceipt {
+	t.Helper()
+	var receipt models.NotifyDeliveryReceipt
+	if err := svc.db.Where("run_id = ?", runID).First(&receipt).Error; err != nil {
+		t.Fatal(err)
+	}
+	return receipt
+}
+
+// A push parked behind a busy conversation has not reached anyone. Recording it
+// as delivered is what made a run that stopped for a human look like a run that
+// had been told about.
+func TestAttemptDeliver_deferredIsNotDelivered(t *testing.T) {
+	db := setupRunNotifyDB(t)
+	seedNotifyProject(t, db, true, []string{"waiting_human"}, "inherit", nil)
+	d := &fakeTrackingDeliverer{err: ErrRunNotifyDeferred}
+	svc := NewRunNotifyService(db, d, "")
+	svc.SetRetryDelays([]time.Duration{0, 0, 0})
+
+	svc.AttemptDeliver(RunNotifyEvent{
+		ProjectID: "proj-n1", RunID: "run-def", WorkflowID: "wf-n1",
+		NodeID: "gate", Iteration: 1, Kind: "waiting_human",
+	})
+
+	if got := len(d.tracks); got != 1 {
+		t.Fatalf("attempts=%d want 1 — a queued push must not be retried into duplicates", got)
+	}
+	if status := receiptFor(t, svc, "run-def").DeliveryStatus; status != "deferred" {
+		t.Fatalf("delivery status = %q want deferred", status)
+	}
+}
+
+func TestSettlePushSent_deferredBecomesDelivered(t *testing.T) {
+	db := setupRunNotifyDB(t)
+	seedNotifyProject(t, db, true, []string{"waiting_human"}, "inherit", nil)
+	d := &fakeTrackingDeliverer{err: ErrRunNotifyDeferred}
+	svc := NewRunNotifyService(db, d, "")
+	svc.SetRetryDelays([]time.Duration{0})
+
+	svc.AttemptDeliver(RunNotifyEvent{
+		ProjectID: "proj-n1", RunID: "run-settle", WorkflowID: "wf-n1",
+		NodeID: "gate", Iteration: 3, Kind: "waiting_human",
+	})
+	track := d.lastTrack()
+	if track == "" {
+		t.Fatal("deliverer was not handed a tracking token")
+	}
+
+	svc.SettlePushSent(track)
+
+	if status := receiptFor(t, svc, "run-settle").DeliveryStatus; status != "delivered" {
+		t.Fatalf("delivery status = %q want delivered", status)
+	}
+}
+
+// A late flush must not rewrite a receipt that already has a settled story.
+func TestSettlePushSent_leavesSettledReceiptsAlone(t *testing.T) {
+	db := setupRunNotifyDB(t)
+	seedNotifyProject(t, db, true, []string{"waiting_human"}, "inherit", nil)
+	d := &fakeTrackingDeliverer{err: ErrRunNotifyNoTarget}
+	svc := NewRunNotifyService(db, d, "")
+
+	svc.AttemptDeliver(RunNotifyEvent{
+		ProjectID: "proj-n1", RunID: "run-notarget", WorkflowID: "wf-n1",
+		NodeID: "gate", Iteration: 1, Kind: "waiting_human",
+	})
+
+	svc.SettlePushSent(receiptTrackID("run-notarget", "gate", 1, "waiting_human"))
+
+	if status := receiptFor(t, svc, "run-notarget").DeliveryStatus; status != "no_target" {
+		t.Fatalf("delivery status = %q want no_target", status)
+	}
+}

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -1,5 +1,13 @@
 import { beforeAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { formatTrigger, fmtCompactDuration, fmtDuration, relTime, truncateText } from './format'
+import {
+  formatTrigger,
+  formatRunOrigin,
+  formatRunOriginTitle,
+  fmtCompactDuration,
+  fmtDuration,
+  relTime,
+  truncateText,
+} from './format'
 import { i18n } from './i18n'
 import { loadLocaleMessages } from './loadLocaleMessages'
 
@@ -103,6 +111,39 @@ describe('formatTrigger', () => {
     expect(formatTrigger('channel')).toBe('channel')
     expect(formatTrigger('qq:cron-timezone-bug')).toBe('qq:cron-timezone-bug')
     expect(formatTrigger('cron-nightly')).toBe('cron-nightly')
+  })
+})
+
+describe('formatRunOrigin', () => {
+  it('names the channel and the person who dispatched the run', () => {
+    i18n.global.locale.value = 'zh-CN'
+    expect(formatRunOrigin({ channel: 'qq', conversationId: 'c1', externalUserId: 'u1' })).toBe(
+      'QQ 派活 · u1',
+    )
+    i18n.global.locale.value = 'en'
+    expect(formatRunOrigin({ channel: 'qq', conversationId: 'c1', externalUserId: 'u1' })).toBe(
+      'From QQ · u1',
+    )
+  })
+
+  it('still names the channel when the dispatcher is unknown', () => {
+    i18n.global.locale.value = 'zh-CN'
+    expect(formatRunOrigin({ channel: 'qq', conversationId: 'c1' })).toBe('QQ 派活')
+  })
+
+  // Runs started in the web UI have no conversation behind them, so the list
+  // must render nothing rather than an empty chip.
+  it('is empty without an origin conversation', () => {
+    expect(formatRunOrigin(undefined)).toBe('')
+    expect(formatRunOrigin({ channel: 'qq' })).toBe('')
+    expect(formatRunOriginTitle(undefined)).toBe('')
+  })
+
+  it('keeps the conversation out of the chip and in the tooltip', () => {
+    i18n.global.locale.value = 'zh-CN'
+    const origin = { channel: 'qq', conversationId: 'conv-9', externalUserId: 'u1' }
+    expect(formatRunOrigin(origin)).not.toContain('conv-9')
+    expect(formatRunOriginTitle(origin)).toContain('conv-9')
   })
 })
 

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,4 +1,5 @@
 import { i18n } from './i18n'
+import type { RunOrigin } from './types'
 
 /** Run-state trigger codes + historical display aliases → i18n keys (not Triggers product page). */
 const TRIGGER_LABEL_KEYS: Record<string, string> = {
@@ -13,6 +14,40 @@ const TRIGGER_LABEL_KEYS: Record<string, string> = {
 export function formatTrigger(raw: string): string {
   const labelKey = TRIGGER_LABEL_KEYS[raw]
   return labelKey ? i18n.global.t(labelKey) : raw
+}
+
+/** Origin channel codes → i18n keys. Unknown channels display their own code. */
+const ORIGIN_CHANNEL_KEYS: Record<string, string> = {
+  qq: 'common.runOrigin.qq',
+}
+
+function originChannelLabel(channel?: string): string {
+  const code = (channel || '').trim().toLowerCase()
+  if (!code) return i18n.global.t('common.runOrigin.chat')
+  const key = ORIGIN_CHANNEL_KEYS[code]
+  return key ? i18n.global.t(key) : code.toUpperCase()
+}
+
+/**
+ * Renders where a run was dispatched from, for the run list. Empty for runs
+ * started in the web UI, which is what keeps the chip off rows that have no
+ * conversation behind them.
+ */
+export function formatRunOrigin(origin?: RunOrigin): string {
+  if (!origin?.conversationId) return ''
+  const channel = originChannelLabel(origin.channel)
+  const user = (origin.externalUserId || '').trim()
+  if (!user) return i18n.global.t('common.runOrigin.label', { channel })
+  return i18n.global.t('common.runOrigin.labelWithUser', { channel, user })
+}
+
+/** The full origin, for the chip's tooltip — the chip itself stays short. */
+export function formatRunOriginTitle(origin?: RunOrigin): string {
+  if (!origin?.conversationId) return ''
+  return i18n.global.t('common.runOrigin.title', {
+    channel: originChannelLabel(origin.channel),
+    conversation: origin.conversationId,
+  })
 }
 
 export function fmtTime(iso: string): string {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -639,6 +639,14 @@ export interface RunVar {
   value: any
 }
 
+/** The conversation a run was dispatched from, when it did not start in the UI. */
+export interface RunOrigin {
+  channel?: string
+  scene?: string
+  conversationId?: string
+  externalUserId?: string
+}
+
 export interface Run {
   id: string
   workflowId: string
@@ -658,6 +666,8 @@ export interface Run {
   currentNodeLabel?: string
   /** Admission priority: high | normal | low (default normal). */
   priority?: 'high' | 'normal' | 'low'
+  /** Where this run was dispatched from. Absent for runs started in the web UI. */
+  origin?: RunOrigin
   tags?: string[]
   attempt?: number
   // The graph snapshot this run executed (pinned at start). Lets the run detail

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -26,6 +26,13 @@
       "api": "API",
       "pmMcp": "Project Management MCP"
     },
+    "runOrigin": {
+      "qq": "QQ",
+      "chat": "Chat",
+      "label": "From {channel}",
+      "labelWithUser": "From {channel} · {user}",
+      "title": "Dispatched from {channel} conversation {conversation}"
+    },
     "statusFilter": {
       "selectedCount": "{n} selected"
     },

--- a/web/src/locales/zh-CN/common.json
+++ b/web/src/locales/zh-CN/common.json
@@ -26,6 +26,13 @@
       "api": "API",
       "pmMcp": "项目管理 MCP"
     },
+    "runOrigin": {
+      "qq": "QQ",
+      "chat": "对话",
+      "label": "{channel} 派活",
+      "labelWithUser": "{channel} 派活 · {user}",
+      "title": "由 {channel} 会话 {conversation} 派发"
+    },
     "statusFilter": {
       "selectedCount": "已选 {n} 项"
     },

--- a/web/src/views/RunListView.vue
+++ b/web/src/views/RunListView.vue
@@ -25,7 +25,14 @@ import {
   initStatusFilterFromStorage,
 } from '@/lib/useStatusFilter'
 import { useBreakpoint } from '@/lib/useBreakpoint'
-import { fmtTime, fmtDuration, truncateText, formatTrigger } from '@/lib/format'
+import {
+  fmtTime,
+  fmtDuration,
+  truncateText,
+  formatTrigger,
+  formatRunOrigin,
+  formatRunOriginTitle,
+} from '@/lib/format'
 import type { Run } from '@/lib/types'
 
 const PAGE_SIZE = 20
@@ -546,6 +553,12 @@ onUnmounted(() => {
             </div>
             <div class="flex flex-wrap items-center gap-1.5">
               <PriorityBadge :priority="r.priority" />
+              <span
+                v-if="formatRunOrigin(r.origin)"
+                data-testid="run-origin-chip"
+                class="chip text-txt2"
+                :title="formatRunOriginTitle(r.origin)"
+              >{{ formatRunOrigin(r.origin) }}</span>
               <span v-for="tag in r.tags || []" :key="tag" class="chip text-txt2">{{ tag }}</span>
             </div>
             <div class="flex min-w-0 flex-col gap-1">
@@ -734,7 +747,15 @@ onUnmounted(() => {
                   {{ r.workflowName }}
                   <span v-if="r.workflowVersion" class="chip ml-1.5">v{{ r.workflowVersion }}</span>
                 </td>
-                <td class="px-5 py-3 text-txt3">{{ formatTrigger(r.trigger) }}</td>
+                <td class="px-5 py-3 text-txt3">
+                  <div>{{ formatTrigger(r.trigger) }}</div>
+                  <div
+                    v-if="formatRunOrigin(r.origin)"
+                    data-testid="run-origin-chip"
+                    class="mt-1 max-w-[168px] truncate text-[11px] text-txt2"
+                    :title="formatRunOriginTitle(r.origin)"
+                  >{{ formatRunOrigin(r.origin) }}</div>
+                </td>
                 <td class="px-5 py-3 text-txt3">
                   <template v-if="r.status === 'queued'">
                     {{ fmtTime(r.createdAt ?? '') }}


### PR DESCRIPTION
## 问题

Run 停在 `waiting_human` 之后，派活的那个会话什么都收不到。从用户那边看，和进程挂死没有区别——他不知道任务是在等他，还是已经死了。

## 三个原因

缺一条都不至于全哑，三条叠在一起才是现在这个结果。

**源会话侧没有暂停事件。** engine 在 `waiting_human` 分支只调 `fireRunNotify`，那是项目级模板通道。终态有 `RunTerminalObserver` 回流到源会话，暂停没有对口的观察者。

**投递说了谎。** `DeliverRunNotify` 在会话忙时把消息压回队列，却返回 `nil`。调用方收到成功，回执记 `delivered`，于是这条通知在账面上已经送到，实际还躺在队列里。

**入队之后没有推动力。** 推送队列只在别的事件恰好碰到同一个会话时才冲刷，而「停下等人」的典型场景恰恰是之后什么都不再发生。

## 改动

- 新增 `RunPausedObserver`（`engine/run_paused.go`）与 `ReflowTaskPaused`（`channels/reflow.go`），让暂停回流到派活的会话，并把任务台账状态同步成 `waiting_human`。不同步的话，状态查询会一直回答任务创建时的状态——这正是一个已经等人半小时的 Run 仍然显示「排队中」的来路。
- 投递改为返回 `ErrRunNotifyDeferred`，回执记 `deferred`；真正发出去时由 `SetPushSentObserver` 结算成 `delivered`。`deferred` 不再触发重试，重试只会往队列里塞重复条目。
- 新增低频 `runPushQueueSweeper`（`cmd/server/push_sweeper.go`）定时冲刷积压，让送达不依赖巧合。
- engine 在 `finish()` 返回 false 时补 `log.Info`，通知策略 miss 的日志从 debug 提到 info。之前这两条路径静默，排查时看不到任何线索。

顺带（第二个 commit）：运行列表标出任务从哪个会话派来。从 IM 派出去的 Run 和页面上手动跑的 Run 原本长得一模一样，出问题要先翻台账才知道该回哪个会话去解释。

## 验证

- `go build ./...` 通过
- `go test ./internal/engine/... ./internal/channels/... ./internal/services/... ./internal/handlers/...` 全绿
- `npx vitest run src/lib/format.test.ts` 18 passed
- 新增测试覆盖：无 observer 时暂停不 panic（`run_paused_test.go`）、忙碌会话下的 deferred 回执与后续结算（`run_notify_deferred_test.go` 两处）

## 待人工确认

- 需要真实走一次「Run 停在 human gate → IM 会话收到提示 → 回复后继续」的端到端，确认措辞在实际渠道里读着自然。
- sweeper 的间隔目前是保守值，建议观察一轮线上积压情况再定。


Made with [Cursor](https://cursor.com)