### PR TITLE
fix(web): 概览看板桌面拉满 KPI 下方剩余视口

### DIFF
--- a/web/src/components/board/RunBoardColumn.test.ts
+++ b/web/src/components/board/RunBoardColumn.test.ts
@@ -96,7 +96,31 @@ describe('RunBoardColumn', () => {
     const body = wrapper.find('[data-testid="run-board-column-body"]')
     expect(body.exists()).toBe(true)
     expect((body.element as HTMLElement).style.maxHeight).toMatch(/min\(\s*52vh\s*,\s*420px\s*\)/)
+    expect(wrapper.find('[data-testid="run-board-column"]').classes()).not.toContain('h-full')
     expect(wrapper.text()).not.toMatch(/列内可独立滚动/)
+    wrapper.unmount()
+  })
+
+  it('fill mode drops max-height, stretches outer, and keeps column-body overflow-y', () => {
+    const wrapper = mountColumn({
+      fill: true,
+      items: [
+        stubRun({ id: 'run-1', status: 'completed', title: '完成-1' }),
+        stubRun({ id: 'run-2', status: 'completed', title: '完成-2' }),
+      ],
+      total: 2,
+    })
+
+    const root = wrapper.find('[data-testid="run-board-column"]')
+    expect(root.classes()).toContain('h-full')
+
+    const body = wrapper.find('[data-testid="run-board-column-body"]')
+    expect(body.exists()).toBe(true)
+    expect(body.classes()).toContain('overflow-y-auto')
+    expect(body.classes()).toContain('min-h-0')
+    expect(body.classes()).toContain('flex-1')
+    expect((body.element as HTMLElement).style.maxHeight).toBe('')
+
     wrapper.unmount()
   })
 })

--- a/web/src/components/board/RunBoardColumn.vue
+++ b/web/src/components/board/RunBoardColumn.vue
@@ -14,8 +14,10 @@ const props = withDefaults(
     total?: number
     loading?: boolean
     loadingText?: string
+    /** Fill parent height without max-height cap (dashboard preview only). */
+    fill?: boolean
   }>(),
-  { accent: 'extra', total: 0, loading: false },
+  { accent: 'extra', total: 0, loading: false, fill: false },
 )
 
 const emit = defineEmits<{ (e: 'select', run: Run): void }>()
