### PR TITLE
feat(shell): 顶栏铃铛落地为 Run 终态运行通知

### DIFF
--- a/web/src/components/shell/AppTopbar.test.ts
+++ b/web/src/components/shell/AppTopbar.test.ts
@@ -1,52 +1,253 @@
 // @vitest-environment happy-dom
 import { createI18n } from 'vue-i18n'
-import { mount } from '@vue/test-utils'
-import { describe, expect, it, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
 import common from '@/locales/zh-CN/common.json'
 import pages from '@/locales/zh-CN/pages.json'
+import shell from '@/locales/zh-CN/shell.json'
+import type { Run } from '@/lib/types'
+
+const push = vi.fn()
 
 vi.mock('vue-router', () => ({
-  useRoute: () => ({ path: '/', meta: {} }),
+  useRoute: () => ({ path: '/', meta: {}, query: {} }),
+  useRouter: () => ({ push }),
 }))
 
 vi.mock('@/lib/useShutdownState', () => ({
   isDraining: () => false,
 }))
 
+vi.mock('@/lib/useAuth', () => ({
+  useAuth: () => ({
+    user: ref({ username: 'tester', expiresAt: 't' }),
+  }),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    listRuns: vi.fn(),
+    getRun: vi.fn(),
+  },
+  isPaginated: (data: unknown): data is { items: unknown[]; total: number } =>
+    data != null && typeof data === 'object' && !Array.isArray(data) && 'items' in data,
+}))
+
+import { api } from '@/lib/api'
+import {
+  __resetRunTerminalNotificationsForTests,
+  RUN_TERMINAL_POOL_SIZE,
+} from '@/lib/useRunTerminalNotifications'
 import AppTopbar from './AppTopbar.vue'
 
