### PR TITLE
feat(web): 优化 Agent Studio 窄屏 chrome 布局与可点性

### DIFF
--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -1333,7 +1333,8 @@
         "chars": "{n} chars",
         "markdownBadge": "Split + sync + minimap",
         "newFileInFolder": "New file here",
-        "newFolderInFolder": "New folder here"
+        "newFolderInFolder": "New folder here",
+        "more": "More"
       },
       "mcp": {
         "hint": "Full mcp.json written to {configRoot}/mcp.json and injected in ACP. New agents include artifact-store by default. Project Management MCP must be added manually and stays separate from artifact-store — do not merge them.",
@@ -1531,7 +1532,9 @@
         "orgSheetTitle": "Agent organization",
         "orgSheetHint": "Read-only: expand groups and switch agents. No group create or drag reorder. Close via backdrop or the close button.",
         "desktopOnlyTitle": "Please complete on desktop",
-        "desktopOnlyDesc": "\"{tab}\" keeps an entry on narrow screens only; please finish full configuration in a desktop browser."
+        "desktopOnlyDesc": "\"{tab}\" keeps an entry on narrow screens only; please finish full configuration in a desktop browser.",
+        "fullNameLabel": "Full name",
+        "fullNameAria": "View full agent name"
       },
       "dialogs": {
         "leaveUnsavedTitle": "Unsaved changes",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -1333,7 +1333,8 @@
         "chars": "{n} 字符",
         "markdownBadge": "分屏+同步+小地图",
         "newFileInFolder": "在此新建文件",
-        "newFolderInFolder": "在此新建文件夹"
+        "newFolderInFolder": "在此新建文件夹",
+        "more": "更多"
       },
       "mcp": {
         "hint": "整份 mcp.json 由你配置,写入 {configRoot}/mcp.json 并在 ACP session 注入。新建 Agent 默认带平台 artifact-store,可自行增删。项目管理 MCP 需手动添加,与 artifact-store 并列、互不合并。",
@@ -1531,7 +1532,9 @@
         "orgSheetTitle": "Agent 组织树",
         "orgSheetHint": "只读浏览：支持折叠展开与切换；不提供分组创建 / 拖拽排序。可通过遮罩或关闭按钮收起。",
         "desktopOnlyTitle": "请在桌面端完成",
-        "desktopOnlyDesc": "「{tab}」本期窄屏仅保留入口，请在桌面浏览器中完成完整配置。"
+        "desktopOnlyDesc": "「{tab}」本期窄屏仅保留入口，请在桌面浏览器中完成完整配置。",
+        "fullNameLabel": "完整名称",
+        "fullNameAria": "查看完整 Agent 名称"
       },
       "dialogs": {
         "leaveUnsavedTitle": "有未保存的修改",

--- a/web/src/views/AgentStudioView.test.ts
+++ b/web/src/views/AgentStudioView.test.ts
@@ -1011,17 +1011,38 @@ describe('AgentStudio mobile core path', () => {
     wrapper.unmount()
   })
 
-  it('keeps file row actions visible without hover on mobile', async () => {
+  it('keeps a single more trigger visible without hover on mobile', async () => {
     mocks.listAgents.mockResolvedValue([agentWithFiles()])
     const wrapper = await mountMobileStudio()
     await flushPromises()
 
-    const actions = wrapper.findAll('[data-test="file-row-action"]')
-    expect(actions.length).toBeGreaterThan(0)
-    for (const btn of actions) {
-      expect(btn.classes().join(' ')).toContain('opacity-100')
-      expect(btn.classes().join(' ')).not.toContain('opacity-0')
+    expect(wrapper.findAll('[data-test="file-row-action"]').length).toBe(0)
+    const mores = wrapper.findAll('[data-test="file-row-more"]')
+    expect(mores.length).toBeGreaterThan(0)
+    for (const btn of mores) {
+      const cls = btn.classes().join(' ')
+      expect(cls).toMatch(/min-h-11/)
+      expect(cls).toMatch(/min-w-11/)
+      expect(cls).not.toContain('opacity-0')
     }
+
+    await wrapper.get('[data-test="file-row-more"][data-path="rules"]').trigger('click')
+    await flushPromises()
+    const folderMenu = document.querySelector('[data-test="explorer-more-menu"]')
+    expect(folderMenu).toBeTruthy()
+    const folderActions = Array.from(folderMenu!.querySelectorAll('[data-test="explorer-more-item"]')).map(
+      (el) => el.getAttribute('data-action'),
+    )
+    expect(folderActions).toEqual(['newFile', 'newFolder', 'rename'])
+
+    await wrapper.get('[data-test="file-row-more"][data-path="AGENTS.md"]').trigger('click')
+    await flushPromises()
+    const fileMenu = document.querySelector('[data-test="explorer-more-menu"]')
+    expect(fileMenu).toBeTruthy()
+    const fileActions = Array.from(fileMenu!.querySelectorAll('[data-test="explorer-more-item"]')).map(
+      (el) => el.getAttribute('data-action'),
+    )
+    expect(fileActions).toEqual(['rename', 'delete'])
     wrapper.unmount()
   })
 
@@ -1051,6 +1072,214 @@ describe('AgentStudio mobile core path', () => {
     expect(wrapper.text()).toContain('新建 Agent')
     expect(wrapper.text()).not.toContain('配置可复用的 Agent')
     expect(wrapper.text()).not.toContain('复制进沙箱')
+    wrapper.unmount()
+  })
+})
+
+describe('AgentStudio mobile chrome', () => {
+  const ModalStub = defineComponent({
+    props: { open: Boolean, title: String },
+    emits: ['close'],
+    template: '<div v-if="open" data-test="modal"><h2>{{ title }}</h2><slot /><slot name="footer" /></div>',
+  })
+  const MdStub = defineComponent({
+    props: { modelValue: String, filePath: String, variant: String },
+    emits: ['update:modelValue'],
+    template:
+      '<div data-test="md-editor" :data-variant="variant">' +
+      '<textarea :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />' +
+      '</div>',
+  })
+
+  function agentWithFiles(): Agent {
+    return {
+      ...agent('public'),
+      files: [
+        { path: 'AGENTS.md', content: '# hello\n' },
+        { path: 'rules/system.md', content: '---\ntitle: system\n---\n\n# rule\n' },
+      ],
+    }
+  }
+
+  async function mountMobileStudio() {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const router = await createStudioRouter()
+    return trackMount(
+      mount(AgentStudioView, {
+        global: {
+          plugins: [i18n, router],
+          stubs: {
+            AppButton: ButtonStub,
+            Icon: true,
+            AppModal: ModalStub,
+            CodeEditor: CodeEditorStub,
+            MarkdownSplitEditor: MdStub,
+            ExplorerContextMenu: true,
+            AgentChatTester: true,
+            AgentGitGuide: true,
+            AgentCreateWizard: true,
+            AgentOrgSidebar: true,
+            AgentDataPanel: true,
+          },
+        },
+      }),
+    )
+  }
+
+  beforeEach(() => {
+    breakpointMocks.isMobile.value = true
+  })
+
+  it('splits name bar into two rows and hides disabled saved button when clean', async () => {
+    mocks.listAgents.mockResolvedValue([{ ...agentWithFiles(), name: 'Approving代办助手' }])
+    const wrapper = await mountMobileStudio()
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="studio-name-row-top"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="studio-name-row-bottom"]').exists()).toBe(true)
+    expect(wrapper.get('[data-test="agent-name"]').text()).toContain('Approving代办助手')
+    expect(wrapper.get('[data-test="org-switch"]').classes().join(' ')).toMatch(/min-h-11/)
+    expect(wrapper.get('[data-test="studio-export"]').classes().join(' ')).toMatch(/min-h-11/)
+    expect(wrapper.find('[data-test="studio-save"]').exists()).toBe(false)
+    expect(wrapper.findAll('button').filter((b) => b.text() === '已保存').length).toBe(0)
+    wrapper.unmount()
+  })
+
+  it('shows unsaved chip and save on dirty two-row bar', async () => {
+    mocks.listAgents.mockResolvedValue([agentWithFiles()])
+    const wrapper = await mountMobileStudio()
+    await flushPromises()
+
+    await wrapper.findAll('button').find((b) => b.text().includes('rules'))!.trigger('click')
+    await flushPromises()
+    await wrapper.findAll('button').find((b) => b.text().includes('system.md'))!.trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-test="md-editor"] textarea').setValue('# dirty chrome\n')
+    await flushPromises()
+
+    expect(wrapper.get('[data-test="studio-name-row-top"]').text()).toContain('未保存')
+    const save = wrapper.get('[data-test="studio-save"]')
+    expect(save.text()).toContain('保存')
+    expect(save.classes().join(' ')).toMatch(/min-h-11/)
+    wrapper.unmount()
+  })
+
+  it('opens full name tip only when the name is truncated', async () => {
+    mocks.listAgents.mockResolvedValue([{ ...agentWithFiles(), name: 'Approving代办助手超长名称' }])
+    const wrapper = await mountMobileStudio()
+    await flushPromises()
+
+    const nameBtn = wrapper.get('[data-test="agent-name"]')
+    await nameBtn.trigger('click')
+    await nextTick()
+    expect(document.querySelector('[data-test="agent-name-tip"]')).toBeNull()
+
+    Object.defineProperty(nameBtn.element, 'scrollWidth', { configurable: true, get: () => 240 })
+    Object.defineProperty(nameBtn.element, 'clientWidth', { configurable: true, get: () => 80 })
+    await nameBtn.trigger('click')
+    await nextTick()
+    const tip = document.querySelector('[data-test="agent-name-tip"]')
+    expect(tip).toBeTruthy()
+    expect(tip!.textContent).toContain('Approving代办助手超长名称')
+    expect(tip!.textContent).toContain('完整名称')
+
+    ;(document.querySelector('[data-test="agent-name-tip-backdrop"]') as HTMLElement).click()
+    await nextTick()
+    expect(document.querySelector('[data-test="agent-name-tip"]')).toBeNull()
+    wrapper.unmount()
+  })
+
+  it('shows tab edge fades from scrollLeft and hides them at the ends', async () => {
+    mocks.listAgents.mockResolvedValue([agentWithFiles()])
+    const wrapper = await mountMobileStudio()
+    await flushPromises()
+
+    const strip = wrapper.get('[data-test="studio-tab-strip"]')
+    const el = strip.element as HTMLElement
+    let scrollLeft = 0
+    Object.defineProperty(el, 'scrollWidth', { configurable: true, get: () => 900 })
+    Object.defineProperty(el, 'clientWidth', { configurable: true, get: () => 320 })
+    Object.defineProperty(el, 'scrollLeft', {
+      configurable: true,
+      get: () => scrollLeft,
+      set: (v: number) => {
+        scrollLeft = v
+      },
+    })
+
+    await strip.trigger('scroll')
+    await nextTick()
+    expect(wrapper.find('[data-test="tab-fade-right"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="tab-fade-left"]').exists()).toBe(false)
+
+    scrollLeft = 40
+    await strip.trigger('scroll')
+    await nextTick()
+    expect(wrapper.find('[data-test="tab-fade-left"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="tab-fade-right"]').exists()).toBe(true)
+
+    scrollLeft = 580
+    await strip.trigger('scroll')
+    await nextTick()
+    expect(wrapper.find('[data-test="tab-fade-right"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="tab-fade-left"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('keeps more menu items at least 44px and mutually exclusive with full name tip', async () => {
+    mocks.listAgents.mockResolvedValue([{ ...agentWithFiles(), name: 'Approving代办助手超长名称' }])
+    const wrapper = await mountMobileStudio()
+    await flushPromises()
+
+    await wrapper.get('[data-test="file-row-more"][data-path="rules"]').trigger('click')
+    await flushPromises()
+    const items = Array.from(document.querySelectorAll('[data-test="explorer-more-item"]'))
+    expect(items.length).toBeGreaterThan(0)
+    for (const item of items) {
+      expect((item as HTMLElement).className).toMatch(/min-h-11/)
+    }
+
+    const nameBtn = wrapper.get('[data-test="agent-name"]')
+    Object.defineProperty(nameBtn.element, 'scrollWidth', { configurable: true, get: () => 240 })
+    Object.defineProperty(nameBtn.element, 'clientWidth', { configurable: true, get: () => 80 })
+    await nameBtn.trigger('click')
+    await nextTick()
+    expect(document.querySelector('[data-test="explorer-more-menu"]')).toBeNull()
+    expect(document.querySelector('[data-test="agent-name-tip"]')).toBeTruthy()
+    wrapper.unmount()
+  })
+})
+
+describe('AgentStudio desktop chrome unchanged', () => {
+  function agentWithFiles(): Agent {
+    return {
+      ...agent('public'),
+      files: [
+        { path: 'AGENTS.md', content: '# hello\n' },
+        { path: 'rules/system.md', content: '---\ntitle: system\n---\n\n# rule\n' },
+      ],
+    }
+  }
+
+  it('keeps single-row name bar, disabled save, and hover row actions', async () => {
+    breakpointMocks.isMobile.value = false
+    mocks.listAgents.mockResolvedValue([agentWithFiles()])
+    const wrapper = await mountStudio()
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="studio-name-row-top"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="studio-name-row-bottom"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="org-switch"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="file-row-more"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="tab-fade-right"]').exists()).toBe(false)
+    const save = wrapper.get('[data-test="studio-save"]')
+    expect(save.text()).toContain('已保存')
+    expect(save.attributes('disabled')).toBeDefined()
+    expect(wrapper.findAll('[data-test="file-row-action"]').length).toBeGreaterThan(0)
     wrapper.unmount()
   })
 })

--- a/web/src/views/AgentStudioView.vue
+++ b/web/src/views/AgentStudioView.vue
@@ -175,6 +175,35 @@ type FilesStep = 'list' | 'edit'
 const filesStep = ref<FilesStep>('list')
 const justSaved = ref(false)
 
+const TAB_FADE_THRESHOLD = 4
+const agentNameEl = ref<HTMLElement | null>(null)
+const tabStripEl = ref<HTMLElement | null>(null)
+const agentNameTruncated = ref(false)
+const showFullNameTip = ref(false)
+const fullNameTipStyle = ref<Record<string, string>>({})
+const tabFadeLeft = ref(false)
+const tabFadeRight = ref(false)
+
+type ExplorerMoreTarget = { dir: boolean; path: string; name: string }
+const explorerMore = ref<ExplorerMoreTarget | null>(null)
+const explorerMoreStyle = ref<Record<string, string>>({})
+const explorerMoreAnchor = ref<HTMLElement | null>(null)
+let tabStripObserver: ResizeObserver | null = null
+
+function closeFullNameTip() {
+  showFullNameTip.value = false
+}
+
+function closeExplorerMore() {
+  explorerMore.value = null
+  explorerMoreAnchor.value = null
+}
+
+function closeMobileChromeOverlays() {
+  closeFullNameTip()
+  closeExplorerMore()
+}
+
 /** Narrow-screen agent org tree bottom sheet (≈70vh). */
 const showOrgSheet = ref(false)
 const orgSheetCollapsed = ref<Set<string>>(new Set())
@@ -669,7 +698,12 @@ watch(isMobile, (mobile) => {
   } else {
     // Desktop sidebar owns org navigation — close sheet to avoid dual entry.
     showOrgSheet.value = false
+    closeMobileChromeOverlays()
   }
+  nextTick(() => {
+    measureAgentNameTruncation()
+    syncTabFade()
+  })
 })
 
 const agentNames = computed(() => agents.value.map((a) => a.name))
