### PR TITLE
fix(web): 硬加载层不再展示已用时与心跳文案

### DIFF
--- a/web/src/components/run/HardLoadLayer.test.ts
+++ b/web/src/components/run/HardLoadLayer.test.ts
@@ -26,13 +26,16 @@ describe('HardLoadLayer', () => {
     vi.useRealTimers()
   })
 
-  it('shows stage, elapsed, and heartbeat without stuck warning before threshold', () => {
+  it('shows stage and heartbeat without elapsed row or stuck warning before threshold', () => {
     vi.useFakeTimers()
     const w = mountLayer({ stuckAfterMs: 10_000, stage: '加载中' })
     expect(w.get('[data-testid="hard-load-layer"]').attributes('aria-busy')).toBe('true')
     expect(w.find('[data-testid="hard-load-heartbeat"]').exists()).toBe(true)
+    expect(w.find('[data-testid="hard-load-heartbeat"] i').exists()).toBe(true)
+    expect(w.findAll('[data-testid="hard-load-heartbeat"] i')).toHaveLength(3)
     expect(w.get('[data-testid="hard-load-stage"]').text()).toBe('加载中')
-    expect(w.get('[data-testid="hard-load-elapsed"]').text()).toMatch(/已用时 0s/)
+    expect(w.find('[data-testid="hard-load-elapsed"]').exists()).toBe(false)
+    expect(w.get('[data-testid="hard-load-layer"]').text()).not.toMatch(/已用时|心跳|Elapsed|heartbeat/)
     expect(w.find('[data-testid="hard-load-stuck"]').exists()).toBe(false)
     vi.advanceTimersByTime(9_000)
     expect(w.find('[data-testid="hard-load-stuck"]').exists()).toBe(false)
@@ -50,7 +53,7 @@ describe('HardLoadLayer', () => {
     w.unmount()
   })
 
-  it('retry resets elapsed and emits retry', async () => {
+  it('retry resets clock and emits retry without restoring elapsed row', async () => {
     vi.useFakeTimers()
     const w = mountLayer({ stuckAfterMs: 1_000 })
     vi.advanceTimersByTime(1_000)
@@ -59,18 +62,23 @@ describe('HardLoadLayer', () => {
     await w.get('[data-testid="hard-load-retry"]').trigger('click')
     expect(w.emitted('retry')).toHaveLength(1)
     expect(w.find('[data-testid="hard-load-stuck"]').exists()).toBe(false)
-    expect(w.get('[data-testid="hard-load-elapsed"]').text()).toMatch(/已用时 0s/)
+    expect(w.find('[data-testid="hard-load-elapsed"]').exists()).toBe(false)
+    expect(w.get('[data-testid="hard-load-layer"]').text()).not.toMatch(/已用时|心跳|Elapsed|heartbeat/)
     w.unmount()
   })
 
-  it('renders English Demo-locked copy', async () => {
+  it('renders English Demo-locked copy without elapsed/heartbeat text', async () => {
     vi.useFakeTimers()
     const w = mountLayer({ stuckAfterMs: 20_000, stage: 'Starting…' }, 'en')
     expect(w.get('[data-testid="hard-load-stage"]').text()).toBe('Starting…')
-    expect(w.get('[data-testid="hard-load-elapsed"]').text()).toMatch(/Elapsed 0s/)
+    expect(w.find('[data-testid="hard-load-heartbeat"]').exists()).toBe(true)
+    expect(w.find('[data-testid="hard-load-elapsed"]').exists()).toBe(false)
+    expect(w.get('[data-testid="hard-load-layer"]').text()).not.toMatch(/已用时|心跳|Elapsed|heartbeat/)
     vi.advanceTimersByTime(20_000)
     await w.vm.$nextTick()
     expect(w.get('[data-testid="hard-load-stuck"]').text()).toMatch(/May be stuck/i)
+    expect(w.find('[data-testid="hard-load-retry"]').exists()).toBe(true)
+    expect(w.get('[data-testid="hard-load-layer"]').text()).not.toMatch(/已用时|心跳|Elapsed|heartbeat/)
     w.unmount()
   })
 })

--- a/web/src/components/run/HardLoadLayer.vue
+++ b/web/src/components/run/HardLoadLayer.vue
@@ -86,9 +86,6 @@ defineExpose({ reset: startClock, elapsedSec, stuck })
       <i class="hard-hb inline-block w-[3px] bg-accent" style="height: 12px; animation-delay: 0.3s" />
     </span>
     <p class="text-[13px] font-semibold text-txt" data-testid="hard-load-stage">{{ stageLabel }}</p>
-    <p class="text-[12px] text-txt3" data-testid="hard-load-elapsed">
-      {{ t('common.loading.elapsed', { s: elapsedSec }) }}
-    </p>
     <div
       v-if="stuck"
       class="max-w-[360px] border border-warn/40 bg-warn/10 px-2.5 py-2 text-[12px] text-warn"

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -324,7 +324,6 @@
     },
     "loading": {
       "label": "Loading",
-      "elapsed": "Elapsed {s}s · heartbeat alive",
       "stuck": "May be stuck · request still running; wait or retry"
     },
     "chatImage": {

--- a/web/src/locales/loadingPendingKeys.test.ts
+++ b/web/src/locales/loadingPendingKeys.test.ts
@@ -32,7 +32,6 @@ describe('loading/pending Demo-locked locale keys', () => {
     ['buttons.creating', '创建中…', 'Creating…'],
     ['buttons.starting', '启动中…', 'Starting…'],
     ['loading.label', '加载中', 'Loading'],
-    ['loading.elapsed', '已用时 {s}s · 心跳存活', 'Elapsed {s}s · heartbeat alive'],
     ['loading.stuck', '可能卡死 · 请求仍在进行，可继续等待或重试', 'May be stuck · request still running; wait or retry'],
   ]
 
@@ -43,9 +42,12 @@ describe('loading/pending Demo-locked locale keys', () => {
     const zhLoad = leafKeys((zhCommon as { common: { loading: unknown } }).common.loading)
     const enLoad = leafKeys((enCommon as { common: { loading: unknown } }).common.loading)
     expect(zhLoad.sort()).toEqual(enLoad.sort())
+    expect(zhLoad.sort()).toEqual(['label', 'stuck'])
+    expect(atPath(zhCommon.common, 'loading.elapsed')).toBeUndefined()
+    expect(atPath(enCommon.common, 'loading.elapsed')).toBeUndefined()
   })
 
-  it('locks Demo pending / stuck / elapsed copy in zh and en', () => {
+  it('locks Demo pending / stuck copy in zh and en', () => {
     for (const [path, zh, en] of demoCommon) {
       expect(atPath(zhCommon.common, path), `zh common.${path}`).toBe(zh)
       expect(atPath(enCommon.common, path), `en common.${path}`).toBe(en)

--- a/web/src/locales/zh-CN/common.json
+++ b/web/src/locales/zh-CN/common.json
@@ -324,7 +324,6 @@
     },
     "loading": {
       "label": "加载中",
-      "elapsed": "已用时 {s}s · 心跳存活",
       "stuck": "可能卡死 · 请求仍在进行，可继续等待或重试"
     },
     "chatImage": {


### PR DESCRIPTION
共享 HardLoadLayer 去掉 elapsed 行与中英词条，保留动画、主阶段与超时卡死/重试，避免加载态暴露协议术语。

Co-authored-by: Cursor <cursoragent@cursor.com>
