### PR TITLE
fix(web): hide token-stats filledTag on legend and rank

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,7 +8,9 @@ title = "approving gitleaks"
 useDefault = true
 
 [allowlist]
-description = "WorkflowApiTab API docs: curl Authorization examples use placeholder YOUR_API_KEY"
+description = "Confirmed placeholders and public model identifiers that resemble API keys"
 regexes = [
   '''YOUR_API_KEY''',
+  '''cursor-grok-4\.5-high-fast''',
+  '''gpt-5\.6-sol-medium''',
 ]

--- a/web/src/components/board/token-stats/TokenModelComposition.test.ts
+++ b/web/src/components/board/token-stats/TokenModelComposition.test.ts
@@ -4,6 +4,8 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import common from '@/locales/zh-CN/common.json'
 import pages from '@/locales/zh-CN/pages.json'
+import enCommon from '@/locales/en/common.json'
+import enPages from '@/locales/en/pages.json'
 import TokenModelComposition from './TokenModelComposition.vue'
 import { colorForModel } from './tokenModelColors'
 
@@ -13,6 +15,25 @@ const i18n = () =>
     locale: 'zh-CN',
     messages: { 'zh-CN': { ...common, ...pages } },
   })
+
+const i18nEn = () =>
+  createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en: { ...enCommon, ...enPages } },
+  })
+
+/** Screenshot-like sample: unknown grey + two filled (ACP_BRIDGE backfill) buckets. */
+const screenshotLikeModels = [
+  { modelKey: '未知/未分桶', name: '未知/未分桶', total: 100, unknown: true },
+  { modelKey: 'cursor-grok-4.5-high-fast', name: 'cursor-grok-4.5-high-fast', total: 80, filled: true },
+  { modelKey: 'gpt-5.6-sol-medium', name: 'gpt-5.6-sol-medium', total: 60, filled: true },
+]
+
+function expectNoFilledTagCopy(text: string) {
+  expect(text).not.toContain('含补全')
+  expect(text).not.toContain('includes filled data')
+}
 
 describe('TokenModelComposition SVG solid pie (g1/g2)', () => {
   it('renders svg/path solid pie without conic-gradient or rounded-full (g1.1/g1.2/g2.1)', () => {
@@ -78,6 +99,9 @@ describe('TokenModelComposition SVG solid pie (g1/g2)', () => {
     expect(legend).toContain('95.5%')
     expect(legend).toContain('50.09M')
     expect(legend).toContain('1059.71M')
+    expect(legend).toContain('cursor-grok-4.5-high-fast')
+    expectNoFilledTagCopy(legend)
+    expect(colorForModel(models[0]!, 0)).toBe('#34D399')
     expect(wrapper.html()).not.toMatch(/conic-gradient/i)
     wrapper.unmount()
   })
@@ -124,6 +148,59 @@ describe('TokenModelComposition SVG solid pie (g1/g2)', () => {
     expect(pie.find('circle').exists()).toBe(true)
     expect(wrapper.html()).not.toMatch(/conic-gradient/i)
     expect(wrapper.find('[data-testid="token-model-legend"]').text()).toMatch(/./)
+    wrapper.unmount()
+  })
+})
+
+describe('TokenModelComposition hides filledTag (g2.1)', () => {
+  it('zh-CN legend: swatch+name only, no 含补全; filled=#34D399 unknown=#71717A', () => {
+    expect(colorForModel(screenshotLikeModels[0]!, 0)).toBe('#71717A')
+    expect(colorForModel(screenshotLikeModels[1]!, 1)).toBe('#34D399')
+    expect(colorForModel(screenshotLikeModels[2]!, 2)).toBe('#34D399')
+
+    const wrapper = mount(TokenModelComposition, {
+      props: { models: screenshotLikeModels },
+      global: { plugins: [i18n()] },
+    })
+    const legend = wrapper.find('[data-testid="token-model-legend"]')
+    const text = legend.text()
+    expect(text).toContain('未知/未分桶')
+    expect(text).toContain('cursor-grok-4.5-high-fast')
+    expect(text).toContain('gpt-5.6-sol-medium')
+    expectNoFilledTagCopy(text)
+    expect(wrapper.html()).not.toContain('含补全')
+
+    const items = legend.findAll('li')
+    expect(items).toHaveLength(3)
+    const unknownSwatch = items[0]!.find('span.h-2\\.5')
+    const filledSwatch = items[1]!.find('span.h-2\\.5')
+    expect(unknownSwatch.attributes('style')).toMatch(/background:\s*#71717A/i)
+    expect(filledSwatch.attributes('style')).toMatch(/background:\s*#34D399/i)
+
+    const nameSpans = items.map((li) => li.findAll('span')[1]!)
+    expect(nameSpans[0]!.classes()).toContain('text-txt3')
+    expect(nameSpans[1]!.classes()).toContain('text-ok')
+    expect(nameSpans[2]!.classes()).toContain('text-ok')
+
+    const fills = wrapper.findAll('[data-testid="token-model-pie-slice"]').map((p) => p.attributes('fill'))
+    expect(fills).toEqual(['#71717A', '#34D399', '#34D399'])
+    wrapper.unmount()
+  })
+
+  it('en locale legend: no includes filled data; filled/#71717A colors unchanged', () => {
+    const wrapper = mount(TokenModelComposition, {
+      props: { models: screenshotLikeModels },
+      global: { plugins: [i18nEn()] },
+    })
+    const text = wrapper.find('[data-testid="token-model-legend"]').text()
+    expect(text).toContain('cursor-grok-4.5-high-fast')
+    expect(text).toContain('gpt-5.6-sol-medium')
+    expectNoFilledTagCopy(text)
+    expect(wrapper.html()).not.toContain('includes filled data')
+    expect(wrapper.html()).not.toContain('含补全')
+
+    const fills = wrapper.findAll('[data-testid="token-model-pie-slice"]').map((p) => p.attributes('fill'))
+    expect(fills).toEqual(['#71717A', '#34D399', '#34D399'])
     wrapper.unmount()
   })
 })

--- a/web/src/components/board/token-stats/TokenModelComposition.vue
+++ b/web/src/components/board/token-stats/TokenModelComposition.vue
@@ -125,7 +125,6 @@ const slices = computed(() => {
           :title="r.name"
         >
           {{ r.name }}
-          <span v-if="r.filled" class="ml-1 text-[10px] text-ok">{{ t('pages.board.tokenStats.filledTag') }}</span>
         </span>
         <span class="tabular-nums text-txt3" :title="fmtTokenCount(r.total)">
           {{ r.pct }}% · {{ fmtCompactTokenCount(r.total) }}

--- a/web/src/components/board/token-stats/TokenModelRank.test.ts
+++ b/web/src/components/board/token-stats/TokenModelRank.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment happy-dom
+import { createI18n } from 'vue-i18n'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import common from '@/locales/zh-CN/common.json'
+import pages from '@/locales/zh-CN/pages.json'
+import enCommon from '@/locales/en/common.json'
+import enPages from '@/locales/en/pages.json'
+import TokenModelRank from './TokenModelRank.vue'
+import { colorForModel } from './tokenModelColors'
+
+const i18nZh = () =>
+  createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common, ...pages } },
+  })
+
+const i18nEn = () =>
+  createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en: { ...enCommon, ...enPages } },
+  })
+
+function expectNoFilledTagCopy(text: string) {
+  expect(text).not.toContain('含补全')
+  expect(text).not.toContain('includes filled data')
+}
+
+const rankModels = [
+  { modelKey: 'cursor-grok-4.5-high-fast', name: 'cursor-grok-4.5-high-fast', total: 800, filled: true },
+  { modelKey: 'gpt-5.6-sol-medium', name: 'gpt-5.6-sol-medium', total: 600, filled: true },
+  { modelKey: '未知/未分桶', name: '未知/未分桶', total: 400, unknown: true },
+  { modelKey: 'other', name: 'other', total: 200, other: true },
+]
+
+describe('TokenModelRank hides filledTag (g2.2)', () => {
+  it('zh-CN: filled/unknown/other rows have no 含补全; data-filled keeps #34D399 / #71717A', () => {
+    expect(colorForModel(rankModels[0]!, 0)).toBe('#34D399')
+    expect(colorForModel(rankModels[2]!, 2)).toBe('#71717A')
+    expect(colorForModel(rankModels[3]!, 3)).toBe('#A1A1AA')
+
+    const wrapper = mount(TokenModelRank, {
+      props: { models: rankModels },
+      global: { plugins: [i18nZh()] },
+    })
+    const root = wrapper.find('[data-testid="token-model-rank"]')
+    expect(root.exists()).toBe(true)
+    expectNoFilledTagCopy(root.text())
+    expect(wrapper.html()).not.toContain('含补全')
+
+    const filledRows = wrapper.findAll('[data-filled="1"]')
+    expect(filledRows).toHaveLength(2)
+    for (const row of filledRows) {
+      expectNoFilledTagCopy(row.text())
+      expect(row.text()).not.toContain('含补全')
+      const bar = row.find('.h-full')
+      expect(bar.attributes('style')).toMatch(/background:\s*#34D399/i)
+      expect(row.find('.text-ok').exists()).toBe(true)
+    }
+
+    const unknownRow = wrapper.find('[data-unknown="1"]')
+    expect(unknownRow.exists()).toBe(true)
+    expect(unknownRow.attributes('data-filled')).toBe('0')
+    expect(unknownRow.text()).toContain('未知/未分桶')
+    expectNoFilledTagCopy(unknownRow.text())
+    expect(unknownRow.find('.h-full').attributes('style')).toMatch(/background:\s*#71717A/i)
+
+    const otherRow = wrapper.find('[data-other="1"]')
+    expect(otherRow.exists()).toBe(true)
+    expect(otherRow.text()).toContain('other（其余模型）')
+    expectNoFilledTagCopy(otherRow.text())
+    expect(otherRow.find('.h-full').attributes('style')).toMatch(/background:\s*#A1A1AA/i)
+
+    expect(root.text()).toContain('cursor-grok-4.5-high-fast')
+    expect(root.text()).toContain('gpt-5.6-sol-medium')
+    wrapper.unmount()
+  })
+
+  it('en locale: no includes filled data; other bucket stays unlabeled; colors unchanged', () => {
+    const wrapper = mount(TokenModelRank, {
+      props: { models: rankModels },
+      global: { plugins: [i18nEn()] },
+    })
+    const root = wrapper.find('[data-testid="token-model-rank"]')
+    expectNoFilledTagCopy(root.text())
+    expect(wrapper.html()).not.toContain('includes filled data')
+    expect(wrapper.html()).not.toContain('含补全')
+
+    const filledRows = wrapper.findAll('[data-filled="1"]')
+    expect(filledRows).toHaveLength(2)
+    for (const row of filledRows) {
+      expectNoFilledTagCopy(row.text())
+      expect(row.find('.h-full').attributes('style')).toMatch(/background:\s*#34D399/i)
+    }
+
+    const unknownRow = wrapper.find('[data-unknown="1"]')
+    expect(unknownRow.find('.h-full').attributes('style')).toMatch(/background:\s*#71717A/i)
+
+    const otherRow = wrapper.find('[data-other="1"]')
+    expect(otherRow.text()).toContain('other (remaining models)')
+    expectNoFilledTagCopy(otherRow.text())
+    wrapper.unmount()
+  })
+
+  it('other bucket does not gain filledTag even if filled=true (g2.2 other)', () => {
+    const wrapper = mount(TokenModelRank, {
+      props: {
+        models: [{ modelKey: 'other', name: 'other', total: 50, other: true, filled: true }],
+      },
+      global: { plugins: [i18nZh()] },
+    })
+    const otherRow = wrapper.find('[data-other="1"]')
+    expect(otherRow.attributes('data-filled')).toBe('1')
+    expectNoFilledTagCopy(otherRow.text())
+    expect(otherRow.text()).toContain('other（其余模型）')
+    wrapper.unmount()
+  })
+})

--- a/web/src/components/board/token-stats/TokenModelRank.vue
+++ b/web/src/components/board/token-stats/TokenModelRank.vue
@@ -39,9 +39,6 @@ function barWidth(total: number): string {
           :title="displayName(m)"
         >
           {{ displayName(m) }}
-          <span v-if="m.filled && !m.other" class="ml-1 text-[10px] font-normal text-ok">
-            {{ t('pages.board.tokenStats.filledTag') }}
-          </span>
         </div>
         <div class="mt-1 h-2 overflow-hidden bg-elevated">
           <div


### PR DESCRIPTION
Stop rendering 「含补全」 / includes filled data after model names so board token stats stay color-only (filled green, unknown grey).

Co-authored-by: Cursor <cursoragent@cursor.com>