@@ -833,6 +867,7 @@ async function applyAssign(syncDraftRequested: boolean) {
 }
 
 function openOrgSheet() {
+  closeMobileChromeOverlays()
   showOrgSheet.value = true
 }
 
@@ -2149,17 +2184,151 @@ function onDocumentClick() {
   hideCtxMenu()
 }
 
+function measureAgentNameTruncation() {
+  const el = agentNameEl.value
+  if (!el) {
+    agentNameTruncated.value = false
+    return
+  }
+  agentNameTruncated.value = el.scrollWidth > el.clientWidth + 1
+}
+
+function placeFullNameTip() {
+  const el = agentNameEl.value
+  if (!el || !showFullNameTip.value) return
+  const rect = el.getBoundingClientRect()
+  const margin = 12
+  fullNameTipStyle.value = {
+    top: `${Math.round(rect.bottom + 8)}px`,
+    left: `${margin}px`,
+    right: `${margin}px`,
+  }
+}
+
+function onAgentNameClick() {
+  measureAgentNameTruncation()
+  if (!agentNameTruncated.value) return
+  closeExplorerMore()
+  showFullNameTip.value = !showFullNameTip.value
+  if (showFullNameTip.value) nextTick(placeFullNameTip)
+}
+
+function syncTabFade() {
+  const el = tabStripEl.value
+  if (!el || !isMobile.value) {
+    tabFadeLeft.value = false
+    tabFadeRight.value = false
+    return
+  }
+  const max = el.scrollWidth - el.clientWidth
+  tabFadeLeft.value = el.scrollLeft > TAB_FADE_THRESHOLD
+  tabFadeRight.value = el.scrollLeft < max - TAB_FADE_THRESHOLD
+}
+
+function bindTabStripObserver() {
+  if (typeof ResizeObserver === 'undefined') return
+  tabStripObserver?.disconnect()
+  tabStripObserver = null
+  if (!tabStripEl.value) return
+  tabStripObserver = new ResizeObserver(() => syncTabFade())
+  tabStripObserver.observe(tabStripEl.value)
+}
+
+function explorerMoreItemCount(target: ExplorerMoreTarget) {
+  if (target.dir) return isProtectedDir(target.path) ? 3 : 4
+  return 2
+}
+
+function placeExplorerMore() {
+  const anchor = explorerMoreAnchor.value
+  const target = explorerMore.value
+  if (!anchor || !target) return
+  const rect = anchor.getBoundingClientRect()
+  const margin = 8
+  const menuWidth = Math.min(220, Math.max(160, window.innerWidth - margin * 2))
+  const menuHeight = explorerMoreItemCount(target) * 44 + 8
+  let left = rect.right - menuWidth
+  left = Math.max(margin, Math.min(left, window.innerWidth - margin - menuWidth))
+  let top = rect.bottom + 4
+  if (top + menuHeight > window.innerHeight - margin) {
+    top = Math.max(margin, rect.top - menuHeight - 4)
+  }
+  explorerMoreStyle.value = {
+    top: `${Math.round(top)}px`,
+    left: `${Math.round(left)}px`,
+    width: `${Math.round(menuWidth)}px`,
+  }
+}
+
+function toggleExplorerMore(e: MouseEvent, row: TreeRow) {
+  const el = e.currentTarget as HTMLElement
+  if (explorerMore.value?.path === row.path) {
+    closeExplorerMore()
+    return
+  }
+  closeFullNameTip()
+  hideCtxMenu()
+  explorerMore.value = { dir: row.dir, path: row.path, name: row.name }
+  explorerMoreAnchor.value = el
+  nextTick(placeExplorerMore)
+}
+
+function onExplorerMoreAction(action: 'newFile' | 'newFolder' | 'rename' | 'delete') {
+  const target = explorerMore.value
+  if (!target) return
+  const row: TreeRow = { name: target.name, path: target.path, dir: target.dir, depth: 0 }
+  closeExplorerMore()
+  if (action === 'newFile' && target.dir) newFile(target.path)
+  else if (action === 'newFolder' && target.dir) newFolder(target.path)
+  else if (action === 'rename') startRename(row)
+  else if (action === 'delete' && !(target.dir && isProtectedDir(target.path))) deleteEntry(row)
+}
+
+function onChromeReposition() {
+  if (showFullNameTip.value) placeFullNameTip()
+  if (explorerMore.value) placeExplorerMore()
+  syncTabFade()
+}
+
+function onChromeKeydown(e: KeyboardEvent) {
+  if (e.key !== 'Escape') return
+  if (showFullNameTip.value || explorerMore.value) closeMobileChromeOverlays()
+}
+
+watch(activeName, () => {
+  closeFullNameTip()
+  nextTick(measureAgentNameTruncation)
+})
+
+watch(tabStripEl, () => {
+  bindTabStripObserver()
+  nextTick(syncTabFade)
+})
+
 onMounted(() => {
   agentListCollapsed.value = readCollapsedState(AGENT_LIST_COLLAPSED_KEY)
   explorerCollapsed.value = readCollapsedState(EXPLORER_COLLAPSED_KEY)
   load()
   document.addEventListener('click', onDocumentClick)
   document.addEventListener('keydown', onExplorerKeydown)
+  document.addEventListener('keydown', onChromeKeydown)
+  window.addEventListener('resize', onChromeReposition)
+  window.addEventListener('scroll', onChromeReposition, true)
+  nextTick(() => {
+    measureAgentNameTruncation()
+    bindTabStripObserver()
+    syncTabFade()
+  })
 })
 
 onBeforeUnmount(() => {
   document.removeEventListener('click', onDocumentClick)
   document.removeEventListener('keydown', onExplorerKeydown)
+  document.removeEventListener('keydown', onChromeKeydown)
+  window.removeEventListener('resize', onChromeReposition)
+  window.removeEventListener('scroll', onChromeReposition, true)
+  tabStripObserver?.disconnect()
+  tabStripObserver = null
   if (toastTimer) clearTimeout(toastTimer)
 })
 </script>
