### PR TITLE
feat(agents): 支持文件夹 Agent 全量导出导入

### DIFF
--- a/server/internal/handlers/org_folder.go
+++ b/server/internal/handlers/org_folder.go
@@ -1,0 +1,128 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/cocofhu/approving/internal/services"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ExportOrgFolder streams a folder ZIP for the given virtual group subtree.
+func (h *Handlers) ExportOrgFolder(c *gin.Context) {
+	if h.Org == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "org service unavailable"})
+		return
+	}
+	groupID := strings.TrimSpace(c.Query("groupId"))
+	if groupID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "groupId is required"})
+		return
+	}
+	raw, filename, err := h.Org.ExportFolderZIP(groupID)
+	if err != nil {
+		writeOrgFolderError(c, err)
+		return
+	}
+	c.Header("Content-Type", "application/zip")
+	c.Header("Content-Disposition", contentDispositionAttachment(filename))
+	c.Data(http.StatusOK, "application/zip", raw)
+}
+
+// ImportOrgFolder accepts a multipart folder ZIP and imports it atomically.
+func (h *Handlers) ImportOrgFolder(c *gin.Context) {
+	if h.Org == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "org service unavailable"})
+		return
+	}
+	file, err := c.FormFile("file")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "file is required"})
+		return
+	}
+	targetGroupID := strings.TrimSpace(c.PostForm("targetGroupId"))
+	mode := services.ImportFolderMode(strings.TrimSpace(c.PostForm("mode")))
+	if mode == "" {
+		mode = services.ImportFolderRename
+	}
+
+	f, err := file.Open()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	defer f.Close()
+
+	limited := io.LimitReader(f, services.OrgFolderMaxBytes+1)
+	raw, err := io.ReadAll(limited)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if int64(len(raw)) > services.OrgFolderMaxBytes {
+		c.JSON(http.StatusBadRequest, gin.H{"error": services.ErrOrgFolderTooLarge.Error()})
+		return
+	}
+
+	result, err := h.Org.ImportFolderZIP(raw, targetGroupID, mode)
+	if err != nil {
+		writeOrgFolderError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+func writeOrgFolderError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, services.ErrOrgFolderGroupNotFound),
+		errors.Is(err, services.ErrOrgFolderTargetNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+	case errors.Is(err, services.ErrOrgConflict):
+		c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
+	case errors.Is(err, services.ErrOrgValidation),
+		errors.Is(err, services.ErrOrgFolderTooLarge),
+		errors.Is(err, services.ErrOrgFolderMissingManifest),
+		errors.Is(err, services.ErrOrgFolderSingleAgent),
+		errors.Is(err, services.ErrOrgFolderInvalidKind),
+		errors.Is(err, services.ErrOrgFolderBadSchema),
+		errors.Is(err, services.ErrOrgFolderInvalidZip),
+		errors.Is(err, services.ErrOrgFolderRootAgentJSON),
+		errors.Is(err, services.ErrOrgFolderNestedZip),
+		errors.Is(err, services.ErrInvalidAgentName):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	default:
+		msg := err.Error()
+		if strings.Contains(msg, "导入失败，已整次回滚") ||
+			strings.Contains(msg, "64MiB") ||
+			strings.Contains(msg, "folder.json") ||
+			strings.Contains(msg, "单 Agent ZIP") ||
+			strings.Contains(msg, "1MiB") ||
+			strings.Contains(msg, "invalid import mode") {
+			c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+			return
+		}
+		_ = c.Error(err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+	}
+}
+
+// contentDispositionAttachment quotes filename and adds RFC 5987 filename*.
+func contentDispositionAttachment(filename string) string {
+	escaped := strings.ReplaceAll(filename, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	var b strings.Builder
+	for i := 0; i < len(filename); i++ {
+		c := filename[i]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+			c == '.' || c == '-' || c == '_' {
+			b.WriteByte(c)
+		} else {
+			fmt.Fprintf(&b, "%%%02X", c)
+		}
+	}
+	return fmt.Sprintf(`attachment; filename="%s"; filename*=UTF-8''%s`, escaped, b.String())
+}

--- a/server/internal/handlers/org_folder_test.go
+++ b/server/internal/handlers/org_folder_test.go
@@ -1,0 +1,134 @@
+package handlers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cocofhu/approving/internal/auth"
+	"github.com/cocofhu/approving/internal/services"
+)
+
+func TestExportImportOrgFolderHTTP(t *testing.T) {
+	hn := newHarness(t)
+	root := t.TempDir()
+	skills := services.NewSkillService(root)
+	hn.h.Skill = skills
+	hn.h.Org = services.NewOrgService(root, skills)
+
+	if err := skills.Save(services.Agent{
+		Name:       "alice",
+		AcpBackend: services.AcpBackendClaudeCode,
+		Files:      []services.AgentFile{{Path: "rules/a.md", Content: "hello"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := hn.h.Org.Put(services.AgentOrg{
+		Groups: []services.OrgGroup{{ID: "g1", Name: "Approving项目组"}},
+		Agents: map[string]services.OrgAgentMembership{
+			"alice": {GroupIDs: []string{"g1"}},
+		},
+	}, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	if w := hn.do(http.MethodGet, "/api/agents/org/export", nil); w.Code != http.StatusBadRequest {
+		t.Fatalf("missing groupId: %d %s", w.Code, w.Body.String())
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agents/org/export?groupId=g1", nil)
+	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: hn.cookie})
+	w := httptest.NewRecorder()
+	hn.r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("export: %d %s", w.Code, w.Body.String())
+	}
+	cd := w.Header().Get("Content-Disposition")
+	if !strings.Contains(cd, `filename="`) || !strings.Contains(cd, "filename*=UTF-8''") {
+		t.Fatalf("Content-Disposition missing quote/RFC5987: %s", cd)
+	}
+	if !strings.Contains(cd, "Approving") {
+		t.Fatalf("download name should keep CJK group title: %s", cd)
+	}
+	zipBytes := append([]byte(nil), w.Body.Bytes()...)
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile("file", "folder.zip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fw.Write(zipBytes); err != nil {
+		t.Fatal(err)
+	}
+	_ = mw.WriteField("mode", "rename")
+	_ = mw.Close()
+	req2 := httptest.NewRequest(http.MethodPost, "/api/agents/org/import", &buf)
+	req2.Header.Set("Content-Type", mw.FormDataContentType())
+	req2.AddCookie(&http.Cookie{Name: auth.CookieName, Value: hn.cookie})
+	w2 := httptest.NewRecorder()
+	hn.r.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("import: %d %s", w2.Code, w2.Body.String())
+	}
+	var result map[string]any
+	if err := json.Unmarshal(w2.Body.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := result["org"]; !ok {
+		t.Fatalf("import response missing org: %s", w2.Body.String())
+	}
+
+	// Single-agent ZIP must be rejected on group import (zero write beyond rename already done).
+	var singleBuf bytes.Buffer
+	zw := multipart.NewWriter(&singleBuf)
+	sfw, _ := zw.CreateFormFile("file", "agent.zip")
+	_, _ = sfw.Write([]byte("PK\x03\x04not-a-folder"))
+	_ = zw.WriteField("mode", "rename")
+	_ = zw.Close()
+	req3 := httptest.NewRequest(http.MethodPost, "/api/agents/org/import", &singleBuf)
+	req3.Header.Set("Content-Type", zw.FormDataContentType())
+	req3.AddCookie(&http.Cookie{Name: auth.CookieName, Value: hn.cookie})
+	w3 := httptest.NewRecorder()
+	hn.r.ServeHTTP(w3, req3)
+	if w3.Code != http.StatusBadRequest {
+		t.Fatalf("single/invalid zip: %d %s", w3.Code, w3.Body.String())
+	}
+}
+
+func TestImportOrgFolderRejectsSingleAgentZIP(t *testing.T) {
+	hn := newHarness(t)
+	root := t.TempDir()
+	skills := services.NewSkillService(root)
+	hn.h.Skill = skills
+	hn.h.Org = services.NewOrgService(root, skills)
+	if err := skills.Save(services.Agent{Name: "solo", Files: []services.AgentFile{{Path: "rules/a.md", Content: "a"}}}); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := skills.ExportZIP("solo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, _ := mw.CreateFormFile("file", "solo.zip")
+	_, _ = fw.Write(raw)
+	_ = mw.WriteField("mode", "rename")
+	_ = mw.Close()
+	req := httptest.NewRequest(http.MethodPost, "/api/agents/org/import", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: hn.cookie})
+	w := httptest.NewRecorder()
+	hn.r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("single agent import: %d %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "单 Agent ZIP") {
+		t.Fatalf("error body: %s", w.Body.String())
+	}
+}

--- a/server/internal/router/router.go
+++ b/server/internal/router/router.go
@@ -157,6 +157,8 @@ func New(h *handlers.Handlers) *gin.Engine {
 		// /agents/org must be registered before /agents/:name so "org" is not captured as a name.
 		api.GET("/agents/org", h.GetAgentsOrg)
 		api.PUT("/agents/org", h.PutAgentsOrg)
+		api.GET("/agents/org/export", h.ExportOrgFolder)
+		api.POST("/agents/org/import", h.ImportOrgFolder)
 		api.GET("/agents/:name/export", h.ExportAgent)
 		api.POST("/agents/import", h.ImportAgent)
 		api.GET("/agents/:name/platform-rules", h.ListAgentPlatformRules)

--- a/server/internal/services/agent_name.go
+++ b/server/internal/services/agent_name.go
@@ -28,6 +28,28 @@ var agentNamePathPattern = regexp.MustCompile(`^[\p{L}\p{N}._-]+$`)
 // fullwidthPunctRe rejects common fullwidth punctuation that must not become identity keys.
 var fullwidthPunctRe = regexp.MustCompile(`[－＿．／＼、，。！？：；（）【】]`)
 
+// SuggestAgentRename returns the first free `{name}_vN` (N starting at 2) that
+// is not in existing and passes NormalizeAndValidateAgentName.
+func SuggestAgentRename(name string, existing map[string]struct{}) string {
+	base, err := NormalizeAndValidateAgentName(name)
+	if err != nil {
+		base = strings.TrimSpace(name)
+	}
+	n := 2
+	for {
+		candidate := fmt.Sprintf("%s_v%d", base, n)
+		if _, taken := existing[candidate]; !taken {
+			if normalized, err := NormalizeAndValidateAgentName(candidate); err == nil {
+				return normalized
+			}
+		}
+		n++
+		if n > 10000 {
+			return candidate
+		}
+	}
+}
+
 // NormalizeAndValidateAgentName NFC-normalizes and validates a write-path Agent name
 // (Create / Rename target / import conflict rename). Returns the normalized name.
 func NormalizeAndValidateAgentName(raw string) (string, error) {

--- a/server/internal/services/agent_name_test.go
+++ b/server/internal/services/agent_name_test.go
@@ -9,6 +9,21 @@ import (
 	"golang.org/x/text/unicode/norm"
 )
 
+func TestSuggestAgentRename_v2v3(t *testing.T) {
+	existing := map[string]struct{}{"agent": {}, "agent_v2": {}}
+	got := SuggestAgentRename("agent", existing)
+	if got != "agent_v3" {
+		t.Fatalf("got %q", got)
+	}
+	if _, err := NormalizeAndValidateAgentName(got); err != nil {
+		t.Fatal(err)
+	}
+	zh := SuggestAgentRename("视觉研发", map[string]struct{}{"视觉研发": {}})
+	if zh != "视觉研发_v2" {
+		t.Fatalf("zh got %q", zh)
+	}
+}
+
 func TestNormalizeAndValidateAgentName_demoSamples(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/server/internal/services/org_folder.go
+++ b/server/internal/services/org_folder.go
@@ -1,0 +1,637 @@
+package services
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const (
+	OrgFolderKind          = "org-folder"
+	OrgFolderSchemaVersion = 1
+	OrgFolderMaxBytes      = 64 << 20 // 64 MiB
+)
+
+var (
+	ErrOrgFolderTooLarge         = errors.New("文件夹包超过 64MiB 上限")
+	ErrOrgFolderMissingManifest  = errors.New("ZIP 缺少 folder.json，无法识别为文件夹包")
+	ErrOrgFolderSingleAgent      = errors.New("这是单 Agent ZIP，组级导入仅接受文件夹包，请改用顶栏「导入」")
+	ErrOrgFolderInvalidKind      = errors.New("folder.json kind 无效，须为 org-folder")
+	ErrOrgFolderBadSchema        = errors.New("不支持的 folder.json schemaVersion")
+	ErrOrgFolderGroupNotFound    = errors.New("组不存在")
+	ErrOrgFolderInvalidZip       = errors.New("ZIP 格式非法或已损坏")
+	ErrOrgFolderRootAgentJSON    = errors.New("文件夹包根目录不得包含 agent.json")
+	ErrOrgFolderNestedZip        = errors.New("文件夹包不得包含嵌套 ZIP")
+	ErrOrgFolderTargetNotFound   = errors.New("目标组不存在")
+)
+
+// orgFolderJSON is the root folder.json inside a folder export ZIP.
+type orgFolderJSON struct {
+	Kind          string                        `json:"kind"`
+	SchemaVersion int                           `json:"schemaVersion"`
+	ExportedAt    string                        `json:"exportedAt"`
+	RootGroupID   string                        `json:"rootGroupId"`
+	Groups        []OrgGroup                    `json:"groups"`
+	Agents        map[string]OrgAgentMembership `json:"agents"`
+	AgentNames    []string                      `json:"agentNames"`
+}
+
+// GroupSubtree is a virtual-group closure (not parentAgent reporting).
+type GroupSubtree struct {
+	RootGroupID string
+	Groups      []OrgGroup
+	AgentNames  []string
+	Memberships map[string]OrgAgentMembership
+}
+
+// ImportFolderMode selects batch rename vs overwrite.
+type ImportFolderMode string
+
+const (
+	ImportFolderRename    ImportFolderMode = "rename"
+	ImportFolderOverwrite ImportFolderMode = "overwrite"
+)
+
+// ImportFolderResult is returned after a successful folder import.
+type ImportFolderResult struct {
+	Org         AgentOrg          `json:"org"`
+	Created     []string          `json:"created,omitempty"`
+	Overwritten []string          `json:"overwritten,omitempty"`
+	Renamed     map[string]string `json:"renamed,omitempty"`
+}
+
+// CollectGroupSubtree returns the target group + descendants + deduped agents.
+// Empty groups are kept. Membership is clipped to the subtree; parentAgent
+// outside the agent set is dropped.
+func CollectGroupSubtree(org AgentOrg, rootGroupID string) (GroupSubtree, error) {
+	rootGroupID = strings.TrimSpace(rootGroupID)
+	if rootGroupID == "" {
+		return GroupSubtree{}, fmt.Errorf("%w: groupId is required", ErrOrgFolderGroupNotFound)
+	}
+	byID := map[string]OrgGroup{}
+	children := map[string][]string{}
+	found := false
+	for _, g := range org.Groups {
+		byID[g.ID] = g
+		p := strings.TrimSpace(g.ParentGroupID)
+		children[p] = append(children[p], g.ID)
+		if g.ID == rootGroupID {
+			found = true
+		}
+	}
+	if !found {
+		return GroupSubtree{}, fmt.Errorf("%w: %s", ErrOrgFolderGroupNotFound, rootGroupID)
+	}
+
+	idSet := map[string]struct{}{rootGroupID: {}}
+	queue := []string{rootGroupID}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		for _, cid := range children[cur] {
+			if _, ok := idSet[cid]; ok {
+				continue
+			}
+			idSet[cid] = struct{}{}
+			queue = append(queue, cid)
+		}
+	}
+
+	groups := make([]OrgGroup, 0, len(idSet))
+	for id := range idSet {
+		g := byID[id]
+		if g.ID == rootGroupID {
+			g.ParentGroupID = ""
+		} else if _, ok := idSet[strings.TrimSpace(g.ParentGroupID)]; !ok {
+			g.ParentGroupID = ""
+		}
+		groups = append(groups, g)
+	}
+	sort.Slice(groups, func(i, j int) bool { return groups[i].ID < groups[j].ID })
+
+	agentSet := map[string]struct{}{}
+	memberships := map[string]OrgAgentMembership{}
+	for name, m := range org.Agents {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		var gids []string
+		for _, gid := range m.GroupIDs {
+			if _, ok := idSet[gid]; ok {
+				gids = append(gids, gid)
+			}
+		}
+		if len(gids) == 0 {
+			continue
+		}
+		agentSet[name] = struct{}{}
+		memberships[name] = OrgAgentMembership{
+			GroupIDs:    uniqueNonEmpty(gids),
+			ParentAgent: strings.TrimSpace(m.ParentAgent),
+		}
+	}
+	for name, m := range memberships {
+		if m.ParentAgent != "" {
+			if _, ok := agentSet[m.ParentAgent]; !ok {
+				m.ParentAgent = ""
+				memberships[name] = m
+			}
+		}
+	}
+	names := make([]string, 0, len(agentSet))
+	for n := range agentSet {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return GroupSubtree{
+		RootGroupID: rootGroupID,
+		Groups:      groups,
+		AgentNames:  names,
+		Memberships: memberships,
+	}, nil
+}
+
+// ExportFolderZIP builds a folder package for groupID. Caller-visible errors.
+func (o *OrgService) ExportFolderZIP(groupID string) ([]byte, string, error) {
+	if o == nil || o.skill == nil {
+		return nil, "", fmt.Errorf("org service unavailable")
+	}
+	o.skill.mu.Lock()
+	defer o.skill.mu.Unlock()
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	org, err := o.loadLocked()
+	if err != nil {
+		return nil, "", err
+	}
+	sub, err := CollectGroupSubtree(org, groupID)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Only export agents that still exist on disk.
+	alive := make([]string, 0, len(sub.AgentNames))
+	aliveSet := map[string]struct{}{}
+	for _, name := range sub.AgentNames {
+		if o.skill.Exists(name) {
+			alive = append(alive, name)
+			aliveSet[name] = struct{}{}
+		} else {
+			delete(sub.Memberships, name)
+		}
+	}
+	for name, m := range sub.Memberships {
+		if m.ParentAgent != "" {
+			if _, ok := aliveSet[m.ParentAgent]; !ok {
+				m.ParentAgent = ""
+				sub.Memberships[name] = m
+			}
+		}
+	}
+	sub.AgentNames = alive
+
+	rootName := groupID
+	for _, g := range sub.Groups {
+		if g.ID == sub.RootGroupID {
+			rootName = g.Name
+			break
+		}
+	}
+	downloadName := sanitizeDownloadFilename(rootName) + ".zip"
+
+	manifest := orgFolderJSON{
+		Kind:          OrgFolderKind,
+		SchemaVersion: OrgFolderSchemaVersion,
+		ExportedAt:    time.Now().UTC().Format(time.RFC3339),
+		RootGroupID:   sub.RootGroupID,
+		Groups:        sub.Groups,
+		Agents:        sub.Memberships,
+		AgentNames:    sub.AgentNames,
+	}
+	meta, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return nil, "", err
+	}
+
+	buf := &bytes.Buffer{}
+	zw := zip.NewWriter(buf)
+	hdr := &zip.FileHeader{Name: "folder.json", Method: zip.Store}
+	w, err := zw.CreateHeader(hdr)
+	if err != nil {
+		_ = zw.Close()
+		return nil, "", err
+	}
+	if _, err := w.Write(meta); err != nil {
+		_ = zw.Close()
+		return nil, "", err
+	}
+
+	for _, name := range sub.AgentNames {
+		prefix := "agents/" + name + "/"
+		if err := o.skill.writeAgentToZip(zw, name, prefix); err != nil {
+			_ = zw.Close()
+			return nil, "", err
+		}
+	}
+	if err := zw.Close(); err != nil {
+		return nil, "", err
+	}
+	out := buf.Bytes()
+	if len(out) > OrgFolderMaxBytes {
+		return nil, "", ErrOrgFolderTooLarge
+	}
+	return out, downloadName, nil
+}
+
+// ImportFolderZIP imports a folder package. targetGroupID empty → new root group.
+func (o *OrgService) ImportFolderZIP(raw []byte, targetGroupID string, mode ImportFolderMode) (result ImportFolderResult, err error) {
+	if o == nil || o.skill == nil {
+		return ImportFolderResult{}, fmt.Errorf("org service unavailable")
+	}
+	if int64(len(raw)) > OrgFolderMaxBytes {
+		return ImportFolderResult{}, ErrOrgFolderTooLarge
+	}
+	switch mode {
+	case ImportFolderRename, ImportFolderOverwrite:
+	default:
+		return ImportFolderResult{}, fmt.Errorf("invalid import mode %q", mode)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+	if err != nil {
+		return ImportFolderResult{}, fmt.Errorf("%w: %v", ErrOrgFolderInvalidZip, err)
+	}
+
+	hasFolder, hasRootAgent := false, false
+	for _, f := range zr.File {
+		name := filepath.ToSlash(f.Name)
+		name = strings.TrimPrefix(name, "./")
+		if strings.HasSuffix(name, "/") {
+			continue
+		}
+		if name == "folder.json" {
+			hasFolder = true
+		}
+		if name == "agent.json" {
+			hasRootAgent = true
+		}
+		if strings.HasSuffix(strings.ToLower(name), ".zip") && strings.HasPrefix(name, "agents/") {
+			return ImportFolderResult{}, ErrOrgFolderNestedZip
+		}
+	}
+	if !hasFolder {
+		if hasRootAgent {
+			return ImportFolderResult{}, ErrOrgFolderSingleAgent
+		}
+		return ImportFolderResult{}, ErrOrgFolderMissingManifest
+	}
+	if hasRootAgent {
+		return ImportFolderResult{}, ErrOrgFolderRootAgentJSON
+	}
+
+	manifest, err := readFolderManifest(zr)
+	if err != nil {
+		return ImportFolderResult{}, err
+	}
+
+	agentExports, err := parseFolderAgents(raw, manifest.AgentNames)
+	if err != nil {
+		return ImportFolderResult{}, err
+	}
+
+	o.skill.mu.Lock()
+	defer o.skill.mu.Unlock()
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	org, err := o.loadLocked()
+	if err != nil {
+		return ImportFolderResult{}, err
+	}
+
+	targetGroupID = strings.TrimSpace(targetGroupID)
+	if targetGroupID != "" {
+		found := false
+		for _, g := range org.Groups {
+			if g.ID == targetGroupID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return ImportFolderResult{}, fmt.Errorf("%w: %s", ErrOrgFolderTargetNotFound, targetGroupID)
+		}
+	}
+
+	idMap := map[string]string{}
+	for _, g := range manifest.Groups {
+		idMap[strings.TrimSpace(g.ID)] = NewGroupID()
+	}
+
+	newGroups := make([]OrgGroup, 0, len(manifest.Groups))
+	for _, g := range manifest.Groups {
+		oldID := strings.TrimSpace(g.ID)
+		ng := OrgGroup{
+			ID:   idMap[oldID],
+			Name: strings.TrimSpace(g.Name),
+		}
+		if oldID == manifest.RootGroupID || strings.TrimSpace(g.ParentGroupID) == "" {
+			ng.ParentGroupID = targetGroupID
+		} else if mapped, ok := idMap[strings.TrimSpace(g.ParentGroupID)]; ok {
+			ng.ParentGroupID = mapped
+		}
+		newGroups = append(newGroups, ng)
+	}
+
+	existingNames := map[string]struct{}{}
+	for _, a := range o.skill.List() {
+		existingNames[a.Name] = struct{}{}
+	}
+
+	nameMap := map[string]string{}
+	created := []string{}
+	overwritten := []string{}
+	renamed := map[string]string{}
+
+	for _, origName := range manifest.AgentNames {
+		origName = strings.TrimSpace(origName)
+		if origName == "" {
+			continue
+		}
+		_, exists := existingNames[origName]
+		finalName := origName
+		if exists {
+			if mode == ImportFolderRename {
+				candidate := SuggestAgentRename(origName, existingNames)
+				normalized, nerr := NormalizeAndValidateAgentName(candidate)
+				if nerr != nil {
+					return ImportFolderResult{}, fmt.Errorf("无法为 %q 生成合法重命名：%w", origName, nerr)
+				}
+				finalName = normalized
+				renamed[origName] = finalName
+				created = append(created, finalName)
+				existingNames[finalName] = struct{}{}
+			} else {
+				overwritten = append(overwritten, origName)
+			}
+		} else {
+			normalized, nerr := NormalizeAndValidateAgentName(origName)
+			if nerr != nil {
+				return ImportFolderResult{}, fmt.Errorf("包内 Agent 名称无效 %q：%w", origName, nerr)
+			}
+			finalName = normalized
+			created = append(created, finalName)
+			existingNames[finalName] = struct{}{}
+		}
+		nameMap[origName] = finalName
+	}
+
+	snapDir, err := os.MkdirTemp("", "org-folder-import-*")
+	if err != nil {
+		return ImportFolderResult{}, err
+	}
+	defer os.RemoveAll(snapDir)
+
+	orgSnap, orgSnapErr := os.ReadFile(o.path())
+	orgExisted := orgSnapErr == nil
+	if orgSnapErr != nil && !os.IsNotExist(orgSnapErr) {
+		return ImportFolderResult{}, orgSnapErr
+	}
+
+	for _, name := range overwritten {
+		src := filepath.Join(o.skill.root, sanitize(name))
+		dst := filepath.Join(snapDir, "agents", sanitize(name))
+		if err := copyDir(src, dst); err != nil {
+			return ImportFolderResult{}, fmt.Errorf("快照 Agent %q 失败：%w", name, err)
+		}
+	}
+
+	var importErr error
+	defer func() {
+		if importErr == nil {
+			return
+		}
+		for _, name := range created {
+			_ = o.skill.deleteUnlocked(name)
+		}
+		for _, name := range overwritten {
+			dst := filepath.Join(o.skill.root, sanitize(name))
+			src := filepath.Join(snapDir, "agents", sanitize(name))
+			_ = os.RemoveAll(dst)
+			_ = copyDir(src, dst)
+		}
+		if orgExisted {
+			_ = os.WriteFile(o.path(), orgSnap, 0o644)
+		} else {
+			_ = os.Remove(o.path())
+		}
+	}()
+
+	for origName, finalName := range nameMap {
+		parsed, ok := agentExports[origName]
+		if !ok {
+			importErr = fmt.Errorf("包内缺少 Agent %q 的快照", origName)
+			return ImportFolderResult{}, fmt.Errorf("导入失败，已整次回滚：%w", importErr)
+		}
+		zipMode := ImportZIPCreate
+		if mode == ImportFolderOverwrite && containsString(overwritten, finalName) {
+			zipMode = ImportZIPOverwrite
+		}
+		if _, err := o.skill.applyAgentExport(parsed.export, parsed.files, finalName, zipMode); err != nil {
+			importErr = err
+			return ImportFolderResult{}, fmt.Errorf("导入失败，已整次回滚：%w", err)
+		}
+	}
+
+	merged := org
+	merged.Groups = append(append([]OrgGroup{}, org.Groups...), newGroups...)
+	if merged.Agents == nil {
+		merged.Agents = map[string]OrgAgentMembership{}
+	}
+	for origName, m := range manifest.Agents {
+		finalName, ok := nameMap[strings.TrimSpace(origName)]
+		if !ok {
+			continue
+		}
+		gids := make([]string, 0, len(m.GroupIDs))
+		for _, gid := range m.GroupIDs {
+			if nid, ok := idMap[strings.TrimSpace(gid)]; ok {
+				gids = append(gids, nid)
+			}
+		}
+		parent := strings.TrimSpace(m.ParentAgent)
+		if parent != "" {
+			if mapped, ok := nameMap[parent]; ok {
+				parent = mapped
+			} else {
+				parent = ""
+			}
+		}
+		nm := OrgAgentMembership{GroupIDs: uniqueNonEmpty(gids), ParentAgent: parent}
+		if len(nm.GroupIDs) == 0 && nm.ParentAgent == "" {
+			if mode == ImportFolderOverwrite && containsString(overwritten, finalName) {
+				delete(merged.Agents, finalName)
+			}
+			continue
+		}
+		merged.Agents[finalName] = nm
+	}
+	// Overwrite with empty package membership still clears other-group affiliation.
+	if mode == ImportFolderOverwrite {
+		for _, name := range overwritten {
+			if _, ok := manifest.Agents[name]; !ok {
+				delete(merged.Agents, name)
+			}
+		}
+	}
+
+	normalized, err := o.validateAndNormalize(merged)
+	if err != nil {
+		importErr = err
+		return ImportFolderResult{}, fmt.Errorf("导入失败，已整次回滚：%w", err)
+	}
+	normalized.Revision = org.Revision + 1
+	if err := o.saveLocked(normalized); err != nil {
+		importErr = err
+		return ImportFolderResult{}, fmt.Errorf("导入失败，已整次回滚：%w", err)
+	}
+
+	return ImportFolderResult{
+		Org:         normalized,
+		Created:     created,
+		Overwritten: overwritten,
+		Renamed:     renamed,
+	}, nil
+}
+
+type parsedFolderAgent struct {
+	export agentExportJSON
+	files  []AgentFile
+}
+
+func readFolderManifest(zr *zip.Reader) (orgFolderJSON, error) {
+	var manifest orgFolderJSON
+	found := false
+	for _, f := range zr.File {
+		name := filepath.ToSlash(f.Name)
+		name = strings.TrimPrefix(name, "./")
+		if name != "folder.json" {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return orgFolderJSON{}, fmt.Errorf("无法读取 folder.json：%v", err)
+		}
+		b, err := io.ReadAll(rc)
+		_ = rc.Close()
+		if err != nil {
+			return orgFolderJSON{}, fmt.Errorf("无法读取 folder.json：%v", err)
+		}
+		if err := json.Unmarshal(b, &manifest); err != nil {
+			return orgFolderJSON{}, fmt.Errorf("folder.json 格式无效：%v", err)
+		}
+		found = true
+		break
+	}
+	if !found {
+		return orgFolderJSON{}, ErrOrgFolderMissingManifest
+	}
+	if strings.TrimSpace(manifest.Kind) != OrgFolderKind {
+		return orgFolderJSON{}, ErrOrgFolderInvalidKind
+	}
+	if manifest.SchemaVersion != OrgFolderSchemaVersion {
+		return orgFolderJSON{}, fmt.Errorf("%w：%d", ErrOrgFolderBadSchema, manifest.SchemaVersion)
+	}
+	if strings.TrimSpace(manifest.RootGroupID) == "" {
+		return orgFolderJSON{}, fmt.Errorf("%w: folder.json 缺少 rootGroupId", ErrOrgFolderInvalidKind)
+	}
+	if manifest.Agents == nil {
+		manifest.Agents = map[string]OrgAgentMembership{}
+	}
+	if len(manifest.AgentNames) == 0 {
+		for name := range manifest.Agents {
+			manifest.AgentNames = append(manifest.AgentNames, name)
+		}
+		sort.Strings(manifest.AgentNames)
+	}
+	return manifest, nil
+}
+
+func parseFolderAgents(raw []byte, names []string) (map[string]parsedFolderAgent, error) {
+	out := map[string]parsedFolderAgent{}
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		prefix := "agents/" + name + "/"
+		export, files, err := parseZipAgent(bytes.NewReader(raw), int64(len(raw)), prefix, WorkspaceFileMaxBytes)
+		if err != nil {
+			return nil, fmt.Errorf("Agent %q：%w", name, err)
+		}
+		out[name] = parsedFolderAgent{export: export, files: files}
+	}
+	return out, nil
+}
+
+func copyDir(src, dst string) error {
+	return filepath.WalkDir(src, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, p)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o644)
+	})
+}
+
+// sanitizeDownloadFilename mirrors web/src/lib/workflowIO.ts sanitizeFilename
+// (ASCII word chars, CJK unified, hyphen, space) without the .json suffix.
+func sanitizeDownloadFilename(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '_' || r == '-' || r == ' ':
+			b.WriteRune(r)
+		case r >= 0x4E00 && r <= 0x9FFF:
+			b.WriteRune(r)
+		default:
+			if unicode.Is(unicode.Han, r) {
+				b.WriteRune(r)
+				continue
+			}
+			b.WriteRune('_')
+		}
+	}
+	s := strings.TrimSpace(b.String())
+	if s == "" {
+		return "folder"
+	}
+	return s
+}

