### PR TITLE
feat(blob): 附件外置为 blob:{id} 引用，DB 不再存 base64

### DIFF
--- a/server/CONFIGURATION.md
+++ b/server/CONFIGURATION.md
@@ -45,3 +45,5 @@ configured on Agent meta env, not in this platform config table.
 | `APPROVING_AUTH_SESSION_TTL` | `auth.session_ttl` | duration | `168h` | Public | Session lifetime |
 | `APPROVING_AUTH_USERS` | `auth.users` | YAML/JSON | `Not set` | Sensitive | Static user array; required explicitly outside local mode |
 | `APPROVING_SECRETS_KEY` | `security.secrets_key` | string | `Not set` | Sensitive | Master AES key for encrypting channel credentials at rest (base64 32 bytes); treat as a fixed salt, do not rotate |
+| `APPROVING_STORAGE_DRIVER` | `storage.driver` | enum | `local` | Public | Attachment storage driver: local (cos reserved) |
+| `APPROVING_BLOBS_ROOT` | `storage.blobs_root` | path | `data/blobs` | Public | Local attachment blob root directory |

--- a/server/cmd/migrate-blobs/main.go
+++ b/server/cmd/migrate-blobs/main.go
@@ -1,0 +1,215 @@
+// Command migrate-blobs externalizes legacy inline base64 PromptImage.data
+// fields into the configured BlobStore and rewrites DB JSON to blob:{id} refs.
+//
+// Usage (from server/):
+//
+//	go run ./cmd/migrate-blobs [config.yaml]
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/cocofhu/approving/internal/blob"
+	"github.com/cocofhu/approving/internal/config"
+	"github.com/cocofhu/approving/internal/database"
+	"github.com/cocofhu/approving/internal/logging"
+	"github.com/cocofhu/approving/internal/models"
+
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+)
+
+func main() {
+	logging.Setup()
+	cfgPath := "config.yaml"
+	if len(os.Args) > 1 {
+		cfgPath = os.Args[1]
+	}
+	if err := config.Load(cfgPath); err != nil {
+		log.Fatal().Err(err).Str("path", cfgPath).Msg("load config failed")
+	}
+	cfg := config.GetConfig()
+	store, err := blob.NewFromConfig(cfg)
+	if err != nil {
+		log.Fatal().Err(err).Msg("blob store init failed")
+	}
+	db, err := database.Open(cfg.Database)
+	if err != nil {
+		log.Fatal().Err(err).Msg("open database failed")
+	}
+	ctx := context.Background()
+	n, err := migrateAll(ctx, db, store)
+	if err != nil {
+		log.Fatal().Err(err).Msg("migrate failed")
+	}
+	log.Info().Int("updated_rows", n).Msg("blob migration complete")
+}
+
+func migrateAll(ctx context.Context, db *gorm.DB, store blob.Store) (int, error) {
+	updated := 0
+	var msgs []models.ChatMessage
+	if err := db.Find(&msgs).Error; err != nil {
+		return 0, err
+	}
+	for i := range msgs {
+		imgs, changed, err := migrateImages(ctx, store, msgs[i].Images)
+		if err != nil {
+			return updated, fmt.Errorf("chat_messages %s: %w", msgs[i].ID, err)
+		}
+		if !changed {
+			continue
+		}
+		msgs[i].Images = imgs
+		if err := db.Model(&msgs[i]).Select("Images").Updates(&msgs[i]).Error; err != nil {
+			return updated, err
+		}
+		updated++
+	}
+
+	var issues []models.PreviewIssue
+	if err := db.Find(&issues).Error; err != nil {
+		return updated, err
+	}
+	for i := range issues {
+		imgs, changed, err := migrateImages(ctx, store, issues[i].Images)
+		if err != nil {
+			return updated, fmt.Errorf("preview_issues %s: %w", issues[i].ID, err)
+		}
+		if !changed {
+			continue
+		}
+		issues[i].Images = imgs
+		if err := db.Model(&issues[i]).Select("Images").Updates(&issues[i]).Error; err != nil {
+			return updated, err
+		}
+		updated++
+	}
+
+	var convs []models.ReactConversation
+	if err := db.Find(&convs).Error; err != nil {
+		return updated, err
+	}
+	for i := range convs {
+		changed := false
+		for j := range convs[i].Messages {
+			imgs, ch, err := migrateImages(ctx, store, convs[i].Messages[j].Images)
+			if err != nil {
+				return updated, fmt.Errorf("react_conversations %d turn %d: %w", convs[i].ID, j, err)
+			}
+			if ch {
+				convs[i].Messages[j].Images = imgs
+				changed = true
+			}
+		}
+		if !changed {
+			continue
+		}
+		if err := db.Model(&convs[i]).Select("Messages").Updates(&convs[i]).Error; err != nil {
+			return updated, err
+		}
+		updated++
+	}
+
+	var vars []models.RunVariable
+	if err := db.Find(&vars).Error; err != nil {
+		return updated, err
+	}
+	for i := range vars {
+		nv, changed, err := migrateValue(ctx, store, vars[i].Value)
+		if err != nil {
+			return updated, fmt.Errorf("run_variables %s/%s: %w", vars[i].RunID, vars[i].Name, err)
+		}
+		if !changed {
+			continue
+		}
+		vars[i].Value = nv
+		if err := db.Save(&vars[i]).Error; err != nil {
+			return updated, err
+		}
+		updated++
+	}
+
+	var runs []models.Run
+	if err := db.Select("id", "inputs").Find(&runs).Error; err != nil {
+		return updated, err
+	}
+	for i := range runs {
+		if len(runs[i].Inputs) == 0 {
+			continue
+		}
+		raw, _ := json.Marshal(runs[i].Inputs)
+		var inputs map[string]any
+		if err := json.Unmarshal(raw, &inputs); err != nil {
+			continue
+		}
+		changed := false
+		for k, v := range inputs {
+			nv, ch, err := migrateValue(ctx, store, v)
+			if err != nil {
+				return updated, fmt.Errorf("runs %s inputs.%s: %w", runs[i].ID, k, err)
+			}
+			if ch {
+				inputs[k] = nv
+				changed = true
+			}
+		}
+		if !changed {
+			continue
+		}
+		runs[i].Inputs = inputs
+		if err := db.Model(&runs[i]).Select("Inputs").Updates(&runs[i]).Error; err != nil {
+			return updated, err
+		}
+		updated++
+	}
+	return updated, nil
+}
+
+func migrateImages(ctx context.Context, store blob.Store, images []models.PromptImage) ([]models.PromptImage, bool, error) {
+	if len(images) == 0 {
+		return images, false, nil
+	}
+	need := false
+	for _, im := range images {
+		if im.Data != "" && im.Ref == "" {
+			need = true
+			break
+		}
+	}
+	if !need {
+		return images, false, nil
+	}
+	out, err := blob.IngestPromptImages(ctx, store, images)
+	return out, true, err
+}
+
+func migrateValue(ctx context.Context, store blob.Store, v any) (any, bool, error) {
+	ct := models.AsCompositeText(v)
+	if ct == nil || len(ct.Images) == 0 {
+		return v, false, nil
+	}
+	imgs, changed, err := migrateImages(ctx, store, ct.Images)
+	if err != nil || !changed {
+		return v, changed, err
+	}
+	return map[string]any{
+		"text": ct.Text,
+		"images": func() []any {
+			out := make([]any, len(imgs))
+			for i, im := range imgs {
+				m := map[string]any{"mimeType": im.MimeType, "ref": im.Ref}
+				if im.Name != "" {
+					m["name"] = im.Name
+				}
+				if im.SizeBytes > 0 {
+					m["sizeBytes"] = im.SizeBytes
+				}
+				out[i] = m
+			}
+			return out
+		}(),
+	}, true, nil
+}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cocofhu/approving/internal/auth"
+	"github.com/cocofhu/approving/internal/blob"
 	"github.com/cocofhu/approving/internal/browser"
 	"github.com/cocofhu/approving/internal/channels"
 	"github.com/cocofhu/approving/internal/channels/qq"
