### PR TITLE
fix(browser): CDP ClusterIP DNS 解析为 IP，修复 websocket 500

### DIFF
--- a/server/internal/browser/cdp_host_test.go
+++ b/server/internal/browser/cdp_host_test.go
@@ -11,6 +11,63 @@ import (
 	"time"
 )
 
+func TestPreferIPAddrResolvesClusterDNS(t *testing.T) {
+	prev := lookupIPAddr
+	t.Cleanup(func() { lookupIPAddr = prev })
+	lookupIPAddr = func(_ context.Context, host string) ([]net.IP, error) {
+		if host != "sbx-m1.sandbox-gateway.svc.cluster.local" {
+			t.Fatalf("lookup host=%q", host)
+		}
+		return []net.IP{net.ParseIP("10.43.9.9"), net.ParseIP("2001:db8::9")}, nil
+	}
+	got := preferIPAddr(context.Background(), "sbx-m1.sandbox-gateway.svc.cluster.local:9222")
+	if got != "10.43.9.9:9222" {
+		t.Fatalf("got %q want 10.43.9.9:9222", got)
+	}
+}
+
+func TestPreferIPAddrLeavesIPUnchanged(t *testing.T) {
+	prev := lookupIPAddr
+	t.Cleanup(func() { lookupIPAddr = prev })
+	lookupIPAddr = func(context.Context, string) ([]net.IP, error) {
+		t.Fatal("must not lookup bare IP")
+		return nil, nil
+	}
+	if got := preferIPAddr(context.Background(), "10.88.0.12:9222"); got != "10.88.0.12:9222" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestAttachSandboxDialsResolvedIP(t *testing.T) {
+	prev := lookupIPAddr
+	t.Cleanup(func() { lookupIPAddr = prev })
+	lookupIPAddr = func(context.Context, string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("10.43.1.2")}, nil
+	}
+	s, _ := newResolverService(map[string]string{
+		"cdp":   "sbx-m1.sandbox-gateway.svc.cluster.local:9222",
+		"novnc": "sbx-m1.sandbox-gateway.svc.cluster.local:6080",
+	})
+	var dialed string
+	s.dial = func(_ context.Context, httpBase string) (Engine, error) {
+		dialed = httpBase
+		return &fakeEngine{name: "sandbox"}, nil
+	}
+	// EnsureSandboxVNC ignores readyProbe when a resolver is present; exercise
+	// attach directly so we only assert the CDP dial host rewrite.
+	s.mu.Lock()
+	_, err := s.attachSandboxLocked(context.Background(), "sb", "203.0.113.9",
+		"sbx-m1.sandbox-gateway.svc.cluster.local:9222",
+		"sbx-m1.sandbox-gateway.svc.cluster.local:6080")
+	s.mu.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dialed != "http://10.43.1.2:9222" {
+		t.Fatalf("dialed %q want http://10.43.1.2:9222", dialed)
+	}
+}
+
 // TestProbeTabCreateUsesLoopbackHostHeader locks the Chrome 149 DevTools rule:
 // PUT /json/new rejects Host that is neither an IP nor localhost. Approving
 // dials ClusterIP DNS (sbx-*.svc.cluster.local) after CDP/noVNC isolation, so

--- a/server/internal/browser/service.go
+++ b/server/internal/browser/service.go
@@ -220,6 +220,36 @@ func dialableEndpoint(addr string) string {
 	return addr
 }
 
