### PR TITLE
fix(web): 消除待审批空收件箱底部留白

### DIFF
--- a/web/e2e/inbox-empty-fill-main.ts
+++ b/web/e2e/inbox-empty-fill-main.ts
@@ -1,0 +1,62 @@
+import '../src/styles/global.css'
+import { createApp, defineComponent, h } from 'vue'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import { i18n } from '../src/lib/i18n'
+import { initLocale, setLocale } from '../src/lib/locale'
+import { installIdleScrollbar } from '../src/lib/idleScrollbar'
+import { setTheme } from '../src/lib/theme'
+import GatesInboxView from '../src/views/GatesInboxView.vue'
+
+const params = new URLSearchParams(window.location.search)
+const theme = params.get('theme') === 'light' ? 'light' : 'dark'
+const filterWf = params.get('wf') || ''
+
+const Fixture = defineComponent({
+  name: 'InboxEmptyFillFixture',
+  setup() {
+    return () =>
+      h(
+        'div',
+        {
+          'data-testid': 'inbox-empty-shell',
+          // Mirror AppShell non-full height chain: h-screen overflow-hidden → padded flex col.
+          class: 'flex h-full min-h-0 flex-col overflow-hidden bg-base',
+        },
+        [
+          h(
+            'div',
+            {
+              class: 'flex h-full min-h-0 flex-col px-4 py-4 md:px-6 md:py-6',
+            },
+            [h(GatesInboxView)],
+          ),
+        ],
+      )
+  },
+})
+
+async function boot() {
+  await initLocale()
+  await setLocale('zh-CN')
+  setTheme(theme)
+  installIdleScrollbar()
+
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/gates', component: { render: () => h('div') }, meta: { titleKey: 'route.gates' } },
+      { path: '/runs/:id', component: { render: () => h('div', { 'data-testid': 'run-page' }, 'run') } },
+    ],
+  })
+
+  const query: Record<string, string> = {}
+  if (filterWf) query.wf = filterWf
+  await router.push({ path: '/gates', query })
+
+  createApp({ render: () => h(Fixture) })
+    .use(i18n)
+    .use(router)
+    .mount('#app')
+}
+
+void boot()

--- a/web/e2e/inbox-empty-fill.html
+++ b/web/e2e/inbox-empty-fill.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Inbox empty fill e2e</title>
+  </head>
+  <body class="bg-base text-txt">
+    <div id="app" class="h-screen"></div>
+    <script type="module" src="./inbox-empty-fill-main.ts"></script>
+  </body>
+</html>

