### PR TITLE
Polish SettingsView number input rows to match Demo.

### DIFF
--- a/web/src/views/SettingsView.test.ts
+++ b/web/src/views/SettingsView.test.ts
@@ -82,6 +82,59 @@ describe('SettingsView loading source lock', () => {
   })
 })
 
+describe('SettingsView number input polish (Demo 优化后)', () => {
+  it('skeleton keeps w-[88px] number placeholder width', () => {
+    expect(src).toMatch(/data-testid="settings-form-skeleton"/)
+    expect(src).toMatch(/h-9 w-\[88px\] bg-elevated animate-pulse/)
+  })
+
+  it('number rows: label/for, chip unit, no empty w-9, disabled visual, scoped spinner hide', () => {
+    // g1.1 — no empty unit placeholder
+    expect(src).not.toMatch(/<span v-else class="w-9"\s*\/>/)
+    // g1.2 — TTL unit via .chip + common.minutes (NodeInspector-aligned)
+    expect(src).toMatch(/class="chip">\{\{\s*t\('common\.minutes'\)\s*\}\}<\/span>/)
+    expect(src).not.toMatch(/common\.format\.minutes/)
+    // g1.3 / f7 — width + right align preserved
+    expect(src).toMatch(/settings-number-input w-\[88px\] text-right/)
+    // g2.1 — locked/saving disabled visual
+    expect(src).toMatch(/disabled:cursor-not-allowed disabled:opacity-55/)
+    // g2.2 — scoped spinner hide (not global.css)
+    expect(src).toMatch(/\.settings-number-input\[type='number'\]::-webkit-inner-spin-button/)
+    expect(src).toMatch(/appearance:\s*textfield/)
+    // g3.1 — label/for + stable id
+    expect(src).toMatch(/:for="`setting-\$\{key\}`"/)
+    expect(src).toMatch(/:id="`setting-\$\{key\}`"/)
+  })
+
+  it('mounted: unit rows show chip 分钟; no-unit rows have only input on the right', async () => {
+    apiMocks.getSettings.mockResolvedValue(SETTINGS)
+    apiMocks.listSandboxes.mockResolvedValue([])
+    apiMocks.dashboard.mockResolvedValue({ running: 0 })
+    const w = mountSettings()
+    await flushPromises()
+
+    const runTtl = w.find('#setting-run_sandbox_ttl_minutes')
+    expect(runTtl.exists()).toBe(true)
+    expect(runTtl.classes()).toContain('settings-number-input')
+    const runCtrl = runTtl.element.parentElement!
+    expect(runCtrl.querySelector('.chip')?.textContent).toContain('分钟')
+    expect(runCtrl.querySelectorAll('span.w-9').length).toBe(0)
+
+    const mcr = w.find('#setting-max_concurrent_runs')
+    expect(mcr.exists()).toBe(true)
+    const mcrCtrl = mcr.element.parentElement!
+    expect(mcrCtrl.querySelector('.chip')).toBeNull()
+    expect(mcrCtrl.querySelectorAll('span.w-9').length).toBe(0)
+
+    // label association: clicking title focuses input when enabled
+    const label = w.find('label[for="setting-max_concurrent_runs"]')
+    expect(label.exists()).toBe(true)
+    expect(label.text()).toContain('最大并发运行数')
+
+    w.unmount()
+  })
+})
+
 describe('SettingsView first skeleton vs reset keep form', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/web/src/views/SettingsView.vue
+++ b/web/src/views/SettingsView.vue
@@ -383,7 +383,10 @@ onBeforeUnmount(() => {
             <div class="flex items-start justify-between gap-4">
               <div class="min-w-0 flex-1">
                 <div class="flex flex-wrap items-center gap-1.5">
-                  <span class="text-sm font-medium text-txt">{{ settingLabel(key) }}</span>
+                  <label
+                    :for="`setting-${key}`"
+                    class="text-sm font-medium text-txt"
+                  >{{ settingLabel(key) }}</label>
                   <span
                     class="rounded-full border border-line bg-elevated px-2 py-0.5 text-[10px] text-txt3"
                     :title="t('pages.settings.sourceTitle', { source: itemOf(key)!.source })"
@@ -405,14 +408,14 @@ onBeforeUnmount(() => {
               </div>
               <div class="flex shrink-0 items-center gap-2">
                 <input
+                  :id="`setting-${key}`"
                   v-model.number="form[key]"
                   type="number"
                   :min="itemOf(key)!.min"
                   :disabled="itemOf(key)!.locked || saving"
-                  class="input w-[88px] text-right"
+                  class="input settings-number-input w-[88px] text-right disabled:cursor-not-allowed disabled:opacity-55"
                 />
-                <span v-if="settingHasUnit(key)" class="w-9 text-xs text-txt3">{{ t('common.format.minutes') }}</span>
-                <span v-else class="w-9" />
+                <span v-if="settingHasUnit(key)" class="chip">{{ t('common.minutes') }}</span>
               </div>
             </div>
           </template>
@@ -426,3 +429,16 @@ onBeforeUnmount(() => {
     </p>
   </div>
 </template>
+
+<style scoped>
+/* Hide native number spinner — scoped to SettingsView number inputs only (g2.2 / f5) */
+.settings-number-input[type='number']::-webkit-outer-spin-button,
+.settings-number-input[type='number']::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.settings-number-input[type='number'] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+</style>


### PR DESCRIPTION
Align TTL units with chip, drop empty placeholders, add disabled visuals,
label/for association, and page-scoped spinner hide without touching global .input.

Co-authored-by: Cursor <cursoragent@cursor.com>
