### PR TITLE
fix(web): 工作流/沙箱变量 Tab 铺满去底边框贴底

### DIFF
--- a/web/e2e/project-detail.spec.ts
+++ b/web/e2e/project-detail.spec.ts
@@ -369,14 +369,13 @@ test.describe('ProjectDetailView 沙箱/工作流变量面板布局', () => {
     await expect(newNote.getByText('停用的行会保留 key/value，但不参与注入；开关与字段变更须保存后，才影响下次注入。')).toBeVisible()
     await page.keyboard.press('Escape')
 
-    const shell = page
-      .locator('.border.border-line.bg-surface')
-      .filter({ hasText: '暂无沙箱环境变量' })
-      .first()
+    const shell = page.getByTestId('sandbox-env-empty-shell')
     await expect(shell).toBeVisible()
     const box = await shell.boundingBox()
     expect(box?.height).toBeGreaterThanOrEqual(360)
     expect(box?.width).toBeGreaterThan(900)
+    // 空态壳底贴近视口主区底，消除卡外页底空洞（g2.2 / 对齐 meta footerBox）
+    expect(box!.y + box!.height).toBeGreaterThan(800 - 80)
 
     const addBtn = shell.getByRole('button', { name: '添加一行' })
     await expect(addBtn).toBeVisible()
@@ -387,7 +386,7 @@ test.describe('ProjectDetailView 沙箱/工作流变量面板布局', () => {
     await gotoProjectDetailWithProject(page, MOCK_PROJECT_WITH_VARS)
     await page.getByRole('button', { name: '沙箱环境变量' }).click()
 
-    const panel = page.locator('.border.border-line.bg-surface').filter({ hasText: 'KEY' }).first()
+    const panel = page.getByTestId('sandbox-env-data-panel')
     await expect(panel.getByText('KEY', { exact: true })).toBeVisible()
     await expect(panel.getByText('VALUE', { exact: true })).toBeVisible()
     await expect(panel.getByText('类型', { exact: true })).toBeVisible()
@@ -398,13 +397,17 @@ test.describe('ProjectDetailView 沙箱/工作流变量面板布局', () => {
     await expect(panel.getByTestId('sandbox-env-enabled')).toBeVisible()
     await expect(panel.getByText('开', { exact: true })).toBeVisible()
 
-    const foot = panel.locator('.border-t.border-line').last()
+    const foot = panel.getByTestId('sandbox-env-footer')
     const addBtn = foot.getByRole('button', { name: '添加一行' })
     const saveBtn = foot.getByRole('button', { name: '保存' })
     await expect(addBtn).toBeVisible()
     await expect(addBtn).toHaveClass(/border/)
     await expect(saveBtn).toBeVisible()
     await expect(saveBtn).toHaveClass(/bg-accent/)
+    // 有数据底栏贴近视口主区底（g2.2）
+    const footBox = await foot.boundingBox()
+    expect(footBox).toBeTruthy()
+    expect(footBox!.y + footBox!.height).toBeGreaterThan(800 - 80)
   })
 
   test('沙箱启用开关：旧 mock 无 enabled 时行显示为开', async ({ page }) => {
@@ -522,7 +525,7 @@ test.describe('ProjectDetailView 沙箱/工作流变量面板布局', () => {
     await expect(onRow).toHaveAttribute('data-env-enabled', 'false')
     await expect(onRow.getByText('关', { exact: true })).toBeVisible()
 
-    const panel = page.locator('.border.border-line.bg-surface').filter({ hasText: 'KEY' }).first()
+    const panel = page.getByTestId('sandbox-env-data-panel')
     await panel.getByRole('button', { name: '保存' }).click()
     await expect.poll(() => saveBody).not.toBeNull()
     const apiUrl = saveBody!.sandboxEnv?.find((e) => e.key === 'API_URL')
@@ -535,14 +538,13 @@ test.describe('ProjectDetailView 沙箱/工作流变量面板布局', () => {
     await gotoProjectDetailWithProject(page, MOCK_PROJECT)
     await page.getByRole('button', { name: '工作流变量' }).click()
 
-    const shell = page
-      .locator('.border.border-line.bg-surface')
-      .filter({ hasText: '暂无工作流变量' })
-      .first()
+    const shell = page.getByTestId('workflow-vars-empty-shell')
     await expect(shell).toBeVisible()
     const box = await shell.boundingBox()
     expect(box?.height).toBeGreaterThanOrEqual(360)
     expect(box?.width).toBeGreaterThan(900)
+    // 空态壳底贴近视口主区底（g2.2 / 与沙箱同构）
+    expect(box!.y + box!.height).toBeGreaterThan(800 - 80)
 
     const addBtn = shell.getByRole('button', { name: '添加一行' })
     await expect(addBtn).toHaveClass(/bg-accent/)
@@ -564,16 +566,20 @@ test.describe('ProjectDetailView 沙箱/工作流变量面板布局', () => {
     await gotoProjectDetailWithProject(page, MOCK_PROJECT_WITH_VARS)
     await page.getByRole('button', { name: '工作流变量' }).click()
 
-    const panel = page.locator('.border.border-line.bg-surface').filter({ hasText: '默认值' }).first()
+    const panel = page.getByTestId('workflow-vars-data-panel')
     await expect(panel.getByText('名称', { exact: true })).toBeVisible()
     await expect(panel.getByText('默认值', { exact: true })).toBeVisible()
     await expect(panel.getByText('类型', { exact: true })).toBeVisible()
     await expect(panel.getByText('操作', { exact: true })).toBeVisible()
     await expect(panel.getByPlaceholder('描述（可选）')).toHaveValue('部署区域')
 
-    const foot = panel.locator('.border-t.border-line').last()
+    const foot = panel.getByTestId('workflow-vars-footer')
     await expect(foot.getByRole('button', { name: '添加一行' })).toHaveClass(/border/)
     await expect(foot.getByRole('button', { name: '保存' })).toHaveClass(/bg-accent/)
+    // 有数据底栏贴近视口主区底（g2.2）
+    const footBox = await foot.boundingBox()
+    expect(footBox).toBeTruthy()
+    expect(footBox!.y + footBox!.height).toBeGreaterThan(800 - 80)
 
     // g2.2 / F2: 有数据态同样无 varsHint、无「合并规则」
     await expect(page.getByRole('button', { name: '合并规则' })).toHaveCount(0)
@@ -587,14 +593,11 @@ test.describe('ProjectDetailView 沙箱/工作流变量面板布局', () => {
     await gotoProjectDetailWithProject(page, MOCK_PROJECT)
     await page.getByRole('button', { name: '沙箱环境变量' }).click()
 
-    const emptyShell = page
-      .locator('.border.border-line.bg-surface')
-      .filter({ hasText: '暂无沙箱环境变量' })
-      .first()
+    const emptyShell = page.getByTestId('sandbox-env-empty-shell')
     await emptyShell.getByRole('button', { name: '添加一行' }).click()
 
     await expect(page.getByText('暂无沙箱环境变量')).toHaveCount(0)
-    const panel = page.locator('.border.border-line.bg-surface').filter({ hasText: 'KEY' }).first()
+    const panel = page.getByTestId('sandbox-env-data-panel')
     await expect(panel.getByText('KEY', { exact: true })).toBeVisible()
     await expect(panel.getByRole('button', { name: '明文' })).toBeVisible()
     await expect(panel.getByRole('button', { name: '保存' })).toBeVisible()

--- a/web/src/views/ProjectDetailView.metaLayout.test.ts
+++ b/web/src/views/ProjectDetailView.metaLayout.test.ts
@@ -72,8 +72,30 @@ describe('ProjectDetailView meta tab keeps existing chrome and save semantics (g
     expect(shellSrc).toMatch(/<main[\s\S]*class="relative min-h-0 flex-1 overflow-hidden"/)
     expect(detailSrc).toMatch(/tab === 'cronJobs'" class="flex min-h-\[420px\] flex-col"/)
     expect(detailSrc).toMatch(/tab === 'notify' && project" class="min-h-\[420px\]"/)
-    expect(detailSrc).toMatch(/tab === 'sandboxEnv'" class="flex min-h-\[420px\] flex-col"/)
-    expect(detailSrc).toMatch(/tab === 'variables'" class="flex min-h-\[420px\] flex-col"/)
+    // variables / sandboxEnv 已接入铺满链（对齐 meta），不再锁定 420 硬底
+    expect(detailSrc).toMatch(/tab === 'sandboxEnv'" class="flex min-h-0 flex-1 flex-col"/)
+    expect(detailSrc).toMatch(/tab === 'variables'" class="flex min-h-0 flex-1 flex-col"/)
     expect(detailSrc).toMatch(/tab === 'audit'" class="flex min-h-0 flex-1 flex-col"/)
+  })
+
+  it('variables / sandboxEnv shells drop bottom border and use three-zone flex (fill-height)', () => {
+    const sandboxStart = detailSrc.indexOf("tab === 'sandboxEnv'")
+    const variablesStart = detailSrc.indexOf("tab === 'variables'")
+    const auditStart = detailSrc.indexOf("tab === 'audit'")
+    expect(sandboxStart).toBeGreaterThanOrEqual(0)
+    expect(variablesStart).toBeGreaterThan(sandboxStart)
+    expect(auditStart).toBeGreaterThan(variablesStart)
+    const sandbox = detailSrc.slice(sandboxStart, variablesStart)
+    const variables = detailSrc.slice(variablesStart, auditStart)
+
+    for (const block of [sandbox, variables]) {
+      expect(block).toMatch(/border border-b-0 border-line bg-surface/)
+      expect(block).toMatch(/scroll-area flex min-h-0 flex-1 flex-col overflow-y-auto/)
+      expect(block).toMatch(/flex shrink-0 flex-wrap gap-2 border-t border-line/)
+      expect(block).not.toMatch(/min-h-\[420px\]/)
+    }
+    expect(sandbox).toMatch(/mb-3 flex shrink-0 flex-wrap items-baseline/)
+    expect(sandbox).toMatch(/data-testid="sandbox-env-footer"/)
+    expect(variables).toMatch(/data-testid="workflow-vars-footer"/)
   })
 })

--- a/web/src/views/ProjectDetailView.vue
+++ b/web/src/views/ProjectDetailView.vue
@@ -807,7 +807,10 @@ onUnmounted(() => {
     >
       <i class="admin-list-thin-bar bg-accent" />
     </div>
-    <div :class="showRefreshProgress ? 'opacity-[0.55]' : ''">
+    <div
+      class="flex min-h-0 flex-1 flex-col"
+      :class="showRefreshProgress ? 'opacity-[0.55]' : ''"
+    >
     <div class="mb-4 shrink-0">
       <button
         type="button"
@@ -1405,9 +1408,9 @@ onUnmounted(() => {
         </div>
       </div>
 
-      <!-- Sandbox env tab -->
-      <div v-else-if="tab === 'sandboxEnv'" class="flex min-h-[420px] flex-col">
-        <div class="mb-3 flex flex-wrap items-baseline gap-x-3 gap-y-1.5">
+      <!-- Sandbox env tab: fill remaining main area, no page void under card -->
+      <div v-else-if="tab === 'sandboxEnv'" class="flex min-h-0 flex-1 flex-col">
+        <div class="mb-3 flex shrink-0 flex-wrap items-baseline gap-x-3 gap-y-1.5">
           <p class="m-0 text-[13px] text-txt3">{{ t('pages.projectDetail.envHint') }}</p>
           <button
             type="button"
@@ -1419,12 +1422,13 @@ onUnmounted(() => {
           </button>
         </div>
 
-        <!-- Empty: same shell as data panel, min-h centered, primary CTA -->
+        <!-- Empty: same shell as data panel, fill + centered CTA, no bottom border -->
         <div
           v-if="!envRows.length"
-          class="flex min-h-[360px] flex-1 flex-col border border-line bg-surface shadow-[var(--shadow-card)]"
+          class="flex min-h-[360px] flex-1 flex-col border border-b-0 border-line bg-surface shadow-[var(--shadow-card)]"
+          data-testid="sandbox-env-empty-shell"
         >
-          <div class="flex flex-1 flex-col justify-center">
+          <div class="flex flex-1 flex-col items-center justify-center">
             <EmptyState
               icon="variable"
               :title="t('pages.projectDetail.envEmptyTitle')"
@@ -1437,13 +1441,14 @@ onUnmounted(() => {
           </div>
         </div>
 
-        <!-- Data: unified panel with head / rows / foot -->
+        <!-- Data: head / scroll rows / foot stick to shell bottom -->
         <div
           v-else
-          class="flex flex-1 flex-col overflow-hidden border border-line bg-surface shadow-[var(--shadow-card)]"
+          class="flex min-h-0 flex-1 flex-col overflow-hidden border border-b-0 border-line bg-surface shadow-[var(--shadow-card)]"
+          data-testid="sandbox-env-data-panel"
         >
           <div
-            class="hidden gap-2 border-b border-line bg-elevated/55 px-3 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-txt3 sm:grid sm:grid-cols-[minmax(0,1.1fr)_minmax(0,1.4fr)_88px_96px_40px]"
+            class="hidden shrink-0 gap-2 border-b border-line bg-elevated/55 px-3 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-txt3 sm:grid sm:grid-cols-[minmax(0,1.1fr)_minmax(0,1.4fr)_88px_96px_40px]"
           >
             <span>{{ t('pages.projectDetail.envKey') }}</span>
             <span>{{ t('pages.projectDetail.colValue') }}</span>
@@ -1452,7 +1457,7 @@ onUnmounted(() => {
             <span>{{ t('common.table.actions') }}</span>
           </div>
 
-          <div class="flex flex-col">
+          <div class="scroll-area flex min-h-0 flex-1 flex-col overflow-y-auto">
             <div
               v-for="(row, i) in envRows"
               :key="i"
@@ -1528,7 +1533,10 @@ onUnmounted(() => {
             </div>
           </div>
 
-          <div class="flex flex-wrap gap-2 border-t border-line bg-surface p-3">
+          <div
+            class="flex shrink-0 flex-wrap gap-2 border-t border-line bg-surface p-3"
+            data-testid="sandbox-env-footer"
+          >
             <AppButton variant="outline" icon="plus" @click="addEnvRow">
               {{ t('pages.projectDetail.addRow') }}
             </AppButton>
@@ -1539,14 +1547,15 @@ onUnmounted(() => {
         </div>
       </div>
 
-      <!-- Variables tab: no varsHint / merge-rules row (Demo after); sandbox tab keeps them -->
-      <div v-else-if="tab === 'variables'" class="flex min-h-[420px] flex-col">
+      <!-- Variables tab: fill remaining main area; no varsHint / merge-rules row -->
+      <div v-else-if="tab === 'variables'" class="flex min-h-0 flex-1 flex-col">
         <!-- Empty: same shell as sandbox tab -->
         <div
           v-if="!varRows.length"
-          class="flex min-h-[360px] flex-1 flex-col border border-line bg-surface shadow-[var(--shadow-card)]"
+          class="flex min-h-[360px] flex-1 flex-col border border-b-0 border-line bg-surface shadow-[var(--shadow-card)]"
+          data-testid="workflow-vars-empty-shell"
         >
-          <div class="flex flex-1 flex-col justify-center">
+          <div class="flex flex-1 flex-col items-center justify-center">
             <EmptyState
               icon="doc"
               :title="t('pages.projectDetail.varsEmptyTitle')"
@@ -1559,13 +1568,14 @@ onUnmounted(() => {
           </div>
         </div>
 
-        <!-- Data: unified panel; main row 4-col + secondary desc/options -->
+        <!-- Data: head / scroll rows / foot stick to shell bottom -->
         <div
           v-else
-          class="flex flex-1 flex-col overflow-hidden border border-line bg-surface shadow-[var(--shadow-card)]"
+          class="flex min-h-0 flex-1 flex-col overflow-hidden border border-b-0 border-line bg-surface shadow-[var(--shadow-card)]"
+          data-testid="workflow-vars-data-panel"
         >
           <div
-            class="hidden gap-2 border-b border-line bg-elevated/55 px-3 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-txt3 sm:grid sm:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)_minmax(120px,auto)_40px]"
+            class="hidden shrink-0 gap-2 border-b border-line bg-elevated/55 px-3 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-txt3 sm:grid sm:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)_minmax(120px,auto)_40px]"
           >
             <span>{{ t('pages.projectDetail.colVarName') }}</span>
             <span>{{ t('pages.projectDetail.colDefault') }}</span>
@@ -1573,7 +1583,7 @@ onUnmounted(() => {
             <span>{{ t('common.table.actions') }}</span>
           </div>
 
-          <div class="flex flex-col">
+          <div class="scroll-area flex min-h-0 flex-1 flex-col overflow-y-auto">
             <div
               v-for="(row, i) in varRows"
               :key="i"
@@ -1694,7 +1704,10 @@ onUnmounted(() => {
             </div>
           </div>
 
-          <div class="flex flex-wrap gap-2 border-t border-line bg-surface p-3">
+          <div
+            class="flex shrink-0 flex-wrap gap-2 border-t border-line bg-surface p-3"
+            data-testid="workflow-vars-footer"
+          >
             <AppButton variant="outline" icon="plus" @click="addVarRow">
               {{ t('pages.projectDetail.addRow') }}
             </AppButton>


### PR DESCRIPTION
消除变量双 Tab 卡外页底空洞：接入 min-h-0 flex-1 高度链，内容壳 border-b-0，有数据三区 flex；同步改写 metaLayout 硬底断言并补 e2e 贴底检查。

Co-authored-by: Cursor <cursoragent@cursor.com>
