### PR TITLE
feat(web): 去掉 Agent Studio 常驻说明并右对齐顶栏

### DIFF
--- a/web/src/components/agent/AgentOrgSidebar.test.ts
+++ b/web/src/components/agent/AgentOrgSidebar.test.ts
@@ -4,6 +4,8 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import common from '@/locales/zh-CN/common.json'
 import pages from '@/locales/zh-CN/pages.json'
+import enCommon from '@/locales/en/common.json'
+import enPages from '@/locales/en/pages.json'
 import type { AgentOrg } from '@/lib/api'
 import AgentOrgSidebar from './AgentOrgSidebar.vue'
 
@@ -294,6 +296,48 @@ describe('AgentOrgSidebar context menus', () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.emitted('remove-from-group')?.[0]).toEqual(['alice', 'g_dev'])
     wrapper.unmount()
+  })
+})
+
+describe('AgentOrgSidebar dragHint removal', () => {
+  function mountSidebarEn(org: AgentOrg = sampleOrg) {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'en',
+      messages: { en: { ...enCommon, ...enPages } },
+    })
+    return mount(AgentOrgSidebar, {
+      props: {
+        org,
+        agentNames,
+        activeName: '',
+        collapsed: false,
+      },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          Icon: { template: '<span class="icon" />' },
+          Teleport: true,
+        },
+      },
+    })
+  }
+
+  it('不再展示中文 dragHint 与虚线提示框', () => {
+    const wrapper = mountSidebar()
+    expect(wrapper.text()).not.toContain('拖拽 Agent 调整归属')
+    expect(wrapper.text()).not.toContain('真删请用顶栏 Agent 管理入口')
+    expect(wrapper.find('.scroll-area p.border-dashed').exists()).toBe(false)
+    expect(wrapper.html()).not.toContain('border-dashed border-line-strong')
+    expect(wrapper.find('[data-org-manage]').exists()).toBe(true)
+  })
+
+  it('不再展示英文 dragHint', () => {
+    const wrapper = mountSidebarEn()
+    expect(wrapper.text()).not.toContain('Drag agents to change membership')
+    expect(wrapper.text()).not.toContain('hard delete via the Agent management')
+    expect(wrapper.find('.scroll-area p.border-dashed').exists()).toBe(false)
+    expect(wrapper.text()).toContain('Ungrouped')
   })
 })
 