@@ -144,6 +145,11 @@ func main() {
 	// (startup.sh extracts before agent start). Served at /sandbox-inject/:id.
 	injectStore := sandbox.NewBundleStore()
 
+	blobStore, err := blob.NewFromConfig(cfg)
+	if err != nil {
+		log.Fatal().Err(err).Msg("blob store init failed")
+	}
+
 	projectSvc := services.NewProjectService(db)
 	auditSvc := services.NewProjectAuditService(db)
 	services.BackfillAuditElevatedFields(db)
@@ -161,6 +167,7 @@ func main() {
 		SandboxCreateTimeout: cfg.SandboxCreateTimeout(),
 		MCPEndpoint:          cfg.Server.MCPAdvertise,
 		InjectStore:          injectStore,
+		Blobs:                blobStore,
 		ProfilesRoot:         cfg.Engine.ProfilesRoot,
 		PlatformRulesRoot:    cfg.Engine.PlatformRulesRoot,
 		ProjectEnvForWorkflow: func(workflowID string) map[string]string {
@@ -168,6 +175,7 @@ func main() {
 		},
 	})
 	eng := engine.New(db, provider, host, artifactSvc, cfg.Engine.MaxConcurrentRuns)
+	eng.SetBlobStore(blobStore)
 	eng.SetProjectVarsLookup(func(workflowID string) []models.ProjectVariable {
 		return projectSvc.VariablesForWorkflow(workflowID)
 	})
@@ -233,6 +241,7 @@ func main() {
 		InjectStore:     injectStore,
 		InjectAdvertise: cfg.Server.MCPAdvertise,
 		CreateTimeout:   cfg.SandboxCreateTimeout(),
+		Blobs:           blobStore,
 	})
 	log.Info().Str("gateway", cfg.Sandbox.GatewayURL).Msg("sandbox control plane: sandbox-gateway")
 	sbxSvc := services.NewSandboxService(db, sbxMgr, skillSvc, host, services.SandboxOptions{
@@ -282,12 +291,14 @@ func main() {
 	// The engine snapshots them into the preview_issues run variable at gate
 	// resume so a downstream node consumes them via {{vars.preview_issues}}.
 	issueSvc := services.NewIssueService(db)
+	issueSvc.SetBlobStore(blobStore)
 	eng.SetIssueService(issueSvc)
 
 	coord := shutdown.New(cfg.AgentChatTimeout())
 	authSvc := auth.NewService(db, config.GetConfig)
 
 	pmSvc := services.NewPmService(db, skillSvc)
+	pmSvc.SetBlobStore(blobStore)
 	pmProgress := services.NewPmProgress(pmSvc, runSvc, artifactSvc)
 	wfSvc := services.NewWorkflowService(db)
 	wfSvc.SetSkills(skillSvc)
@@ -383,6 +394,7 @@ func main() {
 		Browser:       browserSvc,
 		Audit:         auditSvc,
 		InjectBundles: injectStore,
+		Blobs:         blobStore,
 		Onboarding:    services.NewOnboardingService(projectSvc, skillSvc, wfSvc),
 	}
 

--- a/server/internal/blob/factory.go
+++ b/server/internal/blob/factory.go
@@ -1,0 +1,31 @@
+package blob
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cocofhu/approving/internal/config"
+)
+
+// NewFromConfig builds a Store from storage config. Unsupported drivers error.
+func NewFromConfig(cfg *config.Config) (Store, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config required")
+	}
+	driver := strings.ToLower(strings.TrimSpace(cfg.Storage.Driver))
+	if driver == "" {
+		driver = "local"
+	}
+	switch driver {
+	case "local":
+		root := strings.TrimSpace(cfg.Storage.BlobsRoot)
+		if root == "" {
+			root = "data/blobs"
+		}
+		return NewLocalFS(root)
+	case "cos":
+		return nil, fmt.Errorf("storage.driver=cos is not implemented yet; use local")
+	default:
+		return nil, fmt.Errorf("unknown storage.driver %q", driver)
+	}
+}

--- a/server/internal/blob/ingest.go
+++ b/server/internal/blob/ingest.go
@@ -1,0 +1,213 @@
+package blob
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/cocofhu/approving/internal/models"
+)
+
+// IngestPromptImages externalizes any image with inline Data into store,
+// clears Data, and fills Ref / SizeBytes. Images that already have Ref are
+// left alone (Data still stripped). Nil store with inline Data is an error.
+func IngestPromptImages(ctx context.Context, store Store, images []models.PromptImage) ([]models.PromptImage, error) {
+	if len(images) == 0 {
+		return images, nil
+	}
+	out := make([]models.PromptImage, len(images))
+	for i, im := range images {
+		out[i] = im
+		if ref := strings.TrimSpace(im.Ref); ref != "" {
+			if _, err := ParseRef(ref); err != nil {
+				return nil, fmt.Errorf("image[%d]: %w", i, err)
+			}
+			out[i].Ref = ref
+			out[i].Data = ""
+			continue
+		}
+		data := strings.TrimSpace(im.Data)
+		if data == "" {
+			return nil, fmt.Errorf("image[%d]: missing data and ref", i)
+		}
+		if store == nil {
+			return nil, fmt.Errorf("image[%d]: blob store not configured", i)
+		}
+		raw, err := base64.StdEncoding.DecodeString(data)
+		if err != nil {
+			return nil, fmt.Errorf("image[%d]: decode base64: %w", i, err)
+		}
+		ref, err := store.Put(ctx, bytes.NewReader(raw), Meta{
+			MimeType: im.MimeType,
+			Name:     im.Name,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("image[%d]: store: %w", i, err)
+		}
+		out[i].Ref = ref.String()
+		out[i].Data = ""
+		out[i].SizeBytes = int64(len(raw))
+		if out[i].MimeType == "" {
+			out[i].MimeType = "application/octet-stream"
+		}
+	}
+	return out, nil
+}
+
+// IngestBytes stores raw bytes and returns a PromptImage with Ref set.
+func IngestBytes(ctx context.Context, store Store, raw []byte, mimeType, name string) (models.PromptImage, error) {
+	if store == nil {
+		return models.PromptImage{}, fmt.Errorf("blob store not configured")
+	}
+	if len(raw) == 0 {
+		return models.PromptImage{}, fmt.Errorf("empty attachment")
+	}
+	ref, err := store.Put(ctx, bytes.NewReader(raw), Meta{MimeType: mimeType, Name: name})
+	if err != nil {
+		return models.PromptImage{}, err
+	}
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+	return models.PromptImage{
+		Ref:       ref.String(),
+		MimeType:  mimeType,
+		Name:      name,
+		SizeBytes: int64(len(raw)),
+	}, nil
+}
+
+// IngestCompositeInputs walks a launch inputs map and externalizes any
+// composite {text, images[]} values in place. Returns the same map.
+func IngestCompositeInputs(ctx context.Context, store Store, inputs map[string]any) (map[string]any, error) {
+	if inputs == nil {
+		return inputs, nil
+	}
+	for k, v := range inputs {
+		nv, err := ingestValue(ctx, store, v)
+		if err != nil {
+			return nil, fmt.Errorf("input %q: %w", k, err)
+		}
+		inputs[k] = nv
+	}
+	return inputs, nil
+}
+
+func ingestValue(ctx context.Context, store Store, v any) (any, error) {
+	if ct := models.AsCompositeText(v); ct != nil && len(ct.Images) > 0 {
+		imgs, err := IngestPromptImages(ctx, store, ct.Images)
+		if err != nil {
+			return nil, err
+		}
+		ct.Images = imgs
+		return map[string]any{
+			"text":   ct.Text,
+			"images": promptImagesToAny(imgs),
+		}, nil
+	}
+	return v, nil
+}
+
+func promptImagesToAny(imgs []models.PromptImage) []any {
+	out := make([]any, len(imgs))
+	for i, im := range imgs {
+		m := map[string]any{"mimeType": im.MimeType}
+		if im.Ref != "" {
+			m["ref"] = im.Ref
+		} else if im.Data != "" {
+			// Legacy dual-read: keep inline data when not yet externalized.
+			m["data"] = im.Data
+		}
+		if im.Name != "" {
+			m["name"] = im.Name
+		}
+		if im.SizeBytes > 0 {
+			m["sizeBytes"] = im.SizeBytes
+		}
+		out[i] = m
+	}
+	return out
+}
+
+// ResolveForWire returns copies with Data filled for ACP/LLM transport.
+// Ref-backed images are loaded from store; legacy inline Data is kept.
+// When store is nil, only inline Data images are returned.
+func ResolveForWire(ctx context.Context, store Store, images []models.PromptImage) ([]models.PromptImage, error) {
+	if len(images) == 0 {
+		return images, nil
+	}
+	out := make([]models.PromptImage, 0, len(images))
+	for i, im := range images {
+		if data := strings.TrimSpace(im.Data); data != "" {
+			cp := im
+			out = append(out, cp)
+			continue
+		}
+		ref := strings.TrimSpace(im.Ref)
+		if ref == "" {
+			continue
+		}
+		if store == nil {
+			return nil, fmt.Errorf("image[%d]: blob store not configured to resolve %s", i, ref)
+		}
+		parsed, err := ParseRef(ref)
+		if err != nil {
+			return nil, fmt.Errorf("image[%d]: %w", i, err)
+		}
+		rc, meta, err := store.Open(ctx, parsed)
+		if err != nil {
+			return nil, fmt.Errorf("image[%d]: open %s: %w", i, ref, err)
+		}
+		raw, err := io.ReadAll(rc)
+		_ = rc.Close()
+		if err != nil {
+			return nil, fmt.Errorf("image[%d]: read %s: %w", i, ref, err)
+		}
+		mime := im.MimeType
+		if mime == "" {
+			mime = meta.MimeType
+		}
+		name := im.Name
+		if name == "" {
+			name = meta.Name
+		}
+		out = append(out, models.PromptImage{
+			Data:      base64.StdEncoding.EncodeToString(raw),
+			MimeType:  mime,
+			Name:      name,
+			Ref:       ref,
+			SizeBytes: int64(len(raw)),
+		})
+	}
+	return out, nil
+}
+
+// StripData clears inline Data when Ref is already set (defensive before persist).
+// Legacy rows with only Data are left untouched for dual-read.
+func StripData(images []models.PromptImage) []models.PromptImage {
+	if len(images) == 0 {
+		return images
+	}
+	out := make([]models.PromptImage, len(images))
+	for i, im := range images {
+		out[i] = im
+		if strings.TrimSpace(im.Ref) != "" {
+			out[i].Data = ""
+		}
+	}
+	return out
+}
+
+// StripDataInValue clears PromptImage.Data inside composite map/struct values.
+func StripDataInValue(v any) any {
+	if ct := models.AsCompositeText(v); ct != nil && len(ct.Images) > 0 {
+		return map[string]any{
+			"text":   ct.Text,
+			"images": promptImagesToAny(StripData(ct.Images)),
+		}
+	}
+	return v
+}

--- a/server/internal/blob/local.go
+++ b/server/internal/blob/local.go
@@ -1,0 +1,117 @@
+package blob
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// LocalFS stores blobs under Root as <aa>/<id>/blob + meta.json.
+type LocalFS struct {
+	Root string
+}
+
+// NewLocalFS creates the root directory if needed.
+func NewLocalFS(root string) (*LocalFS, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return nil, fmt.Errorf("blobs root required")
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return nil, err
+	}
+	return &LocalFS{Root: root}, nil
+}
+
+func (s *LocalFS) dirFor(id string) string {
+	prefix := id
+	if len(prefix) >= 2 {
+		prefix = id[:2]
+	}
+	return filepath.Join(s.Root, prefix, id)
+}
+
+func (s *LocalFS) Put(ctx context.Context, r io.Reader, meta Meta) (Ref, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	id := strings.ReplaceAll(uuid.NewString(), "-", "")
+	dir := s.dirFor(id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	blobPath := filepath.Join(dir, "blob")
+	f, err := os.OpenFile(blobPath, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0o644)
+	if err != nil {
+		return "", err
+	}
+	h := sha256.New()
+	n, copyErr := io.Copy(io.MultiWriter(f, h), r)
+	closeErr := f.Close()
+	if copyErr != nil {
+		_ = os.RemoveAll(dir)
+		return "", copyErr
+	}
+	if closeErr != nil {
+		_ = os.RemoveAll(dir)
+		return "", closeErr
+	}
+	meta.Size = n
+	meta.SHA256 = hex.EncodeToString(h.Sum(nil))
+	if meta.MimeType == "" {
+		meta.MimeType = "application/octet-stream"
+	}
+	raw, err := json.Marshal(meta)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return "", err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), raw, 0o644); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", err
+	}
+	return MakeRef(id), nil
+}
+
+func (s *LocalFS) Open(ctx context.Context, ref Ref) (io.ReadCloser, Meta, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, Meta{}, err
+	}
+	parsed, err := ParseRef(string(ref))
+	if err != nil {
+		return nil, Meta{}, err
+	}
+	dir := s.dirFor(parsed.ID())
+	metaRaw, err := os.ReadFile(filepath.Join(dir, "meta.json"))
+	if err != nil {
+		return nil, Meta{}, err
+	}
+	var meta Meta
+	if err := json.Unmarshal(metaRaw, &meta); err != nil {
+		return nil, Meta{}, err
+	}
+	f, err := os.Open(filepath.Join(dir, "blob"))
+	if err != nil {
+		return nil, Meta{}, err
+	}
+	return f, meta, nil
+}
+
+func (s *LocalFS) Delete(ctx context.Context, ref Ref) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	parsed, err := ParseRef(string(ref))
+	if err != nil {
+		return err
+	}
+	return os.RemoveAll(s.dirFor(parsed.ID()))
+}