-describe('AppTopbar', () => {
-  it('renders header with theme toggle', () => {
-    const i18n = createI18n({
-      legacy: false,
-      locale: 'zh-CN',
-      messages: { 'zh-CN': { ...common, ...pages } },
-    })
-    const wrapper = mount(AppTopbar, {
-      global: {
-        plugins: [i18n],
-        stubs: { Icon: true, LangSelect: { template: '<div data-testid="lang" />' } },
+function run(partial: Partial<Run> & Pick<Run, 'id' | 'status'>): Run {
+  return {
+    workflowId: 'wf',
+    workflowName: 'demo-wf',
+    title: partial.title ?? `Run ${partial.id}`,
+    trigger: 'manual',
+    startedAt: partial.startedAt ?? '2026-08-10T12:00:00Z',
+    durationSec: 1,
+    progress: 100,
+    nodeRuns: {},
+    artifacts: [],
+    ...partial,
+  }
+}
+
+function paged(items: Run[], total = items.length) {
+  return { items, total, page: 1, pageSize: RUN_TERMINAL_POOL_SIZE, hasMore: false }
+}
+
+function mountTopbar() {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common, ...pages, ...shell } },
+  })
+  return mount(AppTopbar, {
+    global: {
+      plugins: [i18n],
+      stubs: {
+        Icon: true,
+        LangSelect: { template: '<div data-testid="lang" />' },
+        Transition: false,
       },
-    })
+    },
+    attachTo: document.body,
+  })
+}
+
+describe('AppTopbar run notifications', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    __resetRunTerminalNotificationsForTests()
+    push.mockReset()
+    vi.mocked(api.listRuns).mockReset()
+    vi.mocked(api.getRun).mockReset()
+    vi.mocked(api.listRuns).mockResolvedValue(paged([]))
+    vi.mocked(api.getRun).mockResolvedValue(run({ id: 'r1', status: 'completed', artifacts: [] }))
+  })
+
+  afterEach(() => {
+    __resetRunTerminalNotificationsForTests()
+  })
+
+  it('renders header with theme toggle and bell aria', async () => {
+    const wrapper = mountTopbar()
+    await flushPromises()
     expect(wrapper.find('header').exists()).toBe(true)
     expect(wrapper.find('[data-testid="lang"]').exists()).toBe(true)
+    const bell = wrapper.find('[data-testid="run-notifications-bell"]')
+    expect(bell.exists()).toBe(true)
+    expect(bell.attributes('aria-label')).toBe('运行通知')
+    expect(bell.attributes('aria-haspopup')).toBe('true')
+    expect(bell.attributes('aria-expanded')).toBe('false')
+    expect(wrapper.find('[data-testid="run-notifications-badge"]').exists()).toBe(false)
     wrapper.unmount()
   })
 
   it('emits toggle-menu from mobile menu button', async () => {
-    const i18n = createI18n({
-      legacy: false,
-      locale: 'zh-CN',
-      messages: { 'zh-CN': { ...common, ...pages } },
-    })
-    const wrapper = mount(AppTopbar, {
-      global: {
-        plugins: [i18n],
-        stubs: { Icon: true, LangSelect: true },
-      },
-    })
+    const wrapper = mountTopbar()
+    await flushPromises()
     await wrapper.find('button').trigger('click')
     expect(wrapper.emitted('toggle-menu')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('shows unread badge and opens panel with empty state', async () => {
+    const wrapper = mountTopbar()
+    await flushPromises()
+    await wrapper.find('[data-testid="run-notifications-bell"]').trigger('click')
+    await nextTick()
+    expect(wrapper.find('[data-testid="run-notifications-panel"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="run-notifications-empty"]').text()).toContain('暂无运行通知')
+    wrapper.unmount()
+  })
+
+  it('caps dropdown at 5 items and shows more hint; view-all does not mark read', async () => {
+    const items = Array.from({ length: 7 }, (_, i) =>
+      run({
+        id: `r${i}`,
+        status: i === 0 ? 'failed' : 'completed',
+        startedAt: `2026-08-10T1${i}:00:00Z`,
+      }),
+    )
+    vi.mocked(api.listRuns).mockResolvedValue(paged(items, 7))
+    const wrapper = mountTopbar()
+    await flushPromises()
+
+    const badge = wrapper.find('[data-testid="run-notifications-badge"]')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toBe('7')
+    expect(badge.classes().join(' ')).toMatch(/bg-err/)
+
+    await wrapper.find('[data-testid="run-notifications-bell"]').trigger('click')
+    await nextTick()
+    expect(wrapper.findAll('[data-testid="run-notifications-item"]')).toHaveLength(5)
+    expect(wrapper.find('[data-testid="run-notifications-more"]').text()).toContain('还有 2 条')
+
+    await wrapper.find('[data-testid="run-notifications-view-all"]').trigger('click')
+    expect(push).toHaveBeenCalledWith({ path: '/runs', query: { status: 'completed,failed' } })
+    // Panel closed; unread unchanged (no batch mark-read)
+    expect(wrapper.find('[data-testid="run-notifications-badge"]').text()).toBe('7')
+    wrapper.unmount()
+  })
+
+  it('clicking failed item marks read and navigates to run detail without output modal', async () => {
+    vi.mocked(api.listRuns).mockResolvedValue(
+      paged([run({ id: 'fail-1', status: 'failed', title: 'boom' })]),
+    )
+    const wrapper = mountTopbar()
+    await flushPromises()
+    await wrapper.find('[data-testid="run-notifications-bell"]').trigger('click')
+    await nextTick()
+    await wrapper.find('[data-testid="run-notifications-item"]').trigger('click')
+    await flushPromises()
+    expect(push).toHaveBeenCalledWith('/runs/fail-1')
+    expect(wrapper.find('[data-testid="run-notifications-badge"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="run-output-empty"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('clicking completed item marks read and opens output modal (empty artifacts)', async () => {
+    vi.mocked(api.listRuns).mockResolvedValue(
+      paged([run({ id: 'ok-1', status: 'completed', title: 'done' })]),
+    )
+    vi.mocked(api.getRun).mockResolvedValue(
+      run({ id: 'ok-1', status: 'completed', artifacts: [] }),
+    )
+    const wrapper = mountTopbar()
+    await flushPromises()
+    await wrapper.find('[data-testid="run-notifications-bell"]').trigger('click')
+    await nextTick()
+    await wrapper.find('[data-testid="run-notifications-item"]').trigger('click')
+    await flushPromises()
+    await nextTick()
+    expect(push).not.toHaveBeenCalled()
+    expect(api.getRun).toHaveBeenCalledWith('ok-1')
+    expect(wrapper.vm.outputOpen).toBe(true)
+    expect(wrapper.vm.outputRunId).toBe('ok-1')
+    await vi.waitFor(() => {
+      expect(document.body.querySelector('[data-testid="run-output-empty"]')).toBeTruthy()
+    })
+    expect(document.body.querySelector('[data-testid="run-output-empty"]')?.textContent).toContain(
+      '本次运行暂无产出',
+    )
+    expect(wrapper.find('[data-testid="run-notifications-badge"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('completed with artifacts shows ppt cards and preview; no download control', async () => {
+    vi.mocked(api.listRuns).mockResolvedValue(
+      paged([run({ id: 'ok-2', status: 'completed', title: 'done' })]),
+    )
+    vi.mocked(api.getRun).mockResolvedValue(
+      run({
+        id: 'ok-2',
+        status: 'completed',
+        artifacts: [
+          {
+            id: 'a1',
+            name: 'summary.md',
+            kind: 'markdown',
+            nodeId: 'n1',
+            runId: 'ok-2',
+            workflowName: 'demo-wf',
+            sizeBytes: 10,
+            createdAt: '2026-08-10T12:00:00Z',
+          },
+          {
+            id: 'a2',
+            name: 'result.json',
+            kind: 'json',
+            nodeId: 'n1',
+            runId: 'ok-2',
+            workflowName: 'demo-wf',
+            sizeBytes: 20,
+            createdAt: '2026-08-10T12:00:00Z',
+          },
+        ],
+      }),
+    )
+    const wrapper = mountTopbar()
+    await flushPromises()
+    await wrapper.find('[data-testid="run-notifications-bell"]').trigger('click')
+    await nextTick()
+    await wrapper.find('[data-testid="run-notifications-item"]').trigger('click')
+    await flushPromises()
+    await nextTick()
+    expect(wrapper.vm.outputOpen).toBe(true)
+    await vi.waitFor(() => {
+      expect(document.body.querySelector('[data-testid="run-output-deck"]')).toBeTruthy()
+    })
+    expect(document.body.querySelectorAll('[data-testid="run-output-card"]')).toHaveLength(2)
+    expect(document.body.querySelector('[data-testid="run-output-preview"]')).toBeTruthy()
+    expect(document.body.querySelector('[data-testid="run-output-open-run"]')).toBeTruthy()
+    expect(document.body.querySelector('[data-testid="run-output-done"]')).toBeTruthy()
+    expect(document.body.querySelector('[data-testid="artifact-download"]')).toBeNull()
+    expect(document.body.querySelector('a[download]')).toBeNull()
     wrapper.unmount()
   })
 })

--- a/web/src/components/shell/AppTopbar.vue
+++ b/web/src/components/shell/AppTopbar.vue
@@ -1,18 +1,39 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
-import { useRoute } from 'vue-router'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import Icon from '../ui/Icon.vue'
 import LangSelect from '../ui/LangSelect.vue'
+import RunOutputPptModal from './RunOutputPptModal.vue'
 import { theme, toggleTheme } from '@/lib/theme'
 import { isDraining } from '@/lib/useShutdownState'
 import { locale, setLocale, type AppLocale } from '@/lib/locale'
+import { relTime } from '@/lib/format'
+import { useRunTerminalNotifications } from '@/lib/useRunTerminalNotifications'
 
 const emit = defineEmits<{ (e: 'toggle-menu'): void }>()
 
 const { t } = useI18n()
 const route = useRoute()
+const router = useRouter()
 const menuOpen = ref(false)
+const panelOpen = ref(false)
+const bellWrapEl = ref<HTMLElement | null>(null)
+
+const {
+  previewItems,
+  remainingCount,
+  unreadCount,
+  hasUnreadFailed,
+  badgeLabel,
+  markRead,
+  startPolling,
+  stopPolling,
+} = useRunTerminalNotifications()
+
+const outputOpen = ref(false)
+const outputRunId = ref<string | null>(null)
+const outputContext = ref('')
 
 const themeTitle = computed(() =>
   t(theme.value === 'dark' ? 'shell.theme.toLight' : 'shell.theme.toDark'),
@@ -22,6 +43,7 @@ watch(
   () => route.path,
   () => {
     menuOpen.value = false
+    panelOpen.value = false
   },
 )
 
@@ -34,7 +56,87 @@ function onLocaleSelect(v: AppLocale) {
   void setLocale(v)
 }
 
-defineExpose({ menuOpen, toggleMenu })
+function togglePanel() {
+  panelOpen.value = !panelOpen.value
+}
+
+function closePanel() {
+  panelOpen.value = false
+}
+
+function onDocClick(ev: MouseEvent) {
+  if (!panelOpen.value) return
+  const root = bellWrapEl.value
+  if (root && ev.target instanceof Node && root.contains(ev.target)) return
+  closePanel()
+}
+
+function onDocKeydown(ev: KeyboardEvent) {
+  if (ev.key === 'Escape' && panelOpen.value) {
+    closePanel()
+  }
+}
+
+function statusLabel(status: string) {
+  return status === 'failed'
+    ? t('common.status.failed')
+    : t('common.status.completed')
+}
+
+function itemContext(item: { workflowName: string; runId: string; title: string }) {
+  const wf = item.workflowName || item.title
+  return wf ? `${wf} · ${item.runId}` : item.runId
+}
+
+async function onItemClick(item: {
+  runId: string
+  status: 'completed' | 'failed'
+  title: string
+  workflowName: string
+}) {
+  markRead(item.runId)
+  closePanel()
+  if (item.status === 'failed') {
+    await router.push(`/runs/${item.runId}`)
+    return
+  }
+  outputContext.value = itemContext(item)
+  outputRunId.value = item.runId
+  outputOpen.value = true
+}
+
+function closeOutputModal() {
+  outputOpen.value = false
+  outputRunId.value = null
+  outputContext.value = ''
+}
+
+function viewAll() {
+  // Opening "view all" must NOT batch-mark read (plan g2.3 / f3).
+  closePanel()
+  void router.push({ path: '/runs', query: { status: 'completed,failed' } })
+}
+
+onMounted(() => {
+  startPolling()
+  document.addEventListener('click', onDocClick)
+  document.addEventListener('keydown', onDocKeydown)
+})
+
+onBeforeUnmount(() => {
+  stopPolling()
+  document.removeEventListener('click', onDocClick)
+  document.removeEventListener('keydown', onDocKeydown)
+})
+
+defineExpose({
+  menuOpen,
+  toggleMenu,
+  panelOpen,
+  togglePanel,
+  outputOpen,
+  outputRunId,
+})
 </script>
 
 <template>
@@ -63,8 +165,113 @@ defineExpose({ menuOpen, toggleMenu })
     >
       <Icon :name="theme === 'dark' ? 'sun' : 'moon'" :size="18" />
     </button>
-    <button class="relative flex h-9 w-9 items-center justify-center rounded-md text-txt2 hover:bg-elevated hover:text-txt">
-      <Icon name="bell" :size="18" />
-    </button>
+    <div ref="bellWrapEl" class="relative">
+      <button
+        type="button"
+        class="relative flex h-9 w-9 items-center justify-center rounded-md text-txt2 hover:bg-elevated hover:text-txt"
+        :class="panelOpen ? 'bg-elevated text-txt' : ''"
+        data-testid="run-notifications-bell"
+        :aria-label="t('shell.runNotifications.title')"
+        aria-haspopup="true"
+        :aria-expanded="panelOpen ? 'true' : 'false'"
+        @click.stop="togglePanel"
+      >
+        <Icon name="bell" :size="18" />
+        <span
+          v-if="badgeLabel"
+          class="absolute right-0.5 top-0.5 inline-flex h-4 min-w-4 items-center justify-center px-1 text-[10px] font-bold leading-none text-white"
+          :class="hasUnreadFailed ? 'bg-err' : 'bg-accent'"
+          data-testid="run-notifications-badge"
+        >{{ badgeLabel }}</span>
+      </button>
+
+      <div
+        v-if="panelOpen"
+        class="absolute right-0 top-[calc(100%+6px)] z-40 flex w-[min(380px,calc(100vw-2rem))] flex-col border border-line-strong bg-elevated shadow-card"
+        role="menu"
+        :aria-label="t('shell.runNotifications.title')"
+        data-testid="run-notifications-panel"
+        @click.stop
+      >
+        <div class="flex items-center justify-between border-b border-line px-3.5 py-3">
+          <h3 class="m-0 text-[13px] font-semibold text-txt">{{ t('shell.runNotifications.title') }}</h3>
+          <span class="text-xs text-txt3">
+            {{ t('shell.runNotifications.unreadCount', { n: unreadCount }) }}
+          </span>
+        </div>
+
+        <div class="max-h-[360px] overflow-auto">
+          <div
+            v-if="!previewItems.length"
+            class="px-5 py-9 text-center"
+            data-testid="run-notifications-empty"
+          >
+            <p class="m-0 text-[13px] text-txt2">{{ t('shell.runNotifications.empty') }}</p>
+            <p class="mt-1.5 text-xs text-txt3">{{ t('shell.runNotifications.emptyHint') }}</p>
+          </div>
+          <button
+            v-for="item in previewItems"
+            :key="item.runId"
+            type="button"
+            class="relative block w-full border-b border-line px-3.5 py-3 text-left hover:bg-overlay"
+            :class="item.unread ? 'bg-accent/5' : ''"
+            data-testid="run-notifications-item"
+            :data-run-id="item.runId"
+            :data-status="item.status"
+            :data-unread="item.unread ? 'true' : 'false'"
+            @click="onItemClick(item)"
+          >
+            <span
+              v-if="item.unread"
+              class="absolute bottom-0 left-0 top-0 w-0.5 bg-accent"
+              aria-hidden="true"
+            />
+            <div class="mb-1 flex items-center gap-2">
+              <span
+                class="shrink-0 border px-1.5 py-0.5 text-[10px] font-semibold"
+                :class="
+                  item.status === 'failed'
+                    ? 'border-err/45 text-err'
+                    : 'border-ok/40 text-ok'
+                "
+              >{{ statusLabel(item.status) }}</span>
+              <span class="truncate text-[13px] font-medium text-txt">{{ item.title }}</span>
+            </div>
+            <div class="truncate text-xs text-txt3">
+              {{ itemContext(item) }}
+              <template v-if="item.status === 'completed'">
+                · {{ t('shell.runNotifications.clickForOutput') }}
+              </template>
+              · {{ relTime(item.startedAt) }}
+            </div>
+          </button>
+        </div>
+
+        <div class="flex flex-col gap-2 border-t border-line px-3.5 py-2.5">
+          <div
+            v-if="remainingCount > 0"
+            class="text-xs text-txt3"
+            data-testid="run-notifications-more"
+          >
+            {{ t('shell.runNotifications.moreHint', { n: remainingCount }) }}
+          </div>
+          <button
+            type="button"
+            class="w-full border border-line bg-transparent px-3 py-2 text-[13px] text-accent-2 hover:border-accent hover:bg-accent-dim hover:text-accent"
+            data-testid="run-notifications-view-all"
+            @click="viewAll"
+          >
+            {{ t('shell.runNotifications.viewAll') }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <RunOutputPptModal
+      :open="outputOpen"
+      :run-id="outputRunId"
+      :context-label="outputContext"
+      @close="closeOutputModal"
+    />
   </header>
 </template>

--- a/web/src/components/shell/RunOutputPptModal.vue
+++ b/web/src/components/shell/RunOutputPptModal.vue
@@ -1,0 +1,204 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
+import AppModal from '@/components/ui/AppModal.vue'
+import { api } from '@/lib/api'
+import type { Artifact } from '@/lib/types'
+
+const props = defineProps<{
+  open: boolean
+  runId: string | null
+  contextLabel?: string
+}>()
+
+const emit = defineEmits<{ (e: 'close'): void }>()
+
+const { t } = useI18n()
+const router = useRouter()
+
+const loading = ref(false)
+const loadError = ref<string | null>(null)
+const artifacts = ref<Artifact[]>([])
+const runTitle = ref('')
+const activeIdx = ref(0)
+
+const activeArtifact = computed(() => artifacts.value[activeIdx.value] ?? null)
+
+const subtitle = computed(() => {
+  const parts = [props.runId, props.contextLabel, runTitle.value].filter(Boolean)
+  return parts.join(' · ')
+})
+
+async function load() {
+  const id = props.runId
+  if (!id) {
+    artifacts.value = []
+    runTitle.value = ''
+    loadError.value = null
+    return
+  }
+  loading.value = true
+  loadError.value = null
+  activeIdx.value = 0
+  try {
+    const run = await api.getRun(id)
+    runTitle.value = (run.title || '').trim() || run.workflowName || id
+    artifacts.value = Array.isArray(run.artifacts) ? run.artifacts : []
+  } catch (err) {
+    artifacts.value = []
+    runTitle.value = ''
+    loadError.value = err instanceof Error && err.message ? err.message : String(err || 'load failed')
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(
+  () => [props.open, props.runId] as const,
+  ([open]) => {
+    if (open && props.runId) void load()
+    if (!open) {
+      artifacts.value = []
+      loadError.value = null
+      activeIdx.value = 0
+    }
+  },
+)
+
+function selectCard(idx: number) {
+  activeIdx.value = idx
+}
+
+function close() {
+  emit('close')
+}
+
+function openRunDetail() {
+  const id = props.runId
+  close()
+  if (id) void router.push(`/runs/${id}`)
+}
+
+function slideNo(idx: number, total: number): string {
+  const n = String(idx + 1).padStart(2, '0')
+  const t = String(total).padStart(2, '0')
+  return `${n} / ${t}`
+}
+
+function displayTitle(a: Artifact): string {
+  const base = a.name.replace(/\.[^.]+$/, '')
+  return base || a.name
+}
+</script>
+
+<template>
+  <AppModal
+    :open="open"
+    :title="t('shell.runNotifications.outputTitle')"
+    :width="920"
+    close-on-esc
+    @close="close"
+  >
+    <p class="mb-3 text-xs text-txt3">{{ subtitle || '—' }}</p>
+    <p class="mb-4 text-xs text-txt2">{{ t('shell.runNotifications.outputHint') }}</p>
+
+    <div v-if="loading" class="py-10 text-center text-sm text-txt2" data-testid="run-output-loading">
+      {{ t('shell.runNotifications.loadingOutputs') }}
+    </div>
+    <div v-else-if="loadError" class="border border-err/35 bg-err/8 px-3 py-3 text-sm text-err">
+      {{ loadError }}
+    </div>
+    <div
+      v-else-if="!artifacts.length"
+      class="border border-line bg-base px-4 py-10 text-center"
+      data-testid="run-output-empty"
+    >
+      <p class="text-sm text-txt2">{{ t('shell.runNotifications.noArtifacts') }}</p>
+      <p class="mt-1.5 text-xs text-txt3">{{ t('shell.runNotifications.noArtifactsHint') }}</p>
+    </div>
+    <template v-else>
+      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3" data-testid="run-output-deck">
+        <button
+          v-for="(a, idx) in artifacts"
+          :key="a.id || `${a.name}-${idx}`"
+          type="button"
+          class="border border-line bg-base text-left transition-colors hover:border-accent"
+          :class="idx === activeIdx ? 'border-accent ring-2 ring-accent/30' : ''"
+          data-testid="run-output-card"
+          @click="selectCard(idx)"
+        >
+          <div
+            class="relative flex aspect-video flex-col justify-between overflow-hidden border-b border-line bg-gradient-to-br from-elevated via-base to-accent-dim/40 p-3.5"
+          >
+            <div class="relative z-[1] text-[10px] uppercase tracking-wider text-accent-2">
+              {{ (a.kind || 'file').toUpperCase() }}
+            </div>
+            <div class="relative z-[1] line-clamp-2 text-sm font-semibold leading-snug text-txt">
+              {{ displayTitle(a) }}
+            </div>
+            <div class="relative z-[1] font-mono text-[11px] text-txt3">
+              {{ slideNo(idx, artifacts.length) }}
+            </div>
+          </div>
+          <div class="px-3 py-2.5">
+            <div class="truncate text-[13px] font-medium text-txt">{{ a.name }}</div>
+            <div class="mt-1 text-[11px] text-txt3">
+              <span class="inline-flex border border-line bg-elevated px-1.5 py-0.5">{{ a.kind }}</span>
+              {{ t('shell.runNotifications.outputCard') }}
+            </div>
+          </div>
+        </button>
+      </div>
+
+      <div
+        v-if="activeArtifact"
+        class="mt-4 border border-line bg-base"
+        data-testid="run-output-preview"
+      >
+        <div class="flex items-center justify-between border-b border-line px-3.5 py-2.5 text-xs text-txt2">
+          <span>{{ t('shell.runNotifications.previewLabel') }} · {{ activeArtifact.name }}</span>
+          <span class="border border-line bg-elevated px-1.5 py-0.5 text-[10px]">16:9</span>
+        </div>
+        <div
+          class="flex aspect-video max-h-80 flex-col justify-center gap-2.5 bg-gradient-to-br from-elevated to-base px-8 py-7"
+        >
+          <div class="text-[11px] uppercase tracking-wider text-accent-2">
+            {{ (activeArtifact.kind || 'file').toUpperCase() }} · SLIDE
+            {{ String(activeIdx + 1).padStart(2, '0') }}
+          </div>
+          <div class="text-[22px] font-semibold tracking-tight text-txt">
+            {{ displayTitle(activeArtifact) }}
+          </div>
+          <div class="max-w-xl text-[13px] leading-relaxed text-txt2">
+            {{
+              t('shell.runNotifications.previewSummary', {
+                kind: activeArtifact.kind,
+                name: activeArtifact.name,
+              })
+            }}
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <template #footer>
+      <button
+        type="button"
+        class="border border-line bg-transparent px-3 py-2 text-[13px] text-txt2 hover:border-line-strong hover:text-txt"
+        data-testid="run-output-open-run"
+        @click="openRunDetail"
+      >
+        {{ t('shell.runNotifications.openRunDetail') }}
+      </button>
+      <button
+        type="button"
+        class="border border-transparent bg-accent px-3 py-2 text-[13px] text-white hover:brightness-110"
+        data-testid="run-output-done"
+        @click="close"
+      >
+        {{ t('shell.runNotifications.done') }}
+      </button>
+    </template>
+  </AppModal>
+</template>

--- a/web/src/lib/useRunTerminalNotifications.test.ts
+++ b/web/src/lib/useRunTerminalNotifications.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Run } from '@/lib/types'
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    listRuns: vi.fn(),
+  },
+  isPaginated: (data: unknown): data is { items: unknown[]; total: number } =>
+    data != null && typeof data === 'object' && !Array.isArray(data) && 'items' in data,
+}))
+
+vi.mock('@/lib/useAuth', () => ({
+  useAuth: () => ({
+    user: { value: { username: 'alice', expiresAt: 't' } },
+  }),
+}))
+
+import { api } from '@/lib/api'
+import {
+  __resetRunTerminalNotificationsForTests,
+  formatUnreadBadge,
+  mapRunToNotification,
+  RUN_TERMINAL_PANEL_LIMIT,
+  RUN_TERMINAL_POOL_SIZE,
+  storageKeyForUser,
+  useRunTerminalNotifications,
+} from './useRunTerminalNotifications'
+
+function run(partial: Partial<Run> & Pick<Run, 'id' | 'status'>): Run {
+  return {
+    workflowId: 'wf',
+    workflowName: 'demo-wf',
+    title: partial.title ?? `Run ${partial.id}`,
+    trigger: 'manual',
+    startedAt: partial.startedAt ?? '2026-08-10T12:00:00Z',
+    durationSec: 1,
+    progress: 100,
+    nodeRuns: {},
+    artifacts: [],
+    ...partial,
+  }
+}
+
+function paged(items: Run[], total = items.length) {
+  return { items, total, page: 1, pageSize: RUN_TERMINAL_POOL_SIZE, hasMore: total > items.length }
+}
+
+describe('formatUnreadBadge', () => {
+  it('hides zero, shows 1–98, caps at 99+', () => {
+    expect(formatUnreadBadge(0)).toBe('')
+    expect(formatUnreadBadge(1)).toBe('1')
+    expect(formatUnreadBadge(98)).toBe('98')
+    expect(formatUnreadBadge(99)).toBe('99+')
+    expect(formatUnreadBadge(120)).toBe('99+')
+  })
+})
+
+describe('mapRunToNotification', () => {
+  it('maps completed/failed and rejects other statuses', () => {
+    expect(mapRunToNotification(run({ id: 'r1', status: 'completed' }))).toMatchObject({
+      runId: 'r1',
+      status: 'completed',
+    })
+    expect(mapRunToNotification(run({ id: 'r2', status: 'failed' }))?.status).toBe('failed')
+    expect(mapRunToNotification(run({ id: 'r3', status: 'running' }))).toBeNull()
+  })
+
+  it('falls back title to workflowName then runId', () => {
+    expect(
+      mapRunToNotification(run({ id: 'r1', status: 'completed', title: '  ' }))?.title,
+    ).toBe('demo-wf')
+    expect(
+      mapRunToNotification(
+        run({ id: 'r2', status: 'completed', title: '', workflowName: '' }),
+      )?.title,
+    ).toBe('r2')
+  })
+})
+
+describe('useRunTerminalNotifications', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    __resetRunTerminalNotificationsForTests()
+    vi.mocked(api.listRuns).mockReset()
+    vi.mocked(api.listRuns).mockResolvedValue(paged([]))
+  })
+
+  it('loads pool via listRuns(completed,failed) newest-first window', async () => {
+    const items = [
+      run({ id: 'a', status: 'completed', startedAt: '2026-08-10T13:00:00Z' }),
+      run({ id: 'b', status: 'failed', startedAt: '2026-08-10T12:00:00Z' }),
+    ]
+    vi.mocked(api.listRuns).mockResolvedValue(paged(items, 2))
+    const n = useRunTerminalNotifications()
+    await n.refresh({ source: 'mount' })
+    expect(api.listRuns).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'completed,failed',
+        page: 1,
+        pageSize: RUN_TERMINAL_POOL_SIZE,
+        sort: 'started_at',
+        order: 'desc',
+      }),
+    )
+    expect(n.pool.value.map((x) => x.runId)).toEqual(['a', 'b'])
+    expect(n.unreadCount.value).toBe(2)
+    expect(n.badgeLabel.value).toBe('2')
+    expect(n.hasUnreadFailed.value).toBe(true)
+  })
+
+  it('computes unread from per-user localStorage read set', async () => {
+    localStorage.setItem(storageKeyForUser('alice'), JSON.stringify(['a']))
+    vi.mocked(api.listRuns).mockResolvedValue(
+      paged([
+        run({ id: 'a', status: 'completed' }),
+        run({ id: 'b', status: 'completed' }),
+      ]),
+    )
+    const n = useRunTerminalNotifications()
+    await n.refresh({ source: 'mount' })
+    expect(n.unreadCount.value).toBe(1)
+    expect(n.badgeLabel.value).toBe('1')
+    expect(n.hasUnreadFailed.value).toBe(false)
+    expect(n.previewItems.value.find((x) => x.runId === 'a')?.unread).toBe(false)
+    expect(n.previewItems.value.find((x) => x.runId === 'b')?.unread).toBe(true)
+  })
+
+  it('markRead updates only that run and persists', async () => {
+    vi.mocked(api.listRuns).mockResolvedValue(
+      paged([
+        run({ id: 'a', status: 'failed' }),
+        run({ id: 'b', status: 'completed' }),
+      ]),
+    )
+    const n = useRunTerminalNotifications()
+    await n.refresh({ source: 'mount' })
+    expect(n.unreadCount.value).toBe(2)
+    n.markRead('a')
+    expect(n.unreadCount.value).toBe(1)
+    expect(n.hasUnreadFailed.value).toBe(false)
+    expect(JSON.parse(localStorage.getItem(storageKeyForUser('alice')) || '[]')).toContain('a')
+    // No batch API — second item stays unread
+    expect(n.previewItems.value.find((x) => x.runId === 'b')?.unread).toBe(true)
+  })
+
+  it('previewItems caps at 5 and remainingCount is T-5', async () => {
+    const items = Array.from({ length: 7 }, (_, i) =>
+      run({ id: `r${i}`, status: i % 2 === 0 ? 'completed' : 'failed' }),
+    )
+    vi.mocked(api.listRuns).mockResolvedValue(paged(items, 7))
+    const n = useRunTerminalNotifications()
+    await n.refresh({ source: 'manual' })
+    expect(n.previewItems.value).toHaveLength(RUN_TERMINAL_PANEL_LIMIT)
+    expect(n.remainingCount.value).toBe(2)
+    expect(n.poolTotal.value).toBe(7)
+  })
+
+  it('badge is empty when unread is 0', async () => {
+    vi.mocked(api.listRuns).mockResolvedValue(paged([run({ id: 'a', status: 'completed' })]))
+    const n = useRunTerminalNotifications()
+    await n.refresh({ source: 'mount' })
+    n.markRead('a')
+    expect(n.unreadCount.value).toBe(0)
+    expect(n.badgeLabel.value).toBe('')
+  })
+})

