### PR TITLE
fix(web): fill project meta tab to remove page void

### DIFF
--- a/web/e2e/project-detail.spec.ts
+++ b/web/e2e/project-detail.spec.ts
@@ -592,12 +592,19 @@ test.describe('ProjectDetailView 项目信息面板', () => {
     await expect(deleteBtn).toHaveClass(/text-err/)
     await expect(saveBtn).toBeVisible()
     await expect(saveBtn).toHaveClass(/bg-accent/)
+    // 无改动时保存仍可点（现网 savingMeta，非 Demo dirty-disable）（g2.1 / g3.2）
+    await expect(saveBtn).toBeEnabled()
 
     // 左删右存：删除在保存左侧（g2.1 / g3.2）
     const deleteBox = await deleteBtn.boundingBox()
     const saveBox = await saveBtn.boundingBox()
     expect(deleteBox && saveBox).toBeTruthy()
     expect(deleteBox!.x).toBeLessThan(saveBox!.x)
+
+    // 脚栏贴近主区底，消除卡外页底空洞（g1.1 / g1.2 / g3.2）
+    const footerBox = await footer.boundingBox()
+    expect(footerBox).toBeTruthy()
+    expect(footerBox!.y + footerBox!.height).toBeGreaterThan(800 - 80)
 
     // 点击删除 → 既有确认弹窗 → 取消后仍停留详情且项目未删
     await deleteBtn.click()
@@ -607,6 +614,129 @@ test.describe('ProjectDetailView 项目信息面板', () => {
     await expect(page.getByText('删除项目 · Demo Project')).toHaveCount(0)
     await expect(page.getByRole('heading', { name: 'Demo Project' })).toBeVisible()
     await expect(panel.getByTestId('project-meta-delete')).toBeVisible()
+  })
+
+  test('保存后页头名称同步；其它 Tab 仍可切换（g2.2 / g3.2）', async ({ page }) => {
+    let savedName = MOCK_PROJECT.name
+    await page.setViewportSize({ width: 1280, height: 800 })
+    await page.route('**/api/projects/proj-1', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ ...MOCK_PROJECT, name: savedName }),
+        })
+        return
+      }
+      if (route.request().method() === 'PATCH' || route.request().method() === 'PUT') {
+        const body = route.request().postDataJSON() as { name?: string; description?: string }
+        savedName = body.name?.trim() || savedName
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            ...MOCK_PROJECT,
+            name: savedName,
+            description: body.description ?? MOCK_PROJECT.description,
+          }),
+        })
+        return
+      }
+      await route.continue()
+    })
+    await page.route('**/api/workflows**', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(MOCK_WORKFLOWS),
+        })
+        return
+      }
+      await route.continue()
+    })
+    await page.route('**/api/runs**', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ items: [], total: 0, page: 1, pageSize: 20, hasMore: false }),
+        })
+        return
+      }
+      await route.continue()
+    })
+    await page.route('**/api/projects/proj-1/pm-leader', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ enabled: false }),
+      })
+    })
+    await page.route('**/api/projects/proj-1/cron-jobs', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ items: [] }),
+        })
+        return
+      }
+      await route.continue()
+    })
+    await page.route('**/api/projects/proj-1/channel**', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ channel: null, secretsKeyConfigured: false }),
+        })
+        return
+      }
+      await route.continue()
+    })
+    await page.route('**/api/projects/*/token-stats**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          window: '30d',
+          bucketWidth: 'day',
+          timezone: 'UTC',
+          empty: true,
+          trend: [],
+          composition: {
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheWriteTokens: 0,
+            total: 0,
+          },
+          workflows: [],
+        }),
+      })
+    })
+    await page.goto('/project-detail.html')
+    await expect(page.getByRole('heading', { name: 'Demo Project' })).toBeVisible({ timeout: 10_000 })
+    await page.getByRole('button', { name: '项目信息' }).click()
+
+    await page.locator('#project-meta-name').fill('Renamed Project')
+    await page.getByTestId('project-meta-footer').getByRole('button', { name: '保存' }).click()
+    await expect(page.getByRole('heading', { name: 'Renamed Project' })).toBeVisible({ timeout: 5_000 })
+
+    await page.getByRole('button', { name: '沙箱环境变量' }).click()
+    await expect(page.getByText('暂无沙箱环境变量')).toBeVisible()
+    await expect(page).toHaveURL(/tab=sandboxEnv/)
+    await page.getByRole('button', { name: '定时任务' }).click()
+    await expect(page.getByText('暂无定时任务')).toBeVisible()
+    await expect(page).toHaveURL(/tab=cronJobs/)
+    await page.getByRole('button', { name: '通知' }).click()
+    await expect(page.getByTestId('project-notify-panel')).toBeVisible()
+    await expect(page).toHaveURL(/tab=notify/)
+    await page.getByRole('button', { name: '项目信息' }).click()
+    await expect(page.getByTestId('project-meta-footer')).toBeVisible()
+    await expect(page.locator('#project-meta-name')).toHaveValue('Renamed Project')
+    await expect(page).toHaveURL(/tab=meta/)
   })
 })
 