@@ -40,7 +42,7 @@ function badgeLabel(): string {
 <template>
   <div
     class="flex min-h-[200px] flex-col border border-line bg-base"
-    :class="accentClass[accent] || accentClass.extra"
+    :class="[accentClass[accent] || accentClass.extra, fill ? 'h-full' : '']"
     data-testid="run-board-column"
   >
     <div class="flex items-center gap-2 border-b border-line bg-surface px-3 py-2.5">
@@ -55,7 +57,7 @@ function badgeLabel(): string {
     </div>
     <div
       class="scroll-area flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-2.5"
-      style="max-height: min(52vh, 420px)"
+      :style="fill ? undefined : { maxHeight: 'min(52vh, 420px)' }"
       data-testid="run-board-column-body"
     >
       <template v-if="loading && !items.length">

--- a/web/src/views/DashboardView.fill.test.ts
+++ b/web/src/views/DashboardView.fill.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const dir = dirname(fileURLToPath(import.meta.url))
+const src = readFileSync(join(dir, 'DashboardView.vue'), 'utf8')
+const boardSrc = readFileSync(join(dir, 'BoardView.vue'), 'utf8')
+const shellSrc = readFileSync(join(dir, '../components/shell/AppShell.vue'), 'utf8')
+
+describe('DashboardView desktop fill height chain (g1 / g2)', () => {
+  it('root uses md+ flex fill without overflow-hidden', () => {
+    expect(src).toMatch(/data-testid="dashboard-view"[^>]*class="[^"]*flex flex-col md:h-full md:min-h-0/)
+    expect(src).not.toMatch(/data-testid="dashboard-view"[^>]*overflow-hidden/)
+    expect(src).not.toMatch(/calc\(100vh/)
+  })
+
+  it('keeps title, KPI, and error bar shrink-0', () => {
+    expect(src).toMatch(/mb-5 flex shrink-0 items-center justify-between/)
+    expect(src).toMatch(/mb-6 grid shrink-0 grid-cols-2/)
+    expect(src).toMatch(/mb-4 flex shrink-0 flex-wrap/)
+  })
+
+  it('board card flex-1 only when hasProject; empty state stays natural height', () => {
+    expect(src).toMatch(
+      /:class="hasProject \? 'md:flex md:min-h-0 md:flex-1 md:flex-col md:overflow-hidden' : ''"/,
+    )
+    expect(src).toMatch(/data-testid="dashboard-board-empty"/)
+    expect(src).toMatch(/data-testid="dashboard-select-project"/)
+    expect(src).toMatch(/pages\.dashboard\.noProjectBoard/)
+    expect(src).toMatch(/pages\.dashboard\.selectProject/)
+  })
+
+  it('desktop dual columns stretch; small screen keeps items-start', () => {
+    expect(src).toMatch(
+      /grid grid-cols-1 items-start gap-3\.5 md:grid-cols-2 md:min-h-0 md:flex-1 md:items-stretch/,
+    )
+    expect(src).not.toMatch(/grid grid-cols-1 items-stretch/)
+  })
+
+  it('passes fill to both overview columns only', () => {
+    const fillBindings = src.match(/:fill="true"/g) || []
+    expect(fillBindings.length).toBe(2)
+    expect(boardSrc).not.toMatch(/:fill(?:="true")?/)
+  })
+
+  it('keeps full-board entry, preview drawer, and KPI wiring unchanged', () => {
+    expect(src).toMatch(/data-testid="dashboard-view-full-board"/)
+    expect(src).toMatch(/RunBoardPreviewDrawer/)
+    expect(src).toMatch(/pages\.dashboard\.kpi\.running/)
+    expect(src).toMatch(/pages\.dashboard\.kpi\.waitingHuman/)
+    expect(src).toMatch(/pages\.dashboard\.kpi\.failed/)
+    expect(src).toMatch(/pages\.dashboard\.kpi\.completed/)
+    expect(src).toMatch(/query: \{ tab: 'board' \}/)
+  })
+})
+
+describe('BoardView / AppShell unchanged by dashboard fill (g3.3)', () => {
+  it('does not alter AppShell height chain', () => {
+    expect(shellSrc).toMatch(/h-screen/)
+    expect(shellSrc).toMatch(/min-h-0 flex-1/)
+  })
+
+  it('full board still uses default RunBoardColumn without fill', () => {
+    expect(boardSrc).toMatch(/<RunBoardColumn/)
+    expect(boardSrc).not.toMatch(/:fill/)
+  })
+})

--- a/web/src/views/DashboardView.vue
+++ b/web/src/views/DashboardView.vue
@@ -102,8 +102,8 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div data-testid="dashboard-view">
-    <div class="mb-5 flex items-center justify-between">
+  <div data-testid="dashboard-view" class="flex flex-col md:h-full md:min-h-0">
+    <div class="mb-5 flex shrink-0 items-center justify-between">
       <div>
         <h2 class="text-lg font-semibold text-txt">{{ t('pages.dashboard.title') }}</h2>
         <p class="text-sm text-txt3">{{ t('pages.dashboard.subtitle') }}</p>
@@ -112,7 +112,7 @@ onUnmounted(() => {
 
     <div
       v-if="loadError"
-      class="mb-4 flex flex-wrap items-center justify-between gap-2 border border-err/40 bg-err/10 px-3 py-2 text-[13px] text-err"
+      class="mb-4 flex shrink-0 flex-wrap items-center justify-between gap-2 border border-err/40 bg-err/10 px-3 py-2 text-[13px] text-err"
       data-testid="dashboard-load-error"
     >
       <span>{{ t('pages.board.loadFailed') }}</span>
@@ -126,7 +126,7 @@ onUnmounted(() => {
       </button>
     </div>
 
-    <div class="mb-6 grid grid-cols-2 gap-4 md:grid-cols-4">
+    <div class="mb-6 grid shrink-0 grid-cols-2 gap-4 md:grid-cols-4">
       <div v-for="k in kpis" :key="k.label" class="card p-4">
         <div class="flex items-center justify-between">
           <span class="text-[13px] text-txt2">{{ k.label }}</span>
@@ -136,8 +136,11 @@ onUnmounted(() => {
       </div>
     </div>
 
-    <div class="card">
-      <div class="flex items-center justify-between border-b border-line px-5 py-3">
+    <div
+      class="card"
+      :class="hasProject ? 'md:flex md:min-h-0 md:flex-1 md:flex-col md:overflow-hidden' : ''"
+    >
+      <div class="flex shrink-0 items-center justify-between border-b border-line px-5 py-3">
         <h3 class="text-sm font-semibold text-txt">{{ t('pages.dashboard.boardTitle') }}</h3>
         <button
           v-if="hasProject"
@@ -148,7 +151,10 @@ onUnmounted(() => {
           {{ t('pages.dashboard.viewFullBoard') }}
         </button>
       </div>
-      <div class="p-3.5">
+      <div
+        class="p-3.5"
+        :class="hasProject ? 'md:flex md:min-h-0 md:flex-1 md:flex-col' : ''"
+      >
         <div
           v-if="!hasProject"
           class="flex flex-col items-center justify-center gap-3 px-4 py-10 text-center"
@@ -164,7 +170,10 @@ onUnmounted(() => {
             {{ t('pages.dashboard.selectProject') }}
           </button>
         </div>
-        <div v-else class="grid grid-cols-1 items-start gap-3.5 md:grid-cols-2">
+        <div
+          v-else
+          class="grid grid-cols-1 items-start gap-3.5 md:grid-cols-2 md:min-h-0 md:flex-1 md:items-stretch"
+        >
           <RunBoardColumn
             :title="t('pages.board.columns.active')"
             :hint="t('pages.board.hints.active')"
@@ -174,6 +183,7 @@ onUnmounted(() => {
             :loading="showInitialLoading"
             :loading-text="t('pages.board.loading')"
             :empty-text="t('pages.board.empty.active')"
+            :fill="true"
             @select="openPreview"
           />
           <RunBoardColumn
@@ -185,6 +195,7 @@ onUnmounted(() => {
             :loading="showInitialLoading"
             :loading-text="t('pages.board.loading')"
             :empty-text="t('pages.board.empty.completed')"
+            :fill="true"
             @select="openPreview"
           />
         </div>


### PR DESCRIPTION
打通 DashboardView md+ 高度链，并为 RunBoardColumn 增加仅概览开启的 fill，消除看板下方大块留白；完整看板 max-height 与 pageSize=5 不变。

Co-authored-by: Cursor <cursoragent@cursor.com>
