### PR TITLE
feat(i18n): 精简工作流变量空态副文案为 Demo 定稿

### DIFF
--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -517,7 +517,7 @@
       "envEmptyTitle": "No sandbox env yet",
       "envEmptyDesc": "Add KEY/VALUE rows to write into node Spec.Env. Secret values are masked on read.",
       "varsEmptyTitle": "No workflow variables yet",
-      "varsEmptyDesc": "Define project-level defaults (string / number / bool / select, etc.). Ask-at-launch still belongs on pipeline input nodes.",
+      "varsEmptyDesc": "Add a row to configure project-level defaults.",
       "varName": "Name",
       "varValue": "Default",
       "varDescPlaceholder": "Description (optional)",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -517,7 +517,7 @@
       "envEmptyTitle": "暂无沙箱环境变量",
       "envEmptyDesc": "添加 KEY/VALUE 行后，将写入节点沙箱 Spec.Env。密钥项回读会打码。",
       "varsEmptyTitle": "暂无工作流变量",
-      "varsEmptyDesc": "定义项目级默认值（string / number / bool / select 等）。启动询问仍在流水线 input 节点配置。",
+      "varsEmptyDesc": "添加一行后，即可配置项目级默认值。",
       "varName": "变量名",
       "varValue": "默认值",
       "varDescPlaceholder": "描述（可选）",


### PR DESCRIPTION
空态副文在 max-w-sm 下折成两句技术说明；改为与已批准 Demo 逐字一致的一句，去掉类型枚举与 Ask/input 边界。

Co-authored-by: Cursor <cursoragent@cursor.com>
