### PR TITLE
fix(web): Teleport Token 趋势 tooltip 并按 Demo placeAfter 定位

### DIFF
--- a/web/e2e/board-token-stats.spec.ts
+++ b/web/e2e/board-token-stats.spec.ts
@@ -23,33 +23,34 @@ function stubRun(partial: {
   }
 }
 
+function dayBucket(offset: number, totals: { total: number; workflowTotal: number; pmTotal: number }) {
+  const d = new Date(2026, 6, 11 + offset)
+  const bucket = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  return {
+    bucket,
+    ...totals,
+    inputTokens: Math.floor(totals.total * 0.4),
+    outputTokens: Math.floor(totals.total * 0.3),
+    cacheReadTokens: Math.floor(totals.total * 0.2),
+    cacheWriteTokens: Math.max(0, totals.total - Math.floor(totals.total * 0.9)),
+  }
+}
+
+/** Near-30d series: left-edge 2026-07-11 is a 0-value point (g4.5 hover). */
+const TREND_30D_LEFT_ZERO = Array.from({ length: 30 }, (_, i) => {
+  if (i === 0) return dayBucket(0, { total: 0, workflowTotal: 0, pmTotal: 0 })
+  if (i === 22) return dayBucket(i, { total: 124_000_000, workflowTotal: 96_000_000, pmTotal: 28_000_000 })
+  const total = i * 12_000
+  const pm = Math.floor(total * 0.25)
+  return dayBucket(i, { total, workflowTotal: total - pm, pmTotal: pm })
+})
+
 const STATS_30D = {
   window: '30d',
   bucketWidth: 'day',
   timezone: 'Asia/Shanghai',
   empty: false,
-  trend: [
-    {
-      bucket: '2026-07-24',
-      total: 1200,
-      workflowTotal: 900,
-      pmTotal: 300,
-      inputTokens: 500,
-      outputTokens: 400,
-      cacheReadTokens: 200,
-      cacheWriteTokens: 100,
-    },
-    {
-      bucket: '2026-07-25',
-      total: 800,
-      workflowTotal: 600,
-      pmTotal: 200,
-      inputTokens: 300,
-      outputTokens: 250,
-      cacheReadTokens: 150,
-      cacheWriteTokens: 100,
-    },
-  ],
+  trend: TREND_30D_LEFT_ZERO,
   composition: {
     inputTokens: 800,
     outputTokens: 650,
@@ -69,6 +70,7 @@ const STATS_30D = {
 const STATS_7D = {
   ...STATS_30D,
   window: '7d',
+  trend: TREND_30D_LEFT_ZERO.slice(-7),
   composition: { ...STATS_30D.composition, total: 900 },
   workflows: [
     { workflowId: 'wf-a', name: 'approve-main', total: 600 },
@@ -455,5 +457,91 @@ test.describe('看板 Token 统计图', () => {
     const detailShot = path.join(testInfo.outputDir, 'project-detail-token-stats.png')
     await page.screenshot({ path: detailShot, fullPage: true })
     await testInfo.attach('project-detail-token-stats', { path: detailShot, contentType: 'image/png' })
+  })
+
+  test('近 30 天左端 0 值点 hover：文案完整、盒子不裁切、离开隐藏、窄屏仍可见 (g4.5)', async ({ page }, testInfo) => {
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await mockBoardShell(page)
+    await page.route('**/api/projects/*/token-stats**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(STATS_30D),
+      })
+    })
+
+    await page.goto('/board.html?start=project-board&memory=1&projectId=proj-1')
+    await expect(page.getByTestId('token-stats-charts')).toBeVisible({ timeout: 15_000 })
+    const canvas = page.getByTestId('token-trend-chart').locator('canvas')
+    await expect(canvas).toBeVisible()
+
+    async function hoverLeftZeroPoint() {
+      const box = await canvas.boundingBox()
+      expect(box).toBeTruthy()
+      const ys = [box!.height - 28, Math.floor(box!.height * 0.55)]
+      const xs = [40, 48, 56, 64, 72, 84, 96]
+      for (const y of ys) {
+        for (const x of xs) {
+          if (x >= box!.width - 4 || y >= box!.height - 4) continue
+          await canvas.hover({ position: { x, y } })
+          const loc = page.getByTestId('token-trend-tooltip')
+          if (await loc.isVisible().catch(() => false)) {
+            const text = await loc.innerText()
+            if (text.includes('07-11')) return
+          }
+        }
+      }
+      throw new Error('left-edge 07-11 tooltip not shown')
+    }
+
+    await expect(async () => {
+      await hoverLeftZeroPoint()
+    }).toPass({ timeout: 12_000 })
+
+    const tip = page.getByTestId('token-trend-tooltip')
+    await expect(tip).toContainText('07-11')
+    await expect(tip).toContainText('workflow')
+    await expect(tip).toContainText('pm')
+    const tipText = (await tip.innerText()).replace(/\s+/g, ' ')
+    expect(tipText).toMatch(/07-11\s*·\s*0/)
+    expect(tipText).not.toMatch(/(^|\s)-11\s*·/)
+
+    const tipBox = await tip.boundingBox()
+    expect(tipBox).toBeTruthy()
+    expect(tipBox!.x).toBeGreaterThanOrEqual(0)
+    expect(tipBox!.y).toBeGreaterThanOrEqual(0)
+    expect(tipBox!.x + tipBox!.width).toBeLessThanOrEqual(1280 + 1)
+    expect(tipBox!.y + tipBox!.height).toBeLessThanOrEqual(900 + 1)
+
+    const hoverShot = path.join(testInfo.outputDir, 'token-trend-tooltip-left-zero.png')
+    await page.screenshot({ path: hoverShot, fullPage: true })
+    await testInfo.attach('token-trend-tooltip-left-zero', { path: hoverShot, contentType: 'image/png' })
+
+    await page.mouse.move(4, 4)
+    await expect(page.getByTestId('token-trend-tooltip')).toHaveCount(0)
+
+    await page.setViewportSize({ width: 390, height: 844 })
+    await expect(page.getByTestId('token-trend-wrap')).toBeVisible()
+    const panelBox = await page.getByTestId('token-stats-panel').boundingBox()
+    const wrapBox = await page.getByTestId('token-trend-wrap').boundingBox()
+    expect(panelBox && wrapBox).toBeTruthy()
+    expect(wrapBox!.x).toBeGreaterThanOrEqual(panelBox!.x - 1)
+    expect(wrapBox!.x + wrapBox!.width).toBeLessThanOrEqual(panelBox!.x + panelBox!.width + 2)
+
+    await expect(async () => {
+      await hoverLeftZeroPoint()
+    }).toPass({ timeout: 12_000 })
+    const narrowTip = page.getByTestId('token-trend-tooltip')
+    await expect(narrowTip).toContainText('07-11')
+    const narrowTipBox = await narrowTip.boundingBox()
+    expect(narrowTipBox).toBeTruthy()
+    expect(narrowTipBox!.x).toBeGreaterThanOrEqual(0)
+    expect(narrowTipBox!.y).toBeGreaterThanOrEqual(0)
+    expect(narrowTipBox!.x + narrowTipBox!.width).toBeLessThanOrEqual(390 + 1)
+    expect(narrowTipBox!.y + narrowTipBox!.height).toBeLessThanOrEqual(844 + 1)
+
+    const narrowHoverShot = path.join(testInfo.outputDir, 'token-trend-tooltip-narrow.png')
+    await page.screenshot({ path: narrowHoverShot, fullPage: true })
+    await testInfo.attach('token-trend-tooltip-narrow', { path: narrowHoverShot, contentType: 'image/png' })
   })
 })

