### PR TITLE
fix(runs): 运行列表白卡拉满剩余视口，消除底部灰底留白

### DIFF
--- a/web/src/views/RunListView.fill.test.ts
+++ b/web/src/views/RunListView.fill.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const dir = dirname(fileURLToPath(import.meta.url))
+const src = readFileSync(join(dir, 'RunListView.vue'), 'utf8')
+const shellSrc = readFileSync(join(dir, '../components/shell/AppShell.vue'), 'utf8')
+const routerSrc = readFileSync(join(dir, '../router/index.ts'), 'utf8')
+const workflowSrc = readFileSync(join(dir, 'WorkflowListView.vue'), 'utf8')
+const sandboxSrc = readFileSync(join(dir, 'SandboxListView.vue'), 'utf8')
+const projectSrc = readFileSync(join(dir, 'ProjectListView.vue'), 'utf8')
+const zhCommon = readFileSync(join(dir, '../locales/zh-CN/common.json'), 'utf8')
+const zhPages = readFileSync(join(dir, '../locales/zh-CN/pages.json'), 'utf8')
+
+const EMPTY_CARD_CLASS =
+  'card flex min-h-0 flex-1 flex-col items-center justify-center overflow-auto'
+const FILL_CARD_CLASS = 'card flex min-h-0 flex-1 flex-col overflow-hidden'
+
+describe('RunListView fill height chain (g1)', () => {
+  it('root uses flex h-full min-h-0 flex-col without calc(100vh) (g1.1)', () => {
+    expect(src).toMatch(/<div class="flex h-full min-h-0 flex-col">/)
+    expect(src).not.toMatch(/calc\(100vh/)
+  })
+
+  it('keeps title and filter bar shrink-0 (g1.2)', () => {
+    expect(src).toMatch(
+      /mb-5 flex shrink-0 flex-col gap-2\.5 md:flex-row md:items-start md:justify-between/,
+    )
+  })
+
+  it('desktop and mobile main cards flex-1 min-h-0; empty/fail may overflow-auto (g1.3)', () => {
+    const emptyCards = src.match(new RegExp(`class="${EMPTY_CARD_CLASS.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[^"]*"`, 'g')) || []
+    expect(emptyCards.length).toBeGreaterThanOrEqual(4)
+    expect(src).toMatch(new RegExp(FILL_CARD_CLASS.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+    expect(src).toMatch(/class="flex min-h-0 flex-1 flex-col overflow-hidden"/)
+  })
+
+  it('loading skeleton still uses SKELETON_ROWS=6 at top, not centered empty (g1.4)', () => {
+    expect(src).toMatch(/const SKELETON_ROWS = 6/)
+    expect(src).toMatch(/v-for="n in SKELETON_ROWS"/)
+    expect(src).toMatch(/:key="'skel-card-' \+ n"/)
+    expect(src).toMatch(/:key="'skel-' \+ n"/)
+    const mobile = src.slice(src.indexOf('<!-- Mobile card list -->'), src.indexOf('<!-- Desktop table -->'))
+    expect(mobile).toMatch(/initialLoading[\s\S]*overflow-y-auto[\s\S]*SKELETON_ROWS/)
+    expect(mobile).not.toMatch(/initialLoading[\s\S]*items-center justify-center[\s\S]*SKELETON_ROWS/)
+  })
+})
+
+describe('RunListView empty / fail split out of table (g2)', () => {
+  it('desktop empty/no-match is a centered fill card, not thead+td[colspan] (g2.1)', () => {
+    expect(src).not.toMatch(/colspan/)
+    expect(src).toMatch(/emptyMessage/)
+    expect(src).toMatch(/common\.empty\.noRuns/)
+    expect(src).toMatch(/common\.empty\.noMatchingRuns/)
+    expect(src).not.toMatch(/EmptyState/)
+    const desktop = src.slice(src.indexOf('<!-- Desktop table -->'))
+    expect(desktop).toMatch(new RegExp(EMPTY_CARD_CLASS.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+    expect(desktop).toMatch(/\{\{\s*emptyMessage\s*\}\}/)
+  })
+
+  it('desktop fail is centered fill card without alert icon box (g2.2)', () => {
+    expect(src).not.toMatch(/inline-flex h-10 w-10 items-center justify-center border border-err\/30/)
+    expect(src).not.toMatch(/<Icon name="alert" :size="18"/)
+    expect(src).toMatch(/pages\.runList\.loadFailedTitle/)
+    expect(src).toMatch(/pages\.runList\.loadFailedDesc/)
+    const desktopFail = src.slice(
+      src.indexOf('<!-- Desktop table -->'),
+      src.indexOf('<!-- Desktop table (loading skeleton or rows) -->'),
+    )
+    expect(desktopFail).toMatch(/initialLoadFailed/)
+    expect(desktopFail).toMatch(new RegExp(EMPTY_CARD_CLASS.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+    expect(desktopFail).not.toMatch(/<table/)
+    expect(desktopFail).not.toMatch(/Icon name="alert"/)
+  })
+
+  it('mobile empty/fail use the same flex-1 centered fill card (g2.3)', () => {
+    const mobile = src.slice(src.indexOf('<!-- Mobile card list -->'), src.indexOf('<!-- Desktop table -->'))
+    const emptyCards = mobile.match(new RegExp(`class="${EMPTY_CARD_CLASS.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[^"]*"`, 'g')) || []
+    expect(emptyCards.length).toBe(2)
+    expect(mobile).toMatch(/initialLoadFailed/)
+    expect(mobile).toMatch(/emptyMessage/)
+    expect(mobile).not.toMatch(/inline-flex h-10 w-10/)
+    expect(mobile).not.toMatch(/Icon name="alert"/)
+    expect(mobile).not.toMatch(/applySortClick/)
+  })
+})
+
+describe('RunListView sticky table + pager pin (g3)', () => {
+  it('desktop table wrap is overflow-auto with sticky elevated thead (g3.1)', () => {
+    expect(src).toMatch(/class="min-h-0 flex-1 overflow-auto"/)
+    expect(src).toMatch(/thead th\s*\{[^}]*position:\s*sticky/s)
+    expect(src).toMatch(/thead th\s*\{[^}]*top:\s*0/s)
+    expect(src).toMatch(/thead th\s*\{[^}]*background:\s*rgb\(var\(--c-elevated\)\)/s)
+  })
+
+  it('Pagination shrink-0 still gates on total > PAGE_SIZE and binds page (g3.2)', () => {
+    expect(src).toMatch(/const PAGE_SIZE = 20/)
+    const pagers = src.match(/<Pagination v-if="total > PAGE_SIZE" v-model:page="page"/g) || []
+    expect(pagers.length).toBe(2)
+    const shrinkPagers = src.match(/<Pagination v-if="total > PAGE_SIZE" v-model:page="page" class="shrink-0"/g) || []
+    expect(shrinkPagers.length).toBe(2)
+  })
+
+  it('mobile data list uses overflow-y-auto and pins pager (g3.3)', () => {
+    const mobile = src.slice(src.indexOf('<!-- Mobile card list -->'), src.indexOf('<!-- Desktop table -->'))
+    expect(mobile).toMatch(/min-h-0 flex-1 flex-col gap-2 overflow-y-auto/)
+    expect(mobile).toMatch(/<Pagination v-if="total > PAGE_SIZE" v-model:page="page" class="shrink-0"/)
+    expect(mobile).not.toMatch(/applySortClick/)
+    expect(mobile).not.toMatch(/sort-icon/)
+  })
+})
+
+describe('RunListView fill scope lock (g4.3)', () => {
+  it('does not alter AppShell height chain or /runs meta.full', () => {
+    expect(shellSrc).toMatch(/h-screen/)
+    expect(shellSrc).toMatch(/min-h-0 flex-1/)
+    expect(routerSrc).toMatch(
+      /path: '\/runs', name: 'runs', component: \(\) => import\('@\/views\/RunListView\.vue'\), meta: \{ titleKey: 'route\.runs' \}/,
+    )
+    expect(routerSrc).not.toMatch(/path: '\/runs'[^}]*full:\s*true/)
+  })
+
+  it('does not change other list pages, EmptyState, or empty/fail i18n strings', () => {
+    expect(workflowSrc).toMatch(/^\s*<div>\s*$/m)
+    expect(sandboxSrc).toMatch(/^\s*<div>\s*$/m)
+    expect(projectSrc).toMatch(/^\s*<div>\s*$/m)
+    expect(src).not.toMatch(/EmptyState/)
+    expect(zhCommon).toMatch(/"noRuns": "暂无运行记录"/)
+    expect(zhCommon).toMatch(/"noMatchingRuns": "无匹配运行记录"/)
+    expect(zhPages).toMatch(/"loadFailedTitle": "加载失败"/)
+    expect(zhPages).toMatch(/"loadFailedDesc": "无法加载运行记录，后台轮询将自动重试。筛选与翻页仍可使用。"/)
+  })
+})

--- a/web/src/views/RunListView.vue
+++ b/web/src/views/RunListView.vue
@@ -442,8 +442,8 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div>
-    <div class="mb-5 flex flex-col gap-2.5 md:flex-row md:items-start md:justify-between">
+  <div class="flex h-full min-h-0 flex-col">
+    <div class="mb-5 flex shrink-0 flex-col gap-2.5 md:flex-row md:items-start md:justify-between">
       <div class="min-w-0">
         <h2 class="text-lg font-semibold text-txt">{{ t('pages.runList.title') }}</h2>
         <p class="text-sm text-txt3">{{ t('pages.runList.subtitle') }}</p>
@@ -473,40 +473,50 @@ onUnmounted(() => {
     </div>
 
     <!-- Mobile card list -->
-    <div v-if="isMobile" :class="{ 'table-loading': showTableLoading }">
+    <div
+      v-if="isMobile"
+      class="flex min-h-0 flex-1 flex-col overflow-hidden"
+      :class="{ 'table-loading': showTableLoading }"
+    >
       <template v-if="initialLoading">
-        <div class="flex flex-col gap-2">
-          <div
-            v-for="n in SKELETON_ROWS"
-            :key="'skel-card-' + n"
-            class="rounded-lg border border-line bg-surface p-3"
-          >
-            <div class="flex items-start justify-between gap-3">
-              <div class="min-w-0 flex-1">
-                <div class="h-3.5 w-[75%] rounded bg-elevated animate-pulse" />
-                <div class="mt-1.5 h-2.5 w-20 rounded bg-elevated animate-pulse" />
+        <div class="card flex min-h-0 flex-1 flex-col overflow-hidden p-2">
+          <div class="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
+            <div
+              v-for="n in SKELETON_ROWS"
+              :key="'skel-card-' + n"
+              class="rounded-lg border border-line bg-surface p-3"
+            >
+              <div class="flex items-start justify-between gap-3">
+                <div class="min-w-0 flex-1">
+                  <div class="h-3.5 w-[75%] rounded bg-elevated animate-pulse" />
+                  <div class="mt-1.5 h-2.5 w-20 rounded bg-elevated animate-pulse" />
+                </div>
+                <div class="h-5 w-14 shrink-0 rounded bg-elevated animate-pulse" />
               </div>
-              <div class="h-5 w-14 shrink-0 rounded bg-elevated animate-pulse" />
+              <div class="mt-2 flex items-center gap-2">
+                <div class="h-1.5 w-20 shrink-0 rounded-full bg-elevated animate-pulse" />
+                <div class="h-2.5 w-7 rounded bg-elevated animate-pulse" />
+              </div>
+              <div class="mt-2.5 h-2.5 w-[55%] rounded bg-elevated animate-pulse" />
             </div>
-            <div class="mt-2 flex items-center gap-2">
-              <div class="h-1.5 w-20 shrink-0 rounded-full bg-elevated animate-pulse" />
-              <div class="h-2.5 w-7 rounded bg-elevated animate-pulse" />
-            </div>
-            <div class="mt-2.5 h-2.5 w-[55%] rounded bg-elevated animate-pulse" />
           </div>
         </div>
       </template>
-      <div v-else-if="initialLoadFailed" class="card px-5 py-10 text-center">
-        <div class="mx-auto mb-2.5 inline-flex h-10 w-10 items-center justify-center border border-err/30 bg-err/10 text-err">
-          <Icon name="alert" :size="18" />
-        </div>
+      <div
+        v-else-if="initialLoadFailed"
+        class="card flex min-h-0 flex-1 flex-col items-center justify-center overflow-auto px-5 py-10 text-center"
+      >
         <div class="text-[13px] font-medium text-txt">{{ t('pages.runList.loadFailedTitle') }}</div>
         <p class="mx-auto mt-1 max-w-[360px] text-xs text-txt3">{{ t('pages.runList.loadFailedDesc') }}</p>
       </div>
-      <div v-else-if="!runs.length" class="card px-5 py-10 text-center text-[13px] text-txt3">
+      <div
+        v-else-if="!runs.length"
+        class="card flex min-h-0 flex-1 flex-col items-center justify-center overflow-auto px-5 py-10 text-center text-[13px] text-txt3"
+      >
         {{ emptyMessage }}
       </div>
-      <div v-else class="flex flex-col gap-2">
+      <div v-else class="card flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div class="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-2">
         <!--
           custom + navigate (not a real <a>): ops @click.stop must not sit inside
           a native link, or stopPropagation blocks Vue Router's preventDefault and
@@ -595,12 +605,37 @@ onUnmounted(() => {
             </div>
           </div>
         </RouterLink>
+        </div>
+        <Pagination v-if="total > PAGE_SIZE" v-model:page="page" class="shrink-0" :page-size="PAGE_SIZE" :total="total" />
       </div>
-      <Pagination v-if="total > PAGE_SIZE" v-model:page="page" :page-size="PAGE_SIZE" :total="total" />
     </div>
 
     <!-- Desktop table -->
-    <div v-else class="card overflow-hidden" :class="{ 'table-loading': showTableLoading }">
+    <div
+      v-else-if="initialLoadFailed"
+      class="card flex min-h-0 flex-1 flex-col items-center justify-center overflow-auto px-5 py-10 text-center"
+      :class="{ 'table-loading': showTableLoading }"
+    >
+      <div class="text-[13px] font-medium text-txt">{{ t('pages.runList.loadFailedTitle') }}</div>
+      <p class="mx-auto mt-1 max-w-[360px] text-xs text-txt3">{{ t('pages.runList.loadFailedDesc') }}</p>
+    </div>
+
+    <!-- Desktop: empty / no matching -->
+    <div
+      v-else-if="!runs.length && !initialLoading"
+      class="card flex min-h-0 flex-1 flex-col items-center justify-center overflow-auto px-5 py-10 text-center text-[13px] text-txt3"
+      :class="{ 'table-loading': showTableLoading }"
+    >
+      {{ emptyMessage }}
+    </div>
+
+    <!-- Desktop table (loading skeleton or rows) -->
+    <div
+      v-else
+      class="card flex min-h-0 flex-1 flex-col overflow-hidden"
+      :class="{ 'table-loading': showTableLoading }"
+    >
+      <div class="min-h-0 flex-1 overflow-auto">
       <table class="w-full text-sm">
         <thead>
           <tr class="text-left text-[11px] uppercase tracking-wider text-txt3">
@@ -687,20 +722,6 @@ onUnmounted(() => {
               </td>
             </tr>
           </template>
-          <tr v-else-if="initialLoadFailed">
-            <td colspan="10" class="px-5 py-10 text-center">
-              <div class="mx-auto mb-2.5 inline-flex h-10 w-10 items-center justify-center border border-err/30 bg-err/10 text-err">
-                <Icon name="alert" :size="18" />
-              </div>
-              <div class="text-[13px] font-medium text-txt">{{ t('pages.runList.loadFailedTitle') }}</div>
-              <p class="mx-auto mt-1 max-w-[360px] text-xs text-txt3">{{ t('pages.runList.loadFailedDesc') }}</p>
-            </td>
-          </tr>
-          <tr v-else-if="!runs.length">
-            <td colspan="10" class="px-5 py-10 text-center text-[13px] text-txt3">
-              {{ emptyMessage }}
-            </td>
-          </tr>
           <template v-else>
             <RouterLink
               v-for="r in runs"
@@ -796,7 +817,8 @@ onUnmounted(() => {
           </template>
         </tbody>
       </table>
-      <Pagination v-if="total > PAGE_SIZE" v-model:page="page" :page-size="PAGE_SIZE" :total="total" />
+      </div>
+      <Pagination v-if="total > PAGE_SIZE" v-model:page="page" class="shrink-0" :page-size="PAGE_SIZE" :total="total" />
     </div>
 
     <AppModal
@@ -874,6 +896,13 @@ onUnmounted(() => {
 <style scoped>
 .table-loading {
   opacity: 0.55;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: rgb(var(--c-elevated));
 }
 
 @keyframes nodeLabelFadeIn {


### PR DESCRIPTION
接入壳层 flex 高度链，空/失败拆出短表居中现网文案，有数据时 sticky 表头+卡内滚动+分页钉底。

Co-authored-by: Cursor <cursoragent@cursor.com>