--- a/web/src/views/ProjectDetailView.metaLayout.test.ts
+++ b/web/src/views/ProjectDetailView.metaLayout.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const viewsDir = dirname(fileURLToPath(import.meta.url))
+const detailSrc = readFileSync(join(viewsDir, 'ProjectDetailView.vue'), 'utf8')
+const shellSrc = readFileSync(join(viewsDir, '../components/shell/AppShell.vue'), 'utf8')
+
+function metaTabBlock(): string {
+  const start = detailSrc.indexOf("tab === 'meta'")
+  expect(start, 'missing meta tab block').toBeGreaterThanOrEqual(0)
+  const end = detailSrc.indexOf('ref="fileInput"', start)
+  expect(end, 'missing end marker after meta tab').toBeGreaterThan(start)
+  return detailSrc.slice(start, end)
+}
+
+describe('ProjectDetailView meta tab fill-height chain (g1.1 / g1.2 / g1.3)', () => {
+  it('outer wrapper uses min-h-0 flex-1 instead of 420px hard floor (g1.1)', () => {
+    const meta = metaTabBlock()
+    expect(meta).toMatch(/class="flex min-h-0 flex-1 flex-col"/)
+    expect(meta).not.toMatch(/min-h-\[420px\]/)
+    expect(meta).not.toMatch(/\bmin-h-\[[0-9]+vh\]/)
+    expect(meta).not.toMatch(/\bh-\[[0-9]+vh\]/)
+    expect(meta).toMatch(/flex flex-1 flex-col overflow-hidden border border-line bg-surface shadow-\[var\(--shadow-card\)\]/)
+  })
+
+  it('head/footer shrink-0 and fields scroll inside remaining height (g1.2)', () => {
+    const meta = metaTabBlock()
+    expect(meta).toMatch(/shrink-0 border-b border-line bg-elevated\/55/)
+    expect(meta).toMatch(
+      /scroll-area flex min-h-0 flex-1 flex-col gap-3\.5 overflow-y-auto p-4/,
+    )
+    expect(meta).toMatch(
+      /flex shrink-0 flex-wrap items-center justify-between[\s\S]*data-testid="project-meta-footer"/,
+    )
+  })
+
+  it('textarea stays min-h-[120px] without flex-1 stretch (g1.3)', () => {
+    const meta = metaTabBlock()
+    const ta = meta.match(/<textarea[\s\S]*?\/>/)
+    expect(ta?.[0], 'missing meta textarea').toBeTruthy()
+    expect(ta![0]).toMatch(/min-h-\[120px\]/)
+    expect(ta![0]).toMatch(/rows="5"/)
+    expect(ta![0]).toMatch(/resize-y/)
+    expect(ta![0]).not.toMatch(/flex-1/)
+  })
+})
+
+describe('ProjectDetailView meta tab keeps existing chrome and save semantics (g1.4 / g2.1 / g2.2)', () => {
+  it('keeps near-full-width card chrome and live tokens, not Demo skin (g1.4)', () => {
+    const meta = metaTabBlock()
+    expect(meta).toMatch(/border border-line bg-surface shadow-\[var\(--shadow-card\)\]/)
+    expect(meta).toMatch(/bg-elevated\/55/)
+    expect(meta).not.toMatch(/max-w-\[/)
+    expect(meta).not.toMatch(/mx-auto/)
+    expect(meta).not.toMatch(/border-radius:\s*0/)
+    expect(meta).not.toMatch(/#7B61FF/)
+  })
+
+  it('save stays bound to savingMeta, not Demo dirty-disable (g2.1)', () => {
+    const meta = metaTabBlock()
+    expect(meta).toMatch(/:disabled="savingMeta"/)
+    expect(meta).not.toMatch(/!dirty/)
+    expect(detailSrc).toMatch(/savingMeta\.value = true/)
+    expect(detailSrc).toMatch(/async function saveMeta\(/)
+  })
+
+  it('does not change AppShell height chain or other short tabs (g2.2)', () => {
+    expect(shellSrc).toMatch(/class="relative flex h-screen w-screen overflow-hidden bg-base text-txt"/)
+    expect(shellSrc).toMatch(/<main class="relative min-h-0 flex-1 overflow-hidden">/)
+    expect(detailSrc).toMatch(/tab === 'cronJobs'" class="flex min-h-\[420px\] flex-col"/)
+    expect(detailSrc).toMatch(/tab === 'notify' && project" class="min-h-\[420px\]"/)
+    expect(detailSrc).toMatch(/tab === 'sandboxEnv'" class="flex min-h-\[420px\] flex-col"/)
+    expect(detailSrc).toMatch(/tab === 'variables'" class="flex min-h-\[420px\] flex-col"/)
+    expect(detailSrc).toMatch(/tab === 'audit'" class="flex min-h-0 flex-1 flex-col"/)
+  })
+})

--- a/web/src/views/ProjectDetailView.vue
+++ b/web/src/views/ProjectDetailView.vue
@@ -1586,12 +1586,12 @@ onUnmounted(() => {
         <ProjectAuditPanel :project-id="projectId" :force-denied="auditForceDenied" />
       </div>
 
-      <!-- Project info (meta) tab: near-full-width panel (shell / head / fields / primary save) -->
-      <div v-else-if="tab === 'meta'" class="flex min-h-[420px] flex-col">
+      <!-- Project info (meta) tab: fill remaining main area (no page void under card) -->
+      <div v-else-if="tab === 'meta'" class="flex min-h-0 flex-1 flex-col">
         <div
           class="flex flex-1 flex-col overflow-hidden border border-line bg-surface shadow-[var(--shadow-card)]"
         >
-          <div class="border-b border-line bg-elevated/55 px-4 py-3.5">
+          <div class="shrink-0 border-b border-line bg-elevated/55 px-4 py-3.5">
             <h2 class="m-0 text-sm font-semibold text-txt">
               {{ t('pages.projectDetail.metaTitle') }}
             </h2>
@@ -1600,7 +1600,7 @@ onUnmounted(() => {
             </p>
           </div>
 
-          <div class="flex flex-1 flex-col gap-3.5 p-4">
+          <div class="scroll-area flex min-h-0 flex-1 flex-col gap-3.5 overflow-y-auto p-4">
             <div>
               <label class="label" for="project-meta-name">{{ t('pages.projectList.nameLabel') }}</label>
               <input
@@ -1616,14 +1616,14 @@ onUnmounted(() => {
                 id="project-meta-desc"
                 v-model="editDesc"
                 rows="5"
-                class="input min-h-[120px]"
+                class="input min-h-[120px] resize-y"
                 :placeholder="t('pages.projectDetail.metaDescPlaceholder')"
               />
             </div>
           </div>
 
           <div
-            class="flex flex-wrap items-center justify-between gap-2 border-t border-line bg-surface p-3"
+            class="flex shrink-0 flex-wrap items-center justify-between gap-2 border-t border-line bg-surface p-3"
             data-testid="project-meta-footer"
           >
             <AppButton


### PR DESCRIPTION
Give the project info card the same min-h-0 flex-1 chain as audit/PM settings so the footer sits at the remaining viewport and the short form no longer leaves a hole under the card.

Co-authored-by: Cursor <cursoragent@cursor.com>