--- a/server/internal/services/org_folder_test.go
+++ b/server/internal/services/org_folder_test.go
@@ -1,0 +1,340 @@
+package services
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func setupFolderOrg(t *testing.T) (*SkillService, *OrgService) {
+	t.Helper()
+	root := t.TempDir()
+	skill := NewSkillService(root)
+	for _, name := range []string{"alice", "bob", "carol", "outside"} {
+		if err := skill.Save(Agent{
+			Name:       name,
+			AcpBackend: AcpBackendClaudeCode,
+			Env:        map[string]string{"TOKEN": name + "-secret"},
+			Files:      []AgentFile{{Path: "rules/" + name + ".md", Content: "# " + name}},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	orgSvc := NewOrgService(root, skill)
+	gRoot := OrgGroup{ID: "g_root", Name: "Approving项目组"}
+	gSub := OrgGroup{ID: "g_pipe", Name: "Pipeline(GitHub)", ParentGroupID: "g_root"}
+	gEmpty := OrgGroup{ID: "g_empty", Name: "空组", ParentGroupID: "g_root"}
+	gOther := OrgGroup{ID: "g_other", Name: "其他组"}
+	if _, err := orgSvc.Put(AgentOrg{
+		Groups: []OrgGroup{gRoot, gSub, gEmpty, gOther},
+		Agents: map[string]OrgAgentMembership{
+			"alice":   {GroupIDs: []string{"g_root", "g_other"}, ParentAgent: "outside"},
+			"bob":     {GroupIDs: []string{"g_pipe", "g_root"}, ParentAgent: "alice"},
+			"carol":   {GroupIDs: []string{"g_pipe"}},
+			"outside": {GroupIDs: []string{"g_other"}},
+		},
+	}, 0); err != nil {
+		t.Fatal(err)
+	}
+	return skill, orgSvc
+}
+
+func TestCollectGroupSubtree_emptyGroupsDedupAndClip(t *testing.T) {
+	_, orgSvc := setupFolderOrg(t)
+	org, err := orgSvc.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sub, err := CollectGroupSubtree(org, "g_root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sub.Groups) != 3 {
+		t.Fatalf("groups=%d %+v", len(sub.Groups), sub.Groups)
+	}
+	ids := map[string]struct{}{}
+	for _, g := range sub.Groups {
+		ids[g.ID] = struct{}{}
+	}
+	if _, ok := ids["g_empty"]; !ok {
+		t.Fatal("empty group missing")
+	}
+	if _, ok := ids["g_other"]; ok {
+		t.Fatal("outside group should not be in subtree")
+	}
+	if len(sub.AgentNames) != 3 {
+		t.Fatalf("agents=%v", sub.AgentNames)
+	}
+	alice := sub.Memberships["alice"]
+	if len(alice.GroupIDs) != 1 || alice.GroupIDs[0] != "g_root" {
+		t.Fatalf("alice groupIds clipped: %+v", alice.GroupIDs)
+	}
+	if alice.ParentAgent != "" {
+		t.Fatalf("outside parentAgent must be dropped, got %q", alice.ParentAgent)
+	}
+	if sub.Memberships["bob"].ParentAgent != "alice" {
+		t.Fatalf("in-subtree parentAgent kept: %+v", sub.Memberships["bob"])
+	}
+}
+
+func TestExportFolderZIP_emptyGroupAndFilename(t *testing.T) {
+	_, orgSvc := setupFolderOrg(t)
+	raw, filename, err := orgSvc.ExportFolderZIP("g_empty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filename != "空组.zip" {
+		t.Fatalf("filename=%q", filename)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var folderStore bool
+	var hasRootAgent bool
+	for _, f := range zr.File {
+		if f.Name == "folder.json" {
+			if f.Method != zip.Store {
+				t.Fatalf("folder.json method=%d want Store", f.Method)
+			}
+			folderStore = true
+			rc, _ := f.Open()
+			b, _ := io.ReadAll(rc)
+			_ = rc.Close()
+			var man orgFolderJSON
+			if err := json.Unmarshal(b, &man); err != nil {
+				t.Fatal(err)
+			}
+			if man.Kind != OrgFolderKind || man.SchemaVersion != 1 {
+				t.Fatalf("manifest %+v", man)
+			}
+			if len(man.AgentNames) != 0 {
+				t.Fatalf("empty group agents=%v", man.AgentNames)
+			}
+			if len(man.Groups) != 1 || man.Groups[0].Name != "空组" {
+				t.Fatalf("groups %+v", man.Groups)
+			}
+		}
+		if f.Name == "agent.json" {
+			hasRootAgent = true
+		}
+	}
+	if !folderStore {
+		t.Fatal("missing folder.json")
+	}
+	if hasRootAgent {
+		t.Fatal("root agent.json must not appear")
+	}
+}
+
+func TestExportImportFolder_remapMountRenameOverwriteRollback(t *testing.T) {
+	skill, orgSvc := setupFolderOrg(t)
+
+	raw, _, err := orgSvc.ExportFolderZIP("g_root")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Top-bar import → new root group, remap ids, drop outside parent.
+	dstRoot := t.TempDir()
+	dstSkill := NewSkillService(dstRoot)
+	dstOrg := NewOrgService(dstRoot, dstSkill)
+	if err := dstSkill.Save(Agent{Name: "alice", Files: []AgentFile{{Path: "rules/old.md", Content: "old"}}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := dstOrg.Put(AgentOrg{
+		Groups: []OrgGroup{{ID: "g_local", Name: "本地组"}},
+		Agents: map[string]OrgAgentMembership{"alice": {GroupIDs: []string{"g_local"}}},
+	}, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	renamed, err := dstOrg.ImportFolderZIP(raw, "", ImportFolderRename)
+	if err != nil {
+		t.Fatalf("rename import: %v", err)
+	}
+	if renamed.Renamed["alice"] != "alice_v2" {
+		t.Fatalf("rename map %+v", renamed.Renamed)
+	}
+	if _, ok := dstSkill.Get("alice_v2"); !ok {
+		t.Fatal("alice_v2 missing")
+	}
+	oldAlice, _ := dstSkill.Get("alice")
+	if len(oldAlice.Files) != 1 || oldAlice.Files[0].Path != "rules/old.md" {
+		t.Fatalf("original alice must be untouched: %+v", oldAlice.Files)
+	}
+	// New ids must not reuse source UUIDs.
+	for _, g := range renamed.Org.Groups {
+		if g.ID == "g_root" || g.ID == "g_pipe" || g.ID == "g_empty" {
+			t.Fatalf("reused source group id %s", g.ID)
+		}
+	}
+	var newRoot *OrgGroup
+	for i := range renamed.Org.Groups {
+		if renamed.Org.Groups[i].Name == "Approving项目组" && renamed.Org.Groups[i].ParentGroupID == "" {
+			newRoot = &renamed.Org.Groups[i]
+			break
+		}
+	}
+	if newRoot == nil {
+		t.Fatalf("new root missing: %+v", renamed.Org.Groups)
+	}
+	importedAlice := renamed.Org.Agents["alice_v2"]
+	if importedAlice.ParentAgent != "" {
+		t.Fatalf("outside parentAgent restored: %+v", importedAlice)
+	}
+	if !containsString(importedAlice.GroupIDs, newRoot.ID) {
+		t.Fatalf("alice_v2 not in new root: %+v", importedAlice.GroupIDs)
+	}
+	// Original alice still in g_local.
+	if got := renamed.Org.Agents["alice"].GroupIDs; len(got) != 1 || got[0] != "g_local" {
+		t.Fatalf("untouched alice membership %+v", renamed.Org.Agents["alice"])
+	}
+
+	// Overwrite import under target group: alice workspace cleared, only package membership.
+	over, err := dstOrg.ImportFolderZIP(raw, "g_local", ImportFolderOverwrite)
+	if err != nil {
+		t.Fatalf("overwrite import: %v", err)
+	}
+	alice2, ok := dstSkill.Get("alice")
+	if !ok {
+		t.Fatal("alice missing after overwrite")
+	}
+	if alice2.AcpBackend != AcpBackendClaudeCode {
+		t.Fatalf("overwrite acpBackend=%q", alice2.AcpBackend)
+	}
+	hasOld := false
+	for _, f := range alice2.Files {
+		if f.Path == "rules/old.md" {
+			hasOld = true
+		}
+	}
+	if hasOld {
+		t.Fatalf("overwrite must clear old workspace: %+v", alice2.Files)
+	}
+	m := over.Org.Agents["alice"]
+	if containsString(m.GroupIDs, "g_local") {
+		t.Fatalf("overwrite alice must drop pre-import g_local membership, got %+v", m)
+	}
+	var mountedRoot *OrgGroup
+	for i := range over.Org.Groups {
+		g := over.Org.Groups[i]
+		if g.Name == "Approving项目组" && g.ParentGroupID == "g_local" {
+			mountedRoot = &g
+			break
+		}
+	}
+	if mountedRoot == nil {
+		t.Fatalf("package root not mounted under target: %+v", over.Org.Groups)
+	}
+	if !containsString(m.GroupIDs, mountedRoot.ID) {
+		t.Fatalf("overwrite alice membership %+v want %s", m.GroupIDs, mountedRoot.ID)
+	}
+
+	// Rollback: invalid group name after agents would be written.
+	bad := buildCorruptFolderZip(t, raw)
+	before, _ := dstOrg.Get()
+	beforeAlice, _ := dstSkill.Get("alice")
+	if _, err := dstOrg.ImportFolderZIP(bad, "", ImportFolderRename); err == nil {
+		t.Fatal("expected rollback error")
+	} else if !strings.Contains(err.Error(), "整次回滚") {
+		t.Fatalf("rollback message: %v", err)
+	}
+	after, _ := dstOrg.Get()
+	if after.Revision != before.Revision {
+		t.Fatalf("org revision changed after rollback: %d -> %d", before.Revision, after.Revision)
+	}
+	afterAlice, _ := dstSkill.Get("alice")
+	if len(afterAlice.Files) != len(beforeAlice.Files) {
+		t.Fatalf("alice files changed after rollback")
+	}
+	// No extra alice_vN from failed import beyond what rename+overwrite already created.
+	_ = skill
+}
+
+func buildCorruptFolderZip(t *testing.T, good []byte) []byte {
+	t.Helper()
+	zr, err := zip.NewReader(bytes.NewReader(good), int64(len(good)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := &bytes.Buffer{}
+	zw := zip.NewWriter(buf)
+	for _, f := range zr.File {
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		body, _ := io.ReadAll(rc)
+		_ = rc.Close()
+		if f.Name == "folder.json" {
+			var man orgFolderJSON
+			_ = json.Unmarshal(body, &man)
+			man.Groups = append(man.Groups, OrgGroup{ID: "g_bad", Name: ""})
+			body, _ = json.Marshal(man)
+			hdr := &zip.FileHeader{Name: "folder.json", Method: zip.Store}
+			w, _ := zw.CreateHeader(hdr)
+			_, _ = w.Write(body)
+			continue
+		}
+		w, _ := zw.Create(f.Name)
+		_, _ = w.Write(body)
+	}
+	_ = zw.Close()
+	return buf.Bytes()
+}
+
+func TestImportFolderZIP_singleAgentRejectedAndOversize(t *testing.T) {
+	_, orgSvc := setupFolderOrg(t)
+	meta := []byte(`{"name":"solo","schemaVersion":1,"exportedAt":"2026-01-01T00:00:00Z"}`)
+	single := buildTestZip(t, meta, map[string][]byte{"rules/a.md": []byte("a")})
+	if _, err := orgSvc.ImportFolderZIP(single, "", ImportFolderRename); err == nil || !strings.Contains(err.Error(), "单 Agent ZIP") {
+		t.Fatalf("single agent: %v", err)
+	}
+	if _, err := orgSvc.Get(); err != nil {
+		t.Fatal(err)
+	}
+	big := make([]byte, OrgFolderMaxBytes+1)
+	if _, err := orgSvc.ImportFolderZIP(big, "", ImportFolderRename); err == nil || !strings.Contains(err.Error(), "64") {
+		t.Fatalf("oversize: %v", err)
+	}
+}
+
+func TestSanitizeDownloadFilename_cjkAndUnsafe(t *testing.T) {
+	if got := sanitizeDownloadFilename("Approving项目组"); got != "Approving项目组" {
+		t.Fatalf("got %q", got)
+	}
+	if got := sanitizeDownloadFilename("Pipeline(GitHub)"); got != "Pipeline_GitHub_" {
+		t.Fatalf("got %q", got)
+	}
+	if got := sanitizeDownloadFilename("a/b\\c"); got != "a_b_c" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestExportFolderZIP_groupNotFound(t *testing.T) {
+	_, orgSvc := setupFolderOrg(t)
+	if _, _, err := orgSvc.ExportFolderZIP("g_missing"); err == nil {
+		t.Fatal("expected not found")
+	}
+}
+
+func TestCopyDirRoundTrip(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir() + "/out"
+	if err := os.WriteFile(filepath.Join(src, "a.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyDir(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dst, "a.txt"))
+	if err != nil || string(got) != "hi" {
+		t.Fatalf("copy: %s %v", got, err)
+	}
+}

--- a/server/internal/services/skill.go
+++ b/server/internal/services/skill.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/cocofhu/approving/internal/models"
 
@@ -26,7 +27,10 @@ import (
 // skills, AGENTS.md, scripts, …), layers the platform base rules + the resolved
 // mcp.json on top, and injects the env vars. Files the agent authors are loaded
 // natively by the in-container ACP agent.
-type SkillService struct{ root string }
+type SkillService struct {
+	root string
+	mu   sync.Mutex
+}
 
 // NewSkillService builds the service. It ships no preset agents (users create
 // their own); it only migrates any existing agents to the current on-disk layout.
@@ -444,6 +448,12 @@ func (s *SkillService) readConfig(name string) agentConfig {
 // workspace/ tree is fully rewritten so removed files disappear from disk; the
 // legacy rules.md / skills/ / cursor/ are dropped on save.
 func (s *SkillService) Save(a Agent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.saveUnlocked(a)
+}
+
+func (s *SkillService) saveUnlocked(a Agent) error {
 	name := sanitize(a.Name)
 	if name == "" {
 		return fmt.Errorf("invalid agent name")
@@ -506,6 +516,12 @@ func (s *SkillService) Save(a Agent) error {
 
 // Delete removes an agent and all its files.
 func (s *SkillService) Delete(name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.deleteUnlocked(name)
+}
+
+func (s *SkillService) deleteUnlocked(name string) error {
 	n := sanitize(name)
 	if n == "" {
 		return fmt.Errorf("invalid agent name")
@@ -517,6 +533,8 @@ func (s *SkillService) Delete(name string) error {
 // so the change either fully succeeds or leaves the old agent untouched (no
 // half-copied intermediate state).
 func (s *SkillService) Rename(old, newName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	o, n := sanitize(old), sanitize(newName)
 	if o == "" || n == "" {
 		return fmt.Errorf("invalid agent name")

--- a/server/internal/services/skill_zip.go
+++ b/server/internal/services/skill_zip.go
@@ -158,6 +158,7 @@ func parseZipAgent(r io.ReaderAt, size int64, prefix string, maxFileBytes int) (
 			name = strings.TrimPrefix(name, prefix)
 		} else if strings.HasPrefix(name, "agents/") {
 			// Single-agent ZIP must not be confused with folder layout entries.
+			continue
 		}
 		if name == "agent.json" {
 			if foundMeta {

--- a/server/internal/services/skill_zip.go
+++ b/server/internal/services/skill_zip.go
@@ -20,6 +20,7 @@ const AgentExportSchemaVersion = 1
 type agentExportJSON struct {
 	Name              string               `json:"name"`
 	GitCredentialType string               `json:"gitCredentialType,omitempty"`
+	AcpBackend        string               `json:"acpBackend,omitempty"`
 	MCP               []MCPServer          `json:"mcp,omitempty"`
 	Env               map[string]string    `json:"env,omitempty"`
 	Layout            *AgentLayout         `json:"layout,omitempty"`
@@ -30,14 +31,33 @@ type agentExportJSON struct {
 
 // ExportZIP builds a portable ZIP for one agent from on-disk state.
 func (s *SkillService) ExportZIP(name string) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	buf := &bytes.Buffer{}
+	zw := zip.NewWriter(buf)
+	if err := s.writeAgentToZip(zw, name, ""); err != nil {
+		_ = zw.Close()
+		return nil, err
+	}
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// writeAgentToZip writes one agent's export snapshot into zw under prefix
+// ("" for single-agent ZIP, "agents/{name}/" for folder packages).
+// agent.json is stored uncompressed. Caller must hold s.mu.
+func (s *SkillService) writeAgentToZip(zw *zip.Writer, name, prefix string) error {
 	a, ok := s.Get(name)
 	if !ok {
-		return nil, fmt.Errorf("agent %q not found", name)
+		return fmt.Errorf("agent %q not found", name)
 	}
 	layout := a.Layout.withDefaults()
 	export := agentExportJSON{
 		Name:              name,
 		GitCredentialType: a.GitCredentialType,
+		AcpBackend:        a.AcpBackend,
 		MCP:               a.MCP,
 		Env:               a.Env,
 		Layout:            &layout,
@@ -47,20 +67,15 @@ func (s *SkillService) ExportZIP(name string) ([]byte, error) {
 	}
 	meta, err := json.MarshalIndent(export, "", "  ")
 	if err != nil {
-		return nil, err
+		return err
 	}
-
-	buf := &bytes.Buffer{}
-	zw := zip.NewWriter(buf)
-	// Store agent.json uncompressed so browser peek can read it without
-	// DecompressionStream (which hangs on Go deflate-raw in Chromium).
-	metaHdr := &zip.FileHeader{Name: "agent.json", Method: zip.Store}
+	metaHdr := &zip.FileHeader{Name: prefix + "agent.json", Method: zip.Store}
 	w, err := zw.CreateHeader(metaHdr)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if _, err := w.Write(meta); err != nil {
-		return nil, err
+		return err
 	}
 
 	work := filepath.Join(s.root, sanitize(name), WorkDirName)
@@ -81,7 +96,7 @@ func (s *SkillService) ExportZIP(name string) ([]byte, error) {
 			if err != nil {
 				return err
 			}
-			fw, err := zw.Create(rel)
+			fw, err := zw.Create(prefix + rel)
 			if err != nil {
 				return err
 			}
@@ -89,15 +104,10 @@ func (s *SkillService) ExportZIP(name string) ([]byte, error) {
 			return err
 		})
 		if err != nil {
-			_ = zw.Close()
-			return nil, err
+			return err
 		}
 	}
-
-	if err := zw.Close(); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
+	return nil
 }
 
 // ImportZIPMode selects create vs overwrite semantics.
@@ -110,6 +120,95 @@ const (
 
 // ImportZIP parses a ZIP export and writes the agent to disk.
 func (s *SkillService) ImportZIP(raw []byte, targetName string, mode ImportZIPMode) (Agent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	export, files, err := parseZipAgent(bytes.NewReader(raw), int64(len(raw)), "", 0)
+	if err != nil {
+		return Agent{}, err
+	}
+	return s.applyAgentExport(export, files, targetName, mode)
+}
+
+// parseZipAgent reads agent.json + workspace files from a ZIP, optionally under prefix.
+// maxFileBytes > 0 enforces a per-file workspace size cap.
+func parseZipAgent(r io.ReaderAt, size int64, prefix string, maxFileBytes int) (agentExportJSON, []AgentFile, error) {
+	zr, err := zip.NewReader(r, size)
+	if err != nil {
+		return agentExportJSON{}, nil, fmt.Errorf("ZIP 格式非法：%v", err)
+	}
+	prefix = strings.TrimPrefix(filepath.ToSlash(prefix), "./")
+	if prefix != "" && !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+
+	var export agentExportJSON
+	var files []AgentFile
+	foundMeta := false
+
+	for _, f := range zr.File {
+		name := filepath.ToSlash(f.Name)
+		name = strings.TrimPrefix(name, "./")
+		if strings.HasSuffix(name, "/") {
+			continue
+		}
+		if prefix != "" {
+			if !strings.HasPrefix(name, prefix) {
+				continue
+			}
+			name = strings.TrimPrefix(name, prefix)
+		} else if strings.HasPrefix(name, "agents/") {
+			// Single-agent ZIP must not be confused with folder layout entries.
+		}
+		if name == "agent.json" {
+			if foundMeta {
+				return agentExportJSON{}, nil, fmt.Errorf("ZIP 包含多个 agent.json")
+			}
+			rc, err := f.Open()
+			if err != nil {
+				return agentExportJSON{}, nil, fmt.Errorf("无法读取 agent.json：%v", err)
+			}
+			b, err := io.ReadAll(rc)
+			_ = rc.Close()
+			if err != nil {
+				return agentExportJSON{}, nil, fmt.Errorf("无法读取 agent.json：%v", err)
+			}
+			if err := json.Unmarshal(b, &export); err != nil {
+				return agentExportJSON{}, nil, fmt.Errorf("agent.json 格式无效：%v", err)
+			}
+			if export.SchemaVersion != AgentExportSchemaVersion {
+				return agentExportJSON{}, nil, fmt.Errorf("不支持的 schemaVersion：%d。当前仅支持 schemaVersion=%d。", export.SchemaVersion, AgentExportSchemaVersion)
+			}
+			foundMeta = true
+			continue
+		}
+
+		rel := safeRel(name)
+		if rel == "" || strings.Contains(name, "..") || strings.HasPrefix(name, "/") || filepath.IsAbs(name) {
+			return agentExportJSON{}, nil, fmt.Errorf("ZIP 包含非法路径：%s", f.Name)
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return agentExportJSON{}, nil, fmt.Errorf("无法读取 %s：%v", f.Name, err)
+		}
+		body, err := io.ReadAll(rc)
+		_ = rc.Close()
+		if err != nil {
+			return agentExportJSON{}, nil, fmt.Errorf("无法读取 %s：%v", f.Name, err)
+		}
+		if maxFileBytes > 0 && len(body) > maxFileBytes {
+			return agentExportJSON{}, nil, fmt.Errorf("工作区文件 %s 超过 1MiB 上限", name)
+		}
+		files = append(files, AgentFile{Path: rel, Content: string(body)})
+	}
+
+	if !foundMeta {
+		return agentExportJSON{}, nil, fmt.Errorf("ZIP 缺少根目录 agent.json")
+	}
+	return export, files, nil
+}
+
+// applyAgentExport writes a parsed export to disk. Caller must hold s.mu.
+func (s *SkillService) applyAgentExport(export agentExportJSON, files []AgentFile, targetName string, mode ImportZIPMode) (Agent, error) {
 	targetName = strings.TrimSpace(targetName)
 	if targetName == "" {
 		return Agent{}, fmt.Errorf("target name is required")
@@ -127,72 +226,15 @@ func (s *SkillService) ImportZIP(raw []byte, targetName string, mode ImportZIPMo
 		return Agent{}, fmt.Errorf("agent %q not found", targetName)
 	}
 
-	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
-	if err != nil {
-		return Agent{}, fmt.Errorf("ZIP 格式非法：%v", err)
-	}
-
 	safeName := sanitize(targetName)
 	if safeName == "" {
 		return Agent{}, fmt.Errorf("invalid agent name")
 	}
 	workRoot := filepath.Join(s.root, safeName, WorkDirName)
-
-	var export agentExportJSON
-	var files []AgentFile
-	foundMeta := false
-
-	for _, f := range zr.File {
-		name := filepath.ToSlash(f.Name)
-		name = strings.TrimPrefix(name, "./")
-		if strings.HasSuffix(name, "/") {
-			continue
+	for _, f := range files {
+		if _, err := underRoot(workRoot, f.Path); err != nil {
+			return Agent{}, fmt.Errorf("ZIP 包含非法路径：%s", f.Path)
 		}
-		if name == "agent.json" {
-			if foundMeta {
-				return Agent{}, fmt.Errorf("ZIP 包含多个 agent.json")
-			}
-			rc, err := f.Open()
-			if err != nil {
-				return Agent{}, fmt.Errorf("无法读取 agent.json：%v", err)
-			}
-			b, err := io.ReadAll(rc)
-			_ = rc.Close()
-			if err != nil {
-				return Agent{}, fmt.Errorf("无法读取 agent.json：%v", err)
-			}
-			if err := json.Unmarshal(b, &export); err != nil {
-				return Agent{}, fmt.Errorf("agent.json 格式无效：%v", err)
-			}
-			if export.SchemaVersion != AgentExportSchemaVersion {
-				return Agent{}, fmt.Errorf("不支持的 schemaVersion：%d。当前仅支持 schemaVersion=%d。", export.SchemaVersion, AgentExportSchemaVersion)
-			}
-			foundMeta = true
-			continue
-		}
-
-		rel := safeRel(name)
-		if rel == "" || strings.Contains(name, "..") || strings.HasPrefix(name, "/") || filepath.IsAbs(name) {
-			return Agent{}, fmt.Errorf("ZIP 包含非法路径：%s", f.Name)
-		}
-		// Zip Slip under-root barrier (CodeQL #19): reject before accepting content.
-		if _, err := underRoot(workRoot, rel); err != nil {
-			return Agent{}, fmt.Errorf("ZIP 包含非法路径：%s", f.Name)
-		}
-		rc, err := f.Open()
-		if err != nil {
-			return Agent{}, fmt.Errorf("无法读取 %s：%v", f.Name, err)
-		}
-		body, err := io.ReadAll(rc)
-		_ = rc.Close()
-		if err != nil {
-			return Agent{}, fmt.Errorf("无法读取 %s：%v", f.Name, err)
-		}
-		files = append(files, AgentFile{Path: rel, Content: string(body)})
-	}
-
-	if !foundMeta {
-		return Agent{}, fmt.Errorf("ZIP 缺少根目录 agent.json")
 	}
 
 	var layout AgentLayout
@@ -213,6 +255,7 @@ func (s *SkillService) ImportZIP(raw []byte, targetName string, mode ImportZIPMo
 	agent := Agent{
 		Name:              targetName,
 		ProjectID:         projectID,
+		AcpBackend:        export.AcpBackend,
 		GitCredentialType: export.GitCredentialType,
 		Files:             files,
 		MCP:               export.MCP,
@@ -226,7 +269,7 @@ func (s *SkillService) ImportZIP(raw []byte, targetName string, mode ImportZIPMo
 	if projectID == "" {
 		agent.MCP = StripProjectPlatformMCP(agent.MCP)
 	}
-	if err := s.Save(agent); err != nil {
+	if err := s.saveUnlocked(agent); err != nil {
 		return Agent{}, err
 	}
 	out, ok := s.Get(targetName)

--- a/server/internal/services/skill_zip_test.go
+++ b/server/internal/services/skill_zip_test.go
@@ -41,6 +41,7 @@ func TestExportImportZIPRoundTrip(t *testing.T) {
 	binary := []byte{0x00, 0x01, 0xFF, 0xFE, 0x89, 0x50, 0x4E, 0x47}
 	err := s.Save(Agent{
 		Name:              "trip",
+		AcpBackend:        AcpBackendClaudeCode,
 		GitCredentialType: "gitlab_https",
 		Env:               map[string]string{"GITLAB_TOKEN": "secret"},
 		MCP:               DefaultPlatformMCP(),
@@ -71,6 +72,9 @@ func TestExportImportZIPRoundTrip(t *testing.T) {
 	}
 	if imported.GitCredentialType != "gitlab_https" {
 		t.Fatalf("gitCredentialType = %q, want gitlab_https", imported.GitCredentialType)
+	}
+	if imported.AcpBackend != AcpBackendClaudeCode {
+		t.Fatalf("acpBackend = %q, want %s", imported.AcpBackend, AcpBackendClaudeCode)
 	}
 	if len(imported.Files) != 2 {
 		t.Fatalf("files = %d", len(imported.Files))
@@ -134,6 +138,48 @@ func TestImportZIPOverwriteClearsOldFiles(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(root, "target", WorkDirName, "skills", "keep", "SKILL.md")); !os.IsNotExist(err) {
 		t.Fatal("old cursor file should be removed on overwrite")
+	}
+}
+
+func TestImportZIPAcpBackendCreateAndOverwrite(t *testing.T) {
+	s := NewSkillService(t.TempDir())
+	if err := s.Save(Agent{Name: "src", AcpBackend: AcpBackendTrae}); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := s.ExportZIP("src")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dst := NewSkillService(t.TempDir())
+	created, err := dst.ImportZIP(raw, "src-copy", ImportZIPCreate)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if created.AcpBackend != AcpBackendTrae {
+		t.Fatalf("create acpBackend=%q", created.AcpBackend)
+	}
+	if err := dst.Save(Agent{Name: "src-copy", AcpBackend: AcpBackendCursor}); err != nil {
+		t.Fatal(err)
+	}
+	over, err := dst.ImportZIP(raw, "src-copy", ImportZIPOverwrite)
+	if err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	if over.AcpBackend != AcpBackendTrae {
+		t.Fatalf("overwrite acpBackend=%q", over.AcpBackend)
+	}
+}
+
+func TestImportZIPMissingAcpBackendDefaultsCursor(t *testing.T) {
+	s := NewSkillService(t.TempDir())
+	meta := []byte(`{"name":"legacy","schemaVersion":1,"exportedAt":"2026-01-01T00:00:00Z"}`)
+	raw := buildTestZip(t, meta, map[string][]byte{"rules/a.md": []byte("a")})
+	got, err := s.ImportZIP(raw, "legacy", ImportZIPCreate)
+	if err != nil {
+		t.Fatalf("import legacy: %v", err)
+	}
+	if got.AcpBackend != AcpBackendCursor {
+		t.Fatalf("default acpBackend=%q", got.AcpBackend)
 	}
 }
 

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -23,6 +23,8 @@ servers:
 tags:
   - name: artifacts
     description: Platform-wide artifact catalog
+  - name: agents
+    description: Agent Studio export/import (single agent and org-folder)
 
 paths:
   /runs/{id}/gates/{nodeId}/primary-artifacts:
@@ -228,6 +230,139 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+
+  /agents/org/export:
+    get:
+      operationId: exportOrgFolder
+      tags: [agents]
+      summary: Export a virtual-group subtree as a folder ZIP
+      description: |
+        Downloads a folder package (`folder.json` + `agents/{name}/`) for the
+        given virtual group and all descendant groups (including empty groups).
+        Auth matches other Agent APIs (session cookie / APIMiddleware). Must be
+        registered before `/agents/{name}/export` so `name=org` is not captured.
+      parameters:
+        - name: groupId
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: ZIP attachment
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        '400':
+          description: Missing groupId or package too large
+        '401':
+          description: Unauthenticated
+        '404':
+          description: Group not found
+
+  /agents/org/import:
+    post:
+      operationId: importOrgFolder
+      tags: [agents]
+      summary: Import a folder ZIP (atomic)
+      description: |
+        Multipart import of an `org-folder` ZIP. Optional `targetGroupId` mounts
+        the package root as a child of that group; omit it to create a new root
+        group. `mode` is `rename` (default, `name_v2`) or `overwrite`.
+        Failures roll back to the pre-import environment. Auth is session only.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                targetGroupId:
+                  type: string
+                mode:
+                  type: string
+                  enum: [rename, overwrite]
+      responses:
+        '200':
+          description: Imported org snapshot
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  org: { type: object }
+                  created:
+                    type: array
+                    items: { type: string }
+                  overwritten:
+                    type: array
+                    items: { type: string }
+                  renamed:
+                    type: object
+                    additionalProperties: { type: string }
+        '400':
+          description: Invalid package, single-agent ZIP, oversize, or validation
+        '401':
+          description: Unauthenticated
+        '404':
+          description: Target group not found
+
+  /agents/{name}/export:
+    get:
+      operationId: exportAgent
+      tags: [agents]
+      summary: Export one Agent as a ZIP
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: ZIP attachment
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        '401':
+          description: Unauthenticated
+        '404':
+          description: Agent not found
+
+  /agents/import:
+    post:
+      operationId: importAgent
+      tags: [agents]
+      summary: Import a single-agent ZIP
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file, targetName]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                targetName:
+                  type: string
+                mode:
+                  type: string
+                  enum: [create, overwrite]
+      responses:
+        '200':
+          description: Imported agent
+        '400':
+          description: Invalid ZIP or name
+        '401':
+          description: Unauthenticated
 
 components:
   parameters:

--- a/web/src/components/agent/AgentOrgSidebar.test.ts
+++ b/web/src/components/agent/AgentOrgSidebar.test.ts
@@ -226,7 +226,7 @@ describe('AgentOrgSidebar two-column right-edge count layout', () => {
 })
 
 describe('AgentOrgSidebar context menus', () => {
-  it('组头行右键弹出新建子组/重命名/删除', async () => {
+  it('组头行右键弹出新建子组/导出/导入/重命名/删除', async () => {
     const wrapper = mountSidebar(sampleOrg, true)
     const group = wrapper
       .findAll('[data-org-kind="group"]')
@@ -236,10 +236,30 @@ describe('AgentOrgSidebar context menus', () => {
     const menu = document.querySelector('[data-org-ctx-menu]') as HTMLElement | null
     expect(menu).toBeTruthy()
     expect(menu?.getAttribute('data-org-ctx-kind')).toBe('group')
-    expect(menu?.querySelectorAll('[data-org-ctx-action]')).toHaveLength(3)
+    const actions = [...(menu?.querySelectorAll('[data-org-ctx-action]') || [])].map(
+      (el) => el.getAttribute('data-org-ctx-action'),
+    )
+    expect(actions).toEqual(['newChild', 'export', 'import', 'rename', 'delete'])
+    expect(menu?.querySelectorAll('[data-org-ctx-action]')).toHaveLength(5)
     expect(menu?.textContent).toContain('新建子组')
+    expect(menu?.textContent).toContain('导出')
+    expect(menu?.textContent).toContain('导入')
+    expect(menu?.textContent).not.toContain('导出文件夹')
 
-    const renameBtn = menu!.querySelector('[data-org-ctx-action="rename"]') as HTMLButtonElement
+    const exportBtn = menu!.querySelector('[data-org-ctx-action="export"]') as HTMLButtonElement
+    exportBtn.click()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('export-group')?.[0]).toEqual(['g_dev'])
+    expect(document.querySelector('[data-org-ctx-menu]')).toBeNull()
+
+    await group.trigger('contextmenu', { clientX: 12, clientY: 24 })
+    const importBtn = document.querySelector('[data-org-ctx-action="import"]') as HTMLButtonElement
+    importBtn.click()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('import-group')?.[0]).toEqual(['g_dev'])
+
+    await group.trigger('contextmenu', { clientX: 12, clientY: 24 })
+    const renameBtn = document.querySelector('[data-org-ctx-action="rename"]') as HTMLButtonElement
     renameBtn.click()
     await wrapper.vm.$nextTick()
     expect(wrapper.emitted('rename-group')?.[0]).toEqual(['g_dev'])

--- a/web/src/components/agent/AgentOrgSidebar.vue
+++ b/web/src/components/agent/AgentOrgSidebar.vue
@@ -25,6 +25,8 @@ const emit = defineEmits<{
   (e: 'create-child-group', parentId: string): void
   (e: 'rename-group', groupId: string): void
   (e: 'delete-group', groupId: string): void
+  (e: 'export-group', groupId: string): void
+  (e: 'import-group', groupId: string): void
   (e: 'move-group', groupId: string, newParentId: string): void
   (e: 'move-agent', agentName: string, sourceGroupId: string, targetGroupId: string): void
   (e: 'toggle-collapsed'): void
@@ -124,6 +126,8 @@ function onCtxAction(action: string) {
   if (current.kind === 'group') {
     const id = current.groupId
     if (action === 'newChild') emit('create-child-group', id)
+    else if (action === 'export') emit('export-group', id)
+    else if (action === 'import') emit('import-group', id)
     else if (action === 'rename') emit('rename-group', id)
     else if (action === 'delete') emit('delete-group', id)
     return
@@ -400,6 +404,24 @@ function onDrop(e: DragEvent, row: OrgTreeRow) {
           >
             <Icon name="plus" :size="13" class="text-txt3" />
             {{ t('pages.agentStudio.org.newChildGroup') }}
+          </button>
+          <button
+            type="button"
+            data-org-ctx-action="export"
+            class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12px] text-txt2 hover:bg-overlay hover:text-txt"
+            @click="onCtxAction('export')"
+          >
+            <Icon name="download" :size="13" class="text-txt3" />
+            {{ t('pages.agentStudio.exportImport.export') }}
+          </button>
+          <button
+            type="button"
+            data-org-ctx-action="import"
+            class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12px] text-txt2 hover:bg-overlay hover:text-txt"
+            @click="onCtxAction('import')"
+          >
+            <Icon name="input" :size="13" class="text-txt3" />
+            {{ t('pages.agentStudio.exportImport.import') }}
           </button>
           <button
             type="button"

--- a/web/src/lib/agentIO.test.ts
+++ b/web/src/lib/agentIO.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   peekAgentZipName,
+  peekZipPackage,
   resolveImportName,
   suggestRename,
   validateAgentName,
@@ -93,5 +94,119 @@ describe('peekAgentZipName', () => {
     const file = new File([empty], 'empty.zip', { type: 'application/zip' })
     const result = await peekAgentZipName(file)
     expect(result.error).toBe('missing agent.json')
+  })
+})
+
+function crc32(data: Uint8Array): number {
+  let c = ~0 >>> 0
+  for (let i = 0; i < data.length; i++) {
+    c ^= data[i]
+    for (let k = 0; k < 8; k++) c = (c >>> 1) ^ (0xedb88320 & -(c & 1))
+  }
+  return ~c >>> 0
+}
+
+function u16(n: number) {
+  const b = new Uint8Array(2)
+  new DataView(b.buffer).setUint16(0, n, true)
+  return b
+}
+
+function u32(n: number) {
+  const b = new Uint8Array(4)
+  new DataView(b.buffer).setUint32(0, n, true)
+  return b
+}
+
+function concat(...parts: Uint8Array[]) {
+  const out = new Uint8Array(parts.reduce((s, p) => s + p.length, 0))
+  let o = 0
+  for (const p of parts) {
+    out.set(p, o)
+    o += p.length
+  }
+  return out
+}
+
+function storeZip(files: Record<string, string>): Uint8Array {
+  const locals: Uint8Array[] = []
+  const centrals: Uint8Array[] = []
+  let offset = 0
+  for (const [name, text] of Object.entries(files)) {
+    const nameB = new TextEncoder().encode(name)
+    const data = new TextEncoder().encode(text)
+    const crc = crc32(data)
+    const local = concat(
+      new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+      u32(crc),
+      u32(data.length),
+      u32(data.length),
+      u16(nameB.length),
+      u16(0),
+      nameB,
+      data,
+    )
+    locals.push(local)
+    centrals.push(
+      concat(
+        new Uint8Array([0x50, 0x4b, 0x01, 0x02, 0x14, 0x00, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+        u32(crc),
+        u32(data.length),
+        u32(data.length),
+        u16(nameB.length),
+        u16(0),
+        u16(0),
+        u16(0),
+        u16(0),
+        u32(0),
+        u32(offset),
+        nameB,
+      ),
+    )
+    offset += local.length
+  }
+  const localAll = concat(...locals)
+  const centralAll = concat(...centrals)
+  return concat(
+    localAll,
+    centralAll,
+    new Uint8Array([0x50, 0x4b, 0x05, 0x06, 0x00, 0x00, 0x00, 0x00]),
+    u16(locals.length),
+    u16(locals.length),
+    u32(centralAll.length),
+    u32(localAll.length),
+    u16(0),
+  )
+}
+
+describe('peekZipPackage', () => {
+  it('prefers folder.json org-folder over agent.json', async () => {
+    const raw = storeZip({
+      'folder.json': JSON.stringify({
+        kind: 'org-folder',
+        schemaVersion: 1,
+        rootGroupId: 'g1',
+        groups: [{ id: 'g1', name: 'Approving项目组' }],
+        agentNames: ['alice', 'bob'],
+      }),
+      'agent.json': JSON.stringify({ name: 'should-not-win', schemaVersion: 1 }),
+    })
+    const peek = await peekZipPackage(new File([raw], 'folder.zip', { type: 'application/zip' }))
+    expect(peek).toEqual({
+      kind: 'org-folder',
+      agentNames: ['alice', 'bob'],
+      rootGroupName: 'Approving项目组',
+    })
+  })
+
+  it('falls back to root agent.json for single-agent zip', async () => {
+    const peek = await peekZipPackage(goExportFile())
+    expect(peek).toEqual({ kind: 'agent', name: 'peek_test' })
+  })
+
+  it('returns unrecognized when neither manifest exists', async () => {
+    const raw = storeZip({ 'readme.txt': 'no manifests' })
+    const peek = await peekZipPackage(new File([raw], 'x.zip', { type: 'application/zip' }))
+    expect(peek.kind).toBe('unknown')
   })
 })

--- a/web/src/lib/agentIO.test.ts
+++ b/web/src/lib/agentIO.test.ts
@@ -191,7 +191,7 @@ describe('peekZipPackage', () => {
       }),
       'agent.json': JSON.stringify({ name: 'should-not-win', schemaVersion: 1 }),
     })
-    const peek = await peekZipPackage(new File([raw], 'folder.zip', { type: 'application/zip' }))
+    const peek = await peekZipPackage(new File([Uint8Array.from(raw)], 'folder.zip', { type: 'application/zip' }))
     expect(peek).toEqual({
       kind: 'org-folder',
       agentNames: ['alice', 'bob'],
@@ -206,7 +206,7 @@ describe('peekZipPackage', () => {
 
   it('returns unrecognized when neither manifest exists', async () => {
     const raw = storeZip({ 'readme.txt': 'no manifests' })
-    const peek = await peekZipPackage(new File([raw], 'x.zip', { type: 'application/zip' }))
+    const peek = await peekZipPackage(new File([Uint8Array.from(raw)], 'x.zip', { type: 'application/zip' }))
     expect(peek.kind).toBe('unknown')
   })
 })

--- a/web/src/lib/agentIO.ts
+++ b/web/src/lib/agentIO.ts
@@ -107,7 +107,7 @@ export async function peekZipPackage(file: File): Promise<ZipPeek> {
 export async function peekAgentZipName(file: File): Promise<{ name?: string; error?: string }> {
   const peek = await peekZipPackage(file)
   if (peek.kind === 'agent') return { name: peek.name }
-  if (peek.error === 'invalid zip') return { error: 'invalid zip' }
+  if (peek.kind === 'unknown' && peek.error === 'invalid zip') return { error: 'invalid zip' }
   return { error: 'missing agent.json' }
 }
 

--- a/web/src/lib/agentIO.ts
+++ b/web/src/lib/agentIO.ts
@@ -59,17 +59,56 @@ export function suggestRename(name: string, existing: string[]): string {
   return candidate
 }
 
-/** Read agent.json name field from a ZIP file (client-side peek for conflict UI). */
-export async function peekAgentZipName(file: File): Promise<{ name?: string; error?: string }> {
+export type ZipPeek =
+  | { kind: 'org-folder'; agentNames: string[]; rootGroupName?: string }
+  | { kind: 'agent'; name?: string }
+  | { kind: 'unknown'; error: string }
+
+/** Peek a ZIP: folder.json (org-folder) first, then root agent.json. */
+export async function peekZipPackage(file: File): Promise<ZipPeek> {
   try {
     const buf = new Uint8Array(await file.arrayBuffer())
-    const text = await readZipTextEntry(buf, 'agent.json')
-    if (text == null) return { error: 'missing agent.json' }
-    const json = JSON.parse(text) as { name?: string }
-    return { name: typeof json.name === 'string' ? json.name.trim() : undefined }
+    const folderText = await readZipTextEntry(buf, 'folder.json')
+    if (folderText != null) {
+      try {
+        const json = JSON.parse(folderText) as {
+          kind?: string
+          agentNames?: unknown
+          agents?: Record<string, unknown>
+          groups?: { id?: string; name?: string }[]
+          rootGroupId?: string
+        }
+        if (json?.kind === 'org-folder') {
+          let names: string[] = []
+          if (Array.isArray(json.agentNames)) {
+            names = json.agentNames.map((n) => String(n).trim()).filter(Boolean)
+          } else if (json.agents && typeof json.agents === 'object') {
+            names = Object.keys(json.agents)
+          }
+          const rootGroupName = json.groups?.find((g) => g.id === json.rootGroupId)?.name
+          return { kind: 'org-folder', agentNames: names, rootGroupName }
+        }
+      } catch {
+        return { kind: 'unknown', error: 'invalid zip' }
+      }
+    }
+    const agentText = await readZipTextEntry(buf, 'agent.json')
+    if (agentText != null) {
+      const json = JSON.parse(agentText) as { name?: string }
+      return { kind: 'agent', name: typeof json.name === 'string' ? json.name.trim() : undefined }
+    }
+    return { kind: 'unknown', error: 'unrecognized' }
   } catch {
-    return { error: 'invalid zip' }
+    return { kind: 'unknown', error: 'invalid zip' }
   }
+}
+
+/** Read agent.json name field from a ZIP file (client-side peek for conflict UI). */
+export async function peekAgentZipName(file: File): Promise<{ name?: string; error?: string }> {
+  const peek = await peekZipPackage(file)
+  if (peek.kind === 'agent') return { name: peek.name }
+  if (peek.error === 'invalid zip') return { error: 'invalid zip' }
+  return { error: 'missing agent.json' }
 }
 
 function readUint16LE(data: Uint8Array, off: number): number {

--- a/web/src/lib/agentOrg.ts
+++ b/web/src/lib/agentOrg.ts
@@ -60,6 +60,36 @@ export function ungroupedAgents(org: AgentOrg, agentNames: string[]): string[] {
   return agentNames.filter((n) => groupIdsOf(org, n).length === 0)
 }
 
+/** All virtual-group ids in the subtree rooted at rootId (including root). */
+export function groupSubtreeIds(org: AgentOrg, rootId: string): Set<string> {
+  const ids = new Set<string>()
+  if (!rootId) return ids
+  ids.add(rootId)
+  const groups = org.groups || []
+  let added = true
+  while (added) {
+    added = false
+    for (const g of groups) {
+      if (g.parentGroupId && ids.has(g.parentGroupId) && !ids.has(g.id)) {
+        ids.add(g.id)
+        added = true
+      }
+    }
+  }
+  return ids
+}
+
+/** Agent names that belong to any group in the subtree. */
+export function agentNamesInSubtree(org: AgentOrg, rootId: string, agentNames: string[]): string[] {
+  const gids = groupSubtreeIds(org, rootId)
+  return agentNames.filter((n) => groupIdsOf(org, n).some((id) => gids.has(id)))
+}
+
+export function isAgentInGroupSubtree(org: AgentOrg, agentName: string, rootGroupId: string): boolean {
+  const ids = groupSubtreeIds(org, rootGroupId)
+  return groupIdsOf(org, agentName).some((id) => ids.has(id))
+}
+
 /** Would attaching child as descendant of ancestor create a cycle? */
 export function wouldCreateGroupCycle(org: AgentOrg, childId: string, newParentId: string): boolean {
   if (!newParentId) return false

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -219,6 +219,31 @@ export interface AgentOrg {
   agents: Record<string, OrgAgentMembership>
 }
 
+/** Result of POST /agents/org/import. */
+export interface OrgFolderImportResult {
+  org: AgentOrg
+  created?: string[]
+  overwritten?: string[]
+  renamed?: Record<string, string>
+}
+
+function filenameFromContentDisposition(header: string | null, fallback: string): string {
+  if (!header) return fallback
+  const star = /filename\*=(?:UTF-8''|utf-8'')([^;]+)/i.exec(header)
+  if (star?.[1]) {
+    try {
+      return decodeURIComponent(star[1])
+    } catch {
+      /* ignore */
+    }
+  }
+  const quoted = /filename="([^"]+)"/i.exec(header)
+  if (quoted?.[1]) return quoted[1]
+  const plain = /filename=([^;]+)/i.exec(header)
+  if (plain?.[1]) return plain[1].trim()
+  return fallback
+}
+
 export interface SandboxView {
   id: number
   name: string
@@ -806,6 +831,52 @@ export const api = {
       throw new Error(msg)
     }
     return res.blob()
+  },
+  exportOrgFolder: async (groupId: string): Promise<{ blob: Blob; filename: string }> => {
+    const res = await fetch(`${BASE}/agents/org/export?groupId=${encodeURIComponent(groupId)}`, {
+      credentials: 'include',
+    })
+    if (!res.ok) {
+      let msg = `${res.status} export failed`
+      try {
+        const body = await res.json()
+        if (body?.error) msg = body.error
+      } catch {
+        // non-JSON
+      }
+      throw new Error(msg)
+    }
+    const blob = await res.blob()
+    const filename = filenameFromContentDisposition(
+      res.headers.get('Content-Disposition'),
+      'folder.zip',
+    )
+    return { blob, filename }
+  },
+  importOrgFolder: async (
+    zipFile: File,
+    opts: { targetGroupId?: string; mode: 'rename' | 'overwrite' },
+  ): Promise<OrgFolderImportResult> => {
+    const fd = new FormData()
+    fd.append('file', zipFile)
+    if (opts.targetGroupId) fd.append('targetGroupId', opts.targetGroupId)
+    fd.append('mode', opts.mode)
+    const res = await fetch(`${BASE}/agents/org/import`, {
+      method: 'POST',
+      credentials: 'include',
+      body: fd,
+    })
+    if (!res.ok) {
+      let msg = `${res.status} import failed`
+      try {
+        const body = await res.json()
+        if (body?.error) msg = body.error
+      } catch {
+        // non-JSON
+      }
+      throw new Error(msg)
+    }
+    return (await res.json()) as OrgFolderImportResult
   },
   importAgent: async (zipFile: File, opts: { targetName: string; mode: 'create' | 'overwrite' }): Promise<Agent> => {
     const fd = new FormData()

--- a/web/src/lib/useAgentImport.test.ts
+++ b/web/src/lib/useAgentImport.test.ts
@@ -7,77 +7,160 @@ import common from '@/locales/zh-CN/common.json'
 import pages from '@/locales/zh-CN/pages.json'
 
 const importAgent = vi.fn()
+const importOrgFolder = vi.fn()
+const peekZipPackage = vi.fn()
+
 vi.mock('@/lib/api', () => ({
-  api: { importAgent: (...args: unknown[]) => importAgent(...args) },
+  api: {
+    importAgent: (...args: unknown[]) => importAgent(...args),
+    importOrgFolder: (...args: unknown[]) => importOrgFolder(...args),
+  },
 }))
 
 vi.mock('@/lib/agentIO', () => ({
+  peekZipPackage: (...args: unknown[]) => peekZipPackage(...args),
   peekAgentZipName: vi.fn(async () => ({ name: 'agent-a' })),
   resolveImportName: (name: string) => name,
-  suggestRename: (name: string) => `${name}-2`,
+  suggestRename: (name: string) => `${name}_v2`,
   normalizeAgentName: (name: string) => name,
-  validateAgentName: () => null,
+  validateAgentName: () => '',
 }))
 
 import { useAgentImport } from './useAgentImport'
-import { peekAgentZipName } from './agentIO'
+
+function mountHook(opts: Partial<Parameters<typeof useAgentImport>[0]> = {}) {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common, ...pages } },
+  })
+  let api: ReturnType<typeof useAgentImport> | null = null
+  mount(
+    defineComponent({
+      setup() {
+        api = useAgentImport({
+          dirty: () => false,
+          agentNames: () => ['agent-a'],
+          onImported: vi.fn(),
+          onFolderImported: vi.fn(),
+          ...opts,
+        })
+        return () => h('div')
+      },
+    }),
+    { global: { plugins: [i18n] } },
+  )
+  return api!
+}
 
 describe('useAgentImport', () => {
   beforeEach(() => {
     importAgent.mockReset()
+    importOrgFolder.mockReset()
+    peekZipPackage.mockReset()
     importAgent.mockResolvedValue({ name: 'agent-a' })
-    vi.mocked(peekAgentZipName).mockResolvedValue({ name: 'agent-a' })
+    importOrgFolder.mockResolvedValue({ org: { revision: 2, groups: [], agents: {} } })
   })
 
   it('imports zip and handles dirty/conflict flows', async () => {
-    const i18n = createI18n({
-      legacy: false,
-      locale: 'zh-CN',
-      messages: { 'zh-CN': { ...common, ...pages } },
-    })
+    peekZipPackage.mockResolvedValue({ kind: 'agent', name: 'agent-a' })
     const onImported = vi.fn()
-    let api: ReturnType<typeof useAgentImport> | null = null
-    mount(
-      defineComponent({
-        setup() {
-          api = useAgentImport({
-            dirty: () => true,
-            agentNames: () => ['agent-a'],
-            onImported,
-          })
-          return () => h('div')
-        },
-      }),
-      { global: { plugins: [i18n] } },
-    )
+    let api = mountHook({ dirty: () => true, onImported })
 
-    api!.triggerImport()
-    expect(api!.showDiscardConfirm.value).toBe(true)
-    api!.onDiscardCancel()
-    expect(api!.showDiscardConfirm.value).toBe(false)
+    api.triggerImport()
+    await Promise.resolve()
+    expect(api.showDiscardConfirm.value).toBe(true)
+    api.onDiscardCancel()
+    expect(api.showDiscardConfirm.value).toBe(false)
 
-    api = null
-    mount(
-      defineComponent({
-        setup() {
-          api = useAgentImport({
-            dirty: () => false,
-            agentNames: () => ['agent-a'],
-            onImported,
-          })
-          return () => h('div')
-        },
-      }),
-      { global: { plugins: [i18n] } },
-    )
+    api = mountHook({ dirty: () => false, onImported })
     const input = document.createElement('input')
-    api!.fileInput.value = input
+    api.fileInput.value = input
     const file = new File(['z'], 'agent-a.zip', { type: 'application/zip' })
     Object.defineProperty(input, 'files', { value: [file] })
-    await api!.handleFileChange({ target: input } as unknown as Event)
-    expect(api!.showConflict.value).toBe(true)
-    api!.selectConflict('overwrite')
-    await api!.confirmConflict()
+    await api.handleFileChange({ target: input } as unknown as Event)
+    expect(api.showConflict.value).toBe(true)
+    api.selectConflict('overwrite')
+    await api.confirmConflict()
     expect(importAgent).toHaveBeenCalled()
+    expect(importOrgFolder).not.toHaveBeenCalled()
+  })
+
+  it('top-bar folder zip goes to org import without targetGroupId', async () => {
+    peekZipPackage.mockResolvedValue({ kind: 'org-folder', agentNames: ['bob', 'carol'] })
+    const onFolderImported = vi.fn()
+    const api = mountHook({
+      agentNames: () => ['agent-a'],
+      onFolderImported,
+    })
+    const input = document.createElement('input')
+    api.fileInput.value = input
+    const file = new File(['z'], 'folder.zip', { type: 'application/zip' })
+    Object.defineProperty(input, 'files', { value: [file] })
+    await api.handleFileChange({ target: input } as unknown as Event)
+    expect(api.showBatchConflict.value).toBe(false)
+    expect(importOrgFolder).toHaveBeenCalledWith(file, { targetGroupId: undefined, mode: 'rename' })
+    expect(onFolderImported).toHaveBeenCalled()
+    expect(importAgent).not.toHaveBeenCalled()
+  })
+
+  it('folder zip with name conflicts shows one batch dialog', async () => {
+    peekZipPackage.mockResolvedValue({ kind: 'org-folder', agentNames: ['agent-a', 'bob'] })
+    const api = mountHook({ agentNames: () => ['agent-a', 'other'] })
+    const input = document.createElement('input')
+    api.fileInput.value = input
+    const file = new File(['z'], 'folder.zip', { type: 'application/zip' })
+    Object.defineProperty(input, 'files', { value: [file] })
+    await api.handleFileChange({ target: input } as unknown as Event)
+    expect(api.showBatchConflict.value).toBe(true)
+    expect(api.batchConflictNames.value).toEqual(['agent-a'])
+    expect(importOrgFolder).not.toHaveBeenCalled()
+
+    await api.confirmBatchOverwrite()
+    expect(importOrgFolder).toHaveBeenCalledWith(file, { targetGroupId: undefined, mode: 'overwrite' })
+  })
+
+  it('group import rejects single-agent zip and does not write', async () => {
+    peekZipPackage.mockResolvedValue({ kind: 'agent', name: 'solo' })
+    const api = mountHook()
+    const input = document.createElement('input')
+    api.fileInput.value = input
+    api.triggerGroupImport('g_dev')
+    const file = new File(['z'], 'solo.zip', { type: 'application/zip' })
+    Object.defineProperty(input, 'files', { value: [file] })
+    await api.handleFileChange({ target: input } as unknown as Event)
+    expect(api.showImportError.value).toBe(true)
+    expect(api.importError.value).toMatch(/单 Agent ZIP/)
+    expect(api.importError.value).toMatch(/文件夹包/)
+    expect(api.importError.value).toMatch(/顶栏/)
+    expect(api.importError.value).toMatch(/导入/)
+    expect(importAgent).not.toHaveBeenCalled()
+    expect(importOrgFolder).not.toHaveBeenCalled()
+  })
+
+  it('group import of folder zip passes targetGroupId', async () => {
+    peekZipPackage.mockResolvedValue({ kind: 'org-folder', agentNames: ['bob'] })
+    const api = mountHook({ agentNames: () => [] })
+    const input = document.createElement('input')
+    api.fileInput.value = input
+    api.triggerGroupImport('g_dev')
+    const file = new File(['z'], 'folder.zip', { type: 'application/zip' })
+    Object.defineProperty(input, 'files', { value: [file] })
+    await api.handleFileChange({ target: input } as unknown as Event)
+    expect(importOrgFolder).toHaveBeenCalledWith(file, { targetGroupId: 'g_dev', mode: 'rename' })
+  })
+
+  it('unrecognized zip shows visible error and does not write', async () => {
+    peekZipPackage.mockResolvedValue({ kind: 'unknown', error: 'unrecognized' })
+    const api = mountHook()
+    const input = document.createElement('input')
+    api.fileInput.value = input
+    const file = new File(['z'], 'mystery.zip', { type: 'application/zip' })
+    Object.defineProperty(input, 'files', { value: [file] })
+    await api.handleFileChange({ target: input } as unknown as Event)
+    expect(api.showImportError.value).toBe(true)
+    expect(api.importError.value).toMatch(/无法识别/)
+    expect(importAgent).not.toHaveBeenCalled()
+    expect(importOrgFolder).not.toHaveBeenCalled()
   })
 })

--- a/web/src/lib/useAgentImport.ts
+++ b/web/src/lib/useAgentImport.ts
@@ -1,22 +1,27 @@
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { api } from '@/lib/api'
+import { api, type Agent, type AgentOrg } from '@/lib/api'
 import {
   peekAgentZipName,
+  peekZipPackage,
   resolveImportName,
   suggestRename,
   validateAgentName,
   normalizeAgentName,
 } from '@/lib/agentIO'
 import { useToast } from '@/lib/useToast'
-import type { Agent } from '@/lib/api'
 
 export type ConflictAction = 'overwrite' | 'rename' | 'cancel'
+export type FolderConflictAction = 'rename' | 'overwrite' | 'cancel'
 
 export function useAgentImport(opts: {
   dirty: () => boolean
+  agentDirty?: () => boolean
+  orgDirty?: () => boolean
+  persistOrg?: () => Promise<boolean>
   agentNames: () => string[]
   onImported: (agent: Agent) => void | Promise<void>
+  onFolderImported?: (org: AgentOrg) => void | Promise<void>
 }) {
   const { t } = useI18n()
   const toast = useToast()
@@ -32,19 +37,54 @@ export function useAgentImport(opts: {
   const renameValue = ref('')
   const renameError = ref('')
 
+  const showBatchConflict = ref(false)
+  const batchConflictNames = ref<string[]>([])
+
   let pendingFile: File | null = null
+  let pendingTargetGroupId: string | null = null
+  let requireFolder = false
+
+  function agentIsDirty() {
+    return opts.agentDirty ? opts.agentDirty() : opts.dirty()
+  }
+
+  async function persistOrgIfNeeded(): Promise<boolean> {
+    if (!opts.orgDirty?.()) return true
+    if (!opts.persistOrg) return true
+    return opts.persistOrg()
+  }
 
   function triggerImport() {
-    if (opts.dirty()) {
-      showDiscardConfirm.value = true
-      return
-    }
-    fileInput.value?.click()
+    pendingTargetGroupId = null
+    requireFolder = false
+    void (async () => {
+      if (!(await persistOrgIfNeeded())) return
+      if (agentIsDirty()) {
+        showDiscardConfirm.value = true
+        return
+      }
+      fileInput.value?.click()
+    })()
+  }
+
+  function triggerGroupImport(groupId: string) {
+    pendingTargetGroupId = groupId
+    requireFolder = true
+    void (async () => {
+      if (!(await persistOrgIfNeeded())) return
+      if (agentIsDirty()) {
+        showDiscardConfirm.value = true
+        return
+      }
+      fileInput.value?.click()
+    })()
   }
 
   function onDiscardCancel() {
     showDiscardConfirm.value = false
     pendingFile = null
+    pendingTargetGroupId = null
+    requireFolder = false
   }
 
   function onDiscardConfirm() {
@@ -65,8 +105,40 @@ export function useAgentImport(opts: {
     }
 
     pendingFile = file
-    const peek = await peekAgentZipName(file)
-    if (peek.error) {
+    const peek = await peekZipPackage(file)
+
+    if (peek.kind === 'unknown') {
+      importError.value =
+        peek.error === 'invalid zip'
+          ? t('pages.agentStudio.exportImport.importError.invalidZip')
+          : t('pages.agentStudio.exportImport.importError.unrecognized')
+      showImportError.value = true
+      pendingFile = null
+      return
+    }
+
+    if (requireFolder) {
+      if (peek.kind === 'agent') {
+        importError.value = t('pages.agentStudio.exportImport.importError.singleAgentOnGroup')
+        showImportError.value = true
+        pendingFile = null
+        return
+      }
+      await beginFolderImport(peek.agentNames)
+      return
+    }
+
+    if (peek.kind === 'org-folder') {
+      await beginFolderImport(peek.agentNames)
+      return
+    }
+
+    await beginSingleAgentImport(file, peek.name)
+  }
+
+  async function beginSingleAgentImport(file: File, peekedName?: string) {
+    const peek = peekedName != null ? { name: peekedName } : await peekAgentZipName(file)
+    if ('error' in peek && peek.error && peekedName == null) {
       importError.value =
         peek.error === 'missing agent.json'
           ? t('pages.agentStudio.exportImport.importError.missingAgentJson')
@@ -76,7 +148,7 @@ export function useAgentImport(opts: {
       return
     }
 
-    const targetName = normalizeAgentName(resolveImportName(peek.name, file.name))
+    const targetName = normalizeAgentName(resolveImportName(peekedName ?? peek.name, file.name))
     const nameErr = validateAgentName(targetName)
     if (nameErr === 'required' || nameErr === 'invalid') {
       importError.value = t('pages.agentStudio.exportImport.importError.invalidName')
@@ -96,6 +168,17 @@ export function useAgentImport(opts: {
     }
 
     await runImport(targetName, 'create')
+  }
+
+  async function beginFolderImport(agentNames: string[]) {
+    const existing = new Set(opts.agentNames())
+    const conflicts = agentNames.filter((n) => existing.has(n))
+    if (conflicts.length > 0) {
+      batchConflictNames.value = conflicts
+      showBatchConflict.value = true
+      return
+    }
+    await runFolderImport('rename')
   }
 
   function selectConflict(action: ConflictAction) {
@@ -141,6 +224,24 @@ export function useAgentImport(opts: {
     await runImport(newName, 'create')
   }
 
+  function closeBatchConflict() {
+    showBatchConflict.value = false
+    pendingFile = null
+    pendingTargetGroupId = null
+    requireFolder = false
+    batchConflictNames.value = []
+  }
+
+  async function confirmBatchRename() {
+    showBatchConflict.value = false
+    await runFolderImport('rename')
+  }
+
+  async function confirmBatchOverwrite() {
+    showBatchConflict.value = false
+    await runFolderImport('overwrite')
+  }
+
   async function runImport(targetName: string, mode: 'create' | 'overwrite') {
     const file = pendingFile
     pendingFile = null
@@ -156,6 +257,32 @@ export function useAgentImport(opts: {
     }
   }
 
+  async function runFolderImport(mode: 'rename' | 'overwrite') {
+    const file = pendingFile
+    const targetGroupId = pendingTargetGroupId
+    pendingFile = null
+    pendingTargetGroupId = null
+    requireFolder = false
+    if (!file) return
+
+    try {
+      const result = await api.importOrgFolder(file, {
+        targetGroupId: targetGroupId || undefined,
+        mode,
+      })
+      if (opts.onFolderImported) {
+        await opts.onFolderImported(result.org)
+      }
+      toast.success(t('pages.agentStudio.exportImport.folderImportSuccess'))
+    } catch (err: any) {
+      const msg = String(err?.message || err)
+      importError.value = msg.includes('整次回滚')
+        ? msg
+        : `${t('pages.agentStudio.exportImport.importError.rolledBack')} ${msg}`
+      showImportError.value = true
+    }
+  }
+
   return {
     fileInput,
     showDiscardConfirm,
@@ -166,12 +293,18 @@ export function useAgentImport(opts: {
     conflictAction,
     renameValue,
     renameError,
+    showBatchConflict,
+    batchConflictNames,
     triggerImport,
+    triggerGroupImport,
     onDiscardCancel,
     onDiscardConfirm,
     handleFileChange,
     selectConflict,
     closeConflict,
     confirmConflict,
+    closeBatchConflict,
+    confirmBatchRename,
+    confirmBatchOverwrite,
   }
 }

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -1463,6 +1463,23 @@
         "import": "Import",
         "exportSuccess": "Downloaded {name}.zip",
         "importSuccess": "Agent \"{name}\" imported",
+        "folderExportSuccess": "Downloaded {name}.zip",
+        "folderImportSuccess": "Folder imported",
+        "folderSecrets": {
+          "title": "Exporting a folder takes secrets with it",
+          "body": "The package includes environment variables/secrets. After download it leaves this environment; only share with trusted recipients.",
+          "confirm": "Confirm and download"
+        },
+        "batchConflict": {
+          "title": "Duplicate agent names detected",
+          "intro": "These agents already exist in this environment:",
+          "rename": "Rename all",
+          "renameDesc": "Create conflicting agents with a name_v2 suffix; do not overwrite existing workspaces",
+          "overwrite": "Overwrite all",
+          "overwriteDesc": "Clear target workspaces and remove these agents from other groups here; keep only membership from the import package",
+          "cancel": "Cancel entire import",
+          "cancelDesc": "Abort import without creating or changing any agents or groups"
+        },
         "unsavedExport": {
           "title": "Cannot export",
           "message": "Agent \"{name}\" has unsaved changes. Export includes only saved on-disk content.",
@@ -1493,6 +1510,10 @@
           "invalidZip": "Invalid ZIP file.",
           "missingAgentJson": "ZIP is missing root agent.json.",
           "invalidName": "Agent name does not match naming rules.",
+          "unrecognized": "Unrecognized ZIP: neither a folder package nor a single-agent export.",
+          "singleAgentOnGroup": "This is a single-agent ZIP. Group import only accepts a folder package; use the top-bar Import instead.",
+          "folderTooLarge": "Folder package exceeds the 64MiB limit.",
+          "rolledBack": "Import failed and was fully rolled back.",
           "ok": "OK"
         }
       },

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -1463,6 +1463,23 @@
         "import": "导入",
         "exportSuccess": "已下载 {name}.zip",
         "importSuccess": "Agent「{name}」导入成功",
+        "folderExportSuccess": "已下载 {name}.zip",
+        "folderImportSuccess": "文件夹导入成功",
+        "folderSecrets": {
+          "title": "导出文件夹将带走密钥",
+          "body": "导出包内含环境变量/密钥。下载后文件将离开本环境，请仅发送给受信任的接收方。",
+          "confirm": "确认并下载"
+        },
+        "batchConflict": {
+          "title": "检测到同名 Agent",
+          "intro": "以下 Agent 与当前环境同名：",
+          "rename": "全部重命名",
+          "renameDesc": "冲突项将按 name_v2 规则创建为新 Agent，不覆盖已有工作区",
+          "overwrite": "全部覆盖",
+          "overwriteDesc": "清空目标工作区，并移除这些 Agent 在本环境其它组中的归属，仅保留导入包内关系",
+          "cancel": "取消整次导入",
+          "cancelDesc": "中止导入，不创建或修改任何 Agent 或组"
+        },
         "unsavedExport": {
           "title": "无法导出",
           "message": "当前 Agent「{name}」有未保存的修改。导出仅包含已落盘版本，请先保存或放弃修改后再导出。",
@@ -1493,6 +1510,10 @@
           "invalidZip": "ZIP 格式非法，请检查后重试。",
           "missingAgentJson": "ZIP 缺少根目录 agent.json，请检查后重试。",
           "invalidName": "Agent 名称不符合命名规则，请检查 agent.json 或 ZIP 文件名。",
+          "unrecognized": "无法识别该 ZIP，既不是文件夹包也不是单 Agent 导出。",
+          "singleAgentOnGroup": "这是单 Agent ZIP。组右键导入仅接受文件夹包，请改用顶栏「导入」。",
+          "folderTooLarge": "文件夹包超过 64MiB 上限。",
+          "rolledBack": "导入失败，已整次回滚。",
           "ok": "知道了"
         }
       },

--- a/web/src/views/AgentStudioView.vue
+++ b/web/src/views/AgentStudioView.vue
@@ -28,6 +28,7 @@ import {
   wouldCreateGroupCycle,
   wouldCreateReportingCycle,
   buildOrgTreeRows,
+  isAgentInGroupSubtree,
   UNGROUPED_ID,
 } from '@/lib/agentOrg'
 import type { GitCredentialType } from '@/lib/gitCredentialAnalysis'
@@ -468,9 +469,14 @@ const renameBlockedTarget = ref('')
 
 const showUnsavedExport = ref(false)
 const exporting = ref(false)
+const showFolderSecrets = ref(false)
+const pendingFolderExportGroupId = ref('')
 
 const agentImport = useAgentImport({
-  dirty: () => dirty.value,
+  dirty: () => agentDirty.value,
+  agentDirty: () => agentDirty.value,
+  orgDirty: () => orgDirty.value,
+  persistOrg: () => persistOrg(org.value),
   agentNames: () => agents.value.map((a) => a.name),
   onImported: async (agent) => {
     const i = agents.value.findIndex((a) => a.name === agent.name)
@@ -483,6 +489,25 @@ const agentImport = useAgentImport({
     await reloadOrg()
     select(agent.name)
   },
+  onFolderImported: async (importedOrg) => {
+    org.value = importedOrg
+    orgBaseline.value = orgSnapshot(importedOrg)
+    try {
+      const list = await api.listAgents()
+      agents.value = list || []
+      if (activeName.value && agents.value.some((a) => a.name === activeName.value)) {
+        const a = agents.value.find((x) => x.name === activeName.value)!
+        const loaded = toDraft(a)
+        originalJson.value = JSON.stringify(fromDraftRaw(loaded))
+        normalizeDraftRegions(loaded)
+        draft.value = loaded
+      } else if (agents.value.length) {
+        select(agents.value[0].name)
+      }
+    } catch (e: any) {
+      error.value = String(e?.message || e)
+    }
+  },
 })
 const {
   fileInput: importFileInput,
@@ -494,13 +519,19 @@ const {
   conflictAction: importConflictAction,
   renameValue: importRenameValue,
   renameError: importRenameError,
+  showBatchConflict,
+  batchConflictNames,
   triggerImport,
+  triggerGroupImport,
   onDiscardCancel: onImportDiscardCancel,
   onDiscardConfirm: onImportDiscardConfirm,
   handleFileChange: onImportFileChange,
   selectConflict: selectImportConflict,
   closeConflict: closeImportConflict,
   confirmConflict: confirmImportConflict,
+  closeBatchConflict,
+  confirmBatchRename,
+  confirmBatchOverwrite,
 } = agentImport
 
 function recToKV(rec?: Record<string, string>): KV[] {
@@ -595,11 +626,11 @@ function orgSnapshot(o: AgentOrg): string {
   })
 }
 
-const dirty = computed(() => {
-  const agentDirty = !!draft.value && JSON.stringify(fromDraft(draft.value)) !== originalJson.value
-  const orgDirty = orgSnapshot(org.value) !== orgBaseline.value
-  return agentDirty || orgDirty
-})
+const agentDirty = computed(
+  () => !!draft.value && JSON.stringify(fromDraft(draft.value)) !== originalJson.value,
+)
+const orgDirty = computed(() => orgSnapshot(org.value) !== orgBaseline.value)
+const dirty = computed(() => agentDirty.value || orgDirty.value)
 
 watch(dirty, (d) => {
   if (d) justSaved.value = false
@@ -1442,6 +1473,7 @@ async function doExport(name: string) {
 
 function triggerExport() {
   if (!activeName.value || exporting.value) return
+  pendingFolderExportGroupId.value = ''
   if (dirty.value) {
     showUnsavedExport.value = true
     return
@@ -1451,10 +1483,15 @@ function triggerExport() {
 
 function cancelUnsavedExport() {
   showUnsavedExport.value = false
+  pendingFolderExportGroupId.value = ''
 }
 
 async function discardAndExport() {
   showUnsavedExport.value = false
+  if (pendingFolderExportGroupId.value) {
+    showFolderSecrets.value = true
+    return
+  }
   if (!activeName.value) return
   await doExport(activeName.value)
 }
@@ -1463,7 +1500,55 @@ async function saveThenExport() {
   const ok = await save()
   if (!ok) return
   showUnsavedExport.value = false
+  if (pendingFolderExportGroupId.value) {
+    showFolderSecrets.value = true
+    return
+  }
   if (activeName.value) await doExport(activeName.value)
+}
+
+async function onExportGroup(groupId: string) {
+  if (exporting.value) return
+  if (orgDirty.value) {
+    if (!(await persistOrg(org.value))) return
+  }
+  const inSubtree =
+    !!activeName.value && isAgentInGroupSubtree(org.value, activeName.value, groupId)
+  if (inSubtree && agentDirty.value) {
+    pendingFolderExportGroupId.value = groupId
+    showUnsavedExport.value = true
+    return
+  }
+  pendingFolderExportGroupId.value = groupId
+  showFolderSecrets.value = true
+}
+
+function cancelFolderSecrets() {
+  showFolderSecrets.value = false
+  pendingFolderExportGroupId.value = ''
+}
+
+async function confirmFolderSecrets() {
+  const groupId = pendingFolderExportGroupId.value
+  showFolderSecrets.value = false
+  pendingFolderExportGroupId.value = ''
+  if (!groupId || exporting.value) return
+  exporting.value = true
+  error.value = ''
+  try {
+    const { blob, filename } = await api.exportOrgFolder(groupId)
+    downloadZip(blob, filename)
+    const base = filename.replace(/\.zip$/i, '')
+    showToast(t('pages.agentStudio.exportImport.folderExportSuccess', { name: base }))
+  } catch (e: any) {
+    error.value = String(e?.message || e)
+  } finally {
+    exporting.value = false
+  }
+}
+
+function onImportGroup(groupId: string) {
+  triggerGroupImport(groupId)
 }
 
 const showCreateWizard = ref(false)
@@ -1896,6 +1981,8 @@ onBeforeUnmount(() => {
         @create-child-group="openCreateChildGroup"
         @rename-group="openRenameGroup"
         @delete-group="confirmDeleteGroup"
+        @export-group="onExportGroup"
+        @import-group="onImportGroup"
         @move-group="onMoveGroup"
         @move-agent="onMoveAgent"
         @toggle-collapsed="toggleAgentListCollapsed"
@@ -2969,6 +3056,63 @@ onBeforeUnmount(() => {
           >{{ t('common.buttons.cancel') }}</AppButton>
         </div>
       </template>
+    </AppModal>
+
+    <!-- folder export secrets warning (Demo) -->
+    <AppModal
+      :open="showFolderSecrets"
+      :title="t('pages.agentStudio.exportImport.folderSecrets.title')"
+      :width="460"
+      close-on-esc
+      @close="cancelFolderSecrets"
+    >
+      <p class="text-[13px] leading-6 text-txt2">{{ t('pages.agentStudio.exportImport.folderSecrets.body') }}</p>
+      <template #footer>
+        <AppButton size="sm" variant="ghost" @click="cancelFolderSecrets">{{ t('common.buttons.cancel') }}</AppButton>
+        <AppButton size="sm" variant="primary" :disabled="exporting" @click="confirmFolderSecrets">
+          {{ t('pages.agentStudio.exportImport.folderSecrets.confirm') }}
+        </AppButton>
+      </template>
+    </AppModal>
+
+    <!-- folder batch name conflict (Demo) -->
+    <AppModal
+      :open="showBatchConflict"
+      :title="t('pages.agentStudio.exportImport.batchConflict.title')"
+      :width="480"
+      close-on-esc
+      @close="closeBatchConflict"
+    >
+      <p class="text-[13px] leading-6 text-txt2">{{ t('pages.agentStudio.exportImport.batchConflict.intro') }}</p>
+      <ul class="mt-2 max-h-32 overflow-auto border border-line bg-base px-3 py-2 text-[12px] text-txt">
+        <li v-for="n in batchConflictNames" :key="n" class="font-mono">{{ n }}</li>
+      </ul>
+      <div class="mt-3 flex flex-col gap-2">
+        <button
+          type="button"
+          class="w-full border border-accent/50 bg-accent-dim px-3 py-2.5 text-left"
+          @click="confirmBatchRename"
+        >
+          <div class="text-[13px] font-medium text-txt">{{ t('pages.agentStudio.exportImport.batchConflict.rename') }}</div>
+          <div class="text-[11.5px] text-txt3">{{ t('pages.agentStudio.exportImport.batchConflict.renameDesc') }}</div>
+        </button>
+        <button
+          type="button"
+          class="w-full border border-err/40 bg-base px-3 py-2.5 text-left hover:bg-err/10"
+          @click="confirmBatchOverwrite"
+        >
+          <div class="text-[13px] font-medium text-err">{{ t('pages.agentStudio.exportImport.batchConflict.overwrite') }}</div>
+          <div class="text-[11.5px] text-txt3">{{ t('pages.agentStudio.exportImport.batchConflict.overwriteDesc') }}</div>
+        </button>
+        <button
+          type="button"
+          class="w-full border border-line bg-base px-3 py-2.5 text-left hover:bg-elevated"
+          @click="closeBatchConflict"
+        >
+          <div class="text-[13px] font-medium text-txt">{{ t('pages.agentStudio.exportImport.batchConflict.cancel') }}</div>
+          <div class="text-[11.5px] text-txt3">{{ t('pages.agentStudio.exportImport.batchConflict.cancelDesc') }}</div>
+        </button>
+      </div>
     </AppModal>
 
     <!-- unsaved export guide -->


### PR DESCRIPTION
一次打包组子树（含空组）并原子导入，避免跨环境手工逐个搬运；冲突走 name_v2/全部覆盖，失败整次回滚。

Co-authored-by: Cursor <cursoragent@cursor.com>