--- a/web/src/lib/useRunTerminalNotifications.ts
+++ b/web/src/lib/useRunTerminalNotifications.ts
@@ -1,0 +1,266 @@
+import { computed, ref } from 'vue'
+import { api, isPaginated } from '@/lib/api'
+import type { Run } from '@/lib/types'
+import { createTimeoutController, isAbortError } from '@/lib/loadingRequest'
+import { DEFAULT_LOADING_TIMEOUT_MS } from '@/lib/loadingTypes'
+import { useAuth } from '@/lib/useAuth'
+
+/** Recent completed/failed runs that form the notification pool (plan: ~50). */
+export const RUN_TERMINAL_POOL_SIZE = 50
+/** Dropdown preview hard limit. */
+export const RUN_TERMINAL_PANEL_LIMIT = 5
+/** Align with AppSidebarNav pending-gates peek interval. */
+export const RUN_TERMINAL_POLL_MS = 15_000
+
+export type RunTerminalStatus = 'completed' | 'failed'
+
+export interface RunTerminalNotification {
+  runId: string
+  status: RunTerminalStatus
+  title: string
+  workflowName: string
+  startedAt: string
+}
+
+export type RunTerminalRefreshSource =
+  | 'mount'
+  | 'sidebar-poll'
+  | 'visibility'
+  | 'focus'
+  | 'manual'
+
+export function formatUnreadBadge(n: number): string {
+  if (n <= 0) return ''
+  if (n >= 99) return '99+'
+  return String(n)
+}
+
+export function storageKeyForUser(username: string): string {
+  return `approving.runTerminalNotifications.readIds.${username || 'anonymous'}`
+}
+
+export function mapRunToNotification(run: Run): RunTerminalNotification | null {
+  if (run.status !== 'completed' && run.status !== 'failed') return null
+  const title = (run.title || '').trim() || run.workflowName || run.id
+  return {
+    runId: run.id,
+    status: run.status,
+    title,
+    workflowName: run.workflowName || '',
+    startedAt: run.startedAt || run.createdAt || '',
+  }
+}
+
+function loadReadIds(username: string): Set<string> {
+  if (typeof localStorage === 'undefined') return new Set()
+  try {
+    const raw = localStorage.getItem(storageKeyForUser(username))
+    if (!raw) return new Set()
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return new Set()
+    return new Set(parsed.filter((x): x is string => typeof x === 'string'))
+  } catch {
+    return new Set()
+  }
+}
+
+function persistReadIds(username: string, ids: Set<string>) {
+  if (typeof localStorage === 'undefined') return
+  try {
+    localStorage.setItem(storageKeyForUser(username), JSON.stringify([...ids]))
+  } catch {
+    // Quota / private mode — ignore; unread will reset next session.
+  }
+}
+
+const pool = ref<RunTerminalNotification[]>([])
+const readIds = ref<Set<string>>(new Set())
+const usernameKey = ref('anonymous')
+const error = ref<string | null>(null)
+const lastRefreshSource = ref<RunTerminalRefreshSource | null>(null)
+const lastPeekAt = ref(0)
+const loading = ref(false)
+
+let refreshPromise: Promise<void> | null = null
+let refreshGeneration = 0
+let abortCtrl: AbortController | null = null
+let pollTimer: number | undefined
+let listenersAttached = false
+let readIdsHydrated = false
+
+const unreadCount = computed(
+  () => pool.value.filter((n) => !readIds.value.has(n.runId)).length,
+)
+
+const hasUnreadFailed = computed(() =>
+  pool.value.some((n) => !readIds.value.has(n.runId) && n.status === 'failed'),
+)
+
+const badgeLabel = computed(() => formatUnreadBadge(unreadCount.value))
+
+const previewItems = computed(() =>
+  pool.value.slice(0, RUN_TERMINAL_PANEL_LIMIT).map((n) => ({
+    ...n,
+    unread: !readIds.value.has(n.runId),
+  })),
+)
+
+const remainingCount = computed(() => Math.max(pool.value.length - RUN_TERMINAL_PANEL_LIMIT, 0))
+
+const poolTotal = computed(() => pool.value.length)
+
+function ensureUsername() {
+  const { user } = useAuth()
+  const next = user.value?.username?.trim() || 'anonymous'
+  if (next !== usernameKey.value) {
+    usernameKey.value = next
+    readIds.value = loadReadIds(next)
+    readIdsHydrated = true
+    return
+  }
+  if (!readIdsHydrated) {
+    readIds.value = loadReadIds(next)
+    readIdsHydrated = true
+  }
+}
+
+function markRead(runId: string) {
+  if (!runId || readIds.value.has(runId)) return
+  const next = new Set(readIds.value)
+  next.add(runId)
+  readIds.value = next
+  persistReadIds(usernameKey.value, next)
+}
+
+async function fetchPool(signal?: AbortSignal): Promise<RunTerminalNotification[]> {
+  const data = await api.listRuns({
+    status: 'completed,failed',
+    page: 1,
+    pageSize: RUN_TERMINAL_POOL_SIZE,
+    sort: 'started_at',
+    order: 'desc',
+    signal,
+  })
+  const items = isPaginated(data) ? data.items : data
+  const mapped: RunTerminalNotification[] = []
+  for (const run of items) {
+    const n = mapRunToNotification(run)
+    if (n) mapped.push(n)
+  }
+  return mapped
+}
+
+async function refresh(opts?: { source?: RunTerminalRefreshSource }): Promise<void> {
+  ensureUsername()
+  if (refreshPromise) return refreshPromise
+
+  const gen = ++refreshGeneration
+  abortCtrl?.abort()
+  abortCtrl = new AbortController()
+  const tc = createTimeoutController(DEFAULT_LOADING_TIMEOUT_MS, abortCtrl.signal)
+
+  const holder: { flight: Promise<void> | null } = { flight: null }
+  holder.flight = (async () => {
+    loading.value = true
+    try {
+      const next = await fetchPool(tc.signal)
+      if (gen !== refreshGeneration) return
+      pool.value = next
+      // Keep read set bounded to current pool (+ already-persisted ids intersecting pool).
+      const poolIds = new Set(next.map((n) => n.runId))
+      const pruned = new Set([...readIds.value].filter((id) => poolIds.has(id)))
+      if (pruned.size !== readIds.value.size) {
+        readIds.value = pruned
+        persistReadIds(usernameKey.value, pruned)
+      }
+      error.value = null
+      lastRefreshSource.value = opts?.source ?? null
+      lastPeekAt.value = Date.now()
+    } catch (err) {
+      if (gen !== refreshGeneration) return
+      if (isAbortError(err) && !tc.timedOut) return
+      error.value = err instanceof Error && err.message ? err.message : String(err || 'load failed')
+    } finally {
+      tc.clear()
+      if (refreshPromise === holder.flight) refreshPromise = null
+      loading.value = false
+    }
+  })()
+  refreshPromise = holder.flight
+  return holder.flight
+}
+
+function onVisibility() {
+  if (typeof document !== 'undefined' && document.visibilityState === 'visible') {
+    void refresh({ source: 'visibility' })
+  }
+}
+
+function onFocus() {
+  void refresh({ source: 'focus' })
+}
+
+function startPolling() {
+  ensureUsername()
+  stopPolling()
+  void refresh({ source: 'mount' })
+  if (typeof window === 'undefined') return
+  pollTimer = window.setInterval(() => {
+    void refresh({ source: 'sidebar-poll' })
+  }, RUN_TERMINAL_POLL_MS)
+  if (!listenersAttached) {
+    document.addEventListener('visibilitychange', onVisibility)
+    window.addEventListener('focus', onFocus)
+    listenersAttached = true
+  }
+}
+
+function stopPolling() {
+  if (pollTimer != null) {
+    clearInterval(pollTimer)
+    pollTimer = undefined
+  }
+  if (listenersAttached && typeof window !== 'undefined') {
+    document.removeEventListener('visibilitychange', onVisibility)
+    window.removeEventListener('focus', onFocus)
+    listenersAttached = false
+  }
+  abortCtrl?.abort()
+  abortCtrl = null
+}
+
+/** Test helper: reset module singleton state. */
+export function __resetRunTerminalNotificationsForTests() {
+  stopPolling()
+  pool.value = []
+  readIds.value = new Set()
+  usernameKey.value = 'anonymous'
+  error.value = null
+  lastRefreshSource.value = null
+  lastPeekAt.value = 0
+  loading.value = false
+  refreshPromise = null
+  refreshGeneration = 0
+  readIdsHydrated = false
+}
+
+export function useRunTerminalNotifications() {
+  return {
+    pool,
+    poolTotal,
+    previewItems,
+    remainingCount,
+    unreadCount,
+    hasUnreadFailed,
+    badgeLabel,
+    error,
+    loading,
+    lastRefreshSource,
+    lastPeekAt,
+    markRead,
+    refresh,
+    startPolling,
+    stopPolling,
+    ensureUsername,
+  }
+}

