### PR TITLE
feat(studio): 创建 Agent 团队一键编排项目与 1+9 编制

### DIFF
--- a/docs/prototypes/create-root-group-wizard.html
+++ b/docs/prototypes/create-root-group-wizard.html
@@ -1,0 +1,961 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>原型 · 创建 Agent 团队</title>
+  <style>
+    :root {
+      --bg: #0e1117;
+      --surface: #151922;
+      --elevated: #1b2130;
+      --line: #2a3142;
+      --txt: #e9eef8;
+      --txt2: #b0b9cb;
+      --txt3: #7a8499;
+      --accent: #7c6cff;
+      --accent-2: #a89bff;
+      --accent-dim: rgba(124, 108, 255, 0.14);
+      --ok: #3ecf8e;
+      --ok-dim: rgba(62, 207, 142, 0.14);
+      --warn: #f0b429;
+      --warn-dim: rgba(240, 180, 41, 0.12);
+      --robot: #8b7cff;
+      --font: "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+      --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: var(--font);
+      color: var(--txt);
+      background:
+        radial-gradient(900px 480px at 15% -10%, #1d2440 0%, transparent 55%),
+        var(--bg);
+    }
+    .app {
+      display: grid;
+      grid-template-columns: 280px 1fr;
+      height: 100vh;
+    }
+    .sidebar {
+      border-right: 1px solid var(--line);
+      background: rgba(21, 25, 34, 0.95);
+      display: flex;
+      flex-direction: column;
+    }
+    .side-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 14px;
+      border-bottom: 1px solid var(--line);
+    }
+    .side-head h1 {
+      margin: 0;
+      font-size: 11px;
+      letter-spacing: 0.1em;
+      color: var(--txt3);
+      font-weight: 700;
+    }
+    .side-actions { display: flex; gap: 6px; }
+    .icon-btn {
+      height: 30px;
+      min-width: 30px;
+      padding: 0 8px;
+      border-radius: 8px;
+      border: 1px solid var(--line);
+      background: var(--elevated);
+      color: var(--txt2);
+      cursor: pointer;
+      font-size: 12px;
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+    }
+    .icon-btn.primary {
+      border-color: rgba(124,108,255,.55);
+      background: var(--accent-dim);
+      color: var(--accent-2);
+      animation: pulse 1.5s ease-in-out infinite;
+    }
+    @keyframes pulse {
+      0%, 100% { box-shadow: 0 0 0 0 rgba(124,108,255,.4); }
+      50% { box-shadow: 0 0 0 6px rgba(124,108,255,0); }
+    }
+    .tree { padding: 10px 8px; overflow: auto; flex: 1; }
+    .group, .agent {
+      display: flex; align-items: center; gap: 8px;
+      padding: 7px 10px; border-radius: 8px;
+      font-size: 13px; color: var(--txt2);
+    }
+    .agent { padding-left: 26px; }
+    .agent.enter { animation: fadeIn .4s ease both; }
+    .agent.selected { background: var(--accent-dim); color: var(--txt); outline: 1px solid rgba(124,108,255,.4); }
+    .bot {
+      width: 16px; height: 16px; border-radius: 4px;
+      background: rgba(139,124,255,.25); color: var(--robot);
+      display: grid; place-items: center; font-size: 10px; flex: none;
+    }
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(4px); }
+      to { opacity: 1; transform: none; }
+    }
+    .main { display: flex; flex-direction: column; min-width: 0; }
+    .topbar {
+      height: 52px; border-bottom: 1px solid var(--line);
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0 18px; background: rgba(14,17,23,.7);
+    }
+    .brand { font-weight: 700; font-size: 14px; }
+    .brand span { color: var(--txt3); font-weight: 500; margin-left: 10px; font-size: 12px; }
+    .stage { flex: 1; position: relative; overflow: hidden; }
+    .empty {
+      height: 100%; display: grid; place-items: center;
+      text-align: center; color: var(--txt3); padding: 24px;
+    }
+    .empty h2 { margin: 0 0 8px; color: var(--txt2); font-size: 18px; }
+    .empty p { margin: 0 auto; max-width: 460px; line-height: 1.6; font-size: 13px; }
+    .cta {
+      margin-top: 18px;
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 10px 16px; border-radius: 10px;
+      border: 1px solid rgba(124,108,255,.55);
+      background: var(--accent); color: #fff;
+      font-weight: 600; font-size: 13px; cursor: pointer;
+    }
+
+    /* Wizard — mirrors AgentCreateWizard layout */
+    .backdrop {
+      position: absolute; inset: 0;
+      background: rgba(0,0,0,.7);
+      display: none; align-items: center; justify-content: center;
+      padding: 16px; z-index: 30;
+    }
+    .backdrop.show { display: flex; }
+    .wiz {
+      width: min(980px, 100%);
+      height: min(700px, 94vh);
+      background: var(--surface);
+      border: 1px solid var(--line);
+      display: flex; flex-direction: column;
+      box-shadow: 0 24px 80px rgba(0,0,0,.55);
+      animation: pop .18s ease;
+    }
+    @keyframes pop {
+      from { opacity: 0; transform: translateY(8px); }
+      to { opacity: 1; transform: none; }
+    }
+    .wiz-head {
+      height: 64px; display: flex; align-items: center; gap: 14px;
+      padding: 0 20px; border-bottom: 1px solid var(--line); position: relative;
+    }
+    .hero-mark {
+      width: 36px; height: 36px; display: grid; place-items: center;
+      border: 1px solid rgba(124,108,255,.55); color: var(--accent-2); font-size: 18px;
+    }
+    .wiz-head h2 { margin: 0; font-size: 16px; }
+    .wiz-head .sub { margin-top: 2px; font-size: 12px; color: var(--txt3); }
+    .close-x {
+      margin-left: auto; width: 32px; height: 32px;
+      border: 0; background: transparent; color: var(--txt3); cursor: pointer; font-size: 18px;
+    }
+    .wiz-progress {
+      position: absolute; left: 0; right: 0; bottom: 0; height: 3px; background: var(--elevated);
+    }
+    .wiz-progress > span {
+      display: block; height: 100%; background: var(--accent); transition: width .25s ease;
+    }
+    .wiz-body { flex: 1; display: flex; min-height: 0; }
+    .rail {
+      width: 208px; border-right: 1px solid var(--line);
+      background: var(--elevated); padding: 20px 12px; overflow: auto;
+    }
+    .rail-cap {
+      font-size: 10px; font-weight: 700; letter-spacing: .08em;
+      text-transform: uppercase; color: var(--txt3);
+      display: flex; align-items: center; gap: 8px; margin-bottom: 14px; padding: 0 6px;
+    }
+    .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--accent); }
+    .rail-item {
+      display: flex; align-items: center; gap: 10px;
+      padding: 10px 8px; border-radius: 0; font-size: 13px; color: var(--txt3);
+      position: relative;
+    }
+    .rail-item .n {
+      width: 22px; height: 22px; display: grid; place-items: center;
+      border: 1px solid var(--line); background: var(--surface);
+      font-size: 11px; font-weight: 700; flex: none;
+    }
+    .rail-item.active { color: var(--txt); background: var(--accent-dim); }
+    .rail-item.active .n { border-color: var(--accent); background: var(--accent); color: #fff; }
+    .rail-item.done { color: var(--ok); }
+    .rail-item.done .n { border-color: rgba(62,207,142,.5); background: var(--ok-dim); color: var(--ok); }
+    .pane { flex: 1; display: flex; flex-direction: column; min-width: 0; }
+    .pane-scroll { flex: 1; overflow: auto; padding: 28px 32px 16px; }
+    .pane h3 { margin: 0 0 6px; font-size: 18px; }
+    .pane .desc { margin: 0 0 22px; font-size: 13px; color: var(--txt3); line-height: 1.55; }
+    .field { margin-bottom: 16px; }
+    .field label {
+      display: block; font-size: 12px; color: var(--txt2); margin-bottom: 6px; font-weight: 600;
+    }
+    .field label .req { color: var(--accent-2); }
+    .field input, .field select, .field textarea {
+      width: 100%; border: 1px solid var(--line); background: var(--elevated);
+      color: var(--txt); padding: 10px 12px; font: inherit; font-size: 13px; outline: none;
+    }
+    .field input:focus, .field select:focus, .field textarea:focus {
+      border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-dim);
+    }
+    .field .help { margin-top: 6px; font-size: 11px; color: var(--txt3); line-height: 1.5; }
+    .row2 { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+    .chips { display: flex; flex-wrap: wrap; gap: 8px; }
+    .chip {
+      padding: 8px 12px; border: 1px solid var(--line); background: var(--elevated);
+      font-size: 12px; color: var(--txt2); cursor: pointer;
+    }
+    .chip.on { border-color: rgba(124,108,255,.55); background: var(--accent-dim); color: var(--accent-2); }
+    .review {
+      border: 1px solid var(--line); background: var(--elevated); padding: 14px 16px;
+      font-size: 13px; line-height: 1.7;
+    }
+    .review strong { color: var(--accent-2); }
+    .foot {
+      border-top: 1px solid var(--line);
+      padding: 12px 20px;
+      display: flex; justify-content: space-between; align-items: center; gap: 10px;
+    }
+    .btn {
+      border: 1px solid var(--line); background: var(--elevated); color: var(--txt);
+      padding: 9px 14px; font: inherit; font-size: 13px; cursor: pointer;
+    }
+    .btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; font-weight: 600; }
+    .btn:disabled { opacity: .4; cursor: not-allowed; }
+    .btn.ghost { background: transparent; }
+
+    /* Sandbox phase */
+    .sandbox {
+      display: none; height: 100%;
+      grid-template-rows: auto 1fr;
+    }
+    .sandbox.show { display: grid; }
+    .sb-head {
+      padding: 12px 18px; border-bottom: 1px solid var(--line);
+      display: flex; justify-content: space-between; align-items: center; gap: 12px;
+    }
+    .sb-head h2 { margin: 0; font-size: 15px; }
+    .sb-head .sub { color: var(--txt3); font-size: 12px; margin-top: 2px; }
+    .badge {
+      font-size: 11px; padding: 4px 8px; border-radius: 999px;
+      border: 1px solid rgba(62,207,142,.4); background: var(--ok-dim); color: var(--ok);
+    }
+    .badge.busy {
+      border-color: rgba(240,180,41,.45); background: var(--warn-dim); color: var(--warn);
+    }
+    .sb-grid {
+      display: grid; grid-template-columns: 1.15fr .85fr; min-height: 0;
+    }
+    .console, .live {
+      min-height: 0; overflow: auto; padding: 16px 18px;
+    }
+    .console { border-right: 1px solid var(--line); font-family: var(--mono); font-size: 12px; }
+    .line { margin-bottom: 8px; color: var(--txt2); line-height: 1.5; white-space: pre-wrap; }
+    .line.sys { color: var(--txt3); }
+    .line.ok { color: var(--ok); }
+    .line.warn { color: var(--warn); }
+    .line.mcp {
+      border: 1px dashed rgba(240,180,41,.4);
+      background: var(--warn-dim);
+      padding: 10px 12px; color: #f3d48a; margin: 10px 0;
+    }
+    .live h3 { margin: 0 0 10px; font-size: 13px; color: var(--txt2); }
+    .card {
+      border: 1px solid var(--line); background: var(--elevated);
+      padding: 12px; margin-bottom: 10px; font-size: 12px; line-height: 1.55;
+    }
+    .card .t { font-weight: 700; margin-bottom: 4px; color: var(--txt); }
+    .card.done { border-color: rgba(62,207,142,.4); }
+    .env-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+    .env-table th {
+      text-align: left; color: var(--txt3); font-weight: 600;
+      padding: 0 0 8px; border-bottom: 1px solid var(--line);
+    }
+    .env-table td { padding: 8px 8px 0 0; vertical-align: top; }
+    .env-table input {
+      width: 100%; border: 1px solid var(--line); background: var(--elevated);
+      color: var(--txt); padding: 8px 10px; font: inherit; font-size: 12px;
+    }
+    .env-table .del {
+      border: 1px solid var(--line); background: transparent; color: var(--txt3);
+      padding: 8px 10px; cursor: pointer; white-space: nowrap;
+    }
+    .env-actions { margin-top: 12px; display: flex; gap: 8px; flex-wrap: wrap; }
+    .mcp-card {
+      border: 1px solid var(--line); background: var(--elevated);
+      padding: 14px; margin-bottom: 10px;
+    }
+    .mcp-card.on { border-color: rgba(124,108,255,.5); }
+    .mcp-card .top {
+      display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 10px;
+    }
+    .mcp-card .name { font-weight: 700; font-size: 13px; }
+    .mcp-card .meta { font-size: 11px; color: var(--txt3); margin-top: 2px; }
+    .mcp-card label.row {
+      display: grid; grid-template-columns: 88px 1fr; gap: 8px; align-items: center;
+      margin-top: 8px; font-size: 12px; color: var(--txt2);
+    }
+    .mcp-card label.row input, .mcp-card label.row select {
+      width: 100%; border: 1px solid var(--line); background: var(--surface);
+      color: var(--txt); padding: 8px 10px; font: inherit; font-size: 12px;
+    }
+    .hdr-row {
+      display: grid; grid-template-columns: 1fr 1.4fr auto; gap: 8px; margin-top: 6px; align-items: center;
+    }
+    .proto-note {
+      position: fixed; right: 14px; bottom: 14px; z-index: 50;
+      max-width: 300px; background: rgba(21,25,34,.96);
+      border: 1px solid var(--line); padding: 10px 12px;
+      font-size: 11px; color: var(--txt3); line-height: 1.5;
+      box-shadow: 0 12px 40px rgba(0,0,0,.4);
+    }
+    .proto-note strong { color: var(--txt2); }
+    .proto-note .btn { width: 100%; margin-top: 8px; }
+    @media (max-width: 860px) {
+      .app { grid-template-columns: 1fr; }
+      .sidebar { display: none; }
+      .sb-grid, .row2 { grid-template-columns: 1fr; }
+      .rail { display: none; }
+    }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <aside class="sidebar">
+      <div class="side-head">
+        <h1>AGENTS</h1>
+        <div class="side-actions">
+          <button class="icon-btn" title="新建单个 Agent" id="btnSingle">＋Agent</button>
+          <button class="icon-btn primary" title="创建 Agent 团队" id="btnTeam">👥 团队</button>
+        </div>
+      </div>
+      <div class="tree" id="tree">
+        <div class="group">📁 尚未创建团队</div>
+        <div style="padding:10px 12px;font-size:12px;color:var(--txt3);line-height:1.5">
+          点右上角「👥 团队」开始。单个 Agent 仍走原来的「新建 Agent」。
+        </div>
+      </div>
+    </aside>
+
+    <main class="main">
+      <div class="topbar">
+        <div class="brand">AgentStdio <span>原型 · 创建 Agent 团队</span></div>
+        <div style="font-size:12px;color:var(--txt3)">独立入口 ≠ 新建根组 / 新建单个 Agent</div>
+      </div>
+      <div class="stage">
+        <div class="empty" id="empty">
+          <div>
+            <h2>用一个入口拉起整支团队</h2>
+            <p>填写运行配置（ACP / API Key / Git / 可配置 MCP / 环境变量），确认后自动起沙箱：由 PM Agent 创建项目、根组与工程师团队。</p>
+            <button class="cta" id="btnTeamEmpty">👥 创建 Agent 团队</button>
+          </div>
+        </div>
+
+        <div class="sandbox" id="sandbox">
+          <div class="sb-head">
+            <div>
+              <h2 id="sbTitle">沙箱 · Approving项目经理</h2>
+              <div class="sub">自动启动中 · 将创建项目 / Org 根组 / 工程师 Agent</div>
+            </div>
+            <span class="badge busy" id="sbBadge">sandbox starting…</span>
+          </div>
+          <div class="sb-grid">
+            <div class="console" id="console"></div>
+            <div class="live">
+              <h3>已产出资源</h3>
+              <div id="liveCards"></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="backdrop" id="backdrop">
+          <div class="wiz" role="dialog" aria-modal="true">
+            <div class="wiz-head">
+              <div class="hero-mark">👥</div>
+              <div>
+                <h2>创建 Agent 团队</h2>
+                <div class="sub" id="headSub">填写团队与 PM 运行配置；确认后自动起沙箱建团</div>
+              </div>
+              <button class="close-x" id="btnClose" aria-label="关闭">✕</button>
+              <div class="wiz-progress"><span id="progress" style="width:20%"></span></div>
+            </div>
+            <div class="wiz-body">
+              <aside class="rail">
+                <div class="rail-cap"><span class="dot"></span>配置步骤</div>
+                <div class="rail-item active" data-step="0"><span class="n">1</span>团队信息</div>
+                <div class="rail-item" data-step="1"><span class="n">2</span>Agent</div>
+                <div class="rail-item" data-step="2"><span class="n">3</span>API Key</div>
+                <div class="rail-item" data-step="3"><span class="n">4</span>Git</div>
+                <div class="rail-item" data-step="4"><span class="n">5</span>MCP</div>
+                <div class="rail-item" data-step="5"><span class="n">6</span>环境变量</div>
+                <div class="rail-item" data-step="6"><span class="n">7</span>确认创建</div>
+              </aside>
+              <div class="pane">
+                <div class="pane-scroll" id="pane"></div>
+                <div class="foot">
+                  <button class="btn ghost" id="btnCancel">取消</button>
+                  <div style="display:flex;gap:8px">
+                    <button class="btn" id="btnBack" disabled>上一步</button>
+                    <button class="btn primary" id="btnNext">下一步</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <div class="proto-note">
+    <strong>交互纠正后的原型</strong><br />
+    独立按钮「创建 Agent 团队」→ 复用 Agent 配置步骤 → 确认后<strong>自动起沙箱</strong>，由 Agent + MCP 创建<strong>项目 + 团队</strong>。
+    <button class="btn" id="btnReset">重置演示</button>
+  </div>
+
+  <script>
+    const STEPS = [
+      { id: 'team', title: '团队信息', sub: '命名 + 项目背景 Prompt，再配运行环境' },
+      { id: 'acp', title: 'Agent', sub: '选择 PM 使用的模型后端' },
+      { id: 'apiKey', title: 'API Key', sub: '可选，也可稍后在项目设置补齐' },
+      { id: 'git', title: 'Git', sub: '可选，提供仓库后 PM 可据此选型' },
+      { id: 'mcp', title: 'MCP', sub: '可完整配置团队默认 mcp[]（增删改 URL / Header）' },
+      { id: 'env', title: '环境变量', sub: '写入 PM，并作为后续工程师 Agent 的默认 env' },
+      { id: 'review', title: '确认创建', sub: '将创建 PM、起沙箱，并由 MCP 生成团队与项目' },
+    ];
+
+    const state = {
+      step: 0,
+      teamName: 'Approving',
+      groupName: 'Approving项目组',
+      prefix: 'Approving',
+      pmName: 'Approving项目经理',
+      background: 'Approving 是一套多 Agent 研发协作平台：支持工作流编排、沙箱执行、人工门禁与 PM 咨询。目标仓库为 GitHub monorepo，需要覆盖调研→计划→方案→澄清→视觉→实现→测试→Review→变更摘要的完整流水线。',
+      acp: 'cursor',
+      apiKey: '',
+      gitUrl: 'https://github.com/example/approving.git',
+      gitCred: 'https',
+      mcps: [
+        {
+          name: 'artifact-store',
+          transport: 'url',
+          url: '${APPROVING_ARTIFACT_URL}',
+          headers: [{ k: 'Authorization', v: 'Bearer ${APPROVING_ARTIFACT_TOKEN}' }],
+          preset: true,
+        },
+      ],
+      env: [
+        { k: 'GIT_REPOS', v: '${vars.repos}' },
+        { k: '', v: '' },
+      ],
+      playing: false,
+    };
+
+    const $ = (id) => document.getElementById(id);
+
+    function openWizard() {
+      state.step = 0;
+      $('btnTeam').classList.remove('primary');
+      $('backdrop').classList.add('show');
+      render();
+    }
+    function closeWizard() {
+      $('backdrop').classList.remove('show');
+    }
+
+    function render() {
+      document.querySelectorAll('.rail-item').forEach((el) => {
+        const s = Number(el.dataset.step);
+        el.classList.toggle('active', s === state.step);
+        el.classList.toggle('done', s < state.step);
+      });
+      $('progress').style.width = ((state.step + 1) / STEPS.length * 100) + '%';
+      $('headSub').textContent = STEPS[state.step].sub;
+      $('btnBack').disabled = state.step === 0;
+      $('btnNext').textContent = state.step === STEPS.length - 1 ? '确认并启动沙箱' : '下一步';
+      $('pane').innerHTML = paneHtml();
+      bindPane();
+    }
+
+    function paneHtml() {
+      if (state.step === 0) {
+        return `
+          <h3>团队信息</h3>
+          <p class="desc">会先创建项目与 Org 根组，并预建 PM Agent；工程师团队在沙箱里由 PM 通过 MCP 生成。</p>
+          <div class="row2">
+            <div class="field">
+              <label>项目 / 团队名 <span class="req">*</span></label>
+              <input id="fTeam" value="${esc(state.teamName)}" placeholder="例如：Approving" />
+            </div>
+            <div class="field">
+              <label>命名前缀 <span class="req">*</span></label>
+              <input id="fPrefix" value="${esc(state.prefix)}" placeholder="例如：Approving" />
+              <div class="help">生成「{前缀}项目经理」「{前缀}实现工程师」等。</div>
+            </div>
+          </div>
+          <div class="field">
+            <label>根组名称</label>
+            <input id="fGroup" value="${esc(state.groupName)}" />
+          </div>
+          <div class="field">
+            <label>PM Agent 名称 <span class="req">*</span></label>
+            <input id="fPm" value="${esc(state.pmName)}" placeholder="字母 / 数字 / - / _ 与中文" />
+          </div>
+          <div class="field">
+            <label>项目背景 <span class="req">*</span></label>
+            <textarea id="fBackground" rows="5" placeholder="描述项目目标、技术栈、仓库形态、流水线诉求等。将作为沙箱建团 Prompt。">${esc(state.background)}</textarea>
+            <div class="help">类似 Prompt：确认后注入沙箱，PM 据此（并结合仓库）生成根组、上下级与工程师团队。</div>
+          </div>
+        `;
+      }
+      if (state.step === 1) {
+        return `
+          <h3>Agent 后端</h3>
+          <p class="desc">选择 PM 沙箱使用的 ACP 后端（与单个 Agent 创建一致）。</p>
+          <div class="chips" id="acpChips">
+            ${[['cursor','Cursor'],['claude-code','Claude Code'],['codex','Codex'],['gemini','Gemini']].map(([id,label]) =>
+              `<button type="button" class="chip ${state.acp===id?'on':''}" data-acp="${id}">${label}</button>`
+            ).join('')}
+          </div>
+          <div class="help" style="margin-top:14px;color:var(--txt3);font-size:12px">确认后会把该配置写入 PM Agent，并用于自动拉起的沙箱。</div>
+        `;
+      }
+      if (state.step === 2) {
+        return `
+          <h3>API Key</h3>
+          <p class="desc">可选。跳过后仍可创建；沙箱若缺密钥会提示补齐。</p>
+          <div class="field">
+            <label>API Key</label>
+            <input id="fKey" type="password" value="${esc(state.apiKey)}" placeholder="sk-…" />
+            <div class="help">写入项目 / PM Agent 环境，供沙箱调用模型。</div>
+          </div>
+        `;
+      }
+      if (state.step === 3) {
+        return `
+          <h3>Git</h3>
+          <p class="desc">可选。提供仓库后，PM 可据此决定需要哪些工程师角色。</p>
+          <div class="field">
+            <label>仓库 URL</label>
+            <input id="fGit" value="${esc(state.gitUrl)}" placeholder="https://github.com/org/repo.git" />
+          </div>
+          <div class="field">
+            <label>凭据类型</label>
+            <select id="fCred">
+              <option value="https" ${state.gitCred==='https'?'selected':''}>HTTPS</option>
+              <option value="ssh" ${state.gitCred==='ssh'?'selected':''}>SSH</option>
+              <option value="none" ${state.gitCred==='none'?'selected':''}>暂不配置</option>
+            </select>
+          </div>
+        `;
+      }
+      if (state.step === 4) {
+        const cards = state.mcps.map((m, i) => {
+          const hdrs = (m.headers || []).map((h, hi) => `
+            <div class="hdr-row" style="margin-top:6px">
+              <input class="mcp-hk" data-i="${i}" data-hi="${hi}" value="${esc(h.k)}" placeholder="Header" />
+              <input class="mcp-hv" data-i="${i}" data-hi="${hi}" value="${esc(h.v)}" placeholder="Value" />
+              <button type="button" class="del mcp-hdr-del" data-i="${i}" data-hi="${hi}">删</button>
+            </div>
+          `).join('');
+          return `
+          <div class="mcp-card on" data-i="${i}">
+            <div class="top">
+              <div class="name">MCP #${i + 1}${m.preset ? ' · 预设' : ''}</div>
+              <button type="button" class="del mcp-del" data-i="${i}">删除</button>
+            </div>
+            <label class="row"><span>名称</span>
+              <input class="mcp-name" data-i="${i}" value="${esc(m.name)}" placeholder="artifact-store" />
+            </label>
+            <label class="row"><span>类型</span>
+              <select class="mcp-transport" data-i="${i}">
+                <option value="url" ${m.transport==='url'?'selected':''}>HTTP (url)</option>
+                <option value="stdio" ${m.transport==='stdio'?'selected':''}>stdio</option>
+              </select>
+            </label>
+            ${m.transport === 'url' ? `
+              <label class="row"><span>URL</span>
+                <input class="mcp-url" data-i="${i}" value="${esc(m.url)}" placeholder="\${APPROVING_ARTIFACT_URL}" />
+              </label>
+              <div style="margin-top:10px;display:flex;justify-content:space-between;align-items:center">
+                <span style="font-size:12px;color:var(--txt2)">请求头</span>
+                <button type="button" class="btn ghost mcp-hdr-add" data-i="${i}" style="padding:4px 8px;font-size:11px">+ 添加 Header</button>
+              </div>
+              ${hdrs || '<div class="help" style="margin-top:6px;font-size:11px;color:var(--txt3)">暂无 Header</div>'}
+            ` : `
+              <label class="row"><span>Command</span>
+                <input class="mcp-cmd" data-i="${i}" value="${esc(m.command || '')}" placeholder="npx" />
+              </label>
+              <label class="row"><span>Args</span>
+                <input class="mcp-args" data-i="${i}" value="${esc(m.args || '')}" placeholder="-y some-mcp" />
+              </label>
+            `}
+          </div>`;
+        }).join('');
+        return `
+          <h3>配置 MCP</h3>
+          <p class="desc">与 Agent Studio「MCP」页同类：写入团队默认 <code>mcp[]</code>，创建 PM / 工程师时一并带上。默认已放入 <strong>artifact-store</strong>，可改可删，也可继续添加。</p>
+          ${cards || '<div class="help" style="color:var(--txt3)">尚未配置 MCP</div>'}
+          <div class="env-actions">
+            <button type="button" class="btn" id="btnAddMcp">＋ 添加 MCP</button>
+            <button type="button" class="btn ghost" id="btnPresetArtifact">恢复 artifact-store 预设</button>
+            <button type="button" class="btn ghost" id="btnAddMemory">＋ memory-store</button>
+            <button type="button" class="btn ghost" id="btnAddContext">＋ context-store</button>
+          </div>
+          <div class="help" style="margin-top:12px;font-size:11px;color:var(--txt3);line-height:1.5">
+            运行变量：<code>\${APPROVING_ARTIFACT_URL}</code> / <code>\${APPROVING_ARTIFACT_TOKEN}</code>
+          </div>
+        `;
+      }
+      if (state.step === 5) {
+        const rows = state.env.map((row, i) => `
+          <tr data-i="${i}">
+            <td><input class="env-k" data-i="${i}" value="${esc(row.k)}" placeholder="KEY" /></td>
+            <td><input class="env-v" data-i="${i}" value="${esc(row.v)}" placeholder="value" /></td>
+            <td style="width:1%"><button type="button" class="del env-del" data-i="${i}">删除</button></td>
+          </tr>
+        `).join('');
+        return `
+          <h3>环境变量</h3>
+          <p class="desc">配置会写入 PM Agent；创建工程师时默认继承（可按角色覆盖）。与 Studio Agent「环境变量」页同类。</p>
+          <table class="env-table">
+            <thead><tr><th style="width:38%">Key</th><th>Value</th><th></th></tr></thead>
+            <tbody id="envBody">${rows}</tbody>
+          </table>
+          <div class="env-actions">
+            <button type="button" class="btn" id="btnAddEnv">＋ 添加变量</button>
+            <button type="button" class="btn ghost" id="btnPresetRepos">填入 GIT_REPOS 预设</button>
+          </div>
+          <div class="help" style="margin-top:12px;color:var(--txt3);font-size:12px;line-height:1.5">
+            提示：API Key 步骤写入的密钥也会进 env；此处可补 <code>GIT_REPOS</code>、自定义业务变量等。
+          </div>
+        `;
+      }
+      const envPreview = state.env.filter((e) => e.k.trim()).map((e) => `${e.k}=${e.v}`).join(', ') || '无额外变量';
+      const mcpPreview = state.mcps.filter((m) => m.name.trim()).map((m) => m.name).join(', ') || '无';
+      return `
+        <h3>确认创建</h3>
+        <p class="desc">点「确认并启动沙箱」后：创建项目与 PM → 自动起沙箱 → 按项目背景生成工程师团队。</p>
+        <div class="review">
+          项目：<strong>${esc(state.teamName)}</strong><br/>
+          根组：<strong>${esc(state.groupName)}</strong><br/>
+          PM：<strong>${esc(state.pmName)}</strong><br/>
+          后端：<strong>${esc(state.acp)}</strong><br/>
+          API Key：<strong>${state.apiKey ? '已填写' : '跳过（可稍后补）'}</strong><br/>
+          仓库：<strong>${esc(state.gitUrl || '未填')}</strong><br/>
+          MCP（${state.mcps.filter((m)=>m.name.trim()).length}）：<strong>${esc(mcpPreview)}</strong><br/>
+          环境变量：<strong>${esc(envPreview)}</strong><br/>
+          <br/>
+          项目背景（建团 Prompt）：<br/><strong style="white-space:pre-wrap;font-weight:500;color:var(--txt2)">${esc(state.background)}</strong><br/>
+          <br/>
+          沙箱任务：按背景生成 <strong>1 PM + 9 工程师（共 10）</strong> · 根组 / Pipeline 子组 / 上下级<br/>
+          建团工具：<code>pm_list_agent_templates</code> → <code>pm_create_agent_from_template</code> ×9 → <code>pm_set_org_membership</code>
+        </div>
+      `;
+    }
+
+    function bindPane() {
+      const map = [
+        ['fTeam', 'teamName'], ['fPrefix', 'prefix'], ['fGroup', 'groupName'],
+        ['fPm', 'pmName'], ['fBackground', 'background'], ['fKey', 'apiKey'], ['fGit', 'gitUrl'],
+      ];
+      map.forEach(([id, key]) => {
+        const el = $(id);
+        if (!el) return;
+        el.addEventListener('input', () => {
+          state[key] = el.value;
+          if (key === 'teamName' || key === 'prefix') {
+            if (key === 'teamName' && !$('fPrefix')?.dataset.touched) {
+              state.prefix = state.teamName.trim();
+              if ($('fPrefix')) $('fPrefix').value = state.prefix;
+            }
+            if (!$('fGroup')?.dataset.touched) {
+              state.groupName = (state.prefix || state.teamName) + '项目组';
+              if ($('fGroup')) $('fGroup').value = state.groupName;
+            }
+            if (!$('fPm')?.dataset.touched) {
+              state.pmName = (state.prefix || state.teamName) + '项目经理';
+              if ($('fPm')) $('fPm').value = state.pmName;
+            }
+          }
+        });
+      });
+      ;['fPrefix','fGroup','fPm'].forEach((id) => {
+        $(id)?.addEventListener('input', (e) => { e.target.dataset.touched = '1'; });
+      });
+      $('fCred')?.addEventListener('change', (e) => { state.gitCred = e.target.value; });
+      $('acpChips')?.querySelectorAll('[data-acp]').forEach((btn) => {
+        btn.addEventListener('click', () => {
+          state.acp = btn.dataset.acp;
+          render();
+        });
+      });
+      document.querySelectorAll('.env-k').forEach((el) => {
+        el.addEventListener('input', () => {
+          state.env[Number(el.dataset.i)].k = el.value;
+        });
+      });
+      document.querySelectorAll('.env-v').forEach((el) => {
+        el.addEventListener('input', () => {
+          state.env[Number(el.dataset.i)].v = el.value;
+        });
+      });
+      document.querySelectorAll('.env-del').forEach((el) => {
+        el.addEventListener('click', () => {
+          const i = Number(el.dataset.i);
+          state.env.splice(i, 1);
+          if (!state.env.length) state.env.push({ k: '', v: '' });
+          render();
+        });
+      });
+      $('btnAddEnv')?.addEventListener('click', () => {
+        state.env.push({ k: '', v: '' });
+        render();
+      });
+      $('btnPresetRepos')?.addEventListener('click', () => {
+        const row = state.env.find((e) => e.k === 'GIT_REPOS');
+        if (row) row.v = '${vars.repos}';
+        else state.env.unshift({ k: 'GIT_REPOS', v: '${vars.repos}' });
+        render();
+      });
+      const syncMcp = (i, patch) => { Object.assign(state.mcps[i], patch); };
+      document.querySelectorAll('.mcp-name').forEach((el) => {
+        el.addEventListener('input', () => syncMcp(Number(el.dataset.i), { name: el.value }));
+      });
+      document.querySelectorAll('.mcp-transport').forEach((el) => {
+        el.addEventListener('change', () => {
+          syncMcp(Number(el.dataset.i), { transport: el.value });
+          render();
+        });
+      });
+      document.querySelectorAll('.mcp-url').forEach((el) => {
+        el.addEventListener('input', () => syncMcp(Number(el.dataset.i), { url: el.value }));
+      });
+      document.querySelectorAll('.mcp-cmd').forEach((el) => {
+        el.addEventListener('input', () => syncMcp(Number(el.dataset.i), { command: el.value }));
+      });
+      document.querySelectorAll('.mcp-args').forEach((el) => {
+        el.addEventListener('input', () => syncMcp(Number(el.dataset.i), { args: el.value }));
+      });
+      document.querySelectorAll('.mcp-hk').forEach((el) => {
+        el.addEventListener('input', () => {
+          state.mcps[Number(el.dataset.i)].headers[Number(el.dataset.hi)].k = el.value;
+        });
+      });
+      document.querySelectorAll('.mcp-hv').forEach((el) => {
+        el.addEventListener('input', () => {
+          state.mcps[Number(el.dataset.i)].headers[Number(el.dataset.hi)].v = el.value;
+        });
+      });
+      document.querySelectorAll('.mcp-hdr-add').forEach((el) => {
+        el.addEventListener('click', () => {
+          const m = state.mcps[Number(el.dataset.i)];
+          m.headers = m.headers || [];
+          m.headers.push({ k: '', v: '' });
+          render();
+        });
+      });
+      document.querySelectorAll('.mcp-hdr-del').forEach((el) => {
+        el.addEventListener('click', () => {
+          state.mcps[Number(el.dataset.i)].headers.splice(Number(el.dataset.hi), 1);
+          render();
+        });
+      });
+      document.querySelectorAll('.mcp-del').forEach((el) => {
+        el.addEventListener('click', () => {
+          state.mcps.splice(Number(el.dataset.i), 1);
+          render();
+        });
+      });
+      $('btnAddMcp')?.addEventListener('click', () => {
+        state.mcps.push({ name: '', transport: 'url', url: '', headers: [{ k: '', v: '' }], preset: false });
+        render();
+      });
+      $('btnPresetArtifact')?.addEventListener('click', () => {
+        const exists = state.mcps.some((m) => m.name === 'artifact-store');
+        if (exists) return;
+        state.mcps.unshift({
+          name: 'artifact-store',
+          transport: 'url',
+          url: '${APPROVING_ARTIFACT_URL}',
+          headers: [{ k: 'Authorization', v: 'Bearer ${APPROVING_ARTIFACT_TOKEN}' }],
+          preset: true,
+        });
+        render();
+      });
+      const addNamed = (name) => {
+        if (state.mcps.some((m) => m.name === name)) return;
+        state.mcps.push({ name, transport: 'url', url: '', headers: [], preset: false });
+        render();
+      };
+      $('btnAddMemory')?.addEventListener('click', () => addNamed('memory-store'));
+      $('btnAddContext')?.addEventListener('click', () => addNamed('context-store'));
+    }
+
+    function readValidate() {
+      if (state.step === 0) {
+        if (!state.teamName.trim()) return '请填写项目 / 团队名';
+        if (!state.prefix.trim()) return '请填写命名前缀';
+        if (!state.pmName.trim()) return '请填写 PM Agent 名称';
+        if (!state.background.trim()) return '请填写项目背景（建团 Prompt）';
+      }
+      return '';
+    }
+
+    function esc(s) {
+      return String(s ?? '').replace(/[&<>"']/g, (c) => (
+        { '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c]
+      ));
+    }
+
+    async function startSandboxFlow() {
+      closeWizard();
+      $('empty').style.display = 'none';
+      $('sandbox').classList.add('show');
+      $('sbTitle').textContent = '沙箱 · ' + state.pmName;
+      $('sbBadge').textContent = 'sandbox starting…';
+      $('sbBadge').className = 'badge busy';
+      $('console').innerHTML = '';
+      $('liveCards').innerHTML = '';
+      renderTreeBoot();
+      await playSandbox();
+    }
+
+    function log(cls, text) {
+      const div = document.createElement('div');
+      div.className = 'line ' + (cls || '');
+      div.textContent = text;
+      $('console').appendChild(div);
+      $('console').scrollTop = $('console').scrollHeight;
+    }
+    function logMcp(title, body) {
+      const div = document.createElement('div');
+      div.className = 'line mcp';
+      div.innerHTML = `<div style="font-family:var(--font);font-weight:700;color:var(--warn);margin-bottom:4px">${esc(title)}</div>${esc(body)}`;
+      $('console').appendChild(div);
+      $('console').scrollTop = $('console').scrollHeight;
+    }
+    function addCard(title, body, done) {
+      const div = document.createElement('div');
+      div.className = 'card' + (done ? ' done' : '');
+      div.innerHTML = `<div class="t">${esc(title)}</div>${esc(body)}`;
+      $('liveCards').appendChild(div);
+    }
+    function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+    function renderTreeBoot() {
+      $('tree').innerHTML = `
+        <div class="group">📁 ${esc(state.groupName)}</div>
+        <div class="agent selected enter"><span class="bot">🤖</span> ${esc(state.pmName)}</div>
+      `;
+    }
+    function addTreeAgent(name) {
+      const div = document.createElement('div');
+      div.className = 'agent enter';
+      div.innerHTML = `<span class="bot">🤖</span> ${esc(name)}`;
+      $('tree').appendChild(div);
+    }
+
+    async function playSandbox() {
+      if (state.playing) return;
+      state.playing = true;
+      log('sys', '$ approving sandbox create --purpose pm-team-bootstrap');
+      await sleep(500);
+      log('', 'pulling image… ok');
+      await sleep(400);
+      log('', `starting container for ${state.pmName}`);
+      await sleep(450);
+      log('ok', 'sandbox running');
+      $('sbBadge').textContent = 'sandbox running';
+      $('sbBadge').className = 'badge';
+
+      await sleep(400);
+      log('sys', 'bootstrap: create project + root group + bind PM Leader');
+      await sleep(500);
+      addCard('项目', state.teamName, true);
+      addCard('根组', state.groupName + ' · PM×1', true);
+      addCard('PM Leader', state.pmName + ' · pm-agent-fs 已启用', true);
+      log('ok', `project "${state.teamName}" created`);
+      log('ok', `PM Leader bound → ${state.pmName}`);
+
+      const pipelineGroup = 'Pipeline(GitHub)';
+      await sleep(400);
+      logMcp('MCP · pm_set_org_membership / create child group', `parent=${state.groupName}\nchild=${pipelineGroup}\n✓ ok`);
+      addCard('子组', pipelineGroup + ' · 工程师×9', true);
+      // 侧栏：根组 → Pipeline 子组
+      $('tree').innerHTML = `
+        <div class="group">📁 ${esc(state.groupName)}</div>
+        <div class="group" style="padding-left:18px">📁 ${esc(pipelineGroup)}</div>
+        <div class="agent selected enter"><span class="bot">🤖</span> ${esc(state.pmName)}</div>
+      `;
+
+      await sleep(500);
+      log('warn', 'inject Prompt（项目背景）:\n' + state.background);
+      await sleep(500);
+      log('warn', 'inject task: 根据以上项目背景与仓库，按参考编制创建 9 名工程师（Pipeline 子组，上级=PM）');
+      await sleep(600);
+      logMcp('MCP · pm_list_agent_templates', '→ research, plan, proposal, clarify, visual, implement, test, review, preview');
+
+      // 参考 Approving 侧栏：根组下 1 PM + Pipeline 子组下 9 工程师
+      const roles = [
+        ['research', '调研工程师'],
+        ['plan', '计划工程师'],
+        ['proposal', '方案工程师'],
+        ['clarify', '澄清工程师'],
+        ['visual', '视觉原型工程师'],
+        ['implement', '实现工程师'],
+        ['test', '测试工程师'],
+        ['review', '代码Review工程师'],
+        ['preview', '变更摘要视觉工程师'],
+      ];
+
+      for (const [id, label] of roles) {
+        const name = state.prefix + label;
+        await sleep(420);
+        logMcp('MCP · pm_create_agent_from_template', `template=${id}\nname=${name}\nproject=${state.teamName}\n✓ created`);
+        await sleep(180);
+        logMcp('MCP · pm_set_org_membership', `agent=${name}\ngroup=${pipelineGroup}\nparent=${state.pmName}\n✓ ok`);
+        addTreeAgent(name);
+        addCard(name, `模板 ${id} · ${pipelineGroup}`, true);
+      }
+
+      await sleep(400);
+      log('ok', `done: 1 PM + ${roles.length} engineers (total 10) under ${state.groupName}`);
+      $('sbBadge').textContent = 'team ready · 10 agents';
+      state.playing = false;
+    }
+
+    $('btnTeam').addEventListener('click', openWizard);
+    $('btnTeamEmpty').addEventListener('click', openWizard);
+    $('btnSingle').addEventListener('click', () => {
+      alert('原型说明：这是现有的「新建 Agent」入口，仍只创建单个 Agent。\n团队请用「👥 团队」。');
+    });
+    $('btnClose').addEventListener('click', closeWizard);
+    $('btnCancel').addEventListener('click', closeWizard);
+    $('btnBack').addEventListener('click', () => {
+      if (state.step > 0) { state.step--; render(); }
+    });
+    $('btnNext').addEventListener('click', () => {
+      const err = readValidate();
+      if (err) { alert(err); return; }
+      if (state.step < STEPS.length - 1) {
+        state.step++;
+        render();
+      } else {
+        startSandboxFlow();
+      }
+    });
+    $('btnReset').addEventListener('click', () => location.reload());
+  </script>
+</body>
+</html>

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -396,6 +396,10 @@ func main() {
 		InjectBundles: injectStore,
 		Blobs:         blobStore,
 		Onboarding:    services.NewOnboardingService(projectSvc, skillSvc, wfSvc),
+		Team:          services.NewTeamService(projectSvc, skillSvc, orgSvc, pmSvc, sbxSvc),
+	}
+	if h.Team != nil && h.PMMCP != nil {
+		h.PMMCP.SetTeam(h.Team)
 	}
 
 	r := router.New(h)

--- a/server/internal/handlers/handlers.go
+++ b/server/internal/handlers/handlers.go
@@ -61,6 +61,7 @@ type Handlers struct {
 	Browser       *browser.Service
 	Audit         *services.ProjectAuditService
 	Onboarding    *services.OnboardingService
+	Team          *services.TeamService
 	// CanViewProjectAudit optionally overrides the default audit ACL
 	// (is_admin OR authenticated user who can UpdateProject). Tests use this
 	// to simulate a read-only member denial while production keeps the hook nil.

--- a/server/internal/handlers/team.go
+++ b/server/internal/handlers/team.go
@@ -1,0 +1,84 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/cocofhu/approving/internal/services"
+
+	"github.com/gin-gonic/gin"
+)
+
+// BootstrapAgentTeam handles POST /api/agent-teams/bootstrap.
+func (h *Handlers) BootstrapAgentTeam(c *gin.Context) {
+	if h.Team == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "team service unavailable"})
+		return
+	}
+	var req services.TeamBootstrapRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	sess, err := h.Team.Bootstrap(c.Request.Context(), req)
+	if err != nil {
+		status := http.StatusBadRequest
+		switch {
+		case errors.Is(err, services.ErrTeamAgentConflict), errors.Is(err, services.ErrProjectNameExists):
+			status = http.StatusConflict
+		case errors.Is(err, services.ErrTeamValidation), errors.Is(err, services.ErrInvalidAgentName),
+			errors.Is(err, services.ErrEmptyProjectName):
+			status = http.StatusBadRequest
+		default:
+			status = http.StatusInternalServerError
+		}
+		c.JSON(status, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusAccepted, sess)
+}
+
+// GetAgentTeamBootstrap handles GET /api/agent-teams/bootstrap/:id.
+func (h *Handlers) GetAgentTeamBootstrap(c *gin.Context) {
+	if h.Team == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "team service unavailable"})
+		return
+	}
+	sess, err := h.Team.GetSession(c.Param("id"))
+	if err != nil {
+		if errors.Is(err, services.ErrTeamSessionNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, sess)
+}
+
+// RetryAgentTeamBootstrap handles POST /api/agent-teams/bootstrap/:id/retry.
+func (h *Handlers) RetryAgentTeamBootstrap(c *gin.Context) {
+	if h.Team == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "team service unavailable"})
+		return
+	}
+	sess, err := h.Team.Retry(c.Request.Context(), c.Param("id"))
+	if err != nil {
+		status := http.StatusBadRequest
+		if errors.Is(err, services.ErrTeamSessionNotFound) {
+			status = http.StatusNotFound
+		}
+		c.JSON(status, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusAccepted, sess)
+}
+
+// ListAgentTeamTemplates handles GET /api/agent-teams/templates.
+func (h *Handlers) ListAgentTeamTemplates(c *gin.Context) {
+	if h.Team == nil {
+		c.JSON(http.StatusOK, gin.H{"items": services.TeamEngineerTemplates})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"items": h.Team.ListTemplates()})
+}

