### PR TITLE
fix(web): 审计页铺满剩余视口并提升分页对比度

### DIFF
--- a/web/src/components/project/AuditFilterDropdown.vue
+++ b/web/src/components/project/AuditFilterDropdown.vue
@@ -221,12 +221,12 @@ defineExpose({ close })
   align-items: center;
   gap: 6px;
   max-width: 220px;
-  border: 1px solid var(--line, #e4e4e7);
-  background: var(--card, #fff);
+  border: 1px solid rgb(var(--c-line));
+  background: rgb(var(--c-surface));
   padding: 0 8px 0 10px;
   font: inherit;
   font-size: 12px;
-  color: var(--txt, #18181b);
+  color: rgb(var(--c-txt));
   cursor: pointer;
   text-align: left;
   white-space: nowrap;
@@ -242,19 +242,19 @@ defineExpose({ close })
   white-space: normal;
 }
 .audit-dd-trig:hover:not(:disabled) {
-  border-color: #d4d4d8;
-  background: #fafafa;
+  border-color: rgb(var(--c-line-strong));
+  background: rgb(var(--c-elevated));
 }
 .audit-dd.open .audit-dd-trig {
-  border-color: color-mix(in srgb, var(--accent, #7c3aed) 55%, #c4b5fd);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent, #7c3aed) 12%, transparent);
+  border-color: rgb(var(--c-accent));
+  box-shadow: 0 0 0 3px rgb(var(--c-accent) / 0.12);
 }
 .audit-dd-trig:disabled {
   opacity: 0.45;
   cursor: not-allowed;
 }
 .audit-dd-trig .k {
-  color: var(--txt3, #71717a);
+  color: rgb(var(--c-txt2));
   font-weight: 500;
   flex: 0 0 auto;
 }
@@ -270,20 +270,20 @@ defineExpose({ close })
   max-width: none;
 }
 .audit-dd-trig .v.muted {
-  color: var(--txt3, #a1a1aa);
+  color: rgb(var(--c-txt2));
   font-weight: 400;
 }
 .caret {
   width: 12px;
   height: 12px;
-  color: var(--txt3, #a1a1aa);
+  color: rgb(var(--c-txt2));
   flex: 0 0 auto;
   margin-left: auto;
   transition: transform 0.12s;
 }
 .audit-dd.open .caret {
   transform: rotate(180deg);
-  color: var(--accent, #7c3aed);
+  color: rgb(var(--c-accent));
 }
 </style>
 

--- a/web/src/components/project/ProjectAuditPanel.vue
+++ b/web/src/components/project/ProjectAuditPanel.vue
@@ -561,7 +561,7 @@ onMounted(() => {
   <div class="audit-panel" data-testid="project-audit-panel">
     <div
       v-if="denied || forceDenied"
-      class="flex flex-1 flex-col items-center justify-center gap-2 border border-dashed border-line bg-surface px-6 py-16 text-center"
+      class="flex min-h-0 flex-1 flex-col items-center justify-center gap-2 border border-dashed border-line bg-surface px-6 py-16 text-center"
       data-testid="project-audit-denied"
     >
       <div class="text-sm font-semibold text-txt">{{ t('pages.projectDetail.audit.deniedTitle') }}</div>
@@ -805,12 +805,12 @@ onMounted(() => {
         <span v-if="mode === 'run' && runId">Run <b>{{ shortRun(runId) }}</b></span>
       </div>
 
-      <div v-if="loading" class="py-10 text-center text-[13px] text-txt3">
+      <div v-if="loading" class="list-placeholder text-[13px] text-txt2">
         {{ t('pages.projectDetail.audit.loading') }}
       </div>
       <div
         v-else-if="noRuns"
-        class="empty"
+        class="empty list-placeholder"
         data-testid="project-audit-empty-runs"
       >
         <div class="big">{{ t('pages.projectDetail.audit.emptyRunsTitle') }}</div>
@@ -823,6 +823,7 @@ onMounted(() => {
       </div>
       <EmptyState
         v-else-if="!events.length"
+        class="list-placeholder"
         data-testid="project-audit-empty"
         :title="t('pages.projectDetail.audit.emptyTitle')"
         :desc="t('pages.projectDetail.audit.emptyDesc')"
@@ -957,6 +958,7 @@ onMounted(() => {
 
       <Pagination
         v-if="!noRuns"
+        class="shrink-0"
         :page="page"
         :page-size="pageSize"
         :total="total"
@@ -975,10 +977,11 @@ onMounted(() => {
 .audit-panel {
   display: flex;
   flex-direction: column;
-  min-height: 420px;
-  border: 1px solid var(--line, #ececef);
-  background: var(--card, #fff);
+  flex: 1;
+  min-height: 0;
   overflow: hidden;
+  border: 1px solid rgb(var(--c-line));
+  background: rgb(var(--c-surface));
 }
 .panel-hd {
   display: flex;
@@ -986,19 +989,20 @@ onMounted(() => {
   justify-content: space-between;
   gap: 12px;
   flex-wrap: wrap;
+  flex-shrink: 0;
   padding: 14px 16px 12px;
-  border-bottom: 1px solid var(--line, #ececef);
+  border-bottom: 1px solid rgb(var(--c-line));
 }
 .panel-hd h4 {
   margin: 0;
   font-size: 15px;
   font-weight: 650;
   letter-spacing: -0.02em;
-  color: var(--txt, #18181b);
+  color: rgb(var(--c-txt));
 }
 .seg {
   display: inline-flex;
-  background: #f4f4f5;
+  background: rgb(var(--c-elevated));
   padding: 3px;
   gap: 2px;
 }
@@ -1009,16 +1013,16 @@ onMounted(() => {
   padding: 0 12px;
   font: inherit;
   font-size: 12px;
-  color: var(--txt3, #71717a);
+  color: rgb(var(--c-txt2));
   cursor: pointer;
   font-weight: 500;
 }
 .seg button:hover {
-  color: var(--txt, #18181b);
+  color: rgb(var(--c-txt));
 }
 .seg button.on {
-  background: #fff;
-  color: var(--txt, #18181b);
+  background: rgb(var(--c-surface));
+  color: rgb(var(--c-txt));
   font-weight: 600;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
 }
@@ -1027,8 +1031,9 @@ onMounted(() => {
   flex-wrap: wrap;
   align-items: center;
   gap: 8px;
+  flex-shrink: 0;
   padding: 12px 16px;
-  border-bottom: 1px solid var(--line, #ececef);
+  border-bottom: 1px solid rgb(var(--c-line));
 }
 .search {
   flex: 1 1 180px;
@@ -1074,7 +1079,7 @@ onMounted(() => {
   padding: 0 12px;
   border: 1px solid #e4e4e7;
   background: #fff;
-  color: var(--txt, #18181b);
+  color: rgb(var(--c-txt));
   font: inherit;
   font-size: 12px;
   font-weight: 500;
@@ -1094,8 +1099,9 @@ onMounted(() => {
   flex-wrap: wrap;
   gap: 6px;
   align-items: center;
+  flex-shrink: 0;
   padding: 0 16px 12px;
-  border-bottom: 1px solid var(--line, #ececef);
+  border-bottom: 1px solid rgb(var(--c-line));
 }
 .chip {
   display: inline-flex;
@@ -1106,11 +1112,11 @@ onMounted(() => {
   background: #f4f4f5;
   border: 1px solid #e4e4e7;
   font-size: 11px;
-  color: var(--txt, #18181b);
+  color: rgb(var(--c-txt));
 }
 .chip em {
   font-style: normal;
-  color: var(--txt3, #71717a);
+  color: rgb(var(--c-txt2));
   font-weight: 500;
 }
 .chip b {
@@ -1121,26 +1127,26 @@ onMounted(() => {
   height: 18px;
   border: 0;
   background: transparent;
-  color: var(--txt3, #71717a);
+  color: rgb(var(--c-txt2));
   cursor: pointer;
   font-size: 13px;
   line-height: 1;
 }
 .chip .x:hover {
-  color: var(--txt, #18181b);
+  color: rgb(var(--c-txt));
   background: #e4e4e7;
 }
 .linkish {
   border: 0;
   background: transparent;
-  color: var(--txt3, #71717a);
+  color: rgb(var(--c-txt2));
   font: inherit;
   font-size: 11px;
   cursor: pointer;
   padding: 0 4px;
 }
 .linkish:hover {
-  color: var(--accent, #7c3aed);
+  color: rgb(var(--c-accent));
 }
 .meta {
   display: flex;
@@ -1148,13 +1154,14 @@ onMounted(() => {
   align-items: center;
   gap: 10px;
   flex-wrap: wrap;
+  flex-shrink: 0;
   padding: 8px 16px;
   font-size: 12px;
-  color: var(--txt3, #71717a);
-  border-bottom: 1px solid var(--line, #ececef);
+  color: rgb(var(--c-txt2));
+  border-bottom: 1px solid rgb(var(--c-line));
 }
 .meta b {
-  color: var(--txt, #18181b);
+  color: rgb(var(--c-txt));
   font-weight: 600;
   font-variant-numeric: tabular-nums;
 }
@@ -1169,34 +1176,36 @@ onMounted(() => {
   padding: 6px 16px;
 }
 .meta-mobile b {
-  color: var(--txt, #18181b);
+  color: rgb(var(--c-txt));
   font-weight: 600;
   font-variant-numeric: tabular-nums;
 }
 .table-wrap {
+  flex: 1;
+  min-height: 0;
   overflow: auto;
-  max-height: 520px;
 }
 table {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   min-width: 820px;
 }
 thead th {
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: 2;
   text-align: left;
   padding: 9px 14px;
-  background: #fafafa;
-  color: var(--txt3, #71717a);
+  background: rgb(var(--c-elevated));
+  color: rgb(var(--c-txt2));
   font-size: 11px;
   font-weight: 600;
-  border-bottom: 1px solid var(--line, #ececef);
+  border-bottom: 1px solid rgb(var(--c-line));
 }
 td {
   padding: 11px 14px;
-  border-bottom: 1px solid var(--line, #ececef);
+  border-bottom: 1px solid rgb(var(--c-line));
   vertical-align: middle;
   font-size: 13px;
 }
@@ -1215,16 +1224,16 @@ tr.row.fail td:first-child {
 tr.detail td {
   padding: 0;
   background: #fafafa;
-  border-bottom: 1px solid var(--line, #ececef);
+  border-bottom: 1px solid rgb(var(--c-line));
 }
 .detail-inner {
   padding: 12px 14px 14px;
   margin-left: 2px;
-  border-left: 2px solid var(--accent, #7c3aed);
+  border-left: 2px solid rgb(var(--c-accent));
 }
 .detail-meta {
   font-size: 12px;
-  color: var(--txt3, #71717a);
+  color: rgb(var(--c-txt2));
   margin-bottom: 8px;
   display: flex;
   flex-wrap: wrap;
@@ -1233,15 +1242,15 @@ tr.detail td {
 .detail-meta code {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 11px;
-  color: var(--txt, #18181b);
+  color: rgb(var(--c-txt));
   background: #fff;
-  border: 1px solid var(--line, #ececef);
+  border: 1px solid rgb(var(--c-line));
   padding: 1px 5px;
 }
 .payload {
   margin: 0;
   padding: 10px 12px;
-  border: 1px solid var(--line, #ececef);
+  border: 1px solid rgb(var(--c-line));
   background: #fff;
   font: 11px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   white-space: pre-wrap;
@@ -1260,7 +1269,7 @@ tr.detail td {
   font-size: 12px;
 }
 .who {
-  color: var(--txt, #18181b);
+  color: rgb(var(--c-txt));
   font-weight: 500;
 }
 .act {
@@ -1304,15 +1313,23 @@ tr.detail td {
 .summary {
   color: #3f3f46;
 }
+.list-placeholder {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
 .empty {
   padding: 48px 16px;
   text-align: center;
-  color: var(--txt3, #71717a);
+  color: rgb(var(--c-txt2));
 }
 .empty .big {
   font-size: 14px;
   font-weight: 600;
-  color: var(--txt, #18181b);
+  color: rgb(var(--c-txt));
   margin-bottom: 4px;
 }
 .col-run-hide :deep(.col-run),
@@ -1341,7 +1358,7 @@ tr.detail td {
   flex: 1;
   min-width: 0;
   font-size: 12px;
-  color: var(--txt, #18181b);
+  color: rgb(var(--c-txt));
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1350,7 +1367,7 @@ tr.detail td {
   flex: 0 0 auto;
   font-size: 11px;
   font-weight: 600;
-  color: var(--accent, #7c3aed);
+  color: rgb(var(--c-accent));
   white-space: nowrap;
 }
 .filters-editor {
@@ -1396,6 +1413,9 @@ tr.detail td {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
   padding: 12px 16px;
 }
 .event-card {
@@ -1414,7 +1434,7 @@ tr.detail td {
   border-color: #c4b5fd;
 }
 .event-card.open {
-  border-color: var(--accent, #7c3aed);
+  border-color: rgb(var(--c-accent));
   background: #faf8ff;
 }
 .event-card.fail {
@@ -1467,9 +1487,9 @@ tr.detail td {
 .ec-detail code {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 11px;
-  color: var(--txt, #18181b);
+  color: rgb(var(--c-txt));
   background: #fff;
-  border: 1px solid var(--line, #ececef);
+  border: 1px solid rgb(var(--c-line));
   padding: 1px 5px;
 }
 .ec-detail .payload {
@@ -1478,7 +1498,7 @@ tr.detail td {
 .ec-hint {
   margin-top: 6px;
   font-size: 10px;
-  color: var(--accent, #7c3aed);
+  color: rgb(var(--c-accent));
 }
 @media (max-width: 768px) {
   .filters:not(.filters-mobile) {

--- a/web/src/components/ui/Pagination.test.ts
+++ b/web/src/components/ui/Pagination.test.ts
@@ -1,4 +1,7 @@
 // @vitest-environment happy-dom
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { createI18n } from 'vue-i18n'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -6,6 +9,8 @@ import { ref } from 'vue'
 import commonZh from '@/locales/zh-CN/common.json'
 import commonEn from '@/locales/en/common.json'
 import Pagination from './Pagination.vue'
+
+const pagerSrc = readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'Pagination.vue'), 'utf8')
 
 const isMobile = ref(false)
 
@@ -180,5 +185,53 @@ describe('Pagination', () => {
     expect(prev.text()).toMatch(/上一页/)
     expect(next.text()).toMatch(/下一页/)
     wrapper.unmount()
+  })
+
+  it('disables both prev and next on a single page and keeps them visible', () => {
+    const wrapper = mountPager({ page: 1, pageSize: 10, total: 8 })
+    const btns = wrapper.findAll('button.pg-btn')
+    expect(btns).toHaveLength(2)
+    expect((btns[0]!.element as HTMLButtonElement).disabled).toBe(true)
+    expect((btns[1]!.element as HTMLButtonElement).disabled).toBe(true)
+    expect(wrapper.text()).toMatch(/上一页/)
+    expect(wrapper.text()).toMatch(/下一页/)
+    wrapper.unmount()
+  })
+
+  it('active page uses accent-2 on accent-dim with purple border and inset shadow', () => {
+    const start = pagerSrc.indexOf('.page-num.active {')
+    expect(start).toBeGreaterThanOrEqual(0)
+    const block = pagerSrc.slice(start, pagerSrc.indexOf('}', start) + 1)
+    expect(block).toMatch(/color:\s*rgb\(var\(--c-accent-2\)\)/)
+    expect(block).toMatch(/background:\s*rgb\(var\(--c-accent-dim\)\)/)
+    expect(block).toMatch(/border-color:\s*#7b61ff/)
+    expect(block).toMatch(/box-shadow:\s*inset 0 0 0 1px rgba\(123,\s*97,\s*255/)
+    expect(block).not.toMatch(/color:\s*#fff/)
+  })
+
+  it('disabled prev/next uses txt2 at full opacity (not 0.45 fade)', () => {
+    const start = pagerSrc.indexOf('.pg-btn:disabled {')
+    expect(start).toBeGreaterThanOrEqual(0)
+    const block = pagerSrc.slice(start, pagerSrc.indexOf('}', start) + 1)
+    expect(block).toMatch(/color:\s*rgb\(var\(--c-txt2\)\)/)
+    expect(block).toMatch(/opacity:\s*1/)
+    expect(block).toMatch(/cursor:\s*not-allowed/)
+    expect(block).not.toMatch(/opacity:\s*0\.45/)
+  })
+
+  it('disabled page nums and pageSize select stay readable with txt2', () => {
+    const numStart = pagerSrc.indexOf('.page-num:disabled {')
+    expect(numStart).toBeGreaterThanOrEqual(0)
+    const numBlock = pagerSrc.slice(numStart, pagerSrc.indexOf('}', numStart) + 1)
+    expect(numBlock).toMatch(/color:\s*rgb\(var\(--c-txt2\)\)/)
+    expect(numBlock).toMatch(/opacity:\s*1/)
+    expect(numBlock).not.toMatch(/opacity:\s*0\.45/)
+
+    const sizeStart = pagerSrc.indexOf('.pg-size-select:disabled {')
+    expect(sizeStart).toBeGreaterThanOrEqual(0)
+    const sizeBlock = pagerSrc.slice(sizeStart, pagerSrc.indexOf('}', sizeStart) + 1)
+    expect(sizeBlock).toMatch(/color:\s*rgb\(var\(--c-txt2\)\)/)
+    expect(sizeBlock).toMatch(/opacity:\s*1/)
+    expect(sizeBlock).not.toMatch(/opacity:\s*0\.45/)
   })
 })

--- a/web/src/components/ui/Pagination.vue
+++ b/web/src/components/ui/Pagination.vue
@@ -191,7 +191,8 @@ function onPageSizeChange(event: Event) {
   background: rgb(var(--c-overlay));
 }
 .pg-btn:disabled {
-  opacity: 0.45;
+  color: rgb(var(--c-txt2));
+  opacity: 1;
   cursor: not-allowed;
 }
 .page-nums {
@@ -209,7 +210,7 @@ function onPageSizeChange(event: Event) {
   transition: border-color 0.12s, color 0.12s, background 0.12s;
 }
 .page-num.active {
-  color: #fff;
+  color: rgb(var(--c-accent-2));
   background: rgb(var(--c-accent-dim));
   border-color: #7b61ff;
   box-shadow: inset 0 0 0 1px rgba(123, 97, 255, 0.35);
@@ -220,7 +221,8 @@ function onPageSizeChange(event: Event) {
   color: rgb(var(--c-txt));
 }
 .page-num:disabled {
-  opacity: 0.45;
+  color: rgb(var(--c-txt2));
+  opacity: 1;
   cursor: not-allowed;
 }
 .pg-size {
@@ -244,7 +246,8 @@ function onPageSizeChange(event: Event) {
   font-size: 12px;
 }
 .pg-size-select:disabled {
-  opacity: 0.45;
+  color: rgb(var(--c-txt2));
+  opacity: 1;
   cursor: not-allowed;
 }
 </style>

--- a/web/src/views/ProjectDetailView.auditLayout.test.ts
+++ b/web/src/views/ProjectDetailView.auditLayout.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const viewsDir = dirname(fileURLToPath(import.meta.url))
+const detailSrc = readFileSync(join(viewsDir, 'ProjectDetailView.vue'), 'utf8')
+const panelSrc = readFileSync(join(viewsDir, '../components/project/ProjectAuditPanel.vue'), 'utf8')
+const filterSrc = readFileSync(join(viewsDir, '../components/project/AuditFilterDropdown.vue'), 'utf8')
+const runListSrc = readFileSync(join(viewsDir, 'RunListView.vue'), 'utf8')
+const gatesSrc = readFileSync(join(viewsDir, 'GatesInboxView.vue'), 'utf8')
+const artifactsSrc = readFileSync(join(viewsDir, 'ArtifactsView.vue'), 'utf8')
+
+function cssBlock(src: string, selector: string): string {
+  const start = src.indexOf(`${selector} {`)
+  expect(start, `missing CSS block ${selector}`).toBeGreaterThanOrEqual(0)
+  const end = src.indexOf('}', start)
+  return src.slice(start, end + 1)
+}
+
+describe('ProjectDetailView audit tab fill-height chain (g1.1 / g5.1)', () => {
+  it('audit tab uses min-h-0 flex-1 instead of 420px hard floor', () => {
+    const auditBlock = detailSrc.slice(detailSrc.indexOf("tab === 'audit'"), detailSrc.indexOf("tab === 'meta'"))
+    expect(auditBlock).toMatch(/class="flex min-h-0 flex-1 flex-col"/)
+    expect(auditBlock).toMatch(/data-testid="project-audit-tab"/)
+    expect(auditBlock).not.toMatch(/min-h-\[420px\]/)
+  })
+})
+
+describe('ProjectAuditPanel fill layout + sticky header + tokens (g1.2–g4.2 / g5.1)', () => {
+  it('panel consumes remaining height without 420/520 hard floors', () => {
+    const panel = cssBlock(panelSrc, '.audit-panel')
+    expect(panel).toMatch(/flex:\s*1/)
+    expect(panel).toMatch(/min-height:\s*0/)
+    expect(panel).toMatch(/overflow:\s*hidden/)
+    expect(panel).not.toMatch(/min-height:\s*420px/)
+    expect(panelSrc).not.toMatch(/max-height:\s*520px/)
+    expect(panelSrc).not.toMatch(/min-height:\s*420px/)
+
+    const wrap = cssBlock(panelSrc, '.table-wrap')
+    expect(wrap).toMatch(/flex:\s*1/)
+    expect(wrap).toMatch(/min-height:\s*0/)
+    expect(wrap).toMatch(/overflow:\s*auto/)
+
+    const cards = cssBlock(panelSrc, '.event-cards')
+    expect(cards).toMatch(/flex:\s*1/)
+    expect(cards).toMatch(/min-height:\s*0/)
+    expect(cards).toMatch(/overflow:\s*auto/)
+
+    expect(cssBlock(panelSrc, '.panel-hd')).toMatch(/flex-shrink:\s*0/)
+    expect(cssBlock(panelSrc, '.filters')).toMatch(/flex-shrink:\s*0/)
+    expect(cssBlock(panelSrc, '.chips')).toMatch(/flex-shrink:\s*0/)
+    expect(cssBlock(panelSrc, '.meta')).toMatch(/flex-shrink:\s*0/)
+
+    expect(panelSrc).toMatch(/<Pagination[\s\S]*?class="shrink-0"/)
+    expect(panelSrc).toMatch(/v-if="!noRuns"/)
+    expect(panelSrc).toMatch(/AUDIT_PAGE_SIZE_OPTIONS = \[5, 10, 20\]/)
+  })
+
+  it('desktop thead sticks with elevated bg and txt2 (not Demo txt3 / #fafafa)', () => {
+    const th = cssBlock(panelSrc, 'thead th')
+    expect(th).toMatch(/position:\s*sticky/)
+    expect(th).toMatch(/top:\s*0/)
+    expect(th).toMatch(/background:\s*rgb\(var\(--c-elevated\)\)/)
+    expect(th).toMatch(/color:\s*rgb\(var\(--c-txt2\)\)/)
+    expect(th).not.toMatch(/#fafafa/)
+    expect(th).not.toMatch(/--c-txt3/)
+    expect(cssBlock(panelSrc, 'table')).toMatch(/border-collapse:\s*separate/)
+    expect(cssBlock(panelSrc, 'table')).toMatch(/border-spacing:\s*0/)
+  })
+
+  it('title / stats / filter trigger use global --c-* tokens', () => {
+    expect(cssBlock(panelSrc, '.panel-hd h4')).toMatch(/color:\s*rgb\(var\(--c-txt\)\)/)
+    expect(cssBlock(panelSrc, '.meta')).toMatch(/color:\s*rgb\(var\(--c-txt2\)\)/)
+    expect(cssBlock(panelSrc, '.audit-panel')).toMatch(/background:\s*rgb\(var\(--c-surface\)\)/)
+    expect(cssBlock(panelSrc, '.audit-panel')).toMatch(/border:\s*1px solid rgb\(var\(--c-line\)\)/)
+    expect(cssBlock(panelSrc, '.seg')).toMatch(/background:\s*rgb\(var\(--c-elevated\)\)/)
+    expect(panelSrc).not.toMatch(/var\(--txt/)
+    expect(panelSrc).not.toMatch(/var\(--card/)
+    expect(panelSrc).not.toMatch(/var\(--line/)
+    expect(panelSrc).not.toMatch(/var\(--accent/)
+
+    const trig = cssBlock(filterSrc, '.audit-dd-trig')
+    expect(trig).toMatch(/color:\s*rgb\(var\(--c-txt\)\)/)
+    expect(trig).toMatch(/background:\s*rgb\(var\(--c-surface\)\)/)
+    expect(trig).toMatch(/border:\s*1px solid rgb\(var\(--c-line\)\)/)
+    expect(cssBlock(filterSrc, '.audit-dd-trig .k')).toMatch(/color:\s*rgb\(var\(--c-txt2\)\)/)
+    expect(filterSrc).not.toMatch(/var\(--txt/)
+    expect(filterSrc).not.toMatch(/var\(--card/)
+    expect(filterSrc).not.toMatch(/var\(--line/)
+    expect(filterSrc).not.toMatch(/var\(--accent/)
+  })
+
+  it('loading / noRuns / empty / denied occupy remaining slot and center', () => {
+    const slot = cssBlock(panelSrc, '.list-placeholder')
+    expect(slot).toMatch(/flex:\s*1/)
+    expect(slot).toMatch(/min-height:\s*0/)
+    expect(slot).toMatch(/align-items:\s*center/)
+    expect(slot).toMatch(/justify-content:\s*center/)
+    expect(panelSrc).toMatch(/class="list-placeholder text-\[13px\] text-txt2"/)
+    expect(panelSrc).toMatch(/class="empty list-placeholder"/)
+    expect(panelSrc).toMatch(/data-testid="project-audit-empty"/)
+    expect(panelSrc).toMatch(/data-testid="project-audit-empty-runs"/)
+    expect(panelSrc).toMatch(/data-testid="project-audit-denied"/)
+    expect(panelSrc).toMatch(/flex min-h-0 flex-1 flex-col items-center justify-center/)
+  })
+
+  it('keeps audit e2e testids and dual-mode slots', () => {
+    for (const id of [
+      'project-audit-panel',
+      'project-audit-list',
+      'project-audit-mode-run',
+      'project-audit-mode-all',
+      'project-audit-empty-runs',
+    ]) {
+      expect(panelSrc).toContain(`data-testid="${id}"`)
+    }
+    expect(panelSrc).toContain('summary-test-id="project-audit-pager-info"')
+    expect(panelSrc).toContain('page-size-test-id="project-audit-page-size"')
+  })
+})
+
+describe('shared Pagination consumers keep existing page interaction (g5.2)', () => {
+  it('Run list still gates pager on total > PAGE_SIZE and binds page', () => {
+    expect(runListSrc).toMatch(/import Pagination from '@\/components\/ui\/Pagination\.vue'/)
+    expect(runListSrc).toMatch(/<Pagination v-if="total > PAGE_SIZE" v-model:page="page"/)
+  })
+
+  it('Gates inbox still gates pager on listTotal > PAGE_SIZE and binds listPage', () => {
+    expect(gatesSrc).toMatch(/import Pagination from '@\/components\/ui\/Pagination\.vue'/)
+    expect(gatesSrc).toMatch(/<Pagination v-if="listTotal > PAGE_SIZE" v-model:page="listPage"/)
+  })
+
+  it('Artifacts list still gates pager on pageTotal > PAGE_SIZE with shrink-0', () => {
+    expect(artifactsSrc).toMatch(/import Pagination from '@\/components\/ui\/Pagination\.vue'/)
+    expect(artifactsSrc).toMatch(/v-if="pageTotal > PAGE_SIZE"/)
+    expect(artifactsSrc).toMatch(/v-model:page="page"/)
+    expect(artifactsSrc).toMatch(/class="shrink-0"/)
+  })
+})

--- a/web/src/views/ProjectDetailView.vue
+++ b/web/src/views/ProjectDetailView.vue
@@ -1565,7 +1565,7 @@ onUnmounted(() => {
         </div>
       </div>
 
-      <div v-else-if="tab === 'audit'" class="flex min-h-[420px] flex-col" data-testid="project-audit-tab">
+      <div v-else-if="tab === 'audit'" class="flex min-h-0 flex-1 flex-col" data-testid="project-audit-tab">
         <ProjectAuditPanel :project-id="projectId" :force-denied="auditForceDenied" />
       </div>
 


### PR DESCRIPTION
少数据时审计 Tab 未接入全高 flex 链导致下方大块留白，共享分页当前页白字叠浅底、禁用态过淡。按 Demo 优化后打通铺满+列表内滚+分页贴底，并修正当前页/禁用态对比度。

Co-authored-by: Cursor <cursoragent@cursor.com>