--- a/web/src/locales/en/shell.json
+++ b/web/src/locales/en/shell.json
@@ -20,6 +20,25 @@
       "openNav": "Open navigation menu",
       "closeNav": "Close navigation menu",
       "backToList": "Back to list"
+    },
+    "runNotifications": {
+      "title": "Run notifications",
+      "unreadCount": "{n} unread",
+      "empty": "No run notifications",
+      "emptyHint": "Completed or failed runs will show up here",
+      "moreHint": "{n} more not shown",
+      "viewAll": "View all notifications",
+      "clickForOutput": "Click to view outputs",
+      "outputTitle": "Run outputs",
+      "outputHint": "Browse this run’s outputs as 16:9 PPT-style cards. Select a card to preview.",
+      "outputCard": "Output card",
+      "noArtifacts": "This run has no outputs",
+      "noArtifactsHint": "Open the run detail to inspect execution",
+      "openRunDetail": "Open run detail",
+      "done": "Done",
+      "previewLabel": "Preview",
+      "previewSummary": "Kind {kind} · artifact {name} (in-app summary preview)",
+      "loadingOutputs": "Loading outputs…"
     }
   }
 }

--- a/web/src/locales/zh-CN/shell.json
+++ b/web/src/locales/zh-CN/shell.json
@@ -20,6 +20,25 @@
       "openNav": "打开导航菜单",
       "closeNav": "关闭导航菜单",
       "backToList": "返回列表"
+    },
+    "runNotifications": {
+      "title": "运行通知",
+      "unreadCount": "{n} 条未读",
+      "empty": "暂无运行通知",
+      "emptyHint": "执行完成或失败后会出现在这里",
+      "moreHint": "还有 {n} 条未展示",
+      "viewAll": "查看全部通知",
+      "clickForOutput": "点击查看产出",
+      "outputTitle": "运行产出",
+      "outputHint": "以 PPT 幻灯片卡片浏览本次输出产物，点击卡片可预览。",
+      "outputCard": "产出卡片",
+      "noArtifacts": "本次运行暂无产出",
+      "noArtifactsHint": "可打开 Run 详情查看执行过程",
+      "openRunDetail": "打开 Run 详情",
+      "done": "完成",
+      "previewLabel": "预览",
+      "previewSummary": "类型 {kind} · 产物 {name}（站内摘要预览）",
+      "loadingOutputs": "正在加载产出…"
     }
   }
 }


### PR DESCRIPTION
以 listRuns(completed,failed) 为事件源与本地已读集驱动角标/下拉，成功打开 PPT 产出模态、失败跳转 Run 详情，并与待审批 Inbox 隔离。

Co-authored-by: Cursor <cursoragent@cursor.com>