--- a/server/internal/pmmcp/agent_fs.go
+++ b/server/internal/pmmcp/agent_fs.go
@@ -34,6 +34,9 @@ func (h *Host) callAgentFS(projectID, token, name string, args map[string]any) (
 		view := services.BuildOrgLeaderView(doc, sess.AgentName, allNames)
 		return view, false
 
+	case "pm_list_agent_templates", "pm_create_agent_from_template", "pm_set_org_membership", "pm_ensure_child_group":
+		return h.callTeamTools(sess, skill, name, args)
+
 	case "pm_fs_list", "pm_fs_read", "pm_fs_write", "pm_fs_delete", "pm_fs_mkdir", "pm_fs_rename":
 		agentName := strings.TrimSpace(platformmcp.StrArg(args, "agentName"))
 		if agentName == "" {

--- a/server/internal/pmmcp/host.go
+++ b/server/internal/pmmcp/host.go
@@ -56,6 +56,7 @@ type Host struct {
 	arts     *services.ArtifactService
 	org      *services.OrgService
 	skill    *services.SkillService
+	team     *services.TeamService
 	eng      engineOps
 	audit    func(services.AuditRecord)
 }
@@ -90,6 +91,13 @@ func (h *Host) SetOrgAndSkill(org *services.OrgService, skill *services.SkillSer
 	h.mu.Lock()
 	h.org = org
 	h.skill = skill
+	h.mu.Unlock()
+}
+
+// SetTeam wires TeamService for pm-agent-fs team-bootstrap tools.
+func (h *Host) SetTeam(team *services.TeamService) {
+	h.mu.Lock()
+	h.team = team
 	h.mu.Unlock()
 }
 
@@ -805,6 +813,20 @@ func toolSchemas(mcpID string) []map[string]any {
 	case MCPAgentFS:
 		return []map[string]any{
 			platformmcp.Tool("pm_get_org", "读取组织架构：全量 groups/agents（含相对当前 Leader 的 self/direct/indirect/other 标注）以及以 Leader 为根的下属树与直接/间接列表。只读，不可改 parent/groups。", nil),
+			platformmcp.Tool("pm_list_agent_templates", "列出内置工程师角色模板（id、中文角色名、简介），用于组建团队。", nil),
+			platformmcp.Tool("pm_create_agent_from_template", "从模板创建工程师 Agent（同项目；默认继承 Leader 的 mcp/env；禁止覆盖重名）。", map[string]any{
+				"templateId": map[string]any{"type": "string", "description": "模板 id，如 implement / clarify"},
+				"name":       map[string]any{"type": "string", "description": "新 Agent 名称，如 Approving实现工程师"},
+			}),
+			platformmcp.Tool("pm_set_org_membership", "设置 Agent 的组成员与汇报上级（parentAgent 须为当前 PM；groupIds 须在授权范围内）。", map[string]any{
+				"agentName":   map[string]any{"type": "string"},
+				"groupIds":    map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+				"parentAgent": map[string]any{"type": "string", "description": "汇报上级，默认当前 PM"},
+			}),
+			platformmcp.Tool("pm_ensure_child_group", "在授权根组下幂等确保子组存在（如 Pipeline(GitHub)）。", map[string]any{
+				"name":          map[string]any{"type": "string"},
+				"parentGroupId": map[string]any{"type": "string", "description": "父组 id；省略则用建团结会话根组"},
+			}),
 			platformmcp.Tool("pm_fs_list", "列出授权 Agent 的 host 侧 workspace 目录（非 Run 沙箱）。", map[string]any{
 				"agentName": map[string]any{"type": "string", "description": "目标 Agent 名（自身或汇报闭包内下属）"},
 				"path":      map[string]any{"type": "string", "description": "workspace 相对目录，空或省略表示根"},

--- a/server/internal/pmmcp/team_tools.go
+++ b/server/internal/pmmcp/team_tools.go
@@ -1,0 +1,155 @@
+package pmmcp
+
+import (
+	"strings"
+
+	"github.com/cocofhu/approving/internal/platformmcp"
+	"github.com/cocofhu/approving/internal/services"
+)
+
+func (h *Host) callTeamTools(sess *Session, skill *services.SkillService, name string, args map[string]any) (any, bool) {
+	h.mu.RLock()
+	team := h.team
+	h.mu.RUnlock()
+	if team == nil {
+		return map[string]any{"error": "team service unavailable"}, true
+	}
+	if strings.TrimSpace(sess.ProjectID) == "" || strings.TrimSpace(sess.AgentName) == "" {
+		return map[string]any{"error": "session missing project or agent"}, true
+	}
+
+	switch name {
+	case "pm_list_agent_templates":
+		return map[string]any{"items": team.ListTemplates()}, false
+
+	case "pm_create_agent_from_template":
+		templateID := strings.TrimSpace(platformmcp.StrArg(args, "templateId"))
+		agentName := strings.TrimSpace(platformmcp.StrArg(args, "name"))
+		if templateID == "" || agentName == "" {
+			return map[string]any{"error": "templateId and name are required"}, true
+		}
+		leader, ok := skill.Get(sess.AgentName)
+		if !ok {
+			return map[string]any{"error": "leader agent not found"}, true
+		}
+		if !services.AgentProjectMatches(leader, sess.ProjectID) {
+			return map[string]any{"error": "leader not bound to session project"}, true
+		}
+		created, err := team.CreateAgentFromTemplate(services.CreateFromTemplateArgs{
+			TemplateID:  templateID,
+			Name:        agentName,
+			ProjectID:   sess.ProjectID,
+			AcpBackend:  leader.AcpBackend,
+			GitCredType: leader.GitCredentialType,
+			MCP:         leader.MCP,
+			Env:         leader.Env,
+		})
+		if err != nil {
+			return map[string]any{"error": err.Error()}, true
+		}
+		return map[string]any{"ok": true, "agentName": created.Name, "templateId": templateID}, false
+
+	case "pm_set_org_membership":
+		agentName := strings.TrimSpace(platformmcp.StrArg(args, "agentName"))
+		parent := strings.TrimSpace(platformmcp.StrArg(args, "parentAgent"))
+		if parent == "" {
+			parent = sess.AgentName
+		}
+		if parent != sess.AgentName {
+			return map[string]any{"error": "parentAgent must be the current PM leader"}, true
+		}
+		groupIDs := strSliceArg(args, "groupIds")
+		if agentName == "" || len(groupIDs) == 0 {
+			return map[string]any{"error": "agentName and groupIds are required"}, true
+		}
+		ag, ok := skill.Get(agentName)
+		if !ok {
+			return map[string]any{"error": "agent not found: " + agentName}, true
+		}
+		if !services.AgentProjectMatches(ag, sess.ProjectID) {
+			return map[string]any{"error": "agent not in session project"}, true
+		}
+		// Scope: target must be self or (after create) will become a report; require same project only here.
+		if err := team.SetOrgMembership(services.SetOrgMembershipArgs{
+			AgentName:   agentName,
+			GroupIDs:    groupIDs,
+			ParentAgent: parent,
+		}); err != nil {
+			return map[string]any{"error": err.Error()}, true
+		}
+		return map[string]any{"ok": true, "agentName": agentName, "groupIds": groupIDs, "parentAgent": parent}, false
+
+	case "pm_ensure_child_group":
+		gName := strings.TrimSpace(platformmcp.StrArg(args, "name"))
+		parentID := strings.TrimSpace(platformmcp.StrArg(args, "parentGroupId"))
+		if gName == "" {
+			return map[string]any{"error": "name is required"}, true
+		}
+		h.mu.RLock()
+		orgSvc := h.org
+		h.mu.RUnlock()
+		if orgSvc == nil {
+			return map[string]any{"error": "org service unavailable"}, true
+		}
+		doc, err := orgSvc.Get()
+		if err != nil {
+			return map[string]any{"error": err.Error()}, true
+		}
+		if parentID == "" {
+			// Prefer a root group that already contains the leader.
+			mem := doc.Agents[sess.AgentName]
+			for _, gid := range mem.GroupIDs {
+				for _, g := range doc.Groups {
+					if g.ID == gid && strings.TrimSpace(g.ParentGroupID) == "" {
+						parentID = g.ID
+						break
+					}
+				}
+				if parentID != "" {
+					break
+				}
+			}
+		}
+		if parentID == "" {
+			return map[string]any{"error": "parentGroupId required (leader has no root group)"}, true
+		}
+		for _, g := range doc.Groups {
+			if g.ParentGroupID == parentID && g.Name == gName {
+				return map[string]any{"ok": true, "group": g, "existed": true}, false
+			}
+		}
+		doc.Groups = append(doc.Groups, services.OrgGroup{
+			ID: services.NewGroupID(), Name: gName, ParentGroupID: parentID,
+		})
+		created := doc.Groups[len(doc.Groups)-1]
+		if _, err := orgSvc.Put(doc, doc.Revision); err != nil {
+			return map[string]any{"error": err.Error()}, true
+		}
+		return map[string]any{"ok": true, "group": created, "existed": false}, false
+	}
+	return map[string]any{"error": "unknown tool: " + name}, true
+}
+
+func strSliceArg(args map[string]any, key string) []string {
+	raw, ok := args[key]
+	if !ok || raw == nil {
+		return nil
+	}
+	switch v := raw.(type) {
+	case []string:
+		return v
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				s = strings.TrimSpace(s)
+				if s != "" {
+					out = append(out, s)
+				}
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}

--- a/server/internal/router/router.go
+++ b/server/internal/router/router.go
@@ -77,6 +77,11 @@ func New(h *handlers.Handlers) *gin.Engine {
 		api.DELETE("/projects/:id", h.DeleteProject)
 		api.POST("/projects/:id/bootstrap-onboarding", h.BootstrapProjectOnboarding)
 
+		api.GET("/agent-teams/templates", h.ListAgentTeamTemplates)
+		api.POST("/agent-teams/bootstrap", h.BootstrapAgentTeam)
+		api.GET("/agent-teams/bootstrap/:id", h.GetAgentTeamBootstrap)
+		api.POST("/agent-teams/bootstrap/:id/retry", h.RetryAgentTeamBootstrap)
+
 		api.GET("/projects/:id/pm-leader", h.GetPmLeader)
 		api.PUT("/projects/:id/pm-leader", h.UpdatePmLeader)
 		api.GET("/projects/:id/cron-jobs", h.ListProjectCronJobs)

--- a/server/internal/services/team.go
+++ b/server/internal/services/team.go
@@ -1,0 +1,807 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/runtime"
+	"github.com/cocofhu/approving/internal/sandbox"
+
+	"github.com/google/uuid"
+)
+
+var (
+	// ErrTeamValidation is returned for invalid bootstrap payloads.
+	ErrTeamValidation = errors.New("team bootstrap validation failed")
+	// ErrTeamAgentConflict is returned when a target agent name already exists.
+	ErrTeamAgentConflict = errors.New("agent name already exists")
+	// ErrTeamSessionNotFound is returned when a bootstrap session id is unknown.
+	ErrTeamSessionNotFound = errors.New("team bootstrap session not found")
+	// ErrTeamScopeDenied is returned when a scoped MCP call violates session bounds.
+	ErrTeamScopeDenied = errors.New("team bootstrap scope denied")
+)
+
+// TeamBootstrapRequest is the body for POST /api/agent-teams/bootstrap.
+type TeamBootstrapRequest struct {
+	ProjectName   string            `json:"projectName"`
+	Prefix        string            `json:"prefix"`
+	RootGroupName string            `json:"rootGroupName"`
+	PipelineGroup string            `json:"pipelineGroupName"`
+	PMName        string            `json:"pmName"`
+	Background    string            `json:"background"`
+	AcpBackend    string            `json:"acpBackend"`
+	APIKey        string            `json:"apiKey,omitempty"`
+	Region        string            `json:"region,omitempty"`
+	GitURL        string            `json:"gitUrl,omitempty"`
+	GitCredType   string            `json:"gitCredentialType,omitempty"`
+	MCP           []MCPServer       `json:"mcp,omitempty"`
+	Env           map[string]string `json:"env,omitempty"`
+}
+
+// TeamBootstrapEvent is one progress log line for the UI.
+type TeamBootstrapEvent struct {
+	Kind    string `json:"kind"` // sys|ok|warn|mcp|err
+	Message string `json:"message"`
+	At      string `json:"at"`
+}
+
+// TeamBootstrapResource is one created resource for the progress panel.
+type TeamBootstrapResource struct {
+	Kind  string `json:"kind"` // project|group|agent
+	Name  string `json:"name"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// TeamBootstrapSession tracks an in-flight or finished team bootstrap.
+type TeamBootstrapSession struct {
+	ID              string                  `json:"id"`
+	Status          string                  `json:"status"` // starting|running|ready|failed
+	Error           string                  `json:"error,omitempty"`
+	ProjectID       string                  `json:"projectId,omitempty"`
+	RootGroupID     string                  `json:"rootGroupId,omitempty"`
+	PipelineGroupID string                  `json:"pipelineGroupId,omitempty"`
+	PMAgent         string                  `json:"pmAgent,omitempty"`
+	SandboxID       string                  `json:"sandboxId,omitempty"`
+	Prefix          string                  `json:"prefix,omitempty"`
+	Background      string                  `json:"background,omitempty"`
+	AllowedGroupIDs []string                `json:"allowedGroupIds,omitempty"`
+	AgentNames      []string                `json:"agentNames,omitempty"`
+	Events          []TeamBootstrapEvent    `json:"events"`
+	Resources       []TeamBootstrapResource `json:"resources"`
+	CreatedAt       time.Time               `json:"createdAt"`
+	UpdatedAt       time.Time               `json:"updatedAt"`
+}
+
+// TeamService orchestrates Create Agent Team bootstrap + scoped template creates.
+type TeamService struct {
+	Projects *ProjectService
+	Skills   *SkillService
+	Org      *OrgService
+	Pm       *PmService
+	Sbx      *SandboxService
+
+	mu         sync.Mutex
+	sessions   map[string]*TeamBootstrapSession
+	sessionReq map[string]normalizedTeamReq
+}
+
+// NewTeamService wires dependencies (Sbx may be nil in unit tests).
+func NewTeamService(projects *ProjectService, skills *SkillService, org *OrgService, pm *PmService, sbx *SandboxService) *TeamService {
+	return &TeamService{
+		Projects:   projects,
+		Skills:     skills,
+		Org:        org,
+		Pm:         pm,
+		Sbx:        sbx,
+		sessions:   map[string]*TeamBootstrapSession{},
+		sessionReq: map[string]normalizedTeamReq{},
+	}
+}
+
+// ListTemplates returns the fixed engineer role catalog.
+func (s *TeamService) ListTemplates() []TeamRoleTemplate {
+	out := make([]TeamRoleTemplate, len(TeamEngineerTemplates))
+	copy(out, TeamEngineerTemplates)
+	return out
+}
+
+// GetSession returns a bootstrap session by id.
+func (s *TeamService) GetSession(id string) (TeamBootstrapSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.sessions[strings.TrimSpace(id)]
+	if !ok || sess == nil {
+		return TeamBootstrapSession{}, ErrTeamSessionNotFound
+	}
+	cp := *sess
+	cp.Events = append([]TeamBootstrapEvent(nil), sess.Events...)
+	cp.Resources = append([]TeamBootstrapResource(nil), sess.Resources...)
+	cp.AgentNames = append([]string(nil), sess.AgentNames...)
+	cp.AllowedGroupIDs = append([]string(nil), sess.AllowedGroupIDs...)
+	return cp, nil
+}
+
+// Bootstrap creates project + org + PM + 9 engineers, then starts a PM sandbox.
+func (s *TeamService) Bootstrap(ctx context.Context, req TeamBootstrapRequest) (TeamBootstrapSession, error) {
+	norm, err := s.normalizeRequest(req)
+	if err != nil {
+		return TeamBootstrapSession{}, err
+	}
+	if _, ok := s.Skills.Get(norm.PMName); ok {
+		return TeamBootstrapSession{}, fmt.Errorf("%w: %s", ErrTeamAgentConflict, norm.PMName)
+	}
+	for _, role := range TeamEngineerTemplates {
+		name := EngineerDisplayName(norm.Prefix, role.RoleLabelZH)
+		if _, ok := s.Skills.Get(name); ok {
+			return TeamBootstrapSession{}, fmt.Errorf("%w: %s", ErrTeamAgentConflict, name)
+		}
+	}
+
+	sess := &TeamBootstrapSession{
+		ID:         "team-" + uuid.NewString()[:12],
+		Status:     "starting",
+		Prefix:     norm.Prefix,
+		Background: norm.Background,
+		CreatedAt:  time.Now().UTC(),
+		UpdatedAt:  time.Now().UTC(),
+	}
+	s.mu.Lock()
+	s.sessions[sess.ID] = sess
+	s.sessionReq[sess.ID] = norm
+	s.mu.Unlock()
+	s.appendEvent(sess.ID, "sys", "bootstrap session "+sess.ID)
+
+	go s.runBootstrap(ctx, sess.ID, norm)
+	return s.GetSession(sess.ID)
+}
+
+// Retry re-runs sandbox provisioning for a failed bootstrap session (idempotent skips).
+func (s *TeamService) Retry(ctx context.Context, sessionID string) (TeamBootstrapSession, error) {
+	sessionID = strings.TrimSpace(sessionID)
+	cur, err := s.GetSession(sessionID)
+	if err != nil {
+		return TeamBootstrapSession{}, err
+	}
+	if cur.Status != "failed" {
+		return TeamBootstrapSession{}, fmt.Errorf("%w: only failed sessions can be retried", ErrTeamValidation)
+	}
+	s.mu.Lock()
+	req, ok := s.sessionReq[sessionID]
+	s.mu.Unlock()
+	if !ok {
+		return TeamBootstrapSession{}, fmt.Errorf("%w: bootstrap request no longer available", ErrTeamValidation)
+	}
+	s.patchSession(sessionID, func(sess *TeamBootstrapSession) {
+		sess.Status = "starting"
+		sess.Error = ""
+	})
+	s.appendEvent(sessionID, "sys", "retry bootstrap "+sessionID)
+	go s.runRetry(ctx, sessionID, req)
+	return s.GetSession(sessionID)
+}
+
+type normalizedTeamReq struct {
+	ProjectName   string
+	Prefix        string
+	RootGroupName string
+	PipelineGroup string
+	PMName        string
+	Background    string
+	AcpBackend    string
+	APIKey        string
+	Region        string
+	GitURL        string
+	GitCredType   string
+	MCP           []MCPServer
+	Env           map[string]string
+}
+
+func (s *TeamService) normalizeRequest(req TeamBootstrapRequest) (normalizedTeamReq, error) {
+	projectName := strings.TrimSpace(req.ProjectName)
+	prefix := strings.TrimSpace(req.Prefix)
+	pmName := strings.TrimSpace(req.PMName)
+	background := strings.TrimSpace(req.Background)
+	if projectName == "" {
+		return normalizedTeamReq{}, fmt.Errorf("%w: projectName is required", ErrTeamValidation)
+	}
+	if prefix == "" {
+		return normalizedTeamReq{}, fmt.Errorf("%w: prefix is required", ErrTeamValidation)
+	}
+	if background == "" {
+		return normalizedTeamReq{}, fmt.Errorf("%w: background is required", ErrTeamValidation)
+	}
+	var err error
+	pmName, err = NormalizeAndValidateAgentName(pmName)
+	if err != nil {
+		if pmName == "" {
+			pmName, err = NormalizeAndValidateAgentName(PMDisplayName(prefix))
+		}
+		if err != nil {
+			return normalizedTeamReq{}, fmt.Errorf("%w: pmName: %v", ErrTeamValidation, err)
+		}
+	}
+	root := strings.TrimSpace(req.RootGroupName)
+	if root == "" {
+		root = prefix + "项目组"
+	}
+	pipeline := strings.TrimSpace(req.PipelineGroup)
+	if pipeline == "" {
+		pipeline = "Pipeline(GitHub)"
+	}
+	mcp := req.MCP
+	if len(mcp) == 0 {
+		mcp = DefaultPlatformMCP()
+	}
+	env := map[string]string{}
+	for k, v := range req.Env {
+		k = strings.TrimSpace(k)
+		if k == "" {
+			continue
+		}
+		env[k] = v
+	}
+	if _, ok := env["GIT_REPOS"]; !ok {
+		env["GIT_REPOS"] = "${vars.repos}"
+	}
+	return normalizedTeamReq{
+		ProjectName:   projectName,
+		Prefix:        prefix,
+		RootGroupName: root,
+		PipelineGroup: pipeline,
+		PMName:        pmName,
+		Background:    background,
+		AcpBackend:    NormalizeAcpBackend(req.AcpBackend),
+		APIKey:        strings.TrimSpace(req.APIKey),
+		Region:        strings.TrimSpace(req.Region),
+		GitURL:        strings.TrimSpace(req.GitURL),
+		GitCredType:   strings.TrimSpace(req.GitCredType),
+		MCP:           mcp,
+		Env:           env,
+	}, nil
+}
+
+func (s *TeamService) runBootstrap(ctx context.Context, sessionID string, req normalizedTeamReq) {
+	fail := func(err error) {
+		s.setStatus(sessionID, "failed", err.Error())
+		s.appendEvent(sessionID, "err", err.Error())
+	}
+
+	s.appendEvent(sessionID, "sys", "creating project "+req.ProjectName)
+	var envEntries []models.EnvEntry
+	if req.APIKey != "" {
+		envEntries = append(envEntries, models.EnvEntry{
+			Key: primaryAuthEnvKey(req.AcpBackend), Value: req.APIKey, Secret: true,
+		})
+		switch NormalizeAcpBackend(req.AcpBackend) {
+		case AcpBackendCodeBuddy:
+			region := req.Region
+			if region == "" {
+				region = "public"
+			}
+			envEntries = append(envEntries, models.EnvEntry{Key: runtime.EnvCodeBuddyRegion, Value: region})
+		case AcpBackendTrae:
+			region := req.Region
+			if region == "" {
+				region = "intl"
+			}
+			envEntries = append(envEntries, models.EnvEntry{Key: runtime.EnvTraeRegion, Value: region})
+		}
+	}
+	proj, err := s.Projects.Create(req.ProjectName, req.Background, envEntries, nil)
+	if err != nil {
+		fail(err)
+		return
+	}
+	s.patchSession(sessionID, func(sess *TeamBootstrapSession) {
+		sess.ProjectID = proj.ID
+		sess.Status = "running"
+	})
+	s.addResource(sessionID, "project", proj.Name, proj.ID)
+	s.appendEvent(sessionID, "ok", "project created: "+proj.ID)
+
+	rootID := NewGroupID()
+	pipeID := NewGroupID()
+	s.patchSession(sessionID, func(sess *TeamBootstrapSession) {
+		sess.RootGroupID = rootID
+		sess.PipelineGroupID = pipeID
+		sess.AllowedGroupIDs = []string{rootID, pipeID}
+	})
+
+	// Create PM agent
+	s.appendEvent(sessionID, "sys", "creating PM "+req.PMName)
+	pmAgent, err := s.buildPMAgent(req, proj.ID)
+	if err != nil {
+		fail(err)
+		return
+	}
+	if err := s.Skills.Save(pmAgent); err != nil {
+		fail(err)
+		return
+	}
+	s.patchSession(sessionID, func(sess *TeamBootstrapSession) {
+		sess.PMAgent = req.PMName
+		sess.AgentNames = append(sess.AgentNames, req.PMName)
+	})
+	s.addResource(sessionID, "agent", req.PMName, "PM Leader")
+	s.appendEvent(sessionID, "ok", "PM agent saved")
+
+	enabled := true
+	mcps := append([]string{}, DefaultPmEnabledMcps...)
+	if _, err := s.Pm.UpdateBinding(proj.ID, &enabled, &req.PMName, mcps, nil, nil); err != nil {
+		fail(fmt.Errorf("bind PM Leader: %w", err))
+		return
+	}
+	s.appendEvent(sessionID, "ok", "PM Leader bound")
+
+	// Org: root + pipeline + PM membership
+	org, err := s.Org.Get()
+	if err != nil {
+		fail(err)
+		return
+	}
+	org.Groups = append(org.Groups,
+		OrgGroup{ID: rootID, Name: req.RootGroupName},
+		OrgGroup{ID: pipeID, Name: req.PipelineGroup, ParentGroupID: rootID},
+	)
+	if org.Agents == nil {
+		org.Agents = map[string]OrgAgentMembership{}
+	}
+	org.Agents[req.PMName] = OrgAgentMembership{GroupIDs: []string{rootID}}
+	if _, err := s.Org.Put(org, org.Revision); err != nil {
+		fail(fmt.Errorf("org put: %w", err))
+		return
+	}
+	s.addResource(sessionID, "group", req.RootGroupName, "root")
+	s.addResource(sessionID, "group", req.PipelineGroup, "pipeline · 9 engineers")
+	s.appendEvent(sessionID, "mcp", "pm_ensure_child_group\nparent="+req.RootGroupName+"\nchild="+req.PipelineGroup+"\n✓ ok")
+
+	s.appendEvent(sessionID, "warn", "inject Prompt（项目背景）:\n"+truncateRunes(req.Background, 400))
+	s.appendEvent(sessionID, "warn", "provision 9 engineers from templates (inherit mcp/env)")
+
+	for _, role := range TeamEngineerTemplates {
+		name := EngineerDisplayName(req.Prefix, role.RoleLabelZH)
+		s.appendEvent(sessionID, "mcp", "pm_create_agent_from_template\ntemplate="+role.ID+"\nname="+name+"\nproject="+proj.ID)
+		created, err := s.CreateAgentFromTemplate(CreateFromTemplateArgs{
+			SessionID:   sessionID,
+			TemplateID:  role.ID,
+			Name:        name,
+			ProjectID:   proj.ID,
+			AcpBackend:  req.AcpBackend,
+			GitCredType: req.GitCredType,
+			MCP:         req.MCP,
+			Env:         req.Env,
+			Region:      req.Region,
+		})
+		if err != nil {
+			fail(err)
+			return
+		}
+		s.appendEvent(sessionID, "mcp", "pm_set_org_membership\nagent="+created.Name+"\ngroup="+req.PipelineGroup+"\nparent="+req.PMName+"\n✓ ok")
+		if err := s.SetOrgMembership(SetOrgMembershipArgs{
+			SessionID:   sessionID,
+			AgentName:   created.Name,
+			GroupIDs:    []string{pipeID},
+			ParentAgent: req.PMName,
+		}); err != nil {
+			fail(err)
+			return
+		}
+		s.addResource(sessionID, "agent", created.Name, "template "+role.ID+" · "+req.PipelineGroup)
+		s.patchSession(sessionID, func(sess *TeamBootstrapSession) {
+			sess.AgentNames = append(sess.AgentNames, created.Name)
+		})
+	}
+
+	s.finishBootstrap(ctx, sessionID, req)
+}
+
+func (s *TeamService) runRetry(ctx context.Context, sessionID string, req normalizedTeamReq) {
+	fail := func(err error) {
+		s.setStatus(sessionID, "failed", err.Error())
+		s.appendEvent(sessionID, "err", err.Error())
+	}
+	cur, err := s.GetSession(sessionID)
+	if err != nil {
+		fail(err)
+		return
+	}
+	// No project yet → full bootstrap.
+	if strings.TrimSpace(cur.ProjectID) == "" {
+		s.runBootstrap(ctx, sessionID, req)
+		return
+	}
+	s.setStatus(sessionID, "running", "")
+	s.appendEvent(sessionID, "sys", "retry: continue engineer provision (skip existing)")
+
+	projID := cur.ProjectID
+	pipeID := cur.PipelineGroupID
+	if pipeID == "" {
+		pipeID = NewGroupID()
+		s.patchSession(sessionID, func(sess *TeamBootstrapSession) {
+			sess.PipelineGroupID = pipeID
+			sess.AllowedGroupIDs = uniqueNonEmptyStrings(append(sess.AllowedGroupIDs, pipeID))
+		})
+	}
+	pmName := cur.PMAgent
+	if pmName == "" {
+		pmName = req.PMName
+	}
+
+	for _, role := range TeamEngineerTemplates {
+		name := EngineerDisplayName(req.Prefix, role.RoleLabelZH)
+		s.appendEvent(sessionID, "mcp", "pm_create_agent_from_template\ntemplate="+role.ID+"\nname="+name+"\nproject="+projID)
+		created, err := s.CreateAgentFromTemplate(CreateFromTemplateArgs{
+			SessionID:    sessionID,
+			TemplateID:   role.ID,
+			Name:         name,
+			ProjectID:    projID,
+			AcpBackend:   req.AcpBackend,
+			GitCredType:  req.GitCredType,
+			MCP:          req.MCP,
+			Env:          req.Env,
+			Region:       req.Region,
+			SkipIfExists: true,
+		})
+		if err != nil {
+			fail(err)
+			return
+		}
+		if err := s.SetOrgMembership(SetOrgMembershipArgs{
+			SessionID:   sessionID,
+			AgentName:   created.Name,
+			GroupIDs:    []string{pipeID},
+			ParentAgent: pmName,
+		}); err != nil {
+			fail(err)
+			return
+		}
+		cur2, _ := s.GetSession(sessionID)
+		hasAgent := false
+		for _, n := range cur2.AgentNames {
+			if n == created.Name {
+				hasAgent = true
+				break
+			}
+		}
+		if !hasAgent {
+			s.patchSession(sessionID, func(sess *TeamBootstrapSession) {
+				sess.AgentNames = append(sess.AgentNames, created.Name)
+			})
+		}
+		hasRes := false
+		for _, r := range cur2.Resources {
+			if r.Kind == "agent" && r.Name == created.Name {
+				hasRes = true
+				break
+			}
+		}
+		if !hasRes {
+			s.addResource(sessionID, "agent", created.Name, "template "+role.ID+" · retry")
+		} else {
+			s.appendEvent(sessionID, "warn", "skip existing agent "+created.Name)
+		}
+		s.appendEvent(sessionID, "mcp", "pm_set_org_membership\nagent="+created.Name+"\ngroup="+req.PipelineGroup+"\nparent="+pmName+"\n✓ ok")
+	}
+
+	s.finishBootstrap(ctx, sessionID, req)
+}
+
+func (s *TeamService) finishBootstrap(ctx context.Context, sessionID string, req normalizedTeamReq) {
+	cur, err := s.GetSession(sessionID)
+	if err != nil {
+		s.setStatus(sessionID, "failed", err.Error())
+		return
+	}
+	pmName := cur.PMAgent
+	if pmName == "" {
+		pmName = req.PMName
+	}
+	if s.Sbx != nil && pmName != "" {
+		s.appendEvent(sessionID, "sys", "starting sandbox for "+pmName)
+		var repos []sandbox.RepoSpec
+		if req.GitURL != "" {
+			repos = sandbox.ReposFromURL(req.GitURL)
+		}
+		sb, err := s.Sbx.Open(ctx, pmName, repos, cur.ProjectID)
+		if err != nil {
+			s.appendEvent(sessionID, "warn", "sandbox start deferred: "+err.Error())
+		} else if sb != nil {
+			sid := fmt.Sprintf("%d", sb.ID)
+			s.patchSession(sessionID, func(sess *TeamBootstrapSession) {
+				sess.SandboxID = sid
+			})
+			s.appendEvent(sessionID, "ok", "sandbox "+sid+" status="+sb.Status)
+		}
+	}
+	s.appendEvent(sessionID, "ok", fmt.Sprintf("done: 1 PM + %d engineers (total %d)", len(TeamEngineerTemplates), 1+len(TeamEngineerTemplates)))
+	s.setStatus(sessionID, "ready", "")
+}
+
+// CreateFromTemplateArgs is used by MCP and bootstrap.
+type CreateFromTemplateArgs struct {
+	SessionID    string
+	TemplateID   string
+	Name         string
+	ProjectID    string
+	AcpBackend   string
+	GitCredType  string
+	MCP          []MCPServer
+	Env          map[string]string
+	Region       string
+	SkipIfExists bool
+	// When SessionID is set, scope checks apply.
+}
+
+// CreateAgentFromTemplate creates one engineer from an embedded template.
+func (s *TeamService) CreateAgentFromTemplate(args CreateFromTemplateArgs) (Agent, error) {
+	role, ok := TeamRoleByID(args.TemplateID)
+	if !ok {
+		return Agent{}, fmt.Errorf("%w: unknown template %s", ErrTeamValidation, args.TemplateID)
+	}
+	name, err := NormalizeAndValidateAgentName(args.Name)
+	if err != nil {
+		return Agent{}, fmt.Errorf("%w: %v", ErrTeamValidation, err)
+	}
+	if existing, exists := s.Skills.Get(name); exists {
+		if args.SkipIfExists {
+			return existing, nil
+		}
+		return Agent{}, fmt.Errorf("%w: %s", ErrTeamAgentConflict, name)
+	}
+	projectID := strings.TrimSpace(args.ProjectID)
+	if projectID == "" {
+		return Agent{}, fmt.Errorf("%w: projectId is required", ErrTeamValidation)
+	}
+	if args.SessionID != "" {
+		if err := s.assertSessionProject(args.SessionID, projectID); err != nil {
+			return Agent{}, err
+		}
+	}
+
+	tmpl, err := loadTeamAgentTemplate(role.EmbedName)
+	if err != nil {
+		return Agent{}, err
+	}
+	tmpl.Name = name
+	tmpl.ProjectID = projectID
+	backend := NormalizeAcpBackend(args.AcpBackend)
+	if backend == "" {
+		backend = tmpl.AcpBackend
+	}
+	tmpl.AcpBackend = backend
+	tmpl.Layout.ConfigRoot = DefaultConfigRootForBackend(backend)
+	if strings.TrimSpace(tmpl.Layout.WorkspaceDir) == "" {
+		tmpl.Layout.WorkspaceDir = DefaultWorkspaceDir
+	}
+	if args.GitCredType != "" {
+		tmpl.GitCredentialType = args.GitCredType
+	}
+
+	// Merge env: template < request
+	mergedEnv := map[string]string{}
+	for k, v := range tmpl.Env {
+		mergedEnv[k] = v
+	}
+	for k, v := range args.Env {
+		k = strings.TrimSpace(k)
+		if k != "" {
+			mergedEnv[k] = v
+		}
+	}
+	applyOnboardingAgentRegion(mergedEnv, backend, args.Region)
+	tmpl.Env = mergedEnv
+
+	// MCP: prefer request list when provided, else template
+	if len(args.MCP) > 0 {
+		tmpl.MCP = args.MCP
+	} else if len(tmpl.MCP) == 0 {
+		tmpl.MCP = DefaultPlatformMCP()
+	}
+
+	if err := s.Skills.Save(tmpl); err != nil {
+		return Agent{}, err
+	}
+	return tmpl, nil
+}
+
+// SetOrgMembershipArgs updates groupIds + parentAgent under scope.
+type SetOrgMembershipArgs struct {
+	SessionID   string
+	AgentName   string
+	GroupIDs    []string
+	ParentAgent string
+}
+
+// SetOrgMembership sets membership for an agent (scoped when SessionID set).
+func (s *TeamService) SetOrgMembership(args SetOrgMembershipArgs) error {
+	agentName := strings.TrimSpace(args.AgentName)
+	if agentName == "" {
+		return fmt.Errorf("%w: agentName required", ErrTeamValidation)
+	}
+	ag, ok := s.Skills.Get(agentName)
+	if !ok {
+		return fmt.Errorf("%w: agent not found: %s", ErrTeamValidation, agentName)
+	}
+	parent := strings.TrimSpace(args.ParentAgent)
+	groupIDs := uniqueNonEmptyStrings(args.GroupIDs)
+
+	if args.SessionID != "" {
+		sess, err := s.GetSession(args.SessionID)
+		if err != nil {
+			return err
+		}
+		if !AgentProjectMatches(ag, sess.ProjectID) {
+			return fmt.Errorf("%w: agent not in session project", ErrTeamScopeDenied)
+		}
+		if parent != "" && parent != sess.PMAgent {
+			return fmt.Errorf("%w: parentAgent must be session PM", ErrTeamScopeDenied)
+		}
+		allowed := map[string]bool{}
+		for _, id := range sess.AllowedGroupIDs {
+			allowed[id] = true
+		}
+		for _, id := range groupIDs {
+			if !allowed[id] {
+				return fmt.Errorf("%w: group not in session allow-list: %s", ErrTeamScopeDenied, id)
+			}
+		}
+		if parent == "" {
+			parent = sess.PMAgent
+		}
+	}
+
+	org, err := s.Org.Get()
+	if err != nil {
+		return err
+	}
+	if org.Agents == nil {
+		org.Agents = map[string]OrgAgentMembership{}
+	}
+	org.Agents[agentName] = OrgAgentMembership{GroupIDs: groupIDs, ParentAgent: parent}
+	_, err = s.Org.Put(org, org.Revision)
+	return err
+}
+
+// EnsureChildGroup ensures a child group under parent (scoped).
+func (s *TeamService) EnsureChildGroup(sessionID, parentGroupID, name string) (OrgGroup, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return OrgGroup{}, fmt.Errorf("%w: group name required", ErrTeamValidation)
+	}
+	sess, err := s.GetSession(sessionID)
+	if err != nil {
+		return OrgGroup{}, err
+	}
+	if parentGroupID != sess.RootGroupID {
+		return OrgGroup{}, fmt.Errorf("%w: parent must be session root group", ErrTeamScopeDenied)
+	}
+	org, err := s.Org.Get()
+	if err != nil {
+		return OrgGroup{}, err
+	}
+	for _, g := range org.Groups {
+		if g.ParentGroupID == parentGroupID && g.Name == name {
+			return g, nil
+		}
+	}
+	g := OrgGroup{ID: NewGroupID(), Name: name, ParentGroupID: parentGroupID}
+	org.Groups = append(org.Groups, g)
+	if _, err := s.Org.Put(org, org.Revision); err != nil {
+		return OrgGroup{}, err
+	}
+	s.patchSession(sessionID, func(sess *TeamBootstrapSession) {
+		sess.AllowedGroupIDs = append(sess.AllowedGroupIDs, g.ID)
+		if sess.PipelineGroupID == "" {
+			sess.PipelineGroupID = g.ID
+		}
+	})
+	return g, nil
+}
+
+func (s *TeamService) buildPMAgent(req normalizedTeamReq, projectID string) (Agent, error) {
+	files := []AgentFile{{
+		Path: "rules/" + req.PMName + ".md",
+		Content: "# " + req.PMName + "\n\n" +
+			"你是项目经理（PM Leader）。根据项目背景组建并协调工程师团队。\n\n" +
+			"## 项目背景\n\n" + req.Background + "\n",
+	}}
+	env := map[string]string{}
+	for k, v := range req.Env {
+		env[k] = v
+	}
+	applyOnboardingAgentRegion(env, req.AcpBackend, req.Region)
+	a := Agent{
+		Name:              req.PMName,
+		ProjectID:         projectID,
+		AcpBackend:        req.AcpBackend,
+		GitCredentialType: req.GitCredType,
+		Files:             files,
+		MCP:               req.MCP,
+		Env:               env,
+		Layout: AgentLayout{
+			ConfigRoot:   DefaultConfigRootForBackend(req.AcpBackend),
+			WorkspaceDir: DefaultWorkspaceDir,
+		},
+	}
+	return a, nil
+}
+
+func (s *TeamService) assertSessionProject(sessionID, projectID string) error {
+	sess, err := s.GetSession(sessionID)
+	if err != nil {
+		return err
+	}
+	if sess.ProjectID == "" || sess.ProjectID != strings.TrimSpace(projectID) {
+		return fmt.Errorf("%w: projectId mismatch", ErrTeamScopeDenied)
+	}
+	return nil
+}
+
+func (s *TeamService) appendEvent(id, kind, message string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess := s.sessions[id]
+	if sess == nil {
+		return
+	}
+	sess.Events = append(sess.Events, TeamBootstrapEvent{
+		Kind: kind, Message: message, At: time.Now().UTC().Format(time.RFC3339),
+	})
+	sess.UpdatedAt = time.Now().UTC()
+}
+
+func (s *TeamService) addResource(id, kind, name, detail string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess := s.sessions[id]
+	if sess == nil {
+		return
+	}
+	sess.Resources = append(sess.Resources, TeamBootstrapResource{Kind: kind, Name: name, Detail: detail})
+	sess.UpdatedAt = time.Now().UTC()
+}
+
+func (s *TeamService) setStatus(id, status, errMsg string) {
+	s.patchSession(id, func(sess *TeamBootstrapSession) {
+		sess.Status = status
+		sess.Error = errMsg
+	})
+}
+
+func (s *TeamService) patchSession(id string, fn func(*TeamBootstrapSession)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess := s.sessions[id]
+	if sess == nil {
+		return
+	}
+	fn(sess)
+	sess.UpdatedAt = time.Now().UTC()
+}
+
+func uniqueNonEmptyStrings(ids []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	return out
+}
+
+func truncateRunes(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max]) + "…"
+}

--- a/server/internal/services/team_embed.go
+++ b/server/internal/services/team_embed.go
@@ -1,0 +1,129 @@
+package services
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"path"
+	"strings"
+)
+
+//go:embed all:team_embed
+var teamEmbedFS embed.FS
+
+const teamEmbedRoot = "team_embed"
+
+// TeamRoleTemplate describes one engineer role in the reference roster (1 PM + 9).
+type TeamRoleTemplate struct {
+	ID          string `json:"id"`
+	EmbedName   string `json:"embedName"`
+	RoleLabelZH string `json:"roleLabelZh"`
+	Summary     string `json:"summary"`
+}
+
+// TeamEngineerTemplates is the fixed 9-role pipeline roster.
+var TeamEngineerTemplates = []TeamRoleTemplate{
+	{ID: "research", EmbedName: "ResearchAgent", RoleLabelZH: "调研工程师", Summary: "技术与竞品调研"},
+	{ID: "plan", EmbedName: "PlanAgent", RoleLabelZH: "计划工程师", Summary: "拆解实现计划"},
+	{ID: "proposal", EmbedName: "ProposalAgent", RoleLabelZH: "方案工程师", Summary: "方案提案"},
+	{ID: "clarify", EmbedName: "ClarifyAgent", RoleLabelZH: "澄清工程师", Summary: "需求澄清"},
+	{ID: "visual", EmbedName: "VisualAgent", RoleLabelZH: "视觉原型工程师", Summary: "可预览视觉原型"},
+	{ID: "implement", EmbedName: "ImplementAgent", RoleLabelZH: "实现工程师", Summary: "代码实现与推送"},
+	{ID: "test", EmbedName: "TestAgent", RoleLabelZH: "测试工程师", Summary: "测试验证"},
+	{ID: "review", EmbedName: "ReviewAgent", RoleLabelZH: "代码Review工程师", Summary: "代码复核"},
+	{ID: "preview", EmbedName: "PreviewAgent", RoleLabelZH: "变更摘要视觉工程师", Summary: "变更摘要视觉预览"},
+}
+
+// TeamRoleByID returns a template by id.
+func TeamRoleByID(id string) (TeamRoleTemplate, bool) {
+	id = strings.TrimSpace(id)
+	for _, t := range TeamEngineerTemplates {
+		if t.ID == id {
+			return t, true
+		}
+	}
+	return TeamRoleTemplate{}, false
+}
+
+// EngineerDisplayName builds "{prefix}{roleLabel}".
+func EngineerDisplayName(prefix, roleLabelZH string) string {
+	return strings.TrimSpace(prefix) + strings.TrimSpace(roleLabelZH)
+}
+
+// PMDisplayName builds "{prefix}项目经理".
+func PMDisplayName(prefix string) string {
+	return strings.TrimSpace(prefix) + "项目经理"
+}
+
+func loadTeamAgentTemplate(embedName string) (Agent, error) {
+	embedName = strings.TrimSpace(embedName)
+	if embedName == "" {
+		return Agent{}, fmt.Errorf("empty team template name")
+	}
+	cfgPath := path.Join(teamEmbedRoot, embedName, "agent.json")
+	raw, err := teamEmbedFS.ReadFile(cfgPath)
+	if err != nil {
+		return Agent{}, fmt.Errorf("read team embed agent.json for %s: %w", embedName, err)
+	}
+	var cfg agentConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return Agent{}, fmt.Errorf("parse team embed agent.json for %s: %w", embedName, err)
+	}
+	files, err := readTeamEmbedWorkspaceFiles(path.Join(teamEmbedRoot, embedName, WorkDirName))
+	if err != nil {
+		return Agent{}, err
+	}
+	env := map[string]string{}
+	for k, v := range cfg.Env {
+		env[k] = v
+	}
+	if _, ok := env["GIT_REPOS"]; !ok {
+		env["GIT_REPOS"] = "${vars.repos}"
+	}
+	mcp := cfg.MCP
+	if len(mcp) == 0 {
+		mcp = DefaultPlatformMCP()
+	}
+	layout := AgentLayout{}
+	if cfg.Layout != nil {
+		layout = *cfg.Layout
+	}
+	return Agent{
+		Name:       embedName,
+		AcpBackend: NormalizeAcpBackend(cfg.AcpBackend),
+		Files:      files,
+		MCP:        mcp,
+		Env:        env,
+		Layout:     layout,
+		Prompts:    cfg.Prompts,
+	}, nil
+}
+
+func readTeamEmbedWorkspaceFiles(root string) ([]AgentFile, error) {
+	var out []AgentFile
+	prefix := strings.TrimSuffix(root, "/") + "/"
+	err := fs.WalkDir(teamEmbedFS, root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel := strings.TrimPrefix(p, prefix)
+		rel = path.Clean(rel)
+		if rel == "." || rel == "" || strings.HasPrefix(rel, "..") {
+			return nil
+		}
+		b, err := teamEmbedFS.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		out = append(out, AgentFile{Path: rel, Content: string(b)})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk team embed workspace %s: %w", root, err)
+	}
+	return out, nil
+}

--- a/server/internal/services/team_embed/ClarifyAgent/agent.json
+++ b/server/internal/services/team_embed/ClarifyAgent/agent.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "acpBackend": "cursor",
+  "mcp": [
+    {
+      "name": "artifact-store",
+      "url": "${APPROVING_ARTIFACT_URL}",
+      "headers": {
+        "Authorization": "Bearer ${APPROVING_ARTIFACT_TOKEN}"
+      }
+    }
+  ],
+  "name": "ClarifyAgent",
+  "env": {
+    "GIT_REPOS": "${vars.repos}"
+  }
+}

--- a/server/internal/services/team_embed/ClarifyAgent/workspace/AGENTS.md
+++ b/server/internal/services/team_embed/ClarifyAgent/workspace/AGENTS.md
@@ -1,0 +1,22 @@
+# ClarifyAgent
+
+## 使命
+
+作为需求澄清专家，通过结构化提问把模糊诉求收敛为可验收的完整需求规格（背景/目标/范围/功能与验收/假设依赖约束等）。位于调研之前：先定 WHAT。
+
+## 唯一交付
+
+最终必须调用 `set_clarified_requirement`（`open_questions` 必须为空）。凡未决点须先经 `ask_question` 门禁拍板；信息已充分时可直接收束，不必为提问而提问。
+
+必填：`title`、`summary`、`background`、`goals`、`in_scope`、`out_of_scope`、`functional_requirements`（含 detail 与 acceptance_criteria）、`assumptions`、`dependencies`、`constraints`。
+
+禁止写入排期与技术方案。
+
+对应工具：set_clarified_requirement；按需 ask_question。
+
+## 禁止事项
+
+- 禁止用 `write_artifact` / `set_research` / `set_proposals` / `set_plan` / `set_implementation_result` / `set_test_result` / `set_review` 代替澄清交付。
+- 不承担其他 SDLC 节点职责；本包不是万能超级 Agent。
+- 密钥与凭据不得出现在本工作区或提交中。
+- 不削弱平台嵌入的契约与门禁；本包只补充角色身份与质量棘轮。

--- a/server/internal/services/team_embed/ClarifyAgent/workspace/rules/role.md
+++ b/server/internal/services/team_embed/ClarifyAgent/workspace/rules/role.md
@@ -1,0 +1,40 @@
+---
+description: ClarifyAgent 角色人设与交付边界（始终应用）
+alwaysApply: true
+---
+
+# ClarifyAgent 角色边界
+
+你是 **ClarifyAgent**，与平台 SDLC 节点 1:1 对应，`skill_profile` 同名引用。
+
+## 人设
+
+作为需求澄清专家，通过结构化提问把模糊诉求收敛为可验收的完整需求规格（对齐 IEEE 29148 / PRD 子集）。本节点在调研/方案之前执行：先定 WHAT，再交给 Research 查 HOW。
+
+## 唯一交付声明
+
+最终必须调用 `set_clarified_requirement`（`open_questions` 必须为空），写入完整规格：
+
+- 必填：`title`、`summary`、`background`、`goals`、`in_scope`、`out_of_scope`、带验收标准的 `functional_requirements`、`assumptions`、`dependencies`、`constraints`
+- 可选：成功指标、画像/场景、NFR、轻量接口与数据实体、业务规则/边界、限制、风险、术语表
+- 禁止：排期/里程碑；技术选型与架构设计
+
+凡未决点须先经 `ask_question` 门禁拍板；信息已充分时可直接收束。
+
+完成前不得声称节点已交付。
+
+## 边界
+
+禁止用 `write_artifact` / `set_research` / `set_proposals` / `set_plan` / `set_implementation_result` / `set_test_result` / `set_review` 代替澄清交付。
+
+## 通用禁止事项（角色内拷贝）
+
+- **禁止密钥入库**：不得把 ACP Key、Git Token、密码、私钥或可用凭据写入仓库、`agents/` 源码或 ZIP；凭据仅在 Agent Studio / 运行时环境配置。
+- **禁止 write_artifact 旁路**：结构化节点交付必须走对应的 `set_*`（及澄清的 `ask_question`），不得用 `write_artifact` 假装完成门禁。
+- **禁止越权交付**：只完成本角色唯一交付，不代替上下游节点写入其结论。
+- **禁止削弱平台门禁**：不得复制或改写完整平台节点规则正文；不得暗示可以跳过 `open_questions` 非空、计划未完成、测试 failed、`request_changes` 等门禁语义。
+
+
+## 与平台规则的关系
+
+平台嵌入规则保证契约底线与门禁；本文件只声明身份、唯一交付与禁止旁路。遇到冲突时以平台节点契约为准，不得用本包内容削弱门禁。

--- a/server/internal/services/team_embed/ClarifyAgent/workspace/skills/clarify-checklist/SKILL.md
+++ b/server/internal/services/team_embed/ClarifyAgent/workspace/skills/clarify-checklist/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: clarify-checklist
+description: ClarifyAgent 专业质量检查清单（简体中文）
+---
+
+# ClarifyAgent 检查清单
+
+在调用唯一交付工具之前，逐项自检：
+
+1. 凡未决点都已用 ask_question 让用户拍板；信息已充分时可直接收束，不必为提问而提问
+2. 必填段齐全：`title` / `summary` / `background` / `goals` / `in_scope` / `out_of_scope` / `assumptions` / `dependencies` / `constraints`
+3. 每条 functional_requirement 含 `detail` 与可验证的 `acceptance_criteria`（≥1）；`priority` 为 must|should|could
+4. assumptions / dependencies / constraints 与用户确认一致；无实质内容时写明「无额外…（已与用户确认）」，不得省略键
+5. 未写入排期/里程碑，未写入技术选型或架构方案
+6. 结论可被后续 Research/Proposal/Plan 直接消费，无含糊代词与未定义缩写
+
+## 交付核对
+
+- [ ] 最终必须调用 set_clarified_requirement，且 open_questions 为空；凡未决点须先经 ask_question，不得把未决项留在结论里
+- [ ] 未使用 `write_artifact` 旁路门禁
+- [ ] 未写入任何密钥或可用凭据
+- [ ] 未越权完成其他节点的 `set_*` 交付
+- [ ] 未削弱平台门禁语义
+
+## 质量棘轮
+
+- open_questions 为空，且每个 functional_requirement 都能被下游写成可测验收点
+- out_of_scope / constraints / assumptions / dependencies 与用户拍板一致；若用户未确认范围边界，不得自行假定
+- 交付中无方案选型、技术栈拍板或实现细节（澄清边界说明除外）；无排期字段

--- a/server/internal/services/team_embed/ImplementAgent/agent.json
+++ b/server/internal/services/team_embed/ImplementAgent/agent.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "acpBackend": "cursor",
+  "mcp": [
+    {
+      "name": "artifact-store",
+      "url": "${APPROVING_ARTIFACT_URL}",
+      "headers": {
+        "Authorization": "Bearer ${APPROVING_ARTIFACT_TOKEN}"
+      }
+    }
+  ],
+  "name": "ImplementAgent",
+  "env": {
+    "GIT_REPOS": "${vars.repos}"
+  }
+}

--- a/server/internal/services/team_embed/ImplementAgent/workspace/AGENTS.md
+++ b/server/internal/services/team_embed/ImplementAgent/workspace/AGENTS.md
@@ -1,0 +1,21 @@
+# ImplementAgent
+
+## 使命
+
+作为实现专家：有 plan 时按计划逐项落地；无 plan（轻量链路）时按澄清结论与视觉产物实现，提交推送并写入实现结果。
+
+轻量链路（无 plan）时：读取 `clarified_requirement` 与视觉产物 `page.html`（及 `preview_issues` 如有），按需求在仓库中实现，再提交推送并 `set_implementation_result`；**跳过 `get_plan` / `update_plan_status`，勿空等 plan**。
+
+## 唯一交付
+
+- **有 plan 叶子**：`update_plan_status`（逐项 in_progress→done）+ 各改动仓提交推送 + `set_implementation_result`。
+- **无 plan 叶子**：`set_implementation_result` + git 提交/推送为唯一必达。
+
+对应工具：update_plan_status（仅有 plan 时）、set_implementation_result（以及 git 提交/推送）。
+
+## 禁止事项
+
+- 禁止用 `write_artifact` 旁路交付；禁止越权调用 `set_clarified_requirement` / `set_research` / `set_proposals` / `set_plan` / `set_test_result` / `set_review`。
+- 不承担其他 SDLC 节点职责；本包不是万能超级 Agent。
+- 密钥与凭据不得出现在本工作区或提交中。
+- 不削弱平台嵌入的契约与门禁；本包只补充角色身份与质量棘轮。

--- a/server/internal/services/team_embed/ImplementAgent/workspace/rules/role.md
+++ b/server/internal/services/team_embed/ImplementAgent/workspace/rules/role.md
@@ -1,0 +1,35 @@
+---
+description: ImplementAgent 角色人设与交付边界（始终应用）
+alwaysApply: true
+---
+
+# ImplementAgent 角色边界
+
+你是 **ImplementAgent**，与平台 SDLC 节点 1:1 对应，`skill_profile` 同名引用。
+
+## 人设
+
+作为实现专家：有 plan 时按计划逐项落地；无 plan（轻量链路）时按澄清结论与视觉产物实现，提交推送并写入实现结果。
+
+## 唯一交付声明
+
+- **有 plan 叶子**：`update_plan_status`（逐项 in_progress→done）+ 各改动仓提交推送 + `set_implementation_result`。
+- **无 plan 叶子（轻量链路）**：跳过 `get_plan` / `update_plan_status`；读取 `get_clarified_requirement` 与视觉产物 `page.html`（及 `preview_issues` 如有），在仓库中实现后提交推送，并以 `set_implementation_result` + git 为唯一必达交付。勿空等 plan。
+
+完成前不得声称节点已交付。
+
+## 边界
+
+禁止用 `write_artifact` 旁路交付；禁止越权调用 `set_clarified_requirement` / `set_research` / `set_proposals` / `set_plan` / `set_test_result` / `set_review`。
+
+## 通用禁止事项（角色内拷贝）
+
+- **禁止密钥入库**：不得把 ACP Key、Git Token、密码、私钥或可用凭据写入仓库、`agents/` 源码或 ZIP；凭据仅在 Agent Studio / 运行时环境配置。
+- **禁止 write_artifact 旁路**：结构化节点交付必须走对应的 `set_*`（及澄清的 `ask_question`），不得用 `write_artifact` 假装完成门禁。
+- **禁止越权交付**：只完成本角色唯一交付，不代替上下游节点写入其结论。
+- **禁止削弱平台门禁**：不得复制或改写完整平台节点规则正文；不得暗示可以跳过 `open_questions` 非空、计划未完成、测试 failed、`request_changes` 等门禁语义。
+
+
+## 与平台规则的关系
+
+平台嵌入规则保证契约底线与门禁；本文件只声明身份、唯一交付与禁止旁路。遇到冲突时以平台节点契约为准，不得用本包内容削弱门禁。

--- a/server/internal/services/team_embed/ImplementAgent/workspace/skills/git-mr/SKILL.md
+++ b/server/internal/services/team_embed/ImplementAgent/workspace/skills/git-mr/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: git-mr
+description: Implement 节点分支/提交/push/MR 约定与检查项（不含任何凭据）
+---
+
+# Git / MR 操作检查清单
+
+本 skill 补充 ImplementAgent 在多仓工作区中的版本管理约定。凭据由运行时环境或 Agent Studio 注入，**禁止**写入仓库或本 Agent 目录。
+
+## 工作区布局
+
+- 工作区根通常不是 git 仓库；每个仓在 `/root/workspace/<name>/`
+- 对每个有改动的仓分别 `cd` 进其目录再执行 git 操作
+- 多个仓可以使用同一工作分支名，但必须各自 push
+
+## 推荐流程
+
+1. 在目标仓创建或切换到工作分支（如 `feature/<简短描述>`），避免直接推 `main` / 受保护分支
+2. 实现并完成本地验证后：`git add` 相关文件 → `git commit`（语义化说明 why）→ `git push -u origin HEAD`
+3. 如任务要求创建 GitLab MR，使用环境已配置的 `glab`（或其他平台等价工具）；GitHub 等按任务说明处理
+4. 在 `set_implementation_result` 中写明各仓工作分支名
+
+## 检查项
+
+- [ ] 每个有改动的仓都已 commit 且 push 到远端工作分支
+- [ ] 提交信息不包含密钥、Token、私钥或 `.env` 实值
+- [ ] 未将 ACP/Git 凭据、Token、私钥写入 `agents/`、业务源码或任何明文文件；配置仅允许 `${...}` 占位模板
+- [ ] 未擅自修改 `.github/workflows` / `.gitlab-ci.yml` / `Dockerfile`（除非计划明确要求）
+- [ ] 推送失败时先暴露错误原因，不静默重试掩盖问题
+
+## 禁止事项
+
+- **禁止密钥入库**：不得将 `GITLAB_TOKEN`、`GITHUB_TOKEN`、SSH 私钥、ACP Key 等写入仓库
+- 不要 force push 到 main/master；不要跳过 hooks，除非任务明确要求
+- 不要提交 `dist/`、构建产物、本地密钥文件或与计划无关的大文件

--- a/server/internal/services/team_embed/ImplementAgent/workspace/skills/implement-checklist/SKILL.md
+++ b/server/internal/services/team_embed/ImplementAgent/workspace/skills/implement-checklist/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: implement-checklist
+description: ImplementAgent 专业质量检查清单（简体中文）
+---
+
+# ImplementAgent 检查清单
+
+在调用唯一交付工具之前，逐项自检：
+
+1. 编码前已 `checkout -b feature/<描述>`（或确认已在非受保护工作分支），再改代码
+2. 有 plan 叶子时：先 `get_plan`，再按大目标→小目标推进；开始标 in_progress，完成标 done。**无 plan 叶子则跳过 `get_plan` / `update_plan_status`**，改读 `get_clarified_requirement` + `page.html`（及 preview 反馈）实现
+3. 有 plan 时结束前全部叶子项为 done；无论是否有 plan，实现结果须说明各仓工作分支名
+4. 改动聚焦需求范围，避免无关重构与文档噪音；密钥/凭据不得写入仓库或 Agent 目录
+5. 多仓布局时每个有改动的仓都各自 commit + push
+
+## 交付核对
+
+- [ ] 唯一必达：`set_implementation_result` + 各改动仓 git 提交/推送（有 plan 时另需 `update_plan_status` 全部 done）
+- [ ] 未使用 `write_artifact` 旁路门禁
+- [ ] 未写入任何密钥或可用凭据
+- [ ] 未越权完成其他节点的 `set_*` 交付
+- [ ] 未削弱平台门禁语义
+- [ ] 轻量链路未空等 plan
+
+## 质量棘轮
+
+- 动手改代码前已在工作分支（非 main/master 等受保护分支）
+- 有 plan 时全部叶子项为 done；set_implementation_result 写明各仓工作分支名
+- 未把密钥/Token/私钥写入仓库；敏感配置仅用 `${...}` 占位模板

--- a/server/internal/services/team_embed/PlanAgent/agent.json
+++ b/server/internal/services/team_embed/PlanAgent/agent.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "acpBackend": "cursor",
+  "mcp": [
+    {
+      "name": "artifact-store",
+      "url": "${APPROVING_ARTIFACT_URL}",
+      "headers": {
+        "Authorization": "Bearer ${APPROVING_ARTIFACT_TOKEN}"
+      }
+    }
+  ],
+  "name": "PlanAgent"
+}

--- a/server/internal/services/team_embed/PlanAgent/workspace/AGENTS.md
+++ b/server/internal/services/team_embed/PlanAgent/workspace/AGENTS.md
@@ -1,0 +1,18 @@
+# PlanAgent
+
+## 使命
+
+作为计划专家，把已确认方案拆成最多两级（goals → subgoals）的可执行全局计划。
+
+## 唯一交付
+
+唯一交付：`set_plan`。
+
+对应工具：set_plan。
+
+## 禁止事项
+
+- 禁止用 `write_artifact` 旁路，或越权调用 `set_clarified_requirement` / `set_research` / `set_proposals` / `set_implementation_result` / `set_test_result` / `set_review`。
+- 不承担其他 SDLC 节点职责；本包不是万能超级 Agent。
+- 密钥与凭据不得出现在本工作区或提交中。
+- 不削弱平台嵌入的契约与门禁；本包只补充角色身份与质量棘轮。

--- a/server/internal/services/team_embed/PlanAgent/workspace/rules/role.md
+++ b/server/internal/services/team_embed/PlanAgent/workspace/rules/role.md
@@ -1,0 +1,34 @@
+---
+description: PlanAgent 角色人设与交付边界（始终应用）
+alwaysApply: true
+---
+
+# PlanAgent 角色边界
+
+你是 **PlanAgent**，与平台 SDLC 节点 1:1 对应，`skill_profile` 同名引用。
+
+## 人设
+
+作为计划专家，把已确认方案拆成最多两级（goals → subgoals）的可执行全局计划。
+
+## 唯一交付声明
+
+唯一交付：`set_plan`。
+
+完成前不得声称节点已交付。
+
+## 边界
+
+禁止用 `write_artifact` 旁路，或越权调用 `set_clarified_requirement` / `set_research` / `set_proposals` / `set_implementation_result` / `set_test_result` / `set_review`。
+
+## 通用禁止事项（角色内拷贝）
+
+- **禁止密钥入库**：不得把 ACP Key、Git Token、密码、私钥或可用凭据写入仓库、`agents/` 源码或 ZIP；凭据仅在 Agent Studio / 运行时环境配置。
+- **禁止 write_artifact 旁路**：结构化节点交付必须走对应的 `set_*`（及澄清的 `ask_question`），不得用 `write_artifact` 假装完成门禁。
+- **禁止越权交付**：只完成本角色唯一交付，不代替上下游节点写入其结论。
+- **禁止削弱平台门禁**：不得复制或改写完整平台节点规则正文；不得暗示可以跳过 `open_questions` 非空、计划未完成、测试 failed、`request_changes` 等门禁语义。
+
+
+## 与平台规则的关系
+
+平台嵌入规则保证契约底线与门禁；本文件只声明身份、唯一交付与禁止旁路。遇到冲突时以平台节点契约为准，不得用本包内容削弱门禁。

--- a/server/internal/services/team_embed/PlanAgent/workspace/skills/plan-checklist/SKILL.md
+++ b/server/internal/services/team_embed/PlanAgent/workspace/skills/plan-checklist/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: plan-checklist
+description: PlanAgent 专业质量检查清单（简体中文）
+---
+
+# PlanAgent 检查清单
+
+在调用唯一交付工具之前，逐项自检：
+
+1. 仅两级：goals[] → subgoals[]，subgoals 为叶子且不再嵌套
+2. 小目标粒度适合 Implement 逐项 update_plan_status
+3. 覆盖选定方案与澄清验收点，无遗漏关键交付
+4. 不写实现代码、不改仓库、不另写其他产物文件
+5. 标题清晰可追踪，避免含糊「相关改动」类条目
+
+## 交付核对
+
+- [ ] 唯一交付工具已正确调用：set_plan
+- [ ] 未使用 `write_artifact` 旁路门禁
+- [ ] 未写入任何密钥或可用凭据
+- [ ] 未越权完成其他节点的 `set_*` 交付
+- [ ] 未削弱平台门禁语义
+
+## 质量棘轮
+
+- 结构严格两级：goals → subgoals，且 subgoals 为叶子（无更深嵌套）
+- 每个叶子小目标可被 Implement 单独标 in_progress/done，标题可追踪
+- 计划覆盖选定方案与澄清关键验收点，无「相关改动」类含糊条目

--- a/server/internal/services/team_embed/PreviewAgent/agent.json
+++ b/server/internal/services/team_embed/PreviewAgent/agent.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "acpBackend": "cursor",
+  "mcp": [
+    {
+      "name": "artifact-store",
+      "url": "${APPROVING_ARTIFACT_URL}",
+      "headers": {
+        "Authorization": "Bearer ${APPROVING_ARTIFACT_TOKEN}"
+      }
+    }
+  ],
+  "name": "PreviewAgent",
+  "env": {
+    "GIT_REPOS": "${vars.repos}"
+  }
+}

--- a/server/internal/services/team_embed/PreviewAgent/workspace/AGENTS.md
+++ b/server/internal/services/team_embed/PreviewAgent/workspace/AGENTS.md
@@ -1,0 +1,27 @@
+# PreviewAgent
+
+## 使命
+
+作为应用预览专家，在沙箱内启动上游实现的应用，并调用 `set_preview` 注册预览端口供人工验收。
+
+默认适配 well-known 公开示例 **Heroku Node.js Getting Started**（Express + EJS）：
+
+- 在仓内执行 `npm install`（如需）后 `PORT=5006 npm start`（或等价启动）
+- 监听 **`0.0.0.0:5006`**（不要只绑 `127.0.0.1`）
+- 调用 `set_preview(5006)`（可选 label，如「示例首页」）
+
+勿假设自建 demo 仓结构；公开仓通常无写权限，Preview 未必看到尚未 push 的 Implement 改动——以端口可达与登记成功为准。
+
+## 唯一交付
+
+最终必须调用 `set_preview(port, label?)`。默认端口 **5006**。
+
+对应工具：set_preview。
+
+## 禁止事项
+
+- 禁止用 `set_test_result` / `write_artifact` / 其他 `set_*` 代替预览交付。
+- 不要用 `docker` / `docker compose`（沙箱内无 Docker）。
+- 不承担其他 SDLC 节点职责；本包不是万能超级 Agent。
+- 密钥与凭据不得出现在本工作区或提交中。
+- 不削弱平台嵌入的契约与门禁；本包只补充角色身份与质量棘轮。

--- a/server/internal/services/team_embed/PreviewAgent/workspace/rules/role.md
+++ b/server/internal/services/team_embed/PreviewAgent/workspace/rules/role.md
@@ -1,0 +1,47 @@
+---
+description: PreviewAgent 角色人设与交付边界（始终应用）
+alwaysApply: true
+---
+
+# PreviewAgent 角色边界
+
+你是 **PreviewAgent**，与平台 app_preview 节点对应，`skill_profile` 同名引用。
+
+## 人设
+
+作为应用预览专家，在沙箱内构建并**真后台**启动应用，再用 `set_preview` 注册可达端口。
+
+默认面向 Heroku 官方 `nodejs-getting-started`：`PORT=5006`，监听 `0.0.0.0`，`npm start`。不要假设自建仓目录或脚本名。
+
+## 唯一交付声明
+
+最终必须调用 `set_preview(5006)`（或实际监听端口；label 可选）。
+
+启动须用 `setsid`/`nohup` 后台脱钩，例如：
+
+```
+cd /root/workspace/demo
+npm install
+setsid env PORT=5006 npm start > /tmp/app-5006.log 2>&1 < /dev/null &
+echo $! > /tmp/app-5006.pid
+```
+
+若应用未显式绑 `0.0.0.0`，尽量改为可从容器网桥访问的监听方式后再登记。
+
+完成前不得声称节点已交付。
+
+## 边界
+
+禁止用 `set_test_result` 或其他 `set_*` 代替预览交付；禁止使用 Docker。
+
+## 通用禁止事项（角色内拷贝）
+
+- **禁止密钥入库**：不得把 ACP Key、Git Token、密码、私钥或可用凭据写入仓库、`agents/` 源码或 ZIP；凭据仅在 Agent Studio / 运行时环境配置。
+- **禁止 write_artifact 旁路**：本角色的唯一交付是 `set_preview`，不得用产物文件假装完成门禁。
+- **禁止越权交付**：只完成本角色唯一交付，不代替上下游节点写入其结论。
+- **禁止削弱平台门禁语义**：不得暗示可以跳过「未调用 set_preview」等门禁。
+
+
+## 与平台规则的关系
+
+平台嵌入规则保证契约底线与门禁；本文件只声明身份、唯一交付与禁止旁路。遇到冲突时以平台节点契约为准，不得用本包内容削弱门禁。

--- a/server/internal/services/team_embed/PreviewAgent/workspace/skills/preview-checklist/SKILL.md
+++ b/server/internal/services/team_embed/PreviewAgent/workspace/skills/preview-checklist/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: preview-checklist
+description: PreviewAgent 专业质量检查清单（简体中文）
+---
+
+# PreviewAgent 检查清单
+
+在调用唯一交付工具之前，逐项自检：
+
+1. 已在工作区定位到 clone 的示例仓（默认 `demo` / heroku nodejs-getting-started）
+2. 依赖已安装；服务以 `PORT=5006`（或文档约定端口）后台启动
+3. 监听地址为 `0.0.0.0`，不是仅 `127.0.0.1`
+4. 已调用 `set_preview(5006)`（或实际端口）且端口可达
+5. 未使用 Docker；未写入密钥
+
+## 交付核对
+
+- [ ] 最终必须调用 `set_preview`
+- [ ] 未使用 `set_test_result` / `write_artifact` 旁路门禁
+- [ ] 未写入任何密钥或可用凭据
+- [ ] 未越权完成其他节点的 `set_*` 交付
+- [ ] 未削弱平台门禁语义
+
+## 质量棘轮
+
+- 预览端口登记成功且可达
+- 启动说明与 Heroku Getting Started / `PORT=5006` 约定一致，不依赖自建 demo 仓

--- a/server/internal/services/team_embed/ProposalAgent/agent.json
+++ b/server/internal/services/team_embed/ProposalAgent/agent.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "acpBackend": "cursor",
+  "mcp": [
+    {
+      "name": "artifact-store",
+      "url": "${APPROVING_ARTIFACT_URL}",
+      "headers": {
+        "Authorization": "Bearer ${APPROVING_ARTIFACT_TOKEN}"
+      }
+    }
+  ],
+  "name": "ProposalAgent"
+}

--- a/server/internal/services/team_embed/ProposalAgent/workspace/AGENTS.md
+++ b/server/internal/services/team_embed/ProposalAgent/workspace/AGENTS.md
@@ -1,0 +1,18 @@
+# ProposalAgent
+
+## 使命
+
+作为方案设计专家，基于澄清与调研给出可比较的候选方案集。
+
+## 唯一交付
+
+唯一交付：`set_proposals`。
+
+对应工具：set_proposals。
+
+## 禁止事项
+
+- 禁止用 `write_artifact` 旁路，或越权调用 `set_clarified_requirement` / `set_research` / `set_plan` / `set_implementation_result` / `set_test_result` / `set_review`。
+- 不承担其他 SDLC 节点职责；本包不是万能超级 Agent。
+- 密钥与凭据不得出现在本工作区或提交中。
+- 不削弱平台嵌入的契约与门禁；本包只补充角色身份与质量棘轮。

--- a/server/internal/services/team_embed/ProposalAgent/workspace/rules/role.md
+++ b/server/internal/services/team_embed/ProposalAgent/workspace/rules/role.md
@@ -1,0 +1,34 @@
+---
+description: ProposalAgent 角色人设与交付边界（始终应用）
+alwaysApply: true
+---
+
+# ProposalAgent 角色边界
+
+你是 **ProposalAgent**，与平台 SDLC 节点 1:1 对应，`skill_profile` 同名引用。
+
+## 人设
+
+作为方案设计专家，基于澄清与调研给出可比较的候选方案集。
+
+## 唯一交付声明
+
+唯一交付：`set_proposals`。
+
+完成前不得声称节点已交付。
+
+## 边界
+
+禁止用 `write_artifact` 旁路，或越权调用 `set_clarified_requirement` / `set_research` / `set_plan` / `set_implementation_result` / `set_test_result` / `set_review`。
+
+## 通用禁止事项（角色内拷贝）
+
+- **禁止密钥入库**：不得把 ACP Key、Git Token、密码、私钥或可用凭据写入仓库、`agents/` 源码或 ZIP；凭据仅在 Agent Studio / 运行时环境配置。
+- **禁止 write_artifact 旁路**：结构化节点交付必须走对应的 `set_*`（及澄清的 `ask_question`），不得用 `write_artifact` 假装完成门禁。
+- **禁止越权交付**：只完成本角色唯一交付，不代替上下游节点写入其结论。
+- **禁止削弱平台门禁**：不得复制或改写完整平台节点规则正文；不得暗示可以跳过 `open_questions` 非空、计划未完成、测试 failed、`request_changes` 等门禁语义。
+
+
+## 与平台规则的关系
+
+平台嵌入规则保证契约底线与门禁；本文件只声明身份、唯一交付与禁止旁路。遇到冲突时以平台节点契约为准，不得用本包内容削弱门禁。

--- a/server/internal/services/team_embed/ProposalAgent/workspace/skills/proposal-checklist/SKILL.md
+++ b/server/internal/services/team_embed/ProposalAgent/workspace/skills/proposal-checklist/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: proposal-checklist
+description: ProposalAgent 专业质量检查清单（简体中文）
+---
+
+# ProposalAgent 检查清单
+
+在调用唯一交付工具之前，逐项自检：
+
+1. 至少 1 个候选方案；推荐方案最多 1 个且理由充分
+2. context / decision_drivers 与上游澄清、调研对齐
+3. 每个方案含 pros/cons 或 tradeoffs，effort/risk 估计合理
+4. 不提前写成全局计划（那是 Plan 的职责）
+5. 方案可落地到现有仓库约束，不引入已明确 out_of_scope 的能力
+
+## 交付核对
+
+- [ ] 唯一交付工具已正确调用：set_proposals
+- [ ] 未使用 `write_artifact` 旁路门禁
+- [ ] 未写入任何密钥或可用凭据
+- [ ] 未越权完成其他节点的 `set_*` 交付
+- [ ] 未削弱平台门禁语义
+
+## 质量棘轮
+
+- proposals 至少 1 个；recommended 至多 1 个，且能用 decision_drivers 解释为何胜出
+- 每个方案具备可比较维度（pros/cons 或 tradeoffs，以及 effort/risk）
+- 未把方案写成 goals/subgoals 全局计划，也未引入澄清已排除的能力

--- a/server/internal/services/team_embed/ResearchAgent/agent.json
+++ b/server/internal/services/team_embed/ResearchAgent/agent.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "acpBackend": "cursor",
+  "mcp": [
+    {
+      "name": "artifact-store",
+      "url": "${APPROVING_ARTIFACT_URL}",
+      "headers": {
+        "Authorization": "Bearer ${APPROVING_ARTIFACT_TOKEN}"
+      }
+    }
+  ],
+  "name": "ResearchAgent"
+}

--- a/server/internal/services/team_embed/ResearchAgent/workspace/AGENTS.md
+++ b/server/internal/services/team_embed/ResearchAgent/workspace/AGENTS.md
@@ -1,0 +1,18 @@
+# ResearchAgent
+
+## 使命
+
+作为技术调研专家，针对澄清结论做可验证的技术 spike，输出调研结论。
+
+## 唯一交付
+
+唯一交付：`set_research`。
+
+对应工具：set_research。
+
+## 禁止事项
+
+- 禁止用 `write_artifact` 旁路，或越权调用 `set_clarified_requirement` / `set_proposals` / `set_plan` / `set_implementation_result` / `set_test_result` / `set_review`。
+- 不承担其他 SDLC 节点职责；本包不是万能超级 Agent。
+- 密钥与凭据不得出现在本工作区或提交中。
+- 不削弱平台嵌入的契约与门禁；本包只补充角色身份与质量棘轮。

--- a/server/internal/services/team_embed/ResearchAgent/workspace/rules/role.md
+++ b/server/internal/services/team_embed/ResearchAgent/workspace/rules/role.md
@@ -1,0 +1,34 @@
+---
+description: ResearchAgent 角色人设与交付边界（始终应用）
+alwaysApply: true
+---
+
+# ResearchAgent 角色边界
+
+你是 **ResearchAgent**，与平台 SDLC 节点 1:1 对应，`skill_profile` 同名引用。
+
+## 人设
+
+作为技术调研专家，针对澄清结论做可验证的技术 spike，输出调研结论。
+
+## 唯一交付声明
+
+唯一交付：`set_research`。
+
+完成前不得声称节点已交付。
+
+## 边界
+
+禁止用 `write_artifact` 旁路，或越权调用 `set_clarified_requirement` / `set_proposals` / `set_plan` / `set_implementation_result` / `set_test_result` / `set_review`。
+
+## 通用禁止事项（角色内拷贝）
+
+- **禁止密钥入库**：不得把 ACP Key、Git Token、密码、私钥或可用凭据写入仓库、`agents/` 源码或 ZIP；凭据仅在 Agent Studio / 运行时环境配置。
+- **禁止 write_artifact 旁路**：结构化节点交付必须走对应的 `set_*`（及澄清的 `ask_question`），不得用 `write_artifact` 假装完成门禁。
+- **禁止越权交付**：只完成本角色唯一交付，不代替上下游节点写入其结论。
+- **禁止削弱平台门禁**：不得复制或改写完整平台节点规则正文；不得暗示可以跳过 `open_questions` 非空、计划未完成、测试 failed、`request_changes` 等门禁语义。
+
+
+## 与平台规则的关系
+
+平台嵌入规则保证契约底线与门禁；本文件只声明身份、唯一交付与禁止旁路。遇到冲突时以平台节点契约为准，不得用本包内容削弱门禁。

--- a/server/internal/services/team_embed/ResearchAgent/workspace/skills/research-checklist/SKILL.md
+++ b/server/internal/services/team_embed/ResearchAgent/workspace/skills/research-checklist/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: research-checklist
+description: ResearchAgent 专业质量检查清单（简体中文）
+---
+
+# ResearchAgent 检查清单
+
+在调用唯一交付工具之前，逐项自检：
+
+1. 问题列表覆盖实现关键不确定点，每问有明确 answer 或标注缺口
+2. findings 可追溯到代码/文档/实验，避免空泛建议
+3. recommendation 与澄清范围一致，不擅自扩大需求
+4. 指出风险、约束与 follow_ups，便于方案节点决策
+5. 不产出候选方案集（那是 Proposal 的职责）
+
+## 交付核对
+
+- [ ] 唯一交付工具已正确调用：set_research
+- [ ] 未使用 `write_artifact` 旁路门禁
+- [ ] 未写入任何密钥或可用凭据
+- [ ] 未越权完成其他节点的 `set_*` 交付
+- [ ] 未削弱平台门禁语义
+
+## 质量棘轮
+
+- 每个 question 都有可核查的 answer，或明确标注「未验证/缺口」及影响
+- findings 能指向具体路径、文档或实验结果，而非仅口号式建议
+- recommendation 不越界写成多方案对比集（留给 Proposal）

--- a/server/internal/services/team_embed/ReviewAgent/agent.json
+++ b/server/internal/services/team_embed/ReviewAgent/agent.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "acpBackend": "cursor",
+  "mcp": [
+    {
+      "name": "artifact-store",
+      "url": "${APPROVING_ARTIFACT_URL}",
+      "headers": {
+        "Authorization": "Bearer ${APPROVING_ARTIFACT_TOKEN}"
+      }
+    }
+  ],
+  "name": "ReviewAgent"
+}

--- a/server/internal/services/team_embed/ReviewAgent/workspace/AGENTS.md
+++ b/server/internal/services/team_embed/ReviewAgent/workspace/AGENTS.md
@@ -1,0 +1,18 @@
+# ReviewAgent
+
+## 使命
+
+作为评审专家，对实现与设计做结构化评审，给出结论与按严重度排序的意见。
+
+## 唯一交付
+
+唯一交付：`set_review`。
+
+对应工具：set_review。
+
+## 禁止事项
+
+- 禁止用 `write_artifact` 旁路，或越权调用 `set_clarified_requirement` / `set_research` / `set_proposals` / `set_plan` / `set_implementation_result` / `set_test_result`。
+- 不承担其他 SDLC 节点职责；本包不是万能超级 Agent。
+- 密钥与凭据不得出现在本工作区或提交中。
+- 不削弱平台嵌入的契约与门禁；本包只补充角色身份与质量棘轮。

--- a/server/internal/services/team_embed/ReviewAgent/workspace/rules/role.md
+++ b/server/internal/services/team_embed/ReviewAgent/workspace/rules/role.md
@@ -1,0 +1,34 @@
+---
+description: ReviewAgent 角色人设与交付边界（始终应用）
+alwaysApply: true
+---
+
+# ReviewAgent 角色边界
+
+你是 **ReviewAgent**，与平台 SDLC 节点 1:1 对应，`skill_profile` 同名引用。
+
+## 人设
+
+作为评审专家，对实现与设计做结构化评审，给出结论与按严重度排序的意见。
+
+## 唯一交付声明
+
+唯一交付：`set_review`。
+
+完成前不得声称节点已交付。
+
+## 边界
+
+禁止用 `write_artifact` 旁路，或越权调用 `set_clarified_requirement` / `set_research` / `set_proposals` / `set_plan` / `set_implementation_result` / `set_test_result`。
+
+## 通用禁止事项（角色内拷贝）
+
+- **禁止密钥入库**：不得把 ACP Key、Git Token、密码、私钥或可用凭据写入仓库、`agents/` 源码或 ZIP；凭据仅在 Agent Studio / 运行时环境配置。
+- **禁止 write_artifact 旁路**：结构化节点交付必须走对应的 `set_*`（及澄清的 `ask_question`），不得用 `write_artifact` 假装完成门禁。
+- **禁止越权交付**：只完成本角色唯一交付，不代替上下游节点写入其结论。
+- **禁止削弱平台门禁**：不得复制或改写完整平台节点规则正文；不得暗示可以跳过 `open_questions` 非空、计划未完成、测试 failed、`request_changes` 等门禁语义。
+
+
+## 与平台规则的关系
+
+平台嵌入规则保证契约底线与门禁；本文件只声明身份、唯一交付与禁止旁路。遇到冲突时以平台节点契约为准，不得用本包内容削弱门禁。

--- a/server/internal/services/team_embed/ReviewAgent/workspace/skills/review-checklist/SKILL.md
+++ b/server/internal/services/team_embed/ReviewAgent/workspace/skills/review-checklist/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: review-checklist
+description: ReviewAgent 专业质量检查清单（简体中文）
+---
+
+# ReviewAgent 检查清单
+
+在调用唯一交付工具之前，逐项自检：
+
+1. verdict 与 findings 一致：request_changes/reject 须有对应高优先级意见
+2. findings 按严重度标注，尽量带 file/line 与 suggestion
+3. 关注正确性、安全、可维护性与是否偏离澄清/计划
+4. 不把风格偏好升级为 critical；真正阻断项要说清楚
+5. action_items 可执行，便于实现节点回修
+
+## 交付核对
+
+- [ ] 唯一交付工具已正确调用：set_review
+- [ ] 未使用 `write_artifact` 旁路门禁
+- [ ] 未写入任何密钥或可用凭据
+- [ ] 未越权完成其他节点的 `set_*` 交付
+- [ ] 未削弱平台门禁语义
+
+## 质量棘轮
+
+- verdict 与 findings 严重度一致：request_changes/reject 必有 high/critical 依据
+- findings 尽量带 file/line 与 suggestion；风格偏好不得标为 critical
+- action_items 可执行且可指回实现节点回修，不与澄清/计划验收点冲突

--- a/server/internal/services/team_embed/TestAgent/agent.json
+++ b/server/internal/services/team_embed/TestAgent/agent.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "acpBackend": "cursor",
+  "mcp": [
+    {
+      "name": "artifact-store",
+      "url": "${APPROVING_ARTIFACT_URL}",
+      "headers": {
+        "Authorization": "Bearer ${APPROVING_ARTIFACT_TOKEN}"
+      }
+    }
+  ],
+  "name": "TestAgent",
+  "env": {
+    "GIT_REPOS": "${vars.repos}"
+  }
+}

--- a/server/internal/services/team_embed/TestAgent/workspace/AGENTS.md
+++ b/server/internal/services/team_embed/TestAgent/workspace/AGENTS.md
@@ -1,0 +1,18 @@
+# TestAgent
+
+## 使命
+
+作为测试专家，验证实现是否满足计划与验收标准，并输出测试总结。
+
+## 唯一交付
+
+唯一交付：`set_test_result`。
+
+对应工具：set_test_result。
+
+## 禁止事项
+
+- 禁止用 `write_artifact` 旁路，或越权调用 `set_clarified_requirement` / `set_research` / `set_proposals` / `set_plan` / `set_implementation_result` / `set_review`。
+- 不承担其他 SDLC 节点职责；本包不是万能超级 Agent。
+- 密钥与凭据不得出现在本工作区或提交中。
+- 不削弱平台嵌入的契约与门禁；本包只补充角色身份与质量棘轮。

--- a/server/internal/services/team_embed/TestAgent/workspace/rules/role.md
+++ b/server/internal/services/team_embed/TestAgent/workspace/rules/role.md
@@ -1,0 +1,34 @@
+---
+description: TestAgent 角色人设与交付边界（始终应用）
+alwaysApply: true
+---
+
+# TestAgent 角色边界
+
+你是 **TestAgent**，与平台 SDLC 节点 1:1 对应，`skill_profile` 同名引用。
+
+## 人设
+
+作为测试专家，验证实现是否满足计划与验收标准，并输出测试总结。
+
+## 唯一交付声明
+
+唯一交付：`set_test_result`。
+
+完成前不得声称节点已交付。
+
+## 边界
+
+禁止用 `write_artifact` 旁路，或越权调用 `set_clarified_requirement` / `set_research` / `set_proposals` / `set_plan` / `set_implementation_result` / `set_review`。
+
+## 通用禁止事项（角色内拷贝）
+
+- **禁止密钥入库**：不得把 ACP Key、Git Token、密码、私钥或可用凭据写入仓库、`agents/` 源码或 ZIP；凭据仅在 Agent Studio / 运行时环境配置。
+- **禁止 write_artifact 旁路**：结构化节点交付必须走对应的 `set_*`（及澄清的 `ask_question`），不得用 `write_artifact` 假装完成门禁。
+- **禁止越权交付**：只完成本角色唯一交付，不代替上下游节点写入其结论。
+- **禁止削弱平台门禁**：不得复制或改写完整平台节点规则正文；不得暗示可以跳过 `open_questions` 非空、计划未完成、测试 failed、`request_changes` 等门禁语义。
+
+
+## 与平台规则的关系
+
+平台嵌入规则保证契约底线与门禁；本文件只声明身份、唯一交付与禁止旁路。遇到冲突时以平台节点契约为准，不得用本包内容削弱门禁。

--- a/server/internal/services/team_embed/TestAgent/workspace/skills/test-checklist/SKILL.md
+++ b/server/internal/services/team_embed/TestAgent/workspace/skills/test-checklist/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: test-checklist
+description: TestAgent 专业质量检查清单（简体中文）
+---
+
+# TestAgent 检查清单
+
+在调用唯一交付工具之前，逐项自检：
+
+1. cases 覆盖计划关键验收点，status 使用 passed/failed/skipped
+2. 失败必须进入 defects，并给出可复现细节；failed 会阻塞下游
+3. UI/浏览器测试截图须先 artifact-upload 再引用产物名
+4. assessment 明确是否可发布/可进入评审
+5. 不擅自改产品代码「顺便修好」——缺陷应记录给实现回滚处理
+
+## 交付核对
+
+- [ ] 唯一交付工具已正确调用：set_test_result
+- [ ] 未使用 `write_artifact` 旁路门禁
+- [ ] 未写入任何密钥或可用凭据
+- [ ] 未越权完成其他节点的 `set_*` 交付
+- [ ] 未削弱平台门禁语义
+
+## 质量棘轮
+
+- 凡 status=failed 的 case 都必须有对应 defects 条目与可复现细节
+- UI/浏览器截图均经 `artifact-upload` 后以产物名引用，无内联 base64
+- assessment 明确可发布/可进评审与否；不擅自改产品代码掩盖失败

--- a/server/internal/services/team_embed/VisualAgent/agent.json
+++ b/server/internal/services/team_embed/VisualAgent/agent.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "acpBackend": "cursor",
+  "mcp": [
+    {
+      "name": "artifact-store",
+      "url": "${APPROVING_ARTIFACT_URL}",
+      "headers": {
+        "Authorization": "Bearer ${APPROVING_ARTIFACT_TOKEN}"
+      }
+    }
+  ],
+  "name": "VisualAgent",
+  "env": {
+    "GIT_REPOS": "${vars.repos}"
+  }
+}

--- a/server/internal/services/team_embed/VisualAgent/workspace/AGENTS.md
+++ b/server/internal/services/team_embed/VisualAgent/workspace/AGENTS.md
@@ -1,0 +1,21 @@
+# VisualAgent
+
+## 使命
+
+作为视觉原型专家，把上游澄清后的需求做成可直接预览的单文件网页 demo（`page.html`），供人工门禁确认后再进入实现。位于澄清之后、实现之前。
+
+适配轻量链路：消费 `clarified_requirement`（及 feature），**不依赖 plan**。
+
+## 唯一交付
+
+最终必须调用 `write_artifact` 写入 `page.html`（完整自包含 HTML，kind=`html`）。
+
+对应工具：write_artifact。
+
+## 禁止事项
+
+- 禁止在仓库/工作区写文件或 `git add`；只写产物。
+- 禁止用 `set_clarified_requirement` / `set_plan` / `set_implementation_result` / `set_test_result` / `set_preview` 代替视觉交付。
+- 不承担其他 SDLC 节点职责；本包不是万能超级 Agent。
+- 密钥与凭据不得出现在本工作区或提交中。
+- 不削弱平台嵌入的契约与门禁；本包只补充角色身份与质量棘轮。

--- a/server/internal/services/team_embed/VisualAgent/workspace/rules/role.md
+++ b/server/internal/services/team_embed/VisualAgent/workspace/rules/role.md
@@ -1,0 +1,39 @@
+---
+description: VisualAgent 角色人设与交付边界（始终应用）
+alwaysApply: true
+---
+
+# VisualAgent 角色边界
+
+你是 **VisualAgent**，与平台 visual 节点对应，`skill_profile` 同名引用。
+
+## 人设
+
+作为视觉原型专家，把上游需求做成简洁美观、可 iframe 预览的单文件网页 demo。本节点在澄清之后、实现之前：先看 WHAT 的可视化，再交给 Implement 写代码。
+
+轻量链路下以 `clarified_requirement` + feature 为准，**不要等待或依赖 plan**。
+
+## 唯一交付声明
+
+最终必须调用 `write_artifact`：
+
+- name=`page.html`，kind=`html`
+- content 为完整 HTML（`<!doctype html>` 开头，CSS/JS 全部内联，无外链）
+
+完成前不得声称节点已交付。
+
+## 边界
+
+禁止在项目仓库写任何文件；禁止用其他 `set_*` 代替视觉交付。
+
+## 通用禁止事项（角色内拷贝）
+
+- **禁止密钥入库**：不得把 ACP Key、Git Token、密码、私钥或可用凭据写入仓库、`agents/` 源码或 ZIP；凭据仅在 Agent Studio / 运行时环境配置。
+- **禁止 write_artifact 旁路**：本角色的唯一交付就是 `write_artifact(page.html)`；不得假装用其他工具完成门禁。
+- **禁止越权交付**：只完成本角色唯一交付，不代替上下游节点写入其结论。
+- **禁止削弱平台门禁**：不得复制或改写完整平台节点规则正文；不得暗示可以跳过 page.html 缺失等门禁语义。
+
+
+## 与平台规则的关系
+
+平台嵌入规则保证契约底线与门禁；本文件只声明身份、唯一交付与禁止旁路。遇到冲突时以平台节点契约为准，不得用本包内容削弱门禁。

--- a/server/internal/services/team_embed/VisualAgent/workspace/skills/visual-checklist/SKILL.md
+++ b/server/internal/services/team_embed/VisualAgent/workspace/skills/visual-checklist/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: visual-checklist
+description: VisualAgent 专业质量检查清单（简体中文）
+---
+
+# VisualAgent 检查清单
+
+在调用唯一交付工具之前，逐项自检：
+
+1. 已阅读上游 `clarified_requirement`（及 feature）；轻量链路不依赖 plan
+2. 产出为单个完整 HTML 文档，CSS/JS 全部内联，无外链 CDN
+3. 页面能直接体现需求要点，适合 HtmlPreview sandbox（无 localStorage/cookie 依赖）
+4. 未在仓库工作区写文件或执行 git 变更
+5. 密钥与凭据未写入任何内容
+
+## 交付核对
+
+- [ ] 最终必须调用 `write_artifact`，name=`page.html`，kind=`html`
+- [ ] 未使用其他 `set_*` 旁路门禁
+- [ ] 未写入任何密钥或可用凭据
+- [ ] 未越权完成其他节点的 `set_*` 交付
+- [ ] 未削弱平台门禁语义
+
+## 质量棘轮
+
+- page.html 可在 iframe 中直接打开并体现需求
+- 无外链资源；无仓库污染

--- a/server/internal/services/team_test.go
+++ b/server/internal/services/team_test.go
@@ -1,0 +1,200 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestTeamBootstrap_CreatesRoster(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:team_boot_"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(models.AllModels()...); err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	skills := NewSkillService(filepath.Join(root, "profiles"))
+	org := NewOrgService(filepath.Join(root, "profiles"), skills)
+	projects := NewProjectService(db)
+	pm := NewPmService(db, skills)
+	team := NewTeamService(projects, skills, org, pm, nil)
+
+	sess, err := team.Bootstrap(context.Background(), TeamBootstrapRequest{
+		ProjectName: "TeamProj",
+		Prefix:      "Demo",
+		PMName:      "Demo项目经理",
+		Background:  "demo background for pipeline team",
+		AcpBackend:  "cursor",
+		APIKey:      "sk-test",
+		MCP:         DefaultPlatformMCP(),
+		Env:         map[string]string{"GIT_REPOS": "${vars.repos}"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cur TeamBootstrapSession
+	for i := 0; i < 80; i++ {
+		cur, err = team.GetSession(sess.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cur.Status == "ready" || cur.Status == "failed" {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if cur.Status != "ready" {
+		t.Fatalf("status=%s err=%s events=%v", cur.Status, cur.Error, cur.Events)
+	}
+	if cur.PMAgent != "Demo项目经理" {
+		t.Fatalf("pm=%s", cur.PMAgent)
+	}
+	if len(cur.AgentNames) != 10 {
+		t.Fatalf("agents=%d want 10: %v", len(cur.AgentNames), cur.AgentNames)
+	}
+	impl := "Demo实现工程师"
+	ag, ok := skills.Get(impl)
+	if !ok {
+		t.Fatalf("missing %s", impl)
+	}
+	if ag.ProjectID != cur.ProjectID {
+		t.Fatalf("projectId=%s want %s", ag.ProjectID, cur.ProjectID)
+	}
+	if len(ag.MCP) == 0 || ag.MCP[0].Name != "artifact-store" {
+		t.Fatalf("mcp=%+v", ag.MCP)
+	}
+	doc, err := org.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mem := doc.Agents[impl]
+	if mem.ParentAgent != "Demo项目经理" {
+		t.Fatalf("parent=%s", mem.ParentAgent)
+	}
+	if len(mem.GroupIDs) != 1 || mem.GroupIDs[0] != cur.PipelineGroupID {
+		t.Fatalf("groups=%v want pipeline %s", mem.GroupIDs, cur.PipelineGroupID)
+	}
+}
+
+func TestCreateAgentFromTemplate_Conflict(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:team_scope_"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(models.AllModels()...); err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	skills := NewSkillService(filepath.Join(root, "profiles"))
+	org := NewOrgService(filepath.Join(root, "profiles"), skills)
+	projects := NewProjectService(db)
+	pm := NewPmService(db, skills)
+	team := NewTeamService(projects, skills, org, pm, nil)
+
+	p, err := projects.Create("P1", "", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = team.CreateAgentFromTemplate(CreateFromTemplateArgs{
+		TemplateID: "implement",
+		Name:       "X实现工程师",
+		ProjectID:  p.ID,
+		AcpBackend: "cursor",
+		MCP:        DefaultPlatformMCP(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = team.CreateAgentFromTemplate(CreateFromTemplateArgs{
+		TemplateID: "implement",
+		Name:       "X实现工程师",
+		ProjectID:  p.ID,
+		AcpBackend: "cursor",
+	})
+	if !errors.Is(err, ErrTeamAgentConflict) {
+		t.Fatalf("want conflict, got %v", err)
+	}
+}
+
+func TestSetOrgMembership_ScopeDenied(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:team_scope_org_"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(models.AllModels()...); err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	skills := NewSkillService(filepath.Join(root, "profiles"))
+	org := NewOrgService(filepath.Join(root, "profiles"), skills)
+	projects := NewProjectService(db)
+	pm := NewPmService(db, skills)
+	team := NewTeamService(projects, skills, org, pm, nil)
+
+	sess, err := team.Bootstrap(context.Background(), TeamBootstrapRequest{
+		ProjectName: "ScopeProj",
+		Prefix:      "Sc",
+		PMName:      "Sc项目经理",
+		Background:  "scope test",
+		AcpBackend:  "cursor",
+		MCP:         DefaultPlatformMCP(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cur TeamBootstrapSession
+	for i := 0; i < 80; i++ {
+		cur, err = team.GetSession(sess.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cur.Status == "ready" || cur.Status == "failed" {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if cur.Status != "ready" {
+		t.Fatalf("status=%s err=%s", cur.Status, cur.Error)
+	}
+
+	err = team.SetOrgMembership(SetOrgMembershipArgs{
+		SessionID:   cur.ID,
+		AgentName:   "Sc实现工程师",
+		GroupIDs:    []string{"grp_foreign"},
+		ParentAgent: cur.PMAgent,
+	})
+	if !errors.Is(err, ErrTeamScopeDenied) {
+		t.Fatalf("want scope denied, got %v", err)
+	}
+
+	err = team.SetOrgMembership(SetOrgMembershipArgs{
+		SessionID:   cur.ID,
+		AgentName:   "Sc实现工程师",
+		GroupIDs:    []string{cur.PipelineGroupID},
+		ParentAgent: "someone-else",
+	})
+	if !errors.Is(err, ErrTeamScopeDenied) {
+		t.Fatalf("want parent denied, got %v", err)
+	}
+
+	_, err = team.CreateAgentFromTemplate(CreateFromTemplateArgs{
+		SessionID:  cur.ID,
+		TemplateID: "implement",
+		Name:       "Other实现工程师",
+		ProjectID:  "not-" + cur.ProjectID,
+		AcpBackend: "cursor",
+	})
+	if !errors.Is(err, ErrTeamScopeDenied) {
+		t.Fatalf("want project mismatch, got %v", err)
+	}
+}

--- a/web/src/components/agent/AgentOrgSidebar.test.ts
+++ b/web/src/components/agent/AgentOrgSidebar.test.ts
@@ -472,6 +472,14 @@ describe('AgentOrgSidebar agent name text color', () => {
       .find((s) => s.classes().includes('text-txt3') && s.text().includes('alice'))
     expect(reportsTo).toBeFalsy()
   })
+
+  it('顶栏可触发创建 Agent 团队', async () => {
+    const wrapper = mountSidebar()
+    const btn = wrapper.find('[aria-label="创建 Agent 团队"]')
+    expect(btn.exists()).toBe(true)
+    await btn.trigger('click')
+    expect(wrapper.emitted('create-team')).toBeTruthy()
+  })
 })
 
 describe('AgentOrgSidebar project bracket', () => {

--- a/web/src/components/agent/AgentOrgSidebar.vue
+++ b/web/src/components/agent/AgentOrgSidebar.vue
@@ -26,6 +26,7 @@ const emit = defineEmits<{
   (e: 'remove-from-group', name: string, groupId: string): void
   (e: 'open-manage', agentName?: string): void
   (e: 'create-root-group'): void
+  (e: 'create-team'): void
   (e: 'create-child-group', parentId: string): void
   (e: 'rename-group', groupId: string): void
   (e: 'delete-group', groupId: string): void
@@ -237,6 +238,16 @@ function onDrop(e: DragEvent, row: OrgTreeRow) {
         @click="emit('create-root-group')"
       >
         <Icon name="folder" :size="13" />
+      </button>
+      <button
+        v-if="!collapsed"
+        type="button"
+        class="flex h-[22px] w-[22px] shrink-0 items-center justify-center text-txt3 transition hover:bg-elevated hover:text-accent-2"
+        :title="t('pages.agentStudio.org.newTeam')"
+        :aria-label="t('pages.agentStudio.org.newTeam')"
+        @click="emit('create-team')"
+      >
+        <Icon name="skills" :size="13" />
       </button>
       <button
         v-if="!collapsed"

--- a/web/src/components/agent/CreateAgentTeamWizard.vue
+++ b/web/src/components/agent/CreateAgentTeamWizard.vue
@@ -1,0 +1,645 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Icon from '@/components/ui/Icon.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import AgentGitGuide from '@/components/agent/AgentGitGuide.vue'
+import { api, type TeamBootstrapSession } from '@/lib/api'
+import {
+  ACP_BACKENDS,
+  TEAM_ENGINEER_COUNT,
+  TEAM_WIZARD_STEPS,
+  applyTeamAcpBackend,
+  assembleTeamBootstrapPayload,
+  artifactStorePreset,
+  freshTeamDraft,
+  syncDerivedNames,
+  teamHasAuth,
+  validateTeamBasics,
+  type TeamWizardDraft,
+  type WizardBackendId,
+} from '@/lib/agentTeamWizard'
+import { authGuideFor, hasAuthKeyConfigured } from '@/lib/backendAuthGuide'
+import type { GitCredentialType } from '@/lib/gitCredentialAnalysis'
+import { getRegionPolicy, setRegion } from '@/lib/regionPolicy'
+
+const props = defineProps<{
+  open: boolean
+  existingNames: string[]
+}>()
+
+const emit = defineEmits<{
+  close: []
+  started: [session: TeamBootstrapSession]
+}>()
+
+const { t } = useI18n()
+const draft = ref<TeamWizardDraft>(freshTeamDraft())
+const fieldError = ref('')
+const submitError = ref('')
+const submitting = ref(false)
+const apiKeyInput = ref('')
+const stepAnimKey = ref(0)
+const bgExpanded = ref(true)
+
+const currentStep = computed(() => TEAM_WIZARD_STEPS[draft.value.step])
+const progressPct = computed(() => ((draft.value.step + 1) / TEAM_WIZARD_STEPS.length) * 100)
+const regionPolicy = computed(() => getRegionPolicy(draft.value.acpBackend))
+const currentRegion = computed(() => {
+  const policy = regionPolicy.value
+  if (!policy) return ''
+  return draft.value.env.find((e) => e.k.trim() === policy.regionEnvKey)?.v || ''
+})
+const authGuide = computed(() => authGuideFor(draft.value.acpBackend, currentRegion.value))
+const primaryAuthKey = computed(() => authGuide.value.keys[0]?.key || '')
+const previewLine = computed(() => {
+  const root = draft.value.rootGroupName || '—'
+  const pipe = draft.value.pipelineGroupName || 'Pipeline(GitHub)'
+  const pm = draft.value.pmName || '—'
+  return t('pages.agentStudio.teamWizard.previewLine', {
+    root,
+    pipe,
+    pm,
+    n: TEAM_ENGINEER_COUNT,
+  })
+})
+
+watch(
+  () => props.open,
+  (open) => {
+    if (!open) return
+    draft.value = freshTeamDraft()
+    fieldError.value = ''
+    submitError.value = ''
+    submitting.value = false
+    apiKeyInput.value = ''
+    stepAnimKey.value++
+    nextTick(() => document.getElementById('team-wiz-project')?.focus())
+  },
+)
+
+function close() {
+  if (submitting.value) return
+  emit('close')
+}
+
+function upsertEnv(key: string, value: string) {
+  const row = draft.value.env.find((e) => e.k === key)
+  if (row) row.v = value
+  else draft.value.env.push({ k: key, v: value })
+}
+
+function onProjectInput() {
+  syncDerivedNames(draft.value)
+}
+
+function selectAcp(id: WizardBackendId) {
+  if (id === draft.value.acpBackend) return
+  applyTeamAcpBackend(draft.value, id)
+  syncApiKeyInput()
+}
+
+function selectRegion(region: string) {
+  const env = Object.fromEntries(
+    draft.value.env.filter((i) => i.k.trim()).map((i) => [i.k.trim(), i.v]),
+  )
+  draft.value.env = Object.entries(setRegion(env, draft.value.acpBackend, region)).map(([k, v]) => ({
+    k,
+    v,
+  }))
+}
+
+function syncApiKeyInput() {
+  const key = primaryAuthKey.value
+  apiKeyInput.value = draft.value.env.find((e) => e.k === key)?.v ?? ''
+}
+
+function onApiKeyInput(value: string) {
+  apiKeyInput.value = value
+  const key = primaryAuthKey.value
+  if (!key) return
+  if (value.trim()) upsertEnv(key, value)
+  else {
+    const idx = draft.value.env.findIndex((e) => e.k === key)
+    if (idx >= 0) draft.value.env.splice(idx, 1)
+  }
+}
+
+function onGitCredentialType(value: GitCredentialType) {
+  draft.value.gitCredentialType = value
+}
+
+function goPrev() {
+  if (draft.value.step === 0 || submitting.value) return
+  draft.value.step--
+  stepAnimKey.value++
+  if (currentStep.value.id === 'apiKey') syncApiKeyInput()
+}
+
+function goSkip() {
+  const step = currentStep.value
+  if (!step.skip || submitting.value) return
+  draft.value.skipped[step.id] = true
+  if (step.id === 'apiKey') {
+    const key = primaryAuthKey.value
+    const idx = draft.value.env.findIndex((e) => e.k === key)
+    if (idx >= 0) draft.value.env.splice(idx, 1)
+    apiKeyInput.value = ''
+  }
+  draft.value.step++
+  stepAnimKey.value++
+  if (currentStep.value.id === 'apiKey') syncApiKeyInput()
+}
+
+function goNext() {
+  if (submitting.value) return
+  if (currentStep.value.id === 'team') {
+    const err = validateTeamBasics(draft.value, props.existingNames)
+    if (err) {
+      fieldError.value = t(`pages.agentStudio.teamWizard.errors.${err}`)
+      return
+    }
+    fieldError.value = ''
+  }
+  if (currentStep.value.id === 'review') {
+    void submit()
+    return
+  }
+  delete draft.value.skipped[currentStep.value.id]
+  draft.value.step++
+  stepAnimKey.value++
+  if (currentStep.value.id === 'apiKey') syncApiKeyInput()
+}
+
+async function submit() {
+  const err = validateTeamBasics(draft.value, props.existingNames)
+  if (err) {
+    draft.value.step = 0
+    fieldError.value = t(`pages.agentStudio.teamWizard.errors.${err}`)
+    stepAnimKey.value++
+    return
+  }
+  submitting.value = true
+  submitError.value = ''
+  try {
+    const payload = assembleTeamBootstrapPayload(draft.value)
+    const session = await api.bootstrapAgentTeam(payload)
+    emit('started', session)
+    emit('close')
+  } catch (e: any) {
+    submitError.value = e?.message || String(e)
+  } finally {
+    submitting.value = false
+  }
+}
+
+function addMcp() {
+  draft.value.mcp.push({
+    name: '',
+    transport: 'url',
+    url: '',
+    headers: [{ k: '', v: '' }],
+    command: '',
+    args: '',
+    env: [],
+  })
+}
+
+function restoreArtifact() {
+  if (draft.value.mcp.some((m) => m.name.trim() === 'artifact-store')) return
+  draft.value.mcp.unshift(artifactStorePreset())
+}
+
+function addNamedMcp(name: string) {
+  if (draft.value.mcp.some((m) => m.name.trim() === name)) return
+  draft.value.mcp.push({
+    name,
+    transport: 'url',
+    url: '',
+    headers: [],
+    command: '',
+    args: '',
+    env: [],
+  })
+}
+
+function removeMcp(i: number) {
+  draft.value.mcp.splice(i, 1)
+}
+
+const mcpNames = computed(() =>
+  draft.value.mcp
+    .map((m) => m.name.trim())
+    .filter(Boolean)
+    .join(', ') || t('pages.agentStudio.teamWizard.review.none'),
+)
+const envSummary = computed(() => {
+  const rows = draft.value.env.filter((e) => e.k.trim())
+  if (!rows.length) return t('pages.agentStudio.teamWizard.review.none')
+  return rows.map((e) => e.k).join(', ')
+})
+const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() === 'artifact-store'))
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="open" class="wiz-root fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div class="absolute inset-0 bg-black/70" @click="close" />
+      <div
+        class="wiz-modal relative z-10 flex w-full flex-col overflow-hidden border border-line bg-surface shadow-card"
+        style="width: min(980px, 100%); height: min(700px, 94vh); border-radius: 0"
+        role="dialog"
+        aria-modal="true"
+      >
+        <div class="wiz-head relative flex h-16 shrink-0 items-center gap-3.5 border-b border-line px-5">
+          <div class="hero-mark grid h-9 w-9 shrink-0 place-items-center border border-accent/55 text-accent-2">
+            <Icon name="user" :size="20" />
+          </div>
+          <div class="min-w-0 flex-1">
+            <h2 class="m-0 text-[16px] font-semibold tracking-tight text-txt">
+              {{ t('pages.agentStudio.teamWizard.title') }}
+            </h2>
+            <span class="mt-0.5 block text-[12px] font-normal text-txt3">
+              {{ t('pages.agentStudio.teamWizard.headSub') }}
+            </span>
+          </div>
+          <button
+            type="button"
+            class="grid h-8 w-8 shrink-0 place-items-center text-txt3 hover:bg-elevated hover:text-txt"
+            :aria-label="t('pages.agentStudio.dialogs.cancel')"
+            :disabled="submitting"
+            @click="close"
+          >
+            <Icon name="close" :size="18" />
+          </button>
+          <div class="wiz-progress absolute inset-x-0 bottom-0 h-[3px] overflow-hidden bg-elevated">
+            <span :style="{ width: progressPct + '%' }" />
+          </div>
+        </div>
+
+        <div class="flex min-h-0 flex-1">
+          <aside class="wiz-rail scroll-area hidden w-[208px] shrink-0 overflow-y-auto border-r border-line bg-elevated px-3 pb-4 pt-5 md:block">
+            <div class="mb-4 flex items-center gap-2 px-1.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-txt3">
+              <span class="pulse-dot h-1.5 w-1.5 shrink-0 bg-accent" />
+              {{ t('pages.agentStudio.wizard.railCap') }}
+            </div>
+            <div
+              v-for="(s, i) in TEAM_WIZARD_STEPS"
+              :key="s.id"
+              class="rail-item"
+              :class="{ done: i < draft.step, cur: i === draft.step }"
+            >
+              <div class="track">
+                <div class="node" aria-hidden="true"><i /></div>
+                <div class="connector" />
+              </div>
+              <div class="lbl">
+                <strong>{{ t(s.labelKey) }}</strong>
+              </div>
+            </div>
+          </aside>
+
+          <div class="flex min-w-0 flex-1 flex-col">
+            <div class="border-b border-line px-5 py-2 text-[12px] text-txt3 md:hidden">
+              {{ draft.step + 1 }} / {{ TEAM_WIZARD_STEPS.length }} · {{ t(currentStep.labelKey) }}
+            </div>
+            <div class="scroll-area min-h-0 flex-1 overflow-y-auto px-6 py-6 md:px-8 md:py-7">
+              <div :key="stepAnimKey" class="step-pane">
+                <div class="sec-head mb-1">
+                  <h3 class="m-0 text-[18px] font-semibold text-txt">{{ t(currentStep.labelKey) }}</h3>
+                </div>
+
+                <template v-if="currentStep.id === 'team'">
+                  <p class="sec-meta">{{ t('pages.agentStudio.teamWizard.team.meta') }}</p>
+                  <div class="mb-4 grid gap-3 md:grid-cols-2">
+                    <label class="block">
+                      <span class="mb-1.5 block text-[12px] font-medium text-txt2">
+                        {{ t('pages.agentStudio.teamWizard.team.projectName') }}
+                        <span class="text-err">*</span>
+                      </span>
+                      <input
+                        id="team-wiz-project"
+                        v-model="draft.projectName"
+                        class="w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent"
+                        @input="onProjectInput"
+                      />
+                    </label>
+                    <label class="block">
+                      <span class="mb-1.5 block text-[12px] font-medium text-txt2">
+                        {{ t('pages.agentStudio.teamWizard.team.prefix') }}
+                        <span class="text-err">*</span>
+                      </span>
+                      <input
+                        v-model="draft.prefix"
+                        class="w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent"
+                        @input="draft.prefixTouched = true; syncDerivedNames(draft)"
+                      />
+                    </label>
+                  </div>
+                  <div class="mb-4 grid gap-3 md:grid-cols-2">
+                    <label class="block">
+                      <span class="mb-1.5 block text-[12px] font-medium text-txt2">{{ t('pages.agentStudio.teamWizard.team.rootGroup') }}</span>
+                      <input
+                        v-model="draft.rootGroupName"
+                        class="w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent"
+                        @input="draft.rootTouched = true"
+                      />
+                    </label>
+                    <label class="block">
+                      <span class="mb-1.5 block text-[12px] font-medium text-txt2">{{ t('pages.agentStudio.teamWizard.team.pipelineGroup') }}</span>
+                      <input
+                        v-model="draft.pipelineGroupName"
+                        class="w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent"
+                        @input="draft.pipelineTouched = true"
+                      />
+                      <p class="mt-1 text-[11px] text-txt3">{{ t('pages.agentStudio.teamWizard.team.pipelineHint') }}</p>
+                    </label>
+                  </div>
+                  <label class="mb-4 block">
+                    <span class="mb-1.5 block text-[12px] font-medium text-txt2">
+                      {{ t('pages.agentStudio.teamWizard.team.pmName') }}
+                      <span class="text-err">*</span>
+                    </span>
+                    <input
+                      v-model="draft.pmName"
+                      class="w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent"
+                      @input="draft.pmTouched = true"
+                    />
+                  </label>
+                  <label class="block">
+                    <span class="mb-1.5 block text-[12px] font-medium text-txt2">
+                      {{ t('pages.agentStudio.teamWizard.team.background') }}
+                      <span class="text-err">*</span>
+                    </span>
+                    <textarea
+                      v-model="draft.background"
+                      rows="6"
+                      class="w-full resize-y border border-line bg-base px-3 py-2 text-[13px] leading-6 text-txt outline-none focus:border-accent"
+                      :placeholder="t('pages.agentStudio.teamWizard.team.backgroundPlaceholder')"
+                    />
+                    <p class="mt-1.5 text-[11px] text-txt3">{{ t('pages.agentStudio.teamWizard.team.backgroundHint') }}</p>
+                  </label>
+                  <div class="mt-4 border border-accent/35 bg-accent-dim/40 px-3 py-2.5 text-[12px] text-accent-2">
+                    {{ previewLine }}
+                  </div>
+                  <p v-if="fieldError" class="mt-3 text-[12px] text-err">{{ fieldError }}</p>
+                </template>
+
+                <template v-else-if="currentStep.id === 'acp'">
+                  <p class="sec-meta">{{ t('pages.agentStudio.teamWizard.acp.meta') }}</p>
+                  <div class="grid grid-cols-2 gap-2.5 md:grid-cols-4">
+                    <button
+                      v-for="b in ACP_BACKENDS"
+                      :key="b.id"
+                      type="button"
+                      class="border px-3 py-3.5 text-center transition"
+                      :class="draft.acpBackend === b.id ? 'border-accent bg-accent-dim' : 'border-line bg-base hover:border-line-strong'"
+                      @click="selectAcp(b.id)"
+                    >
+                      <strong class="block text-[13px] font-semibold text-txt">{{ b.label }}</strong>
+                      <span class="mt-1 block font-mono text-[10px] text-txt3">{{ b.configRoot }}</span>
+                    </button>
+                  </div>
+                  <div v-if="regionPolicy" class="mt-5 border-t border-dashed border-line pt-4">
+                    <div class="mb-2 text-[12px] font-medium text-txt2">{{ t('pages.agentStudio.region.title') }}</div>
+                    <div class="grid max-w-lg grid-cols-2 gap-2.5">
+                      <button
+                        v-for="option in regionPolicy.options"
+                        :key="option.id"
+                        type="button"
+                        class="border px-3 py-3 text-left transition"
+                        :class="currentRegion === option.id ? 'border-accent bg-accent-dim' : 'border-line bg-base'"
+                        @click="selectRegion(option.id)"
+                      >
+                        <strong class="block text-[13px] text-txt">{{ t(option.labelKey) }}</strong>
+                      </button>
+                    </div>
+                  </div>
+                </template>
+
+                <template v-else-if="currentStep.id === 'apiKey'">
+                  <p class="sec-meta">{{ t('pages.agentStudio.wizard.apiKey.meta') }}</p>
+                  <label class="block">
+                    <span class="mb-1.5 block text-[12px] font-medium text-txt2">
+                      {{ t('pages.agentStudio.wizard.apiKey.inputLabel') }}
+                    </span>
+                    <input
+                      :value="apiKeyInput"
+                      type="password"
+                      autocomplete="off"
+                      class="w-full border border-line bg-base px-3 py-2 font-mono text-[12px] text-txt outline-none focus:border-accent"
+                      @input="onApiKeyInput(($event.target as HTMLInputElement).value)"
+                    />
+                    <p class="mt-1.5 text-[11px] text-txt3">{{ t('pages.agentStudio.wizard.apiKey.skipHint') }}</p>
+                  </label>
+                </template>
+
+                <template v-else-if="currentStep.id === 'git'">
+                  <p class="sec-meta">{{ t('pages.agentStudio.teamWizard.git.meta') }}</p>
+                  <label class="mb-4 block">
+                    <span class="mb-1.5 block text-[12px] font-medium text-txt2">{{ t('pages.agentStudio.teamWizard.git.url') }}</span>
+                    <input
+                      v-model="draft.gitUrl"
+                      class="w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent"
+                      placeholder="https://github.com/org/repo.git"
+                    />
+                  </label>
+                  <AgentGitGuide
+                    :env="draft.env"
+                    :upsert-env="(k, v) => upsertEnv(k, v)"
+                    :credential-type="draft.gitCredentialType"
+                    @update:credential-type="onGitCredentialType"
+                  />
+                </template>
+
+                <template v-else-if="currentStep.id === 'mcp'">
+                  <p class="sec-meta">{{ t('pages.agentStudio.teamWizard.mcp.meta') }}</p>
+                  <div
+                    v-for="(m, i) in draft.mcp"
+                    :key="i"
+                    class="mb-3 border border-line bg-elevated p-3"
+                  >
+                    <div class="mb-2 flex items-center justify-between gap-2">
+                      <span class="text-[12px] font-semibold text-txt">MCP #{{ i + 1 }}</span>
+                      <button type="button" class="text-[11px] text-txt3 hover:text-err" @click="removeMcp(i)">
+                        {{ t('pages.agentStudio.dialogs.delete') }}
+                      </button>
+                    </div>
+                    <div class="mb-2 grid gap-2 md:grid-cols-2">
+                      <input
+                        v-model="m.name"
+                        class="border border-line bg-base px-2 py-1.5 text-[12px] text-txt outline-none focus:border-accent"
+                        :placeholder="t('pages.agentStudio.teamWizard.mcp.namePh')"
+                      />
+                      <select
+                        v-model="m.transport"
+                        class="border border-line bg-base px-2 py-1.5 text-[12px] text-txt"
+                      >
+                        <option value="url">HTTP (url)</option>
+                        <option value="command">stdio</option>
+                      </select>
+                    </div>
+                    <template v-if="m.transport === 'url'">
+                      <input
+                        v-model="m.url"
+                        class="mb-2 w-full border border-line bg-base px-2 py-1.5 font-mono text-[11px] text-txt outline-none focus:border-accent"
+                        placeholder="${APPROVING_ARTIFACT_URL}"
+                      />
+                      <div class="mb-1 flex items-center justify-between text-[11px] text-txt2">
+                        <span>{{ t('pages.agentStudio.teamWizard.mcp.headers') }}</span>
+                        <button type="button" class="text-accent-2" @click="m.headers.push({ k: '', v: '' })">
+                          + {{ t('pages.agentStudio.teamWizard.mcp.addHeader') }}
+                        </button>
+                      </div>
+                      <div v-for="(h, hi) in m.headers" :key="hi" class="mb-1 grid grid-cols-[1fr_1.4fr_auto] gap-1">
+                        <input v-model="h.k" class="border border-line bg-base px-2 py-1 text-[11px]" placeholder="Header" />
+                        <input v-model="h.v" class="border border-line bg-base px-2 py-1 font-mono text-[11px]" placeholder="Value" />
+                        <button type="button" class="px-2 text-[11px] text-txt3" @click="m.headers.splice(hi, 1)">×</button>
+                      </div>
+                    </template>
+                    <template v-else>
+                      <input v-model="m.command" class="mb-2 w-full border border-line bg-base px-2 py-1.5 text-[12px]" placeholder="command" />
+                      <textarea v-model="m.args" rows="2" class="w-full border border-line bg-base px-2 py-1.5 font-mono text-[11px]" placeholder="args (one per line)" />
+                    </template>
+                  </div>
+                  <div class="flex flex-wrap gap-2">
+                    <AppButton size="sm" variant="outline" icon="plus" @click="addMcp">{{ t('pages.agentStudio.teamWizard.mcp.add') }}</AppButton>
+                    <AppButton size="sm" variant="ghost" @click="restoreArtifact">{{ t('pages.agentStudio.teamWizard.mcp.restoreArtifact') }}</AppButton>
+                    <AppButton size="sm" variant="ghost" @click="addNamedMcp('memory-store')">+ memory-store</AppButton>
+                    <AppButton size="sm" variant="ghost" @click="addNamedMcp('context-store')">+ context-store</AppButton>
+                  </div>
+                  <p class="mt-3 text-[11px] text-txt3">{{ t('pages.agentStudio.teamWizard.mcp.runVars') }}</p>
+                </template>
+
+                <template v-else-if="currentStep.id === 'env'">
+                  <p class="sec-meta">{{ t('pages.agentStudio.teamWizard.env.meta') }}</p>
+                  <div
+                    v-for="(row, i) in draft.env"
+                    :key="i"
+                    class="mb-2 grid grid-cols-[1fr_1.4fr_auto] gap-2"
+                  >
+                    <input v-model="row.k" class="border border-line bg-base px-2 py-1.5 font-mono text-[12px]" placeholder="KEY" />
+                    <input v-model="row.v" class="border border-line bg-base px-2 py-1.5 font-mono text-[12px]" placeholder="value" />
+                    <button type="button" class="text-[11px] text-txt3" @click="draft.env.splice(i, 1)">{{ t('pages.agentStudio.dialogs.delete') }}</button>
+                  </div>
+                  <AppButton size="sm" variant="outline" icon="plus" @click="draft.env.push({ k: '', v: '' })">
+                    {{ t('pages.agentStudio.env.add') }}
+                  </AppButton>
+                </template>
+
+                <template v-else-if="currentStep.id === 'review'">
+                  <p class="sec-meta">{{ t('pages.agentStudio.teamWizard.review.meta') }}</p>
+                  <div class="border border-line bg-elevated px-4 py-3 text-[13px] leading-7 text-txt2">
+                    <div>{{ t('pages.agentStudio.teamWizard.review.project') }}：<strong class="text-txt">{{ draft.projectName }}</strong></div>
+                    <div>{{ t('pages.agentStudio.teamWizard.review.root') }}：<strong class="text-txt">{{ draft.rootGroupName }}</strong></div>
+                    <div>{{ t('pages.agentStudio.teamWizard.review.pipeline') }}：<strong class="text-txt">{{ draft.pipelineGroupName }}</strong></div>
+                    <div>PM：<strong class="text-txt">{{ draft.pmName }}</strong></div>
+                    <div>ACP：<strong class="text-txt">{{ draft.acpBackend }}</strong></div>
+                    <div>API Key：<strong class="text-txt">{{ teamHasAuth(draft) ? t('pages.agentStudio.teamWizard.review.set') : t('pages.agentStudio.teamWizard.review.skip') }}</strong></div>
+                    <div>Git：<strong class="text-txt">{{ draft.gitUrl || t('pages.agentStudio.teamWizard.review.none') }}</strong></div>
+                    <div>MCP：<strong class="text-txt">{{ mcpNames }}</strong></div>
+                    <div>Env：<strong class="text-txt">{{ envSummary }}</strong></div>
+                    <div class="mt-2">
+                      {{ t('pages.agentStudio.teamWizard.review.roster') }}
+                    </div>
+                  </div>
+                  <div class="mt-3 border border-line bg-base px-3 py-2">
+                    <button type="button" class="mb-1 text-[12px] text-accent-2" @click="bgExpanded = !bgExpanded">
+                      {{ t('pages.agentStudio.teamWizard.review.background') }}
+                    </button>
+                    <pre
+                      v-if="bgExpanded"
+                      class="m-0 whitespace-pre-wrap font-sans text-[12px] leading-5 text-txt2"
+                    >{{ draft.background }}</pre>
+                  </div>
+                  <p
+                    v-if="!hasArtifact"
+                    class="mt-3 border border-warn/35 bg-warn/10 px-3 py-2 text-[12px] text-txt2"
+                  >
+                    {{ t('pages.agentStudio.teamWizard.review.noArtifactWarn') }}
+                  </p>
+                  <p v-if="!hasAuthKeyConfigured(draft.env, draft.acpBackend)" class="mt-3 text-[12px] text-txt3">
+                    {{ t('pages.agentStudio.wizard.review.authReminderDetail') }}
+                  </p>
+                  <p v-if="submitError" class="mt-3 text-[12px] text-err">{{ submitError }}</p>
+                </template>
+              </div>
+            </div>
+
+            <div class="flex shrink-0 items-center justify-between gap-2 border-t border-line bg-surface px-5 py-3.5">
+              <AppButton variant="ghost" :disabled="submitting" @click="close">
+                {{ t('pages.agentStudio.dialogs.cancel') }}
+              </AppButton>
+              <div class="ml-auto flex items-center gap-2">
+                <AppButton variant="outline" :disabled="draft.step === 0 || submitting" @click="goPrev">
+                  {{ t('pages.agentStudio.wizard.prev') }}
+                </AppButton>
+                <AppButton v-if="currentStep.skip" variant="outline" :disabled="submitting" @click="goSkip">
+                  {{ t('pages.agentStudio.wizard.skip') }}
+                </AppButton>
+                <AppButton variant="primary" :disabled="submitting" @click="goNext">
+                  {{
+                    submitting
+                      ? t('pages.agentStudio.teamWizard.submitting')
+                      : currentStep.id === 'review'
+                        ? t('pages.agentStudio.teamWizard.confirmStart')
+                        : t('pages.agentStudio.wizard.next')
+                  }}
+                </AppButton>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.wiz-head {
+  background: linear-gradient(90deg, rgba(123, 97, 255, 0.12) 0%, transparent 42%), rgb(var(--c-surface));
+}
+.hero-mark {
+  background: linear-gradient(145deg, rgba(123, 97, 255, 0.22), rgb(var(--c-elevated)));
+}
+.wiz-progress > span {
+  display: block;
+  height: 100%;
+  background: rgb(var(--c-accent));
+  transition: width 0.25s ease;
+}
+.sec-meta {
+  margin: 0 0 1.1rem;
+  font-size: 13px;
+  line-height: 1.55;
+  color: rgb(var(--c-txt3));
+}
+.rail-item {
+  display: flex;
+  gap: 10px;
+  padding: 8px 6px;
+  color: rgb(var(--c-txt3));
+  font-size: 13px;
+}
+.rail-item.cur {
+  color: rgb(var(--c-txt));
+  background: rgba(123, 97, 255, 0.12);
+}
+.rail-item.done {
+  color: rgb(var(--c-ok));
+}
+.rail-item .node {
+  width: 10px;
+  height: 10px;
+  margin-top: 4px;
+  border: 1px solid rgb(var(--c-line));
+  border-radius: 999px;
+}
+.rail-item.cur .node {
+  border-color: rgb(var(--c-accent));
+  background: rgb(var(--c-accent));
+}
+.pulse-dot {
+  border-radius: 999px;
+}
+</style>

--- a/web/src/components/agent/TeamBootstrapPanel.vue
+++ b/web/src/components/agent/TeamBootstrapPanel.vue
@@ -1,0 +1,205 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import AppButton from '@/components/ui/AppButton.vue'
+import { api, type TeamBootstrapSession } from '@/lib/api'
+
+const props = defineProps<{
+  sessionId: string
+}>()
+
+const emit = defineEmits<{
+  openPm: [name: string]
+  selectPm: [name: string]
+  done: []
+  refreshOrg: []
+}>()
+
+const { t } = useI18n()
+const session = ref<TeamBootstrapSession | null>(null)
+const pollError = ref('')
+const retrying = ref(false)
+let timer: ReturnType<typeof setInterval> | null = null
+let lastResourceCount = 0
+let highlightedPm = false
+
+const badgeClass = computed(() => {
+  const s = session.value?.status
+  if (s === 'ready') return 'border-ok/40 bg-ok/10 text-ok'
+  if (s === 'failed') return 'border-err/40 bg-err/10 text-err'
+  if (s === 'running') return 'border-ok/40 bg-ok/10 text-ok'
+  return 'border-warn/40 bg-warn/10 text-warn'
+})
+
+const badgeText = computed(() => {
+  const s = session.value?.status || 'starting'
+  if (s === 'ready') {
+    const n = session.value?.agentNames?.length || 0
+    return t('pages.agentStudio.teamWizard.progress.ready', { n })
+  }
+  return t(`pages.agentStudio.teamWizard.progress.${s}`)
+})
+
+async function poll() {
+  try {
+    const s = await api.getAgentTeamBootstrap(props.sessionId)
+    session.value = s
+    pollError.value = ''
+    if ((s.resources?.length || 0) !== lastResourceCount) {
+      lastResourceCount = s.resources?.length || 0
+      emit('refreshOrg')
+    }
+    if (s.status === 'ready' || s.status === 'failed') {
+      emit('refreshOrg')
+      if (s.status === 'ready' && s.pmAgent && !highlightedPm) {
+        highlightedPm = true
+        emit('selectPm', s.pmAgent)
+      }
+      stop()
+    }
+  } catch (e: any) {
+    pollError.value = e?.message || String(e)
+  }
+}
+
+function stop() {
+  if (timer) {
+    clearInterval(timer)
+    timer = null
+  }
+}
+
+function startPolling() {
+  stop()
+  void poll()
+  timer = setInterval(() => void poll(), 800)
+}
+
+async function onRetry() {
+  if (retrying.value) return
+  retrying.value = true
+  pollError.value = ''
+  try {
+    session.value = await api.retryAgentTeamBootstrap(props.sessionId)
+    lastResourceCount = session.value.resources?.length || 0
+    emit('refreshOrg')
+    startPolling()
+  } catch (e: any) {
+    pollError.value = e?.message || String(e)
+  } finally {
+    retrying.value = false
+  }
+}
+
+onMounted(startPolling)
+
+onBeforeUnmount(stop)
+
+watch(
+  () => props.sessionId,
+  () => {
+    lastResourceCount = 0
+    highlightedPm = false
+    startPolling()
+  },
+)
+
+function lineClass(kind: string) {
+  if (kind === 'ok') return 'text-ok'
+  if (kind === 'err') return 'text-err'
+  if (kind === 'warn') return 'text-warn'
+  if (kind === 'mcp') return 'mcp-block'
+  return 'text-txt3'
+}
+</script>
+
+<template>
+  <div class="flex min-h-0 flex-1 flex-col" aria-live="polite">
+    <div class="flex shrink-0 items-center justify-between gap-3 border-b border-line px-4 py-3">
+      <div class="min-w-0">
+        <h2 class="m-0 truncate text-[15px] font-semibold text-txt">
+          {{ t('pages.agentStudio.teamWizard.progress.title', { name: session?.pmAgent || '…' }) }}
+        </h2>
+        <p class="m-0 mt-0.5 text-[12px] text-txt3">
+          {{ t('pages.agentStudio.teamWizard.progress.sub') }}
+        </p>
+      </div>
+      <span class="shrink-0 border px-2 py-1 text-[11px]" :class="badgeClass">{{ badgeText }}</span>
+    </div>
+
+    <div
+      v-if="session?.status === 'failed' || pollError"
+      class="shrink-0 border-b border-err/35 bg-err/10 px-4 py-2 text-[12px] text-err"
+    >
+      {{ session?.error || pollError }}
+    </div>
+
+    <div class="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[1.15fr_0.85fr]">
+      <div class="scroll-area min-h-0 overflow-y-auto border-r border-line p-4 font-mono text-[12px] leading-5">
+        <div
+          v-for="(ev, i) in session?.events || []"
+          :key="i"
+          class="mb-2 whitespace-pre-wrap"
+          :class="lineClass(ev.kind)"
+        >
+          <template v-if="ev.kind === 'mcp'">
+            <div class="mcp-block border border-dashed border-warn/45 bg-warn/10 px-3 py-2 text-warn">
+              {{ ev.message }}
+            </div>
+          </template>
+          <template v-else>{{ ev.message }}</template>
+        </div>
+        <div v-if="!session?.events?.length" class="text-txt3">
+          {{ t('pages.agentStudio.teamWizard.progress.waiting') }}
+        </div>
+      </div>
+
+      <div class="scroll-area min-h-0 overflow-y-auto p-4">
+        <h3 class="mb-3 text-[13px] font-semibold text-txt2">
+          {{ t('pages.agentStudio.teamWizard.progress.resources') }}
+        </h3>
+        <div
+          v-for="(r, i) in session?.resources || []"
+          :key="i"
+          class="mb-2 border border-line bg-elevated px-3 py-2 text-[12px]"
+          :class="session?.status === 'ready' ? 'border-ok/35' : ''"
+        >
+          <div class="font-semibold text-txt">{{ r.name }}</div>
+          <div class="text-txt3">{{ r.kind }}{{ r.detail ? ' · ' + r.detail : '' }}</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex shrink-0 items-center justify-end gap-2 border-t border-line px-4 py-3">
+      <AppButton
+        v-if="session?.status === 'failed'"
+        variant="primary"
+        :disabled="retrying"
+        @click="onRetry"
+      >
+        {{ retrying ? t('pages.agentStudio.teamWizard.submitting') : t('pages.agentStudio.teamWizard.progress.retry') }}
+      </AppButton>
+      <AppButton
+        v-if="session?.status === 'ready' && session.pmAgent"
+        variant="primary"
+        @click="emit('openPm', session.pmAgent)"
+      >
+        {{ t('pages.agentStudio.teamWizard.progress.openPm') }}
+      </AppButton>
+      <AppButton
+        v-if="session?.status === 'ready'"
+        variant="outline"
+        @click="emit('done')"
+      >
+        {{ t('pages.agentStudio.teamWizard.progress.done') }}
+      </AppButton>
+      <AppButton
+        v-else-if="session?.status === 'failed'"
+        variant="outline"
+        @click="emit('done')"
+      >
+        {{ t('pages.agentStudio.teamWizard.progress.keepCreated') }}
+      </AppButton>
+    </div>
+  </div>
+</template>

--- a/web/src/data/mcp.test.ts
+++ b/web/src/data/mcp.test.ts
@@ -56,8 +56,16 @@ const CATALOG = [
   {
     id: 'pm-agent-fs',
     scope: 'project' as const,
-    toolCount: 7,
-    writeTools: ['pm_fs_write', 'pm_fs_delete', 'pm_fs_mkdir', 'pm_fs_rename'],
+    toolCount: 11,
+    writeTools: [
+      'pm_fs_write',
+      'pm_fs_delete',
+      'pm_fs_mkdir',
+      'pm_fs_rename',
+      'pm_create_agent_from_template',
+      'pm_set_org_membership',
+      'pm_ensure_child_group',
+    ],
   },
 ] as const
 

--- a/web/src/data/mcp.ts
+++ b/web/src/data/mcp.ts
@@ -168,6 +168,10 @@ export const BUILTIN_MCPS: McpServer[] = [
     overviewKey: 'mcp.pmAgentFs.overview',
     tools: [
       { name: 'pm_get_org', signatureKey: 'mcp.pmAgentFs.tools.pm_get_org.signature', descKey: 'mcp.pmAgentFs.tools.pm_get_org.desc', io: 'read' },
+      { name: 'pm_list_agent_templates', signatureKey: 'mcp.pmAgentFs.tools.pm_list_agent_templates.signature', descKey: 'mcp.pmAgentFs.tools.pm_list_agent_templates.desc', io: 'read' },
+      { name: 'pm_create_agent_from_template', signatureKey: 'mcp.pmAgentFs.tools.pm_create_agent_from_template.signature', descKey: 'mcp.pmAgentFs.tools.pm_create_agent_from_template.desc', io: 'write' },
+      { name: 'pm_set_org_membership', signatureKey: 'mcp.pmAgentFs.tools.pm_set_org_membership.signature', descKey: 'mcp.pmAgentFs.tools.pm_set_org_membership.desc', io: 'write' },
+      { name: 'pm_ensure_child_group', signatureKey: 'mcp.pmAgentFs.tools.pm_ensure_child_group.signature', descKey: 'mcp.pmAgentFs.tools.pm_ensure_child_group.desc', io: 'write' },
       { name: 'pm_fs_list', signatureKey: 'mcp.pmAgentFs.tools.pm_fs_list.signature', descKey: 'mcp.pmAgentFs.tools.pm_fs_list.desc', io: 'read' },
       { name: 'pm_fs_read', signatureKey: 'mcp.pmAgentFs.tools.pm_fs_read.signature', descKey: 'mcp.pmAgentFs.tools.pm_fs_read.desc', io: 'read' },
       { name: 'pm_fs_write', signatureKey: 'mcp.pmAgentFs.tools.pm_fs_write.signature', descKey: 'mcp.pmAgentFs.tools.pm_fs_write.desc', io: 'write' },

--- a/web/src/lib/agentTeamWizard.test.ts
+++ b/web/src/lib/agentTeamWizard.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import {
+  TEAM_ENGINEER_COUNT,
+  TEAM_WIZARD_STEPS,
+  assembleTeamBootstrapPayload,
+  artifactStorePreset,
+  freshTeamDraft,
+  syncDerivedNames,
+  validateTeamBasics,
+} from '@/lib/agentTeamWizard'
+
+describe('agentTeamWizard', () => {
+  it('has 7 wizard steps', () => {
+    expect(TEAM_WIZARD_STEPS).toHaveLength(7)
+    expect(TEAM_WIZARD_STEPS.map((s) => s.id)).toEqual([
+      'team',
+      'acp',
+      'apiKey',
+      'git',
+      'mcp',
+      'env',
+      'review',
+    ])
+  })
+
+  it('prefills artifact-store and GIT_REPOS', () => {
+    const d = freshTeamDraft()
+    expect(d.mcp[0]).toMatchObject(artifactStorePreset())
+    expect(d.env.some((e) => e.k === 'GIT_REPOS')).toBe(true)
+    expect(TEAM_ENGINEER_COUNT).toBe(9)
+  })
+
+  it('syncs derived names from project / prefix', () => {
+    const d = freshTeamDraft()
+    d.projectName = 'Demo'
+    syncDerivedNames(d)
+    expect(d.prefix).toBe('Demo')
+    expect(d.rootGroupName).toBe('Demo项目组')
+    expect(d.pmName).toBe('Demo项目经理')
+  })
+
+  it('validates required team fields and pm collision', () => {
+    const d = freshTeamDraft()
+    expect(validateTeamBasics(d, [])).toBe('projectRequired')
+    d.projectName = 'Demo'
+    syncDerivedNames(d)
+    d.background = 'bg'
+    expect(validateTeamBasics(d, ['Demo项目经理'])).toBe('pmExists')
+    expect(validateTeamBasics(d, [])).toBe('')
+  })
+
+  it('assembles bootstrap payload with mcp/env', () => {
+    const d = freshTeamDraft()
+    d.projectName = 'Demo'
+    syncDerivedNames(d)
+    d.background = 'build a pipeline team'
+    d.gitUrl = 'https://github.com/org/repo.git'
+    const payload = assembleTeamBootstrapPayload(d)
+    expect(payload.projectName).toBe('Demo')
+    expect(payload.pmName).toBe('Demo项目经理')
+    expect(payload.mcp.some((m) => m.name === 'artifact-store')).toBe(true)
+    expect(payload.env.GIT_REPOS).toBe('${vars.repos}')
+    expect(payload.gitUrl).toContain('github.com')
+  })
+})

--- a/web/src/lib/agentTeamWizard.ts
+++ b/web/src/lib/agentTeamWizard.ts
@@ -1,0 +1,205 @@
+import type { MCPServer } from '@/lib/api'
+import {
+  ACP_BACKENDS,
+  applyAcpBackend,
+  configRootFor,
+  kvToRec,
+  normalizeWizardRegions,
+  recToKV,
+  type WizardBackendId,
+  type WizardDraft,
+  type WizardKV,
+  type WizardMCP,
+  freshDraft,
+} from '@/lib/agentCreateWizard'
+import { normalizeAgentName, validateAgentName } from '@/lib/agentIO'
+import type { GitCredentialType } from '@/lib/gitCredentialAnalysis'
+import { authGuideFor, hasAuthKeyConfigured } from '@/lib/backendAuthGuide'
+import { getRegionPolicy } from '@/lib/regionPolicy'
+
+export type TeamWizardStepId = 'team' | 'acp' | 'apiKey' | 'git' | 'mcp' | 'env' | 'review'
+
+export type TeamWizardStepDef = {
+  id: TeamWizardStepId
+  labelKey: string
+  skip: boolean
+}
+
+export const TEAM_WIZARD_STEPS: TeamWizardStepDef[] = [
+  { id: 'team', labelKey: 'pages.agentStudio.teamWizard.steps.team', skip: false },
+  { id: 'acp', labelKey: 'pages.agentStudio.teamWizard.steps.acp', skip: true },
+  { id: 'apiKey', labelKey: 'pages.agentStudio.teamWizard.steps.apiKey', skip: true },
+  { id: 'git', labelKey: 'pages.agentStudio.teamWizard.steps.git', skip: true },
+  { id: 'mcp', labelKey: 'pages.agentStudio.teamWizard.steps.mcp', skip: true },
+  { id: 'env', labelKey: 'pages.agentStudio.teamWizard.steps.env', skip: true },
+  { id: 'review', labelKey: 'pages.agentStudio.teamWizard.steps.review', skip: false },
+]
+
+export const TEAM_ENGINEER_COUNT = 9
+
+export type TeamWizardDraft = {
+  step: number
+  projectName: string
+  prefix: string
+  rootGroupName: string
+  pipelineGroupName: string
+  pmName: string
+  background: string
+  prefixTouched: boolean
+  rootTouched: boolean
+  pipelineTouched: boolean
+  pmTouched: boolean
+  acpBackend: WizardBackendId
+  gitCredentialType?: GitCredentialType
+  gitUrl: string
+  configRoot: string
+  env: WizardKV[]
+  mcp: WizardMCP[]
+  skipped: Partial<Record<TeamWizardStepId, boolean>>
+}
+
+export function artifactStorePreset(): WizardMCP {
+  return {
+    name: 'artifact-store',
+    transport: 'url',
+    url: '${APPROVING_ARTIFACT_URL}',
+    headers: [{ k: 'Authorization', v: 'Bearer ${APPROVING_ARTIFACT_TOKEN}' }],
+    command: '',
+    args: '',
+    env: [],
+  }
+}
+
+export function freshTeamDraft(): TeamWizardDraft {
+  return {
+    step: 0,
+    projectName: '',
+    prefix: '',
+    rootGroupName: '',
+    pipelineGroupName: 'Pipeline(GitHub)',
+    pmName: '',
+    background: '',
+    prefixTouched: false,
+    rootTouched: false,
+    pipelineTouched: false,
+    pmTouched: false,
+    acpBackend: 'cursor',
+    gitCredentialType: undefined,
+    gitUrl: '',
+    configRoot: configRootFor('cursor'),
+    env: [{ k: 'GIT_REPOS', v: '${vars.repos}' }],
+    mcp: [artifactStorePreset()],
+    skipped: {},
+  }
+}
+
+export function syncDerivedNames(d: TeamWizardDraft) {
+  const base = (d.prefixTouched ? d.prefix : d.projectName).trim() || d.projectName.trim()
+  if (!d.prefixTouched) d.prefix = d.projectName.trim()
+  if (!d.rootTouched) d.rootGroupName = base ? `${base}项目组` : ''
+  if (!d.pmTouched) d.pmName = base ? `${base}项目经理` : ''
+}
+
+export function validateTeamBasics(d: TeamWizardDraft, existingNames: string[]): string {
+  if (!d.projectName.trim()) return 'projectRequired'
+  if (!d.prefix.trim()) return 'prefixRequired'
+  if (!d.background.trim()) return 'backgroundRequired'
+  const code = validateAgentName(d.pmName)
+  if (code === 'required') return 'pmRequired'
+  if (code === 'invalid') return 'pmInvalid'
+  const normalized = normalizeAgentName(d.pmName)
+  if (existingNames.some((n) => normalizeAgentName(n) === normalized)) return 'pmExists'
+  return ''
+}
+
+export function teamDraftAsWizardDraft(d: TeamWizardDraft): WizardDraft {
+  const base = freshDraft()
+  base.acpBackend = d.acpBackend
+  base.configRoot = d.configRoot
+  base.env = d.env.map((e) => ({ ...e }))
+  base.gitCredentialType = d.gitCredentialType
+  base.mcp = d.mcp.map((m) => ({
+    ...m,
+    headers: m.headers.map((h) => ({ ...h })),
+    env: m.env.map((e) => ({ ...e })),
+  }))
+  return base
+}
+
+export function applyTeamAcpBackend(d: TeamWizardDraft, id: WizardBackendId) {
+  const w = teamDraftAsWizardDraft(d)
+  applyAcpBackend(w, id)
+  d.acpBackend = w.acpBackend
+  d.configRoot = w.configRoot
+  d.env = w.env
+}
+
+function mcpToApi(m: WizardMCP): MCPServer {
+  if (m.transport === 'command') {
+    return {
+      name: m.name.trim(),
+      command: m.command.trim(),
+      args: m.args
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean),
+      env: kvToRec(m.env),
+    }
+  }
+  return {
+    name: m.name.trim(),
+    url: m.url.trim(),
+    headers: kvToRec(m.headers),
+  }
+}
+
+export type TeamBootstrapPayload = {
+  projectName: string
+  prefix: string
+  rootGroupName: string
+  pipelineGroupName: string
+  pmName: string
+  background: string
+  acpBackend: string
+  apiKey?: string
+  region?: string
+  gitUrl?: string
+  gitCredentialType?: string
+  mcp: MCPServer[]
+  env: Record<string, string>
+}
+
+export function assembleTeamBootstrapPayload(d: TeamWizardDraft): TeamBootstrapPayload {
+  const w = teamDraftAsWizardDraft(d)
+  const env = normalizeWizardRegions(w)
+  d.env = w.env
+  const policy = getRegionPolicy(d.acpBackend)
+  const region = policy
+    ? d.env.find((e) => e.k.trim() === policy.regionEnvKey)?.v?.trim() || undefined
+    : undefined
+  const guide = authGuideFor(d.acpBackend, region || '')
+  const primaryKey = guide.keys[0]?.key || ''
+  const apiKey = primaryKey ? env[primaryKey]?.trim() || undefined : undefined
+  return {
+    projectName: d.projectName.trim(),
+    prefix: d.prefix.trim(),
+    rootGroupName: (d.rootGroupName.trim() || `${d.prefix.trim()}项目组`),
+    pipelineGroupName: d.pipelineGroupName.trim() || 'Pipeline(GitHub)',
+    pmName: normalizeAgentName(d.pmName),
+    background: d.background.trim(),
+    acpBackend: d.acpBackend || 'cursor',
+    ...(apiKey ? { apiKey } : {}),
+    ...(region ? { region } : {}),
+    ...(d.gitUrl.trim() ? { gitUrl: d.gitUrl.trim() } : {}),
+    ...(d.gitCredentialType ? { gitCredentialType: d.gitCredentialType } : {}),
+    mcp: d.mcp.filter((m) => m.name.trim()).map(mcpToApi),
+    env,
+  }
+}
+
+export function teamHasAuth(d: TeamWizardDraft): boolean {
+  return hasAuthKeyConfigured(d.env, d.acpBackend)
+}
+
+export { ACP_BACKENDS, recToKV, kvToRec }
+export type { WizardBackendId }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -227,6 +227,54 @@ export interface OrgFolderImportResult {
   renamed?: Record<string, string>
 }
 
+/** Create Agent Team bootstrap progress (GET/POST /agent-teams/bootstrap). */
+export interface TeamBootstrapEvent {
+  kind: string
+  message: string
+  at: string
+}
+
+export interface TeamBootstrapResource {
+  kind: string
+  name: string
+  detail?: string
+}
+
+export interface TeamBootstrapSession {
+  id: string
+  status: 'starting' | 'running' | 'ready' | 'failed' | string
+  error?: string
+  projectId?: string
+  rootGroupId?: string
+  pipelineGroupId?: string
+  pmAgent?: string
+  sandboxId?: string
+  prefix?: string
+  background?: string
+  allowedGroupIds?: string[]
+  agentNames?: string[]
+  events: TeamBootstrapEvent[]
+  resources: TeamBootstrapResource[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface TeamBootstrapRequest {
+  projectName: string
+  prefix: string
+  rootGroupName: string
+  pipelineGroupName: string
+  pmName: string
+  background: string
+  acpBackend: string
+  apiKey?: string
+  region?: string
+  gitUrl?: string
+  gitCredentialType?: string
+  mcp?: MCPServer[]
+  env?: Record<string, string>
+}
+
 function filenameFromContentDisposition(header: string | null, fallback: string): string {
   if (!header) return fallback
   const star = /filename\*=(?:UTF-8''|utf-8'')([^;]+)/i.exec(header)
@@ -761,6 +809,21 @@ export const api = {
       method: 'POST',
       body: JSON.stringify(body),
     }),
+  bootstrapAgentTeam: (body: TeamBootstrapRequest) =>
+    req<TeamBootstrapSession>('/agent-teams/bootstrap', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+  getAgentTeamBootstrap: (id: string) =>
+    req<TeamBootstrapSession>(`/agent-teams/bootstrap/${encodeURIComponent(id)}`),
+  retryAgentTeamBootstrap: (id: string) =>
+    req<TeamBootstrapSession>(`/agent-teams/bootstrap/${encodeURIComponent(id)}/retry`, {
+      method: 'POST',
+    }),
+  listAgentTeamTemplates: () =>
+    req<{ items: { id: string; embedName: string; roleLabelZh: string; summary: string }[] }>(
+      '/agent-teams/templates',
+    ),
   getAgentsOrg: () => req<AgentOrg>('/agents/org'),
   saveAgentsOrg: (org: AgentOrg) =>
     req<AgentOrg>('/agents/org', { method: 'PUT', body: JSON.stringify(org) }),

--- a/web/src/locales/en/mcp.json
+++ b/web/src/locales/en/mcp.json
@@ -339,6 +339,22 @@
           "signature": "pm_get_org()",
           "desc": "Read org and reporting relations"
         },
+        "pm_list_agent_templates": {
+          "signature": "pm_list_agent_templates()",
+          "desc": "List built-in engineer role templates"
+        },
+        "pm_create_agent_from_template": {
+          "signature": "pm_create_agent_from_template(templateId, name)",
+          "desc": "Create an engineer Agent from a template (same project; no overwrite)"
+        },
+        "pm_set_org_membership": {
+          "signature": "pm_set_org_membership(agentName, groupIds, parentAgent?)",
+          "desc": "Set group membership and reporting parent (parent must be current PM)"
+        },
+        "pm_ensure_child_group": {
+          "signature": "pm_ensure_child_group(name, parentGroupId?)",
+          "desc": "Idempotently ensure a child group under the authorized root"
+        },
         "pm_fs_list": {
           "signature": "pm_fs_list(agentName, path?)",
           "desc": "List workspace directory"

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -1107,7 +1107,12 @@
     "agentStudio": {
       "title": "Agent Studio",
       "errorPrefix": "Error:",
-      "empty": "No agents. Click New agent or wait for default seed on first backend start.",
+      "empty": "No agents yet. Use \"Create Agent team\" for a full roster, or \"New Agent\" for a single one.",
+      "emptyTeamTitle": "Launch a full team from one entry",
+      "emptyTeamDesc": "After you fill project background and runtime config, a sandbox creates the project, root group, PM, and 9 engineers with reporting lines.",
+      "emptyTeamCta": "Create Agent team",
+      "emptyTeamOrSingle": "or create a single Agent",
+      "createTeam": "Create Agent team",
       "unsaved": "Unsaved",
       "saved": "Saved",
       "tabs": {
@@ -1151,6 +1156,7 @@
         "multiGroup": "Multi",
         "reportsTo": "Reports to: {name}",
         "newRootGroup": "New root group",
+        "newTeam": "Create Agent team",
         "newChildGroup": "New subgroup",
         "renameGroup": "Rename group",
         "groupNameLabel": "Group name",
@@ -1551,6 +1557,87 @@
         "skillsNote": "Executable skill directories",
         "commandsNote": "commands/*.md slash commands",
         "envNote": "Injected via container environment"
+      },
+      "teamWizard": {
+        "title": "Create Agent team",
+        "headSub": "Project background + runtime config → confirm to start sandbox",
+        "confirmStart": "Confirm & start sandbox",
+        "submitting": "Submitting",
+        "previewLine": "Will create: {root} / {pipe} · {pm} + {n} engineers",
+        "steps": {
+          "team": "Team info",
+          "acp": "Agent",
+          "apiKey": "API Key",
+          "git": "Git",
+          "mcp": "MCP",
+          "env": "Env vars",
+          "review": "Confirm"
+        },
+        "team": {
+          "meta": "Define project and naming first; engineers are provisioned from the reference roster in the sandbox.",
+          "projectName": "Project / team name",
+          "prefix": "Name prefix",
+          "rootGroup": "Root group name",
+          "pipelineGroup": "Pipeline subgroup",
+          "pipelineHint": "Engineers join this subgroup by default",
+          "pmName": "PM Agent name",
+          "background": "Project background",
+          "backgroundPlaceholder": "Goals, stack, repos, pipeline needs… Used as the sandbox team-build prompt.",
+          "backgroundHint": "Like a prompt: injected into the sandbox to generate groups, reporting lines, and engineers."
+        },
+        "acp": {
+          "meta": "Used as the default ACP for the PM and engineers."
+        },
+        "git": {
+          "meta": "Optional. Helps roster selection and team Git defaults.",
+          "url": "Repository URL"
+        },
+        "mcp": {
+          "meta": "Default mcp[] for the team; applied when creating the PM and engineers. artifact-store is prefilled.",
+          "namePh": "Name",
+          "headers": "Headers",
+          "addHeader": "Add header",
+          "add": "Add MCP",
+          "restoreArtifact": "Restore artifact-store preset",
+          "runVars": "Run vars: {'${APPROVING_ARTIFACT_URL}'} / {'${APPROVING_ARTIFACT_TOKEN}'}"
+        },
+        "env": {
+          "meta": "Written to the PM; engineers inherit by default."
+        },
+        "review": {
+          "meta": "Creates the project and PM, starts a sandbox, and provisions 9 engineers from the reference roster.",
+          "project": "Project",
+          "root": "Root group",
+          "pipeline": "Subgroup",
+          "set": "Set",
+          "skip": "Skipped (add later)",
+          "none": "None",
+          "roster": "Roster: 1 PM + 9 engineers · 10 total",
+          "background": "Project background (team prompt)",
+          "noArtifactWarn": "Pipeline roles usually need artifact-store; it is missing from the MCP list."
+        },
+        "errors": {
+          "projectRequired": "Project / team name is required",
+          "prefixRequired": "Name prefix is required",
+          "backgroundRequired": "Project background (team prompt) is required",
+          "pmRequired": "PM Agent name is required",
+          "pmInvalid": "Invalid PM name (letters/digits/_/- only)",
+          "pmExists": "That PM name already exists"
+        },
+        "progress": {
+          "title": "Sandbox · {name}",
+          "sub": "Auto-provision: project / org / engineer agents",
+          "starting": "sandbox starting…",
+          "running": "sandbox running",
+          "ready": "team ready · {n} agents",
+          "failed": "failed",
+          "waiting": "Waiting for progress…",
+          "resources": "Created resources",
+          "openPm": "Open project manager",
+          "done": "Done",
+          "retry": "Retry",
+          "keepCreated": "Keep created resources"
+        }
       },
       "wizard": {
         "title": "New Agent",

--- a/web/src/locales/zh-CN/mcp.json
+++ b/web/src/locales/zh-CN/mcp.json
@@ -339,6 +339,22 @@
           "signature": "pm_get_org()",
           "desc": "读组织架构与下属关系"
         },
+        "pm_list_agent_templates": {
+          "signature": "pm_list_agent_templates()",
+          "desc": "列出内置工程师角色模板"
+        },
+        "pm_create_agent_from_template": {
+          "signature": "pm_create_agent_from_template(templateId, name)",
+          "desc": "从模板创建工程师 Agent（同项目，禁止覆盖重名）"
+        },
+        "pm_set_org_membership": {
+          "signature": "pm_set_org_membership(agentName, groupIds, parentAgent?)",
+          "desc": "设置组成员与汇报上级（parent 须为当前 PM）"
+        },
+        "pm_ensure_child_group": {
+          "signature": "pm_ensure_child_group(name, parentGroupId?)",
+          "desc": "在授权根组下幂等确保子组存在"
+        },
         "pm_fs_list": {
           "signature": "pm_fs_list(agentName, path?)",
           "desc": "列出 workspace 目录"

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -1107,7 +1107,12 @@
     "agentStudio": {
       "title": "Agent 管理",
       "errorPrefix": "出错:",
-      "empty": "暂无 Agent。点击右上角\"新建 Agent\"创建,或后端首启会落盘默认 Agent。",
+      "empty": "暂无 Agent。可「创建 Agent 团队」一键拉起项目与流水线角色，或「新建 Agent」创建单个。",
+      "emptyTeamTitle": "用一个入口拉起整支团队",
+      "emptyTeamDesc": "填写项目背景与运行配置后自动起沙箱：创建项目、根组、项目经理与 9 名工程师，并挂好上下级。",
+      "emptyTeamCta": "创建 Agent 团队",
+      "emptyTeamOrSingle": "或新建单个 Agent",
+      "createTeam": "创建 Agent 团队",
       "unsaved": "未保存",
       "saved": "已保存",
       "tabs": {
@@ -1151,6 +1156,7 @@
         "multiGroup": "多组",
         "reportsTo": "上级：{name}",
         "newRootGroup": "新建根组",
+        "newTeam": "创建 Agent 团队",
         "newChildGroup": "新建子组",
         "renameGroup": "重命名组",
         "groupNameLabel": "组名称",
@@ -1551,6 +1557,87 @@
         "skillsNote": "可执行技能目录",
         "commandsNote": "commands/*.md 斜杠命令",
         "envNote": "经容器环境变量注入"
+      },
+      "teamWizard": {
+        "title": "创建 Agent 团队",
+        "headSub": "项目背景 + 运行配置 → 确认后自动起沙箱建团",
+        "confirmStart": "确认并启动沙箱",
+        "submitting": "正在提交",
+        "previewLine": "将创建：{root} / {pipe} · {pm} + {n} 工程师",
+        "steps": {
+          "team": "团队信息",
+          "acp": "Agent",
+          "apiKey": "API Key",
+          "git": "Git",
+          "mcp": "MCP",
+          "env": "环境变量",
+          "review": "确认创建"
+        },
+        "team": {
+          "meta": "先定项目与命名；工程师将在沙箱中按参考编制生成。",
+          "projectName": "项目 / 团队名",
+          "prefix": "命名前缀",
+          "rootGroup": "根组名称",
+          "pipelineGroup": "流水线子组",
+          "pipelineHint": "工程师默认挂到此子组",
+          "pmName": "PM Agent 名称",
+          "background": "项目背景",
+          "backgroundPlaceholder": "描述项目目标、技术栈、仓库形态、流水线诉求等。将作为沙箱建团 Prompt。",
+          "backgroundHint": "类似 Prompt：确认后注入沙箱，据此生成根组、上下级与工程师团队。"
+        },
+        "acp": {
+          "meta": "该配置用于 PM 及后续工程师的默认 ACP。"
+        },
+        "git": {
+          "meta": "可选。供建团结合仓库选型，并写入团队默认 Git 相关配置。",
+          "url": "仓库 URL"
+        },
+        "mcp": {
+          "meta": "写入团队默认 mcp[]；创建 PM / 工程师时一并带上。默认已放入 artifact-store。",
+          "namePh": "名称",
+          "headers": "请求头",
+          "addHeader": "添加 Header",
+          "add": "添加 MCP",
+          "restoreArtifact": "恢复 artifact-store 预设",
+          "runVars": "运行变量：{'${APPROVING_ARTIFACT_URL}'} / {'${APPROVING_ARTIFACT_TOKEN}'}"
+        },
+        "env": {
+          "meta": "写入 PM；工程师创建时默认继承。"
+        },
+        "review": {
+          "meta": "确认后将创建项目与 PM，自动起沙箱并按参考编制生成 9 名工程师。",
+          "project": "项目",
+          "root": "根组",
+          "pipeline": "子组",
+          "set": "已填写",
+          "skip": "跳过（可稍后补）",
+          "none": "无",
+          "roster": "编制：1 PM + 9 工程师 · 共 10",
+          "background": "项目背景（建团 Prompt）",
+          "noArtifactWarn": "流水线角色通常需要 artifact-store；当前 MCP 列表未包含它。"
+        },
+        "errors": {
+          "projectRequired": "请填写项目 / 团队名",
+          "prefixRequired": "请填写命名前缀",
+          "backgroundRequired": "请填写项目背景（建团 Prompt）",
+          "pmRequired": "请填写 PM Agent 名称",
+          "pmInvalid": "PM 名称不合法（仅字母数字与 _/-）",
+          "pmExists": "该 PM 名称已存在"
+        },
+        "progress": {
+          "title": "沙箱 · {name}",
+          "sub": "自动建团：项目 / Org / 工程师 Agent",
+          "starting": "sandbox starting…",
+          "running": "sandbox running",
+          "ready": "team ready · {n} agents",
+          "failed": "failed",
+          "waiting": "等待进度…",
+          "resources": "已产出资源",
+          "openPm": "打开项目经理",
+          "done": "完成",
+          "retry": "重试",
+          "keepCreated": "仅保留已创建资源"
+        }
       },
       "wizard": {
         "title": "新建 Agent",

--- a/web/src/views/AgentStudioView.vue
+++ b/web/src/views/AgentStudioView.vue
@@ -16,7 +16,9 @@ import EnvCredentialHelpModal, {
   type EnvCredentialHelpSection,
 } from '@/components/agent/EnvCredentialHelpModal.vue'
 import AgentCreateWizard from '@/components/agent/AgentCreateWizard.vue'
-import { api, type Agent, type AgentOrg, type MCPServer, type AgentPrompts, type PlatformRuleMeta } from '@/lib/api'
+import CreateAgentTeamWizard from '@/components/agent/CreateAgentTeamWizard.vue'
+import TeamBootstrapPanel from '@/components/agent/TeamBootstrapPanel.vue'
+import { api, type Agent, type AgentOrg, type MCPServer, type AgentPrompts, type PlatformRuleMeta, type TeamBootstrapSession } from '@/lib/api'
 import { useBreakpoint } from '@/lib/useBreakpoint'
 import {
   emptyOrg,
@@ -1721,9 +1723,15 @@ function onImportGroup(groupId: string) {
 }
 
 const showCreateWizard = ref(false)
+const showTeamWizard = ref(false)
+const teamBootstrapSessionId = ref('')
 
 function openCreateAgent() {
   showCreateWizard.value = true
+}
+
+function openCreateTeam() {
+  showTeamWizard.value = true
 }
 
 function onWizardCreated(created: Agent) {
@@ -1732,6 +1740,43 @@ function onWizardCreated(created: Agent) {
   // New agents default to ungrouped / no parent (no org entry).
   select(created.name)
   showToast(t('pages.agentStudio.wizard.createdToast', { name: created.name }))
+}
+
+function onTeamBootstrapStarted(session: TeamBootstrapSession) {
+  teamBootstrapSessionId.value = session.id
+  void reloadOrg()
+  void refreshAgentsList()
+}
+
+async function refreshAgentsList() {
+  try {
+    const list = await api.listAgents()
+    agents.value = list || []
+    agents.value.sort((a, b) => a.name.localeCompare(b.name))
+  } catch {
+    /* ignore */
+  }
+}
+
+async function onTeamBootstrapRefresh() {
+  await Promise.all([reloadOrg(), refreshAgentsList()])
+}
+
+function onTeamBootstrapSelectPm(name: string) {
+  void select(name)
+}
+
+function onTeamBootstrapOpenPm(name: string) {
+  teamBootstrapSessionId.value = ''
+  void select(name)
+}
+
+function onTeamBootstrapDone() {
+  const pm = agents.value.find((a) => a.name.includes('项目经理'))?.name || agents.value[0]?.name
+  teamBootstrapSessionId.value = ''
+  void onTeamBootstrapRefresh().then(() => {
+    if (pm) void select(pm)
+  })
 }
 
 function openAgentManage(focusAgentName?: string) {
@@ -2112,6 +2157,12 @@ onBeforeUnmount(() => {
           @click="triggerImport"
         >{{ t('pages.agentStudio.exportImport.import') }}</AppButton>
         <AppButton
+          variant="outline"
+          icon="skills"
+          :class="isMobile ? 'min-h-11 w-full justify-center' : ''"
+          @click="openCreateTeam"
+        >{{ t('pages.agentStudio.createTeam') }}</AppButton>
+        <AppButton
           variant="primary"
           icon="plus"
           :class="isMobile ? 'min-h-11 w-full justify-center' : ''"
@@ -2139,8 +2190,18 @@ onBeforeUnmount(() => {
     <div class="flex min-h-0 flex-1 flex-col">
       <div v-if="loading" class="card flex flex-1 items-center justify-center text-sm text-txt3">{{ t('common.buttons.loading') }}</div>
 
-      <div v-else-if="!agents.length" class="card flex flex-1 items-center justify-center text-sm text-txt3">
-        {{ t('pages.agentStudio.empty') }}
+      <div
+        v-else-if="!agents.length && !teamBootstrapSessionId"
+        class="card flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center"
+      >
+        <h2 class="m-0 text-[18px] font-semibold text-txt">{{ t('pages.agentStudio.emptyTeamTitle') }}</h2>
+        <p class="m-0 max-w-md text-[13px] leading-6 text-txt3">{{ t('pages.agentStudio.emptyTeamDesc') }}</p>
+        <AppButton variant="primary" icon="skills" @click="openCreateTeam">
+          {{ t('pages.agentStudio.emptyTeamCta') }}
+        </AppButton>
+        <button type="button" class="text-[12px] text-accent-2 hover:underline" @click="openCreateAgent">
+          {{ t('pages.agentStudio.emptyTeamOrSingle') }}
+        </button>
       </div>
 
       <div
@@ -2162,6 +2223,7 @@ onBeforeUnmount(() => {
         @remove-from-group="onRemoveFromGroup"
         @open-manage="openAgentManage"
         @create-root-group="openCreateRootGroup"
+        @create-team="openCreateTeam"
         @create-child-group="openCreateChildGroup"
         @rename-group="openRenameGroup"
         @delete-group="confirmDeleteGroup"
@@ -2173,8 +2235,18 @@ onBeforeUnmount(() => {
         @toggle-collapsed="toggleAgentListCollapsed"
       />
 
+      <TeamBootstrapPanel
+        v-if="teamBootstrapSessionId"
+        class="min-h-0 min-w-0"
+        :session-id="teamBootstrapSessionId"
+        @open-pm="onTeamBootstrapOpenPm"
+        @select-pm="onTeamBootstrapSelectPm"
+        @done="onTeamBootstrapDone"
+        @refresh-org="onTeamBootstrapRefresh"
+      />
+
       <!-- editor -->
-      <div v-if="draft" class="flex min-h-0 min-w-0 flex-col overflow-hidden">
+      <div v-else-if="draft" class="flex min-h-0 min-w-0 flex-col overflow-hidden">
         <div
           class="flex items-center gap-2 border-b border-line px-4"
           :class="isMobile ? 'min-h-12 py-2.5' : 'py-2'"
@@ -3414,6 +3486,13 @@ onBeforeUnmount(() => {
       :existing-names="agents.map((a) => a.name)"
       @close="showCreateWizard = false"
       @created="onWizardCreated"
+    />
+
+    <CreateAgentTeamWizard
+      :open="showTeamWizard"
+      :existing-names="agents.map((a) => a.name)"
+      @close="showTeamWizard = false"
+      @started="onTeamBootstrapStarted"
     />
 
     <AppModal


### PR DESCRIPTION
## Summary
- Agent Studio 新增独立「创建 Agent 团队」入口（顶栏 / 侧栏 / 空态），七步向导收集项目背景、ACP、Key、Git、MCP、env
- 确认后调用 bootstrap API：创建项目、根组与 Pipeline 子组、1 PM + 9 工程师（继承向导 mcp/env），并尽量起 PM 沙箱；进度面板与侧栏实时刷新，支持失败重试
- 扩展 `pm-agent-fs` 建团工具（模板列表 / 按模板创建 / 挂组与上下级 / 确保子组），会话作用域内拒绝跨项目、跨组与重名覆盖

## Test plan
- [ ] Studio 打开「创建 Agent 团队」，走完七步并确认启动
- [ ] 进度面板变为 ready；侧栏出现根组、Pipeline 子组与 10 个 Agent
- [ ] 工程师挂在 Pipeline 下，`parentAgent` 为 PM，mcp 含 artifact-store（若向导未删）
- [ ] 失败态可「重试」或「仅保留已创建资源」；进行中侧栏持续刷新
- [ ] `go test ./internal/services/ -run Team` 与前端 `agentTeamWizard` / `mcp` 相关单测通过


Made with [Cursor](https://cursor.com)