### PR TITLE
feat(notify): 开通运行完成 QQ 通知并深链直达输出手风琴

### DIFF
--- a/server/internal/engine/engine.go
+++ b/server/internal/engine/engine.go
@@ -1407,6 +1407,11 @@ func (e *Engine) finish(runID, status string) bool {
 	if res.Error != nil {
 		return false
 	}
+	if status == "completed" {
+		// All finish(completed) paths (execute drain, resume, review) fire once
+		// here. Receipt (runId,nodeId,iteration,kind) dedups RowsAffected==0 reentry.
+		e.fireCompletedRunNotify(runID)
+	}
 	if status == "failed" || status == "cancelled" {
 		e.finalizeActiveStateRuns(runID, status)
 		e.supersedePendingGates(runID, status)

--- a/server/internal/engine/run_notify.go
+++ b/server/internal/engine/run_notify.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"strings"
+	"time"
 
 	"github.com/cocofhu/approving/internal/models"
 
@@ -19,7 +20,7 @@ type RunNotifyEvent struct {
 	NodeID       string
 	NodeLabel    string
 	Iteration    int
-	Kind         string // waiting_human | failed
+	Kind         string // waiting_human | failed | completed
 }
 
 // RunNotifier is an optional async observer for Run lifecycle transitions.
@@ -40,7 +41,7 @@ func (e *Engine) fireRunNotify(c *execCtx, node *models.Node, kind string) {
 		return
 	}
 	kind = strings.TrimSpace(kind)
-	if kind != models.NotifyKindWaitingHuman && kind != models.NotifyKindFailed {
+	if kind != models.NotifyKindWaitingHuman && kind != models.NotifyKindFailed && kind != models.NotifyKindCompleted {
 		return
 	}
 	iter := 0
@@ -92,4 +93,89 @@ func (e *Engine) fireRunNotify(c *execCtx, node *models.Node, kind string) {
 		}()
 		n.NotifyRunLifecycle(ev)
 	}()
+}
+
+// fireCompletedRunNotify resolves the last output node (or graph/sentinel
+// fallback) and fires a run-level completed notify. Dedup is the delivery
+// receipt (runId, nodeId, iteration, kind) — finish(completed) may return true
+// even when RowsAffected==0, so callers must not rely on that flag.
+func (e *Engine) fireCompletedRunNotify(runID string) {
+	if e.runNotify == nil || strings.TrimSpace(runID) == "" {
+		return
+	}
+	c, err := e.loadCtx(runID)
+	if err != nil || c == nil || c.run == nil {
+		log.Warn().Err(err).Str("run_id", runID).Msg("run-notify: completed loadCtx failed")
+		return
+	}
+	nodeID, label, iter := e.resolveCompletedNotifyTarget(c)
+	if c.iter == nil {
+		c.iter = map[string]int{}
+	}
+	if iter < 1 {
+		iter = 1
+	}
+	c.iter[nodeID] = iter
+	e.fireRunNotify(c, &models.Node{ID: nodeID, Label: label, Type: "output"}, models.NotifyKindCompleted)
+}
+
+// resolveCompletedNotifyTarget picks {node} + receipt key for completed:
+// 1) last executed output node by startedAt (aligned with lastOutputNodeId)
+// 2) first output node in the graph if none executed
+// 3) sentinel _run + label「输出」 if the graph has no output node
+func (e *Engine) resolveCompletedNotifyTarget(c *execCtx) (nodeID, label string, iter int) {
+	outputByID := map[string]models.Node{}
+	var graphOutputs []models.Node
+	for _, n := range c.graph.Nodes {
+		if n.Type == "output" {
+			outputByID[n.ID] = n
+			graphOutputs = append(graphOutputs, n)
+		}
+	}
+
+	var states []models.StateRun
+	if err := e.db.Where("run_id = ?", c.run.ID).Find(&states).Error; err != nil {
+		log.Warn().Err(err).Str("run_id", c.run.ID).Msg("run-notify: load state runs for completed failed")
+	}
+
+	var best *models.StateRun
+	var bestAt time.Time
+	for i := range states {
+		s := &states[i]
+		_, inGraph := outputByID[s.NodeID]
+		if !inGraph && s.NodeType != "output" {
+			continue
+		}
+		at := time.Time{}
+		if s.StartedAt != nil {
+			at = *s.StartedAt
+		}
+		if best == nil || at.After(bestAt) || (at.Equal(bestAt) && s.ID > best.ID) {
+			best = s
+			bestAt = at
+		}
+	}
+	if best != nil {
+		lbl := ""
+		if n, ok := outputByID[best.NodeID]; ok {
+			lbl = n.Label
+		}
+		if strings.TrimSpace(lbl) == "" {
+			lbl = best.NodeID
+		}
+		it := best.Iteration
+		if it < 1 {
+			it = 1
+		}
+		return best.NodeID, lbl, it
+	}
+	if len(graphOutputs) > 0 {
+		n := graphOutputs[0]
+		lbl := strings.TrimSpace(n.Label)
+		if lbl == "" {
+			lbl = n.ID
+		}
+		return n.ID, lbl, 1
+	}
+	return models.NotifyCompletedSentinelNodeID, models.NotifyCompletedFallbackLabel, 1
 }

--- a/server/internal/engine/run_notify_test.go
+++ b/server/internal/engine/run_notify_test.go
@@ -169,3 +169,94 @@ func TestFireRunNotifyDirect(t *testing.T) {
 		t.Fatalf("%+v", evs[0])
 	}
 }
