### PR TITLE
feat(preview): noVNC 取点标注携带页面 URL

### DIFF
--- a/server/internal/browser/rod.go
+++ b/server/internal/browser/rod.go
@@ -269,6 +269,7 @@ const pickScript = `() => {
     selector: path(el),
     tagName: el.tagName.toLowerCase(),
     outerHTML: (el.outerHTML || '').slice(0, 4000),
+    url: String(location.href || ''),
     x: r.x, y: r.y, width: r.width, height: r.height
   };
 }`
@@ -287,6 +288,7 @@ func (rp *rodPage) describeBackendNode(id proto.DOMBackendNodeID) (Pick, error) 
 		Selector:  v.Get("selector").Str(),
 		TagName:   v.Get("tagName").Str(),
 		OuterHTML: v.Get("outerHTML").Str(),
+		URL:       v.Get("url").Str(),
 		Box:       [4]float64{v.Get("x").Num(), v.Get("y").Num(), v.Get("width").Num(), v.Get("height").Num()},
 	}, nil
 }

--- a/server/internal/browser/types.go
+++ b/server/internal/browser/types.go
@@ -43,6 +43,8 @@ type Pick struct {
 	Selector  string     `json:"selector"`
 	TagName   string     `json:"tagName"`
 	OuterHTML string     `json:"outerHTML"`
+	// URL is location.href at pick time (SPA navigations included).
+	URL       string     `json:"url,omitempty"`
 	Box       [4]float64 `json:"box"` // x, y, width, height (CSS px)
 }
 