@@ -2330,36 +2499,89 @@ onBeforeUnmount(() => {
       <!-- editor -->
       <div v-else-if="draft" class="flex min-h-0 min-w-0 flex-col overflow-hidden">
         <div
-          class="flex items-center gap-2 border-b border-line px-4"
-          :class="isMobile ? 'min-h-12 py-2.5' : 'py-2'"
+          v-if="isMobile"
+          data-test="studio-name-bar"
+          class="flex flex-col gap-2 border-b border-line px-4 py-2.5"
+        >
+          <div data-test="studio-name-row-top" class="flex min-w-0 items-center gap-2">
+            <Icon name="robot" :size="15" class="shrink-0 text-accent-2" />
+            <button
+              ref="agentNameEl"
+              type="button"
+              data-test="agent-name"
+              class="min-w-0 flex-1 truncate text-left text-[13px] font-medium text-txt"
+              :class="agentNameTruncated ? 'cursor-pointer' : 'cursor-default'"
+              :title="activeName"
+              :aria-label="agentNameTruncated ? t('pages.agentStudio.mobile.fullNameAria') : undefined"
+              @click="onAgentNameClick"
+            >{{ activeName }}</button>
+            <button
+              type="button"
+              data-test="org-switch"
+              class="inline-flex min-h-11 shrink-0 items-center gap-1 rounded border border-line bg-elevated px-2.5 text-[12px] text-txt2 transition hover:border-line-strong hover:text-txt"
+              :title="t('pages.agentStudio.mobile.switchTitle')"
+              :aria-label="t('pages.agentStudio.mobile.switchAria')"
+              @click="openOrgSheet"
+            >
+              <Icon name="menu" :size="14" />
+              <span>{{ t('pages.agentStudio.mobile.switch') }}</span>
+            </button>
+            <span v-if="dirty" class="chip shrink-0 border-warn/30 text-warn">{{ t('pages.agentStudio.unsaved') }}</span>
+            <span
+              v-else-if="justSaved"
+              class="chip shrink-0 border-ok/30 bg-ok/10 text-ok"
+            >{{ t('pages.agentStudio.saved') }}</span>
+          </div>
+          <div data-test="studio-name-row-bottom" class="flex items-center gap-2">
+            <AppButton
+              data-test="studio-export"
+              variant="outline"
+              icon="download"
+              class="min-h-11"
+              :disabled="exporting"
+              @click="triggerExport"
+            >
+              {{ t('pages.agentStudio.exportImport.export') }}
+            </AppButton>
+            <AppButton
+              v-if="dirty"
+              data-test="studio-save"
+              variant="primary"
+              class="min-h-11"
+              :disabled="saving"
+              @click="save"
+            >
+              {{ saving ? t('common.buttons.saving') : t('common.buttons.save') }}
+            </AppButton>
+          </div>
+        </div>
+        <div
+          v-else
+          data-test="studio-name-bar"
+          class="flex items-center gap-2 border-b border-line px-4 py-2"
         >
           <Icon name="robot" :size="15" class="shrink-0 text-accent-2" />
-          <span class="min-w-0 truncate text-[13px] font-medium text-txt">{{ activeName }}</span>
-          <button
-            v-if="isMobile"
-            type="button"
-            data-test="org-switch"
-            class="inline-flex shrink-0 items-center gap-1 rounded border border-line bg-elevated px-2 py-1 text-[12px] text-txt2 transition hover:border-line-strong hover:text-txt"
-            :title="t('pages.agentStudio.mobile.switchTitle')"
-            :aria-label="t('pages.agentStudio.mobile.switchAria')"
-            @click="openOrgSheet"
-          >
-            <Icon name="menu" :size="14" />
-            <span>{{ t('pages.agentStudio.mobile.switch') }}</span>
-          </button>
+          <span class="min-w-0 truncate text-[13px] font-medium text-txt" :title="activeName">{{ activeName }}</span>
           <span v-if="dirty" class="chip shrink-0 border-warn/30 text-warn">{{ t('pages.agentStudio.unsaved') }}</span>
           <span
             v-else-if="justSaved"
             class="chip shrink-0 border-ok/30 bg-ok/10 text-ok"
           >{{ t('pages.agentStudio.saved') }}</span>
           <div class="ml-auto flex shrink-0 items-center gap-2">
-            <AppButton size="sm" variant="outline" icon="download" :disabled="exporting" @click="triggerExport">
+            <AppButton
+              data-test="studio-export"
+              size="sm"
+              variant="outline"
+              icon="download"
+              :disabled="exporting"
+              @click="triggerExport"
+            >
               {{ t('pages.agentStudio.exportImport.export') }}
             </AppButton>
             <AppButton
+              data-test="studio-save"
               size="sm"
               variant="primary"
-              :class="isMobile ? 'min-h-11' : ''"
               :disabled="!dirty || saving"
               @click="save"
             >
@@ -2368,17 +2590,40 @@ onBeforeUnmount(() => {
           </div>
         </div>
 
-        <div class="scroll-area flex gap-1 overflow-x-auto border-b border-line px-3 pt-2 [-webkit-overflow-scrolling:touch]">
-          <button
-            v-for="tabItem in studioTabs"
-            :key="tabItem.k"
-            class="shrink-0 whitespace-nowrap px-3 text-[12px] transition"
-            :class="[
-              isMobile ? 'min-h-11 py-2.5' : 'rounded-t py-1.5',
-              tab === tabItem.k ? 'border-b-2 border-accent text-txt' : 'text-txt3 hover:text-txt2',
-            ]"
-            @click="requestStudioTab(tabItem.k)"
-          >{{ tabItem.l }}</button>
+        <div data-test="studio-tabs" class="relative min-w-0 border-b border-line">
+          <div
+            ref="tabStripEl"
+            data-test="studio-tab-strip"
+            class="scroll-area flex min-w-0 gap-1 overflow-x-auto px-3 pt-2 [-webkit-overflow-scrolling:touch]"
+            @scroll="syncTabFade"
+          >
+            <button
+              v-for="tabItem in studioTabs"
+              :key="tabItem.k"
+              class="shrink-0 whitespace-nowrap px-3 text-[12px] transition"
+              :class="[
+                isMobile ? 'min-h-11 py-2.5' : 'rounded-t py-1.5',
+                tab === tabItem.k ? 'border-b-2 border-accent text-txt' : 'text-txt3 hover:text-txt2',
+              ]"
+              @click="requestStudioTab(tabItem.k)"
+            >{{ tabItem.l }}</button>
+          </div>
+          <div
+            v-if="isMobile && tabFadeLeft"
+            data-test="tab-fade-left"
+            class="pointer-events-none absolute inset-y-0 left-0 flex w-10 items-center justify-center bg-gradient-to-r from-surface to-transparent text-txt2"
+            aria-hidden="true"
+          >
+            <Icon name="chevron-left" :size="14" />
+          </div>
+          <div
+            v-if="isMobile && tabFadeRight"
+            data-test="tab-fade-right"
+            class="pointer-events-none absolute inset-y-0 right-0 flex w-10 items-center justify-center bg-gradient-to-l from-surface to-transparent text-txt2"
+            aria-hidden="true"
+          >
+            <Icon name="chevron-right" :size="14" />
+          </div>
         </div>
 
         <!-- agent working directory (VSCode-style explorer + tabs + editor) -->
@@ -2508,36 +2753,45 @@ onBeforeUnmount(() => {
                     <span class="truncate font-mono">{{ row.name }}</span>
                   </button>
                   <button
-                    v-if="row.dir"
-                    data-test="file-row-action"
-                    class="shrink-0 text-txt3 hover:text-accent-2"
-                    :class="isMobile ? 'flex min-h-9 min-w-9 items-center justify-center opacity-100' : 'opacity-0 group-hover:opacity-100'"
-                    :title="t('pages.agentStudio.explorer.newFileInFolder')"
-                    @click.stop="newFile(row.path)"
-                  ><Icon name="doc" :size="12" /></button>
-                  <button
-                    v-if="row.dir"
-                    data-test="file-row-action"
-                    class="shrink-0 text-txt3 hover:text-accent-2"
-                    :class="isMobile ? 'flex min-h-9 min-w-9 items-center justify-center opacity-100' : 'opacity-0 group-hover:opacity-100'"
-                    :title="t('pages.agentStudio.explorer.newFolderInFolder')"
-                    @click.stop="newFolder(row.path)"
-                  ><Icon name="folder" :size="12" /></button>
-                  <button
-                    data-test="file-row-action"
-                    class="shrink-0 text-txt3 hover:text-accent-2"
-                    :class="isMobile ? 'flex min-h-9 min-w-9 items-center justify-center opacity-100' : 'opacity-0 group-hover:opacity-100'"
-                    :title="t('pages.agentStudio.explorer.rename')"
-                    @click.stop="startRename(row)"
-                  ><Icon name="edit" :size="12" /></button>
-                  <button
-                    v-if="!row.dir || !isProtectedDir(row.path)"
-                    data-test="file-row-action"
-                    class="shrink-0 text-txt3 hover:text-err"
-                    :class="isMobile ? 'flex min-h-9 min-w-9 items-center justify-center opacity-100' : 'opacity-0 group-hover:opacity-100'"
-                    :title="t('pages.agentStudio.explorer.delete')"
-                    @click.stop="deleteEntry(row)"
-                  ><Icon name="close" :size="12" /></button>
+                    v-if="isMobile"
+                    type="button"
+                    data-test="file-row-more"
+                    :data-path="row.path"
+                    class="flex min-h-11 min-w-11 shrink-0 items-center justify-center text-txt3 hover:text-accent-2"
+                    :title="t('pages.agentStudio.explorer.more')"
+                    :aria-label="t('pages.agentStudio.explorer.more')"
+                    :aria-expanded="explorerMore?.path === row.path"
+                    @click.stop="toggleExplorerMore($event, row)"
+                  ><Icon name="more" :size="16" /></button>
+                  <template v-else>
+                    <button
+                      v-if="row.dir"
+                      data-test="file-row-action"
+                      class="shrink-0 text-txt3 opacity-0 hover:text-accent-2 group-hover:opacity-100"
+                      :title="t('pages.agentStudio.explorer.newFileInFolder')"
+                      @click.stop="newFile(row.path)"
+                    ><Icon name="doc" :size="12" /></button>
+                    <button
+                      v-if="row.dir"
+                      data-test="file-row-action"
+                      class="shrink-0 text-txt3 opacity-0 hover:text-accent-2 group-hover:opacity-100"
+                      :title="t('pages.agentStudio.explorer.newFolderInFolder')"
+                      @click.stop="newFolder(row.path)"
+                    ><Icon name="folder" :size="12" /></button>
+                    <button
+                      data-test="file-row-action"
+                      class="shrink-0 text-txt3 opacity-0 hover:text-accent-2 group-hover:opacity-100"
+                      :title="t('pages.agentStudio.explorer.rename')"
+                      @click.stop="startRename(row)"
+                    ><Icon name="edit" :size="12" /></button>
+                    <button
+                      v-if="!row.dir || !isProtectedDir(row.path)"
+                      data-test="file-row-action"
+                      class="shrink-0 text-txt3 opacity-0 hover:text-err group-hover:opacity-100"
+                      :title="t('pages.agentStudio.explorer.delete')"
+                      @click.stop="deleteEntry(row)"
+                    ><Icon name="close" :size="12" /></button>
+                  </template>
                 </template>
               </div>
 
@@ -3553,6 +3807,70 @@ onBeforeUnmount(() => {
     </AppModal>
 
     <input ref="importFileInput" type="file" accept=".zip" class="hidden" @change="onImportFileChange" />
+
+    <Teleport to="body">
+      <div
+        v-if="isMobile && showFullNameTip"
+        data-test="agent-name-tip-backdrop"
+        class="fixed inset-0 z-[9998]"
+        @click="closeFullNameTip"
+      />
+      <div
+        v-if="isMobile && showFullNameTip"
+        data-test="agent-name-tip"
+        class="fixed z-[9999] border border-line bg-elevated px-3 py-2.5 text-[12.5px] text-txt shadow-card"
+        :style="fullNameTipStyle"
+        @click.stop
+      >
+        <small class="mb-1 block text-[11px] text-txt3">{{ t('pages.agentStudio.mobile.fullNameLabel') }}</small>
+        <b class="break-all font-semibold">{{ activeName }}</b>
+      </div>
+      <div
+        v-if="isMobile && explorerMore"
+        data-test="explorer-more-backdrop"
+        class="fixed inset-0 z-[9998]"
+        @click="closeExplorerMore"
+      />
+      <div
+        v-if="isMobile && explorerMore"
+        data-test="explorer-more-menu"
+        class="fixed z-[9999] min-w-[180px] border border-line bg-elevated py-1 shadow-card"
+        :style="explorerMoreStyle"
+        @click.stop
+      >
+        <button
+          v-if="explorerMore.dir"
+          type="button"
+          data-test="explorer-more-item"
+          data-action="newFile"
+          class="flex min-h-11 w-full items-center px-3.5 text-left text-[13px] text-txt hover:bg-overlay"
+          @click="onExplorerMoreAction('newFile')"
+        >{{ t('pages.agentStudio.explorer.newFile') }}</button>
+        <button
+          v-if="explorerMore.dir"
+          type="button"
+          data-test="explorer-more-item"
+          data-action="newFolder"
+          class="flex min-h-11 w-full items-center px-3.5 text-left text-[13px] text-txt hover:bg-overlay"
+          @click="onExplorerMoreAction('newFolder')"
+        >{{ t('pages.agentStudio.explorer.newFolder') }}</button>
+        <button
+          type="button"
+          data-test="explorer-more-item"
+          data-action="rename"
+          class="flex min-h-11 w-full items-center px-3.5 text-left text-[13px] text-txt hover:bg-overlay"
+          @click="onExplorerMoreAction('rename')"
+        >{{ t('pages.agentStudio.explorer.rename') }}</button>
+        <button
+          v-if="!explorerMore.dir || !isProtectedDir(explorerMore.path)"
+          type="button"
+          data-test="explorer-more-item"
+          data-action="delete"
+          class="flex min-h-11 w-full items-center px-3.5 text-left text-[13px] text-err hover:bg-err/10"
+          @click="onExplorerMoreAction('delete')"
+        >{{ t('pages.agentStudio.explorer.delete') }}</button>
+      </div>
+    </Teleport>
 
     <ExplorerContextMenu
       :open="ctxMenu.open"


### PR DESCRIPTION
窄屏名称栏改为两行并去掉重复「已保存」，Tab 增加渐隐+箭头提示，资源管理器行内收成「更多」浮层，便于手机端识别与点按。

Co-authored-by: Cursor <cursoragent@cursor.com>