--- a/server/internal/blob/local_test.go
+++ b/server/internal/blob/local_test.go
@@ -1,0 +1,111 @@
+package blob
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cocofhu/approving/internal/models"
+)
+
+func TestLocalFSPutOpenDelete(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewLocalFS(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	ref, err := store.Put(ctx, bytes.NewReader([]byte("hello")), Meta{MimeType: "text/plain", Name: "a.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(ref.String(), "blob:") {
+		t.Fatalf("ref = %q", ref)
+	}
+	rc, meta, err := store.Open(ctx, ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := io.ReadAll(rc)
+	_ = rc.Close()
+	if string(raw) != "hello" || meta.MimeType != "text/plain" || meta.Name != "a.txt" || meta.Size != 5 {
+		t.Fatalf("got %q meta=%+v", raw, meta)
+	}
+	if meta.SHA256 == "" {
+		t.Fatal("expected sha256")
+	}
+	// Sharded path exists.
+	id := ref.ID()
+	if _, err := filepath.Glob(filepath.Join(root, id[:2], id, "blob")); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Delete(ctx, ref); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.Open(ctx, ref); err == nil {
+		t.Fatal("expected miss after delete")
+	}
+}
+
+func TestParseRefRejectsTraversal(t *testing.T) {
+	for _, s := range []string{"", "file:///tmp/x", "blob:", "blob:../x", "blob:a/b", "blob:a.b"} {
+		if _, err := ParseRef(s); err == nil {
+			t.Fatalf("expected error for %q", s)
+		}
+	}
+	if _, err := ParseRef("blob:abcDEF0123"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIngestAndResolve(t *testing.T) {
+	store := NewMemory()
+	ctx := context.Background()
+	b64 := base64.StdEncoding.EncodeToString([]byte("png-bytes"))
+	out, err := IngestPromptImages(ctx, store, []models.PromptImage{{
+		Data: b64, MimeType: "image/png", Name: "x.png",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out[0].Data != "" || out[0].Ref == "" || out[0].SizeBytes != 9 {
+		t.Fatalf("ingest = %+v", out[0])
+	}
+	wire, err := ResolveForWire(ctx, store, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wire[0].Data != b64 {
+		t.Fatalf("resolve data = %q", wire[0].Data)
+	}
+}
+
+func TestIngestCompositeInputs(t *testing.T) {
+	store := NewMemory()
+	ctx := context.Background()
+	b64 := base64.StdEncoding.EncodeToString([]byte("x"))
+	inputs := map[string]any{
+		"feature": map[string]any{
+			"text": "hi",
+			"images": []any{
+				map[string]any{"data": b64, "mimeType": "image/png", "name": "a.png"},
+			},
+		},
+		"plain": "ok",
+	}
+	got, err := IngestCompositeInputs(ctx, store, inputs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ct := models.AsCompositeText(got["feature"])
+	if ct == nil || len(ct.Images) != 1 || ct.Images[0].Data != "" || ct.Images[0].Ref == "" {
+		t.Fatalf("feature = %#v", got["feature"])
+	}
+	if got["plain"] != "ok" {
+		t.Fatalf("plain = %#v", got["plain"])
+	}
+}

--- a/server/internal/blob/memory.go
+++ b/server/internal/blob/memory.go
@@ -1,0 +1,82 @@
+package blob
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// Memory is an in-process Store for tests.
+type Memory struct {
+	mu   sync.Mutex
+	data map[string]memBlob
+}
+
+type memBlob struct {
+	raw  []byte
+	meta Meta
+}
+
+// NewMemory returns an empty memory store.
+func NewMemory() *Memory {
+	return &Memory{data: map[string]memBlob{}}
+}
+
+func (m *Memory) Put(ctx context.Context, r io.Reader, meta Meta) (Ref, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return "", err
+	}
+	id := strings.ReplaceAll(uuid.NewString(), "-", "")
+	sum := sha256.Sum256(raw)
+	meta.Size = int64(len(raw))
+	meta.SHA256 = hex.EncodeToString(sum[:])
+	if meta.MimeType == "" {
+		meta.MimeType = "application/octet-stream"
+	}
+	m.mu.Lock()
+	m.data[id] = memBlob{raw: raw, meta: meta}
+	m.mu.Unlock()
+	return MakeRef(id), nil
+}
+
+func (m *Memory) Open(ctx context.Context, ref Ref) (io.ReadCloser, Meta, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, Meta{}, err
+	}
+	parsed, err := ParseRef(string(ref))
+	if err != nil {
+		return nil, Meta{}, err
+	}
+	m.mu.Lock()
+	b, ok := m.data[parsed.ID()]
+	m.mu.Unlock()
+	if !ok {
+		return nil, Meta{}, fmt.Errorf("blob not found")
+	}
+	return io.NopCloser(bytes.NewReader(b.raw)), b.meta, nil
+}
+
+func (m *Memory) Delete(ctx context.Context, ref Ref) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	parsed, err := ParseRef(string(ref))
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	delete(m.data, parsed.ID())
+	m.mu.Unlock()
+	return nil
+}

--- a/server/internal/blob/ref.go
+++ b/server/internal/blob/ref.go
@@ -1,0 +1,45 @@
+// Package blob stores attachment bytes outside the database and exposes them
+// via opaque blob:{id} references.
+package blob
+
+import (
+	"fmt"
+	"strings"
+)
+
+const scheme = "blob:"
+
+// Ref is an opaque attachment reference (blob:{id}).
+type Ref string
+
+// ParseRef validates and returns a Ref. Only the blob: scheme is accepted.
+func ParseRef(s string) (Ref, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", fmt.Errorf("empty blob ref")
+	}
+	if !strings.HasPrefix(s, scheme) {
+		return "", fmt.Errorf("unsupported blob scheme: %q", s)
+	}
+	id := strings.TrimPrefix(s, scheme)
+	if id == "" || strings.ContainsAny(id, "/\\..") || strings.Contains(id, "..") {
+		return "", fmt.Errorf("invalid blob id")
+	}
+	for _, r := range id {
+		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_') {
+			return "", fmt.Errorf("invalid blob id character")
+		}
+	}
+	return Ref(scheme + id), nil
+}
+
+// ID returns the id portion without the blob: prefix.
+func (r Ref) ID() string {
+	return strings.TrimPrefix(string(r), scheme)
+}
+
+// String returns the canonical blob:{id} form.
+func (r Ref) String() string { return string(r) }
+
+// MakeRef builds a Ref from a raw id (already validated by the store).
+func MakeRef(id string) Ref { return Ref(scheme + id) }

--- a/server/internal/blob/store.go
+++ b/server/internal/blob/store.go
@@ -1,0 +1,21 @@
+package blob
+
+import (
+	"context"
+	"io"
+)
+
+// Meta describes a stored blob's presentation metadata.
+type Meta struct {
+	MimeType string `json:"mimeType"`
+	Name     string `json:"name,omitempty"`
+	Size     int64  `json:"size"`
+	SHA256   string `json:"sha256,omitempty"`
+}
+
+// Store persists attachment bytes addressed by Ref.
+type Store interface {
+	Put(ctx context.Context, r io.Reader, meta Meta) (Ref, error)
+	Open(ctx context.Context, ref Ref) (io.ReadCloser, Meta, error)
+	Delete(ctx context.Context, ref Ref) error
+}

--- a/server/internal/channels/bridge.go
+++ b/server/internal/channels/bridge.go
@@ -130,6 +130,8 @@ func (b *ChannelBridge) Handle(ctx context.Context, rc ResolvedChannel, in Inbou
 	if err != nil {
 		return Reply{}, err
 	}
+	// AppendMessageSource externalizes bytes; use refs for the ACP turn.
+	images = userMsg.Images
 
 	prompt := userText
 	if !reused {

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -33,6 +33,15 @@ type Config struct {
 	Browser  BrowserConfig  `yaml:"browser"`
 	Auth     AuthConfig     `yaml:"auth"`
 	Security SecurityConfig `yaml:"security"`
+	Storage  StorageConfig  `yaml:"storage"`
+}
+
+// StorageConfig selects how attachment bytes are persisted (DB keeps refs only).
+type StorageConfig struct {
+	// Driver is "local" (default) or "cos" (reserved; not implemented yet).
+	Driver string `yaml:"driver"`
+	// BlobsRoot is the LocalFS directory for blob:{id} objects.
+	BlobsRoot string `yaml:"blobs_root"`
 }
 
 // SecurityConfig holds cross-cutting secrets. SecretsKey is the master key used
@@ -411,6 +420,12 @@ func applyEnvOverrides(c *Config) {
 	if v := env("APPROVING_SECRETS_KEY"); v != "" {
 		c.Security.SecretsKey = v
 	}
+	if v := env("APPROVING_STORAGE_DRIVER"); v != "" {
+		c.Storage.Driver = v
+	}
+	if v := env("APPROVING_BLOBS_ROOT"); v != "" {
+		c.Storage.BlobsRoot = v
+	}
 }
 
 // setDefaults fills any still-empty fields with the built-in defaults. Runs
@@ -445,6 +460,13 @@ func setDefaults(c *Config) {
 	}
 	if c.Engine.ProfilesRoot == "" {
 		c.Engine.ProfilesRoot = "data/profiles"
+	}
+	if c.Storage.Driver == "" {
+		c.Storage.Driver = "local"
+	}
+	c.Storage.Driver = strings.ToLower(strings.TrimSpace(c.Storage.Driver))
+	if c.Storage.BlobsRoot == "" {
+		c.Storage.BlobsRoot = "data/blobs"
 	}
 	if c.Engine.PlatformRulesRoot == "" {
 		c.Engine.PlatformRulesRoot = "data/platform-rules"

--- a/server/internal/config/config_more_test.go
+++ b/server/internal/config/config_more_test.go
@@ -77,12 +77,15 @@ func TestApplyAllEnvOverrides(t *testing.T) {
 	t.Setenv("APPROVING_SANDBOX_MAX_ATTEMPTS", "4")
 	t.Setenv("APPROVING_SANDBOX_RETRY_BACKOFF_SEC", "3")
 	t.Setenv("APPROVING_SANDBOX_WORK_DIR", "/wd")
+	t.Setenv("APPROVING_STORAGE_DRIVER", "local")
+	t.Setenv("APPROVING_BLOBS_ROOT", "/blobs")
 	applyEnvOverrides(c)
 	if c.Server.MCPAdvertise != "http://adv" || c.Database.Path != "/db" ||
 		c.Engine.ExecProvider != "cursor" || c.Engine.MaxConcurrentRuns != 7 ||
 		c.Engine.ProfilesRoot != "/pr" || c.Sandbox.CursorAuthPath != "/auth" ||
 		c.Sandbox.AgentChatTimeoutSeconds != 11 || c.Sandbox.ChatIdleTimeoutSeconds != 12 ||
-		c.Sandbox.MaxAttempts != 4 || c.Sandbox.RetryBackoffSeconds != 3 || c.Sandbox.WorkDir != "/wd" {
+		c.Sandbox.MaxAttempts != 4 || c.Sandbox.RetryBackoffSeconds != 3 || c.Sandbox.WorkDir != "/wd" ||
+		c.Storage.Driver != "local" || c.Storage.BlobsRoot != "/blobs" {
 		t.Fatalf("env overrides not fully applied: %+v", c)
 	}
 }

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -29,6 +29,12 @@ func TestSetDefaults(t *testing.T) {
 	if c.Engine.PlatformRulesRoot != "data/platform-rules" {
 		t.Errorf("default platform_rules_root = %q", c.Engine.PlatformRulesRoot)
 	}
+	if c.Storage.Driver != "local" {
+		t.Errorf("default storage.driver = %q", c.Storage.Driver)
+	}
+	if c.Storage.BlobsRoot != "data/blobs" {
+		t.Errorf("default storage.blobs_root = %q", c.Storage.BlobsRoot)
+	}
 	if c.Sandbox.AgentChatTimeoutSeconds != 600 {
 		t.Errorf("default timeout = %d, want 600", c.Sandbox.AgentChatTimeoutSeconds)
 	}

--- a/server/internal/config/descriptor.go
+++ b/server/internal/config/descriptor.go
@@ -51,5 +51,7 @@ func OptionDescriptors() []OptionDescriptor {
 		{Env: "APPROVING_AUTH_SESSION_TTL", YAML: "auth.session_ttl", Type: "duration", Default: "168h", ZH: "会话有效期", EN: "Session lifetime"},
 		{Env: "APPROVING_AUTH_USERS", YAML: "auth.users", Type: "YAML/JSON", Sensitive: true, ZH: "静态账号数组；非本地部署必须显式配置", EN: "Static user array; required explicitly outside local mode"},
 		{Env: "APPROVING_SECRETS_KEY", YAML: "security.secrets_key", Type: "string", Sensitive: true, ZH: "外部渠道凭据加密主密钥（base64 32 字节）；用于加密存储渠道 app_secret，视作固定盐、请勿轮换", EN: "Master AES key for encrypting channel credentials at rest (base64 32 bytes); treat as a fixed salt, do not rotate"},
+		{Env: "APPROVING_STORAGE_DRIVER", YAML: "storage.driver", Type: "enum", Default: "local", ZH: "附件存储驱动：local（预留 cos）", EN: "Attachment storage driver: local (cos reserved)"},
+		{Env: "APPROVING_BLOBS_ROOT", YAML: "storage.blobs_root", Type: "path", Default: "data/blobs", ZH: "本地附件 blob 根目录", EN: "Local attachment blob root directory"},
 	}
 }

--- a/server/internal/engine/blob_startrun_test.go
+++ b/server/internal/engine/blob_startrun_test.go
@@ -1,0 +1,59 @@
+package engine
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/cocofhu/approving/internal/models"
+)
+
+func TestStartRunExternalizesCompositeImages(t *testing.T) {
+	g := models.Graph{
+		Variables: []models.Variable{{Name: "feature", Type: "string", Ask: true}},
+		Nodes: []models.Node{
+			{ID: "input", Type: "input"},
+			{ID: "output", Type: "output"},
+		},
+		Edges: []models.Edge{{ID: "e1", Source: "input", Target: "output"}},
+	}
+	eng, db := setupEngineGraph(t, g)
+	raw := base64.StdEncoding.EncodeToString([]byte("hello-bytes"))
+	run, err := eng.StartRun("wf", map[string]any{
+		"feature": map[string]any{
+			"text": "hi",
+			"images": []any{
+				map[string]any{"data": raw, "mimeType": "image/png", "name": "a.png"},
+			},
+		},
+	}, "test")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	var stored models.Run
+	if err := db.First(&stored, "id = ?", run.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	inJSON, _ := json.Marshal(stored.Inputs)
+	if strings.Contains(string(inJSON), `"data"`) && strings.Contains(string(inJSON), raw) {
+		t.Fatalf("runs.inputs still contains base64 data: %s", inJSON)
+	}
+	ct := models.AsCompositeText(stored.Inputs["feature"])
+	if ct == nil || len(ct.Images) != 1 || ct.Images[0].Ref == "" || ct.Images[0].Data != "" {
+		t.Fatalf("inputs feature = %#v", stored.Inputs["feature"])
+	}
+	if !strings.HasPrefix(ct.Images[0].Ref, "blob:") {
+		t.Fatalf("ref = %q", ct.Images[0].Ref)
+	}
+
+	var rv models.RunVariable
+	if err := db.Where("run_id = ? AND name = ?", run.ID, "feature").First(&rv).Error; err != nil {
+		t.Fatal(err)
+	}
+	vct := models.AsCompositeText(rv.Value)
+	if vct == nil || len(vct.Images) != 1 || vct.Images[0].Ref == "" || vct.Images[0].Data != "" {
+		t.Fatalf("run_variables.feature = %#v", rv.Value)
+	}
+}

--- a/server/internal/engine/composite_test.go
+++ b/server/internal/engine/composite_test.go
@@ -118,11 +118,11 @@ func TestNodeReqPromptImages(t *testing.T) {
 	run, err := eng.StartRun("wf", map[string]any{
 		"feature": map[string]any{
 			"text":   "f",
-			"images": []any{map[string]any{"data": "fimg", "mimeType": "image/png"}},
+			"images": []any{map[string]any{"data": "ZmltZw==", "mimeType": "image/png"}},
 		},
 		"extra": map[string]any{
 			"text":   "e",
-			"images": []any{map[string]any{"data": "eimg", "mimeType": "image/jpeg"}},
+			"images": []any{map[string]any{"data": "ZWltZw==", "mimeType": "image/jpeg"}},
 		},
 	}, "test")
 	if err != nil {
@@ -137,8 +137,14 @@ func TestNodeReqPromptImages(t *testing.T) {
 	if len(req.PromptImages) != 2 {
 		t.Fatalf("PromptImages = %+v", req.PromptImages)
 	}
-	if req.PromptImages[0].Data != "fimg" || req.PromptImages[1].Data != "eimg" {
-		t.Fatalf("order wrong: %+v", req.PromptImages)
+	if req.PromptImages[0].Ref == "" || req.PromptImages[1].Ref == "" {
+		t.Fatalf("expected blob refs: %+v", req.PromptImages)
+	}
+	if req.PromptImages[0].Data != "" || req.PromptImages[1].Data != "" {
+		t.Fatalf("persisted images must not keep data: %+v", req.PromptImages)
+	}
+	if req.PromptImages[0].MimeType != "image/png" || req.PromptImages[1].MimeType != "image/jpeg" {
+		t.Fatalf("mime order wrong: %+v", req.PromptImages)
 	}
 	_ = db
 }
@@ -166,18 +172,19 @@ func TestPromptImagesIntegration(t *testing.T) {
 	run, err := eng.StartRun("wf", map[string]any{
 		"feature": map[string]any{
 			"text":   "topic",
-			"images": []any{map[string]any{"data": "imgdata", "mimeType": "image/png"}},
+			"images": []any{map[string]any{"data": "aW1nZGF0YQ==", "mimeType": "image/png"}},
 		},
 		"unused": map[string]any{
 			"text":   "x",
-			"images": []any{map[string]any{"data": "skip", "mimeType": "image/png"}},
+			"images": []any{map[string]any{"data": "c2tpcA==", "mimeType": "image/png"}},
 		},
 	}, "test")
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
 	waitRunStatus(t, db, run.ID, "completed")
-	if imgs := fp.lastPromptImages("research"); len(imgs) != 1 || imgs[0].Data != "imgdata" {
+	imgs := fp.lastPromptImages("research")
+	if len(imgs) != 1 || imgs[0].Ref == "" || imgs[0].Data != "" {
 		t.Fatalf("fake provider images = %+v", imgs)
 	}
 }

--- a/server/internal/engine/engine.go
+++ b/server/internal/engine/engine.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cocofhu/approving/internal/blob"
 	"github.com/cocofhu/approving/internal/mcp"
 	"github.com/cocofhu/approving/internal/models"
 	"github.com/cocofhu/approving/internal/runtime"
@@ -109,7 +110,13 @@ type Engine struct {
 
 	// skills looks up Agents for same-project skill_profile runtime gate.
 	skills *services.SkillService
+
+	// blobs externalizes PromptImage bytes (optional in unit tests).
+	blobs blob.Store
 }
+
+// SetBlobStore wires attachment externalization for StartRun / react turns.
+func (e *Engine) SetBlobStore(store blob.Store) { e.blobs = store }
 
 // New builds an engine.
 func New(db *gorm.DB, provider runtime.ExecProvider, host *mcp.Host, store mcp.Store, maxRuns int) *Engine {
@@ -466,6 +473,12 @@ func (e *Engine) startRun(def models.WorkflowDef, graph models.Graph, inputs map
 	if inputs == nil {
 		inputs = map[string]any{}
 	}
+	// Externalize composite launch images before any DB write (runs.inputs + vars).
+	var err error
+	inputs, err = blob.IngestCompositeInputs(context.Background(), e.blobs, inputs)
+	if err != nil {
+		return nil, fmt.Errorf("ingest launch attachments: %w", err)
+	}
 	// Resolve the live value of every global variable: project defaults first,
 	// then Graph.Variables + launcher-submitted Ask values (latter wins on name).
 	var projectVars []models.ProjectVariable
@@ -475,6 +488,13 @@ func (e *Engine) startRun(def models.WorkflowDef, graph models.Graph, inputs map
 	seeded, err := resolveStartVars(graph, inputs, projectVars)
 	if err != nil {
 		return nil, err
+	}
+	for i := range seeded {
+		nv, ierr := blob.IngestCompositeInputs(context.Background(), e.blobs, map[string]any{seeded[i].Name: seeded[i].Value})
+		if ierr != nil {
+			return nil, fmt.Errorf("ingest seed %q: %w", seeded[i].Name, ierr)
+		}
+		seeded[i].Value = nv[seeded[i].Name]
 	}
 	title := computeRunTitle(graph, seeded)
 	// Enqueue as "queued": the priority dispatcher promotes it to "running" (and
@@ -1198,7 +1218,7 @@ func (e *Engine) snapshotCheckpoint(c *execCtx, nodeID string) {
 	}
 	snap := map[string]any{}
 	for k, v := range c.vars {
-		snap[k] = v
+		snap[k] = blob.StripDataInValue(v)
 	}
 	c.run.Checkpoints[nodeID] = snap
 	// Only the checkpoints column — see appendTrace on why a full-row Save is
@@ -1210,6 +1230,7 @@ func (e *Engine) snapshotCheckpoint(c *execCtx, nodeID string) {
 func (c *execCtx) setVar(name string, v any) { c.vars[name] = v }
 
 func (e *Engine) persistVar(runID, name string, v any) {
+	v = blob.StripDataInValue(v)
 	var rv models.RunVariable
 	if err := e.db.Where("run_id = ? AND name = ?", runID, name).First(&rv).Error; err == nil {
 		rv.Value = v

--- a/server/internal/engine/engine_extra_test.go
+++ b/server/internal/engine/engine_extra_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cocofhu/approving/internal/blob"
 	"github.com/cocofhu/approving/internal/database"
 	"github.com/cocofhu/approving/internal/mcp"
 	"github.com/cocofhu/approving/internal/models"
@@ -34,6 +35,7 @@ func setupEngineGraphP(t *testing.T, g models.Graph) (*Engine, *gorm.DB, *fakePr
 	host := mcp.NewHost(arts)
 	p := &fakeProvider{host: host}
 	eng := New(db, p, host, arts, 5)
+	eng.SetBlobStore(blob.NewMemory())
 	cleanupEngineDB(t, eng, db)
 	return eng, db, p
 }

--- a/server/internal/engine/engine_test.go
+++ b/server/internal/engine/engine_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cocofhu/approving/internal/blob"
 	"github.com/cocofhu/approving/internal/database"
 	"github.com/cocofhu/approving/internal/mcp"
 	"github.com/cocofhu/approving/internal/models"
@@ -43,6 +44,7 @@ func setupEngine(t *testing.T) (*Engine, *gorm.DB) {
 	host := mcp.NewHost(arts)
 	provider := &fakeProvider{host: host}
 	eng := New(db, provider, host, arts, 5)
+	eng.SetBlobStore(blob.NewMemory())
 	cleanupEngineDB(t, eng, db)
 	return eng, db
 }
@@ -190,6 +192,7 @@ func setupEngineGraph(t *testing.T, g models.Graph) (*Engine, *gorm.DB) {
 	arts := services.NewArtifactService(db)
 	host := mcp.NewHost(arts)
 	eng := New(db, &fakeProvider{host: host}, host, arts, 5)
+	eng.SetBlobStore(blob.NewMemory())
 	cleanupEngineDB(t, eng, db)
 	return eng, db
 }

--- a/server/internal/engine/nodes.go
+++ b/server/internal/engine/nodes.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cocofhu/approving/internal/blob"
 	"github.com/cocofhu/approving/internal/mcp"
 	"github.com/cocofhu/approving/internal/models"
 	gatenode "github.com/cocofhu/approving/internal/models/nodereg"
@@ -1176,7 +1177,7 @@ func (e *Engine) saveState(c *execCtx, node *models.Node, o nodeOutcome) {
 	// timeline can surface each card's vars-at-that-moment for debugging.
 	snap := map[string]any{}
 	for k, v := range c.vars {
-		snap[k] = v
+		snap[k] = blob.StripDataInValue(v)
 	}
 	sr.VarsSnapshot = snap
 	// Accumulate this execution's built-in MCP tool-call trace so the timeline

--- a/server/internal/engine/resume.go
+++ b/server/internal/engine/resume.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cocofhu/approving/internal/blob"
 	"github.com/cocofhu/approving/internal/mcp"
 	"github.com/cocofhu/approving/internal/models"
 	gatenode "github.com/cocofhu/approving/internal/models/nodereg"
@@ -339,6 +340,11 @@ func (e *Engine) snapshotPreviewIssues(c *execCtx, runID, nodeID string) error {
 func (e *Engine) ReactReply(runID, nodeID, humanText string, images []models.PromptImage, annotations []models.ReactAnnotation, force bool) error {
 	if e.IsHalted() {
 		return errors.New("server is shutting down")
+	}
+	var err error
+	images, err = blob.IngestPromptImages(context.Background(), e.blobs, images)
+	if err != nil {
+		return fmt.Errorf("ingest attachments: %w", err)
 	}
 
 	cPeek, peekErr := e.loadCtx(runID)

--- a/server/internal/engine/review_session.go
+++ b/server/internal/engine/review_session.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cocofhu/approving/internal/blob"
 	"github.com/cocofhu/approving/internal/mcp"
 	"github.com/cocofhu/approving/internal/models"
 	"github.com/cocofhu/approving/internal/runtime"
@@ -206,6 +207,10 @@ func (e *Engine) enqueueReactTurn(runID, producerID, text string, images []model
 	}
 	if strings.TrimSpace(text) == "" && len(images) == 0 && len(annotations) == 0 {
 		return 0, errors.New("text, images, or annotations required")
+	}
+	images, err = blob.IngestPromptImages(context.Background(), e.blobs, images)
+	if err != nil {
+		return 0, fmt.Errorf("ingest attachments: %w", err)
 	}
 	s := e.getOrCreateReviewSession(runID, producerID, kind)
 	item := &reviewQueueItem{

--- a/server/internal/handlers/blobs.go
+++ b/server/internal/handlers/blobs.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/cocofhu/approving/internal/blob"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GetBlob streams a stored attachment by id (blob:{id} without the prefix).
+func (h *Handlers) GetBlob(c *gin.Context) {
+	if h.Blobs == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "blob store unavailable"})
+		return
+	}
+	id := strings.TrimSpace(c.Param("id"))
+	ref, err := blob.ParseRef("blob:" + id)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid blob id"})
+		return
+	}
+	rc, meta, err := h.Blobs.Open(c.Request.Context(), ref)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "blob not found"})
+		return
+	}
+	defer rc.Close()
+	mime := meta.MimeType
+	if mime == "" {
+		mime = "application/octet-stream"
+	}
+	c.Header("Content-Type", mime)
+	if name := strings.TrimSpace(meta.Name); name != "" {
+		c.Header("Content-Disposition", fmt.Sprintf("inline; filename=%q", filepath.Base(name)))
+	}
+	if meta.Size > 0 {
+		c.Header("Content-Length", fmt.Sprintf("%d", meta.Size))
+	}
+	c.Status(http.StatusOK)
+	_, _ = io.Copy(c.Writer, rc)
+}

--- a/server/internal/handlers/handlers.go
+++ b/server/internal/handlers/handlers.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	"github.com/cocofhu/approving/internal/auth"
+	"github.com/cocofhu/approving/internal/blob"
 	"github.com/cocofhu/approving/internal/browser"
 	"github.com/cocofhu/approving/internal/contextmcp"
 	"github.com/cocofhu/approving/internal/engine"
@@ -66,6 +67,8 @@ type Handlers struct {
 	CanViewProjectAudit func(username, projectID string) bool
 	// InjectBundles serves ConfigHome .tgz for gateway SANDBOX_INJECT (no session auth).
 	InjectBundles  *sandbox.BundleStore
+	// Blobs serves externalized attachment bytes (GET /api/blobs/:id).
+	Blobs          blob.Store
 	doctorMu       sync.Mutex
 	doctorSessions map[string]doctorArtifactSession
 }

--- a/server/internal/models/composite.go
+++ b/server/internal/models/composite.go
@@ -57,13 +57,24 @@ func AsCompositeText(v any) *CompositeText {
 					if d, ok := m["data"].(string); ok {
 						pi.Data = d
 					}
+					if r, ok := m["ref"].(string); ok {
+						pi.Ref = r
+					}
 					if mt, ok := m["mimeType"].(string); ok {
 						pi.MimeType = mt
 					}
 					if n, ok := m["name"].(string); ok {
 						pi.Name = n
 					}
-					if pi.Data != "" {
+					switch sb := m["sizeBytes"].(type) {
+					case float64:
+						pi.SizeBytes = int64(sb)
+					case int64:
+						pi.SizeBytes = sb
+					case int:
+						pi.SizeBytes = int64(sb)
+					}
+					if pi.Data != "" || pi.Ref != "" {
 						ct.Images = append(ct.Images, pi)
 					}
 				}

--- a/server/internal/models/composite_test.go
+++ b/server/internal/models/composite_test.go
@@ -57,3 +57,30 @@ func TestExtractImages(t *testing.T) {
 		t.Error("string should yield nil images")
 	}
 }
+
+func TestAsCompositeTextRefAndSizeBytes(t *testing.T) {
+	comp := map[string]any{
+		"text": "t",
+		"images": []any{
+			map[string]any{
+				"ref": "blob:abc", "mimeType": "image/png", "name": "a.png",
+				"sizeBytes": float64(12),
+			},
+			map[string]any{"data": "", "mimeType": "image/jpeg"}, // skipped: no data/ref
+		},
+	}
+	ct := AsCompositeText(comp)
+	if ct == nil || len(ct.Images) != 1 {
+		t.Fatalf("AsCompositeText = %#v", ct)
+	}
+	if ct.Images[0].Ref != "blob:abc" || ct.Images[0].SizeBytes != 12 || ct.Images[0].Name != "a.png" {
+		t.Fatalf("image = %+v", ct.Images[0])
+	}
+	if IsBlankVar(comp) {
+		t.Fatal("ref-only composite should not be blank")
+	}
+	typed := CompositeText{Text: "x", Images: []PromptImage{{Ref: "blob:y", MimeType: "image/png"}}}
+	if got := ExtractImages(typed); len(got) != 1 || got[0].Ref != "blob:y" {
+		t.Fatalf("ExtractImages typed = %+v", got)
+	}
+}

--- a/server/internal/models/models.go
+++ b/server/internal/models/models.go
@@ -536,15 +536,16 @@ func FormatChoiceReply(questions []ReactQuestion) string {
 	return "我的选择:\n" + strings.Join(lines, "\n")
 }
 
-// PromptImage is a base64-encoded image/file attachment for a chat turn. It is
-// the vendor-neutral shape threaded from the UI through the engine/runtime to
-// the sandbox ACP bridge (which accepts {data, mimeType, name}).
-// Name is optional for backward compatibility with older clients; when empty
-// the Bridge falls back to attachment-N.ext.
+// PromptImage is a chat/run attachment. New persistence uses Ref (blob:{id})
+// with bytes in BlobStore; Data is base64 only on inbound requests and when
+// hydrating for ACP wire format. Name is optional; when empty the Bridge falls
+// back to attachment-N.ext.
 type PromptImage struct {
-	Data     string `json:"data"`               // base64 (no data: prefix)
-	MimeType string `json:"mimeType"`           // e.g. image/png or application/pdf
-	Name     string `json:"name,omitempty"`     // original filename when known
+	Data      string `json:"data,omitempty"`      // base64 (no data: prefix); cleared before DB write
+	Ref       string `json:"ref,omitempty"`       // blob:{id} after externalization
+	MimeType  string `json:"mimeType"`            // e.g. image/png or application/pdf
+	Name      string `json:"name,omitempty"`      // original filename when known
+	SizeBytes int64  `json:"sizeBytes,omitempty"` // decoded byte length when known
 }
 
 // Sandbox is a tracked sandbox container. Purposes share this table:

--- a/server/internal/router/router.go
+++ b/server/internal/router/router.go
@@ -150,6 +150,7 @@ func New(h *handlers.Handlers) *gin.Engine {
 		api.GET("/artifacts/:id/content", h.ArtifactContent)
 		api.GET("/artifacts/:id/download", h.DownloadArtifact)
 		api.DELETE("/artifacts/:id", h.DeleteArtifact)
+		api.GET("/blobs/:id", h.GetBlob)
 
 		api.GET("/agents", h.ListAgents)
 		api.POST("/agents", h.CreateAgent)

--- a/server/internal/runtime/acp_provider.go
+++ b/server/internal/runtime/acp_provider.go
@@ -332,6 +332,7 @@ func newBaseACPProvider(host *mcp.Host, opts Options, backend AcpBackend) ExecPr
 		InjectStore:     opts.InjectStore,
 		InjectAdvertise: opts.MCPEndpoint,
 		CreateTimeout:   opts.SandboxCreateTimeout,
+		Blobs:           opts.Blobs,
 	})
 	log.Info().Str("image", mgr.Image).Str("gateway", opts.GatewayURL).Str("acpBackend", string(backend)).
 		Str("bridge", AgentRuntimeLabel(backend)).Msg("sandbox exec provider ready")

--- a/server/internal/runtime/provider.go
+++ b/server/internal/runtime/provider.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cocofhu/approving/internal/blob"
 	"github.com/cocofhu/approving/internal/mcp"
 	"github.com/cocofhu/approving/internal/models"
 	"github.com/cocofhu/approving/internal/sandbox"
@@ -54,6 +55,8 @@ type Options struct {
 	MCPEndpoint string
 	// InjectStore holds short-lived ConfigHome .tgz for gateway bundleUrl inject.
 	InjectStore *sandbox.BundleStore
+	// Blobs resolves blob:{id} attachments for ACP chat turns.
+	Blobs blob.Store
 	// ProfilesRoot is where skill_profile rules live (<root>/<profile>/rules.md),
 	// copied into the per-node /root/.cursor mount.
 	ProfilesRoot string

--- a/server/internal/sandbox/acp.go
+++ b/server/internal/sandbox/acp.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cocofhu/approving/internal/blob"
 	"github.com/cocofhu/approving/internal/models"
 	"github.com/cocofhu/approving/internal/textutil"
 
@@ -91,6 +92,9 @@ type ACPClient struct {
 	cwd        string
 	mcpServers json.RawMessage // JSON array, may be nil
 
+	// blobs resolves blob:{id} attachments to base64 for the wire format.
+	blobs blob.Store
+
 	// password, when set, is the sandbox token the acp-bridge expects
 	// (CURSOR_ACP_PASSWORD). Connect logs in first (POST /api/login) and
 	// carries the returned cursor_acp_session cookie on the /ws handshake.
@@ -147,6 +151,16 @@ func (c *ACPClient) WithIdleTimeout(d time.Duration) *ACPClient {
 func (c *ACPClient) WithBridgeModel(model string) *ACPClient {
 	c.bridgeModel = strings.TrimSpace(model)
 	return c
+}
+
+// WithBlobs wires a blob.Store so chat turns can resolve blob:{id} refs.
+func (c *ACPClient) WithBlobs(store blob.Store) *ACPClient {
+	c.blobs = store
+	return c
+}
+
+func (c *ACPClient) prepareImages(ctx context.Context, images []models.PromptImage) ([]models.PromptImage, error) {
+	return blob.ResolveForWire(ctx, c.blobs, images)
 }
 
 // BridgeModel returns the configured ACP_BRIDGE_MODEL string (may be empty).
@@ -389,6 +403,11 @@ func (c *ACPClient) ChatStructured(ctx context.Context, text string, images []mo
 	if !c.IsConnected() {
 		return nil, fmt.Errorf("%w: not connected", ErrConnClosed)
 	}
+	var err error
+	images, err = c.prepareImages(ctx, images)
+	if err != nil {
+		return nil, err
+	}
 	c.drainEvents()
 	if err := c.send(chatMessage(text, images)); err != nil {
 		return nil, fmt.Errorf("%w: send chat: %v", ErrConnClosed, err)
@@ -454,6 +473,11 @@ func (c *ACPClient) ChatStream(ctx context.Context, text string, images []models
 	if !c.IsConnected() {
 		return nil, fmt.Errorf("%w: not connected", ErrConnClosed)
 	}
+	var err error
+	images, err = c.prepareImages(ctx, images)
+	if err != nil {
+		return nil, err
+	}
 	c.drainEvents()
 	if err := c.send(chatMessage(text, images)); err != nil {
 		return nil, fmt.Errorf("%w: send chat: %v", ErrConnClosed, err)
@@ -517,6 +541,11 @@ func (c *ACPClient) ChatStream(ctx context.Context, text string, images []models
 func (c *ACPClient) ChatStreamResult(ctx context.Context, text string, images []models.PromptImage, onProgress func(*ChatResult)) (*ChatResult, error) {
 	if !c.IsConnected() {
 		return nil, fmt.Errorf("%w: not connected", ErrConnClosed)
+	}
+	var err error
+	images, err = c.prepareImages(ctx, images)
+	if err != nil {
+		return nil, err
 	}
 	c.drainEvents()
 	if err := c.send(chatMessage(text, images)); err != nil {

--- a/server/internal/sandbox/manager.go
+++ b/server/internal/sandbox/manager.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cocofhu/approving/internal/blob"
 	"github.com/cocofhu/approving/internal/config"
 
 	"github.com/google/uuid"
@@ -75,6 +76,9 @@ type Manager struct {
 	// running sandbox with a resolved session endpoint.
 	createTimeout time.Duration
 
+	// blobs resolves blob:{id} attachments when opening ACP clients.
+	blobs blob.Store
+
 	// hostKeys holds per-endpoint TOFU SSH host keys for data-plane dials.
 	hostKeys *hostKeyCache
 }
@@ -99,6 +103,8 @@ type ManagerOptions struct {
 	// finishes provisioning (large cold-start image pull + PVC attach + boot).
 	// 0 → default (see NewManager).
 	CreateTimeout time.Duration
+	// Blobs resolves blob:{id} attachments for ACP chat turns.
+	Blobs blob.Store
 }
 
 // Spec describes one sandbox to create. The sandbox is a generic agent runner:
@@ -272,6 +278,7 @@ func NewManager(gw *GatewayClient, opts ManagerOptions) *Manager {
 		bundles:                 opts.InjectStore,
 		injectAdvertiseFallback: strings.TrimSpace(opts.InjectAdvertise),
 		createTimeout:           createTimeout,
+		blobs:                   opts.Blobs,
 		hostKeys:                newHostKeyCache(),
 	}
 }
@@ -783,7 +790,11 @@ func (s *Sandbox) Destroy(ctx context.Context) {
 // ACP returns a new ACP client wired to this sandbox's session endpoint,
 // pre-authenticated with the sandbox token when the bridge requires it.
 func (s *Sandbox) ACP() *ACPClient {
-	return NewACPClient(s.Host, s.Port).WithPassword(s.Password)
+	c := NewACPClient(s.Host, s.Port).WithPassword(s.Password)
+	if s.mgr != nil && s.mgr.blobs != nil {
+		c = c.WithBlobs(s.mgr.blobs)
+	}
+	return c
 }
 
 // shellArgPattern is the allowlist for remote shell argv fragments (CodeQL #11).

--- a/server/internal/services/issue.go
+++ b/server/internal/services/issue.go
@@ -1,8 +1,11 @@
 package services
 
 import (
+	"context"
+	"fmt"
 	"time"
 
+	"github.com/cocofhu/approving/internal/blob"
 	"github.com/cocofhu/approving/internal/models"
 
 	"github.com/google/uuid"
@@ -13,16 +16,28 @@ import (
 // from the app_preview UI via REST; the engine snapshots them into a run
 // variable (preview_issues) at gate resume so a downstream node can consume
 // them via {{vars.preview_issues}}.
-type IssueService struct{ db *gorm.DB }
+type IssueService struct {
+	db    *gorm.DB
+	blobs blob.Store
+}
 
 // NewIssueService builds the service.
 func NewIssueService(db *gorm.DB) *IssueService { return &IssueService{db: db} }
+
+// SetBlobStore wires attachment externalization for preview issue images.
+func (s *IssueService) SetBlobStore(store blob.Store) { s.blobs = store }
 
 // Create persists a new open preview issue, attributing it to the run's
 // workflow (mirrors ArtifactService.Save's run lookup).
 func (s *IssueService) Create(runID, nodeID, body, selector string, port int, images []models.PromptImage) (models.PreviewIssue, error) {
 	var run models.Run
 	s.db.Select("workflow_id", "workflow_name").First(&run, "id = ?", runID)
+
+	var err error
+	images, err = blob.IngestPromptImages(context.Background(), s.blobs, images)
+	if err != nil {
+		return models.PreviewIssue{}, fmt.Errorf("ingest attachments: %w", err)
+	}
 
 	issue := models.PreviewIssue{
 		ID: "iss-" + uuid.NewString()[:8], RunID: runID, NodeID: nodeID,

--- a/server/internal/services/pm.go
+++ b/server/internal/services/pm.go
@@ -1,11 +1,13 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/cocofhu/approving/internal/blob"
 	"github.com/cocofhu/approving/internal/models"
 
 	"github.com/google/uuid"
@@ -71,6 +73,7 @@ func validPmFailKind(kind string) bool {
 
 // PmService manages project PM Leader binding, memory, and chat persistence.
 type PmService struct {
+	blobs blob.Store
 	db     *gorm.DB
 	skills *SkillService
 }
@@ -79,6 +82,9 @@ type PmService struct {
 func NewPmService(db *gorm.DB, skills *SkillService) *PmService {
 	return &PmService{db: db, skills: skills}
 }
+
+// SetBlobStore wires attachment externalization for chat messages.
+func (s *PmService) SetBlobStore(store blob.Store) { s.blobs = store }
 
 // --- binding ----------------------------------------------------------------
 
@@ -757,6 +763,11 @@ func (s *PmService) AppendMessage(threadID, role, content string, citations []mo
 func (s *PmService) AppendMessageSource(threadID, role, content, source string, citations []models.ProgressCitation, attached *models.AttachedContext, images []models.PromptImage, usage *models.TokenUsage, usageByModel models.TokenUsageByModel) (models.ChatMessage, error) {
 	if role == "" {
 		return models.ChatMessage{}, fmt.Errorf("role required")
+	}
+	var err error
+	images, err = blob.IngestPromptImages(context.Background(), s.blobs, images)
+	if err != nil {
+		return models.ChatMessage{}, fmt.Errorf("ingest attachments: %w", err)
 	}
 	msg := models.ChatMessage{
 		ID: "msg-" + uuid.NewString()[:12], ThreadID: threadID, Role: role, Content: content,

--- a/server/internal/services/pm_blob_test.go
+++ b/server/internal/services/pm_blob_test.go
@@ -1,0 +1,40 @@
+package services
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cocofhu/approving/internal/blob"
+	"github.com/cocofhu/approving/internal/models"
+)
+
+func TestAppendMessageExternalizesImages(t *testing.T) {
+	db := setupPmDB(t)
+	pm := NewPmService(db, nil)
+	pm.SetBlobStore(blob.NewMemory())
+	ps := NewProjectService(db)
+	p, err := ps.Create("BlobProj", "", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	th, err := pm.CreateThread(p.ID, "alice", "", "agent", "user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg, err := pm.AppendMessage(th.ID, "user", "pic", nil, nil, []models.PromptImage{
+		{Data: "aGVsbG8=", MimeType: "image/png", Name: "a.png"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.Images) != 1 || !strings.HasPrefix(msg.Images[0].Ref, "blob:") || msg.Images[0].Data != "" {
+		t.Fatalf("msg images = %+v", msg.Images)
+	}
+	var stored models.ChatMessage
+	if err := db.First(&stored, "id = ?", msg.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(stored.Images) != 1 || stored.Images[0].Data != "" || stored.Images[0].Ref == "" {
+		t.Fatalf("stored = %+v", stored.Images)
+	}
+}

--- a/server/internal/services/pm_test.go
+++ b/server/internal/services/pm_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cocofhu/approving/internal/blob"
 	"github.com/cocofhu/approving/internal/models"
 
 	"gorm.io/driver/sqlite"
@@ -46,6 +47,7 @@ func TestPmBindingEnableRequiresAgent(t *testing.T) {
 func TestPmMemoryAndThreadIsolation(t *testing.T) {
 	db := setupPmDB(t)
 	pm := NewPmService(db, nil)
+	pm.SetBlobStore(blob.NewMemory())
 	ps := NewProjectService(db)
 	p, err := ps.Create("MemProj", "", nil, nil)
 	if err != nil {
@@ -86,15 +88,15 @@ func TestPmMemoryAndThreadIsolation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(imgMsg.Images) != 1 || imgMsg.Images[0].MimeType != "image/png" {
-		t.Fatalf("images not persisted: %+v", imgMsg)
+	if len(imgMsg.Images) != 1 || imgMsg.Images[0].MimeType != "image/png" || imgMsg.Images[0].Ref == "" || imgMsg.Images[0].Data != "" {
+		t.Fatalf("images not externalized: %+v", imgMsg)
 	}
 	msgs, err = pm.ListMessages(ta.ID)
 	if err != nil || len(msgs) != 2 {
 		t.Fatalf("msgs after image=%v err=%v", msgs, err)
 	}
-	if len(msgs[1].Images) != 1 {
-		t.Fatalf("listed message missing images: %+v", msgs[1])
+	if len(msgs[1].Images) != 1 || msgs[1].Images[0].Ref == "" || msgs[1].Images[0].Data != "" {
+		t.Fatalf("listed message missing blob ref: %+v", msgs[1])
 	}
 	bobThreads, _ := pm.ListThreads(p.ID, "bob")
 	if len(bobThreads) != 1 || bobThreads[0].ID != tb.ID {

--- a/web/src/components/run/ClarifyChat.vue
+++ b/web/src/components/run/ClarifyChat.vue
@@ -35,6 +35,7 @@ import {
   formatSendRejectMessage,
   isImageAttachment,
 } from '@/lib/attachments'
+import { imgSrc } from '@/lib/compositeText'
 
 type QueueItem = {
   id?: string
@@ -353,10 +354,6 @@ const turns = computed<ClarifyTurn[]>(() => {
   }
   return list
 })
-
-function imgSrc(im: ClarifyImage): string {
-  return `data:${im.mimeType || 'image/png'};base64,${im.data}`
-}
 
 /** Single-image lightbox for human history attachments (no gallery / Esc). */
 type ImagePreview = { src: string; label: string }

--- a/web/src/components/run/GateApproval.vue
+++ b/web/src/components/run/GateApproval.vue
@@ -1155,8 +1155,8 @@ const canRecordIssue = computed(
       !!pickedElementImage.value?.data),
 )
 
-function collectUnifiedIssueImages(): { data: string; mimeType: string }[] {
-  const images: { data: string; mimeType: string }[] = []
+function collectUnifiedIssueImages(): ClarifyImage[] {
+  const images: ClarifyImage[] = []
   if (pickedElementImage.value?.data) {
     images.push({
       data: pickedElementImage.value.data,
@@ -1164,7 +1164,7 @@ function collectUnifiedIssueImages(): { data: string; mimeType: string }[] {
     })
   }
   for (const im of reactImages.value) {
-    images.push({ data: im.data, mimeType: im.mimeType })
+    if (im.data) images.push({ data: im.data, mimeType: im.mimeType, name: im.name })
   }
   return images
 }
@@ -1245,7 +1245,7 @@ async function sendReactRevise() {
       props.run.id,
       props.gate.nodeId,
       body,
-      reactImages.value.map((im) => ({ data: im.data, mimeType: im.mimeType })),
+      reactImages.value,
       reactAnnotations.value.slice(),
     )
     clearUnifiedDraft()

--- a/web/src/components/run/PreviewFeedbackChat.vue
+++ b/web/src/components/run/PreviewFeedbackChat.vue
@@ -136,8 +136,8 @@ function toggleHistory() {
   if (historyExpanded.value) nextTick(() => scrollToBottom())
 }
 
-function collectImages(): { data: string; mimeType: string }[] {
-  const images: { data: string; mimeType: string }[] = []
+function collectImages(): ClarifyImage[] {
+  const images: ClarifyImage[] = []
   if (props.elementImage?.data) {
     images.push({
       data: props.elementImage.data,
@@ -145,7 +145,7 @@ function collectImages(): { data: string; mimeType: string }[] {
     })
   }
   for (const im of attachments.value) {
-    images.push({ data: im.data, mimeType: im.mimeType })
+    if (im.data) images.push({ data: im.data, mimeType: im.mimeType, name: im.name })
   }
   return images
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -41,6 +41,13 @@ import {
 // an empty/error state.
 const BASE = ((import.meta as any).env?.VITE_API_BASE ?? '/api').replace(/\/$/, '')
 
+/** Browser URL for a stored attachment (`blob:{id}` → `/api/blobs/{id}`). */
+export function blobContentUrl(ref: string): string {
+  const id = String(ref || '').trim().replace(/^blob:/, '')
+  if (!id) return ''
+  return `${BASE}/blobs/${encodeURIComponent(id)}`
+}
+
 const AUTH_WHITELIST = new Set(['/auth/login', '/auth/logout', '/auth/me', '/health', '/live'])
 
 function redirectToLogin() {
@@ -867,6 +874,7 @@ export const api = {
   },
   artifactContent: (id: string) => req<Artifact>(`/artifacts/${id}/content`),
   artifactDownloadUrl: (id: string) => `${origin()}/api/artifacts/${id}/download`,
+  blobContentUrl,
   exportRunLogsUrl: (id: string) => `${origin()}/api/runs/${id}/logs/export`,
   // DELETE returns 204 No Content — must not go through req()'s unconditional res.json().
   deleteArtifact: async (id: string): Promise<void> => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -140,7 +140,7 @@ export interface PreviewIssue {
   body: string
   selector?: string
   port?: number
-  images?: { data: string; mimeType: string }[]
+  images?: ClarifyImage[]
   status: string
   createdAt: string
 }
@@ -678,7 +678,7 @@ export const api = {
     runId: string,
     nodeId: string,
     text: string,
-    images: { data: string; mimeType: string }[] = [],
+    images: ClarifyImage[] = [],
     force = false,
     annotations: ReactAnnotation[] = [],
   ) =>
@@ -696,7 +696,7 @@ export const api = {
     runId: string,
     nodeId: string,
     text: string,
-    images: { data: string; mimeType: string }[] = [],
+    images: ClarifyImage[] = [],
     annotations: ReactAnnotation[] = [],
   ) =>
     req<{ status: string; waiting?: number; producerNodeId?: string }>(
@@ -992,7 +992,7 @@ export const api = {
     body: string,
     selector = '',
     port = 0,
-    images: { data: string; mimeType: string }[] = [],
+    images: ClarifyImage[] = [],
   ) =>
     req<PreviewIssue>(`/runs/${runId}/nodes/${nodeId}/preview-issues`, {
       method: 'POST',

--- a/web/src/lib/attachments.ts
+++ b/web/src/lib/attachments.ts
@@ -32,6 +32,7 @@ export function fileAttachmentName(file: File, index = 0): string {
 
 /** Decode base64 payload length (approx original bytes). */
 export function attachmentByteLength(im: ClarifyImage): number {
+  if (im.sizeBytes && im.sizeBytes > 0) return im.sizeBytes
   if (!im.data) return 0
   const len = im.data.length
   let pad = 0

--- a/web/src/lib/compositeText.test.ts
+++ b/web/src/lib/compositeText.test.ts
@@ -5,6 +5,7 @@ import {
   formatImageCountFull,
   formatVarChip,
   formatVarValue,
+  imgSrc,
   isCompositeText,
 } from './compositeText'
 import { i18n } from './i18n'
@@ -29,6 +30,14 @@ describe('compositeImages', () => {
     const imgs = [{ data: 'x', mimeType: 'image/png' }]
     expect(compositeImages({ text: '', images: imgs })).toEqual(imgs)
     expect(compositeImages('plain')).toEqual([])
+  })
+})
+
+describe('imgSrc', () => {
+  it('prefers blob ref URL over inline data', () => {
+    expect(imgSrc({ ref: 'blob:abc123', data: 'xx', mimeType: 'image/png' })).toBe('/api/blobs/abc123')
+    expect(imgSrc({ data: 'QUJD', mimeType: 'image/png' })).toBe('data:image/png;base64,QUJD')
+    expect(imgSrc({ mimeType: 'image/png' })).toBe('')
   })
 })
 

--- a/web/src/lib/compositeText.ts
+++ b/web/src/lib/compositeText.ts
@@ -1,8 +1,17 @@
 import type { ClarifyImage, CompositeText } from '@/lib/types'
+import { blobContentUrl } from './api'
 import { i18n } from './i18n'
 
+/** Prefer blob:{id} URL; fall back to legacy inline base64 data URL. */
 export function imgSrc(im: ClarifyImage): string {
-  return `data:${im.mimeType || 'image/png'};base64,${im.data}`
+  const ref = (im.ref || '').trim()
+  if (ref.startsWith('blob:')) {
+    return blobContentUrl(ref)
+  }
+  if (im.data) {
+    return `data:${im.mimeType || 'image/png'};base64,${im.data}`
+  }
+  return ''
 }
 
 export function isCompositeText(v: unknown): v is CompositeText {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -499,10 +499,15 @@ export interface Artifact {
 }
 
 export interface ClarifyImage {
-  data: string // base64 (no data: prefix)
+  /** Base64 (no data: prefix) on upload / legacy rows; omitted after blob externalization. */
+  data?: string
+  /** blob:{id} reference after server-side externalization. */
+  ref?: string
   mimeType: string
   /** Original filename when known; forwarded through platform → ACP Bridge. */
   name?: string
+  /** Decoded byte length when known. */
+  sizeBytes?: number
 }
 
 /** Paragraph variable composite value: text + optional image attachments. */

--- a/web/src/views/GatesInboxView.vue
+++ b/web/src/views/GatesInboxView.vue
@@ -1218,7 +1218,7 @@ function backToList() {
 
 async function onClarifySend(
   text: string,
-  images: { data: string; mimeType: string }[] = [],
+  images: import('@/lib/types').ClarifyImage[] = [],
   annotations: import('@/lib/types').ReactAnnotation[] = [],
   force = false,
 ) {

--- a/web/src/views/RunDetailView.vue
+++ b/web/src/views/RunDetailView.vue
@@ -838,7 +838,7 @@ async function onGateResolve(action: string, form: Record<string, any> = {}) {
 }
 async function onClarifySend(
   text: string,
-  images: { data: string; mimeType: string }[] = [],
+  images: import('@/lib/types').ClarifyImage[] = [],
   annotations: import('@/lib/types').ReactAnnotation[] = [],
   force = false,
 ) {


### PR DESCRIPTION
## Summary
- 新增 `blob.Store`（LocalFS 默认 `data/blobs`，接口预留 COS），`PromptImage` 持久化改为 `blob:{id}` + 元数据，新写入不再把 base64 塞进 DB
- StartRun / PM / React·Clarify / Preview Issue / QQ 渠道落库前统一 Ingest；`GET /api/blobs/:id` 读内容，ACP 发送前 Resolve；前端历史预览走 blob URL，上传仍可带 `data`
- 提供 `go run ./cmd/migrate-blobs` 迁移旧行；配置项 `APPROVING_STORAGE_DRIVER` / `APPROVING_BLOBS_ROOT`

## Test plan
- [ ] `go test ./internal/blob/ ./internal/engine/ ./internal/services/ ./internal/channels/ ./internal/handlers/`
- [ ] 启动工作流带复合变量图片：确认 `runs.inputs` / `run_variables` 只有 `ref`，缩略图可显示
- [ ] PM / Clarify 发图后历史消息可预览；进 sandbox 附件仍可用
- [ ] （可选）对含旧 base64 的库跑 `go run ./cmd/migrate-blobs`


Made with [Cursor](https://cursor.com)