--- a/web/e2e/inbox-empty-fill.spec.ts
+++ b/web/e2e/inbox-empty-fill.spec.ts
@@ -1,0 +1,202 @@
+import { expect, test, type Page } from '@playwright/test'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const shotDir = path.join(__dirname, '..', '..', '..', 'test-screenshots')
+
+const MOCK_WORKFLOWS = [
+  {
+    id: 'wf-1',
+    name: '快速上手·轻量',
+    description: '',
+    status: 'published',
+    version: 1,
+    updatedAt: '2026-01-01T00:00:00Z',
+    needsRepo: false,
+    nodes: [],
+    edges: [],
+  },
+]
+
+async function mockApi(page: Page, opts: { filterEmpty?: boolean } = {}) {
+  await page.route('**/api/**', async (route) => {
+    const url = new URL(route.request().url())
+    const p = url.pathname
+    if (p.includes('/gates')) {
+      const filtered = opts.filterEmpty || !!url.searchParams.get('wf')
+      await route.fulfill({
+        json: filtered ? { items: [], total: 5 } : { items: [], total: 0 },
+      })
+      return
+    }
+    if (p.includes('/workflows')) {
+      await route.fulfill({ json: MOCK_WORKFLOWS })
+      return
+    }
+    if (p.includes('/projects')) {
+      await route.fulfill({ json: [] })
+      return
+    }
+    if (p.includes('/health')) {
+      await route.fulfill({ json: { status: 'ok', ready: true } })
+      return
+    }
+    await route.fulfill({ status: 404, json: { error: 'not mocked' } })
+  })
+}
+
+function emptyCard(page: Page) {
+  return page.locator('.card').filter({ hasText: /没有待审批项|该流水线没有待审批项/ })
+}
+
+async function emptyMetrics(page: Page) {
+  return page.evaluate(() => {
+    const cards = Array.from(document.querySelectorAll('.card')).filter((el) =>
+      /没有待审批项|该流水线没有待审批项/.test(el.textContent || ''),
+    )
+    const card = cards[0] as HTMLElement | undefined
+    const empty = card?.firstElementChild as HTMLElement | undefined
+    const heading = Array.from(document.querySelectorAll('h2')).find((el) =>
+      (el.textContent || '').includes('待审批'),
+    ) as HTMLElement | undefined
+    function box(el: Element | null | undefined) {
+      if (!el) return null
+      const r = (el as HTMLElement).getBoundingClientRect()
+      return { top: r.top, bottom: r.bottom, height: r.height, width: r.width }
+    }
+    const cardBox = box(card)
+    const emptyBox = box(empty)
+    const headingBox = box(heading)
+    const cs = card ? getComputedStyle(card) : null
+    return {
+      cardBox,
+      emptyBox,
+      headingBox,
+      viewportH: window.innerHeight,
+      viewportW: window.innerWidth,
+      cardRadius: cs?.borderRadius || '',
+      cardOverflow: cs?.overflow || '',
+      cardScrollH: card?.scrollHeight ?? 0,
+      cardClientH: card?.clientHeight ?? 0,
+      bgBase: getComputedStyle(document.documentElement).getPropertyValue('--c-base').trim(),
+    }
+  })
+}
+
+function expectFillGeometry(
+  m: Awaited<ReturnType<typeof emptyMetrics>>,
+  opts: { minViewportRatio?: number } = {},
+) {
+  const minRatio = opts.minViewportRatio ?? 0.7
+  expect(m.cardBox).not.toBeNull()
+  expect(m.emptyBox).not.toBeNull()
+  // Desktop aligns inbox-unified-budget (card > 70% viewport). Mobile header stacks
+  // (title + tools) so remaining ratio is lower; still must fill leftover height.
+  expect(m.cardBox!.height).toBeGreaterThan(m.viewportH * minRatio)
+  // No large void under the card — only AppShell padding (py-4 / md:py-6) remains.
+  expect(m.viewportH - m.cardBox!.bottom).toBeLessThan(48)
+  expect(m.cardBox!.bottom).toBeGreaterThan(m.viewportH * 0.9)
+  // Must be stretched vs content-sized EmptyState (~py-14 + icon), not a short bar.
+  expect(m.cardBox!.height).toBeGreaterThan(m.emptyBox!.height + 80)
+  // EmptyState roughly vertically centered in the card (not stuck to top/bottom).
+  const cardMid = m.cardBox!.top + m.cardBox!.height / 2
+  const emptyMid = m.emptyBox!.top + m.emptyBox!.height / 2
+  expect(Math.abs(cardMid - emptyMid)).toBeLessThan(48)
+  expect(m.emptyBox!.top).toBeGreaterThan(m.cardBox!.top + 8)
+  expect(m.cardBox!.bottom).toBeGreaterThan(m.emptyBox!.bottom + 8)
+}
+
+async function expectEmptyCardClasses(page: Page) {
+  const className = (await emptyCard(page).getAttribute('class')) || ''
+  expect(className.split(/\s+/)).toEqual(
+    expect.arrayContaining(['card', 'flex', 'min-h-0', 'flex-1', 'flex-col', 'items-center', 'justify-center', 'overflow-auto']),
+  )
+}
+
+test.describe('Inbox empty fill layout (plan g2.3)', () => {
+  test('desktop empty inbox: card fills remaining height, EmptyState centered (g1.2 g2.3 g3.1)', async ({
+    page,
+  }, testInfo) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await mockApi(page)
+    await page.goto('/inbox-empty-fill.html?theme=light')
+    await expect(page.getByRole('heading', { name: '待审批' })).toBeVisible({ timeout: 15_000 })
+    await expect(emptyCard(page)).toBeVisible()
+    await expect(page.getByText('没有待审批项')).toBeVisible()
+
+    const m = await emptyMetrics(page)
+    await page.screenshot({
+      path: path.join(shotDir, 'inbox-empty-desktop-light.png'),
+      fullPage: false,
+    })
+    testInfo.annotations.push({ type: 'metrics', description: JSON.stringify(m) })
+
+    expectFillGeometry(m)
+    await expectEmptyCardClasses(page)
+    // Product chrome already forces zero radius (* { border-radius: 0 !important });
+    // keep .card token class, do not introduce Demo preview-suite skin.
+    expect(m.cardRadius === '0px' || parseFloat(String(m.cardRadius).split(' ')[0] || '0') === 0).toBe(true)
+  })
+
+  test('mobile empty inbox: same fill + center geometry (g1.1 g2.3)', async ({ page }, testInfo) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await mockApi(page)
+    await page.goto('/inbox-empty-fill.html?theme=light')
+    await expect(page.getByRole('heading', { name: '待审批' })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText('没有待审批项')).toBeVisible()
+
+    const m = await emptyMetrics(page)
+    await page.screenshot({
+      path: path.join(shotDir, 'inbox-empty-mobile-light.png'),
+      fullPage: false,
+    })
+    testInfo.annotations.push({ type: 'metrics', description: JSON.stringify(m) })
+    expectFillGeometry(m, { minViewportRatio: 0.55 })
+    await expectEmptyCardClasses(page)
+  })
+
+  test('pipeline filter empty uses same fill wrapper + pipeline copy (g1.3 g2.3)', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await mockApi(page, { filterEmpty: true })
+    await page.goto('/inbox-empty-fill.html?theme=light&wf=wf-1')
+    await expect(page.getByText('该流水线没有待审批项')).toBeVisible({ timeout: 15_000 })
+    const m = await emptyMetrics(page)
+    expectFillGeometry(m)
+    await expectEmptyCardClasses(page)
+  })
+
+  test('dark theme empty card still fills without large base-color void (g3.1)', async ({ page }, testInfo) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await mockApi(page)
+    await page.goto('/inbox-empty-fill.html?theme=dark')
+    await expect(page.getByText('没有待审批项')).toBeVisible({ timeout: 15_000 })
+    const m = await emptyMetrics(page)
+    await page.screenshot({
+      path: path.join(shotDir, 'inbox-empty-desktop-dark.png'),
+      fullPage: false,
+    })
+    testInfo.annotations.push({ type: 'metrics', description: JSON.stringify(m) })
+    expectFillGeometry(m)
+  })
+
+  test('short viewport: chrome stays, empty card scrolls instead of overflowing (g1.3 g2.3)', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 360 })
+    await mockApi(page)
+    await page.goto('/inbox-empty-fill.html?theme=light')
+    await expect(page.getByRole('heading', { name: '待审批' })).toBeVisible({ timeout: 15_000 })
+    await expect(emptyCard(page)).toBeVisible()
+
+    const m = await emptyMetrics(page)
+    expect(m.headingBox).not.toBeNull()
+    expect(m.headingBox!.top).toBeGreaterThanOrEqual(0)
+    expect(m.cardBox).not.toBeNull()
+    // Card stays inside the viewport (does not blow past chrome).
+    expect(m.cardBox!.bottom).toBeLessThanOrEqual(m.viewportH + 1)
+    expect(m.cardBox!.top).toBeGreaterThan(m.headingBox!.bottom - 1)
+    // overflow-auto allows internal scroll when EmptyState exceeds card height.
+    expect(['auto', 'overlay', 'scroll']).toContain(m.cardOverflow)
+  })
+})