--- a/server/internal/models/models.go
+++ b/server/internal/models/models.go
@@ -387,9 +387,11 @@ type ReactMessage struct {
 // JSONPath (structured product field), Selector (visual DOM element), and/or
 // Quote (paragraph excerpt from a text selection) may be set; Note carries the
 // human's instruction for that spot. Truncated marks soft-capped quotes.
+// URL is the page location.href at DOM pick time (SPA navigations).
 type ReactAnnotation struct {
 	JSONPath  string `json:"jsonPath,omitempty"`
 	Selector  string `json:"selector,omitempty"`
+	URL       string `json:"url,omitempty"`
 	Label     string `json:"label,omitempty"`
 	Note      string `json:"note,omitempty"`
 	Quote     string `json:"quote,omitempty"`
@@ -420,6 +422,7 @@ func RenderAnnotations(anns []ReactAnnotation) string {
 		if note == "" {
 			note = "(见下方文字说明)"
 		}
+		pageURL := strings.TrimSpace(a.URL)
 		if quote != "" {
 			if ref == "" {
 				fmt.Fprintf(&b, "%d. [段落摘录] 引用原文: 「%s」", i+1, quote)
@@ -437,6 +440,9 @@ func RenderAnnotations(anns []ReactAnnotation) string {
 				b.WriteString(" (已截断)")
 			}
 			fmt.Fprintf(&b, " → %s\n", note)
+			if kind == "页面元素" && pageURL != "" {
+				fmt.Fprintf(&b, "   页面 URL: %s\n", pageURL)
+			}
 			continue
 		}
 		if ref == "" {
@@ -444,6 +450,9 @@ func RenderAnnotations(anns []ReactAnnotation) string {
 			continue
 		}
 		fmt.Fprintf(&b, "%d. [%s] `%s`%s → %s\n", i+1, kind, ref, label, note)
+		if kind == "页面元素" && pageURL != "" {
+			fmt.Fprintf(&b, "   页面 URL: %s\n", pageURL)
+		}
 	}
 	return b.String()
 }

--- a/server/internal/models/models_test.go
+++ b/server/internal/models/models_test.go
@@ -393,13 +393,14 @@ func TestRenderAnnotations(t *testing.T) {
 	}
 	got := RenderAnnotations([]ReactAnnotation{
 		{JSONPath: "proposals[p1].title", Label: "方案 A", Note: "更具体"},
-		{Selector: "#hero h1", Note: ""},
+		{Selector: "#hero h1", URL: "http://127.0.0.1:5173/settings?tab=1", Note: ""},
 		{JSONPath: "summary", Quote: "划选的一段原文", Label: "概述", Note: "改这句"},
 		{Quote: "未绑定摘录", Truncated: true, Note: ""},
 	})
 	for _, part := range []string{
 		"字段路径", "proposals[p1].title", "(方案 A)", "更具体",
 		"页面元素", "#hero h1", "(见下方文字说明)",
+		"页面 URL: http://127.0.0.1:5173/settings?tab=1",
 		"引用原文", "划选的一段原文", "未绑定摘录", "已截断", "段落摘录",
 	} {
 		if !strings.Contains(got, part) {

--- a/web/src/components/run/AnnotationChip.vue
+++ b/web/src/components/run/AnnotationChip.vue
@@ -51,7 +51,7 @@ const showFieldLabel = computed(() => kind.value === 'field' && !!fieldLabel.val
   <span
     class="inline-flex max-w-full items-start gap-1 border px-1.5 py-0.5 text-[11px] leading-snug"
     :class="chipClass"
-    :title="ann.note || path || ann.quote || ''"
+    :title="ann.note || ann.url || path || ann.quote || ''"
     :data-testid="testId"
     :data-chip-kind="kind"
   >

--- a/web/src/components/run/AppPreviewPanel.vue
+++ b/web/src/components/run/AppPreviewPanel.vue
@@ -2,6 +2,7 @@
 import { ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { api, type PreviewPort } from '@/lib/api'
+import type { AppPreviewPickPayload } from '@/lib/previewPickUrl'
 import NovncPreviewPanel from './NovncPreviewPanel.vue'
 import PreviewFeedbackChat from './PreviewFeedbackChat.vue'
 
@@ -18,8 +19,8 @@ const props = withDefaults(
 )
 
 const emit = defineEmits<{
-  (e: 'pick', payload: { selector: string; tagName: string; outerHTML: string }): void
-  (e: 'staged-pick', payload: { selector: string; tagName: string; outerHTML: string } | null): void
+  (e: 'pick', payload: AppPreviewPickPayload): void
+  (e: 'staged-pick', payload: AppPreviewPickPayload | null): void
   (e: 'issues-changed'): void
 }>()
 
@@ -36,12 +37,12 @@ function isApiPort(p: PreviewPort): boolean {
   return label.includes('api')
 }
 
-function onPick(payload: { selector: string; tagName: string; outerHTML: string }) {
+function onPick(payload: AppPreviewPickPayload) {
   pickedSelector.value = payload.selector
   emit('pick', payload)
 }
 
-function onStagedPick(payload: { selector: string; tagName: string; outerHTML: string } | null) {
+function onStagedPick(payload: AppPreviewPickPayload | null) {
   if (payload) pickedSelector.value = payload.selector
   emit('staged-pick', payload)
 }

--- a/web/src/components/run/GateApproval.test.ts
+++ b/web/src/components/run/GateApproval.test.ts
@@ -2620,10 +2620,29 @@ describe('GateApproval app_preview reject without form', () => {
       selector: '#hero',
       tagName: 'DIV',
       outerHTML: '<div id="hero">x</div>',
+      url: 'http://127.0.0.1:5173/settings?tab=1',
     })
     await flushPromises()
-    // Annotation chip appears in review composer (selector label).
+    // Annotation chip: path · selector; full url stays on annotation.
+    expect(wrapper.text()).toContain('/settings?tab=1 · #hero')
+    const vm = wrapper.vm as any
+    expect(vm.reactAnnotations?.[0]?.url).toBe('http://127.0.0.1:5173/settings?tab=1')
+    wrapper.unmount()
+  })
+
+  it('hot app_preview VNC pick without url still stages selector', async () => {
+    const wrapper = appPreviewHotMount()
+    await flushPromises()
+    const panel = wrapper.findComponent({ name: 'AppPreviewPanel' })
+    await panel.vm.$emit('pick', {
+      selector: '#hero',
+      tagName: 'DIV',
+      outerHTML: '<div id="hero">x</div>',
+    })
+    await flushPromises()
     expect(wrapper.text()).toContain('#hero')
+    const vm = wrapper.vm as any
+    expect(vm.reactAnnotations?.[0]?.url).toBeUndefined()
     wrapper.unmount()
   })
 

--- a/web/src/components/run/GateApproval.vue
+++ b/web/src/components/run/GateApproval.vue
@@ -64,6 +64,7 @@ import {
 } from '@/lib/gateUpstream'
 import GateProductEditor from './GateProductEditor.vue'
 import type { ClarifyImage, Gate, Run, ReactAnnotation } from '@/lib/types'
+import { previewPickLabel } from '@/lib/previewPickUrl'
 
 const props = defineProps<{
   gate: Gate
@@ -209,14 +210,21 @@ function onHtmlPreviewPick(payload: { selector: string; tagName: string; imageDa
   }
 }
 
-/** VNC/app_preview pick payload uses outerHTML (no imageDataUrl). */
-function onAppPreviewPick(payload: { selector: string; tagName: string; outerHTML: string }) {
+/** VNC/app_preview pick payload uses outerHTML (no imageDataUrl); url is page href at pick. */
+function onAppPreviewPick(payload: {
+  selector: string
+  tagName: string
+  outerHTML: string
+  url?: string
+}) {
   pickedSelector.value = payload.selector
   pickedElementImage.value = null
   if (canReactRevise.value) {
+    const url = (payload.url || '').trim()
     pushReactAnnotation({
       selector: payload.selector,
-      label: payload.selector || payload.tagName,
+      url: url || undefined,
+      label: previewPickLabel(url, payload.selector, payload.tagName),
     })
   }
 }

--- a/web/src/components/run/NovncPreviewPanel.vue
+++ b/web/src/components/run/NovncPreviewPanel.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { api } from '@/lib/api'
 import { PreviewVncChannel } from '@/lib/previewVncChannel'
 import { createPreviewFpsCounter } from '@/lib/previewFps'
+import type { AppPreviewPickPayload } from '@/lib/previewPickUrl'
 // @ts-expect-error noVNC ships without bundled types
 // Pinned to exact 1.5.0 (see package.json). Official path is HTTP + x11vnc -nopw
 // (None auth) + PreviewVncChannel demux. noVNC's Secure Context Log.Error is
@@ -26,9 +27,9 @@ const props = withDefaults(
 )
 
 const emit = defineEmits<{
-  (e: 'pick', payload: { selector: string; tagName: string; outerHTML: string }): void
+  (e: 'pick', payload: AppPreviewPickPayload): void
   /** Element picked in inspect mode but not yet added to chat (last staged). */
-  (e: 'staged-pick', payload: { selector: string; tagName: string; outerHTML: string } | null): void
+  (e: 'staged-pick', payload: AppPreviewPickPayload | null): void
 }>()
 
 const { t } = useI18n()
@@ -42,7 +43,7 @@ const isFullscreen = ref(false)
 const status = ref<'connecting' | 'live' | 'closed' | 'error'>('connecting')
 const statusMsg = ref('')
 const inspect = ref(false)
-const picked = ref<{ selector: string; tagName: string; outerHTML: string } | null>(null)
+const picked = ref<AppPreviewPickPayload | null>(null)
 const address = ref('about:blank')
 
 let rfb: InstanceType<typeof RFB> | null = null
@@ -109,6 +110,9 @@ function handleCtrlText(data: string) {
       break
     case 'picked':
       picked.value = msg.pick
+      if (typeof msg.pick?.url === 'string' && msg.pick.url) {
+        address.value = msg.pick.url
+      }
       // Server already left inspect mode after one-shot pick.
       clearInspect('picked', { syncRemote: false })
       if (msg.pick) emit('staged-pick', msg.pick)

--- a/web/src/lib/previewPickUrl.test.ts
+++ b/web/src/lib/previewPickUrl.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { previewPickLabel, previewPickPath } from './previewPickUrl'
+
+describe('previewPickPath', () => {
+  it('extracts pathname+search+hash', () => {
+    expect(previewPickPath('http://127.0.0.1:5173/settings?tab=1#x')).toBe('/settings?tab=1#x')
+  })
+
+  it('returns / for root', () => {
+    expect(previewPickPath('http://127.0.0.1:3000/')).toBe('/')
+  })
+
+  it('accepts already-relative paths', () => {
+    expect(previewPickPath('/app/home')).toBe('/app/home')
+  })
+
+  it('returns empty for blank or opaque', () => {
+    expect(previewPickPath('')).toBe('')
+    expect(previewPickPath('not a url')).toBe('')
+  })
+})
+
+describe('previewPickLabel', () => {
+  it('joins path and selector', () => {
+    expect(previewPickLabel('http://127.0.0.1:5173/settings', '#hero', 'div')).toBe(
+      '/settings · #hero',
+    )
+  })
+
+  it('falls back to selector when url missing', () => {
+    expect(previewPickLabel('', '#hero', 'div')).toBe('#hero')
+  })
+})

--- a/web/src/lib/previewPickUrl.ts
+++ b/web/src/lib/previewPickUrl.ts
@@ -1,0 +1,35 @@
+/**
+ * Path (+ search + hash) from a full href for compact pick/chip labels.
+ * Returns "" when href is empty or not a valid absolute URL.
+ */
+export function previewPickPath(href: string | undefined | null): string {
+  const raw = (href || '').trim()
+  if (!raw) return ''
+  try {
+    const u = new URL(raw)
+    return `${u.pathname}${u.search}${u.hash}` || '/'
+  } catch {
+    // Relative or opaque — treat as already-path-like.
+    if (raw.startsWith('/')) return raw
+    return ''
+  }
+}
+
+/** Chip / annotation label: `path · selector`, or selector when path missing. */
+export function previewPickLabel(
+  href: string | undefined | null,
+  selector: string,
+  tagName?: string,
+): string {
+  const sel = (selector || '').trim() || (tagName || '').trim()
+  const path = previewPickPath(href)
+  if (path && sel) return `${path} · ${sel}`
+  return sel || path
+}
+
+export type AppPreviewPickPayload = {
+  selector: string
+  tagName: string
+  outerHTML: string
+  url?: string
+}

--- a/web/src/lib/reviewQuote.test.ts
+++ b/web/src/lib/reviewQuote.test.ts
@@ -25,6 +25,23 @@ describe('reviewQuote', () => {
     expect(annotationDedupeKey({ quote: 'a' })).toBe('quote||a')
     expect(annotationDedupeKey({ jsonPath: 'summary' })).toBe('field|summary')
     expect(annotationDedupeKey({ selector: '#hero' })).toBe('field|#hero')
+    expect(annotationDedupeKey({ selector: '#hero', url: 'http://127.0.0.1/a' })).toBe(
+      'field|#hero|http://127.0.0.1/a',
+    )
+  })
+
+  it('allows same selector on different page urls', () => {
+    const list: Parameters<typeof pushAnnotationUnique>[0] = []
+    expect(
+      pushAnnotationUnique(list, { selector: '#hero', url: 'http://127.0.0.1/a', label: 'a' }),
+    ).toBe('added')
+    expect(
+      pushAnnotationUnique(list, { selector: '#hero', url: 'http://127.0.0.1/b', label: 'b' }),
+    ).toBe('added')
+    expect(
+      pushAnnotationUnique(list, { selector: '#hero', url: 'http://127.0.0.1/a', label: 'again' }),
+    ).toBe('duplicate')
+    expect(list).toHaveLength(2)
   })
 
   it('allows multiple quotes on the same path and rejects exact duplicates', () => {

--- a/web/src/lib/reviewQuote.ts
+++ b/web/src/lib/reviewQuote.ts
@@ -26,13 +26,15 @@ export function isQuoteAnnotation(ann: ReactAnnotation): boolean {
 /**
  * Dedup key:
  * - quote annotations → quote + path (path may be empty for unbound)
- * - whole-field / selector → path/selector only
+ * - whole-field / selector → path/selector + optional page url (SPA pick)
  */
 export function annotationDedupeKey(ann: ReactAnnotation): string {
   if (isQuoteAnnotation(ann)) {
     return `quote|${ann.jsonPath || ''}|${(ann.quote || '').trim()}`
   }
-  return `field|${ann.jsonPath || ann.selector || ''}`
+  const ref = ann.jsonPath || ann.selector || ''
+  const page = (ann.url || '').trim()
+  return page ? `field|${ref}|${page}` : `field|${ref}`
 }
 
 /** Apply quote soft-cap; leave field/selector annotations unchanged. */

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -542,6 +542,8 @@ export interface ReactQuestion {
 export interface ReactAnnotation {
   jsonPath?: string
   selector?: string
+  /** Page location.href at DOM pick time (SPA navigations). */
+  url?: string
   label?: string
   note?: string
   /** Paragraph excerpt from a text selection ("添加到聊天"). */

--- a/web/src/views/GatesInboxView.vue
+++ b/web/src/views/GatesInboxView.vue
@@ -28,6 +28,7 @@ import { useTagFilter } from '@/lib/useTagFilter'
 import { useProjectContext } from '@/lib/useProjectContext'
 import { usePendingGates } from '@/lib/usePendingGates'
 import { addClarifyAnnotation, useClarifyDraft } from '@/lib/useClarifyDraft'
+import { previewPickLabel, type AppPreviewPickPayload } from '@/lib/previewPickUrl'
 import { useBreakpoint } from '@/lib/useBreakpoint'
 import { relTime } from '@/lib/format'
 import {
@@ -382,11 +383,7 @@ const {
 )
 
 /** VNC pick on app_preview inbox stage → same ReAct annotation chips as Run review. */
-const lastStagedAppPreviewPick = ref<{
-  selector: string
-  tagName: string
-  outerHTML: string
-} | null>(null)
+const lastStagedAppPreviewPick = ref<AppPreviewPickPayload | null>(null)
 
 watch(
   () => (active.value ? itemKey(active.value) : ''),
@@ -395,19 +392,19 @@ watch(
   },
 )
 
-function onAppPreviewStagedPick(
-  payload: { selector: string; tagName: string; outerHTML: string } | null,
-) {
+function onAppPreviewStagedPick(payload: AppPreviewPickPayload | null) {
   lastStagedAppPreviewPick.value = payload
 }
 
-function onAppPreviewReviewPick(payload: { selector: string; tagName: string; outerHTML: string }) {
+function onAppPreviewReviewPick(payload: AppPreviewPickPayload) {
   const rid = active.value?.type === 'clarify' ? active.value.runId : ''
   const nid = active.value?.type === 'clarify' ? active.value.nodeId : ''
   if (!rid || !nid) return
+  const url = (payload.url || '').trim()
   const result = addClarifyAnnotation(rid, nid, {
     selector: payload.selector,
-    label: payload.selector || payload.tagName,
+    url: url || undefined,
+    label: previewPickLabel(url, payload.selector, payload.tagName),
   })
   if (result === 'duplicate') toast.warn(t('pages.reviewComposer.alreadyAdded'))
   lastStagedAppPreviewPick.value = null
@@ -418,10 +415,21 @@ function mergeStagedAppPreviewPick(
 ): import('@/lib/types').ReactAnnotation[] {
   const staged = lastStagedAppPreviewPick.value
   if (!staged?.selector) return annotations
-  if (annotations.some((a) => a.selector === staged.selector)) return annotations
+  const url = (staged.url || '').trim()
+  if (
+    annotations.some(
+      (a) => a.selector === staged.selector && (a.url || '').trim() === url,
+    )
+  ) {
+    return annotations
+  }
   return [
     ...annotations,
-    { selector: staged.selector, label: staged.selector || staged.tagName },
+    {
+      selector: staged.selector,
+      url: url || undefined,
+      label: previewPickLabel(url, staged.selector, staged.tagName),
+    },
   ]
 }
 

--- a/web/src/views/RunDetailView.vue
+++ b/web/src/views/RunDetailView.vue
@@ -38,6 +38,7 @@ import {
 } from '@/lib/reviewLayoutBudget'
 import { useBreakpoint } from '@/lib/useBreakpoint'
 import { addClarifyAnnotation, useClarifyDraft } from '@/lib/useClarifyDraft'
+import { previewPickLabel, type AppPreviewPickPayload } from '@/lib/previewPickUrl'
 import { NODE_DEFS } from '@/data/nodeRegistry'
 import { resolveNodeDisplayLabelFromNode } from '@/lib/resolveNodeDisplayLabel'
 import { fmtTime, fmtDuration, formatTrigger } from '@/lib/format'
@@ -1472,25 +1473,21 @@ const showRunFailureBanner = computed(() => !!runFailureReason.value)
 const { draft: clarifyDraft, attachments: clarifyAttachments, annotations: clarifyAnnotations } = useClarifyDraft(() => runId.value, () => selected.value)
 
 /** VNC pick on app_preview review stage → same ReAct annotation chips as structured ⤴. */
-const lastStagedAppPreviewPick = ref<{
-  selector: string
-  tagName: string
-  outerHTML: string
-} | null>(null)
+const lastStagedAppPreviewPick = ref<AppPreviewPickPayload | null>(null)
 
-function onAppPreviewStagedPick(
-  payload: { selector: string; tagName: string; outerHTML: string } | null,
-) {
+function onAppPreviewStagedPick(payload: AppPreviewPickPayload | null) {
   lastStagedAppPreviewPick.value = payload
 }
 
-function onAppPreviewReviewPick(payload: { selector: string; tagName: string; outerHTML: string }) {
+function onAppPreviewReviewPick(payload: AppPreviewPickPayload) {
   const rid = run.value?.id
   const nid = selNode.value?.id
   if (!rid || !nid) return
+  const url = (payload.url || '').trim()
   const result = addClarifyAnnotation(rid, nid, {
     selector: payload.selector,
-    label: payload.selector || payload.tagName,
+    url: url || undefined,
+    label: previewPickLabel(url, payload.selector, payload.tagName),
   })
   if (result === 'duplicate') toast.warn(t('pages.reviewComposer.alreadyAdded'))
   // Added to pending chips — clear staged so send won't double-attach.
@@ -1502,10 +1499,21 @@ function mergeStagedAppPreviewPick(
 ): import('@/lib/types').ReactAnnotation[] {
   const staged = lastStagedAppPreviewPick.value
   if (!staged?.selector) return annotations
-  if (annotations.some((a) => a.selector === staged.selector)) return annotations
+  const url = (staged.url || '').trim()
+  if (
+    annotations.some(
+      (a) => a.selector === staged.selector && (a.url || '').trim() === url,
+    )
+  ) {
+    return annotations
+  }
   return [
     ...annotations,
-    { selector: staged.selector, label: staged.selector || staged.tagName },
+    {
+      selector: staged.selector,
+      url: url || undefined,
+      label: previewPickLabel(url, staged.selector, staged.tagName),
+    },
   ]
 }
 // Every sandbox-backed node (all "Agent" category types: agent/react/plan/


### PR DESCRIPTION
## Summary
- CDP `Pick` 在取点瞬间写入 `location.href`，经 noVNC WS 传到前端
- `ReactAnnotation.url` + `RenderAnnotations` 输出「页面 URL」，chip label 为 `path · selector`
- 同一 selector 在不同页面 URL 可并存（去重键含 url）

## Test plan
- [ ] 打开 app_preview 复审 → noVNC 跳转到子路由后取点，chip 显示 `/path · #selector`
- [ ] 发送 ReAct 修改，Agent 提示中含 `页面 URL: http://127.0.0.1:...`
- [ ] 无 url 的旧 pick 仍可 staging
- [ ] `go test ./internal/models/ ./internal/browser/`
- [ ] `npm test -- --run src/lib/previewPickUrl.test.ts src/lib/reviewQuote.test.ts src/components/run/GateApproval.test.ts`


Made with [Cursor](https://cursor.com)