### PR TITLE
fix(browser): CDP /json/new 使用 loopback Host，修复 ClusterIP noVNC 探活

### DIFF
--- a/sandbox-gateway/sandbox/scripts/vnc-preview.sh
+++ b/sandbox-gateway/sandbox/scripts/vnc-preview.sh
@@ -63,7 +63,9 @@ if ! curl -fsS "http://127.0.0.1:${CDP_LOOPBACK_PORT}/json/version" >/dev/null 2
   }
 
   if ! pgrep -f "Xvfb ${DISPLAY}" >/dev/null 2>&1; then
-    Xvfb "$DISPLAY" -screen 0 1920x1080x24 >/tmp/sandbox-vnc-xvfb.log 2>&1 &
+    # Close flock FD 9 in children so the lock is released when this script exits
+    # (otherwise Chrome/socat/x11vnc inherit it and block later warmup execs).
+    Xvfb "$DISPLAY" -screen 0 1920x1080x24 9>&- >/tmp/sandbox-vnc-xvfb.log 2>&1 &
     echo $! >"$PID_DIR/xvfb.pid"
     sleep 1
   fi
@@ -77,7 +79,7 @@ if ! curl -fsS "http://127.0.0.1:${CDP_LOOPBACK_PORT}/json/version" >/dev/null 2
     --no-first-run \
     --no-default-browser-check \
     about:blank \
-    >/tmp/sandbox-vnc-chrome.log 2>&1 &
+    9>&- >/tmp/sandbox-vnc-chrome.log 2>&1 &
   echo $! >"$PID_DIR/chrome.pid"
 
   for i in $(seq 1 60); do
@@ -95,18 +97,18 @@ fi
 
 if ! pgrep -f "socat TCP-LISTEN:${CDP_PORT}" >/dev/null 2>&1; then
   socat TCP-LISTEN:"${CDP_PORT}",bind=0.0.0.0,fork,reuseaddr TCP:127.0.0.1:"${CDP_LOOPBACK_PORT}" \
-    >/tmp/sandbox-vnc-socat.log 2>&1 &
+    9>&- >/tmp/sandbox-vnc-socat.log 2>&1 &
   echo $! >"$PID_DIR/socat.pid"
 fi
 
 if ! pgrep -f "x11vnc .* -rfbport ${VNC_PORT}" >/dev/null 2>&1; then
   x11vnc -display "$DISPLAY" -rfbport "$VNC_PORT" -shared -forever -nopw -localhost -cursor arrow \
-    >/tmp/sandbox-vnc-x11vnc.log 2>&1 &
+    9>&- >/tmp/sandbox-vnc-x11vnc.log 2>&1 &
   echo $! >"$PID_DIR/x11vnc.pid"
 fi
 
 if ! pgrep -f "websockify ${WS_PORT}" >/dev/null 2>&1; then
-  websockify "$WS_PORT" "localhost:${VNC_PORT}" >/tmp/sandbox-vnc-websockify.log 2>&1 &
+  websockify "$WS_PORT" "localhost:${VNC_PORT}" 9>&- >/tmp/sandbox-vnc-websockify.log 2>&1 &
   echo $! >"$PID_DIR/websockify.pid"
 fi
 

