### PR TITLE
fix(deps): 清除 js-yaml GHSA-5p4m 受影响版本

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -86,9 +86,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",

--- a/web/package.json
+++ b/web/package.json
@@ -57,7 +57,8 @@
   },
   "overrides": {
     "brace-expansion": "^5.0.9",
-    "minimatch": "^10.2.5"
+    "minimatch": "^10.2.5",
+    "js-yaml": "^4.3.1"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
docs lock 将 gray-matter 传递的 js-yaml 从 3.15.0 升到 3.15.1；
web overrides 增加 ^4.3.1，防止 ESLint 传递链回退到 4.3.0。

Co-authored-by: Cursor <cursoragent@cursor.com>
