### PR TITLE
feat(dashboard): 概览页增加全平台总 Token KPI

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -376,7 +376,7 @@ func main() {
 		APIKeys:          services.NewAPIKeyService(db),
 		Skill:            skillSvc,
 		Org:              orgSvc,
-		Dash:             services.NewDashboardService(db),
+		Dash:             services.NewDashboardService(db, projectSvc),
 		Sbx:              sbxSvc,
 		Preview:          previewSvc,
 		Issues:           issueSvc,

--- a/server/internal/handlers/handlers_test.go
+++ b/server/internal/handlers/handlers_test.go
@@ -109,7 +109,7 @@ func newHarness(t *testing.T) *harness {
 		Arts:             arts,
 		APIKeys:          services.NewAPIKeyService(db),
 		Skill:            skills,
-		Dash:             services.NewDashboardService(db),
+		Dash:             services.NewDashboardService(db, projectSvc),
 		Sbx:              sbx,
 		Eng:              eng,
 		MCP:              host,

--- a/server/internal/services/dashboard.go
+++ b/server/internal/services/dashboard.go
@@ -7,22 +7,31 @@ import (
 )
 
 // DashboardService computes summary statistics for the dashboard.
-type DashboardService struct{ db *gorm.DB }
-
-// NewDashboardService builds the service.
-func NewDashboardService(db *gorm.DB) *DashboardService { return &DashboardService{db: db} }
-
-// Stats is the dashboard summary payload.
-type Stats struct {
-	Running      int64 `json:"running"`
-	WaitingHuman int64 `json:"waitingHuman"`
-	Failed       int64 `json:"failed"`
-	Completed    int64 `json:"completed"`
-	Workflows    int64 `json:"workflows"`
-	Artifacts    int64 `json:"artifacts"`
+type DashboardService struct {
+	db       *gorm.DB
+	projects *ProjectService
 }
 
-// Compute returns the current stats.
+// NewDashboardService builds the service. projects may be nil (Token fields stay null).
+func NewDashboardService(db *gorm.DB, projects *ProjectService) *DashboardService {
+	return &DashboardService{db: db, projects: projects}
+}
+
+// Stats is the dashboard summary payload.
+// Token fields use pointers so JSON null means "never reported"; 0 is a real zero.
+type Stats struct {
+	Running        int64  `json:"running"`
+	WaitingHuman   int64  `json:"waitingHuman"`
+	Failed         int64  `json:"failed"`
+	Completed      int64  `json:"completed"`
+	Workflows      int64  `json:"workflows"`
+	Artifacts      int64  `json:"artifacts"`
+	TotalTokens    *int64 `json:"totalTokens"`
+	WorkflowTokens *int64 `json:"workflowTokens"`
+	PMTokens       *int64 `json:"pmTokens"`
+}
+
+// Compute returns the current stats (Run status counts + platform Token totals).
 func (s *DashboardService) Compute() Stats {
 	var st Stats
 	count := func(status string) int64 {
@@ -36,5 +45,12 @@ func (s *DashboardService) Compute() Stats {
 	st.Completed = count("completed")
 	s.db.Model(&models.WorkflowDef{}).Count(&st.Workflows)
 	s.db.Model(&models.Artifact{}).Count(&st.Artifacts)
+
+	if s.projects != nil {
+		bd := s.projects.PlatformTokenBreakdown()
+		st.TotalTokens = bd.Total
+		st.WorkflowTokens = bd.Workflow
+		st.PMTokens = bd.PM
+	}
 	return st
 }

--- a/server/internal/services/dashboard_tokens_test.go
+++ b/server/internal/services/dashboard_tokens_test.go
@@ -1,0 +1,211 @@
+package services
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/database"
+	"github.com/cocofhu/approving/internal/models"
+)
+
+func int64Ptr(v int64) *int64 { return &v }
+
+func TestAggregatePlatformTokenBreakdown(t *testing.T) {
+	t.Run("all_unreported_nil", func(t *testing.T) {
+		got := AggregatePlatformTokenBreakdown(map[string]ProjectTokenBreakdown{
+			"a": {},
+			"b": {},
+		})
+		if got.Total != nil || got.Workflow != nil || got.PM != nil {
+			t.Fatalf("want all nil, got %+v", got)
+		}
+	})
+
+	t.Run("empty_map_nil", func(t *testing.T) {
+		got := AggregatePlatformTokenBreakdown(nil)
+		if got.Total != nil || got.Workflow != nil || got.PM != nil {
+			t.Fatalf("want all nil, got %+v", got)
+		}
+	})
+
+	t.Run("partial_projects_sum", func(t *testing.T) {
+		got := AggregatePlatformTokenBreakdown(map[string]ProjectTokenBreakdown{
+			"none": {},
+			"wf":   {Workflow: int64Ptr(100), Total: int64Ptr(100)},
+			"pm":   {PM: int64Ptr(40), Total: int64Ptr(40)},
+			"both": {Workflow: int64Ptr(10), PM: int64Ptr(5), Total: int64Ptr(15)},
+		})
+		if got.Workflow == nil || *got.Workflow != 110 {
+			t.Fatalf("workflow=%v want 110", got.Workflow)
+		}
+		if got.PM == nil || *got.PM != 45 {
+			t.Fatalf("pm=%v want 45", got.PM)
+		}
+		if got.Total == nil || *got.Total != 155 {
+			t.Fatalf("total=%v want 155", got.Total)
+		}
+	})
+
+	t.Run("reported_zero", func(t *testing.T) {
+		got := AggregatePlatformTokenBreakdown(map[string]ProjectTokenBreakdown{
+			"z": {Workflow: int64Ptr(0), PM: int64Ptr(0), Total: int64Ptr(0)},
+		})
+		if got.Workflow == nil || *got.Workflow != 0 {
+			t.Fatalf("workflow=%v want 0", got.Workflow)
+		}
+		if got.PM == nil || *got.PM != 0 {
+			t.Fatalf("pm=%v want 0", got.PM)
+		}
+		if got.Total == nil || *got.Total != 0 {
+			t.Fatalf("total=%v want 0", got.Total)
+		}
+	})
+
+	t.Run("one_side_only", func(t *testing.T) {
+		got := AggregatePlatformTokenBreakdown(map[string]ProjectTokenBreakdown{
+			"a": {Workflow: int64Ptr(7), Total: int64Ptr(7)},
+			"b": {},
+		})
+		if got.Workflow == nil || *got.Workflow != 7 {
+			t.Fatalf("workflow=%v want 7", got.Workflow)
+		}
+		if got.PM != nil {
+			t.Fatalf("pm should be nil, got %v", got.PM)
+		}
+		if got.Total == nil || *got.Total != 7 {
+			t.Fatalf("total=%v want 7", got.Total)
+		}
+	})
+}
+
+func TestPlatformTokenBreakdown_matchesPerProjectSum(t *testing.T) {
+	db, err := database.OpenSQLiteTest(filepath.Join(t.TempDir(), "platform_tokens.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewProjectService(db)
+	dash := NewDashboardService(db, s)
+
+	mustCreate := func(v any) {
+		t.Helper()
+		if err := db.Create(v).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// No usage anywhere → null (not 0).
+	_, err = s.Create("EmptyA", "", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.Create("EmptyB", "", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := dash.Compute()
+	if st.TotalTokens != nil || st.WorkflowTokens != nil || st.PMTokens != nil {
+		t.Fatalf("no usage: want null tokens, got total=%v wf=%v pm=%v",
+			st.TotalTokens, st.WorkflowTokens, st.PMTokens)
+	}
+
+	partial, err := s.Create("Partial", "", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zero, err := s.Create("Zero", "", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pmOnly, err := s.Create("PMOnly", "", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mustCreate(&models.WorkflowDef{ID: "wf-partial", ProjectID: partial.ID, Name: "w", Status: "draft", Version: 1})
+	mustCreate(&models.Run{ID: "run-partial", WorkflowID: "wf-partial", Status: "completed"})
+	mustCreate(&models.StateRun{
+		RunID: "run-partial", NodeID: "n1", Status: "completed",
+		Usage: &models.TokenUsage{InputTokens: 100, OutputTokens: 28},
+	})
+
+	mustCreate(&models.WorkflowDef{ID: "wf-zero", ProjectID: zero.ID, Name: "w", Status: "draft", Version: 1})
+	mustCreate(&models.Run{ID: "run-zero", WorkflowID: "wf-zero", Status: "cancelled"})
+	mustCreate(&models.StateRun{
+		RunID: "run-zero", NodeID: "n1", Status: "cancelled",
+		Usage: &models.TokenUsage{},
+	})
+
+	mustCreate(&models.ChatThread{ID: "th-pm", ProjectID: pmOnly.ID, UserID: "u1", Title: "t"})
+	mustCreate(&models.ChatMessage{
+		ID: "msg-pm", ThreadID: "th-pm", Role: "assistant", Content: "hi",
+		Status: "ok", CreatedAt: time.Now(),
+		Usage: &models.TokenUsage{InputTokens: 10, OutputTokens: 5},
+	})
+
+	platform := s.PlatformTokenBreakdown()
+	// per-project: partial=128 wf, zero=0 wf, pmOnly=15 pm → platform wf=128, pm=15, total=143
+	if platform.Workflow == nil || *platform.Workflow != 128 {
+		t.Fatalf("platform workflow=%v want 128", platform.Workflow)
+	}
+	if platform.PM == nil || *platform.PM != 15 {
+		t.Fatalf("platform pm=%v want 15", platform.PM)
+	}
+	if platform.Total == nil || *platform.Total != 143 {
+		t.Fatalf("platform total=%v want 143", platform.Total)
+	}
+
+	// Same data: sum of each project's totalTokens equals platform total.
+	ids := []string{partial.ID, zero.ID, pmOnly.ID}
+	bd := s.TokenBreakdownByProjectIDs(ids)
+	var sum int64
+	for _, id := range ids {
+		if bd[id].Total != nil {
+			sum += *bd[id].Total
+		}
+	}
+	if platform.Total == nil || *platform.Total != sum {
+		t.Fatalf("platform total %v != per-project sum %d", platform.Total, sum)
+	}
+
+	st = dash.Compute()
+	if st.TotalTokens == nil || *st.TotalTokens != 143 {
+		t.Fatalf("dashboard totalTokens=%v want 143", st.TotalTokens)
+	}
+	if st.WorkflowTokens == nil || *st.WorkflowTokens != 128 {
+		t.Fatalf("dashboard workflowTokens=%v want 128", st.WorkflowTokens)
+	}
+	if st.PMTokens == nil || *st.PMTokens != 15 {
+		t.Fatalf("dashboard pmTokens=%v want 15", st.PMTokens)
+	}
+
+	// All reported zeros → 0 (not null).
+	db2, err := database.OpenSQLiteTest(filepath.Join(t.TempDir(), "platform_zero.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2 := NewProjectService(db2)
+	z, err := s2.Create("OnlyZero", "", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db2.Create(&models.WorkflowDef{ID: "wf-z", ProjectID: z.ID, Name: "w", Status: "draft", Version: 1}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db2.Create(&models.Run{ID: "run-z", WorkflowID: "wf-z", Status: "completed"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db2.Create(&models.StateRun{
+		RunID: "run-z", NodeID: "n1", Status: "completed",
+		Usage: &models.TokenUsage{},
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	got := NewDashboardService(db2, s2).Compute()
+	if got.TotalTokens == nil || *got.TotalTokens != 0 {
+		t.Fatalf("reported zero total=%v want 0", got.TotalTokens)
+	}
+	if got.WorkflowTokens == nil || *got.WorkflowTokens != 0 {
+		t.Fatalf("reported zero workflow=%v want 0", got.WorkflowTokens)
+	}
+}

--- a/server/internal/services/project.go
+++ b/server/internal/services/project.go
@@ -149,6 +149,58 @@ func (s *ProjectService) TokenBreakdownByProjectIDs(projectIDs []string) map[str
 	return out
 }
 
+// AggregatePlatformTokenBreakdown sums per-project breakdowns with null-aware
+// semantics: Workflow/PM are sums of reported sides only (all absent → nil);
+// Total is set when either side reported (nil side treated as 0 in the sum).
+func AggregatePlatformTokenBreakdown(byProject map[string]ProjectTokenBreakdown) ProjectTokenBreakdown {
+	var wfSum, pmSum int64
+	var hasWf, hasPm bool
+	for _, b := range byProject {
+		if b.Workflow != nil {
+			wfSum += *b.Workflow
+			hasWf = true
+		}
+		if b.PM != nil {
+			pmSum += *b.PM
+			hasPm = true
+		}
+	}
+	out := ProjectTokenBreakdown{}
+	if hasWf {
+		v := wfSum
+		out.Workflow = &v
+	}
+	if hasPm {
+		v := pmSum
+		out.PM = &v
+	}
+	if hasWf || hasPm {
+		var total int64
+		if hasWf {
+			total += wfSum
+		}
+		if hasPm {
+			total += pmSum
+		}
+		out.Total = &total
+	}
+	return out
+}
+
+// PlatformTokenBreakdown returns the cross-project Token summary for the
+// dashboard KPI (same semantics as summing each project's TokenBreakdown).
+func (s *ProjectService) PlatformTokenBreakdown() ProjectTokenBreakdown {
+	projects := s.List()
+	if len(projects) == 0 {
+		return ProjectTokenBreakdown{}
+	}
+	ids := make([]string, len(projects))
+	for i, p := range projects {
+		ids[i] = p.ID
+	}
+	return AggregatePlatformTokenBreakdown(s.TokenBreakdownByProjectIDs(ids))
+}
+
 func (s *ProjectService) sumWorkflowTokensByProjectIDs(projectIDs []string) (sums map[string]int64, has map[string]struct{}) {
 	sums = make(map[string]int64)
 	has = make(map[string]struct{})

--- a/server/internal/services/services_core_test.go
+++ b/server/internal/services/services_core_test.go
@@ -794,7 +794,8 @@ func TestArtifactServiceDeleteByID(t *testing.T) {
 
 func TestDashboardService(t *testing.T) {
 	db := newTestDB(t)
-	s := NewDashboardService(db)
+	projects := NewProjectService(db)
+	s := NewDashboardService(db, projects)
 	db.Create(&models.Run{ID: "a", Status: "running"})
 	db.Create(&models.Run{ID: "b", Status: "waiting_human"})
 	db.Create(&models.Run{ID: "c", Status: "failed"})
@@ -809,5 +810,10 @@ func TestDashboardService(t *testing.T) {
 	}
 	if st.Workflows != 1 || st.Artifacts != 1 {
 		t.Fatalf("stats counts: %+v", st)
+	}
+	// No project Usage → Token fields stay null (not 0).
+	if st.TotalTokens != nil || st.WorkflowTokens != nil || st.PMTokens != nil {
+		t.Fatalf("expected null tokens without usage, got total=%v wf=%v pm=%v",
+			st.TotalTokens, st.WorkflowTokens, st.PMTokens)
 	}
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -326,6 +326,10 @@ export interface DashboardStats {
   completed: number
   workflows: number
   artifacts: number
+  /** Platform-wide cumulative tokens; null = never reported (UI "—"). */
+  totalTokens?: number | null
+  workflowTokens?: number | null
+  pmTokens?: number | null
 }
 
 // SettingItem is one platform scheduling knob: its effective value, where it

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -8,7 +8,14 @@
         "waitingHuman": "Waiting for human",
         "failed": "Failed",
         "completed": "Completed",
-        "ariaNav": "View {label} runs, currently {count}"
+        "ariaNav": "View {label} runs, currently {count}",
+        "totalTokens": "Total Tokens",
+        "totalTokensScope": "Platform · all-time",
+        "totalTokensUnreported": "Platform · no usage reported yet",
+        "totalTokensZero": "Platform · reported total is 0",
+        "totalTokensUpdating": "Updating",
+        "totalTokensAria": "Platform total Token usage, currently {count}",
+        "totalTokensAriaUnreported": "Platform total Token usage, not reported yet"
       },
       "boardTitle": "Requirement progress board",
       "viewFullBoard": "View full board →",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -8,7 +8,14 @@
         "waitingHuman": "等待人工",
         "failed": "失败",
         "completed": "已完成",
-        "ariaNav": "查看{label}的 Run，当前 {count}"
+        "ariaNav": "查看{label}的 Run，当前 {count}",
+        "totalTokens": "总 Token",
+        "totalTokensScope": "全平台 · 历史累计",
+        "totalTokensUnreported": "全平台 · 尚未上报用量",
+        "totalTokensZero": "全平台 · 已上报且合计为 0",
+        "totalTokensUpdating": "更新中",
+        "totalTokensAria": "全平台总 Token 消耗，当前 {count}",
+        "totalTokensAriaUnreported": "全平台总 Token 消耗，尚未上报"
       },
       "boardTitle": "需求进度看板",
       "viewFullBoard": "查看完整看板 →",

--- a/web/src/views/DashboardView.fill.test.ts
+++ b/web/src/views/DashboardView.fill.test.ts
@@ -55,11 +55,13 @@ describe('DashboardView desktop fill height chain (g1 / g2)', () => {
     expect(src).toMatch(/query: \{ tab: 'board' \}/)
   })
 
-  it('KPI grid remains shrink-0 after button conversion (g2.2)', () => {
-    expect(src).toMatch(/mb-6 grid shrink-0 grid-cols-2 gap-4 md:grid-cols-4/)
+  it('KPI grid is five-card responsive (2/3/5) with Token after status (g2.1/g2.2)', () => {
+    expect(src).toMatch(/mb-6 grid shrink-0 grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-5/)
     expect(src).toMatch(/type="button"/)
     expect(src).toMatch(/dashboard-kpi-\$\{k\.status\}/)
     expect(src).toMatch(/goKpiRuns\(k\.status\)/)
+    expect(src).toMatch(/data-testid="dashboard-kpi-total-tokens"/)
+    expect(src).toMatch(/pages\.dashboard\.kpi\.totalTokens/)
   })
 })
 

--- a/web/src/views/DashboardView.kpiNav.test.ts
+++ b/web/src/views/DashboardView.kpiNav.test.ts
@@ -82,6 +82,9 @@ describe('DashboardView KPI → /runs status navigation (g1 / g2.1)', () => {
       waitingHuman: 0,
       failed: 1,
       completed: 157,
+      totalTokens: null,
+      workflowTokens: null,
+      pmTokens: null,
     })
   })
 

--- a/web/src/views/DashboardView.tokenKpi.test.ts
+++ b/web/src/views/DashboardView.tokenKpi.test.ts
@@ -1,0 +1,218 @@
+// @vitest-environment happy-dom
+import { createI18n } from 'vue-i18n'
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import common from '@/locales/zh-CN/common.json'
+import pages from '@/locales/zh-CN/pages.json'
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  dashboard: vi.fn(),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: mocks.push }),
+}))
+
+vi.mock('@/lib/api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/api')>('@/lib/api')
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      dashboard: mocks.dashboard,
+    },
+  }
+})
+
+vi.mock('@/lib/useRunBoard', async () => {
+  const { ref: vueRef } = await import('vue')
+  return {
+    useRunBoard: () => ({
+      load: vi.fn(async () => undefined),
+      column: () => ({ items: [], total: 0 }),
+      loading: vueRef(false),
+      hasLoaded: vueRef(true),
+      error: vueRef(null),
+    }),
+  }
+})
+
+vi.mock('@/lib/useProjectContext', () => ({
+  readStoredProjectId: () => '',
+}))
+
+import DashboardView from './DashboardView.vue'
+
+function mountDashboard() {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common, ...pages } },
+  })
+  return mount(DashboardView, {
+    global: {
+      plugins: [i18n],
+      stubs: {
+        Icon: true,
+        RunBoardColumn: true,
+        RunBoardPreviewDrawer: true,
+        TokenUsageHoverTip: true,
+      },
+    },
+  })
+}
+
+const baseStats = {
+  running: 1,
+  waitingHuman: 2,
+  failed: 0,
+  completed: 10,
+  workflows: 3,
+  artifacts: 4,
+}
+
+describe('DashboardView total Token KPI (g2 / g3.1)', () => {
+  beforeEach(() => {
+    mocks.push.mockReset()
+    mocks.dashboard.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows 总 Token label and platform scope; card is not a navigable button', async () => {
+    mocks.dashboard.mockResolvedValue({
+      ...baseStats,
+      totalTokens: 1_240_000,
+      workflowTokens: 986_200,
+      pmTokens: 253_800,
+    })
+    const wrapper = mountDashboard()
+    await flushPromises()
+
+    const card = wrapper.get('[data-testid="dashboard-kpi-total-tokens"]')
+    expect(card.element.tagName).not.toBe('BUTTON')
+    expect(card.text()).toContain('总 Token')
+    expect(card.text()).toContain('全平台 · 历史累计')
+    expect(wrapper.get('[data-testid="dashboard-kpi-total-tokens-value"]').text()).toBe('1.24M')
+
+    mocks.push.mockClear()
+    await card.trigger('click')
+    expect(mocks.push).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('renders — for never-reported (null) and 0 for reported zero', async () => {
+    mocks.dashboard.mockResolvedValue({
+      ...baseStats,
+      totalTokens: null,
+      workflowTokens: null,
+      pmTokens: null,
+    })
+    const wrapper = mountDashboard()
+    await flushPromises()
+    expect(wrapper.get('[data-testid="dashboard-kpi-total-tokens-value"]').text()).toBe('—')
+    expect(wrapper.get('[data-testid="dashboard-kpi-total-tokens-foot"]').text()).toContain(
+      '尚未上报',
+    )
+    wrapper.unmount()
+
+    mocks.dashboard.mockResolvedValue({
+      ...baseStats,
+      totalTokens: 0,
+      workflowTokens: 0,
+      pmTokens: 0,
+    })
+    const zero = mountDashboard()
+    await flushPromises()
+    expect(zero.get('[data-testid="dashboard-kpi-total-tokens-value"]').text()).toBe('0')
+    expect(zero.get('[data-testid="dashboard-kpi-total-tokens-foot"]').text()).toContain(
+      '已上报且合计为 0',
+    )
+    zero.unmount()
+  })
+
+  it('keeps last success value while refreshing and shows 更新中', async () => {
+    vi.useFakeTimers()
+    let resolveSecond!: (v: unknown) => void
+    mocks.dashboard
+      .mockResolvedValueOnce({
+        ...baseStats,
+        totalTokens: 128400,
+        workflowTokens: 128400,
+        pmTokens: null,
+      })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSecond = resolve
+          }),
+      )
+
+    const wrapper = mountDashboard()
+    await flushPromises()
+    expect(wrapper.get('[data-testid="dashboard-kpi-total-tokens-value"]').text()).toBe('128.4K')
+
+    // Trigger interval refresh while second call is pending.
+    await vi.advanceTimersByTimeAsync(8000)
+    await flushPromises()
+    expect(wrapper.get('[data-testid="dashboard-kpi-total-tokens-value"]').text()).toBe('128.4K')
+    expect(wrapper.get('[data-testid="dashboard-kpi-total-tokens-foot"]').text()).toContain(
+      '更新中',
+    )
+
+    resolveSecond({
+      ...baseStats,
+      totalTokens: 200000,
+      workflowTokens: 200000,
+      pmTokens: null,
+    })
+    await flushPromises()
+    expect(wrapper.get('[data-testid="dashboard-kpi-total-tokens-value"]').text()).toBe('200K')
+    expect(wrapper.get('[data-testid="dashboard-kpi-total-tokens-foot"]').text()).toContain(
+      '全平台 · 历史累计',
+    )
+    wrapper.unmount()
+  })
+
+  it('failed refresh does not flash last success to 0', async () => {
+    vi.useFakeTimers()
+    mocks.dashboard
+      .mockResolvedValueOnce({
+        ...baseStats,
+        totalTokens: 42,
+        workflowTokens: 42,
+        pmTokens: null,
+      })
+      .mockRejectedValueOnce(new Error('network'))
+
+    const wrapper = mountDashboard()
+    await flushPromises()
+    expect(wrapper.get('[data-testid="dashboard-kpi-total-tokens-value"]').text()).toBe('42')
+
+    await vi.advanceTimersByTimeAsync(8000)
+    await flushPromises()
+    expect(wrapper.get('[data-testid="dashboard-kpi-total-tokens-value"]').text()).toBe('42')
+    expect(wrapper.get('[data-testid="dashboard-kpi-total-tokens-value"]').text()).not.toBe('0')
+    wrapper.unmount()
+  })
+
+  it('Token card stays after status KPIs in the same grid', async () => {
+    mocks.dashboard.mockResolvedValue({
+      ...baseStats,
+      totalTokens: 10,
+      workflowTokens: 10,
+      pmTokens: null,
+    })
+    const wrapper = mountDashboard()
+    await flushPromises()
+    const grid = wrapper.get('[data-testid="dashboard-kpi-grid"]')
+    const kids = Array.from(grid.element.children) as HTMLElement[]
+    expect(kids).toHaveLength(5)
+    expect(kids[0].getAttribute('data-testid')).toBe('dashboard-kpi-running')
+    expect(kids[4].getAttribute('data-testid')).toBe('dashboard-kpi-total-tokens')
+    wrapper.unmount()
+  })
+})

--- a/web/src/views/DashboardView.vue
+++ b/web/src/views/DashboardView.vue
@@ -3,19 +3,31 @@ import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import Icon from '@/components/ui/Icon.vue'
+import TokenUsageHoverTip from '@/components/ui/TokenUsageHoverTip.vue'
 import RunBoardColumn from '@/components/board/RunBoardColumn.vue'
 import RunBoardPreviewDrawer from '@/components/board/RunBoardPreviewDrawer.vue'
 import { api, type DashboardStats } from '@/lib/api'
+import { fmtCompactTokenCount } from '@/lib/tokenUsage'
 import { readStoredProjectId } from '@/lib/useProjectContext'
 import { useRunBoard } from '@/lib/useRunBoard'
 import { serializeStatusQuery } from '@/lib/useStatusFilter'
 import type { Run } from '@/lib/types'
+
+type TokenSnapshot = {
+  totalTokens: number | null
+  workflowTokens: number | null
+  pmTokens: number | null
+}
 
 const router = useRouter()
 const { t } = useI18n()
 const stats = ref<DashboardStats | null>(null)
 const statsError = ref<string | null>(null)
 const storedProjectId = ref(readStoredProjectId())
+
+/** Last successful Token snapshot for stale-while-revalidate (never flash to 0). */
+const lastSuccessTokens = ref<TokenSnapshot | null>(null)
+const tokensRefreshing = ref(false)
 
 const hasProject = computed(() => !!storedProjectId.value)
 
@@ -58,6 +70,37 @@ const kpis = computed(() => [
   },
 ])
 
+const displayTokens = computed<TokenSnapshot | null>(() => lastSuccessTokens.value)
+
+const tokenDisplayValue = computed(() =>
+  displayTokens.value ? displayTokens.value.totalTokens : undefined,
+)
+
+const tokenFoot = computed(() => {
+  if (tokensRefreshing.value && lastSuccessTokens.value) {
+    return t('pages.dashboard.kpi.totalTokensUpdating')
+  }
+  if (!lastSuccessTokens.value) {
+    return tokensRefreshing.value
+      ? t('pages.dashboard.kpi.totalTokensUpdating')
+      : t('pages.dashboard.kpi.totalTokensScope')
+  }
+  const total = lastSuccessTokens.value.totalTokens
+  if (total == null) return t('pages.dashboard.kpi.totalTokensUnreported')
+  if (total === 0) return t('pages.dashboard.kpi.totalTokensZero')
+  return t('pages.dashboard.kpi.totalTokensScope')
+})
+
+const tokenAria = computed(() => {
+  const total = tokenDisplayValue.value
+  if (total == null) return t('pages.dashboard.kpi.totalTokensAriaUnreported')
+  return t('pages.dashboard.kpi.totalTokensAria', {
+    count: fmtCompactTokenCount(total),
+  })
+})
+
+const showTokenTip = computed(() => tokenDisplayValue.value != null)
+
 const showInitialLoading = computed(() => hasProject.value && loading.value && !hasLoaded.value)
 const loadError = computed(() => {
   if (statsError.value) return statsError.value
@@ -96,13 +139,31 @@ function goSelectProject() {
   void router.push('/projects')
 }
 
+function snapshotTokens(s: DashboardStats): TokenSnapshot {
+  return {
+    totalTokens: s.totalTokens ?? null,
+    workflowTokens: s.workflowTokens ?? null,
+    pmTokens: s.pmTokens ?? null,
+  }
+}
+
 async function refreshStats() {
+  const hadSuccess = lastSuccessTokens.value != null
+  tokensRefreshing.value = true
   try {
-    stats.value = await api.dashboard()
+    const next = await api.dashboard()
+    stats.value = next
     statsError.value = null
+    lastSuccessTokens.value = snapshotTokens(next)
   } catch (err) {
     console.warn('[DashboardView] dashboard stats failed', err)
     statsError.value = err instanceof Error ? err.message : String(err || 'stats failed')
+    // Keep lastSuccessTokens on failure so we never flash a fake 0.
+    if (!hadSuccess) {
+      // First load failed: still do not invent 0; leave snapshot null.
+    }
+  } finally {
+    tokensRefreshing.value = false
   }
 }
 
@@ -158,7 +219,11 @@ onUnmounted(() => {
       </button>
     </div>
 
-    <div class="mb-6 grid shrink-0 grid-cols-2 gap-4 md:grid-cols-4">
+    <!-- Desktop 5 / mid 3 / narrow 2; Token after status KPIs (plan g2.1) -->
+    <div
+      class="mb-6 grid shrink-0 grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-5"
+      data-testid="dashboard-kpi-grid"
+    >
       <button
         v-for="k in kpis"
         :key="k.status"
@@ -174,6 +239,47 @@ onUnmounted(() => {
         </div>
         <div class="mt-2 text-3xl font-semibold text-txt">{{ k.value }}</div>
       </button>
+
+      <div
+        class="group relative card w-full p-4 text-left transition"
+        :class="[
+          showTokenTip
+            ? 'cursor-help border-accent/45 bg-gradient-to-b from-accent-dim/80 to-surface hover:border-accent'
+            : 'border-accent/35 bg-gradient-to-b from-accent-dim/50 to-surface',
+          tokensRefreshing && lastSuccessTokens ? 'opacity-70' : '',
+        ]"
+        data-testid="dashboard-kpi-total-tokens"
+        role="group"
+        :aria-label="tokenAria"
+        :aria-describedby="showTokenTip ? 'dashboard-token-detail-tip' : undefined"
+        :tabindex="showTokenTip ? 0 : undefined"
+        @click.stop
+      >
+        <div class="flex items-center justify-between gap-2">
+          <span class="text-[13px] text-txt2">{{ t('pages.dashboard.kpi.totalTokens') }}</span>
+          <Icon name="sparkles" :size="18" class="text-accent-2" />
+        </div>
+        <div
+          class="mt-2 font-mono text-3xl font-semibold tabular-nums tracking-tight"
+          :class="tokenDisplayValue == null ? 'text-txt3' : 'text-txt'"
+          data-testid="dashboard-kpi-total-tokens-value"
+        >
+          {{ fmtCompactTokenCount(tokenDisplayValue) }}
+        </div>
+        <div
+          class="mt-1.5 text-[11px] text-txt3"
+          data-testid="dashboard-kpi-total-tokens-foot"
+        >
+          {{ tokenFoot }}
+        </div>
+        <TokenUsageHoverTip
+          v-if="showTokenTip && displayTokens"
+          tip-id="dashboard-token-detail-tip"
+          :total-tokens="displayTokens.totalTokens!"
+          :workflow-tokens="displayTokens.workflowTokens"
+          :pm-tokens="displayTokens.pmTokens"
+        />
+      </div>
     </div>
 
     <div


### PR DESCRIPTION
扩展 /stats/dashboard 返回平台级 total/workflow/pm（null=未上报），
Dashboard 网格扩为五卡并复用 HoverTip 与刷新保留上次值。

Co-authored-by: Cursor <cursoragent@cursor.com>
