### PR TITLE
fix(docker): 允许 team_embed 模板 md 打进镜像

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,3 +29,5 @@ sandbox-gateway/
 !server/internal/sandbox/skills_embed/**/*.md
 !server/internal/services/onboarding_embed/
 !server/internal/services/onboarding_embed/**/*.md
+!server/internal/services/team_embed/
+!server/internal/services/team_embed/**/*.md

--- a/server/internal/services/team_embed.go
+++ b/server/internal/services/team_embed.go
@@ -101,6 +101,9 @@ func loadTeamAgentTemplate(embedName string) (Agent, error) {
 }
 
 func readTeamEmbedWorkspaceFiles(root string) ([]AgentFile, error) {
+	if _, err := fs.Stat(teamEmbedFS, root); err != nil {
+		return nil, fmt.Errorf("team embed workspace missing %s: %w (rebuild image with team_embed/*.md included)", root, err)
+	}
 	var out []AgentFile
 	prefix := strings.TrimSuffix(root, "/") + "/"
 	err := fs.WalkDir(teamEmbedFS, root, func(p string, d fs.DirEntry, err error) error {
@@ -124,6 +127,9 @@ func readTeamEmbedWorkspaceFiles(root string) ([]AgentFile, error) {
 	})
 	if err != nil {
 		return nil, fmt.Errorf("walk team embed workspace %s: %w", root, err)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("team embed workspace empty %s (check Docker .md allowlist for team_embed)", root)
 	}
 	return out, nil
 }

--- a/server/internal/services/team_test.go
+++ b/server/internal/services/team_test.go
@@ -86,6 +86,18 @@ func TestTeamBootstrap_CreatesRoster(t *testing.T) {
 	}
 }
 
+func TestLoadTeamAgentTemplates_AllNine(t *testing.T) {
+	for _, role := range TeamEngineerTemplates {
+		ag, err := loadTeamAgentTemplate(role.EmbedName)
+		if err != nil {
+			t.Fatalf("%s: %v", role.ID, err)
+		}
+		if len(ag.Files) == 0 {
+			t.Fatalf("%s: empty workspace files", role.ID)
+		}
+	}
+}
+
 func TestCreateAgentFromTemplate_Conflict(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open("file:team_scope_"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
 	if err != nil {


### PR DESCRIPTION
## Summary
- 根 `.dockerignore` 的 `**/*.md` 排除规则未放行 `team_embed`，Docker 镜像里工程师模板 workspace 缺失
- 建团在创建「调研工程师」时报 `open team_embed/ResearchAgent/workspace: file does not exist`
- 对齐 `onboarding_embed` / `skills_embed` 放行 `team_embed/**/*.md`，并加强空模板校验与九角色加载单测

## Test plan
- [ ] 重新构建 approving 镜像后执行「创建 Agent 团队」或失败会话「重试」
- [ ] 进度面板可到 ready，侧栏出现 1 PM + 9 工程师
- [ ] `go test ./internal/services/ -run 'LoadTeam|Team'` 通过


Made with [Cursor](https://cursor.com)