### PR TITLE
fix(web): human_gate 画布恢复双出口

### DIFF
--- a/web/src/components/canvas/BaseNode.test.ts
+++ b/web/src/components/canvas/BaseNode.test.ts
@@ -73,23 +73,23 @@ describe('BaseNode', () => {
     wrapper.unmount()
   })
 
-  it('human_gate review: Demo footnote instead of action Handle rows', () => {
+  it('human_gate: dual structured exits (approve / revise) like review', () => {
     const wrapper = mountNode({
       type: 'human_gate',
-      label: '人工门禁',
-      humanGateReview: true,
-      gateActions: [
-        { id: 'approve', label: '批准' },
-        { id: 'revise', label: '退回修改' },
+      label: '人工确认',
+      structuredExits: [
+        { id: 'approve', label: '批准', tone: 'ok' },
+        { id: 'revise', label: '退回修改', tone: 'bad' },
       ],
       status: undefined,
     })
     expect(wrapper.text()).toContain('人工审批')
-    expect(wrapper.text()).toContain('确认并流转 · 待审批')
-    expect(wrapper.text()).not.toContain('批准')
-    expect(wrapper.text()).not.toContain('退回修改')
-    expect(wrapper.text()).not.toContain('未设 goto')
-    expect(wrapper.find('[data-testid="human-gate-body"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('批准')
+    expect(wrapper.text()).toContain('退回修改')
+    expect(wrapper.text()).toContain('未设 goto')
+    expect(wrapper.find('[data-testid="human-gate-body"]').exists()).toBe(false)
+    // target + two action sources + bottom fallback source
+    expect(wrapper.findAll('[data-testid="handle"]').length).toBeGreaterThanOrEqual(4)
     wrapper.unmount()
   })
 })

--- a/web/src/components/canvas/BaseNode.vue
+++ b/web/src/components/canvas/BaseNode.vue
@@ -19,24 +19,18 @@ const props = defineProps<{
     status?: NodeRunStatus
     checkpoint?: boolean
     branches?: { id: string; label: string; isDefault?: boolean }[]
-    /** Legacy: action handles. human_gate no longer renders these rows (Demo footnote). */
+    /** Legacy: action handles (prefer structuredExits for human_gate). */
     gateActions?: { id: string; label: string }[]
     /** app_preview pure ReAct review: badge + single success exit (no action handles). */
     appPreviewReview?: boolean
-    /** human_gate: Demo footnote instead of action Handle rows. */
-    humanGateReview?: boolean
     structuredExits?: { id: string; label: string; tone: 'ok' | 'bad' }[]
   }
   selected?: boolean
 }>()
 
 const isBranch = computed(() => !!props.data.branches?.length)
-/** Action-row gate UI — excluded for human_gate (uses Demo footnote). */
-const isGate = computed(
-  () => !!props.data.gateActions?.length && !props.data.humanGateReview,
-)
+const isGate = computed(() => !!props.data.gateActions?.length)
 const isAppPreviewReview = computed(() => !!props.data.appPreviewReview)
-const isHumanGateReview = computed(() => !!props.data.humanGateReview)
 const isStructuredGate = computed(() => !!props.data.structuredExits?.length)
 const def = computed(() => NODE_DEFS.value[props.data.type])
 const displayLabel = computed(() => {
@@ -81,7 +75,7 @@ const statusBadge = computed(() => {
 
 const subtitle = computed(() => {
   if (isAppPreviewReview.value) return t('pages.workflowEditor.canvas.appPreviewSubtitle')
-  if (isHumanGateReview.value) return t('pages.workflowEditor.canvas.humanGateSubtitle')
+  if (props.data.type === 'human_gate') return t('pages.workflowEditor.canvas.humanGateSubtitle')
   return def.value?.label || props.data.type
 })
 </script>
@@ -122,14 +116,6 @@ const subtitle = computed(() => {
       data-testid="app-preview-body"
     >
       {{ t('pages.workflowEditor.canvas.appPreviewBody') }}
-    </div>
-
-    <div
-      v-if="isHumanGateReview"
-      class="border-t border-line/60 px-3 py-1.5 pl-4 text-[11px] text-txt3"
-      data-testid="human-gate-body"
-    >
-      {{ t('pages.workflowEditor.canvas.humanGateBody') }}
     </div>
 
     <div v-if="isBranch" class="border-t border-line/60">

--- a/web/src/components/canvas/WorkflowCanvas.vue
+++ b/web/src/components/canvas/WorkflowCanvas.vue
@@ -126,6 +126,20 @@ function actionHandles(n: WFNode) {
     .filter((a) => a.id)
 }
 
+function isPositiveGateAction(id: string): boolean {
+  return id === 'approve' || id === 'pass'
+}
+
+// human_gate actions render like review/test structured exits (ok/bad chips +
+// right-side handles). Routing still comes from config.actions[].goto.
+function humanGateExitHandles(n: WFNode) {
+  return actionHandles(n).map((a) => ({
+    id: a.id,
+    label: a.label || a.id,
+    tone: (isPositiveGateAction(a.id) ? 'ok' : 'bad') as 'ok' | 'bad',
+  }))
+}
+
 // test/review expose fixed pass/fail handles for structured gate routing.
 function structuredExitHandles(n: WFNode) {
   if (n.type === 'test') {
@@ -162,11 +176,13 @@ const flowNodes = computed(() => {
     const position = resolvePosition(n)
     const status = props.statusMap?.[n.id]
     const branches = n.type === 'branch' ? branchHandles(n) : undefined
-    const gateActions = n.type === 'human_gate' ? actionHandles(n) : undefined
     const appPreviewReview = n.type === 'app_preview'
-    const humanGateReview = n.type === 'human_gate'
     const structuredExits =
-      n.type === 'test' || n.type === 'review' ? structuredExitHandles(n) : undefined
+      n.type === 'test' || n.type === 'review'
+        ? structuredExitHandles(n)
+        : n.type === 'human_gate'
+          ? humanGateExitHandles(n)
+          : undefined
     const selected = selectedId === n.id
     const fingerprint = flowFingerprint({
       type: n.type,
@@ -176,9 +192,7 @@ const flowNodes = computed(() => {
       position,
       draggable: !modeRun,
       branches,
-      gateActions,
       appPreviewReview,
-      humanGateReview,
       structuredExits,
     })
     return reuseFlowElement(flowNodeCache, n.id, fingerprint, selected, () => ({
@@ -193,9 +207,7 @@ const flowNodes = computed(() => {
         status,
         checkpoint: n.checkpoint,
         branches,
-        gateActions,
         appPreviewReview,
-        humanGateReview,
         structuredExits,
       },
     }))
@@ -307,9 +319,10 @@ const branchEdges = computed(() => {
 // human_gate actions route by their `config.actions[].goto` target (see engine
 // ResumeGate), not by real edges — mirror the branch approach and derive
 // display-only edges from each action's goto. Prefixed `ga:` so handlers can
-// tell them apart from real edges.
+// tell them apart from real edges. Stroke tones match review/test exits.
 const gateEdges = computed(() => {
   const ids = new Set(props.nodes.map((n) => n.id))
+  const strokes = edgeStrokes.value
   const out: any[] = []
   for (const n of props.nodes) {
     if (n.type !== 'human_gate') continue
@@ -319,6 +332,7 @@ const gateEdges = computed(() => {
       const target = a?.goto
       if (!aid || !target || !ids.has(target)) continue
       const label = String(a?.label || aid)
+      const isOk = isPositiveGateAction(aid)
       out.push({
         id: `ga:${n.id}:${aid}`,
         source: n.id,
@@ -326,9 +340,9 @@ const gateEdges = computed(() => {
         target,
         type: 'condition',
         selectable: false,
-        data: { label, tone: 'default', shape: 'step' },
+        data: { label, tone: isOk ? 'ok' : 'err', shape: 'step' },
         markerEnd: MarkerType.ArrowClosed,
-        style: { stroke: BRANCH_COLOR, strokeWidth: 1.6, strokeDasharray: '5 4' },
+        style: { stroke: isOk ? strokes.ok : strokes.err, strokeWidth: 1.6 },
       })
     }
   }


### PR DESCRIPTION
## Summary
- `human_gate` 节点不再使用单出口 Demo 脚注，改为按 `actions` 渲染双出口（默认批准 / 退回修改），视觉对齐 `review`/`test`
- goto 派生连线按 approve/pass → ok、其余 → err 着色，并从对应右侧 Handle 出发

## Test plan
- [ ] 打开含 `human_gate` 的工作流画布，确认卡片右侧有两个输出口（批准 / 退回修改）
- [ ] 为两个 action 分别设置 `goto`，确认连线从对应 Handle 出发且颜色区分
- [ ] 对照 `review` 节点：出口芯片样式一致，底部仍有 fallback handle
- [ ] `npm test -- --run src/components/canvas/BaseNode.test.ts src/components/canvas/WorkflowCanvas.test.ts`


Made with [Cursor](https://cursor.com)