### PR TITLE
feat(web): move Agent Studio env/credential help into AppModal

### DIFF
--- a/web/e2e/agent-create-wizard.spec.ts
+++ b/web/e2e/agent-create-wizard.spec.ts
@@ -51,8 +51,22 @@ test('新建 Agent 五步向导浏览器验收', async ({ page }) => {
   const gitBody = await page.locator('.step-pane').innerText()
   expect(gitBody).not.toContain('未逐仓解析')
   expect(gitBody).not.toContain('无法在此页面逐仓解析')
+  expect(gitBody).not.toContain('不会验证变量引用的实际值')
+  expect(gitBody).not.toContain('远端 clone / push 权限')
   await expect(page.getByText(/GitHub|GitLab|SSH/).first()).toBeVisible()
+  await expect(page.locator('[data-test="git-help-link"]')).toBeVisible()
   await page.screenshot({ path: path.join(OUT, '04-git.png'), fullPage: true })
+
+  await page.locator('[data-test="git-help-link"]').click()
+  await expect(page.getByText('环境变量与凭据')).toBeVisible()
+  await expect(page.getByText(/GITHUB_TOKEN|凭据可通过环境变量/)).toBeVisible()
+  await expect(page.getByText(/不会验证变量引用的实际值|远端 clone/)).toBeVisible()
+  await expect(page.locator('.wiz-rail')).toBeVisible()
+  await expect(page.locator('.sec-head h3')).toHaveText('Git')
+  await page.locator('[data-test="env-help-got-it"]').click()
+  await expect(page.getByText('环境变量与凭据')).toHaveCount(0)
+  await expect(page.locator('.wiz-rail')).toBeVisible()
+  await expect(page.locator('.sec-head h3')).toHaveText('Git')
 
   // Select GitLab + add recommended vars (runtime ${vars.repos}) and assert no dead-end badge.
   await page.getByRole('button', { name: /调整类型/ }).click()

--- a/web/src/components/agent/AgentCreateWizard.test.ts
+++ b/web/src/components/agent/AgentCreateWizard.test.ts
@@ -143,6 +143,42 @@ describe('AgentCreateWizard 5-step IA', () => {
     wrapper.unmount()
   })
 
+  it('Git step help stacks on wizard and does not close or reset it', async () => {
+    const wrapper = mountWizard()
+    fillName('help-agent')
+    await wrapper.vm.$nextTick()
+    buttonByText('下一步').click()
+    await wrapper.vm.$nextTick()
+    buttonByText('下一步').click()
+    await wrapper.vm.$nextTick()
+    buttonByText('跳过').click()
+    await wrapper.vm.$nextTick()
+
+    expect(document.body.textContent).toContain('Git')
+    expect(document.body.textContent).not.toContain('不会验证变量引用的实际值')
+    const helpLink = document.body.querySelector('[data-test="git-help-link"]') as HTMLButtonElement
+    expect(helpLink?.textContent?.trim()).toBe('帮助')
+    helpLink.click()
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+
+    expect(document.body.textContent).toContain('环境变量与凭据')
+    expect(document.body.textContent).toContain('不会验证变量引用的实际值')
+    expect(document.body.querySelectorAll('[data-test="env-credential-help"]')).toHaveLength(1)
+    expect(document.body.querySelector('.wiz-root')).toBeTruthy()
+    expect(railLabels()).toEqual(['基础信息', 'Agent', 'API Key', 'Git', '确认创建'])
+
+    const gotIt = document.body.querySelector('[data-test="env-help-got-it"]') as HTMLButtonElement
+    gotIt.click()
+    await wrapper.vm.$nextTick()
+
+    expect(document.body.querySelector('[data-test="env-credential-help"]')).toBeFalsy()
+    expect(document.body.querySelector('.wiz-root')).toBeTruthy()
+    expect(document.body.textContent).toContain('Git')
+    expect(railLabels()).toEqual(['基础信息', 'Agent', 'API Key', 'Git', '确认创建'])
+    wrapper.unmount()
+  })
+
   it('renders equivalent English site semantics and Agent step label', async () => {
     const wrapper = mountWizard('en')
     expect(railLabels()).toEqual(['Basics', 'Agent', 'API Key', 'Git', 'Confirm'])

--- a/web/src/components/agent/AgentCreateWizard.vue
+++ b/web/src/components/agent/AgentCreateWizard.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import Icon from '@/components/ui/Icon.vue'
 import AppButton from '@/components/ui/AppButton.vue'
 import AgentGitGuide from '@/components/agent/AgentGitGuide.vue'
+import EnvCredentialHelpModal from '@/components/agent/EnvCredentialHelpModal.vue'
 import { api, type Agent } from '@/lib/api'
 import {
   ACP_BACKENDS,
@@ -40,6 +41,7 @@ const creating = ref(false)
 const createError = ref('')
 const pendingAcp = ref<WizardBackendId | null>(null)
 const showAcpConfirm = ref(false)
+const envHelpOpen = ref(false)
 const stepAnimKey = ref(0)
 const apiKeyInput = ref('')
 
@@ -78,6 +80,7 @@ watch(
       creating.value = false
       pendingAcp.value = null
       showAcpConfirm.value = false
+      envHelpOpen.value = false
       apiKeyInput.value = ''
       stepAnimKey.value++
       nextTick(() => {
@@ -475,6 +478,7 @@ function chipClass(kind: string) {
                     "
                     :credential-type="draft.gitCredentialType"
                     @update:credential-type="onGitCredentialType"
+                    @help="envHelpOpen = true"
                   />
                 </template>
 
@@ -534,6 +538,14 @@ function chipClass(kind: string) {
           </div>
         </div>
       </div>
+
+      <EnvCredentialHelpModal
+        :open="open && envHelpOpen"
+        section="git"
+        :backend="draft.acpBackend"
+        elevated
+        @close="envHelpOpen = false"
+      />
 
       <div v-if="showAcpConfirm" class="fixed inset-0 z-[60] flex items-center justify-center p-4">
         <div class="absolute inset-0 bg-black/60" @click="cancelAcpSwitch" />

--- a/web/src/components/agent/AgentGitGuide.test.ts
+++ b/web/src/components/agent/AgentGitGuide.test.ts
@@ -47,15 +47,20 @@ describe('AgentGitGuide', () => {
     expect(wrapper.text()).not.toContain('凭据不完整')
   })
 
-  it('完整状态明确说明只做静态检查，不承诺 clone/push', () => {
+  it('完整状态不再内嵌静态检查长文，改为帮助入口', async () => {
     const wrapper = mountGuide([
       { k: 'GIT_REPOS', v: 'app|https://gitlab.com/acme/app.git|main' },
       { k: 'GITLAB_TOKEN', v: '${vars.gitlab_token}' },
     ])
     expect(wrapper.text()).toContain('配置形态完整')
-    expect(wrapper.text()).toContain('不会验证变量引用的实际值')
-    expect(wrapper.text()).toContain('远端 clone / push 权限')
+    expect(wrapper.text()).not.toContain('不会验证变量引用的实际值')
+    expect(wrapper.text()).not.toContain('远端 clone / push 权限')
     expect(wrapper.text()).not.toContain('可成功 clone')
+    const help = wrapper.get('[data-test="git-help-link"]')
+    expect(help.text()).toBe('帮助')
+    expect(help.attributes('type')).toBe('button')
+    await help.trigger('click')
+    expect(wrapper.emitted('help')).toEqual([['git']])
   })
 
   it('运行时引用未选类型时给出可操作指引，无未逐仓解析告警', () => {
@@ -66,6 +71,7 @@ describe('AgentGitGuide', () => {
     expect(wrapper.text()).toContain('请选择凭据类型')
     expect(wrapper.text()).toContain('GitHub / GitLab / SSH')
     expect(wrapper.text()).toContain('运行时解析')
+    expect(wrapper.text()).not.toContain('本页不逐仓展开')
     expect(wrapper.text()).not.toContain('未逐仓解析')
     expect(wrapper.text()).not.toContain('无法在此页面逐仓解析')
   })
@@ -78,7 +84,7 @@ describe('AgentGitGuide', () => {
     const wrapper = mountGuide(env)
     expect(wrapper.text()).toContain('请选择凭据类型')
 
-    await wrapper.get('header button').trigger('click')
+    await wrapper.findAll('header button').find((b) => b.text() === '调整类型')!.trigger('click')
     const radios = wrapper.findAll('input[type="radio"]')
     await radios[1].setValue()
     const buttons = wrapper.findAll('[data-test="modal"] button')

--- a/web/src/components/agent/AgentGitGuide.vue
+++ b/web/src/components/agent/AgentGitGuide.vue
@@ -24,6 +24,7 @@ const props = defineProps<{
 }>()
 const emit = defineEmits<{
   'update:credentialType': [value: GitCredentialType]
+  help: [section: 'git']
 }>()
 const { t } = useI18n()
 const showChooser = ref(false)
@@ -112,14 +113,24 @@ defineExpose({ isGitEnvKey })
 
 <template>
   <section class="mb-4 overflow-hidden rounded-lg border border-line bg-surface shadow-sm">
-    <header class="flex items-center gap-3 border-b border-line px-4 py-3">
+    <header class="flex items-start gap-3 border-b border-line px-4 py-3">
       <div class="min-w-0 flex-1">
         <div class="text-[13px] font-semibold text-txt">{{ t('pages.agentStudio.git.title') }}</div>
         <div class="mt-0.5 text-[11px] text-txt3">{{ t('pages.agentStudio.git.subtitle') }}</div>
       </div>
-      <AppButton size="sm" variant="outline" @click="openChooser">
-        {{ t('pages.agentStudio.git.adjustType') }}
-      </AppButton>
+      <div class="flex shrink-0 items-center gap-3">
+        <button
+          type="button"
+          class="bg-transparent p-0 text-[12px] text-accent-2 underline underline-offset-[3px] hover:text-[#c4b5fd] focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          data-test="git-help-link"
+          @click="emit('help', 'git')"
+        >
+          {{ t('pages.agentStudio.envHelp.link') }}
+        </button>
+        <AppButton size="sm" variant="outline" @click="openChooser">
+          {{ t('pages.agentStudio.git.adjustType') }}
+        </AppButton>
+      </div>
     </header>
 
     <div class="p-4">
@@ -152,10 +163,9 @@ defineExpose({ isGitEnvKey })
         v-if="showRuntimeResolveBadge"
         class="mt-3 rounded-lg border border-line bg-base/40 px-3.5 py-2.5 text-[11px] leading-5 text-txt2"
       >
-        <span class="mr-2 inline-block rounded bg-elevated px-1.5 py-0.5 text-[10px] text-txt3">
+        <span class="inline-block rounded bg-elevated px-1.5 py-0.5 text-[10px] text-txt3">
           {{ t('pages.agentStudio.git.runtimeResolve') }}
         </span>
-        {{ t('pages.agentStudio.git.runtimeResolveHint') }}
       </div>
 
       <div v-if="analysis.status !== 'disabled'" class="mt-3 rounded-lg border border-line">
@@ -181,9 +191,6 @@ defineExpose({ isGitEnvKey })
           </div>
         </div>
       </div>
-
-      <p class="mt-3 text-[11px] leading-5 text-txt3">{{ t('pages.agentStudio.git.envHint') }}</p>
-      <p class="mt-1.5 text-[11px] leading-5 text-txt3">{{ t('pages.agentStudio.git.boundary') }}</p>
     </div>
   </section>
 

--- a/web/src/components/agent/EnvCredentialHelpModal.test.ts
+++ b/web/src/components/agent/EnvCredentialHelpModal.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+import { nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it } from 'vitest'
+import common from '@/locales/zh-CN/common.json'
+import pages from '@/locales/zh-CN/pages.json'
+import commonEn from '@/locales/en/common.json'
+import pagesEn from '@/locales/en/pages.json'
+import EnvCredentialHelpModal from './EnvCredentialHelpModal.vue'
+
+function mountHelp(
+  props: Record<string, unknown> = {},
+  locale: 'zh-CN' | 'en' = 'zh-CN',
+) {
+  const i18n = createI18n({
+    legacy: false,
+    locale,
+    messages: {
+      'zh-CN': { ...common, ...pages },
+      en: { ...commonEn, ...pagesEn },
+    },
+  })
+  return mount(EnvCredentialHelpModal, {
+    props: { open: true, section: 'inject', ...props },
+    global: {
+      plugins: [i18n],
+      stubs: { Transition: false },
+    },
+    attachTo: document.body,
+  })
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('EnvCredentialHelpModal', () => {
+  it('opens as 640 AppModal with title, chips, Got-it footer and Esc close', async () => {
+    const wrapper = mountHelp({ section: 'inject' })
+    const dialog = document.body.querySelector('.fixed.inset-0 .relative.flex.max-h-\\[88vh\\]') as HTMLElement
+    expect(dialog).toBeTruthy()
+    expect(dialog.style.maxWidth).toBe('640px')
+    expect(document.body.textContent).toContain('环境变量与凭据')
+    expect(document.body.textContent).toContain('注入说明')
+    expect(document.body.textContent).toContain('Git 凭据')
+    expect(document.body.textContent).toContain('ACP 鉴权')
+    expect(document.body.textContent).toContain('知道了')
+    expect(document.body.textContent).toContain('环境变量会注入该 Agent 的沙箱容器')
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(wrapper.emitted('close')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('positions inject / git / acp sections and keeps a single instance when section changes', async () => {
+    const wrapper = mountHelp({ section: 'git' })
+    await nextTick()
+    expect(document.body.querySelectorAll('[data-test="env-credential-help"]')).toHaveLength(1)
+    expect(document.body.querySelector('[data-help-chip="git"]')?.className).toContain('border-accent')
+    expect(document.body.textContent).toContain('不会验证变量引用的实际值')
+    expect(document.body.textContent).toContain('远端 clone / push 权限')
+    expect(document.body.textContent).toContain('本页不逐仓展开')
+
+    await wrapper.setProps({ section: 'acp', backend: 'cursor' })
+    await nextTick()
+    expect(document.body.querySelectorAll('[data-test="env-credential-help"]')).toHaveLength(1)
+    expect(document.body.querySelector('[data-help-chip="acp"]')?.className).toContain('border-accent')
+    expect(document.body.textContent).toContain('APPROVING_CURSOR_API_KEY / CURSOR_API_KEY')
+    expect(document.body.textContent).toContain('Cursor ACP 鉴权')
+    expect(document.body.textContent).not.toMatch(/sk-[a-z0-9]{8,}/i)
+    wrapper.unmount()
+  })
+
+  it('invalid section still opens and stays on inject', async () => {
+    const wrapper = mountHelp({ section: 'nope' })
+    await nextTick()
+    expect(document.body.textContent).toContain('环境变量与凭据')
+    expect(document.body.querySelector('[data-help-chip="inject"]')?.className).toContain('border-accent')
+    wrapper.unmount()
+  })
+
+  it('chip click jumps chapter without closing', async () => {
+    const wrapper = mountHelp({ section: 'inject' })
+    await nextTick()
+    const gitChip = document.body.querySelector('[data-help-chip="git"]') as HTMLButtonElement
+    gitChip.click()
+    await nextTick()
+    expect(wrapper.emitted('close')).toBeUndefined()
+    expect(document.body.querySelector('[data-help-chip="git"]')?.className).toContain('border-accent')
+    wrapper.unmount()
+  })
+
+  it('English copy uses Help / Got it / Env & credentials', async () => {
+    const wrapper = mountHelp({ section: 'inject' }, 'en')
+    expect(document.body.textContent).toContain('Env & credentials')
+    expect(document.body.textContent).toContain('Got it')
+    expect(document.body.textContent).toContain('Injection')
+    expect(document.body.textContent).toContain('Git credentials')
+    expect(document.body.textContent).toContain('ACP auth')
+    wrapper.unmount()
+  })
+
+  it('elevated overlay sits at z-index 60 for wizard stacking', async () => {
+    const wrapper = mountHelp({ section: 'git', elevated: true })
+    await nextTick()
+    await nextTick()
+    const overlay = document.body.querySelector('.fixed.inset-0.flex.items-center') as HTMLElement
+    expect(overlay?.style.zIndex).toBe('60')
+    wrapper.unmount()
+  })
+})

--- a/web/src/components/agent/EnvCredentialHelpModal.vue
+++ b/web/src/components/agent/EnvCredentialHelpModal.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import AppButton from '@/components/ui/AppButton.vue'
+import AppModal from '@/components/ui/AppModal.vue'
+import { BACKEND_AUTH_HINTS } from '@/lib/backendAuthGuide'
+import type { BackendId } from '@/lib/regionPolicy'
+
+export type EnvCredentialHelpSection = 'inject' | 'git' | 'acp'
+
+const SECTIONS: EnvCredentialHelpSection[] = ['inject', 'git', 'acp']
+
+const props = withDefaults(
+  defineProps<{
+    open: boolean
+    section?: string | null
+    backend?: BackendId
+    /** Raise overlay above create-wizard (z-50) without changing AppModal API. */
+    elevated?: boolean
+  }>(),
+  { section: 'inject', backend: 'cursor', elevated: false },
+)
+
+const emit = defineEmits<{ close: [] }>()
+const { t } = useI18n()
+
+const modalRef = ref<{ scrollAreaEl: HTMLElement | null } | null>(null)
+const activeSection = ref<EnvCredentialHelpSection>('inject')
+let lastTrigger: HTMLElement | null = null
+
+function normalizeSection(raw: unknown): EnvCredentialHelpSection {
+  return raw === 'git' || raw === 'acp' || raw === 'inject' ? raw : 'inject'
+}
+
+const authHint = computed(() => BACKEND_AUTH_HINTS[props.backend || 'cursor'])
+const authKeysLabel = computed(() =>
+  authHint.value.alt ? `${authHint.value.key} / ${authHint.value.alt}` : authHint.value.key,
+)
+
+function bumpElevatedZ() {
+  if (!props.elevated) return
+  const overlay = modalRef.value?.scrollAreaEl?.closest('.fixed.inset-0') as HTMLElement | null
+  if (overlay) overlay.style.zIndex = '60'
+}
+
+async function scrollToSection(id: EnvCredentialHelpSection) {
+  activeSection.value = id
+  await nextTick()
+  bumpElevatedZ()
+  const root = modalRef.value?.scrollAreaEl
+  const el = root?.querySelector(`[data-help-section="${id}"]`) as HTMLElement | null
+  el?.scrollIntoView({ block: 'start' })
+}
+
+watch(
+  () => [props.open, props.section] as const,
+  async ([open]) => {
+    if (!open) return
+    await scrollToSection(normalizeSection(props.section))
+  },
+  { immediate: true },
+)
+
+watch(
+  () => props.open,
+  (open, wasOpen) => {
+    if (open && !wasOpen) {
+      lastTrigger = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    }
+    if (!open && wasOpen) {
+      nextTick(() => lastTrigger?.focus())
+    }
+  },
+)
+
+function onClose() {
+  emit('close')
+}
+
+function onChip(id: EnvCredentialHelpSection) {
+  void scrollToSection(id)
+}
+</script>
+
+<template>
+  <AppModal
+    ref="modalRef"
+    :open="open"
+    :title="t('pages.agentStudio.envHelp.title')"
+    :width="640"
+    close-on-esc
+    @close="onClose"
+  >
+    <div class="mb-3.5 flex flex-wrap gap-1.5" data-test="env-credential-help">
+      <button
+        v-for="id in SECTIONS"
+        :key="id"
+        type="button"
+        class="border px-2 py-1 text-[11px]"
+        :class="activeSection === id ? 'border-accent bg-accent-dim text-txt' : 'border-line bg-base text-txt2'"
+        :data-help-chip="id"
+        @click="onChip(id)"
+      >
+        {{ t(`pages.agentStudio.envHelp.chip.${id}`) }}
+      </button>
+    </div>
+
+    <section data-help-section="inject" class="mb-[18px] scroll-mt-2">
+      <h3 class="mb-2 mt-0 text-[13px] font-semibold text-txt">
+        {{ t('pages.agentStudio.envHelp.chip.inject') }}
+      </h3>
+      <p class="mb-2 mt-0 text-[13px] leading-[1.7] text-txt2">
+        {{ t('pages.agentStudio.env.hint') }}
+      </p>
+    </section>
+
+    <section data-help-section="git" class="mb-[18px] scroll-mt-2">
+      <h3 class="mb-2 mt-0 text-[13px] font-semibold text-txt">
+        {{ t('pages.agentStudio.envHelp.chip.git') }}
+      </h3>
+      <p class="mb-2 mt-0 text-[13px] leading-[1.7] text-txt2">
+        {{ t('pages.agentStudio.git.envHint') }}
+      </p>
+      <p class="mb-2 mt-0 text-[13px] leading-[1.7] text-txt2">
+        {{ t('pages.agentStudio.git.boundary') }}
+      </p>
+      <div class="border border-line bg-base px-3 py-2.5 text-[12px] text-txt2">
+        <b class="font-semibold text-txt">{{ t('pages.agentStudio.git.runtimeResolve') }}</b>
+        — {{ t('pages.agentStudio.git.runtimeResolveHint') }}
+      </div>
+    </section>
+
+    <section data-help-section="acp" class="scroll-mt-2">
+      <h3 class="mb-2 mt-0 text-[13px] font-semibold text-txt">
+        {{ t('pages.agentStudio.envHelp.chip.acp') }}
+      </h3>
+      <p class="mb-2 mt-0 text-[13px] leading-[1.7] text-txt2">
+        {{ t('pages.agentStudio.env.backendAuthIntro', { backend: backend || 'cursor' }) }}
+      </p>
+      <p class="mb-2 font-mono text-[12px] text-accent-2">{{ authKeysLabel }}</p>
+      <p class="m-0 text-[13px] leading-[1.7] text-txt2">
+        {{ authHint.note }} — {{ t('pages.agentStudio.env.backendAuthMasked') }}
+      </p>
+    </section>
+
+    <template #footer>
+      <AppButton variant="primary" data-test="env-help-got-it" @click="onClose">
+        {{ t('pages.agentStudio.envHelp.gotIt') }}
+      </AppButton>
+    </template>
+  </AppModal>
+</template>

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -1269,6 +1269,16 @@
         "add": "Add env var",
         "parseError": "Invalid env JSON:"
       },
+      "envHelp": {
+        "link": "Help",
+        "title": "Env & credentials",
+        "gotIt": "Got it",
+        "chip": {
+          "inject": "Injection",
+          "git": "Git credentials",
+          "acp": "ACP auth"
+        }
+      },
       "region": {
         "title": "Service site",
         "domestic": "China",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -1269,6 +1269,16 @@
         "add": "添加环境变量",
         "parseError": "环境变量 JSON 无法解析:"
       },
+      "envHelp": {
+        "link": "帮助",
+        "title": "环境变量与凭据",
+        "gotIt": "知道了",
+        "chip": {
+          "inject": "注入说明",
+          "git": "Git 凭据",
+          "acp": "ACP 鉴权"
+        }
+      },
       "region": {
         "title": "服务站点",
         "domestic": "国内站",

--- a/web/src/views/AgentStudioView.test.ts
+++ b/web/src/views/AgentStudioView.test.ts
@@ -1017,3 +1017,113 @@ describe('AgentStudio mobile core path', () => {
     wrapper.unmount()
   })
 })
+
+describe('AgentStudio env credential help', () => {
+  const HelpAppModalStub = defineComponent({
+    props: { open: Boolean, title: String, width: Number },
+    emits: ['close'],
+    template:
+      '<div v-if="open" data-test="env-help-modal" :data-width="width">' +
+      '<h2>{{ title }}</h2><div data-test="env-help-scroll"><slot /></div><slot name="footer" />' +
+      '</div>',
+  })
+  const GitGuideHelpStub = defineComponent({
+    emits: ['help', 'update:credentialType'],
+    template:
+      '<div data-test="git-guide"><button type="button" data-test="git-help-emit" @click="$emit(\'help\', \'git\')">帮助</button></div>',
+  })
+
+  async function mountStudioWithHelp() {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const router = await createStudioRouter()
+    return mount(AgentStudioView, {
+      global: {
+        plugins: [i18n, router],
+        stubs: {
+          AppButton: ButtonStub,
+          Icon: true,
+          AppModal: HelpAppModalStub,
+          CodeEditor: CodeEditorStub,
+          MarkdownSplitEditor: true,
+          ExplorerContextMenu: true,
+          AgentChatTester: true,
+          AgentGitGuide: GitGuideHelpStub,
+          AgentCreateWizard: true,
+          AgentOrgSidebar: true,
+          AgentDataPanel: true,
+        },
+      },
+    })
+  }
+
+  async function openEnvTab(wrapper: Awaited<ReturnType<typeof mountStudioWithHelp>>) {
+    await wrapper.findAll('button').find((item) => item.text().startsWith('环境变量'))!.trigger('click')
+    await flushPromises()
+  }
+
+  it('moves long copy into one help modal and jumps inject / git / acp', async () => {
+    mocks.listAgents.mockResolvedValue([agent('public')])
+    const wrapper = await mountStudioWithHelp()
+    await flushPromises()
+    await openEnvTab(wrapper)
+
+    expect(wrapper.get('[data-test="env-help-inject"]').text()).toBe('帮助')
+    expect(wrapper.get('[data-test="env-help-acp"]').text()).toBe('帮助')
+    expect(wrapper.text()).toContain('APPROVING_CODEBUDDY_API_KEY')
+    expect(wrapper.text()).not.toContain('环境变量会注入该 Agent 的沙箱容器')
+    expect(wrapper.text()).not.toContain('请在下方添加对应 Key')
+    expect(wrapper.text()).not.toContain('保存后写入 agent.json')
+
+    await wrapper.get('[data-test="env-help-inject"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.findAll('[data-test="env-help-modal"]')).toHaveLength(1)
+    expect(wrapper.get('[data-test="env-help-modal"]').attributes('data-width')).toBe('640')
+    expect(wrapper.get('[data-test="env-help-modal"]').text()).toContain('环境变量与凭据')
+    expect(wrapper.get('[data-help-chip="inject"]').classes().join(' ')).toContain('border-accent')
+    expect(wrapper.get('[data-test="env-help-modal"]').text()).toContain('环境变量会注入该 Agent 的沙箱容器')
+
+    await wrapper.get('[data-test="git-help-emit"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.findAll('[data-test="env-help-modal"]')).toHaveLength(1)
+    expect(wrapper.get('[data-help-chip="git"]').classes().join(' ')).toContain('border-accent')
+    expect(wrapper.get('[data-test="env-help-modal"]').text()).toContain('不会验证变量引用的实际值')
+
+    await wrapper.get('[data-test="env-help-acp"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.findAll('[data-test="env-help-modal"]')).toHaveLength(1)
+    expect(wrapper.get('[data-help-chip="acp"]').classes().join(' ')).toContain('border-accent')
+    expect(wrapper.get('[data-test="env-help-modal"]').text()).toContain('CodeBuddy ACP 鉴权')
+    wrapper.unmount()
+  })
+
+  it('keeps unsaved env draft after closing help', async () => {
+    mocks.listAgents.mockResolvedValue([agent('public')])
+    const wrapper = await mountStudioWithHelp()
+    await flushPromises()
+    await openEnvTab(wrapper)
+
+    await wrapper.findAll('button').find((item) => item.text() === '添加环境变量')!.trigger('click')
+    await flushPromises()
+    const keyInput = wrapper.findAll('input').find((el) => {
+      const node = el.element as HTMLInputElement
+      return node.placeholder === 'KEY' && !node.readOnly && node.value === ''
+    })!
+    await keyInput.setValue('MY_DRAFT_KEY')
+    expect((keyInput.element as HTMLInputElement).value).toBe('MY_DRAFT_KEY')
+
+    await wrapper.get('[data-test="env-help-inject"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-test="env-help-modal"]').exists()).toBe(true)
+    await wrapper.get('[data-test="env-help-got-it"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="env-help-modal"]').exists()).toBe(false)
+    const kept = wrapper.findAll('input').find((el) => (el.element as HTMLInputElement).value === 'MY_DRAFT_KEY')
+    expect(kept).toBeTruthy()
+    wrapper.unmount()
+  })
+})

--- a/web/src/views/AgentStudioView.vue
+++ b/web/src/views/AgentStudioView.vue
@@ -12,6 +12,9 @@ import AgentOrgSidebar from '@/components/agent/AgentOrgSidebar.vue'
 import AgentChatTester from '@/components/agent/AgentChatTester.vue'
 import AgentDataPanel, { type DataSubTab } from '@/components/agent/AgentDataPanel.vue'
 import AgentGitGuide from '@/components/agent/AgentGitGuide.vue'
+import EnvCredentialHelpModal, {
+  type EnvCredentialHelpSection,
+} from '@/components/agent/EnvCredentialHelpModal.vue'
 import AgentCreateWizard from '@/components/agent/AgentCreateWizard.vue'
 import { api, type Agent, type AgentOrg, type MCPServer, type AgentPrompts, type PlatformRuleMeta } from '@/lib/api'
 import { useBreakpoint } from '@/lib/useBreakpoint'
@@ -316,6 +319,14 @@ function selectAcpBackend(id: BackendId) {
 }
 
 const currentAuthHint = computed(() => BACKEND_AUTH_HINTS[draft.value?.acpBackend || 'cursor'])
+
+const envHelpOpen = ref(false)
+const envHelpSection = ref<EnvCredentialHelpSection>('inject')
+
+function openEnvHelp(section: EnvCredentialHelpSection) {
+  envHelpSection.value = section
+  envHelpOpen.value = true
+}
 
 function upsertEnv(key: string, value: string) {
   if (!draft.value) return
@@ -2336,7 +2347,15 @@ onBeforeUnmount(() => {
         <!-- env -->
         <div v-else-if="tab === 'env'" class="flex min-h-0 flex-1 flex-col">
           <div class="flex items-center gap-2 border-b border-line px-4 py-2">
-            <p class="flex-1 text-[11px] text-txt3">{{ t('pages.agentStudio.env.hint') }}</p>
+            <button
+              type="button"
+              class="bg-transparent p-0 text-[12px] text-accent-2 underline underline-offset-[3px] hover:text-[#c4b5fd] focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-accent"
+              data-test="env-help-inject"
+              @click="openEnvHelp('inject')"
+            >
+              {{ t('pages.agentStudio.envHelp.link') }}
+            </button>
+            <span class="flex-1" />
             <button class="rounded border border-line px-2 py-1 text-[11px] text-txt2 hover:border-line-strong" @click="toggleEnvRaw">{{ envRaw ? t('pages.agentStudio.mcp.formEdit') : t('pages.agentStudio.mcp.rawJson') }}</button>
           </div>
 
@@ -2350,12 +2369,21 @@ onBeforeUnmount(() => {
               :upsert-env="upsertEnv"
               :credential-type="draft.gitCredentialType"
               @update:credential-type="draft.gitCredentialType = $event"
+              @help="openEnvHelp('git')"
             />
             <div class="mb-3 rounded-lg border border-line bg-base/50 p-3 text-[11px] leading-6 text-txt3">
-              <div class="mb-1 font-medium text-txt2">{{ t('pages.agentStudio.env.backendAuthTitle') }}</div>
-              <p>{{ t('pages.agentStudio.env.backendAuthIntro', { backend: draft.acpBackend }) }}</p>
-              <p class="mt-1 font-mono text-accent-2">{{ currentAuthHint.key }}<span v-if="currentAuthHint.alt"> / {{ currentAuthHint.alt }}</span></p>
-              <p class="mt-1">{{ currentAuthHint.note }} — {{ t('pages.agentStudio.env.backendAuthMasked') }}</p>
+              <div class="mb-1 flex items-center justify-between gap-2">
+                <div class="font-medium text-txt2">{{ t('pages.agentStudio.env.backendAuthTitle') }}</div>
+                <button
+                  type="button"
+                  class="bg-transparent p-0 text-[12px] text-accent-2 underline underline-offset-[3px] hover:text-[#c4b5fd] focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                  data-test="env-help-acp"
+                  @click="openEnvHelp('acp')"
+                >
+                  {{ t('pages.agentStudio.envHelp.link') }}
+                </button>
+              </div>
+              <p class="font-mono text-accent-2">{{ currentAuthHint.key }}<span v-if="currentAuthHint.alt"> / {{ currentAuthHint.alt }}</span></p>
             </div>
             <template v-for="(e, i) in draft.env" :key="i">
               <div v-if="!isManagedRegionKey(e.k)" class="flex items-center gap-1.5">
@@ -3061,6 +3089,13 @@ onBeforeUnmount(() => {
       :existing-names="agents.map((a) => a.name)"
       @close="showCreateWizard = false"
       @created="onWizardCreated"
+    />
+
+    <EnvCredentialHelpModal
+      :open="envHelpOpen"
+      :section="envHelpSection"
+      :backend="draft?.acpBackend || 'cursor'"
+      @close="envHelpOpen = false"
     />
 
     <AppModal :open="showProjectSwitch" :title="t('pages.agentStudio.project.switchTitle')" :width="460" @close="cancelProjectChange">


### PR DESCRIPTION
Long inline hints crowded the env page and create-wizard Git step.
Open a shared 640-wide modal from three Help links so operators can
read inject/Git/ACP copy without leaving the config flow.

Co-authored-by: Cursor <cursoragent@cursor.com>