--- a/web/src/components/agent/AgentOrgSidebar.vue
+++ b/web/src/components/agent/AgentOrgSidebar.vue
@@ -369,10 +369,6 @@ function onDrop(e: DragEvent, row: OrgTreeRow) {
           </div>
         </template>
       </div>
-
-      <p class="mx-1 mt-2 border border-dashed border-line-strong/60 bg-white/[0.015] px-2.5 py-2 text-[11px] leading-relaxed text-txt3">
-        {{ t('pages.agentStudio.org.dragHint') }}
-      </p>
     </div>
 
     <Teleport to="body">

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -1106,7 +1106,6 @@
     },
     "agentStudio": {
       "title": "Agent Studio",
-      "subtitle": "Reusable agents: workspace (rules/skills/scripts), MCP, env. Nodes reference skill_profile; workspace is copied to {configRoot} in sandbox.",
       "errorPrefix": "Error:",
       "empty": "No agents. Click New agent or wait for default seed on first backend start.",
       "unsaved": "Unsaved",
@@ -1160,7 +1159,6 @@
         "deleteGroupMessage": "Delete group \"{name}\"? Subgroups promote to its parent; members move to the parent or become ungrouped.",
         "groupCycle": "Cannot move a group into itself or its descendants (cycle)",
         "reportingCycle": "Cannot set that parent: it would create a reporting cycle",
-        "dragHint": "Drag agents to change membership; drop on Ungrouped to clear all groups. Right-click a group or agent for org actions; hard delete via the Agent management icon in the header.",
         "removeFromGroup": "Remove from group",
         "removeFromGroupToast": "Removed from group and saved · entity kept",
         "manage": "Manage",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -1106,7 +1106,6 @@
     },
     "agentStudio": {
       "title": "Agent 管理",
-      "subtitle": "配置可复用的 Agent:工作目录(rules / skills / 脚本…)、MCP 服务、环境变量。节点通过 skill_profile 引用,运行时整个工作目录复制进沙箱 {configRoot}。",
       "errorPrefix": "出错:",
       "empty": "暂无 Agent。点击右上角\"新建 Agent\"创建,或后端首启会落盘默认 Agent。",
       "unsaved": "未保存",
@@ -1160,7 +1159,6 @@
         "deleteGroupMessage": "确定删除组「{name}」？子组将提升到其父级；仅属于该组的成员将迁入父组或进入未分组。",
         "groupCycle": "不能将组移入自身或其子孙（会形成环路）",
         "reportingCycle": "不能设置该上级：会形成汇报环路",
-        "dragHint": "拖拽 Agent 调整归属；拖到「未分组」清空全部组归属。右键组或 Agent 可进行组织操作；真删请用顶栏 Agent 管理入口。",
         "removeFromGroup": "移出本组",
         "removeFromGroupToast": "已移出本组并立即保存 · 实体仍在",
         "manage": "管理",

--- a/web/src/views/AgentStudioView.test.ts
+++ b/web/src/views/AgentStudioView.test.ts
@@ -6,6 +6,8 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import common from '@/locales/zh-CN/common.json'
 import pages from '@/locales/zh-CN/pages.json'
+import enCommon from '@/locales/en/common.json'
+import enPages from '@/locales/en/pages.json'
 import type { Agent } from '@/lib/api'
 
 const mocks = vi.hoisted(() => ({
@@ -1014,6 +1016,180 @@ describe('AgentStudio mobile core path', () => {
     expect(wrapper.find('[data-test="org-switch"]').exists()).toBe(true)
     expect(wrapper.text()).toContain('导入')
     expect(wrapper.text()).toContain('新建 Agent')
+    expect(wrapper.text()).not.toContain('配置可复用的 Agent')
+    expect(wrapper.text()).not.toContain('复制进沙箱')
+    wrapper.unmount()
+  })
+})
+
+describe('AgentStudio copy removal (subtitle + toolbar)', () => {
+  const subtitleZh = ['配置可复用的 Agent', '复制进沙箱', '/root/.cursor']
+  const subtitleEn = ['Reusable agents', 'copied to', '/root/.cursor']
+  const demoShell = [
+    '可复用 Agent 配置 · 组织与 skill_profile 引用',
+    '已拖入未分组',
+    'clearToast',
+  ]
+
+  function toolbar(wrapper: Awaited<ReturnType<typeof mountStudio>>) {
+    return wrapper.find('.mb-5.flex.shrink-0')
+  }
+
+  async function mountStudioEn() {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'en',
+      messages: { en: { ...enCommon, ...enPages } },
+    })
+    const router = await createStudioRouter()
+    return mount(AgentStudioView, {
+      global: {
+        plugins: [i18n, router],
+        stubs: {
+          AppButton: ButtonStub,
+          Icon: true,
+          AppModal: true,
+          CodeEditor: CodeEditorStub,
+          MarkdownSplitEditor: true,
+          ExplorerContextMenu: true,
+          AgentChatTester: true,
+          AgentGitGuide: true,
+          AgentCreateWizard: true,
+          AgentOrgSidebar: true,
+          AgentDataPanel: true,
+        },
+      },
+    })
+  }
+
+  it('hides zh subtitle, right-aligns desktop import/new, and does not add a page title', async () => {
+    mocks.listAgents.mockResolvedValue([agent('public')])
+    const wrapper = await mountStudio()
+    await flushPromises()
+
+    const text = wrapper.text()
+    for (const s of subtitleZh) expect(text).not.toContain(s)
+    for (const s of demoShell) expect(text).not.toContain(s)
+    expect(text).not.toMatch(/改前|改后/)
+    expect(wrapper.findAll('h1,h2').some((el) => /Agent\s*(管理|Studio)/i.test(el.text()))).toBe(false)
+
+    const bar = toolbar(wrapper)
+    expect(bar.exists()).toBe(true)
+    expect(bar.classes()).toContain('justify-end')
+    expect(bar.classes()).not.toContain('justify-between')
+    expect(bar.text()).toContain('导入')
+    expect(bar.text()).toContain('新建 Agent')
+    wrapper.unmount()
+  })
+
+  it('hides en subtitle and keeps Import / New agent', async () => {
+    mocks.listAgents.mockResolvedValue([agent('public')])
+    const wrapper = await mountStudioEn()
+    await flushPromises()
+
+    const text = wrapper.text()
+    for (const s of subtitleEn) expect(text).not.toContain(s)
+    expect(text).toContain('Import')
+    expect(text).toContain('New agent')
+    wrapper.unmount()
+  })
+})
+
+describe('AgentStudio org toast and remaining hints', () => {
+  const ModalStub = defineComponent({
+    props: { open: Boolean, title: String },
+    emits: ['close'],
+    template: '<div v-if="open" data-test="modal"><h2>{{ title }}</h2><slot /><slot name="footer" /></div>',
+  })
+  const SidebarStub = defineComponent({
+    emits: ['remove-from-group', 'move-agent', 'open-manage', 'select-agent'],
+    template:
+      '<div data-test="sidebar">' +
+      '<button data-test="remove-from-group" @click="$emit(\'remove-from-group\', \'legacy\', \'g1\')">remove</button>' +
+      '<button data-test="move-ungrouped" @click="$emit(\'move-agent\', \'legacy\', \'g1\', \'\')">ungroup</button>' +
+      '<button data-test="manage" @click="$emit(\'open-manage\')">manage</button>' +
+      '</div>',
+  })
+
+  async function mountHintStudio() {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const router = await createStudioRouter()
+    return mount(AgentStudioView, {
+      global: {
+        plugins: [i18n, router],
+        stubs: {
+          AppButton: ButtonStub,
+          Icon: true,
+          AppModal: ModalStub,
+          CodeEditor: CodeEditorStub,
+          MarkdownSplitEditor: true,
+          ExplorerContextMenu: true,
+          AgentChatTester: true,
+          AgentGitGuide: true,
+          AgentCreateWizard: true,
+          AgentOrgSidebar: SidebarStub,
+          AgentDataPanel: true,
+        },
+      },
+    })
+  }
+
+  beforeEach(() => {
+    mocks.listAgents.mockResolvedValue([agent('public')])
+    mocks.getAgentsOrg.mockResolvedValue({
+      revision: 1,
+      groups: [{ id: 'g1', name: 'Dev' }],
+      agents: { legacy: { groupIds: ['g1'] } },
+    })
+    mocks.saveAgentsOrg.mockImplementation(async (org: { revision?: number; groups?: unknown; agents?: unknown }) => ({
+      revision: (org.revision || 0) + 1,
+      groups: org.groups || [],
+      agents: org.agents || {},
+    }))
+  })
+
+  it('toasts on 移出本组 but not when dragging to ungrouped', async () => {
+    const wrapper = await mountHintStudio()
+    await flushPromises()
+
+    await wrapper.get('[data-test="move-ungrouped"]').trigger('click')
+    await flushPromises()
+    expect(document.body.textContent || '').not.toContain('已拖入未分组')
+    expect(document.body.textContent || '').not.toContain('已移出本组并立即保存')
+    expect(mocks.saveAgentsOrg).toHaveBeenCalled()
+
+    await wrapper.get('[data-test="remove-from-group"]').trigger('click')
+    await flushPromises()
+    expect(document.body.textContent || '').toContain('已移出本组并立即保存 · 实体仍在')
+    expect(document.body.textContent || '').not.toContain('已拖入未分组')
+    wrapper.unmount()
+  })
+
+  it('keeps MCP hint, platform-rules subtitle, manageIntro, and data/meta tabs', async () => {
+    const wrapper = await mountHintStudio()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('数据')
+    expect(wrapper.text()).toContain('元信息')
+    expect(wrapper.text()).not.toContain('可复用 Agent 配置 · 组织与 skill_profile 引用')
+    expect(wrapper.text()).not.toMatch(/改前|改后/)
+
+    await wrapper.findAll('button').find((item) => item.text().startsWith('MCP'))!.trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).toContain('整份 mcp.json 由你配置')
+    expect(wrapper.text()).toContain('/root/.codebuddy/mcp.json')
+
+    await wrapper.findAll('button').find((item) => item.text() === '平台规则')!.trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).toContain('profiles/legacy/platform-rules/')
+
+    await wrapper.get('[data-test="manage"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).toContain('列出全部 Agent。此处「Rename」修改身份名称')
     wrapper.unmount()
   })
 })

--- a/web/src/views/AgentStudioView.vue
+++ b/web/src/views/AgentStudioView.vue
@@ -1848,9 +1848,8 @@ onBeforeUnmount(() => {
   <div class="flex h-full min-h-0 flex-col overflow-hidden">
     <div
       class="mb-5 flex shrink-0 gap-4"
-      :class="isMobile ? 'flex-col items-stretch' : 'items-end justify-between'"
+      :class="isMobile ? 'flex-col items-stretch' : 'justify-end'"
     >
-      <p class="max-w-3xl text-sm text-txt3">{{ t('pages.agentStudio.subtitle', { configRoot: draft?.layout?.configRoot || DEFAULT_CONFIG_ROOT }) }}</p>
       <div class="flex shrink-0 gap-2" :class="isMobile ? 'flex-col' : 'items-center'">
         <AppButton
           variant="outline"


### PR DESCRIPTION
页头 subtitle 与组织树 dragHint 虚线框仅为展示噪音，删除后保留导入/新建、拖拽与右键语义，并补中英文负向断言防止回潮。

Co-authored-by: Cursor <cursoragent@cursor.com>