--- a/web/src/components/board/token-stats/TokenCharts.test.ts
+++ b/web/src/components/board/token-stats/TokenCharts.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment happy-dom
 import { createI18n } from 'vue-i18n'
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 import common from '@/locales/zh-CN/common.json'
 import pages from '@/locales/zh-CN/pages.json'
 import TokenTrendChart from './TokenTrendChart.vue'
@@ -313,6 +314,201 @@ describe('Token charts (g2.3/g2.4)', () => {
     expect(pmDs!.borderDash).toEqual([5, 4])
     expect(wfDs!.borderDash).toBeUndefined()
     expect(String(pmDs!.backgroundColor)).not.toMatch(/245,\s*158,\s*11/)
+    wrapper.unmount()
+  })
+})
+
+type ExternalTooltip = (ctx: {
+  chart: { canvas: HTMLCanvasElement }
+  tooltip: {
+    opacity: number
+    caretX: number
+    caretY: number
+    dataPoints?: { dataIndex: number }[]
+  }
+}) => void | Promise<void>
+
+const TIP_W = 168
+const TIP_H = 72
+
+function mockTipBoxSize() {
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    get() {
+      return (this as HTMLElement).getAttribute?.('data-testid') === 'token-trend-tooltip' ? TIP_W : 600
+    },
+  })
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get() {
+      return (this as HTMLElement).getAttribute?.('data-testid') === 'token-trend-tooltip' ? TIP_H : 200
+    },
+  })
+}
+
+function restoreTipBoxSize() {
+  delete (HTMLElement.prototype as { offsetWidth?: unknown }).offsetWidth
+  delete (HTMLElement.prototype as { offsetHeight?: unknown }).offsetHeight
+}
+
+function leftZeroTrend() {
+  return [
+    {
+      bucket: '2026-07-11',
+      total: 0,
+      workflowTotal: 0,
+      pmTotal: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    },
+    {
+      bucket: '2026-07-12',
+      total: 1_200_000,
+      workflowTotal: 900_000,
+      pmTotal: 300_000,
+      inputTokens: 400,
+      outputTokens: 300,
+      cacheReadTokens: 200,
+      cacheWriteTokens: 100,
+    },
+    {
+      bucket: '2026-08-09',
+      total: 96_000_000,
+      workflowTotal: 72_000_000,
+      pmTotal: 24_000_000,
+      inputTokens: 400,
+      outputTokens: 300,
+      cacheReadTokens: 200,
+      cacheWriteTokens: 100,
+    },
+  ]
+}
+
+function tipBoxInViewport(el: HTMLElement) {
+  const left = parseFloat(el.style.left || '0')
+  const top = parseFloat(el.style.top || '0')
+  const right = left + (el.offsetWidth || TIP_W)
+  const bottom = top + (el.offsetHeight || TIP_H)
+  const vw = window.innerWidth
+  const vh = window.innerHeight
+  expect(left).toBeGreaterThanOrEqual(0)
+  expect(top).toBeGreaterThanOrEqual(0)
+  expect(right).toBeLessThanOrEqual(vw)
+  expect(bottom).toBeLessThanOrEqual(vh)
+  return { left, top, right, bottom }
+}
+
+async function fireExternalTooltip(
+  wrapper: ReturnType<typeof mount>,
+  opts: { caretX: number; caretY: number; dataIndex?: number; opacity?: number; canvasLeft?: number; canvasTop?: number },
+) {
+  const canvas = wrapper.find('canvas').element as HTMLCanvasElement
+  const canvasLeft = opts.canvasLeft ?? 40
+  const canvasTop = opts.canvasTop ?? 80
+  vi.spyOn(canvas, 'getBoundingClientRect').mockReturnValue({
+    x: canvasLeft,
+    y: canvasTop,
+    left: canvasLeft,
+    top: canvasTop,
+    right: canvasLeft + 600,
+    bottom: canvasTop + 178,
+    width: 600,
+    height: 178,
+    toJSON() {
+      return {}
+    },
+  } as DOMRect)
+
+  const vm = wrapper.vm as unknown as { externalTooltip: ExternalTooltip; hideTip: () => void }
+  await vm.externalTooltip({
+    chart: { canvas },
+    tooltip: {
+      opacity: opts.opacity ?? 1,
+      caretX: opts.caretX,
+      caretY: opts.caretY,
+      dataPoints: opts.opacity === 0 ? [] : [{ dataIndex: opts.dataIndex ?? 0 }],
+    },
+  })
+  await nextTick()
+  await nextTick()
+  return vm
+}
+
+describe('TokenTrendChart tooltip visibility (g4.1/g4.2/g4.3/g1.1)', () => {
+  afterEach(() => {
+    restoreTipBoxSize()
+    vi.restoreAllMocks()
+    document.querySelectorAll('[data-testid="token-trend-tooltip"]').forEach((n) => n.remove())
+  })
+
+  it('left-edge total=0 shows full MM-DD · 0 and box stays in viewport (g4.1)', async () => {
+    mockTipBoxSize()
+    const wrapper = mount(TokenTrendChart, {
+      props: { bucketWidth: 'day', trend: leftZeroTrend() },
+      global: { plugins: [i18n()] },
+      attachTo: document.body,
+    })
+
+    await fireExternalTooltip(wrapper, { caretX: 8, caretY: 160, dataIndex: 0 })
+    const tip = document.querySelector('[data-testid="token-trend-tooltip"]') as HTMLElement | null
+    expect(tip).toBeTruthy()
+    const text = (tip!.textContent || '').replace(/\s+/g, ' ')
+    expect(text).toContain('07-11')
+    expect(text).toMatch(/07-11\s*·\s*0/)
+    expect(text).not.toMatch(/(^|\s)-11\s*·/)
+    expect(text).toContain('workflow')
+    expect(text).toContain('pm')
+    tipBoxInViewport(tip!)
+
+    const wrap = wrapper.find('[data-testid="token-trend-wrap"]').element
+    expect(wrap.contains(tip!)).toBe(false)
+    expect(tip!.className).toMatch(/fixed/)
+    expect(tip!.className).toMatch(/z-\[100\]/)
+    expect(tip!.className).toMatch(/pointer-events-none/)
+    expect(tip!.className).toMatch(/rounded-lg/)
+    expect(tip!.className).toMatch(/bg-\[#1a1d23\]/)
+    wrapper.unmount()
+  })
+
+  it('right-edge / high caret flip or clamp keeps box in viewport (g4.2)', async () => {
+    mockTipBoxSize()
+    const wrapper = mount(TokenTrendChart, {
+      props: { bucketWidth: 'day', trend: leftZeroTrend() },
+      global: { plugins: [i18n()] },
+      attachTo: document.body,
+    })
+
+    await fireExternalTooltip(wrapper, { caretX: 590, caretY: 8, dataIndex: 2, canvasLeft: 40, canvasTop: 20 })
+    const tip = document.querySelector('[data-testid="token-trend-tooltip"]') as HTMLElement | null
+    expect(tip).toBeTruthy()
+    const text = (tip!.textContent || '').replace(/\s+/g, ' ')
+    expect(text).toContain('08-09')
+    expect(text).not.toMatch(/translate\(-50%/)
+    tipBoxInViewport(tip!)
+    wrapper.unmount()
+  })
+
+  it('hides tooltip after leaving the trend wrap (g4.3)', async () => {
+    mockTipBoxSize()
+    const wrapper = mount(TokenTrendChart, {
+      props: { bucketWidth: 'day', trend: leftZeroTrend() },
+      global: { plugins: [i18n()] },
+      attachTo: document.body,
+    })
+
+    await fireExternalTooltip(wrapper, { caretX: 80, caretY: 100, dataIndex: 1 })
+    expect(document.querySelector('[data-testid="token-trend-tooltip"]')).toBeTruthy()
+
+    await wrapper.find('[data-testid="token-trend-wrap"]').trigger('mouseleave')
+    await nextTick()
+    expect(document.querySelector('[data-testid="token-trend-tooltip"]')).toBeNull()
+
+    await fireExternalTooltip(wrapper, { caretX: 80, caretY: 100, dataIndex: 1 })
+    expect(document.querySelector('[data-testid="token-trend-tooltip"]')).toBeTruthy()
+    await fireExternalTooltip(wrapper, { caretX: 80, caretY: 100, opacity: 0 })
+    expect(document.querySelector('[data-testid="token-trend-tooltip"]')).toBeNull()
     wrapper.unmount()
   })
 })

--- a/web/src/components/board/token-stats/TokenTrendChart.vue
+++ b/web/src/components/board/token-stats/TokenTrendChart.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import {
   Chart as ChartJS,
@@ -16,7 +16,7 @@ import {
 import { Line } from 'vue-chartjs'
 import type { TokenStatsBucket } from '@/lib/types'
 import { fmtTokenCount } from '@/lib/tokenUsage'
-import { TOKEN_SOURCE_COLORS, formatBucketLabel } from './tokenStatsShared'
+import { TOKEN_SOURCE_COLORS, formatBucketLabel, placeTrendTooltipAfter } from './tokenStatsShared'
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Filler, Tooltip)
 
@@ -32,7 +32,11 @@ const WF_COLOR = TOKEN_SOURCE_COLORS.workflow
 const PM_COLOR = TOKEN_SOURCE_COLORS.pm
 
 const tip = ref({ show: false, x: 0, y: 0, idx: -1 })
+const tipEl = ref<HTMLElement | null>(null)
 const tipBucket = computed(() => (tip.value.idx >= 0 ? props.trend[tip.value.idx] : null))
+
+type LastCaret = { canvas: HTMLCanvasElement; caretX: number; caretY: number }
+let lastCaret: LastCaret | null = null
 
 function fmtCompact(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
@@ -41,13 +45,36 @@ function fmtCompact(n: number): string {
 }
 
 function hideTip() {
+  lastCaret = null
   tip.value = { ...tip.value, show: false, idx: -1 }
+}
+
+function repositionTip() {
+  const el = tipEl.value
+  if (!tip.value.show || !lastCaret || !el) return
+  const { canvas, caretX, caretY } = lastCaret
+  const canvasRect = canvas.getBoundingClientRect()
+  const pos = placeTrendTooltipAfter({
+    caretX: canvasRect.left + caretX,
+    caretY: canvasRect.top + caretY,
+    tipW: el.offsetWidth,
+    tipH: el.offsetHeight,
+  })
+  if (tip.value.x !== pos.left || tip.value.y !== pos.top) {
+    tip.value = { ...tip.value, x: pos.left, y: pos.top }
+  }
+}
+
+async function schedulePlaceTip() {
+  await nextTick()
+  repositionTip()
+  if (tipEl.value && (tipEl.value.offsetWidth === 0 || tipEl.value.offsetHeight === 0)) {
+    requestAnimationFrame(() => repositionTip())
+  }
 }
 
 function externalTooltip(context: { chart: Chart; tooltip: TooltipModel<'line'> }) {
   const { chart, tooltip } = context
-  const wrap = chart.canvas.closest('[data-testid="token-trend-wrap"]') as HTMLElement | null
-  if (!wrap) return
 
   if (tooltip.opacity === 0 || !tooltip.dataPoints?.length) {
     hideTip()
@@ -55,17 +82,18 @@ function externalTooltip(context: { chart: Chart; tooltip: TooltipModel<'line'> 
   }
 
   const idx = tooltip.dataPoints[0]!.dataIndex
-  const rect = wrap.getBoundingClientRect()
-  const canvasRect = chart.canvas.getBoundingClientRect()
-  const caretX = canvasRect.left - rect.left + tooltip.caretX
-  const caretY = canvasRect.top - rect.top + tooltip.caretY
-
+  lastCaret = { canvas: chart.canvas, caretX: tooltip.caretX, caretY: tooltip.caretY }
   tip.value = {
     show: true,
-    x: Math.min(Math.max(caretX, 8), rect.width - 160),
-    y: Math.max(caretY - 8, 8),
+    x: tip.value.show ? tip.value.x : 0,
+    y: tip.value.show ? tip.value.y : 0,
     idx,
   }
+  return schedulePlaceTip()
+}
+
+function onViewportChange() {
+  if (tip.value.show) repositionTip()
 }
 
 const chartData = computed(() => {
@@ -155,8 +183,19 @@ watch(
   () => hideTip(),
 )
 
-/** Exposed for unit tests: option mapping (tick thinning / aspect / tooltip). */
-defineExpose({ chartOptions, chartData })
+onMounted(() => {
+  window.addEventListener('resize', onViewportChange)
+  window.addEventListener('scroll', onViewportChange, true)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', onViewportChange)
+  window.removeEventListener('scroll', onViewportChange, true)
+  hideTip()
+})
+
+/** Exposed for unit tests: option mapping + external tooltip trigger. */
+defineExpose({ chartOptions, chartData, externalTooltip, hideTip })
 </script>
 
 <template>
@@ -166,6 +205,7 @@ defineExpose({ chartOptions, chartData })
     :style="{ height: `${CHART_HEIGHT_PX}px` }"
     role="img"
     :aria-label="t('pages.board.tokenStats.trendTitle')"
+    @mouseleave="hideTip"
   >
     <div
       data-testid="token-trend-legend"
@@ -187,11 +227,14 @@ defineExpose({ chartOptions, chartData })
     <div data-testid="token-trend-chart" class="h-[calc(100%-22px)] w-full">
       <Line :data="chartData" :options="chartOptions" />
     </div>
+  </div>
+  <Teleport to="body">
     <div
       v-if="tip.show && tipBucket"
+      ref="tipEl"
       data-testid="token-trend-tooltip"
-      class="pointer-events-none absolute z-10 min-w-[140px] rounded-lg bg-[#1a1d23] px-2.5 py-2 text-[11px] text-white shadow-lg"
-      :style="{ left: tip.x + 'px', top: tip.y + 'px', transform: 'translate(-50%, -100%)' }"
+      class="pointer-events-none fixed z-[100] min-w-[140px] rounded-lg bg-[#1a1d23] px-2.5 py-2 text-[11px] text-white shadow-lg"
+      :style="{ left: tip.x + 'px', top: tip.y + 'px' }"
     >
       <div class="mb-1 font-semibold">
         {{ formatBucketLabel(tipBucket.bucket, bucketWidth) }}
@@ -216,5 +259,5 @@ defineExpose({ chartOptions, chartData })
         <b class="font-normal tabular-nums text-white">{{ fmtTokenCount(tipBucket.pmTotal || 0) }}</b>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>

--- a/web/src/components/board/token-stats/tokenStatsShared.test.ts
+++ b/web/src/components/board/token-stats/tokenStatsShared.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { formatBucketLabel, placeTrendTooltipAfter, TREND_TOOLTIP_GAP, TREND_TOOLTIP_PAD } from './tokenStatsShared'
+
+describe('formatBucketLabel', () => {
+  it('formats day buckets as MM-DD and week buckets as Wxx', () => {
+    expect(formatBucketLabel('2026-07-11', 'day')).toBe('07-11')
+    expect(formatBucketLabel('2026-W30', 'week')).toBe('W30')
+  })
+})
+
+describe('placeTrendTooltipAfter (Demo placeAfter, g2.1–g2.4)', () => {
+  const vw = 800
+  const vh = 600
+  const tipW = 168
+  const tipH = 72
+
+  function box(caretX: number, caretY: number, w = tipW, h = tipH) {
+    return placeTrendTooltipAfter({ caretX, caretY, tipW: w, tipH: h, vw, vh })
+  }
+
+  it('measures real box with pad=8 gap=10 and prefers above + centered (g2.1/g2.2/g2.3)', () => {
+    const pos = box(400, 300)
+    expect(TREND_TOOLTIP_PAD).toBe(8)
+    expect(TREND_TOOLTIP_GAP).toBe(10)
+    expect(pos.top).toBe(300 - TREND_TOOLTIP_GAP - tipH)
+    expect(pos.left).toBe(400 - tipW / 2)
+  })
+
+  it('flips below then clamps when above would leave the viewport (left-edge 0-value / high point) (g2.2)', () => {
+    const leftZero = box(48, 18)
+    expect(leftZero.top).toBe(18 + TREND_TOOLTIP_GAP)
+    expect(leftZero.top).toBeGreaterThanOrEqual(TREND_TOOLTIP_PAD)
+    expect(leftZero.top + tipH).toBeLessThanOrEqual(vh - TREND_TOOLTIP_PAD)
+
+    const high = box(400, 12)
+    expect(high.top).toBe(12 + TREND_TOOLTIP_GAP)
+    expect(high.top + tipH).toBeLessThanOrEqual(vh - TREND_TOOLTIP_PAD)
+  })
+
+  it('flips left↔right then clamps so left-edge 07-11 and right-edge stay in viewport (g2.3)', () => {
+    const left = box(40, 200)
+    expect(left.left).toBe(40 + TREND_TOOLTIP_GAP)
+    expect(left.left).toBeGreaterThanOrEqual(TREND_TOOLTIP_PAD)
+    expect(left.left + tipW).toBeLessThanOrEqual(vw - TREND_TOOLTIP_PAD)
+
+    const right = box(780, 200)
+    expect(right.left + tipW).toBeLessThanOrEqual(vw - TREND_TOOLTIP_PAD)
+    expect(right.left).toBeGreaterThanOrEqual(TREND_TOOLTIP_PAD)
+  })
+
+  it('keeps full box in viewport when tip is tall vs ~200px chart (no text truncation) (g2.4)', () => {
+    const tallH = 160
+    const pos = placeTrendTooltipAfter({
+      caretX: 400,
+      caretY: 120,
+      tipW: 168,
+      tipH: tallH,
+      vw,
+      vh: 220,
+    })
+    expect(pos.top).toBeGreaterThanOrEqual(TREND_TOOLTIP_PAD)
+    expect(pos.top + tallH).toBeLessThanOrEqual(220 - TREND_TOOLTIP_PAD)
+    expect(pos.left).toBeGreaterThanOrEqual(TREND_TOOLTIP_PAD)
+    expect(pos.left + 168).toBeLessThanOrEqual(vw - TREND_TOOLTIP_PAD)
+  })
+})

--- a/web/src/components/board/token-stats/tokenStatsShared.ts
+++ b/web/src/components/board/token-stats/tokenStatsShared.ts
@@ -39,3 +39,40 @@ export function formatBucketLabel(bucket: string, bucketWidth: string): string {
   if (m) return `${m[2]}-${m[3]}`
   return bucket
 }
+
+/** Demo「修复后」placeAfter: viewport pad / gap. */
+export const TREND_TOOLTIP_PAD = 8
+export const TREND_TOOLTIP_GAP = 10
+
+/**
+ * Viewport placement for TokenTrendChart tooltip (Demo placeAfter).
+ * Prefer above the caret; flip up↔down / left↔right on overflow, then clamp by real box size.
+ */
+export function placeTrendTooltipAfter(input: {
+  caretX: number
+  caretY: number
+  tipW: number
+  tipH: number
+  vw?: number
+  vh?: number
+  pad?: number
+  gap?: number
+}): { left: number; top: number } {
+  const pad = input.pad ?? TREND_TOOLTIP_PAD
+  const gap = input.gap ?? TREND_TOOLTIP_GAP
+  const vw = input.vw ?? (typeof window !== 'undefined' ? window.innerWidth : 0)
+  const vh = input.vh ?? (typeof window !== 'undefined' ? window.innerHeight : 0)
+  const { caretX, caretY, tipW, tipH } = input
+
+  let top = caretY - gap - tipH
+  if (top < pad) top = caretY + gap
+  if (top + tipH > vh - pad) top = Math.max(pad, vh - pad - tipH)
+
+  let left = caretX - tipW / 2
+  if (left < pad) left = caretX + gap
+  if (left + tipW > vw - pad) left = caretX - gap - tipW
+  if (left < pad) left = pad
+  if (left + tipW > vw - pad) left = vw - pad - tipW
+
+  return { left, top }
+}


### PR DESCRIPTION
逃出三层 overflow-x-clip，避免左缘 0 值点被裁成「-11 · 0」；保留 wrap/card/panel 裁切与现网皮肤。

Co-authored-by: Cursor <cursoragent@cursor.com>
