### PR TITLE
feat(web): 结构化产物导出 PNG/PDF 最外层 16px padding

### DIFF
--- a/web/src/components/run/ArtifactPreview.export.test.ts
+++ b/web/src/components/run/ArtifactPreview.export.test.ts
@@ -200,6 +200,44 @@ describe('ArtifactPreview structured export UI', () => {
     wrapper.unmount()
   })
 
+  it('keeps inline ancestor p-4 and export root without resident padding (g3.3)', async () => {
+    const wrapper = mountPreview(structuredArtifact)
+    await flushPromises()
+    const exportRoot = wrapper.find('[data-testid="structured-artifact-export-root"]')
+    expect(exportRoot.exists()).toBe(true)
+    expect(exportRoot.classes()).toContain('structured-artifact-export-root')
+    expect(exportRoot.classes()).not.toContain('p-3')
+    expect(exportRoot.classes()).not.toContain('p-4')
+    expect(exportRoot.classes()).not.toContain('p-5')
+    const rootEl = exportRoot.element as HTMLElement
+    expect(rootEl.style.padding).toBe('')
+    expect(rootEl.getAttribute('style') ?? '').not.toMatch(/padding/i)
+
+    const scrollParent = exportRoot.element.parentElement
+    expect(scrollParent).toBeTruthy()
+    expect(scrollParent!.classList.contains('p-4')).toBe(true)
+    expect(scrollParent!.classList.contains('scroll-area')).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('keeps zoom export root without resident padding (g3.3)', async () => {
+    const wrapper = mountPreview(structuredArtifact)
+    await flushPromises()
+    const enlarge = wrapper.findAll('button').find((b) => b.attributes('title') === '放大查看')
+    expect(enlarge).toBeTruthy()
+    await enlarge!.trigger('click')
+    await flushPromises()
+    const zoomRoot = wrapper.find('[data-testid="structured-artifact-export-root-zoom"]')
+    expect(zoomRoot.exists()).toBe(true)
+    expect(zoomRoot.classes()).toContain('structured-artifact-export-root')
+    expect(zoomRoot.classes()).not.toContain('p-3')
+    expect(zoomRoot.classes()).not.toContain('p-4')
+    expect(zoomRoot.classes()).not.toContain('p-5')
+    const zoomEl = zoomRoot.element as HTMLElement
+    expect(zoomEl.style.padding).toBe('')
+    wrapper.unmount()
+  })
+
   it('shows zoom footer export buttons for structured preview', async () => {
     const wrapper = mountPreview(structuredArtifact)
     await flushPromises()

--- a/web/src/components/ui/AppModal.test.ts
+++ b/web/src/components/ui/AppModal.test.ts
@@ -33,6 +33,14 @@ describe('AppModal', () => {
     wrapper.unmount()
   })
 
+  it('keeps modal body p-5 (ArtifactPreview zoom ancestor, g3.3)', () => {
+    const wrapper = mountModal({ open: true })
+    const body = document.body.querySelector('.modal-scroll-area') as HTMLElement | null
+    expect(body).toBeTruthy()
+    expect(body!.classList.contains('p-5')).toBe(true)
+    wrapper.unmount()
+  })
+
   it('emits close on backdrop click by default', async () => {
     const wrapper = mountModal({ open: true })
     const overlay = document.body.querySelector('.bg-black\\/60') as HTMLElement

--- a/web/src/lib/exportStructuredArtifact.test.ts
+++ b/web/src/lib/exportStructuredArtifact.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  EXPORT_OUTER_PADDING_PX,
+  canvasToPdfBlob,
+  computePdfPageLayout,
+  computePixelRatio,
   exportBasenameFromArtifactName,
   exportFilename,
   exportStructuredArtifact,
@@ -10,19 +14,32 @@ import {
 
 const toCanvasMock = vi.hoisted(() => vi.fn())
 
-vi.mock('html-to-image', () => ({
-  toCanvas: (...args: unknown[]) => toCanvasMock(...args),
-}))
-
-vi.mock('jspdf', () => {
+const jsPdfMocks = vi.hoisted(() => {
+  const instances: Array<{
+    addImage: ReturnType<typeof vi.fn>
+    addPage: ReturnType<typeof vi.fn>
+    output: ReturnType<typeof vi.fn>
+    internal: { pageSize: { getWidth: () => number; getHeight: () => number } }
+  }> = []
   class MockJsPDF {
     internal = { pageSize: { getWidth: () => 210, getHeight: () => 297 } }
     addImage = vi.fn()
     addPage = vi.fn()
     output = vi.fn(() => new Blob(['pdf'], { type: 'application/pdf' }))
+    constructor() {
+      instances.push(this)
+    }
   }
-  return { jsPDF: MockJsPDF }
+  return { MockJsPDF, instances }
 })
+
+vi.mock('html-to-image', () => ({
+  toCanvas: (...args: unknown[]) => toCanvasMock(...args),
+}))
+
+vi.mock('jspdf', () => ({
+  jsPDF: jsPdfMocks.MockJsPDF,
+}))
 
 function mockCanvas(width = 100, height = 200): HTMLCanvasElement {
   const canvas = document.createElement('canvas')
@@ -100,16 +117,26 @@ describe('exportStructuredArtifact', () => {
   beforeEach(() => {
     toCanvasMock.mockReset()
     toCanvasMock.mockResolvedValue(mockCanvas(400, 800))
+    jsPdfMocks.instances.length = 0
     vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:export')
     vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
     vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(((type: string) => {
+      if (type !== '2d') return null
+      return {
+        fillStyle: '',
+        fillRect: vi.fn(),
+        drawImage: vi.fn(),
+      }
+    }) as unknown as typeof HTMLCanvasElement.prototype.getContext)
+    vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue('data:image/png;base64,page')
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
-  it('captures full size with theme background and downloads png', async () => {
+  it('captures full size with theme background, 16px clone padding, and content+32 canvas (g3.1)', async () => {
     document.documentElement.style.setProperty('--c-base', '10 10 11')
     const root = document.createElement('div')
     Object.defineProperty(root, 'scrollWidth', { value: 640 })
@@ -121,10 +148,33 @@ describe('exportStructuredArtifact', () => {
 
     expect(result).toEqual({ filename: 'research.png', incomplete: false })
     expect(toCanvasMock).toHaveBeenCalledTimes(1)
-    const opts = toCanvasMock.mock.calls[0][1]
+    expect(EXPORT_OUTER_PADDING_PX).toBe(16)
+    const opts = toCanvasMock.mock.calls[0][1] as {
+      backgroundColor: string
+      width: number
+      height: number
+      canvasWidth: number
+      canvasHeight: number
+      pixelRatio: number
+      style: Record<string, string>
+    }
+    const contentW = 640
+    const contentH = 1200
+    const exportW = contentW + 2 * EXPORT_OUTER_PADDING_PX
+    const exportH = contentH + 2 * EXPORT_OUTER_PADDING_PX
+    const pixelRatio = computePixelRatio(exportW, exportH)
     expect(opts.backgroundColor).toBe('rgb(10 10 11)')
-    expect(opts.width).toBe(640)
-    expect(opts.height).toBe(1200)
+    expect(opts.width).toBe(exportW)
+    expect(opts.height).toBe(exportH)
+    expect(opts.style.padding).toBe('16px')
+    expect(opts.style.boxSizing).toBe('border-box')
+    expect(opts.style.width).toBe(`${exportW}px`)
+    expect(opts.style.height).toBe(`${exportH}px`)
+    expect(opts.pixelRatio).toBe(pixelRatio)
+    expect(opts.canvasWidth).toBe(Math.ceil(exportW * pixelRatio))
+    expect(opts.canvasHeight).toBe(Math.ceil(exportH * pixelRatio))
+    // g1.1: html-to-image 1.11.13 has no onclone — options must not pass one
+    expect(opts).not.toHaveProperty('onclone')
   })
 
   it('downloads pdf filename for pdf format', async () => {
@@ -147,5 +197,94 @@ describe('exportStructuredArtifact', () => {
     expect(result.incomplete).toBe(true)
     expect(result.filename).toBe('test_result.png')
     vi.useRealTimers()
+  })
+})
+
+describe('computePdfPageLayout / canvasToPdfBlob (g3.2)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    jsPdfMocks.instances.length = 0
+  })
+
+  it('slices content region only so every page has inset destY (not whole-canvas negative Y)', () => {
+    const canvas = { width: 672, height: 3000 }
+    const layout = computePdfPageLayout(canvas, { exportCssWidth: 672 })
+    expect(layout.marginMm).toBeCloseTo((EXPORT_OUTER_PADDING_PX / 672) * 210)
+    expect(layout.insetPx).toBeCloseTo(EXPORT_OUTER_PADDING_PX)
+    expect(layout.slices.length).toBeGreaterThan(1)
+    for (const slice of layout.slices) {
+      expect(slice.destX).toBeCloseTo(layout.insetPx)
+      expect(slice.destY).toBeCloseTo(layout.insetPx)
+      expect(slice.srcX).toBeCloseTo(layout.insetPx)
+      expect(slice.srcY).toBeGreaterThanOrEqual(layout.insetPx - 1e-6)
+      expect(slice.srcY + slice.srcH).toBeLessThanOrEqual(3000 - layout.insetPx + 1e-6)
+    }
+    expect(layout.slices[0]!.srcY).toBeCloseTo(layout.insetPx)
+    expect(layout.slices[1]!.destY).toBeCloseTo(layout.insetPx)
+  })
+
+  it('composites theme fill + inset drawImage on every page of a tall canvas', () => {
+    jsPdfMocks.instances.length = 0
+    const fillRect = vi.fn()
+    const drawImage = vi.fn()
+    const fillStyles: string[] = []
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(((type: string) => {
+      if (type !== '2d') return null
+      return {
+        get fillStyle() {
+          return fillStyles[fillStyles.length - 1] ?? ''
+        },
+        set fillStyle(value: string) {
+          fillStyles.push(value)
+        },
+        fillRect,
+        drawImage,
+      }
+    }) as unknown as typeof HTMLCanvasElement.prototype.getContext)
+    vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue('data:image/png;base64,page')
+
+    const canvas = mockCanvas(672, 3000)
+    const blob = canvasToPdfBlob(canvas, {
+      exportCssWidth: 672,
+      backgroundColor: 'rgb(10 10 11)',
+    })
+    expect(blob.type).toBe('application/pdf')
+
+    const layout = computePdfPageLayout(canvas, { exportCssWidth: 672 })
+    expect(layout.slices.length).toBeGreaterThan(1)
+    expect(jsPdfMocks.instances).toHaveLength(1)
+    const pdf = jsPdfMocks.instances[0]!
+    expect(pdf.addPage).toHaveBeenCalledTimes(layout.slices.length - 1)
+    expect(pdf.addImage).toHaveBeenCalledTimes(layout.slices.length)
+    for (const call of pdf.addImage.mock.calls) {
+      expect(call[2]).toBe(0)
+      expect(call[3]).toBe(0)
+      expect(call[4]).toBe(210)
+      expect(call[5]).toBe(297)
+      expect(call[3]).toBeGreaterThanOrEqual(0)
+    }
+    expect(fillRect).toHaveBeenCalledTimes(layout.slices.length)
+    expect(drawImage).toHaveBeenCalledTimes(layout.slices.length)
+    expect(fillStyles.every((c) => c === 'rgb(10, 10, 11)')).toBe(true)
+    for (let i = 0; i < layout.slices.length; i++) {
+      const slice = layout.slices[i]!
+      expect(fillRect.mock.calls[i]!.slice(0, 4)).toEqual([
+        0,
+        0,
+        layout.pageBmpWidth,
+        layout.pageBmpHeight,
+      ])
+      const drawArgs = drawImage.mock.calls[i]!
+      expect(drawArgs[0]).toBe(canvas)
+      expect(drawArgs[1]).toBeCloseTo(slice.srcX)
+      expect(drawArgs[2]).toBeCloseTo(slice.srcY)
+      expect(drawArgs[3]).toBeCloseTo(slice.srcW)
+      expect(drawArgs[4]).toBeCloseTo(slice.srcH)
+      expect(drawArgs[5]).toBeCloseTo(slice.destX)
+      expect(drawArgs[6]).toBeCloseTo(slice.destY)
+      expect(drawArgs[7]).toBeCloseTo(slice.destW)
+      expect(drawArgs[8]).toBeCloseTo(slice.destH)
+      expect(drawArgs[6]).toBeGreaterThan(0)
+    }
   })
 })

--- a/web/src/lib/exportStructuredArtifact.ts
+++ b/web/src/lib/exportStructuredArtifact.ts
@@ -4,6 +4,12 @@ import { jsPDF } from 'jspdf'
 /** Default wait for test_result screenshot placeholders before exporting. */
 export const TEST_SCREENSHOT_WAIT_MS = 5000
 
+/**
+ * Outer padding injected only on the html-to-image clone (not the live preview DOM).
+ * Gold standard: page.html「改后·16px」; matches inline preview ancestor p-4.
+ */
+export const EXPORT_OUTER_PADDING_PX = 16
+
 /** Soft browser canvas limits; downscale when exceeded. */
 const MAX_CANVAS_SIDE = 16384
 const MAX_CANVAS_AREA = 268_435_456
@@ -71,7 +77,7 @@ export async function waitForTestScreenshots(
   })
 }
 
-function computePixelRatio(width: number, height: number): number {
+export function computePixelRatio(width: number, height: number): number {
   let pixelRatio = Math.min(2, typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1)
   while (
     pixelRatio > 0.25 &&
@@ -84,25 +90,45 @@ function computePixelRatio(width: number, height: number): number {
   return Math.max(0.25, pixelRatio)
 }
 
+/** Content box vs export canvas size (content + 2× outer padding). */
+export function measureStructuredExportBox(el: HTMLElement): {
+  contentWidth: number
+  contentHeight: number
+  exportWidth: number
+  exportHeight: number
+  backgroundColor: string
+} {
+  const backgroundColor = resolveThemeBackgroundColor()
+  const contentWidth = Math.max(el.scrollWidth, el.offsetWidth, 1)
+  const contentHeight = Math.max(el.scrollHeight, el.offsetHeight, 1)
+  return {
+    contentWidth,
+    contentHeight,
+    exportWidth: contentWidth + 2 * EXPORT_OUTER_PADDING_PX,
+    exportHeight: contentHeight + 2 * EXPORT_OUTER_PADDING_PX,
+    backgroundColor,
+  }
+}
+
 /** Capture the full scrollable box of `el` (not just the visible viewport). */
 export async function captureStructuredElement(el: HTMLElement): Promise<HTMLCanvasElement> {
-  const backgroundColor = resolveThemeBackgroundColor()
-  const width = Math.max(el.scrollWidth, el.offsetWidth, 1)
-  const height = Math.max(el.scrollHeight, el.offsetHeight, 1)
-  const pixelRatio = computePixelRatio(width, height)
+  const { exportWidth, exportHeight, backgroundColor } = measureStructuredExportBox(el)
+  const pixelRatio = computePixelRatio(exportWidth, exportHeight)
 
   return toCanvas(el, {
     backgroundColor,
-    width,
-    height,
-    canvasWidth: Math.ceil(width * pixelRatio),
-    canvasHeight: Math.ceil(height * pixelRatio),
+    width: exportWidth,
+    height: exportHeight,
+    canvasWidth: Math.ceil(exportWidth * pixelRatio),
+    canvasHeight: Math.ceil(exportHeight * pixelRatio),
     pixelRatio,
     style: {
       overflow: 'visible',
-      height: `${height}px`,
+      height: `${exportHeight}px`,
       maxHeight: 'none',
-      width: `${width}px`,
+      width: `${exportWidth}px`,
+      padding: `${EXPORT_OUTER_PADDING_PX}px`,
+      boxSizing: 'border-box',
     },
   })
 }
@@ -116,27 +142,149 @@ function canvasToPngBlob(canvas: HTMLCanvasElement): Promise<Blob> {
   })
 }
 
-/** Build a multi-page A4 PDF from a full-height canvas image (bitmap slices). */
-export function canvasToPdfBlob(canvas: HTMLCanvasElement): Blob {
-  const imgData = canvas.toDataURL('image/png')
-  const pdf = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' })
-  const pageWidth = pdf.internal.pageSize.getWidth()
-  const pageHeight = pdf.internal.pageSize.getHeight()
-  const imgWidth = pageWidth
-  const imgHeight = (canvas.height * imgWidth) / Math.max(canvas.width, 1)
+export type CanvasToPdfOptions = {
+  /** CSS width of the export canvas (content + 2× outer padding). */
+  exportCssWidth: number
+  /** Theme background used to fill page margins (must match PNG padding). */
+  backgroundColor: string
+  /** Outer padding in CSS px; defaults to EXPORT_OUTER_PADDING_PX. */
+  outerPaddingPx?: number
+}
 
-  let heightLeft = imgHeight
-  let position = 0
+export type PdfPageSlice = {
+  srcX: number
+  srcY: number
+  srcW: number
+  srcH: number
+  destX: number
+  destY: number
+  destW: number
+  destH: number
+}
 
-  pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight)
-  heightLeft -= pageHeight
+export type PdfPageLayout = {
+  marginMm: number
+  pageWidthMm: number
+  pageHeightMm: number
+  pageBmpWidth: number
+  pageBmpHeight: number
+  insetPx: number
+  slices: PdfPageSlice[]
+}
 
-  while (heightLeft > 0.5) {
-    position -= pageHeight
-    pdf.addPage()
-    pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight)
-    heightLeft -= pageHeight
+/**
+ * Slice only the content region (excluding baked-in 16px outer padding) so every
+ * PDF page can be recomposed with the same inset margins. Do not feed the full
+ * padded canvas through negative-Y addImage — that keeps top padding on page 1
+ * and bottom padding on the last page only.
+ */
+export function computePdfPageLayout(
+  canvas: { width: number; height: number },
+  options: {
+    exportCssWidth: number
+    outerPaddingPx?: number
+    pageWidthMm?: number
+    pageHeightMm?: number
+  },
+): PdfPageLayout {
+  const outerPaddingPx = options.outerPaddingPx ?? EXPORT_OUTER_PADDING_PX
+  const pageWidthMm = options.pageWidthMm ?? 210
+  const pageHeightMm = options.pageHeightMm ?? 297
+  const exportCssWidth = Math.max(options.exportCssWidth, 1)
+  const canvasWidth = Math.max(canvas.width, 1)
+  const canvasHeight = Math.max(canvas.height, 1)
+
+  const marginMm = (outerPaddingPx / exportCssWidth) * pageWidthMm
+  const scale = canvasWidth / exportCssWidth
+  const padCanvas = Math.min(outerPaddingPx * scale, (canvasWidth - 1) / 2, (canvasHeight - 1) / 2)
+
+  const contentLeft = padCanvas
+  const contentTop = padCanvas
+  const contentWidth = Math.max(canvasWidth - 2 * padCanvas, 1)
+  const contentHeight = Math.max(canvasHeight - 2 * padCanvas, 1)
+
+  const pageBmpWidth = canvasWidth
+  const pageBmpHeight = Math.max(1, Math.round(pageBmpWidth * (pageHeightMm / pageWidthMm)))
+  const insetPx = padCanvas
+  const destWidth = Math.max(pageBmpWidth - 2 * insetPx, 1)
+  const destHeight = Math.max(pageBmpHeight - 2 * insetPx, 1)
+
+  const slices: PdfPageSlice[] = []
+  let remaining = contentHeight
+  let srcY = contentTop
+  while (remaining > 0.5 || slices.length === 0) {
+    const srcH = Math.min(remaining, destHeight)
+    slices.push({
+      srcX: contentLeft,
+      srcY,
+      srcW: contentWidth,
+      srcH,
+      destX: insetPx,
+      destY: insetPx,
+      destW: destWidth,
+      destH: srcH,
+    })
+    srcY += srcH
+    remaining -= srcH
+    if (remaining <= 0.5) break
   }
+
+  return {
+    marginMm,
+    pageWidthMm,
+    pageHeightMm,
+    pageBmpWidth,
+    pageBmpHeight,
+    insetPx,
+    slices,
+  }
+}
+
+function cssColorToCanvasFill(color: string): string {
+  const spaceRgb = color.match(/^rgba?\(\s*([\d.]+)\s+([\d.]+)\s+([\d.]+)((?:\s*\/\s*[\d.]+)?)?\s*\)$/i)
+  if (spaceRgb) {
+    const alpha = spaceRgb[4]
+    if (alpha) return `rgba(${spaceRgb[1]}, ${spaceRgb[2]}, ${spaceRgb[3]}${alpha.replace('/', ',')})`
+    return `rgb(${spaceRgb[1]}, ${spaceRgb[2]}, ${spaceRgb[3]})`
+  }
+  return color
+}
+
+/**
+ * Build a multi-page A4 PDF: each page is a theme-filled bitmap with the content
+ * slice drawn into a 16px-equivalent inset rect (margins live in the bitmap so
+ * jsPDF's default white page never shows).
+ */
+export function canvasToPdfBlob(canvas: HTMLCanvasElement, options: CanvasToPdfOptions): Blob {
+  const layout = computePdfPageLayout(canvas, {
+    exportCssWidth: options.exportCssWidth,
+    outerPaddingPx: options.outerPaddingPx,
+  })
+  const fillStyle = cssColorToCanvasFill(options.backgroundColor)
+  const pdf = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' })
+
+  layout.slices.forEach((slice, index) => {
+    const pageCanvas = document.createElement('canvas')
+    pageCanvas.width = layout.pageBmpWidth
+    pageCanvas.height = layout.pageBmpHeight
+    const ctx = pageCanvas.getContext('2d')
+    if (!ctx) throw new Error('PDF page canvas 2d context unavailable')
+    ctx.fillStyle = fillStyle
+    ctx.fillRect(0, 0, layout.pageBmpWidth, layout.pageBmpHeight)
+    ctx.drawImage(
+      canvas,
+      slice.srcX,
+      slice.srcY,
+      slice.srcW,
+      slice.srcH,
+      slice.destX,
+      slice.destY,
+      slice.destW,
+      slice.destH,
+    )
+    if (index > 0) pdf.addPage()
+    pdf.addImage(pageCanvas.toDataURL('image/png'), 'PNG', 0, 0, layout.pageWidthMm, layout.pageHeightMm)
+  })
 
   return pdf.output('blob')
 }
@@ -152,6 +300,7 @@ export async function exportStructuredArtifact(
   options?: { screenshotWaitMs?: number },
 ): Promise<StructuredExportResult> {
   const incomplete = !(await waitForTestScreenshots(el, options?.screenshotWaitMs ?? TEST_SCREENSHOT_WAIT_MS))
+  const box = measureStructuredExportBox(el)
   const canvas = await captureStructuredElement(el)
   const filename = exportFilename(artifactName, format)
 
@@ -159,7 +308,10 @@ export async function exportStructuredArtifact(
     const blob = await canvasToPngBlob(canvas)
     triggerBlobDownload(filename, blob)
   } else {
-    const blob = canvasToPdfBlob(canvas)
+    const blob = canvasToPdfBlob(canvas, {
+      exportCssWidth: box.exportWidth,
+      backgroundColor: box.backgroundColor,
+    })
     triggerBlobDownload(filename, blob)
   }
 


### PR DESCRIPTION
截取 clone 注入留白并扩画布，PDF 每页主题底内缩切片，避免下载图贴边且不改预览布局。

Co-authored-by: Cursor <cursoragent@cursor.com>
