### PR TITLE
fix(i18n): 缩短工作流变量页头 varsHint 为产品语

### DIFF
--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -507,7 +507,7 @@
       "secretForced": "Forced",
       "secretForcedHint": "Official ACP auth keys are always Secret and masked; cannot switch to plain",
       "envHint": "Injected into pipeline node Spec.Env (OS environment variables). You can temporarily disable a row while keeping its key/value; changes take effect on the next injection only after you save.",
-      "varsHint": "Seeded as {'${vars.*}'} defaults at StartRun; not dumped into OS environ as a whole table.",
+      "varsHint": "{'${vars.*}'} defaults at launch; not dumped as a whole into sandbox OS env.",
       "envKey": "KEY",
       "envValue": "value",
       "envEnabled": "Enabled",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -507,7 +507,7 @@
       "secretForced": "强制",
       "secretForcedHint": "官方 ACP 鉴权键强制为密钥，回读打码，不可改为明文",
       "envHint": "注入流水线节点沙箱的 Spec.Env（OS 环境变量）。可临时停用某行并保留 key/value；开关与字段变更须保存后才影响下次注入。",
-      "varsHint": "StartRun 时作为 {'${vars.*}'} 默认值 seed，不会整表注入 OS environ。",
+      "varsHint": "启动运行时作为 {'${vars.*}'} 默认值，不整表注入沙箱环境。",
       "envKey": "KEY",
       "envValue": "value",
       "envEnabled": "启用",


### PR DESCRIPTION
去掉 StartRun/seed/OS environ，按 Demo 字面说明启动默认值且不整表注入沙箱环境。

Co-authored-by: Cursor <cursoragent@cursor.com>