--- a/web/src/views/GatesInboxView.mobileFill.test.ts
+++ b/web/src/views/GatesInboxView.mobileFill.test.ts
@@ -60,6 +60,41 @@ describe('GatesInboxView review/clarify composer mode', () => {
   })
 })
 
+const EMPTY_CARD_CLASS =
+  'card flex min-h-0 flex-1 flex-col items-center justify-center overflow-auto'
+
+describe('GatesInboxView empty inbox fill (plan g1 / g2.1 / g1.3)', () => {
+  it('mobile + desktop empty wrappers both include flex-1 and vertical centering (g1.1 g1.2 g2.1)', () => {
+    const escaped = EMPTY_CARD_CLASS.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const matches = src.match(new RegExp(`class="${escaped}"`, 'g')) || []
+    expect(matches.length).toBe(2)
+    expect(src).toMatch(/items-center justify-center overflow-auto/)
+    expect(src).not.toMatch(/<div v-else class="card">/)
+  })
+
+  it('pipeline-filter empty and global empty share the same fill wrappers (g1.3)', () => {
+    const blocks = [
+      ...src.matchAll(
+        /<div v-else class="card flex min-h-0 flex-1 flex-col items-center justify-center overflow-auto">[\s\S]*?<\/div>/g,
+      ),
+    ]
+    expect(blocks.length).toBe(2)
+    for (const block of blocks) {
+      expect(block[0]).toMatch(/listTotal \? t\('common\.empty\.noPendingGatesForPipeline'\)/)
+      expect(block[0]).toMatch(/listTotal\s+\?\s+t\('common\.empty\.noPendingGatesPipelineDesc'\)/)
+      expect(block[0]).toMatch(/t\('common\.empty\.noPendingGates'\)/)
+      expect(block[0]).toMatch(/t\('common\.empty\.noPendingGatesDesc'\)/)
+    }
+  })
+
+  it('empty wrappers keep .card skin tokens and do not zero-radius (g3.1)', () => {
+    const matches = src.match(/class="card flex min-h-0 flex-1 flex-col items-center justify-center overflow-auto"/g) || []
+    expect(matches.length).toBe(2)
+    expect(src).not.toMatch(/inbox-empty.*rounded-none/)
+    expect(src).not.toMatch(/empty-card.*!rounded-none/)
+  })
+})
+
 describe('GatesInboxView app_preview stage (g2.2)', () => {
   it('mounts AppPreviewPanel with fill + pick wiring on both ReviewShell stages', () => {
     expect(src).toMatch(/import AppPreviewPanel/)

--- a/web/src/views/GatesInboxView.vue
+++ b/web/src/views/GatesInboxView.vue
@@ -1525,7 +1525,7 @@ function itemBadgeClass(it: InboxItem) {
         </div>
         <Pagination v-if="listTotal > PAGE_SIZE" v-model:page="listPage" :page-size="PAGE_SIZE" :total="listTotal" />
       </div>
-      <div v-else class="card">
+      <div v-else class="card flex min-h-0 flex-1 flex-col items-center justify-center overflow-auto">
         <EmptyState
           icon="gate"
           :title="listTotal ? t('common.empty.noPendingGatesForPipeline') : t('common.empty.noPendingGates')"
@@ -1754,7 +1754,7 @@ function itemBadgeClass(it: InboxItem) {
       </div>
     </div>
 
-    <div v-else class="card">
+    <div v-else class="card flex min-h-0 flex-1 flex-col items-center justify-center overflow-auto">
       <EmptyState
         icon="gate"
         :title="listTotal ? t('common.empty.noPendingGatesForPipeline') : t('common.empty.noPendingGates')"


### PR DESCRIPTION
## Summary
- 让桌面与移动端待审批空状态卡片拉满剩余高度并居中内容
- 增加源码断言和 Playwright 几何测试，覆盖筛选空结果、主题与矮视口
- 保持现有 AppShell、EmptyState、文案及有项预览布局不变

## Test plan
- [x] `npx vitest run`（197 files / 1371 tests）
- [x] `inbox-empty-fill.spec.ts`（5 passed）
- [x] `inbox-unified-budget.spec.ts`（4 passed）

Made with [Cursor](https://cursor.com)