### PR TITLE
fix: show three-state placeholders for composite variable images

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Module-specific lint, test, coverage, and E2E commands are documented in [`AGENT
 - Keep ACP API keys and Git credentials in project or Agent env; never commit them.
 - Pin production images by digest; see [Release images and smoke](CONTRIBUTING.md#release-images-and-smoke).
 - Approving is still beta software. Perform your own security review, backups, and capacity validation before production use.
+- **DB ↔ attachment lifecycle:** release Compose separates SQLite (`./.localdata/db`) from app-data/blobs (`./.localdata/app-data`). Backup and clean them as a pair (and include a custom `APPROVING_BLOBS_ROOT` if set); otherwise Run inputs can keep `blob:` refs while `GET /api/blobs/:id` returns 404. Historical orphans are shown as permanent UI placeholders only—this release does not ship an orphan scanner. See [Quick start · Database and attachments](docs/content/en/guide/quick-start.md#database-and-attachments-share-one-lifecycle-backup--cleanup).
 
 ## Documentation
 

--- a/docs/content/en/guide/quick-start.md
+++ b/docs/content/en/guide/quick-start.md
@@ -34,6 +34,16 @@ Then open:
 
 Agent / workspace / platform-rules and SQLite data live under `.localdata` at the repo root (bind mounts: `gateway` / `db` / `app-data`). `./start.sh restart` and `./start.sh down` keep that directory. To wipe: `./start.sh down && rm -rf .localdata`.
 
+### Database and attachments share one lifecycle (backup / cleanup)
+
+In the release stack (`compose.release.yaml`), **SQLite** is mounted at `./.localdata/db` and **app data (including default attachment blobs under `data/blobs` relative to `WORKDIR`)** at `./.localdata/app-data`. Composite variable images keep only `blob:{id}` refs in the DB / Run outputs; bytes live under the blobs directory. Backing up or cleaning only one side creates orphan refs (“ref still present, GET `/api/blobs/:id` → 404”), and Run detail shows **Cannot display / Attachment unavailable**.
+
+Ops rules:
+
+- **Paired backup**: every backup set must include both `./.localdata/db` and `./.localdata/app-data` (or the whole `.localdata` tree).
+- **Paired cleanup / migration / upgrade**: never move only SQLite or delete only the blobs directory; if you override `APPROVING_BLOBS_ROOT`, include that path in the same lifecycle as the database.
+- **Historical orphans**: broken refs are not guaranteed recoverable; the UI only shows a permanent-failure placeholder. This delivery does **not** add an orphan inspection console, bulk scan page, or startup/health-check alerts.
+
 ## Common commands
 
 ```bash

--- a/docs/content/en/help/configuration.md
+++ b/docs/content/en/help/configuration.md
@@ -22,6 +22,10 @@ That document is generated/checked by `go run ./cmd/gen-configdoc`; CI runs `-ch
 
 Image tags / digests, gateway, and sandbox-related variables are in `.env.example`. Agent API keys, `GITHUB_*` / `GITLAB_*` / SSH, and similar belong in agent meta env (values may reference `${vars.<name>}`).
 
+## Database and attachment lifecycle
+
+In the release stack, SQLite (`./.localdata/db`) and app-data / default blobs (`./.localdata/app-data`, or a custom `APPROVING_BLOBS_ROOT`) must be **backed up and cleaned as a pair**; do not migrate only the database. Otherwise composite images can keep orphan `blob:` refs (GET `/api/blobs/:id` → 404). Historical orphans only get a permanent UI placeholder; this delivery does not add an inspection console. See [Quick start](../guide/quick-start.md#database-and-attachments-share-one-lifecycle-backup--cleanup).
+
 ## Related
 
 - [Gateway](../gateway/)

--- a/docs/content/guide/quick-start.md
+++ b/docs/content/guide/quick-start.md
@@ -34,6 +34,16 @@ cd approving
 
 Agent / workspace / platform-rules 与 SQLite 持久在仓库根 `.localdata` 宿主机目录（bind mount：`gateway` / `db` / `app-data`）。`./start.sh restart` 与 `./start.sh down` 会保留该目录。清空数据：`./start.sh down && rm -rf .localdata`。
 
+### 数据库与附件同生命周期（备份 / 清理）
+
+正式栈（`compose.release.yaml`）把 **SQLite** 挂在 `./.localdata/db`，把 **应用数据（含默认附件 blobs，相对 `WORKDIR` 的 `data/blobs`）** 挂在 `./.localdata/app-data`。复合变量附图在库/Run 输出里只保留 `blob:{id}` 引用，字节落在 blobs 目录；若只备份或只清理其中一侧，会出现「库里还有引用、GET `/api/blobs/:id` 却 404」的孤儿引用，Run 详情里附图会显示为「无法显示 / 附件不可用」。
+
+运维约束：
+
+- **成对备份**：同一备份集须同时包含 `./.localdata/db` 与 `./.localdata/app-data`（或整棵 `.localdata`）。
+- **成对清理 / 迁移 / 升级**：不要只搬 SQLite 或只删附件目录；自定义 `APPROVING_BLOBS_ROOT` 时，须把该路径与数据库一并纳入同一生命周期。
+- **历史孤儿**：已损坏的引用不保证可从附件存储找回；界面仅展示永久失败占位。本次交付**不做**孤儿巡检台、批量扫描页或启动/健康检查告警。
+
 ## 常用命令
 
 ```bash

--- a/docs/content/help/configuration.md
+++ b/docs/content/help/configuration.md
@@ -22,6 +22,10 @@ Approving 服务端配置以 YAML / 环境变量为主（本地示例见 `server
 
 镜像 tag / digest、网关与沙箱相关变量见 `.env.example`。Agent 侧 API key、`GITHUB_*` / `GITLAB_*` / SSH 等放在 Agent meta env（值可引用 `${vars.<name>}`）。
 
+## 数据库与附件同生命周期
+
+正式栈中 SQLite（`./.localdata/db`）与应用数据/默认 blobs（`./.localdata/app-data`，或自定义 `APPROVING_BLOBS_ROOT`）必须**成对备份与成对清理**；迁移/升级勿只搬库。否则复合变量附图会出现孤儿 `blob:` 引用（GET `/api/blobs/:id` → 404）。历史孤儿仅界面永久失败占位，本次不做巡检台。详见 [快速开始](../guide/quick-start.md#数据库与附件同生命周期备份--清理)。
+
 ## 相关
 
 - [网关](../gateway/)

--- a/web/src/components/ui/CompositeImageStrip.test.ts
+++ b/web/src/components/ui/CompositeImageStrip.test.ts
@@ -1,27 +1,104 @@
 // @vitest-environment happy-dom
+import { createI18n } from 'vue-i18n'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
+import common from '@/locales/zh-CN/common.json'
 import CompositeImageStrip from './CompositeImageStrip.vue'
 
-describe('CompositeImageStrip', () => {
-  it('renders images from composite value', () => {
-    const wrapper = mount(CompositeImageStrip, {
-      props: {
-        value: {
-          text: 'hi',
-          images: [{ mime: 'image/png', data: 'abc', name: 'a.png' }],
-        },
+function mountStrip(value: unknown, size?: 'sm' | 'md' | 'lg') {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common } },
+  })
+  return mount(CompositeImageStrip, {
+    props: { value, ...(size ? { size } : {}) },
+    global: {
+      plugins: [i18n],
+      stubs: {
+        AppSpinner: { template: '<span data-testid="spinner-stub" />' },
       },
+    },
+  })
+}
+
+describe('CompositeImageStrip', () => {
+  it('renders images from composite value (g1.1 success path)', async () => {
+    const wrapper = mountStrip({
+      text: 'hi',
+      images: [{ mime: 'image/png', data: 'abc', name: 'a.png' }],
     })
-    expect(wrapper.findAll('img').length).toBe(1)
+    const img = wrapper.find('img')
+    expect(img.exists()).toBe(true)
+    expect(wrapper.find('[data-testid="composite-image-loading"]').exists()).toBe(true)
+    await img.trigger('load')
+    expect(wrapper.find('[data-testid="composite-image-ok"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="composite-image-failed"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="composite-image-loading"]').exists()).toBe(false)
     wrapper.unmount()
   })
 
   it('renders nothing when no images', () => {
-    const wrapper = mount(CompositeImageStrip, {
-      props: { value: 'plain text' },
-    })
+    const wrapper = mountStrip('plain text')
     expect(wrapper.find('img').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="composite-image-strip"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('empty src: immediate permanent fail placeholder, not bare broken img (g2.1 / g1.2)', () => {
+    const wrapper = mountStrip({
+      text: '需求描述',
+      images: [{ mime: 'image/png', name: 'missing.png' }],
+    })
+    expect(wrapper.find('[data-testid="composite-image-failed"]').exists()).toBe(true)
+    expect(wrapper.find('img').exists()).toBe(false)
+    expect(wrapper.text()).toContain('无法显示')
+    expect(wrapper.text()).toContain('附件不可用')
+    expect(wrapper.text()).not.toContain('重试')
+    expect(wrapper.text()).not.toContain('404')
+    expect(wrapper.find('button').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('@error / blob load failure → permanent fail without retry (g2.2 / g1.3)', async () => {
+    const wrapper = mountStrip({
+      text: 'feature',
+      images: [{ mime: 'image/png', ref: 'blob:deadbeef', name: 'orphan.png' }],
+    })
+    expect(wrapper.find('[data-testid="composite-image-loading"]').exists()).toBe(true)
+    const img = wrapper.find('img')
+    expect(img.exists()).toBe(true)
+    await img.trigger('error')
+    expect(wrapper.find('[data-testid="composite-image-failed"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('无法显示')
+    expect(wrapper.text()).toContain('附件不可用')
+    expect(wrapper.text()).not.toContain('重试')
+    expect(wrapper.text()).not.toContain('重新上传')
+    expect(wrapper.find('button').exists()).toBe(false)
+    expect(wrapper.find('[data-image-failed="1"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('mixed: success and permanent fail coexist per image (g2.3 / g1.1)', async () => {
+    const wrapper = mountStrip({
+      text: 'multi',
+      images: [
+        { mime: 'image/png', data: 'okbytes', name: 'ok.png' },
+        { mime: 'image/png', name: 'empty.png' },
+        { mime: 'image/png', ref: 'blob:orphan', name: 'gone.png' },
+      ],
+    })
+    const imgs = wrapper.findAll('img')
+    expect(imgs.length).toBe(2)
+    await imgs[0]!.trigger('load')
+    await imgs[1]!.trigger('error')
+
+    expect(wrapper.findAll('[data-testid="composite-image-ok"]').length).toBe(1)
+    expect(wrapper.findAll('[data-testid="composite-image-failed"]').length).toBe(2)
+    expect(wrapper.text()).toContain('无法显示')
+    expect(wrapper.text()).toContain('附件不可用')
+    // Successful thumb still present; failures are independent placeholders
+    expect(wrapper.find('[data-testid="composite-image-ok"] img').exists()).toBe(true)
     wrapper.unmount()
   })
 })

--- a/web/src/components/ui/CompositeImageStrip.vue
+++ b/web/src/components/ui/CompositeImageStrip.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, reactive, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import AppSpinner from './AppSpinner.vue'
 import { compositeImages, imgSrc } from '@/lib/compositeText'
+
+type ThumbStatus = 'loading' | 'ok' | 'failed'
 
 const props = withDefaults(
   defineProps<{
@@ -10,23 +14,105 @@ const props = withDefaults(
   { size: 'sm' },
 )
 
+const { t } = useI18n()
+
 const SIZE_CLS: Record<string, string> = {
   sm: 'h-10 w-10',
   md: 'h-14 w-14',
   lg: 'h-12 w-12',
 }
 
+/** Fail/loading cards need room for copy (Demo: ~140×72). */
+const CARD_CLS: Record<string, string> = {
+  sm: 'min-h-[4.5rem] w-[7.5rem]',
+  md: 'min-h-[5rem] w-36',
+  lg: 'min-h-[4.75rem] w-32',
+}
+
 const images = computed(() => compositeImages(props.value))
 const sizeClass = computed(() => SIZE_CLS[props.size] ?? SIZE_CLS.sm)
+const cardClass = computed(() => CARD_CLS[props.size] ?? CARD_CLS.sm)
+
+/** Per-index status after mount; empty src never enters loading. */
+const statuses = reactive<Record<number, ThumbStatus>>({})
+
+const items = computed(() =>
+  images.value.map((im, index) => {
+    const src = imgSrc(im)
+    const status: ThumbStatus = !src ? 'failed' : (statuses[index] ?? 'loading')
+    return { index, src, status }
+  }),
+)
+
+watch(
+  images,
+  (imgs) => {
+    for (const key of Object.keys(statuses)) {
+      delete statuses[Number(key)]
+    }
+    imgs.forEach((im, index) => {
+      statuses[index] = imgSrc(im) ? 'loading' : 'failed'
+    })
+  },
+  { immediate: true, deep: true },
+)
+
+function onLoad(index: number) {
+  statuses[index] = 'ok'
+}
+
+function onError(index: number) {
+  statuses[index] = 'failed'
+}
 </script>
 
 <template>
-  <div v-if="images.length" class="flex flex-wrap gap-1.5">
-    <img
-      v-for="(im, ii) in images"
-      :key="ii"
-      :src="imgSrc(im)"
-      :class="[sizeClass, 'rounded border border-line object-cover']"
-    />
+  <div v-if="items.length" class="flex flex-wrap gap-1.5" data-testid="composite-image-strip">
+    <template v-for="item in items" :key="item.index">
+      <!-- Permanent failure: empty src or blob/@error; no retry, no HTTP/path details -->
+      <div
+        v-if="item.status === 'failed'"
+        class="flex flex-col items-center justify-center gap-1 border border-err/35 bg-err/[0.06] px-2 py-2 text-center"
+        :class="cardClass"
+        data-image-failed="1"
+        data-testid="composite-image-failed"
+        role="img"
+        :aria-label="`${t('common.compositeImage.cannotDisplay')} · ${t('common.compositeImage.attachmentUnavailable')}`"
+      >
+        <div class="text-[11px] font-semibold text-red-300">
+          {{ t('common.compositeImage.cannotDisplay') }}
+        </div>
+        <div class="text-[11px] leading-snug text-txt3">
+          {{ t('common.compositeImage.attachmentUnavailable') }}
+        </div>
+      </div>
+
+      <!-- Has src: loading overlay until @load; @error → failed -->
+      <div
+        v-else
+        class="relative overflow-hidden border border-line"
+        :class="item.status === 'loading' ? cardClass : sizeClass"
+        :data-testid="item.status === 'loading' ? 'composite-image-loading' : 'composite-image-ok'"
+        :role="item.status === 'loading' ? 'status' : undefined"
+        :aria-label="item.status === 'loading' ? t('common.compositeImage.loading') : undefined"
+      >
+        <div
+          v-if="item.status === 'loading'"
+          class="absolute inset-0 z-[1] flex flex-col items-center justify-center gap-1 bg-elevated text-[11px] text-txt3"
+          aria-hidden="true"
+        >
+          <AppSpinner :size="12" />
+          <span>{{ t('common.compositeImage.loading') }}</span>
+        </div>
+        <img
+          :src="item.src"
+          class="h-full w-full object-cover"
+          :class="item.status === 'loading' ? 'opacity-0' : ''"
+          alt=""
+          @load="onLoad(item.index)"
+          @error="onError(item.index)"
+        />
+      </div>
+    </template>
   </div>
 </template>

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -335,6 +335,11 @@
       "previewAria": "Preview {label}",
       "imageFallback": "Image",
       "imageFallbackN": "Image {n}"
+    },
+    "compositeImage": {
+      "loading": "Loading",
+      "cannotDisplay": "Cannot display",
+      "attachmentUnavailable": "Attachment unavailable"
     }
   }
 }

--- a/web/src/locales/zh-CN/common.json
+++ b/web/src/locales/zh-CN/common.json
@@ -335,6 +335,11 @@
       "previewAria": "预览{label}",
       "imageFallback": "图片",
       "imageFallbackN": "图片 {n}"
+    },
+    "compositeImage": {
+      "loading": "加载中",
+      "cannotDisplay": "无法显示",
+      "attachmentUnavailable": "附件不可用"
     }
   }
 }


### PR DESCRIPTION
Orphan blob refs were rendering as bare broken <img> icons in Run input
panels. CompositeImageStrip now tracks per-image loading/ok/failed states
with Demo-aligned copy, and docs require paired DB/blobs backup.

Co-authored-by: Cursor <cursoragent@cursor.com>