--- a/server/internal/browser/cdp_host_test.go
+++ b/server/internal/browser/cdp_host_test.go
@@ -1,0 +1,138 @@
+package browser
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestProbeTabCreateUsesLoopbackHostHeader locks the Chrome 149 DevTools rule:
+// PUT /json/new rejects Host that is neither an IP nor localhost. Approving
+// dials ClusterIP DNS (sbx-*.svc.cluster.local) after CDP/noVNC isolation, so
+// the probe must rewrite Host to 127.0.0.1 while still dialing the DNS name.
+func TestProbeTabCreateUsesLoopbackHostHeader(t *testing.T) {
+	var sawNewHost, sawCloseHost string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/json/new", func(w http.ResponseWriter, r *http.Request) {
+		sawNewHost = r.Host
+		if !isLoopbackCDPHost(r.Host) {
+			http.Error(w, "Host header is specified and is not an IP address or localhost.", http.StatusInternalServerError)
+			return
+		}
+		if r.Method != http.MethodPut {
+			http.Error(w, "PUT required", http.StatusMethodNotAllowed)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": "tab-dns"})
+	})
+	mux.HandleFunc("/json/close/", func(w http.ResponseWriter, r *http.Request) {
+		sawCloseHost = r.Host
+		if !isLoopbackCDPHost(r.Host) {
+			http.Error(w, "Host header is specified and is not an IP address or localhost.", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	host, portStr, err := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := net.LookupPort("tcp", portStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate ClusterIP DNS dial target (hostname, not IP).
+	dialHost := "sbx-probe.sandbox-gateway.svc.cluster.local"
+	if host == "127.0.0.1" || host == "::1" {
+		// httptest binds loopback; map the DNS name via custom dialer... but
+		// probeTabCreate uses http.DefaultClient. Point URL host at 127.0.0.1
+		// for TCP and rely on Host rewrite — also cover the DNS-shaped path
+		// by calling with a fake hostname that resolves via /etc/hosts is
+		// unreliable. Instead: dial 127.0.0.1 but assert Host rewrite, and
+		// separately assert setCDPRequestHost + a Chrome-like gate on DNS Host.
+		dialHost = "127.0.0.1"
+	}
+
+	s, _, _ := newFakeService(Config{})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if !s.probeTabCreate(ctx, dialHost, port) {
+		t.Fatalf("probeTabCreate failed; newHost=%q closeHost=%q", sawNewHost, sawCloseHost)
+	}
+	if !isLoopbackCDPHost(sawNewHost) {
+		t.Fatalf("PUT /json/new Host=%q want 127.0.0.1:<port>", sawNewHost)
+	}
+	if !isLoopbackCDPHost(sawCloseHost) {
+		t.Fatalf("DELETE /json/close Host=%q want 127.0.0.1:<port>", sawCloseHost)
+	}
+}
+
+func TestProbeTabCreateRejectsDNSHostWithoutRewrite(t *testing.T) {
+	// Document the Chrome failure mode we are guarding against: if Host stays
+	// as Service DNS, /json/new returns 500 and readiness fails.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/json/new", func(w http.ResponseWriter, r *http.Request) {
+		if !isLoopbackCDPHost(r.Host) {
+			http.Error(w, "Host header is specified and is not an IP address or localhost.", http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": "x"})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	_, portStr, err := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := net.LookupPort("tcp", portStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, srv.URL+"/json/new?about:blank", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Host = "sbx-x.sandbox-gateway.svc.cluster.local:9222"
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status=%d want 500 for DNS Host", resp.StatusCode)
+	}
+
+	// With rewrite, same server accepts.
+	req2, err := http.NewRequestWithContext(ctx, http.MethodPut, srv.URL+"/json/new?about:blank", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	setCDPRequestHost(req2, port)
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d want 200 after Host rewrite", resp2.StatusCode)
+	}
+}
+
+func isLoopbackCDPHost(hostport string) bool {
+	h, _, err := net.SplitHostPort(hostport)
+	if err != nil {
+		h = hostport
+	}
+	return h == "127.0.0.1" || h == "::1" || h == "localhost"
+}

--- a/server/internal/browser/service.go
+++ b/server/internal/browser/service.go
@@ -406,12 +406,15 @@ func (s *Service) probeVNCReadyAddrs(ctx context.Context, cdpAddr, novncAddr str
 	if novncP <= 0 {
 		novncP = vncWSport
 	}
-	reqCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, fmt.Sprintf("http://%s:%d/json/version", cdpHost, cdpP), nil)
+	verCtx, verCancel := context.WithTimeout(ctx, 2*time.Second)
+	defer verCancel()
+	req, err := http.NewRequestWithContext(verCtx, http.MethodGet, fmt.Sprintf("http://%s:%d/json/version", cdpHost, cdpP), nil)
 	if err != nil {
 		return false
 	}
+	// Chrome DevTools HTTP rejects non-IP/non-localhost Host on some endpoints;
+	// keep dialing the ClusterIP DNS while advertising a loopback Host.
+	setCDPRequestHost(req, cdpP)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return false
@@ -423,11 +426,23 @@ func (s *Service) probeVNCReadyAddrs(ctx context.Context, cdpAddr, novncAddr str
 		return false
 	}
 	_ = conn.Close()
-	if !s.probeTabCreate(reqCtx, cdpHost, cdpP) {
+	tabCtx, tabCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer tabCancel()
+	if !s.probeTabCreate(tabCtx, cdpHost, cdpP) {
 		log.Warn().Str("cdp", cdpAddr).Msg("vnc-preview tab probe failed")
 		return false
 	}
 	return true
+}
+
+// setCDPRequestHost forces Host to 127.0.0.1:<port> so Chromium accepts
+// /json/new (and related DevTools HTTP) when Approving dials via Service DNS
+// (sbx-*.svc.cluster.local). TCP still targets req.URL.Host.
+func setCDPRequestHost(req *http.Request, port int) {
+	if req == nil || port <= 0 {
+		return
+	}
+	req.Host = net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
 }
 
 // probeTabCreate verifies Chromium can still create a tab (catches zombie CDP).
@@ -436,6 +451,7 @@ func (s *Service) probeTabCreate(ctx context.Context, host string, port int) boo
 	if err != nil {
 		return false
 	}
+	setCDPRequestHost(req, port)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return false
@@ -455,6 +471,7 @@ func (s *Service) probeTabCreate(ctx context.Context, host string, port int) boo
 	if err != nil {
 		return false
 	}
+	setCDPRequestHost(closeReq, port)
 	closeResp, err := http.DefaultClient.Do(closeReq)
 	if err != nil {
 		return false


### PR DESCRIPTION
## Summary
- CDP/noVNC 隔离后 Approving 经 `sbx-*.svc.cluster.local` 拨号；Chrome 149 对 `PUT /json/new` 要求 Host 为 IP/`localhost`，导致 tab probe 失败并误报「未启动浏览器组件」。
- 探测仍拨 ClusterIP DNS，仅将 HTTP Host 改写为 `127.0.0.1:<port>`；tab probe 使用独立 5s 超时。
- `vnc-preview.sh` 后台进程关闭 flock fd 9，避免子进程占锁拖死后续 warmup exec。

## Test plan
- [x] `go test ./internal/browser/ -count=1`
- [ ] 打开沙箱浏览器 Tab，确认 noVNC 不再报「未启动浏览器组件」
- [ ] 日志中不应再持续出现 `vnc-preview tab probe failed`（对 `*.svc.cluster.local:9222`）


Made with [Cursor](https://cursor.com)