### PR TITLE
feat(web): move Agent Studio MCP docs into a help modal

### DIFF
--- a/web/src/components/agent/McpConfigHelpModal.test.ts
+++ b/web/src/components/agent/McpConfigHelpModal.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment happy-dom
+import { nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it } from 'vitest'
+import common from '@/locales/zh-CN/common.json'
+import pages from '@/locales/zh-CN/pages.json'
+import commonEn from '@/locales/en/common.json'
+import pagesEn from '@/locales/en/pages.json'
+import McpConfigHelpModal from './McpConfigHelpModal.vue'
+
+function mountHelp(
+  props: Record<string, unknown> = {},
+  locale: 'zh-CN' | 'en' = 'zh-CN',
+) {
+  const i18n = createI18n({
+    legacy: false,
+    locale,
+    messages: {
+      'zh-CN': { ...common, ...pages },
+      en: { ...commonEn, ...pagesEn },
+    },
+  })
+  return mount(McpConfigHelpModal, {
+    props: { open: true, configRoot: '/root/.codebuddy', ...props },
+    global: {
+      plugins: [i18n],
+      stubs: { Transition: false },
+    },
+    attachTo: document.body,
+  })
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('McpConfigHelpModal', () => {
+  it('opens as 640 AppModal on run, with hint, Got-it footer and Esc close', async () => {
+    const wrapper = mountHelp()
+    const dialog = document.body.querySelector('.fixed.inset-0 .relative.flex.max-h-\\[88vh\\]') as HTMLElement
+    expect(dialog).toBeTruthy()
+    expect(dialog.style.maxWidth).toBe('640px')
+    expect(document.body.textContent).toContain('MCP 配置帮助')
+    expect(document.body.textContent).toContain('运行级变量')
+    expect(document.body.textContent).toContain('Agent 平台 MCP')
+    expect(document.body.textContent).toContain('知道了')
+    expect(document.body.textContent).toContain('整份 mcp.json 由你配置')
+    expect(document.body.textContent).toContain('/root/.codebuddy/mcp.json')
+    expect(document.body.textContent).toContain('APPROVING_ARTIFACT_URL')
+    expect(document.body.textContent).not.toContain('APPROVING_MEMORY_URL')
+    expect(document.body.querySelector('[data-test="mcp-help-run"]')).toBeTruthy()
+    expect(document.body.querySelector('[data-test="mcp-help-agent"]')).toBeFalsy()
+    expect(document.body.querySelector('[data-help-chip="run"]')?.className).toContain('border-accent')
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(wrapper.emitted('close')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('switches exclusively to agent docs without add buttons', async () => {
+    const wrapper = mountHelp()
+    await nextTick()
+    const agentChip = document.body.querySelector('[data-test="mcp-help-chip-agent"]') as HTMLButtonElement
+    agentChip.click()
+    await nextTick()
+    expect(wrapper.emitted('close')).toBeUndefined()
+    expect(document.body.querySelector('[data-help-chip="agent"]')?.className).toContain('border-accent')
+    expect(document.body.querySelector('[data-test="mcp-help-agent"]')).toBeTruthy()
+    expect(document.body.querySelector('[data-test="mcp-help-run"]')).toBeFalsy()
+    expect(document.body.textContent).toContain('APPROVING_MEMORY_URL')
+    expect(document.body.textContent).toContain('pm-progress')
+    expect(document.body.textContent).toContain('Agent 通用平台 MCP')
+    expect(document.body.textContent).not.toContain('+ 添加长期记忆')
+    expect(document.body.textContent).not.toContain('+ memory-store')
+    wrapper.unmount()
+  })
+
+  it('resets to run each time it reopens', async () => {
+    const wrapper = mountHelp()
+    await nextTick()
+    ;(document.body.querySelector('[data-test="mcp-help-chip-agent"]') as HTMLButtonElement).click()
+    await nextTick()
+    expect(document.body.querySelector('[data-test="mcp-help-agent"]')).toBeTruthy()
+
+    await wrapper.setProps({ open: false })
+    await nextTick()
+    await wrapper.setProps({ open: true })
+    await nextTick()
+    expect(document.body.querySelector('[data-help-chip="run"]')?.className).toContain('border-accent')
+    expect(document.body.querySelector('[data-test="mcp-help-run"]')).toBeTruthy()
+    expect(document.body.querySelector('[data-test="mcp-help-agent"]')).toBeFalsy()
+    wrapper.unmount()
+  })
+
+  it('English copy uses Help title / Got it / chips', async () => {
+    const wrapper = mountHelp({}, 'en')
+    expect(document.body.textContent).toContain('MCP config help')
+    expect(document.body.textContent).toContain('Got it')
+    expect(document.body.textContent).toContain('Run-scoped vars')
+    expect(document.body.textContent).toContain('Agent platform MCP')
+    wrapper.unmount()
+  })
+})

--- a/web/src/components/agent/McpConfigHelpModal.vue
+++ b/web/src/components/agent/McpConfigHelpModal.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import { nextTick, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import AppButton from '@/components/ui/AppButton.vue'
+import AppModal from '@/components/ui/AppModal.vue'
+
+export type McpHelpSection = 'run' | 'agent'
+
+const SECTIONS: McpHelpSection[] = ['run', 'agent']
+
+const props = withDefaults(
+  defineProps<{
+    open: boolean
+    configRoot?: string
+  }>(),
+  { configRoot: '' },
+)
+
+const emit = defineEmits<{ close: [] }>()
+const { t } = useI18n()
+
+const activeSection = ref<McpHelpSection>('run')
+let lastTrigger: HTMLElement | null = null
+
+watch(
+  () => props.open,
+  (open, wasOpen) => {
+    if (open && !wasOpen) {
+      activeSection.value = 'run'
+      lastTrigger = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    }
+    if (!open && wasOpen) {
+      nextTick(() => lastTrigger?.focus())
+    }
+  },
+)
+
+function onClose() {
+  emit('close')
+}
+
+function onChip(id: McpHelpSection) {
+  activeSection.value = id
+}
+</script>
+
+<template>
+  <AppModal
+    :open="open"
+    :title="t('pages.agentStudio.mcpHelp.title')"
+    :width="640"
+    close-on-esc
+    @close="onClose"
+  >
+    <div class="mb-3.5 flex flex-wrap gap-1.5" data-test="mcp-config-help">
+      <button
+        v-for="id in SECTIONS"
+        :key="id"
+        type="button"
+        class="border px-2 py-1 text-[11px]"
+        :class="activeSection === id ? 'border-accent bg-accent-dim text-txt' : 'border-line bg-base text-txt2'"
+        :data-help-chip="id"
+        :data-test="`mcp-help-chip-${id}`"
+        @click="onChip(id)"
+      >
+        {{ t(`pages.agentStudio.mcpHelp.chip.${id}`) }}
+      </button>
+    </div>
+
+    <p class="mb-3 border border-line bg-base px-3 py-2.5 text-[12px] leading-[1.7] text-txt2" data-test="mcp-help-hint">
+      {{ t('pages.agentStudio.mcp.hint', { configRoot: configRoot || '' }) }}
+    </p>
+
+    <section v-if="activeSection === 'run'" data-test="mcp-help-run" class="scroll-mt-2">
+      <h3 class="mb-2 mt-0 flex items-center gap-1.5 text-[13px] font-semibold text-txt">
+        {{ t('pages.agentStudio.mcp.runVarsTitle') }}
+        <span class="border border-info/35 px-1.5 py-px text-[10px] font-medium text-info">{{ t('pages.agentStudio.mcp.runScopeTag') }}</span>
+      </h3>
+      <div class="grid gap-2 font-mono text-[12px] text-txt3">
+        <div><code class="text-accent-2">${APPROVING_ARTIFACT_URL}</code> — {{ t('pages.agentStudio.mcp.artifactUrl') }}</div>
+        <div><code class="text-accent-2">${APPROVING_ARTIFACT_TOKEN}</code> — {{ t('pages.agentStudio.mcp.artifactToken') }}</div>
+        <div><code class="text-accent-2">${APPROVING_RUN_ID}</code> · <code class="text-accent-2">${APPROVING_NODE_ID}</code></div>
+        <div><code class="text-accent-2">${vars.&lt;name&gt;}</code> — {{ t('pages.agentStudio.mcp.globalVar') }}</div>
+      </div>
+    </section>
+
+    <section v-else data-test="mcp-help-agent" class="scroll-mt-2">
+      <h3 class="mb-2 mt-0 flex items-center gap-1.5 text-[13px] font-semibold text-txt">
+        {{ t('pages.agentStudio.mcp.agentVarsTitle') }}
+        <span class="border border-ok/35 px-1.5 py-px text-[10px] font-medium text-ok">{{ t('pages.agentStudio.mcp.agentScopeTag') }}</span>
+      </h3>
+      <div class="grid gap-2 font-mono text-[12px] text-txt3">
+        <div><code class="text-accent-2">${APPROVING_MEMORY_URL}</code> / <code class="text-accent-2">${APPROVING_MEMORY_TOKEN}</code> — {{ t('pages.agentStudio.mcp.memoryVars') }}</div>
+        <div><code class="text-accent-2">${APPROVING_CONTEXT_URL}</code> / <code class="text-accent-2">${APPROVING_CONTEXT_TOKEN}</code> — {{ t('pages.agentStudio.mcp.contextVars') }}</div>
+        <div><code class="text-accent-2">${APPROVING_SCHEDULER_URL}</code> / <code class="text-accent-2">${APPROVING_SCHEDULER_TOKEN}</code> — {{ t('pages.agentStudio.mcp.schedulerVars') }}</div>
+      </div>
+      <p class="mt-3 mb-0 text-[12px] leading-[1.7] text-txt3" data-test="mcp-help-agent-scope-note">
+        {{ t('pages.agentStudio.mcp.agentScopeNote') }}
+      </p>
+    </section>
+
+    <template #footer>
+      <AppButton variant="primary" data-test="mcp-help-got-it" @click="onClose">
+        {{ t('pages.agentStudio.mcpHelp.gotIt') }}
+      </AppButton>
+    </template>
+  </AppModal>
+</template>

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -1457,16 +1457,29 @@
         "artifactUrl": "run-scoped artifact MCP endpoint",
         "artifactToken": "run-bound access token",
         "globalVar": "{'${vars.<name>}'} — workflow global, e.g. {'${vars.feature}'}",
-        "addArtifactStore": "+ Add artifact-store (prefilled vars)",
+        "addArtifactStore": "+ Add artifact store",
         "agentVarsTitle": "Agent platform MCPs",
         "agentScopeTag": "agent",
         "memoryVars": "Long-term memory (Agent home project)",
         "contextVars": "Conversation context (persisted chat recall)",
         "schedulerVars": "Scheduled tasks (definition MCP; platform runs them)",
         "agentScopeNote": "Declare in any agent mcp[]. Project Management consult sandboxes also inject these three; enable pm-progress / pm-workflow-read / pm-workflow-write / pm-agent-fs in project Project Management settings, not here.",
-        "addMemoryStore": "+ memory-store",
-        "addContextStore": "+ context-store",
-        "addTaskScheduler": "+ task-scheduler",
+        "addMemoryStore": "+ Add long-term memory",
+        "addContextStore": "+ Add conversation context",
+        "addTaskScheduler": "+ Add scheduled tasks",
+        "quickAddLabel": "Quick add",
+        "displayName": {
+          "artifact": "Artifact store",
+          "memory": "Long-term memory",
+          "context": "Conversation context",
+          "scheduler": "Scheduled tasks"
+        },
+        "scopeNote": {
+          "artifact": "Run-isolated artifact service for this run.",
+          "memory": "Long-term memory, owned by the home project.",
+          "context": "Conversation context for persisted chat recall.",
+          "scheduler": "Scheduled tasks executed by the platform."
+        },
         "agentMcpAlreadyExists": "{name} already exists; no duplicate entry added",
         "agentScopeBadge": "Agent-scoped platform MCP: used in test sandboxes and declared scenes; Project Management consult injects the same endpoints automatically. Independent from artifact-store (run-scoped).",
         "legacyPmHint": "Legacy name pm-leader detected. Platform split it into memory-store / context-store / task-scheduler; enable Project Management-only tools in project Project Management settings.",
@@ -1507,6 +1520,15 @@
         "regionIntl": "International (trae.ai)",
         "add": "Add env var",
         "parseError": "Invalid env JSON:"
+      },
+      "mcpHelp": {
+        "link": "Help",
+        "title": "MCP config help",
+        "gotIt": "Got it",
+        "chip": {
+          "run": "Run-scoped vars",
+          "agent": "Agent platform MCP"
+        }
       },
       "envHelp": {
         "link": "Help",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -1457,16 +1457,29 @@
         "artifactUrl": "本次运行隔离的产物 MCP 端点",
         "artifactToken": "绑定该 run 的访问令牌",
         "globalVar": "{'${vars.<全局变量名>}'} — 工作流全局变量,如 {'${vars.feature}'}",
-        "addArtifactStore": "+ 添加 artifact-store(预填变量)",
+        "addArtifactStore": "+ 添加产物存储",
         "agentVarsTitle": "Agent 通用平台 MCP",
         "agentScopeTag": "agent",
         "memoryVars": "长期记忆（归属 Agent 主项目）",
         "contextVars": "对话上下文（Chat 落库回看）",
         "schedulerVars": "定时任务（定义面；平台调度执行）",
         "agentScopeNote": "可在任意 Agent 的 mcp[] 声明。项目管理咨询沙箱也会自动注入这三项；pm-progress / pm-workflow-read / pm-workflow-write / pm-agent-fs 在项目的项目管理设置中启用，勿写在此处。",
-        "addMemoryStore": "+ memory-store",
-        "addContextStore": "+ context-store",
-        "addTaskScheduler": "+ task-scheduler",
+        "addMemoryStore": "+ 添加长期记忆",
+        "addContextStore": "+ 添加对话上下文",
+        "addTaskScheduler": "+ 添加定时任务",
+        "quickAddLabel": "快捷添加",
+        "displayName": {
+          "artifact": "产物存储",
+          "memory": "长期记忆",
+          "context": "对话上下文",
+          "scheduler": "定时任务"
+        },
+        "scopeNote": {
+          "artifact": "本次运行隔离的产物服务。",
+          "memory": "长期记忆，归属主项目。",
+          "context": "对话上下文，用于 Chat 落库回看。",
+          "scheduler": "定时任务由平台调度执行。"
+        },
         "agentMcpAlreadyExists": "已存在约定名 {name}，未新增重复条目",
         "agentScopeBadge": "Agent 级平台 MCP：测试沙箱与声明场景使用；项目管理咨询由平台自动注入同名端点。与 artifact-store（运行级）保持独立。",
         "legacyPmHint": "检测到旧约定名 pm-leader。平台已拆为 memory-store / context-store / task-scheduler；项目管理专用能力请在项目的项目管理设置启用。",
@@ -1507,6 +1520,15 @@
         "regionIntl": "国际站 (trae.ai)",
         "add": "添加环境变量",
         "parseError": "环境变量 JSON 无法解析:"
+      },
+      "mcpHelp": {
+        "link": "帮助",
+        "title": "MCP 配置帮助",
+        "gotIt": "知道了",
+        "chip": {
+          "run": "运行级变量",
+          "agent": "Agent 平台 MCP"
+        }
       },
       "envHelp": {
         "link": "帮助",

--- a/web/src/views/AgentStudioView.test.ts
+++ b/web/src/views/AgentStudioView.test.ts
@@ -264,18 +264,29 @@ describe('AgentStudio MCP PM leader prefills', () => {
     await flushPromises()
     await openMcpTab(wrapper)
 
-    expect(wrapper.text()).toContain('Agent 通用平台 MCP')
-    expect(wrapper.text()).toContain('APPROVING_MEMORY_URL')
-    expect(wrapper.text()).toContain('pm-progress')
+    expect(wrapper.text()).not.toContain('Agent 通用平台 MCP')
+    expect(wrapper.text()).not.toContain('APPROVING_MEMORY_URL')
+    expect(wrapper.text()).not.toContain('pm-progress')
+    expect(wrapper.text()).not.toContain('整份 mcp.json 由你配置')
+    expect(wrapper.text()).not.toContain('运行级变量(运行时替换')
+    expect(wrapper.get('[data-test="mcp-help-link"]').text()).toBe('帮助')
+    expect(wrapper.get('[data-test="mcp-add-memory"]').text()).toContain('添加长期记忆')
+    expect(wrapper.get('[data-mcp-name="artifact-store"] [data-test="mcp-display-name"]').text()).toBe('产物存储')
+    expect(wrapper.get('[data-mcp-name="artifact-store"] [data-test="mcp-preset-key"]').text()).toBe('artifact-store')
+    expect(wrapper.get('[data-mcp-name="artifact-store"] [data-test="mcp-scope-note"]').text()).toContain('本次运行隔离的产物服务')
 
-    await wrapper.findAll('button').find((item) => item.text().includes('+ memory-store'))!.trigger('click')
+    await wrapper.get('[data-test="mcp-add-memory"]').trigger('click')
     await flushPromises()
 
-    expect(wrapper.findAll('input').filter((el) => (el.element as HTMLInputElement).value === 'memory-store')).toHaveLength(1)
+    expect(wrapper.find('[data-mcp-name="memory-store"]').exists()).toBe(true)
+    expect(wrapper.get('[data-mcp-name="memory-store"] [data-test="mcp-display-name"]').text()).toBe('长期记忆')
+    expect(wrapper.get('[data-mcp-name="memory-store"] [data-test="mcp-preset-key"]').text()).toBe('memory-store')
     expect(wrapper.findAll('input').filter((el) => (el.element as HTMLInputElement).value === '${APPROVING_MEMORY_URL}')).toHaveLength(1)
     expect(wrapper.findAll('input').filter((el) => (el.element as HTMLInputElement).value === 'Bearer ${APPROVING_MEMORY_TOKEN}')).toHaveLength(1)
-    expect(wrapper.text()).toContain('Agent 级平台 MCP')
-    expect(wrapper.findAll('input').filter((el) => (el.element as HTMLInputElement).value === 'artifact-store')).toHaveLength(1)
+    expect(wrapper.get('[data-mcp-name="memory-store"] [data-test="mcp-scope-note"]').text()).toContain('长期记忆，归属主项目')
+    expect(wrapper.find('[data-mcp-name="artifact-store"]').exists()).toBe(true)
+    expect(wrapper.findAll('input').filter((el) => (el.element as HTMLInputElement).value === 'memory-store')).toHaveLength(0)
+    expect(wrapper.findAll('input').filter((el) => (el.element as HTMLInputElement).value === 'artifact-store')).toHaveLength(0)
   })
 
   it('toasts and keeps a single memory-store when adding again', async () => {
@@ -295,13 +306,13 @@ describe('AgentStudio MCP PM leader prefills', () => {
     await flushPromises()
     await openMcpTab(wrapper)
 
-    const addBtn = wrapper.findAll('button').find((item) => item.text().includes('+ memory-store'))!
-    expect(addBtn.exists()).toBe(true)
+    const addBtn = wrapper.get('[data-test="mcp-add-memory"]')
+    expect(addBtn.text()).toContain('添加长期记忆')
     await addBtn.trigger('click')
     await flushPromises()
 
     expect(document.body.textContent || '').toContain('已存在约定名 memory-store')
-    expect(wrapper.findAll('input').filter((el) => (el.element as HTMLInputElement).value === 'memory-store')).toHaveLength(1)
+    expect(wrapper.findAll('[data-mcp-name="memory-store"]')).toHaveLength(1)
   })
 
   it('shows legacy upgrade hint for pm-leader and upgrades in place', async () => {
@@ -327,17 +338,18 @@ describe('AgentStudio MCP PM leader prefills', () => {
     await openMcpTab(wrapper)
 
     expect(wrapper.text()).toContain('检测到旧约定名 pm-leader')
-    await wrapper.findAll('button').find((item) => item.text().includes('一键升级'))!.trigger('click')
+    expect(wrapper.get('[data-test="mcp-legacy-pm-hint"]').exists()).toBe(true)
+    await wrapper.get('[data-test="mcp-upgrade-legacy"]').trigger('click')
     await flushPromises()
 
-    expect(wrapper.findAll('input').filter((el) => (el.element as HTMLInputElement).value === 'pm-leader')).toHaveLength(0)
-    expect(wrapper.findAll('input').filter((el) => (el.element as HTMLInputElement).value === 'memory-store')).toHaveLength(1)
-    expect(wrapper.findAll('input').filter((el) => (el.element as HTMLInputElement).value === 'context-store')).toHaveLength(1)
-    expect(wrapper.findAll('input').filter((el) => (el.element as HTMLInputElement).value === 'task-scheduler')).toHaveLength(1)
-    expect(wrapper.findAll('input').filter((el) => (el.element as HTMLInputElement).value === 'artifact-store')).toHaveLength(1)
+    expect(wrapper.find('[data-mcp-name="pm-leader"]').exists()).toBe(false)
+    expect(wrapper.find('[data-mcp-name="memory-store"]').exists()).toBe(true)
+    expect(wrapper.find('[data-mcp-name="context-store"]').exists()).toBe(true)
+    expect(wrapper.find('[data-mcp-name="task-scheduler"]').exists()).toBe(true)
+    expect(wrapper.find('[data-mcp-name="artifact-store"]').exists()).toBe(true)
   })
 
-  it('hides the agent scope badge after renaming away from memory-store', async () => {
+  it('drops platform display after renaming memory-store in raw JSON', async () => {
     mocks.listAgents.mockResolvedValue([
       {
         ...agent(),
@@ -354,11 +366,26 @@ describe('AgentStudio MCP PM leader prefills', () => {
     await flushPromises()
     await openMcpTab(wrapper)
 
-    expect(wrapper.text()).toContain('Agent 级平台 MCP')
-    const nameInput = wrapper.findAll('input').find((el) => (el.element as HTMLInputElement).value === 'memory-store')!
-    await nameInput.setValue('memory_store')
+    expect(wrapper.get('[data-mcp-name="memory-store"] [data-test="mcp-scope-note"]').exists()).toBe(true)
+    expect(wrapper.get('[data-mcp-name="memory-store"] [data-test="mcp-display-name"]').text()).toBe('长期记忆')
+    await wrapper.findAll('button').find((item) => item.text() === '原始 JSON')!.trigger('click')
     await flushPromises()
-    expect(wrapper.text()).not.toContain('Agent 级平台 MCP')
+    expect(wrapper.find('[data-test="mcp-help-link"]').exists()).toBe(false)
+    await wrapper.get('[data-test="code-editor"]').setValue(
+      JSON.stringify([
+        {
+          name: 'memory_store',
+          url: '${APPROVING_MEMORY_URL}',
+          headers: { Authorization: 'Bearer ${APPROVING_MEMORY_TOKEN}' },
+        },
+      ]),
+    )
+    await wrapper.findAll('button').find((item) => item.text() === '表单编辑')!.trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-mcp-name="memory-store"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="mcp-scope-note"]').exists()).toBe(false)
+    expect(wrapper.get('[data-test="mcp-custom-name"]').element).toMatchObject({ value: 'memory_store' })
+    expect(wrapper.get('[data-test="mcp-help-link"]').exists()).toBe(true)
   })
 
   it('removing memory-store keeps artifact-store intact', async () => {
@@ -383,16 +410,138 @@ describe('AgentStudio MCP PM leader prefills', () => {
     await flushPromises()
     await openMcpTab(wrapper)
 
-    const nameInput = wrapper.findAll('input').find((el) => (el.element as HTMLInputElement).value === 'memory-store')!
-    const card = nameInput.element.closest('.rounded-md.border') as HTMLElement
-    const removeBtn = wrapper.findAll('button').find((item) => {
-      return item.attributes('title') === '移除' && item.element.closest('.rounded-md.border') === card
-    })!
-    await removeBtn.trigger('click')
+    await wrapper.get('[data-mcp-name="memory-store"] [data-test="mcp-remove"]').trigger('click')
     await flushPromises()
 
-    expect(wrapper.findAll('input').filter((el) => (el.element as HTMLInputElement).value === 'memory-store')).toHaveLength(0)
-    expect(wrapper.findAll('input').filter((el) => (el.element as HTMLInputElement).value === 'artifact-store')).toHaveLength(1)
+    expect(wrapper.find('[data-mcp-name="memory-store"]').exists()).toBe(false)
+    expect(wrapper.find('[data-mcp-name="artifact-store"]').exists()).toBe(true)
+  })
+})
+
+describe('AgentStudio MCP config help', () => {
+  const HelpAppModalStub = defineComponent({
+    props: { open: Boolean, title: String, width: Number },
+    emits: ['close'],
+    template:
+      '<div v-if="open" data-test="help-modal" :data-width="width">' +
+      '<h2>{{ title }}</h2><div data-test="help-scroll"><slot /></div><slot name="footer" />' +
+      '</div>',
+  })
+
+  async function mountStudioWithMcpHelp() {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const router = await createStudioRouter()
+    return trackMount(
+      mount(AgentStudioView, {
+        global: {
+          plugins: [i18n, router],
+          stubs: {
+            AppButton: ButtonStub,
+            Icon: true,
+            AppModal: HelpAppModalStub,
+            CodeEditor: CodeEditorStub,
+            MarkdownSplitEditor: true,
+            ExplorerContextMenu: true,
+            AgentChatTester: true,
+            AgentGitGuide: true,
+            AgentCreateWizard: true,
+            AgentOrgSidebar: true,
+            AgentDataPanel: true,
+          },
+        },
+      }),
+    )
+  }
+
+  async function openMcpTab(wrapper: Awaited<ReturnType<typeof mountStudioWithMcpHelp>>) {
+    await wrapper.findAll('button').find((item) => item.text().startsWith('MCP'))!.trigger('click')
+    await flushPromises()
+  }
+
+  it('hides variable docs until help opens on run, then agent chip shows platform copy', async () => {
+    mocks.listAgents.mockResolvedValue([
+      {
+        ...agent(),
+        mcp: [
+          {
+            name: 'artifact-store',
+            url: '${APPROVING_ARTIFACT_URL}',
+            headers: { Authorization: 'Bearer ${APPROVING_ARTIFACT_TOKEN}' },
+          },
+        ],
+      },
+    ])
+    const wrapper = await mountStudioWithMcpHelp()
+    await flushPromises()
+    await openMcpTab(wrapper)
+
+    expect(wrapper.get('[data-test="mcp-help-link"]').text()).toBe('帮助')
+    expect(wrapper.text()).not.toContain('整份 mcp.json 由你配置')
+    expect(wrapper.text()).not.toContain('Agent 通用平台 MCP')
+    expect(wrapper.text()).not.toContain('APPROVING_MEMORY_URL')
+    expect(wrapper.text()).not.toContain('pm-progress')
+
+    await wrapper.get('[data-test="mcp-help-link"]').trigger('click')
+    await flushPromises()
+    const modal = wrapper.get('[data-test="help-modal"]')
+    expect(modal.attributes('data-width')).toBe('640')
+    expect(modal.text()).toContain('MCP 配置帮助')
+    expect(modal.text()).toContain('整份 mcp.json 由你配置')
+    expect(modal.text()).toContain('/root/.codebuddy/mcp.json')
+    expect(modal.text()).toContain('APPROVING_ARTIFACT_URL')
+    expect(wrapper.get('[data-test="mcp-help-run"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="mcp-help-agent"]').exists()).toBe(false)
+    expect(wrapper.get('[data-help-chip="run"]').classes().join(' ')).toContain('border-accent')
+
+    await wrapper.get('[data-test="mcp-help-chip-agent"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.get('[data-test="mcp-help-agent"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="mcp-help-run"]').exists()).toBe(false)
+    expect(wrapper.get('[data-test="help-modal"]').text()).toContain('APPROVING_MEMORY_URL')
+    expect(wrapper.get('[data-test="help-modal"]').text()).toContain('pm-progress')
+    expect(wrapper.get('[data-test="help-modal"]').text()).not.toContain('+ 添加长期记忆')
+  })
+
+  it('hides help in raw JSON and keeps mcp draft after closing help', async () => {
+    mocks.listAgents.mockResolvedValue([
+      {
+        ...agent(),
+        mcp: [
+          {
+            name: 'custom-draft',
+            url: 'https://example.test/sse',
+          },
+        ],
+      },
+    ])
+    const wrapper = await mountStudioWithMcpHelp()
+    await flushPromises()
+    await openMcpTab(wrapper)
+
+    const nameInput = wrapper.get('[data-test="mcp-custom-name"]')
+    await nameInput.setValue('custom-kept')
+    expect((nameInput.element as HTMLInputElement).value).toBe('custom-kept')
+
+    await wrapper.findAll('button').find((item) => item.text() === '原始 JSON')!.trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-test="mcp-help-link"]').exists()).toBe(false)
+
+    await wrapper.findAll('button').find((item) => item.text() === '表单编辑')!.trigger('click')
+    await flushPromises()
+    expect(wrapper.get('[data-test="mcp-help-link"]').exists()).toBe(true)
+
+    await wrapper.get('[data-test="mcp-help-link"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-test="help-modal"]').exists()).toBe(true)
+    await wrapper.get('[data-test="mcp-help-got-it"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="help-modal"]').exists()).toBe(false)
+    expect((wrapper.get('[data-test="mcp-custom-name"]').element as HTMLInputElement).value).toBe('custom-kept')
   })
 })
 
@@ -1442,8 +1591,9 @@ describe('AgentStudio org toast and remaining hints', () => {
 
     await wrapper.findAll('button').find((item) => item.text().startsWith('MCP'))!.trigger('click')
     await flushPromises()
-    expect(wrapper.text()).toContain('整份 mcp.json 由你配置')
-    expect(wrapper.text()).toContain('/root/.codebuddy/mcp.json')
+    expect(wrapper.get('[data-test="mcp-help-link"]').text()).toBe('帮助')
+    expect(wrapper.text()).not.toContain('整份 mcp.json 由你配置')
+    expect(wrapper.text()).not.toContain('/root/.codebuddy/mcp.json')
 
     await wrapper.findAll('button').find((item) => item.text() === '平台规则')!.trigger('click')
     await flushPromises()

--- a/web/src/views/AgentStudioView.test.ts
+++ b/web/src/views/AgentStudioView.test.ts
@@ -338,7 +338,7 @@ describe('AgentStudio MCP PM leader prefills', () => {
     await openMcpTab(wrapper)
 
     expect(wrapper.text()).toContain('检测到旧约定名 pm-leader')
-    expect(wrapper.get('[data-test="mcp-legacy-pm-hint"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="mcp-legacy-pm-hint"]').exists()).toBe(true)
     await wrapper.get('[data-test="mcp-upgrade-legacy"]').trigger('click')
     await flushPromises()
 
@@ -366,7 +366,7 @@ describe('AgentStudio MCP PM leader prefills', () => {
     await flushPromises()
     await openMcpTab(wrapper)
 
-    expect(wrapper.get('[data-mcp-name="memory-store"] [data-test="mcp-scope-note"]').exists()).toBe(true)
+    expect(wrapper.find('[data-mcp-name="memory-store"] [data-test="mcp-scope-note"]').exists()).toBe(true)
     expect(wrapper.get('[data-mcp-name="memory-store"] [data-test="mcp-display-name"]').text()).toBe('长期记忆')
     await wrapper.findAll('button').find((item) => item.text() === '原始 JSON')!.trigger('click')
     await flushPromises()
@@ -385,7 +385,7 @@ describe('AgentStudio MCP PM leader prefills', () => {
     expect(wrapper.find('[data-mcp-name="memory-store"]').exists()).toBe(false)
     expect(wrapper.find('[data-test="mcp-scope-note"]').exists()).toBe(false)
     expect(wrapper.get('[data-test="mcp-custom-name"]').element).toMatchObject({ value: 'memory_store' })
-    expect(wrapper.get('[data-test="mcp-help-link"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="mcp-help-link"]').exists()).toBe(true)
   })
 
   it('removing memory-store keeps artifact-store intact', async () => {
@@ -493,13 +493,13 @@ describe('AgentStudio MCP config help', () => {
     expect(modal.text()).toContain('整份 mcp.json 由你配置')
     expect(modal.text()).toContain('/root/.codebuddy/mcp.json')
     expect(modal.text()).toContain('APPROVING_ARTIFACT_URL')
-    expect(wrapper.get('[data-test="mcp-help-run"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="mcp-help-run"]').exists()).toBe(true)
     expect(wrapper.find('[data-test="mcp-help-agent"]').exists()).toBe(false)
     expect(wrapper.get('[data-help-chip="run"]').classes().join(' ')).toContain('border-accent')
 
     await wrapper.get('[data-test="mcp-help-chip-agent"]').trigger('click')
     await flushPromises()
-    expect(wrapper.get('[data-test="mcp-help-agent"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="mcp-help-agent"]').exists()).toBe(true)
     expect(wrapper.find('[data-test="mcp-help-run"]').exists()).toBe(false)
     expect(wrapper.get('[data-test="help-modal"]').text()).toContain('APPROVING_MEMORY_URL')
     expect(wrapper.get('[data-test="help-modal"]').text()).toContain('pm-progress')
@@ -532,7 +532,7 @@ describe('AgentStudio MCP config help', () => {
 
     await wrapper.findAll('button').find((item) => item.text() === '表单编辑')!.trigger('click')
     await flushPromises()
-    expect(wrapper.get('[data-test="mcp-help-link"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="mcp-help-link"]').exists()).toBe(true)
 
     await wrapper.get('[data-test="mcp-help-link"]').trigger('click')
     await flushPromises()

--- a/web/src/views/AgentStudioView.vue
+++ b/web/src/views/AgentStudioView.vue
@@ -15,6 +15,7 @@ import AgentGitGuide from '@/components/agent/AgentGitGuide.vue'
 import EnvCredentialHelpModal, {
   type EnvCredentialHelpSection,
 } from '@/components/agent/EnvCredentialHelpModal.vue'
+import McpConfigHelpModal from '@/components/agent/McpConfigHelpModal.vue'
 import AgentCreateWizard from '@/components/agent/AgentCreateWizard.vue'
 import CreateAgentTeamWizard from '@/components/agent/CreateAgentTeamWizard.vue'
 import TeamBootstrapPanel from '@/components/agent/TeamBootstrapPanel.vue'
@@ -359,10 +360,30 @@ const currentAuthHint = computed(() => BACKEND_AUTH_HINTS[draft.value?.acpBacken
 
 const envHelpOpen = ref(false)
 const envHelpSection = ref<EnvCredentialHelpSection>('inject')
+const mcpHelpOpen = ref(false)
 
 function openEnvHelp(section: EnvCredentialHelpSection) {
   envHelpSection.value = section
   envHelpOpen.value = true
+}
+
+function openMcpHelp() {
+  mcpHelpOpen.value = true
+}
+
+type PlatformPresetKind = 'artifact' | 'memory' | 'context' | 'scheduler'
+
+function platformPresetKind(name: string): PlatformPresetKind | null {
+  const n = name.trim()
+  if (n === ARTIFACT_STORE) return 'artifact'
+  if (n === MEMORY_STORE) return 'memory'
+  if (n === CONTEXT_STORE) return 'context'
+  if (n === TASK_SCHEDULER) return 'scheduler'
+  return null
+}
+
+function isPlatformPresetName(name: string) {
+  return platformPresetKind(name) !== null
 }
 
 function upsertEnv(key: string, value: string) {
@@ -1089,10 +1110,6 @@ const hasArtifactStore = computed(() => !!draft.value?.mcp.some((m) => m.name.tr
 const hasLegacyPmLeader = computed(() => !!draft.value?.mcp.some((m) => m.name.trim() === LEGACY_PM_LEADER))
 function isLegacyPmLeaderName(name: string) {
   return name.trim() === LEGACY_PM_LEADER
-}
-function isAgentPlatformMcpName(name: string) {
-  const n = name.trim()
-  return n === MEMORY_STORE || n === CONTEXT_STORE || n === TASK_SCHEDULER
 }
 function hasAgentPlatformMcp(name: string) {
   return !!draft.value?.mcp.some((m) => m.name.trim() === name)
@@ -2915,8 +2932,17 @@ onBeforeUnmount(() => {
         <!-- mcp -->
         <div v-else-if="tab === 'mcp'" class="flex min-h-0 flex-1 flex-col">
           <div class="flex items-center gap-2 border-b border-line px-4 py-2">
-            <p class="flex-1 text-[11px] text-txt3">{{ t('pages.agentStudio.mcp.hint', { configRoot: draft?.layout?.configRoot || DEFAULT_CONFIG_ROOT }) }}</p>
             <button class="rounded border border-line px-2 py-1 text-[11px] text-txt2 hover:border-line-strong" @click="toggleMcpRaw">{{ mcpRaw ? t('pages.agentStudio.mcp.formEdit') : t('pages.agentStudio.mcp.rawJson') }}</button>
+            <button
+              v-if="!mcpRaw"
+              type="button"
+              class="bg-transparent p-0 text-[12px] text-accent-2 underline underline-offset-[3px] hover:text-[#c4b5fd] focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-accent"
+              data-test="mcp-help-link"
+              @click="openMcpHelp"
+            >
+              {{ t('pages.agentStudio.mcpHelp.link') }}
+            </button>
+            <span class="flex-1" />
           </div>
 
           <div v-if="mcpRaw" class="flex min-h-0 flex-1 flex-col">
@@ -2925,55 +2951,83 @@ onBeforeUnmount(() => {
           </div>
 
           <div v-else class="scroll-area flex-1 space-y-3 overflow-y-auto p-4">
-            <div class="rounded-md border border-accent/30 bg-accent-dim/40 p-2.5 text-[11px] leading-5 text-txt2">
-              <div class="mb-1 flex items-center gap-1.5 text-txt">
-                <Icon name="sparkles" :size="13" class="text-accent-2" />{{ t('pages.agentStudio.mcp.runVarsTitle') }}
-                <span class="rounded border border-info/35 px-1.5 py-px text-[10px] font-medium text-info">{{ t('pages.agentStudio.mcp.runScopeTag') }}</span>
-              </div>
-              <div class="grid gap-0.5 font-mono text-[10.5px] text-txt3">
-                <div><code class="text-accent-2">${APPROVING_ARTIFACT_URL}</code> — {{ t('pages.agentStudio.mcp.artifactUrl') }}</div>
-                <div><code class="text-accent-2">${APPROVING_ARTIFACT_TOKEN}</code> — {{ t('pages.agentStudio.mcp.artifactToken') }}</div>
-                <div><code class="text-accent-2">${APPROVING_RUN_ID}</code> · <code class="text-accent-2">${APPROVING_NODE_ID}</code></div>
-                <div><code class="text-accent-2">${vars.&lt;name&gt;}</code> — {{ t('pages.agentStudio.mcp.globalVar') }}</div>
-              </div>
-              <button v-if="!hasArtifactStore" class="mt-2 rounded border border-accent/40 px-2 py-1 text-accent-2 hover:bg-accent-dim" @click="addArtifactStore">{{ t('pages.agentStudio.mcp.addArtifactStore') }}</button>
+            <div class="flex flex-wrap items-center gap-1.5 border border-line bg-elevated p-2.5" data-test="mcp-ops-bar">
+              <span class="mr-1 text-[11px] text-txt3">{{ t('pages.agentStudio.mcp.quickAddLabel') }}</span>
+              <button
+                v-if="!hasArtifactStore"
+                class="rounded border border-accent/40 px-2 py-1 text-accent-2 hover:bg-accent-dim"
+                type="button"
+                data-test="mcp-add-artifact"
+                @click="addArtifactStore"
+              >{{ t('pages.agentStudio.mcp.addArtifactStore') }}</button>
+              <button
+                class="rounded border border-accent/40 px-2 py-1 text-accent-2 hover:bg-accent-dim disabled:cursor-not-allowed disabled:opacity-40"
+                type="button"
+                data-test="mcp-add-memory"
+                :disabled="!isProjectBound"
+                @click="addAgentPlatformMcp('memory-store')"
+              >{{ t('pages.agentStudio.mcp.addMemoryStore') }}</button>
+              <button
+                class="rounded border border-accent/40 px-2 py-1 text-accent-2 hover:bg-accent-dim disabled:cursor-not-allowed disabled:opacity-40"
+                type="button"
+                data-test="mcp-add-context"
+                :disabled="!isProjectBound"
+                @click="addAgentPlatformMcp('context-store')"
+              >{{ t('pages.agentStudio.mcp.addContextStore') }}</button>
+              <button
+                class="rounded border border-accent/40 px-2 py-1 text-accent-2 hover:bg-accent-dim disabled:cursor-not-allowed disabled:opacity-40"
+                type="button"
+                data-test="mcp-add-scheduler"
+                :disabled="!isProjectBound"
+                @click="addAgentPlatformMcp('task-scheduler')"
+              >{{ t('pages.agentStudio.mcp.addTaskScheduler') }}</button>
+            </div>
+            <div
+              v-if="!isProjectBound"
+              class="rounded border border-dashed border-warn/40 bg-warn/10 p-2 text-[10.5px] leading-5 text-warn"
+              data-test="mcp-project-required-warn"
+            >
+              {{ t('pages.agentStudio.mcp.projectRequiredForPlatformMcp') }}
+            </div>
+            <div
+              v-if="hasLegacyPmLeader"
+              class="rounded border border-dashed border-warn/40 bg-warn/10 p-2 text-[10.5px] leading-5 text-warn"
+              data-test="mcp-legacy-pm-hint"
+            >
+              <div>{{ t('pages.agentStudio.mcp.legacyPmHint') }}</div>
+              <button
+                class="mt-1.5 rounded border border-warn/40 px-2 py-1 text-warn hover:bg-warn/15"
+                type="button"
+                data-test="mcp-upgrade-legacy"
+                @click="upgradeLegacyPmLeader"
+              >{{ t('pages.agentStudio.mcp.upgradeLegacyPm') }}</button>
             </div>
 
-            <div class="rounded-md border border-ok/30 bg-ok/5 p-2.5 text-[11px] leading-5 text-txt2">
-              <div class="mb-1 flex items-center gap-1.5 text-txt">
-                <Icon name="clock" :size="13" class="text-ok" />{{ t('pages.agentStudio.mcp.agentVarsTitle') }}
-                <span class="rounded border border-ok/35 px-1.5 py-px text-[10px] font-medium text-ok">{{ t('pages.agentStudio.mcp.agentScopeTag') }}</span>
-              </div>
-              <div class="grid gap-0.5 font-mono text-[10.5px] text-txt3">
-                <div><code class="text-accent-2">${APPROVING_MEMORY_URL}</code> / <code class="text-accent-2">${APPROVING_MEMORY_TOKEN}</code> — {{ t('pages.agentStudio.mcp.memoryVars') }}</div>
-                <div><code class="text-accent-2">${APPROVING_CONTEXT_URL}</code> / <code class="text-accent-2">${APPROVING_CONTEXT_TOKEN}</code> — {{ t('pages.agentStudio.mcp.contextVars') }}</div>
-                <div><code class="text-accent-2">${APPROVING_SCHEDULER_URL}</code> / <code class="text-accent-2">${APPROVING_SCHEDULER_TOKEN}</code> — {{ t('pages.agentStudio.mcp.schedulerVars') }}</div>
-              </div>
-              <div class="mt-2 border-t border-line-strong/80 pt-2 text-[10.5px] leading-5 text-txt3">
-                <span class="font-medium text-ok">{{ t('pages.agentStudio.mcp.agentScopeNote') }}</span>
-              </div>
-              <div v-if="!isProjectBound" class="mt-2 rounded border border-dashed border-warn/40 bg-warn/10 p-2 text-[10.5px] leading-5 text-warn">
-                {{ t('pages.agentStudio.mcp.projectRequiredForPlatformMcp') }}
-              </div>
-              <div class="mt-2 flex flex-wrap gap-1.5">
-                <button class="rounded border border-accent/40 px-2 py-1 text-accent-2 hover:bg-accent-dim disabled:cursor-not-allowed disabled:opacity-40" type="button" :disabled="!isProjectBound" @click="addAgentPlatformMcp('memory-store')">{{ t('pages.agentStudio.mcp.addMemoryStore') }}</button>
-                <button class="rounded border border-accent/40 px-2 py-1 text-accent-2 hover:bg-accent-dim disabled:cursor-not-allowed disabled:opacity-40" type="button" :disabled="!isProjectBound" @click="addAgentPlatformMcp('context-store')">{{ t('pages.agentStudio.mcp.addContextStore') }}</button>
-                <button class="rounded border border-accent/40 px-2 py-1 text-accent-2 hover:bg-accent-dim disabled:cursor-not-allowed disabled:opacity-40" type="button" :disabled="!isProjectBound" @click="addAgentPlatformMcp('task-scheduler')">{{ t('pages.agentStudio.mcp.addTaskScheduler') }}</button>
-              </div>
-              <div v-if="hasLegacyPmLeader" class="mt-2 rounded border border-dashed border-warn/40 bg-warn/10 p-2 text-[10.5px] leading-5 text-warn">
-                <div>{{ t('pages.agentStudio.mcp.legacyPmHint') }}</div>
-                <button class="mt-1.5 rounded border border-warn/40 px-2 py-1 text-warn hover:bg-warn/15" type="button" @click="upgradeLegacyPmLeader">{{ t('pages.agentStudio.mcp.upgradeLegacyPm') }}</button>
-              </div>
-            </div>
-
-            <div v-for="(m, i) in draft.mcp" :key="i" class="rounded-md border bg-base p-3" :class="isAgentPlatformMcpName(m.name) || isLegacyPmLeaderName(m.name) ? 'border-ok/30' : 'border-line'">
+            <div
+              v-for="(m, i) in draft.mcp"
+              :key="i"
+              class="rounded-md border bg-base p-3"
+              :class="isPlatformPresetName(m.name) || isLegacyPmLeaderName(m.name) ? 'border-ok/30' : 'border-line'"
+              data-test="mcp-card"
+              :data-mcp-name="m.name.trim()"
+            >
               <div class="mb-2 flex items-center gap-2">
-                <input v-model="m.name" :placeholder="t('pages.agentStudio.mcp.serviceName')" class="flex-1 rounded border border-line bg-surface px-2 py-1 text-[12px] text-txt outline-none focus:border-accent" />
+                <div v-if="isPlatformPresetName(m.name)" class="min-w-0 flex-1">
+                  <div class="text-[12px] font-medium text-txt" data-test="mcp-display-name">{{ t(`pages.agentStudio.mcp.displayName.${platformPresetKind(m.name)}`) }}</div>
+                  <div class="font-mono text-[10.5px] text-txt3" data-test="mcp-preset-key">{{ m.name.trim() }}</div>
+                </div>
+                <input
+                  v-else
+                  v-model="m.name"
+                  :placeholder="t('pages.agentStudio.mcp.serviceName')"
+                  class="flex-1 rounded border border-line bg-surface px-2 py-1 text-[12px] text-txt outline-none focus:border-accent"
+                  data-test="mcp-custom-name"
+                />
                 <select v-model="m.transport" class="rounded border border-line bg-surface px-2 py-1 text-[12px] text-txt2 outline-none">
                   <option value="url">HTTP (url)</option>
                   <option value="command">{{ t('pages.agentStudio.mcp.transportCommand') }}</option>
                 </select>
-                <button class="text-txt3 hover:text-err" :title="t('pages.agentStudio.mcp.remove')" @click="removeMcp(i)"><Icon name="close" :size="14" /></button>
+                <button class="text-txt3 hover:text-err" :title="t('pages.agentStudio.mcp.remove')" data-test="mcp-remove" @click="removeMcp(i)"><Icon name="close" :size="14" /></button>
               </div>
 
               <template v-if="m.transport === 'url'">
@@ -3000,9 +3054,12 @@ onBeforeUnmount(() => {
                 <button class="mt-1.5 text-[11px] text-accent-2 hover:underline" @click="m.env.push({ k: '', v: '' })">{{ t('pages.agentStudio.mcp.addEnv') }}</button>
               </template>
 
-              <div v-if="isAgentPlatformMcpName(m.name)" class="mt-2.5 flex items-start gap-2 border border-dashed border-ok/35 bg-ok/5 p-2 text-[10.5px] leading-5 text-txt2">
-                <Icon name="alert" :size="14" class="mt-0.5 shrink-0 text-ok" />
-                <div>{{ t('pages.agentStudio.mcp.agentScopeBadge') }}</div>
+              <div
+                v-if="isPlatformPresetName(m.name)"
+                class="mt-2.5 border border-dashed border-ok/35 bg-ok/5 p-2 text-[10.5px] leading-5 text-txt2"
+                data-test="mcp-scope-note"
+              >
+                {{ t(`pages.agentStudio.mcp.scopeNote.${platformPresetKind(m.name)}`) }}
               </div>
               <div v-else-if="isLegacyPmLeaderName(m.name)" class="mt-2.5 flex items-start gap-2 border border-dashed border-warn/40 bg-warn/10 p-2 text-[10.5px] leading-5 text-warn">
                 <Icon name="alert" :size="14" class="mt-0.5 shrink-0 text-warn" />
@@ -4007,6 +4064,12 @@ onBeforeUnmount(() => {
       :section="envHelpSection"
       :backend="draft?.acpBackend || 'cursor'"
       @close="envHelpOpen = false"
+    />
+
+    <McpConfigHelpModal
+      :open="mcpHelpOpen"
+      :config-root="draft?.layout?.configRoot || DEFAULT_CONFIG_ROOT"
+      @close="mcpHelpOpen = false"
     />
 
     <AppModal :open="showProjectSwitch" :title="t('pages.agentStudio.project.switchTitle')" :width="460" @close="cancelProjectChange">


### PR DESCRIPTION
Keep the MCP form focused on configuration by hiding run/agent variable
docs behind a help link, locking platform preset names, and showing
friendly Chinese labels with a one-line scope note.

Co-authored-by: Cursor <cursoragent@cursor.com>