+// lookupIPAddr resolves a hostname for CDP/noVNC dial. Overridable in tests.
+var lookupIPAddr = func(ctx context.Context, host string) ([]net.IP, error) {
+	return net.DefaultResolver.LookupIP(ctx, "ip", host)
+}
+
+// preferIPAddr rewrites hostnames (e.g. sbx-*.svc.cluster.local) to a dialable
+// IP. Chrome DevTools rejects WebSocket upgrades whose Host is a DNS name
+// ("not an IP address or localhost"); rod's ResolveURL keeps the dial host in
+// the WS URL, so Approving must dial by IP after CDP/noVNC ClusterIP isolation.
+func preferIPAddr(ctx context.Context, addr string) string {
+	host, port := splitHostPort(addr)
+	if host == "" || port <= 0 {
+		return addr
+	}
+	if net.ParseIP(host) != nil {
+		return addr
+	}
+	ips, err := lookupIPAddr(ctx, host)
+	if err != nil || len(ips) == 0 {
+		log.Warn().Str("addr", addr).Err(err).Msg("cdp/novnc DNS resolve failed; dialing hostname")
+		return addr
+	}
+	for _, ip := range ips {
+		if v4 := ip.To4(); v4 != nil {
+			return net.JoinHostPort(v4.String(), strconv.Itoa(port))
+		}
+	}
+	return net.JoinHostPort(ips[0].String(), strconv.Itoa(port))
+}
+
 // SetReadyProbe overrides the CDP/websockify readiness check (tests / custom
 // health logic). Passing nil restores the default probeVNCReady.
 func (s *Service) SetReadyProbe(fn func(ctx context.Context, ip string) bool) {
@@ -392,6 +422,8 @@ func (s *Service) probeVNCReady(ctx context.Context, ip string) bool {
 }
 
 func (s *Service) probeVNCReadyAddrs(ctx context.Context, cdpAddr, novncAddr string) bool {
+	cdpAddr = preferIPAddr(ctx, cdpAddr)
+	novncAddr = preferIPAddr(ctx, novncAddr)
 	cdpHost, cdpP := splitHostPort(cdpAddr)
 	if cdpHost == "" {
 		return false
@@ -412,8 +444,8 @@ func (s *Service) probeVNCReadyAddrs(ctx context.Context, cdpAddr, novncAddr str
 	if err != nil {
 		return false
 	}
-	// Chrome DevTools HTTP rejects non-IP/non-localhost Host on some endpoints;
-	// keep dialing the ClusterIP DNS while advertising a loopback Host.
+	// Belt-and-suspenders: if DNS resolve failed and we still dial a hostname,
+	// force Host to loopback so /json/version + /json/new are accepted.
 	setCDPRequestHost(req, cdpP)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -436,8 +468,8 @@ func (s *Service) probeVNCReadyAddrs(ctx context.Context, cdpAddr, novncAddr str
 }
 
 // setCDPRequestHost forces Host to 127.0.0.1:<port> so Chromium accepts
-// /json/new (and related DevTools HTTP) when Approving dials via Service DNS
-// (sbx-*.svc.cluster.local). TCP still targets req.URL.Host.
+// DevTools HTTP when the dial target is still a DNS name. Prefer preferIPAddr
+// for WebSocket; rod keeps the dial host in the WS URL Host header.
 func setCDPRequestHost(req *http.Request, port int) {
 	if req == nil || port <= 0 {
 		return
@@ -494,18 +526,22 @@ func (s *Service) attachSandboxLocked(ctx context.Context, name, ip, cdpAddr, no
 		}
 		return cs, nil
 	}
-	host, port := splitHostPort(cdpAddr)
+	dialCDP := preferIPAddr(ctx, cdpAddr)
+	host, port := splitHostPort(dialCDP)
 	if host == "" {
 		host = ip
 	}
 	if port <= 0 {
 		port = cdpPort
 	}
+	if net.ParseIP(host) == nil {
+		return nil, fmt.Errorf("connect sandbox cdp: dial host %q is not an IP (Chrome DevTools rejects DNS Host on websocket)", host)
+	}
 	eng, err := s.dial(ctx, fmt.Sprintf("http://%s:%d", host, port))
 	if err != nil {
 		return nil, fmt.Errorf("connect sandbox cdp: %w", err)
 	}
-	cs := &containerState{name: name, ip: ip, cdpAddr: cdpAddr, novncAddr: novncAddr, engine: eng}
+	cs := &containerState{name: name, ip: ip, cdpAddr: dialCDP, novncAddr: preferIPAddr(ctx, novncAddr), engine: eng}
 	s.containers[name] = cs
 	return cs, nil
 }


### PR DESCRIPTION
## Summary
- #243 修好 `/json/new` Host 后，探活能过，但 `connect sandbox cdp` 仍失败：`websocket bad handshake: 500`。
- Chrome 149 对 DevTools **WebSocket** 同样要求 Host 为 IP/`localhost`；rod `ResolveURL` 会把拨号 host 写进 WS URL。
- 拨号前将 `sbx-*.svc.cluster.local` 解析为 ClusterIP，HTTP/WS Host 自然为 IP；保留 loopback Host 改写作为 DNS 解析失败时的兜底。

## Test plan
- [x] `go test ./internal/browser/ -count=1`
- [ ] 部署后打开沙箱浏览器 Tab，确认不再出现 `websocket bad handshake: 500`
- [ ] 箱内复现：`Host: <dns>` → WS 500；`Host: <ip>` → 101


Made with [Cursor](https://cursor.com)