+
+func TestRunNotifyOnCompleted(t *testing.T) {
+	g := models.Graph{
+		Nodes: []models.Node{
+			{ID: "input", Type: "input", Label: "输入"},
+			{ID: "output", Type: "output", Label: "结束"},
+		},
+		Edges: []models.Edge{
+			{ID: "e1", Source: "input", Target: "output"},
+		},
+	}
+	eng, db, _ := setupEngineGraphP(t, g)
+	proj := models.Project{ID: "proj-run-done", Name: "Done", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	if err := db.Create(&proj).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Model(&models.WorkflowDef{}).Where("id = ?", "wf").
+		Update("project_id", proj.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	rec := &recordingRunNotify{}
+	eng.SetRunNotifier(rec)
+	run, err := eng.StartRun("wf", nil, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitRunStatus(t, db, run.ID, "completed")
+	evs := rec.wait(t, 1)
+	if evs[0].Kind != models.NotifyKindCompleted || evs[0].NodeID != "output" {
+		t.Fatalf("unexpected completed event: %+v", evs[0])
+	}
+	if evs[0].NodeLabel != "结束" || evs[0].Iteration < 1 {
+		t.Fatalf("label/iter: %+v", evs[0])
+	}
+	time.Sleep(50 * time.Millisecond)
+	if rec.count() != 1 {
+		t.Fatalf("completed notify count=%d want 1", rec.count())
+	}
+}
+
+func TestFireCompletedRunNotifySentinel(t *testing.T) {
+	eng, db, _ := setupEngineGraphP(t, models.Graph{
+		Nodes: []models.Node{{ID: "input", Type: "input", Label: "输入"}},
+	})
+	proj := models.Project{ID: "proj-sentinel", Name: "S", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	_ = db.Create(&proj)
+	_ = db.Model(&models.WorkflowDef{}).Where("id = ?", "wf").Update("project_id", proj.ID)
+	rec := &recordingRunNotify{}
+	eng.SetRunNotifier(rec)
+	run := models.Run{ID: "run-sentinel", WorkflowID: "wf", WorkflowName: "W", Status: "completed"}
+	if err := db.Create(&run).Error; err != nil {
+		t.Fatal(err)
+	}
+	eng.fireCompletedRunNotify(run.ID)
+	evs := rec.wait(t, 1)
+	if evs[0].Kind != models.NotifyKindCompleted || evs[0].NodeID != models.NotifyCompletedSentinelNodeID {
+		t.Fatalf("%+v", evs[0])
+	}
+	if evs[0].NodeLabel != models.NotifyCompletedFallbackLabel || evs[0].Iteration != 1 {
+		t.Fatalf("%+v", evs[0])
+	}
+}
+
+func TestFireCompletedRunNotifyGraphFallback(t *testing.T) {
+	eng, db, _ := setupEngineGraphP(t, models.Graph{
+		Nodes: []models.Node{
+			{ID: "input", Type: "input"},
+			{ID: "output", Type: "output", Label: "结束"},
+		},
+	})
+	proj := models.Project{ID: "proj-graph-fb", Name: "G", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	_ = db.Create(&proj)
+	_ = db.Model(&models.WorkflowDef{}).Where("id = ?", "wf").Update("project_id", proj.ID)
+	rec := &recordingRunNotify{}
+	eng.SetRunNotifier(rec)
+	run := models.Run{
+		ID: "run-graph-fb", WorkflowID: "wf", WorkflowName: "W", Status: "completed",
+		Graph: models.Graph{Nodes: []models.Node{
+			{ID: "input", Type: "input"},
+			{ID: "output", Type: "output", Label: "结束"},
+		}},
+	}
+	if err := db.Create(&run).Error; err != nil {
+		t.Fatal(err)
+	}
+	eng.fireCompletedRunNotify(run.ID)
+	evs := rec.wait(t, 1)
+	if evs[0].NodeID != "output" || evs[0].NodeLabel != "结束" || evs[0].Iteration != 1 {
+		t.Fatalf("%+v", evs[0])
+	}
+}

--- a/server/internal/models/notify.go
+++ b/server/internal/models/notify.go
@@ -2,12 +2,19 @@ package models
 
 import "time"
 
-// Notify event kinds delivered in P0. completed may appear in schema/UI as a
-// greyed preview but is never delivered by the P0 engine hook.
+// Notify event kinds. waiting_human and failed are on by default; completed is
+// opt-in (DefaultEvents stays [waiting_human, failed] so existing projects do
+// not start notifying on success).
 const (
 	NotifyKindWaitingHuman = "waiting_human"
 	NotifyKindFailed       = "failed"
-	NotifyKindCompleted    = "completed" // P1 reserved; not delivered in P0
+	NotifyKindCompleted    = "completed"
+)
+
+// Completed notify receipt / deep-link fallbacks when a run has no output node.
+const (
+	NotifyCompletedSentinelNodeID = "_run"
+	NotifyCompletedFallbackLabel  = "输出"
 )
 
 // Workflow notify override modes.
@@ -21,13 +28,14 @@ const (
 // Enabled=nil means default ON (hard-close only when explicitly false).
 // DefaultEvents=nil means the product default [waiting_human, failed]; an
 // explicit empty slice means "no default events".
-// WaitingHumanTemplate / FailedTemplate are optional full message bodies;
-// trim-empty means fall back to FormatRunNotifyMessage (zero regression).
+// WaitingHumanTemplate / FailedTemplate / CompletedTemplate are optional full
+// message bodies; trim-empty means fall back to FormatRunNotifyMessage.
 type ProjectNotifyPolicy struct {
 	Enabled              *bool    `json:"enabled"`
 	DefaultEvents        []string `json:"defaultEvents"`
 	WaitingHumanTemplate string   `json:"waitingHumanTemplate,omitempty"`
 	FailedTemplate       string   `json:"failedTemplate,omitempty"`
+	CompletedTemplate    string   `json:"completedTemplate,omitempty"`
 }
 
 // WorkflowNotifyPolicy is the per-workflow override. Empty Mode ≡ inherit.

--- a/server/internal/services/notify_policy.go
+++ b/server/internal/services/notify_policy.go
@@ -6,16 +6,17 @@ import (
 	"github.com/cocofhu/approving/internal/models"
 )
 
-// ResolveNotifyEvents returns the effective P0 event set for a workflow under
-// a project policy. Aligns with Demo page.html resolveEvents:
+// ResolveNotifyEvents returns the effective event set for a workflow under a
+// project policy. Aligns with Demo page.html resolveEvents:
 //
 //	enabled=false → empty (hard close)
 //	mode=off      → empty
 //	mode=custom   → workflow events (may be empty)
 //	inherit/else  → project defaultEvents
 //
-// Only waiting_human and failed participate in P0 delivery; completed (and any
-// other kind) is filtered out even if present in stored policy.
+// waiting_human, failed, and completed may be delivered when present in the
+// resolved set; unknown kinds are stripped. DefaultEvents still default to
+// waiting_human+failed (completed is opt-in).
 func ResolveNotifyEvents(project models.ProjectNotifyPolicy, workflow models.WorkflowNotifyPolicy) []string {
 	if !project.IsEnabled() {
 		return nil
@@ -45,10 +46,10 @@ func NotifyEventAllowed(events []string, kind string) bool {
 
 func filterP0NotifyEvents(in []string) []string {
 	seen := map[string]bool{}
-	out := make([]string, 0, 2)
+	out := make([]string, 0, 3)
 	for _, e := range in {
 		switch strings.TrimSpace(e) {
-		case models.NotifyKindWaitingHuman, models.NotifyKindFailed:
+		case models.NotifyKindWaitingHuman, models.NotifyKindFailed, models.NotifyKindCompleted:
 			if !seen[e] {
 				seen[e] = true
 				out = append(out, e)
@@ -59,13 +60,10 @@ func filterP0NotifyEvents(in []string) []string {
 }
 
 // NormalizeProjectNotifyPolicy sanitizes a project policy for persistence.
-// Nil Enabled defaults to true; nil DefaultEvents defaults to waiting_human+failed.
-// completed may be stored for schema foresight but is stripped from delivery set
-// at resolve time; we still allow it in DefaultEvents for UI grey-state roundtrip
-// only when explicitly present — P0 UI never writes it as selectable, so strip
-// unknown kinds except the known three for forward-compat storage foresight.
-// Template fields: whitespace-only is trimmed to ""; empty is NOT rewritten to
-// the default QQ body (empty must trigger FormatRunNotifyMessage fallback).
+// Nil Enabled defaults to true; nil DefaultEvents defaults to waiting_human+failed
+// (completed is not added automatically). Known kinds including completed may be
+// stored; unknown kinds are stripped. Template fields: whitespace-only is trimmed
+// to ""; empty is NOT rewritten to the default QQ body.
 func NormalizeProjectNotifyPolicy(p models.ProjectNotifyPolicy) models.ProjectNotifyPolicy {
 	if p.Enabled == nil {
 		on := true
@@ -81,6 +79,9 @@ func NormalizeProjectNotifyPolicy(p models.ProjectNotifyPolicy) models.ProjectNo
 	}
 	if strings.TrimSpace(p.FailedTemplate) == "" {
 		p.FailedTemplate = ""
+	}
+	if strings.TrimSpace(p.CompletedTemplate) == "" {
+		p.CompletedTemplate = ""
 	}
 	return p
 }
@@ -133,7 +134,8 @@ func NotifyPoliciesEqual(a, b models.ProjectNotifyPolicy) bool {
 		return false
 	}
 	return a.WaitingHumanTemplate == b.WaitingHumanTemplate &&
-		a.FailedTemplate == b.FailedTemplate
+		a.FailedTemplate == b.FailedTemplate &&
+		a.CompletedTemplate == b.CompletedTemplate
 }
 
 // WorkflowNotifyPoliciesEqual compares workflow overrides.

--- a/server/internal/services/notify_policy_test.go
+++ b/server/internal/services/notify_policy_test.go
@@ -53,10 +53,16 @@ func TestResolveNotifyEvents(t *testing.T) {
 			want:     nil,
 		},
 		{
-			name:     "completed stripped from inherit",
+			name:     "completed kept when opted in",
 			project:  models.ProjectNotifyPolicy{Enabled: boolPtr(true), DefaultEvents: []string{"waiting_human", "failed", "completed"}},
 			workflow: models.WorkflowNotifyPolicy{Mode: "inherit"},
-			want:     []string{"waiting_human", "failed"},
+			want:     []string{"waiting_human", "failed", "completed"},
+		},
+		{
+			name:     "custom completed only",
+			project:  def,
+			workflow: models.WorkflowNotifyPolicy{Mode: "custom", Events: []string{"completed"}},
+			want:     []string{"completed"},
 		},
 		{
 			name:     "nil project defaults enabled with waiting+failed",
@@ -98,17 +104,26 @@ func TestNotifyPoliciesEqual_includesTemplates(t *testing.T) {
 	if !NotifyPoliciesEqual(base, blank) {
 		t.Fatal("whitespace-only template normalizes to empty")
 	}
+	completed := base
+	completed.CompletedTemplate = "DONE {title}"
+	if NotifyPoliciesEqual(base, completed) {
+		t.Fatal("completedTemplate-only change must not equal")
+	}
 }
 
 func TestNormalizeProjectNotifyPolicy_trimsTemplates(t *testing.T) {
 	got := NormalizeProjectNotifyPolicy(models.ProjectNotifyPolicy{
 		WaitingHumanTemplate: "  hi  ",
 		FailedTemplate:       "\n\t",
+		CompletedTemplate:    " \n",
 	})
 	if got.WaitingHumanTemplate != "  hi  " {
 		t.Fatalf("non-empty must keep surrounding spaces: %q", got.WaitingHumanTemplate)
 	}
 	if got.FailedTemplate != "" {
 		t.Fatalf("failed=%q want empty", got.FailedTemplate)
+	}
+	if got.CompletedTemplate != "" {
+		t.Fatalf("completed=%q want empty", got.CompletedTemplate)
 	}
 }

--- a/server/internal/services/run_notify.go
+++ b/server/internal/services/run_notify.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"errors"
+	"net/url"
 	"strings"
 	"time"
 
@@ -31,7 +32,7 @@ type RunNotifyEvent struct {
 	NodeID       string
 	NodeLabel    string
 	Iteration    int
-	Kind         string // waiting_human | failed
+	Kind         string // waiting_human | failed | completed
 	DeepLinkBase string // PublicAdvertise; empty → relative /runs/{id}
 }
 
@@ -67,8 +68,19 @@ func (s *RunNotifyService) AttemptDeliver(ev RunNotifyEvent) {
 		return
 	}
 	kind := strings.TrimSpace(ev.Kind)
-	if kind != models.NotifyKindWaitingHuman && kind != models.NotifyKindFailed {
+	if kind != models.NotifyKindWaitingHuman && kind != models.NotifyKindFailed && kind != models.NotifyKindCompleted {
 		return
+	}
+	if kind == models.NotifyKindCompleted {
+		if strings.TrimSpace(ev.NodeID) == "" {
+			ev.NodeID = models.NotifyCompletedSentinelNodeID
+		}
+		if ev.Iteration < 1 {
+			ev.Iteration = 1
+		}
+		if strings.TrimSpace(ev.NodeLabel) == "" && ev.NodeID == models.NotifyCompletedSentinelNodeID {
+			ev.NodeLabel = models.NotifyCompletedFallbackLabel
+		}
 	}
 	if strings.TrimSpace(ev.RunID) == "" || strings.TrimSpace(ev.NodeID) == "" || ev.Iteration < 1 {
 		// failed without node context (and malformed waiting_human) → skip, no claim
@@ -213,6 +225,8 @@ func templateForKind(p models.ProjectNotifyPolicy, kind string) string {
 		return p.WaitingHumanTemplate
 	case models.NotifyKindFailed:
 		return p.FailedTemplate
+	case models.NotifyKindCompleted:
+		return p.CompletedTemplate
 	default:
 		return ""
 	}
@@ -220,18 +234,27 @@ func templateForKind(p models.ProjectNotifyPolicy, kind string) string {
 
 // RunNotifyTitle returns the event title used by {title} and the default formatter.
 func RunNotifyTitle(kind string) string {
-	if kind == models.NotifyKindWaitingHuman {
+	switch kind {
+	case models.NotifyKindWaitingHuman:
 		return "等待人工处理"
+	case models.NotifyKindCompleted:
+		return "运行完成"
+	default:
+		return "运行失败"
 	}
-	return "运行失败"
 }
 
 // RunNotifyNodeDisplay returns Label if set, otherwise NodeID (may be empty).
+// The completed sentinel "_run" is not shown; callers fall back to「输出」.
 func RunNotifyNodeDisplay(ev RunNotifyEvent) string {
 	if n := strings.TrimSpace(ev.NodeLabel); n != "" {
 		return n
 	}
-	return strings.TrimSpace(ev.NodeID)
+	id := strings.TrimSpace(ev.NodeID)
+	if id == models.NotifyCompletedSentinelNodeID {
+		return ""
+	}
+	return id
 }
 
 // ReplaceRunNotifyPlaceholders performs literal six-key replacement.
@@ -263,7 +286,7 @@ func RenderRunNotifyMessage(ev RunNotifyEvent, base, template string) string {
 		wfName = "—"
 	}
 	node := RunNotifyNodeDisplay(ev) // custom path: empty stays empty (no line delete)
-	link := runDeepLink(base, ev.RunID)
+	link := runDeepLink(base, ev.RunID, ev.Kind, ev.NodeID)
 	title := RunNotifyTitle(ev.Kind)
 	return ReplaceRunNotifyPlaceholders(template, projectName, wfName, ev.RunID, node, link, title)
 }
@@ -282,7 +305,10 @@ func FormatRunNotifyMessage(ev RunNotifyEvent, base string) string {
 		wfName = "—"
 	}
 	node := RunNotifyNodeDisplay(ev)
-	link := runDeepLink(base, ev.RunID)
+	if kind := strings.TrimSpace(ev.Kind); kind == models.NotifyKindCompleted && node == "" {
+		node = models.NotifyCompletedFallbackLabel
+	}
+	link := runDeepLink(base, ev.RunID, ev.Kind, ev.NodeID)
 	var b strings.Builder
 	b.WriteString("【Approving】")
 	b.WriteString(title)
@@ -306,8 +332,16 @@ func FormatRunNotifyMessage(ev RunNotifyEvent, base string) string {
 	return b.String()
 }
 
-func runDeepLink(base, runID string) string {
+func runDeepLink(base, runID, kind, nodeID string) string {
 	path := "/runs/" + runID
+	if strings.TrimSpace(kind) == models.NotifyKindCompleted {
+		q := url.Values{}
+		q.Set("tab", "output")
+		if n := strings.TrimSpace(nodeID); n != "" && n != models.NotifyCompletedSentinelNodeID {
+			q.Set("node", n)
+		}
+		path += "?" + q.Encode()
+	}
 	base = strings.TrimRight(strings.TrimSpace(base), "/")
 	if base == "" {
 		return path
@@ -317,7 +351,12 @@ func runDeepLink(base, runID string) string {
 
 // FormatRunDeepLinkForTest exposes runDeepLink for unit tests.
 func FormatRunDeepLinkForTest(base, runID string) string {
-	return runDeepLink(base, runID)
+	return runDeepLink(base, runID, "", "")
+}
+
+// FormatCompletedRunDeepLinkForTest exposes completed deep links for unit tests.
+func FormatCompletedRunDeepLinkForTest(base, runID, nodeID string) string {
+	return runDeepLink(base, runID, models.NotifyKindCompleted, nodeID)
 }
 
 // ClaimReceiptForTest exposes claimReceipt for unit tests.

--- a/server/internal/services/run_notify_test.go
+++ b/server/internal/services/run_notify_test.go
@@ -363,3 +363,119 @@ func TestAttemptDeliver_kindsIndependent(t *testing.T) {
 		t.Fatalf("failed should use default: %s", d.calls[1])
 	}
 }
+
+func TestAttemptDeliver_completedOptInAndDedup(t *testing.T) {
+	db := setupRunNotifyDB(t)
+	seedNotifyProject(t, db, true, []string{"waiting_human", "failed", "completed"}, "inherit", nil)
+	d := &fakeRunDeliverer{}
+	svc := NewRunNotifyService(db, d, "https://app.example")
+
+	ev := RunNotifyEvent{
+		ProjectID: "proj-n1", RunID: "run-done", WorkflowID: "wf-n1",
+		NodeID: "output_end", NodeLabel: "结束", Iteration: 1, Kind: models.NotifyKindCompleted,
+	}
+	svc.AttemptDeliver(ev)
+	svc.AttemptDeliver(ev)
+	if d.count() != 1 {
+		t.Fatalf("completed deliver calls=%d want 1", d.count())
+	}
+	text := d.calls[0]
+	if !containsAll(text, "运行完成", "https://app.example/runs/run-done?node=output_end&tab=output", "结束") {
+		t.Fatalf("unexpected completed text: %s", text)
+	}
+	if strings.Contains(text, "运行失败") {
+		t.Fatalf("completed must not use failed title: %s", text)
+	}
+}
+
+func TestAttemptDeliver_completedPolicyMiss(t *testing.T) {
+	db := setupRunNotifyDB(t)
+	seedNotifyProject(t, db, true, []string{"waiting_human", "failed"}, "inherit", nil)
+	d := &fakeRunDeliverer{}
+	svc := NewRunNotifyService(db, d, "")
+	svc.AttemptDeliver(RunNotifyEvent{
+		ProjectID: "proj-n1", RunID: "run-off", WorkflowID: "wf-n1",
+		NodeID: "output", Iteration: 1, Kind: models.NotifyKindCompleted,
+	})
+	if d.count() != 0 {
+		t.Fatal("completed must not deliver when not opted in")
+	}
+	if svc.HasClaimedForTest("run-off", "output", 1, models.NotifyKindCompleted) {
+		t.Fatal("policy miss must not claim completed")
+	}
+}
+
+func TestAttemptDeliver_completedSentinelNode(t *testing.T) {
+	db := setupRunNotifyDB(t)
+	seedNotifyProject(t, db, true, []string{"completed"}, "custom", []string{"completed"})
+	d := &fakeRunDeliverer{}
+	svc := NewRunNotifyService(db, d, "https://app.example")
+	svc.AttemptDeliver(RunNotifyEvent{
+		ProjectID: "proj-n1", RunID: "run-empty", WorkflowID: "wf-n1",
+		Kind: models.NotifyKindCompleted, // no node — coerce sentinel
+	})
+	if d.count() != 1 {
+		t.Fatalf("calls=%d want 1", d.count())
+	}
+	text := d.calls[0]
+	if !containsAll(text, "运行完成", "节点：输出", "https://app.example/runs/run-empty?tab=output") {
+		t.Fatalf("sentinel completed text: %s", text)
+	}
+	if strings.Contains(text, "node=") {
+		t.Fatalf("sentinel deep link must omit node: %s", text)
+	}
+	if !svc.HasClaimedForTest("run-empty", models.NotifyCompletedSentinelNodeID, 1, models.NotifyKindCompleted) {
+		t.Fatal("expected sentinel receipt")
+	}
+}
+
+func TestAttemptDeliver_completedCustomTemplate(t *testing.T) {
+	db := setupRunNotifyDB(t)
+	p := models.Project{
+		ID: "proj-n1", Name: "Demo",
+		NotifyPolicy: models.ProjectNotifyPolicy{
+			Enabled:           boolPtr(true),
+			DefaultEvents:     []string{"completed"},
+			CompletedTemplate: "DONE {title} {run_id} {node}",
+		},
+	}
+	if err := db.Create(&p).Error; err != nil {
+		t.Fatal(err)
+	}
+	wf := models.WorkflowDef{
+		ID: "wf-n1", ProjectID: p.ID, Name: "WF", Status: "published", Version: 1,
+		NotifyPolicy: models.WorkflowNotifyPolicy{Mode: "inherit"},
+	}
+	if err := db.Create(&wf).Error; err != nil {
+		t.Fatal(err)
+	}
+	d := &fakeRunDeliverer{}
+	svc := NewRunNotifyService(db, d, "")
+	svc.AttemptDeliver(RunNotifyEvent{
+		ProjectID: "proj-n1", RunID: "r-c", WorkflowID: "wf-n1",
+		NodeID: "out", NodeLabel: "结束", Iteration: 1, Kind: models.NotifyKindCompleted,
+	})
+	if d.count() != 1 || d.calls[0] != "proj-n1|DONE 运行完成 r-c 结束" {
+		t.Fatalf("unexpected: %v", d.calls)
+	}
+}
+
+func TestRunNotifyTitle_completed(t *testing.T) {
+	if got := RunNotifyTitle(models.NotifyKindCompleted); got != "运行完成" {
+		t.Fatalf("got %q", got)
+	}
+	if got := RunNotifyTitle(models.NotifyKindFailed); got != "运行失败" {
+		t.Fatalf("failed title %q", got)
+	}
+}
+
+func TestFormatRunNotifyMessage_completedDefault(t *testing.T) {
+	got := FormatRunNotifyMessage(RunNotifyEvent{
+		ProjectName: "Demo", WorkflowName: "自我迭代", RunID: "run-1",
+		NodeID: "output_end", NodeLabel: "结束", Kind: models.NotifyKindCompleted,
+	}, "https://app.example")
+	want := "【Approving】运行完成\n项目：Demo\n工作流：自我迭代\nRun：run-1\n节点：结束\n打开：https://app.example/runs/run-1?node=output_end&tab=output"
+	if got != want {
+		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+	}
+}

--- a/server/internal/services/workflow_notify_policy_test.go
+++ b/server/internal/services/workflow_notify_policy_test.go
@@ -76,3 +76,19 @@ func TestFormatRunDeepLinkRelativeWhenBaseEmpty(t *testing.T) {
 		t.Fatalf("got %q", got)
 	}
 }
+
+func TestFormatCompletedRunDeepLink(t *testing.T) {
+	got := FormatCompletedRunDeepLinkForTest("https://app.example", "run-1", "output_end")
+	want := "https://app.example/runs/run-1?node=output_end&tab=output"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+	noNode := FormatCompletedRunDeepLinkForTest("", "run-2", models.NotifyCompletedSentinelNodeID)
+	if noNode != "/runs/run-2?tab=output" {
+		t.Fatalf("sentinel deep link: %q", noNode)
+	}
+	emptyNode := FormatCompletedRunDeepLinkForTest("", "run-3", "")
+	if emptyNode != "/runs/run-3?tab=output" {
+		t.Fatalf("empty node deep link: %q", emptyNode)
+	}
+}

--- a/web/e2e/run-completed-output-main.ts
+++ b/web/e2e/run-completed-output-main.ts
@@ -1,0 +1,46 @@
+/**
+ * Production RunDetailView harness for completed QQ deep link:
+ * /run-completed-output.html?node=end&tab=output[&empty=1]
+ */
+import '../src/styles/global.css'
+import { createApp, h } from 'vue'
+import { createPinia } from 'pinia'
+import { createMemoryHistory, createRouter, RouterView } from 'vue-router'
+import { i18n } from '../src/lib/i18n'
+import { initLocale, setLocale } from '../src/lib/locale'
+import { installIdleScrollbar } from '../src/lib/idleScrollbar'
+import RunDetailView from '../src/views/RunDetailView.vue'
+
+installIdleScrollbar()
+
+async function bootstrap() {
+  await initLocale()
+  await setLocale('zh-CN')
+
+  const params = new URLSearchParams(window.location.search)
+  const node = params.get('node') || ''
+  const tab = params.get('tab') || ''
+  const runId = params.get('run') || 'run-completed-e2e'
+  const query: Record<string, string> = {}
+  if (node) query.node = node
+  if (tab) query.tab = tab
+
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/runs/:id', component: RunDetailView },
+      { path: '/runs', component: { render: () => h('div') } },
+      { path: '/workflows/:id/edit', component: { render: () => h('div') } },
+      { path: '/login', component: { render: () => h('div', { 'data-testid': 'login-stub' }, 'login') } },
+    ],
+  })
+  await router.push({ path: `/runs/${runId}`, query })
+
+  createApp({ render: () => h(RouterView) })
+    .use(createPinia())
+    .use(i18n)
+    .use(router)
+    .mount('#app')
+}
+
+void bootstrap()

--- a/web/e2e/run-completed-output.html
+++ b/web/e2e/run-completed-output.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Run Completed Output Deep Link E2E</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./run-completed-output-main.ts"></script>
+  </body>
+</html>

--- a/web/e2e/run-completed-output.spec.ts
+++ b/web/e2e/run-completed-output.spec.ts
@@ -1,0 +1,173 @@
+/**
+ * g6.2 / g6.3: completed deep link → output accordion / Demo empty / mobile detail.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const nodes = [
+  { id: 'start', type: 'input', label: '开始', position: { x: 0, y: 0 }, config: {} },
+  { id: 'research', type: 'research', label: '代码调研', position: { x: 180, y: 0 }, config: {} },
+  { id: 'end', type: 'output', label: '结束', position: { x: 360, y: 0 }, config: {} },
+]
+
+const outputCards = [
+  {
+    index: 1,
+    template: 'research',
+    title: '调研 · 代码调研',
+    typeTag: 'Markdown',
+    status: 'ok',
+    markdown: '## 调研结论\n首张结果卡正文',
+  },
+  {
+    index: 2,
+    template: 'plan',
+    title: '计划 · 制定计划',
+    typeTag: 'Markdown',
+    status: 'ok',
+    markdown: '## 计划正文\n第二张',
+  },
+  {
+    index: 3,
+    template: 'failed',
+    title: '测试 · 失败卡',
+    typeTag: '来源失败',
+    status: 'failed',
+    errorReason: '上游测试节点失败',
+  },
+]
+
+function mockRun(opts: { empty?: boolean; outputRan?: boolean } = {}) {
+  const empty = !!opts.empty
+  const outputRan = opts.outputRan !== false
+  return {
+    id: 'run-completed-e2e',
+    workflowId: 'wf-completed-e2e',
+    workflowName: '需求→调研→实现',
+    workflowVersion: 1,
+    status: 'completed',
+    trigger: 'manual',
+    startedAt: '2026-08-01T00:00:00Z',
+    durationSec: 120,
+    progress: 1,
+    nodeRuns: {
+      start: { nodeId: 'start', status: 'completed', startedAt: '2026-08-01T00:00:00Z', outputs: {} },
+      research: {
+        nodeId: 'research',
+        status: 'completed',
+        startedAt: '2026-08-01T00:01:00Z',
+        outputs: {},
+      },
+      end: outputRan
+        ? {
+            nodeId: 'end',
+            status: 'completed',
+            startedAt: '2026-08-01T00:02:00Z',
+            outputs: { outputCards: empty ? [] : outputCards },
+          }
+        : { nodeId: 'end', status: 'pending', outputs: {} },
+    },
+    nodeExecutions: {},
+    artifacts: [],
+    trace: [],
+    vars: [],
+    nodes,
+    edges: [
+      { id: 'e1', source: 'start', target: 'research' },
+      { id: 'e2', source: 'research', target: 'end' },
+    ],
+  }
+}
+
+async function mockApi(page: Page, run: ReturnType<typeof mockRun>) {
+  await page.route('**/api/runs/**', async (route) => {
+    const url = new URL(route.request().url())
+    if (url.pathname.endsWith('/events')) {
+      await route.fulfill({ json: { events: [], nextCursor: '', hasMore: false, live: false } })
+      return
+    }
+    if (url.pathname.endsWith('/sandbox-log') || url.pathname.includes('/sandbox')) {
+      await route.fulfill({ json: { content: '', live: false, found: false } })
+      return
+    }
+    if (url.pathname.endsWith('/run-completed-e2e') || url.pathname.includes('/runs/run-completed-e2e')) {
+      await route.fulfill({ json: run })
+      return
+    }
+    await route.fulfill({ status: 404, json: { error: 'not mocked' } })
+  })
+  await page.route('**/api/workflows/**', async (route) => {
+    await route.fulfill({
+      json: {
+        id: 'wf-completed-e2e',
+        name: '需求→调研→实现',
+        status: 'published',
+        version: 1,
+        nodes,
+        edges: [],
+      },
+    })
+  })
+}
+
+async function gotoDeepLink(
+  page: Page,
+  opts: { width?: number; empty?: boolean; outputRan?: boolean; query?: string } = {},
+) {
+  await page.setViewportSize({ width: opts.width ?? 1280, height: 900 })
+  await mockApi(page, mockRun({ empty: opts.empty, outputRan: opts.outputRan }))
+  const qs = opts.query ?? 'node=end&tab=output'
+  await page.goto(`/run-completed-output.html?${qs}`)
+  await expect(page.getByTestId('run-detail-root')).toBeVisible({ timeout: 15_000 })
+}
+
+test.describe('completed 深链输出视图 (g6.2/g6.3)', () => {
+  test('已登录深链：输出视图 + 第 1 张结果卡展开', async ({ page }) => {
+    await gotoDeepLink(page)
+    await expect(page.getByTestId('run-detail-right-panel')).toBeVisible()
+    await expect(page.getByTestId('output-result-cards')).toBeVisible()
+    await expect(page.getByTestId('output-result-card-toggle-0')).toHaveAttribute('aria-expanded', 'true')
+    await expect(page.getByTestId('output-result-card-body-0')).toContainText('首张结果卡正文')
+    await expect(page.getByTestId('output-result-card-body-1')).toHaveCount(0)
+    await expect(page.getByTestId('run-detail-right-panel')).toContainText('结束')
+    await expect(page.getByTestId('run-detail-right-panel')).not.toContainText('打开原始文件')
+    await expect(page.getByTestId('run-detail-right-panel')).not.toContainText('下载')
+
+    await page.getByTestId('output-result-card-toggle-1').click()
+    await expect(page.getByTestId('output-result-card-toggle-0')).toHaveAttribute('aria-expanded', 'false')
+    await expect(page.getByTestId('output-result-card-body-1')).toContainText('第二张')
+
+    await page.getByTestId('output-result-card-toggle-2').click()
+    await expect(page.getByTestId('output-result-card-body-2')).toContainText('上游测试节点失败')
+  })
+
+  test('无结果卡：Demo 空态文案', async ({ page }) => {
+    await gotoDeepLink(page, { empty: true, query: 'tab=output' })
+    await expect(page.getByTestId('node-output-empty')).toBeVisible()
+    await expect(page.getByTestId('node-output-empty')).toContainText('本次没有可预览的结果卡')
+    await expect(page.getByTestId('node-output-empty')).toContainText('这不是加载失败')
+    await expect(page.getByTestId('node-output-empty')).toContainText('Artifacts Tab')
+    await expect(page.getByTestId('run-detail-right-panel')).not.toContainText('该节点尚未执行')
+  })
+
+  test('输出节点未跑过且 run=completed：仍空态而非尚未运行', async ({ page }) => {
+    await gotoDeepLink(page, { outputRan: false, query: 'node=end&tab=output' })
+    await expect(page.getByTestId('node-output-empty')).toBeVisible()
+    await expect(page.getByTestId('node-output-empty')).toContainText('本次没有可预览的结果卡')
+    await expect(page.getByTestId('run-detail-right-panel')).not.toContainText('该节点尚未执行')
+  })
+
+  test('移动端深链首屏为详情面板，可返回时间线', async ({ page }) => {
+    await gotoDeepLink(page, { width: 390 })
+    await expect(page.getByTestId('mobile-main-panel-tabs')).toBeVisible()
+    await expect(page.getByTestId('run-detail-right-panel')).toBeVisible()
+    await expect(page.getByTestId('output-result-cards')).toBeVisible()
+    await expect(page.getByTestId('output-result-card-toggle-0')).toHaveAttribute('aria-expanded', 'true')
+    await expect(page.getByTestId('run-timeline-pane')).toBeHidden()
+
+    await page.getByTestId('mobile-back-to-timeline').click()
+    await expect(page.getByTestId('run-timeline-pane')).toBeVisible()
+    await expect(page.getByTestId('run-detail-right-panel')).toBeHidden()
+    await page.getByTestId('mobile-panel-detail').click()
+    await expect(page.getByTestId('run-detail-right-panel')).toBeVisible()
+  })
+})

--- a/web/e2e/run-notify-ui.spec.ts
+++ b/web/e2e/run-notify-ui.spec.ts
@@ -20,6 +20,7 @@ const MOCK_PROJECT = {
     defaultEvents: ['waiting_human', 'failed'],
     waitingHumanTemplate: '',
     failedTemplate: '',
+    completedTemplate: '',
   },
   createdAt: '2026-01-01T00:00:00Z',
   updatedAt: '2026-01-01T00:00:00Z',
@@ -245,7 +246,7 @@ async function setupNotifyHarness(
 }
 
 test.describe('Run NotifyPolicy UI (P0)', () => {
-  test('通知 Tab：总开关/默认事件/completed 灰态/无渠道提示/可保存', async ({ page }) => {
+  test('通知 Tab：总开关/默认事件/completed 可勾/无渠道提示/可保存', async ({ page }) => {
     const harness = await setupNotifyHarness(page, { hasChannel: false })
 
     await expect(page.getByRole('button', { name: '通知' })).toBeVisible()
@@ -255,10 +256,11 @@ test.describe('Run NotifyPolicy UI (P0)', () => {
     await expect(page.getByTestId('notify-master-toggle')).toHaveAttribute('aria-checked', 'true')
     await expect(page.getByTestId('notify-ev-waiting-human')).toHaveAttribute('aria-checked', 'true')
     await expect(page.getByTestId('notify-ev-failed')).toHaveAttribute('aria-checked', 'true')
-    await expect(page.getByTestId('notify-ev-completed-disabled')).toBeVisible()
-    await expect(
-      page.getByTestId('notify-ev-completed-disabled').locator('button[disabled]'),
-    ).toHaveCount(1)
+    await expect(page.getByTestId('notify-ev-completed')).toBeVisible()
+    await expect(page.getByTestId('notify-ev-completed')).toHaveAttribute('aria-checked', 'false')
+    await expect(page.getByTestId('notify-ev-completed-disabled')).toHaveCount(0)
+    await expect(page.getByTestId('notify-ev-completed').locator('button[disabled]')).toHaveCount(0)
+    await expect(page.getByText('默认关闭，打开后运行成功结束时发 QQ')).toBeVisible()
 
     await page.screenshot({
       path: path.join(shotDir, '01-notify-tab-no-channel.png'),
@@ -273,6 +275,7 @@ test.describe('Run NotifyPolicy UI (P0)', () => {
       defaultEvents: ['waiting_human', 'failed'],
       waitingHumanTemplate: '',
       failedTemplate: '',
+      completedTemplate: '',
     })
 
     await page.screenshot({
@@ -317,6 +320,12 @@ test.describe('Run NotifyPolicy UI (P0)', () => {
     await expect(page.getByTestId('notify-preview-mode')).toContainText('使用系统默认')
     await expect(page.getByTestId('notify-preview-body')).toContainText('【Approving】运行失败')
 
+    // Completed segment: title must be 运行完成, never 运行失败
+    await page.getByTestId('notify-tpl-seg-completed').click()
+    await expect(page.getByTestId('notify-preview-mode')).toContainText('使用系统默认')
+    await expect(page.getByTestId('notify-preview-body')).toContainText('【Approving】运行完成')
+    await expect(page.getByTestId('notify-preview-body')).not.toContainText('运行失败')
+
     // Only toggle master off and save — waiting template must round-trip
     await page.getByTestId('notify-master-toggle').click()
     await page.getByTestId('notify-save').click()
@@ -325,8 +334,12 @@ test.describe('Run NotifyPolicy UI (P0)', () => {
         enabled?: boolean
         waitingHumanTemplate?: string
         failedTemplate?: string
+        completedTemplate?: string
       } | null
-      return p?.enabled === false && p?.waitingHumanTemplate?.includes('📦') && p?.failedTemplate === ''
+      return p?.enabled === false &&
+        p?.waitingHumanTemplate?.includes('📦') &&
+        p?.failedTemplate === '' &&
+        p?.completedTemplate === ''
         ? 'roundtrip'
         : JSON.stringify(p)
     }).toBe('roundtrip')
@@ -372,10 +385,12 @@ test.describe('Run NotifyPolicy UI (P0)', () => {
       return s?.id === 'wf-inherit' ? `${s.via}:${s.notifyPolicy?.mode}:nodes=${Array.isArray(s.nodes)}` : null
     }).toBe('patch-notify-policy:custom:nodes=false')
 
-    // 自我迭代已是 custom：取消「等待人工」，仅留「运行失败」（payload events 仍为内部 key）
+    // 自我迭代已是 custom：第三勾「运行完成」默认不勾；取消「等待人工」，仅留「运行失败」
     const customRow = page.locator('tbody tr', { hasText: '自我迭代' })
     const waitingCb = customRow.locator('label', { hasText: '等待人工' }).locator('input[type="checkbox"]')
+    const completedCb = customRow.locator('label', { hasText: '运行完成' }).locator('input[type="checkbox"]')
     await expect(waitingCb).toBeChecked()
+    await expect(completedCb).not.toBeChecked()
     await waitingCb.click()
     await expect.poll(() => {
       const s = harness.getLastWorkflowSave() as {

--- a/web/src/components/project/ProjectNotifyPanel.vue
+++ b/web/src/components/project/ProjectNotifyPanel.vue
@@ -29,8 +29,10 @@ const toast = useToast()
 const enabled = ref(true)
 const waitingHuman = ref(true)
 const failed = ref(true)
+const completed = ref(false)
 const waitingHumanTemplate = ref('')
 const failedTemplate = ref('')
+const completedTemplate = ref('')
 const templateKind = ref<RunNotifyKind>('waiting_human')
 const hasChannel = ref(false)
 const loadingChannel = ref(true)
@@ -46,6 +48,7 @@ function policyFromProject(p: Project): ProjectNotifyPolicy {
       : ['waiting_human', 'failed'],
     waitingHumanTemplate: raw?.waitingHumanTemplate ?? '',
     failedTemplate: raw?.failedTemplate ?? '',
+    completedTemplate: raw?.completedTemplate ?? '',
   }
 }
 
@@ -55,8 +58,10 @@ function syncFromProject() {
   const ev = new Set(p.defaultEvents || [])
   waitingHuman.value = ev.has('waiting_human')
   failed.value = ev.has('failed')
+  completed.value = ev.has('completed')
   waitingHumanTemplate.value = p.waitingHumanTemplate || ''
   failedTemplate.value = p.failedTemplate || ''
+  completedTemplate.value = p.completedTemplate || ''
 }
 
 async function loadChannel() {
@@ -94,16 +99,14 @@ const statusLabel = computed(() => {
 
 const currentTemplate = computed({
   get() {
-    return templateKind.value === 'waiting_human'
-      ? waitingHumanTemplate.value
-      : failedTemplate.value
+    if (templateKind.value === 'waiting_human') return waitingHumanTemplate.value
+    if (templateKind.value === 'completed') return completedTemplate.value
+    return failedTemplate.value
   },
   set(v: string) {
-    if (templateKind.value === 'waiting_human') {
-      waitingHumanTemplate.value = v
-    } else {
-      failedTemplate.value = v
-    }
+    if (templateKind.value === 'waiting_human') waitingHumanTemplate.value = v
+    else if (templateKind.value === 'completed') completedTemplate.value = v
+    else failedTemplate.value = v
   },
 })
 
@@ -126,12 +129,14 @@ async function save() {
     const defaultEvents: string[] = []
     if (waitingHuman.value) defaultEvents.push('waiting_human')
     if (failed.value) defaultEvents.push('failed')
-    // Always round-trip both templates so enabled/events-only saves cannot wipe them.
+    if (completed.value) defaultEvents.push('completed')
+    // Always round-trip templates so enabled/events-only saves cannot wipe them.
     const notifyPolicy: ProjectNotifyPolicy = {
       enabled: enabled.value,
       defaultEvents,
       waitingHumanTemplate: waitingHumanTemplate.value,
       failedTemplate: failedTemplate.value,
+      completedTemplate: completedTemplate.value,
     }
     const updated = await api.updateProject(props.projectId, { notifyPolicy })
     emit('updated', updated)
@@ -261,25 +266,22 @@ function goChannelSettings() {
               }}</span>
             </span>
           </label>
-          <div
-            class="flex items-start gap-3 opacity-50"
-            data-testid="notify-ev-completed-disabled"
-          >
+          <label class="flex items-start gap-3">
             <AppSwitch
+              v-model="completed"
               class="mt-0.5"
-              :model-value="false"
-              disabled
+              data-testid="notify-ev-completed"
               :aria-label="t('pages.projectDetail.notify.evCompletedLabel')"
             />
             <span>
-              <span class="block text-[13px] font-medium text-txt3">{{
+              <span class="block text-[13px] font-medium text-txt">{{
                 t('pages.projectDetail.notify.evCompletedLabel')
               }}</span>
               <span class="mt-0.5 block text-[12px] text-txt3">{{
                 t('pages.projectDetail.notify.evCompleted')
               }}</span>
             </span>
-          </div>
+          </label>
         </div>
       </div>
     </div>
@@ -320,6 +322,19 @@ function goChannelSettings() {
           @click="templateKind = 'failed'"
         >
           {{ t('pages.projectDetail.notify.segFailed') }}
+        </button>
+        <button
+          type="button"
+          class="flex-1 rounded-md border px-3 py-2 text-[12px] transition"
+          :class="
+            templateKind === 'completed'
+              ? 'border-accent/45 bg-accent-dim text-accent-2'
+              : 'border-line bg-elevated text-txt3 hover:text-txt'
+          "
+          data-testid="notify-tpl-seg-completed"
+          @click="templateKind = 'completed'"
+        >
+          {{ t('pages.projectDetail.notify.segCompleted') }}
         </button>
       </div>
 

--- a/web/src/components/run/NodeOutputPanel.test.ts
+++ b/web/src/components/run/NodeOutputPanel.test.ts
@@ -122,4 +122,45 @@ describe('NodeOutputPanel', () => {
     expect(wrapper.findComponent({ name: 'PlanView' }).exists()).toBe(true)
     wrapper.unmount()
   })
+
+  it('shows Demo empty state when completed output node has no cards (g4.4)', async () => {
+    const node: WFNode = {
+      id: 'end',
+      type: 'output',
+      label: '结束',
+      position: { x: 0, y: 0 },
+      config: {},
+    }
+    const nodeRun: NodeRun = {
+      nodeId: 'end',
+      iteration: 1,
+      status: 'completed',
+      outputs: { outputCards: [] },
+    }
+    const run = { id: 'run-1', status: 'completed', artifacts: [] } as unknown as Run
+    const wrapper = mountPanel(node, nodeRun, run)
+    await flushPromises()
+    expect(wrapper.get('[data-testid="node-output-empty"]').text()).toContain('本次没有可预览的结果卡')
+    expect(wrapper.text()).toContain('这不是加载失败')
+    expect(wrapper.text()).toContain('Artifacts Tab')
+    expect(wrapper.text()).not.toContain('该节点尚未执行')
+    wrapper.unmount()
+  })
+
+  it('shows Demo empty state when run completed but output node never ran (g4.4)', async () => {
+    const node: WFNode = {
+      id: 'end',
+      type: 'output',
+      label: '结束',
+      position: { x: 0, y: 0 },
+      config: {},
+    }
+    const nodeRun: NodeRun = { nodeId: 'end', status: 'pending', outputs: {} }
+    const run = { id: 'run-1', status: 'completed', artifacts: [] } as unknown as Run
+    const wrapper = mountPanel(node, nodeRun, run)
+    await flushPromises()
+    expect(wrapper.get('[data-testid="node-output-empty"]').text()).toContain('本次没有可预览的结果卡')
+    expect(wrapper.text()).not.toContain('该节点尚未执行')
+    wrapper.unmount()
+  })
 })

--- a/web/src/components/run/NodeOutputPanel.vue
+++ b/web/src/components/run/NodeOutputPanel.vue
@@ -395,16 +395,27 @@ function fileStatusClass(s: string): string {
     </div>
 
     <!-- output node: multi-card structured display -->
-    <div v-if="isOutputNode && hasRun" class="mb-3">
+    <div v-if="isOutputNode && (hasRun || run.status === 'completed')" class="mb-3">
       <OutputResultCards v-if="outputCards.length" :cards="outputCards" :run="run" />
-      <div v-else class="px-1 py-8 text-center text-[12px] text-txt3">{{ t('pages.nodeOutput.workflowComplete') }}</div>
+      <div
+        v-else
+        class="px-1 py-8 text-center text-[12px] text-txt3"
+        data-testid="node-output-empty"
+      >
+        <strong class="mb-1.5 block text-[13px] text-txt">{{ t('pages.nodeOutput.noPreviewCardsTitle') }}</strong>
+        <p class="mb-1">{{ t('pages.nodeOutput.noPreviewCardsBody') }}</p>
+        <p>{{ t('pages.nodeOutput.noPreviewCardsHint') }}</p>
+      </div>
     </div>
 
     <div v-if="showOutputMd" class="card p-4">
       <div class="mb-2 text-[10px] font-semibold uppercase tracking-wider text-txt3">{{ t('pages.nodeOutput.output') }}</div>
       <div class="md" v-html="renderMarkdown(nodeRun.outputMd || '')" />
     </div>
-    <div v-else-if="!hasRun" class="px-1 py-8 text-center text-[12px] text-txt3">{{ t('pages.nodeOutput.nodeNotRun') }}</div>
+    <div
+      v-else-if="!hasRun && !(isOutputNode && run.status === 'completed')"
+      class="px-1 py-8 text-center text-[12px] text-txt3"
+    >{{ t('pages.nodeOutput.nodeNotRun') }}</div>
     <div v-else-if="!isOutputNode && node.type !== 'input' && node.type !== 'branch' && node.type !== 'set_var'" class="px-1 py-8 text-center text-[12px] text-txt3">{{ t('pages.nodeOutput.nodeNoOutput') }}</div>
   </div>
 </template>

--- a/web/src/components/run/OutputResultCards.test.ts
+++ b/web/src/components/run/OutputResultCards.test.ts
@@ -37,7 +37,7 @@ const HtmlPreviewStub = defineComponent({
 
 const cards: OutputCard[] = [
   {
-    index: 0,
+    index: 1,
     template: 'research',
     title: '调研结果',
     status: 'ok',
@@ -46,12 +46,20 @@ const cards: OutputCard[] = [
     jsonSnapshot: JSON.stringify({ summary: 'ok', findings: [] }),
   },
   {
-    index: 1,
+    index: 2,
     template: 'custom',
     title: '自定义产物',
     status: 'ok',
     typeTag: '自定义产物',
-    artifactName: 'notes.md',
+    artifactName: 'page.html',
+  },
+  {
+    index: 3,
+    template: 'plan',
+    title: '计划',
+    status: 'ok',
+    typeTag: 'Markdown',
+    markdown: '## 计划正文',
   },
 ]
 
@@ -59,9 +67,9 @@ const run = {
   id: 'run-1',
   artifacts: [
     {
-      id: 'a-notes',
-      name: 'notes.md',
-      kind: 'markdown',
+      id: 'a-page',
+      name: 'page.html',
+      kind: 'html',
       nodeId: 'output',
       runId: 'run-1',
       workflowName: 'wf',
@@ -71,67 +79,98 @@ const run = {
   ],
 } as Run
 
-describe('OutputResultCards', () => {
+function mountCards(list: OutputCard[] = cards) {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common, ...pages } },
+  })
+  return mount(OutputResultCards, {
+    props: { cards: list, run },
+    global: {
+      plugins: [i18n],
+      stubs: { StructuredArtifactView: StructuredStub, HtmlPreview: HtmlPreviewStub },
+    },
+  })
+}
+
+describe('OutputResultCards exclusive accordion (g4)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    apiMocks.artifactContent.mockResolvedValue({ content: '# notes' })
+    apiMocks.artifactContent.mockResolvedValue({ content: '<html>ok</html>' })
   })
 
-  it('renders structured card from json snapshot', async () => {
-    const i18n = createI18n({
-      legacy: false,
-      locale: 'zh-CN',
-      messages: { 'zh-CN': { ...common, ...pages } },
-    })
-    const wrapper = mount(OutputResultCards, {
-      props: { cards: [cards[0]], run },
-      global: {
-        plugins: [i18n],
-        stubs: { StructuredArtifactView: StructuredStub, HtmlPreview: HtmlPreviewStub },
-      },
-    })
+  it('defaults to first card expanded; others collapsed and not mounted', async () => {
+    const wrapper = mountCards()
     await flushPromises()
-    expect(wrapper.text()).toContain('调研结果')
+    const toggles = wrapper.findAll('[data-testid^="output-result-card-toggle-"]')
+    expect(toggles).toHaveLength(3)
+    expect(toggles[0].attributes('aria-expanded')).toBe('true')
+    expect(toggles[1].attributes('aria-expanded')).toBe('false')
+    expect(wrapper.find('[data-testid="output-result-card-body-0"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="output-result-card-body-1"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="structured-view"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="html-preview"]').exists()).toBe(false)
+    expect(apiMocks.artifactContent).not.toHaveBeenCalled()
     wrapper.unmount()
   })
 
-  it('loads custom artifact content', async () => {
-    const i18n = createI18n({
-      legacy: false,
-      locale: 'zh-CN',
-      messages: { 'zh-CN': { ...common, ...pages } },
-    })
-    const wrapper = mount(OutputResultCards, {
-      props: { cards: [cards[1]], run },
-      global: {
-        plugins: [i18n],
-        stubs: { StructuredArtifactView: StructuredStub, HtmlPreview: HtmlPreviewStub },
-      },
-    })
+  it('clicking another title switches exclusive expand and lazy-loads HTML', async () => {
+    const wrapper = mountCards()
     await flushPromises()
-    expect(apiMocks.artifactContent).toHaveBeenCalledWith('a-notes')
+    await wrapper.get('[data-testid="output-result-card-toggle-1"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.get('[data-testid="output-result-card-toggle-0"]').attributes('aria-expanded')).toBe(
+      'false',
+    )
+    expect(wrapper.get('[data-testid="output-result-card-toggle-1"]').attributes('aria-expanded')).toBe(
+      'true',
+    )
+    expect(wrapper.find('[data-testid="output-result-card-body-0"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="html-preview"]').exists()).toBe(true)
+    expect(apiMocks.artifactContent).toHaveBeenCalledWith('a-page')
     wrapper.unmount()
   })
 
-  it('applies failed styling for failed cards', async () => {
-    const i18n = createI18n({
-      legacy: false,
-      locale: 'zh-CN',
-      messages: { 'zh-CN': { ...common, ...pages } },
-    })
-    const wrapper = mount(OutputResultCards, {
-      props: {
-        cards: [{ ...cards[0], status: 'failed', title: '失败卡片' }],
-        run,
-      },
-      global: {
-        plugins: [i18n],
-        stubs: { StructuredArtifactView: StructuredStub, HtmlPreview: HtmlPreviewStub },
-      },
-    })
+  it('clicking the open card collapses all', async () => {
+    const wrapper = mountCards()
     await flushPromises()
-    expect(wrapper.find('article').classes().some((c) => c.includes('err'))).toBe(true)
+    await wrapper.get('[data-testid="output-result-card-toggle-0"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.get('[data-testid="output-result-card-toggle-0"]').attributes('aria-expanded')).toBe(
+      'false',
+    )
+    expect(wrapper.find('[data-testid="output-result-card-body-0"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="structured-view"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('failed cards remain in the list and can expand errorReason', async () => {
+    const wrapper = mountCards([
+      {
+        index: 1,
+        template: 'research',
+        title: '失败卡片',
+        status: 'failed',
+        typeTag: '来源失败',
+        errorReason: '上游节点失败',
+      },
+      cards[2],
+    ])
+    await flushPromises()
+    expect(wrapper.text()).toContain('失败卡片')
+    expect(wrapper.text()).toContain('上游节点失败')
+    await wrapper.get('[data-testid="output-result-card-toggle-1"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).toContain('计划正文')
+    expect(wrapper.text()).not.toMatch(/打开原始文件|下载/)
+    wrapper.unmount()
+  })
+
+  it('does not render open/download actions on result cards', async () => {
+    const wrapper = mountCards([cards[0]])
+    await flushPromises()
+    expect(wrapper.text()).not.toMatch(/打开原始文件|下载/)
     wrapper.unmount()
   })
 })

--- a/web/src/components/run/OutputResultCards.vue
+++ b/web/src/components/run/OutputResultCards.vue
@@ -11,6 +11,9 @@ const props = defineProps<{ cards: OutputCard[]; run: Run }>()
 
 const { t } = useI18n()
 
+/** Exclusive accordion: 0 = first card; -1 = all collapsed. */
+const openIndex = ref(0)
+
 const contentCache = ref<Record<string, string>>({})
 const loading = ref(false)
 
@@ -33,16 +36,32 @@ async function loadArtifactContent(name: string) {
 }
 
 watch(
-  () => props.cards.map((c) => c.artifactName).join(','),
+  () => props.cards.map((c) => `${c.index}:${c.template}`).join(','),
   () => {
-    for (const c of props.cards) {
-      if (c.typeTag === '自定义产物' && c.artifactName && !c.structuredArtifactName) {
-        void loadArtifactContent(c.artifactName)
-      }
+    openIndex.value = props.cards.length ? 0 : -1
+  },
+)
+
+watch(
+  [openIndex, () => props.cards],
+  () => {
+    const i = openIndex.value
+    if (i < 0) return
+    const c = props.cards[i]
+    if (c?.typeTag === '自定义产物' && c.artifactName && !c.structuredArtifactName) {
+      void loadArtifactContent(c.artifactName)
     }
   },
   { immediate: true },
 )
+
+function toggleCard(i: number) {
+  openIndex.value = openIndex.value === i ? -1 : i
+}
+
+function isOpen(i: number) {
+  return openIndex.value === i
+}
 
 function parseDoc(card: OutputCard): unknown {
   const raw = card.jsonSnapshot?.trim()
@@ -68,24 +87,31 @@ function isHtmlArtifact(name?: string): boolean {
 </script>
 
 <template>
-  <div class="space-y-3">
+  <div class="space-y-3" data-testid="output-result-cards">
     <article
-      v-for="{ card, doc } in cardsWithDoc"
+      v-for="({ card, doc }, i) in cardsWithDoc"
       :key="card.index + ':' + card.template"
       class="card overflow-hidden"
       :class="card.status === 'failed' ? 'border-err/30' : ''"
+      :data-testid="`output-result-card-${i}`"
     >
-      <header
-        class="flex items-center gap-2 border-b border-line bg-elevated px-3 py-2.5"
-        :class="card.status === 'failed' ? 'border-err/25 bg-err/10' : ''"
-      >
-        <span class="bg-accent-dim px-1.5 py-0.5 text-[10px] font-semibold text-accent-2">{{ card.index }}</span>
-        <span class="flex-1 truncate text-[12px] font-semibold" :class="card.status === 'failed' ? 'text-err' : 'text-txt'">
-          {{ card.title }}
-        </span>
-        <span class="border border-line px-1.5 py-0.5 text-[10px] text-txt3">{{ card.typeTag }}</span>
-      </header>
-      <div class="p-3">
+      <h3 class="m-0">
+        <button
+          type="button"
+          class="flex w-full items-center gap-2 border-b border-line bg-elevated px-3 py-2.5 text-left"
+          :class="card.status === 'failed' ? 'border-err/25 bg-err/10' : ''"
+          :aria-expanded="isOpen(i) ? 'true' : 'false'"
+          :data-testid="`output-result-card-toggle-${i}`"
+          @click="toggleCard(i)"
+        >
+          <span class="bg-accent-dim px-1.5 py-0.5 text-[10px] font-semibold text-accent-2">{{ card.index }}</span>
+          <span class="flex-1 truncate text-[12px] font-semibold" :class="card.status === 'failed' ? 'text-err' : 'text-txt'">
+            {{ card.title }}
+          </span>
+          <span class="border border-line px-1.5 py-0.5 text-[10px] text-txt3">{{ card.typeTag }}</span>
+        </button>
+      </h3>
+      <div v-if="isOpen(i)" class="p-3" :data-testid="`output-result-card-body-${i}`">
         <template v-if="card.status === 'failed'">
           <p class="text-[12px] text-txt2">
             <strong class="text-err">{{ t('pages.nodeOutput.outputCards.sourceFailedTitle') }}</strong><br />

--- a/web/src/lib/runNotifyTemplate.test.ts
+++ b/web/src/lib/runNotifyTemplate.test.ts
@@ -4,6 +4,7 @@ import {
   formatDefaultRunNotifyMessage,
   renderRunNotifyMessage,
   replaceRunNotifyPlaceholders,
+  runNotifyTitle,
   RUN_NOTIFY_PREVIEW_FAKE,
 } from './runNotifyTemplate'
 
@@ -69,6 +70,17 @@ describe('runNotifyTemplate', () => {
         title: 'T',
       }),
     ).toBe('x P {nope} T')
+  })
+
+  it('completed title is 运行完成 not 运行失败', () => {
+    expect(runNotifyTitle('completed')).toBe('运行完成')
+    expect(formatDefaultRunNotifyMessage('completed', RUN_NOTIFY_PREVIEW_FAKE)).toContain(
+      '【Approving】运行完成',
+    )
+    expect(formatDefaultRunNotifyMessage('completed', RUN_NOTIFY_PREVIEW_FAKE)).not.toContain(
+      '运行失败',
+    )
+    expect(renderRunNotifyMessage('completed', '')).toContain('【Approving】运行完成')
   })
 
   it('default editable skeleton renders to default with fake data', () => {

--- a/web/src/lib/runNotifyTemplate.ts
+++ b/web/src/lib/runNotifyTemplate.ts
@@ -5,7 +5,7 @@
  * FormatRunNotifyMessage / RenderRunNotifyMessage).
  */
 
-export type RunNotifyKind = 'waiting_human' | 'failed'
+export type RunNotifyKind = 'waiting_human' | 'failed' | 'completed'
 
 export const RUN_NOTIFY_PLACEHOLDERS = [
   '{project}',
@@ -36,7 +36,14 @@ export const RUN_NOTIFY_PREVIEW_FAKE: RunNotifyPreviewContext = {
 }
 
 export function runNotifyTitle(kind: RunNotifyKind): string {
-  return kind === 'waiting_human' ? '等待人工处理' : '运行失败'
+  switch (kind) {
+    case 'waiting_human':
+      return '等待人工处理'
+    case 'completed':
+      return '运行完成'
+    default:
+      return '运行失败'
+  }
 }
 
 /**

--- a/web/src/lib/runOutputSelection.test.ts
+++ b/web/src/lib/runOutputSelection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { lastOutputNodeId } from './runOutputSelection'
+import { firstGraphOutputNodeId, lastOutputNodeId, resolveOutputFocusNodeId } from './runOutputSelection'
 import type { Run } from './types'
 
 describe('lastOutputNodeId', () => {
@@ -26,5 +26,44 @@ describe('lastOutputNodeId', () => {
       { id: 'out2', type: 'output' },
     ]
     expect(lastOutputNodeId(run, nodes)).toBe('out2')
+  })
+
+  it('falls back to first graph output when nothing executed', () => {
+    const run = {
+      id: 'r2',
+      workflowId: 'w',
+      workflowName: 'W',
+      status: 'completed',
+      trigger: 'manual',
+      startedAt: '2026-01-01T00:00:00Z',
+      durationSec: 1,
+      progress: 1,
+      nodeRuns: {},
+      artifacts: [],
+    } as Run
+    const nodes = [
+      { id: 'plan', type: 'plan' },
+      { id: 'out1', type: 'output' },
+      { id: 'out2', type: 'output' },
+    ]
+    expect(lastOutputNodeId(run, nodes)).toBeNull()
+    expect(firstGraphOutputNodeId(nodes)).toBe('out1')
+    expect(resolveOutputFocusNodeId(run, nodes)).toBe('out1')
+  })
+
+  it('returns null when graph has no output node', () => {
+    const run = {
+      id: 'r3',
+      workflowId: 'w',
+      workflowName: 'W',
+      status: 'completed',
+      trigger: 'manual',
+      startedAt: '2026-01-01T00:00:00Z',
+      durationSec: 1,
+      progress: 1,
+      nodeRuns: { plan: { nodeId: 'plan', status: 'completed', startedAt: '2026-01-01T00:00:05Z' } },
+      artifacts: [],
+    } as Run
+    expect(resolveOutputFocusNodeId(run, [{ id: 'plan', type: 'plan' }])).toBeNull()
   })
 })

--- a/web/src/lib/runOutputSelection.ts
+++ b/web/src/lib/runOutputSelection.ts
@@ -22,3 +22,19 @@ export function lastOutputNodeId(run: Run, nodes: { id: string; type: string }[]
   }
   return bestId
 }
+
+/** First output node in graph order (fallback when nothing executed). */
+export function firstGraphOutputNodeId(nodes: { id: string; type: string }[]): string | null {
+  return nodes.find((n) => n.type === 'output')?.id ?? null
+}
+
+/**
+ * Focus target for completed notify / live complete:
+ * last executed output node, else first graph output node, else null.
+ */
+export function resolveOutputFocusNodeId(
+  run: Run,
+  nodes: { id: string; type: string }[],
+): string | null {
+  return lastOutputNodeId(run, nodes) || firstGraphOutputNodeId(nodes)
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -76,6 +76,8 @@ export interface ProjectNotifyPolicy {
   waitingHumanTemplate?: string
   /** Full QQ body for failed; trim-empty → legacy FormatRunNotifyMessage. */
   failedTemplate?: string
+  /** Full QQ body for completed; trim-empty → FormatRunNotifyMessage. Opt-in. */
+  completedTemplate?: string
 }
 
 /** Workflow-level notify override: off | inherit | custom. */

--- a/web/src/lib/useAuth.test.ts
+++ b/web/src/lib/useAuth.test.ts
@@ -7,6 +7,7 @@ describe('useAuth', () => {
     expect(authRedirectPath('https://evil')).toBe('/')
     expect(authRedirectPath('//evil')).toBe('/')
     expect(authRedirectPath('/runs?x=1')).toBe('/runs?x=1')
+    expect(authRedirectPath('/runs/r1?node=out&tab=output')).toBe('/runs/r1?node=out&tab=output')
 
     const auth = useAuth()
     auth.clearUser()

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -247,11 +247,12 @@
         "evCompletedLabel": "Run completed",
         "evWaitingHuman": "When a run pauses for your confirmation or action",
         "evFailed": "When a step fails and the run cannot continue",
-        "evCompleted": "Coming soon — not sent yet",
+        "evCompleted": "Off by default; when on, send QQ when a run succeeds",
         "templatesTitle": "Message templates",
         "templatesHint": "Write the full QQ body per trigger; leave empty to use the system default. Workflows only choose triggers, not copy.",
         "segWaitingHuman": "Waiting for human",
         "segFailed": "Run failed",
+        "segCompleted": "Run completed",
         "placeholders": "Placeholders",
         "fillDefault": "Fill / restore default",
         "clearDefault": "Clear (use default)",
@@ -2046,6 +2047,9 @@
       "artifactsMcp": "Artifacts · written via artifact-store MCP",
       "output": "Output",
       "workflowComplete": "Workflow complete.",
+      "noPreviewCardsTitle": "No previewable result cards this run",
+      "noPreviewCardsBody": "The run completed successfully. Final result sources are empty, or no output node ran. This is not a load failure.",
+      "noPreviewCardsHint": "You can still browse all raw artifacts on this page's Artifacts tab.",
       "outputCards": {
         "sourceFailedTitle": "Source node failed / no product",
         "invalidSource": "Invalid or unparseable source reference"

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -247,11 +247,12 @@
         "evCompletedLabel": "运行完成",
         "evWaitingHuman": "运行停下来等待你确认或处理时",
         "evFailed": "某个步骤失败、运行无法继续时",
-        "evCompleted": "即将支持，当前不会推送",
+        "evCompleted": "默认关闭，打开后运行成功结束时发 QQ",
         "templatesTitle": "消息文案模板",
         "templatesHint": "按通知时机编写完整 QQ 正文；留空则使用系统默认文案。工作流只能选择通知时机，不能覆盖文案。",
         "segWaitingHuman": "等待人工",
         "segFailed": "运行失败",
+        "segCompleted": "运行完成",
         "placeholders": "占位符",
         "fillDefault": "填入 / 恢复默认文案",
         "clearDefault": "清空（用默认）",
@@ -2046,6 +2047,9 @@
       "artifactsMcp": "产物 · 经 artifact-store MCP 写入",
       "output": "输出",
       "workflowComplete": "工作流完成。",
+      "noPreviewCardsTitle": "本次没有可预览的结果卡",
+      "noPreviewCardsBody": "运行已成功完成。最终结果来源为空，或本次未执行输出节点。这不是加载失败。",
+      "noPreviewCardsHint": "可从同页 Artifacts Tab 查看全量原始产物。",
       "outputCards": {
         "sourceFailedTitle": "来源节点失败 / 无产物",
         "invalidSource": "无效或无法解析的来源引用"

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -1,7 +1,7 @@
 import { createRouter, createWebHistory, type RouteRecordRaw } from 'vue-router'
 import { updateDocumentTitle } from '@/lib/locale'
 import { authApi } from '@/lib/api'
-import { getAuthState, markAuthReady, useAuth } from '@/lib/useAuth'
+import { authRedirectPath, getAuthState, markAuthReady, useAuth } from '@/lib/useAuth'
 import LoginView from '@/views/LoginView.vue'
 
 const routes: RouteRecordRaw[] = [
@@ -38,8 +38,9 @@ router.beforeEach(async (to) => {
     if (to.name === 'login') {
       const { user, setUser } = useAuth()
       if (user.value) {
+        // Return a string so Vue Router parses ?query (object `{ path }` drops it).
         const redirect = typeof to.query.redirect === 'string' ? to.query.redirect : '/'
-        return { path: redirect.startsWith('/') && !redirect.startsWith('//') ? redirect : '/' }
+        return authRedirectPath(redirect)
       }
       // Do not await /me before painting login — brand LCP must not wait on auth RTT.
       // Keep auth.ready false until /me settles so LoginView can show brand-only shell
@@ -49,8 +50,7 @@ router.beforeEach(async (to) => {
         .then((me) => {
           setUser({ username: me.username, expiresAt: me.expires_at, isAdmin: !!me.is_admin })
           const redirect = typeof to.query.redirect === 'string' ? to.query.redirect : '/'
-          const path = redirect.startsWith('/') && !redirect.startsWith('//') ? redirect : '/'
-          return router.replace(path)
+          return router.replace(authRedirectPath(redirect))
         })
         .catch(() => {
           markAuthReady()

--- a/web/src/router/loginRedirect.test.ts
+++ b/web/src/router/loginRedirect.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment happy-dom
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import { authRedirectPath } from '@/lib/useAuth'
+
+const src = readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'index.ts'), 'utf8')
+
+describe('login redirect query preservation (g3.4)', () => {
+  it('logged-in /login uses string redirect via authRedirectPath, not { path }', () => {
+    expect(src).toMatch(/authRedirectPath/)
+    expect(src).toMatch(/return authRedirectPath\(redirect\)/)
+    // Vue Router does not parse ?query from object-form path.
+    expect(src).not.toMatch(/return \{ path: redirect/)
+    expect(src).not.toMatch(/return \{ path: redirect\.startsWith/)
+  })
+
+  it('string replace keeps node/tab query; object path drops it', async () => {
+    const routes = [
+      { path: '/login', component: { template: '<div />' } },
+      { path: '/runs/:id', component: { template: '<div />' } },
+    ]
+    const keep = createRouter({ history: createMemoryHistory(), routes })
+    await keep.push('/login')
+    await keep.replace(authRedirectPath('/runs/r1?node=end&tab=output'))
+    expect(keep.currentRoute.value.path).toBe('/runs/r1')
+    expect(keep.currentRoute.value.query).toEqual({ node: 'end', tab: 'output' })
+
+    const drop = createRouter({ history: createMemoryHistory(), routes })
+    await drop.push('/login')
+    await drop.replace({ path: '/runs/r1?node=end&tab=output' })
+    expect(drop.currentRoute.value.query).toEqual({})
+  })
+})

--- a/web/src/views/ProjectDetailView.vue
+++ b/web/src/views/ProjectDetailView.vue
@@ -300,13 +300,13 @@ async function setWorkflowNotifyMode(w: Workflow, mode: 'off' | 'inherit' | 'cus
   await persistWorkflowNotify(w, { mode, events })
 }
 
-async function toggleWorkflowNotifyEvent(w: Workflow, ev: 'waiting_human' | 'failed') {
+async function toggleWorkflowNotifyEvent(w: Workflow, ev: 'waiting_human' | 'failed' | 'completed') {
   const cur = new Set(w.notifyPolicy?.events || [])
   if (cur.has(ev)) cur.delete(ev)
   else cur.add(ev)
   await persistWorkflowNotify(w, {
     mode: 'custom',
-    events: ['waiting_human', 'failed'].filter((k) => cur.has(k)),
+    events: (['waiting_human', 'failed', 'completed'] as const).filter((k) => cur.has(k)),
   })
 }
 
@@ -1042,6 +1042,16 @@ onUnmounted(() => {
                     />
                     <span>{{ t('pages.projectDetail.notify.segFailed') }}</span>
                   </label>
+                  <label class="inline-flex items-center gap-1">
+                    <input
+                      type="checkbox"
+                      class="accent-accent"
+                      :checked="wfNotifyHas(w, 'completed')"
+                      :disabled="savingNotifyWfId === w.id"
+                      @change="toggleWorkflowNotifyEvent(w, 'completed')"
+                    />
+                    <span>{{ t('pages.projectDetail.notify.segCompleted') }}</span>
+                  </label>
                 </div>
               </div>
               <button
@@ -1199,6 +1209,16 @@ onUnmounted(() => {
                           @change="toggleWorkflowNotifyEvent(w, 'failed')"
                         />
                         <span>{{ t('pages.projectDetail.notify.segFailed') }}</span>
+                      </label>
+                      <label class="inline-flex items-center gap-1">
+                        <input
+                          type="checkbox"
+                          class="accent-accent"
+                          :checked="wfNotifyHas(w, 'completed')"
+                          :disabled="savingNotifyWfId === w.id"
+                          @change="toggleWorkflowNotifyEvent(w, 'completed')"
+                        />
+                        <span>{{ t('pages.projectDetail.notify.segCompleted') }}</span>
                       </label>
                     </div>
                   </td>

--- a/web/src/views/RunDetailView.test.ts
+++ b/web/src/views/RunDetailView.test.ts
@@ -322,12 +322,23 @@ describe('RunDetailView mobile timeline view contract', () => {
     )
   })
 
-  it('defaults completed→timeline and waiting_human→detail on mobile', () => {
+  it('defaults waiting_human→detail on mobile; live/deep-link completed→detail', () => {
     expect(src).toMatch(/mobileMainPanel\.value = 'timeline'/)
     expect(src).toMatch(/mobileMainPanel\.value = 'detail'/)
-    expect(src).toMatch(/timelineScrollToken\.value \+= 1/)
+    expect(src).toMatch(/outputFocusLock/)
+    expect(src).toMatch(/applyOutputDeepLinkFocus/)
+    expect(src).toMatch(/resolveOutputFocusNodeId/)
+    expect(src).toMatch(/queryParam\('tab'\) === 'output'/)
+    expect(src).toMatch(/if \(isMobile\.value\) mobileMainPanel\.value = 'detail'/)
+    expect(src).toMatch(/prev !== 'running' && prev !== 'waiting_human'/)
+    expect(src).toMatch(/if \(runLoading\.value\) return/)
     expect(src).toMatch(/hasProduct\.value && nodeCompleted\.value\) nodeTab\.value = 'product'/)
     expect(src).toMatch(/:mobile-fill-remaining="true"/)
+  })
+
+  it('does not toast on run completed (g5.3)', () => {
+    expect(src).not.toMatch(/运行已完成/)
+    expect(src).not.toMatch(/toast\.(success|info|warn)\([^)]*complet/i)
   })
 })
 

--- a/web/src/views/RunDetailView.vue
+++ b/web/src/views/RunDetailView.vue
@@ -42,7 +42,7 @@ import { previewPickLabel, type AppPreviewPickPayload } from '@/lib/previewPickU
 import { NODE_DEFS } from '@/data/nodeRegistry'
 import { resolveNodeDisplayLabelFromNode } from '@/lib/resolveNodeDisplayLabel'
 import { fmtTime, fmtDuration, formatTrigger } from '@/lib/format'
-import { lastOutputNodeId } from '@/lib/runOutputSelection'
+import { resolveOutputFocusNodeId } from '@/lib/runOutputSelection'
 import { pickDefaultTimelineNodeId } from '@/lib/runStats'
 import { PRODUCT_NODE_TYPES } from '@/lib/productNodeArtifacts'
 import { applyLiveWsAcpPage } from '@/lib/applyLiveWsAcpPage'
@@ -615,7 +615,7 @@ function syncAllMcpCallsFromRun() {
 }
 
 async function initAfterLoadSuccess() {
-  if (!selected.value) selected.value = defaultNode.value || null
+  if (!applyOutputDeepLinkFocus() && !selected.value) selected.value = defaultNode.value || null
   syncAllMcpCallsFromRun()
   // Rehydrate regardless of which tab is active (default tab stays unchanged).
   void rehydrateNodeEvents(selected.value)
@@ -1560,14 +1560,51 @@ function onNodeTabDisabledClick(id: string) {
   if (id === 'gate') toast.warn(t('pages.runDetail.gateRemoved'))
 }
 const nodeTab = ref('output')
+/** When set, watch(selected) must not steal tab=output (QQ deep link / live complete). */
+const outputFocusLock = ref(false)
+
+function graphNodesForFocus() {
+  return wf.value.nodes.length ? wf.value.nodes : run.value.nodes || []
+}
+
+function queryParam(key: string): string {
+  const raw = route.query[key]
+  if (typeof raw === 'string') return raw.trim()
+  if (Array.isArray(raw) && typeof raw[0] === 'string') return String(raw[0]).trim()
+  return ''
+}
+
+/** Parse ?node=&tab=output (completed QQ deep link). Returns true when applied. */
+function applyOutputDeepLinkFocus(): boolean {
+  const qNode = queryParam('node')
+  const qTab = queryParam('tab')
+  if (qTab !== 'output' && !qNode) return false
+
+  const nodes = graphNodesForFocus()
+  const focusId =
+    (qNode && nodes.some((n) => n.id === qNode) ? qNode : null) ||
+    resolveOutputFocusNodeId(run.value, nodes)
+
+  outputFocusLock.value = true
+  if (focusId) {
+    manual.value = false
+    selected.value = focusId
+  }
+  nodeTab.value = 'output'
+  if (isMobile.value) mobileMainPanel.value = 'detail'
+  return true
+}
 
 /**
  * Mobile (≤768) list-detail: mutually exclusive timeline vs node detail.
  * Desktop keeps side-by-side panes; this state is ignored when !isMobile.
- * Defaults: completed → timeline; waiting_human → detail; else timeline.
+ * Defaults: waiting_human or deep-link tab=output → detail; else timeline.
+ * Live running→completed also switches to detail (see status watch).
  */
 const mobileMainPanel = ref<'timeline' | 'detail'>(
-  isMobile.value && run.value.status === 'waiting_human' ? 'detail' : 'timeline',
+  isMobile.value && (run.value.status === 'waiting_human' || queryParam('tab') === 'output')
+    ? 'detail'
+    : 'timeline',
 )
 /** Bumped to re-scroll selected timeline item (e.g. back from detail). */
 const timelineScrollToken = ref(0)
@@ -1605,6 +1642,10 @@ const canvasPaneStyle = computed(() =>
 watch(
   selected,
   () => {
+    if (outputFocusLock.value) {
+      nodeTab.value = 'output'
+      return
+    }
     // app_preview: Gate 仅壳，主交互为复审对话 + VNC
     if (hasAppPreview.value && reviewActive.value) nodeTab.value = 'review'
     else if (gateActive.value) nodeTab.value = 'gate'
@@ -1616,21 +1657,25 @@ watch(
   },
   { immediate: true },
 )
-// On mobile, prioritize the active human gate when entering or when gate appears.
+watch(nodeTab, (tab) => {
+  if (outputFocusLock.value && tab !== 'output') outputFocusLock.value = false
+})
+// Live running/waiting_human→completed: select last output node, open output view,
+// mobile detail. Skip hard-load hydration (emptyRun dummy running → completed).
 watch(
   () => run.value.status,
-  (st) => {
+  (st, prev) => {
     if (st !== 'completed') return
-    const id = lastOutputNodeId(run.value, wf.value.nodes)
-    if (!id) return
-    manual.value = false
-    selected.value = id
-    nodeTab.value = 'output'
-    // Completed: first land on timeline with last item selected (scroll via token).
-    if (isMobile.value) {
-      mobileMainPanel.value = 'timeline'
-      timelineScrollToken.value += 1
+    if (runLoading.value) return
+    if (prev !== 'running' && prev !== 'waiting_human') return
+    const id = resolveOutputFocusNodeId(run.value, graphNodesForFocus())
+    if (id) {
+      manual.value = false
+      selected.value = id
     }
+    outputFocusLock.value = true
+    nodeTab.value = 'output'
+    if (isMobile.value) mobileMainPanel.value = 'detail'
   },
 )
 
@@ -1741,6 +1786,7 @@ const detailTabs = computed(() => {
 })
 
 function selectNode(id: string) {
+  outputFocusLock.value = false
   manual.value = true
   selected.value = id
   if (isMobile.value) mobileMainPanel.value = 'detail'
@@ -1773,6 +1819,7 @@ watch([viewMode, isMobile, defaultNode], () => {
 // the iteration pointer (watch above), so route the desired index through
 // pendingIter when the node actually changes.
 function selectExecution(nodeId: string, idx: number) {
+  outputFocusLock.value = false
   manual.value = true
   if (selected.value === nodeId) {
     selIterIdx.value = idx

--- a/web/vite.e2e.config.ts
+++ b/web/vite.e2e.config.ts
@@ -237,6 +237,9 @@ export default defineConfig({
           new URL('./e2e/run-detail-mobile-panel.html', import.meta.url),
         ),
         'run-detail-real': fileURLToPath(new URL('./e2e/run-detail-real.html', import.meta.url)),
+        'run-completed-output': fileURLToPath(
+          new URL('./e2e/run-completed-output.html', import.meta.url),
+        ),
         'gate-mobile-fill': fileURLToPath(new URL('./e2e/gate-mobile-fill.html', import.meta.url)),
         'gate-cold-silent': fileURLToPath(new URL('./e2e/gate-cold-silent.html', import.meta.url)),
         'clarify-inbox-product': fileURLToPath(


### PR DESCRIPTION
成功 completed 后按 opt-in 投递一条运行级通知，点击落到输出视图并默认展开第 1 张结果卡；默认关闭以免刷屏。

Co-authored-by: Cursor <cursoragent@cursor.com>
