### PR TITLE
fix: keep public gate approval smooth after long idle

### DIFF
--- a/server/internal/gateshare/preview.go
+++ b/server/internal/gateshare/preview.go
@@ -16,35 +16,43 @@ const (
 	ProductKindStructured = "structured"
 	ProductKindAppPreview = "app_preview"
 
-	// HeaderKnownVisualHTMLHash / HeaderKnownUpstreamHash let silent pollers
-	// ask the server to omit unchanged large fields (field-level sparse update).
+	// HeaderKnown* let silent pollers ask the server to omit unchanged large
+	// fields (field-level sparse update).
 	HeaderKnownVisualHTMLHash = "X-Gate-Known-Visual-Html-Hash"
 	HeaderKnownUpstreamHash   = "X-Gate-Known-Upstream-Hash"
+	HeaderKnownStructuredHash = "X-Gate-Known-Structured-Hash"
+	HeaderKnownTurnsHash      = "X-Gate-Known-Turns-Hash"
+	// HeaderSilentPoll marks a background poll. HeaderIssueNonce requests a
+	// fresh one-time nonce (first load, foreground resume, or near TTL).
+	HeaderSilentPoll = "X-Gate-Silent-Poll"
+	HeaderIssueNonce = "X-Gate-Issue-Nonce"
 )
 
 // PreviewDTO is the leak-free public GET payload for the workbench-style page.
 type PreviewDTO struct {
-	Status            string            `json:"status"`
-	Kind              string            `json:"kind,omitempty"`
-	Title             string            `json:"title,omitempty"`
-	Description       string            `json:"description,omitempty"`
-	RemainingSec      *int64            `json:"remainingSec,omitempty"`
-	ExpiresAt         *time.Time        `json:"expiresAt,omitempty"`
-	Actions           map[string]string `json:"actions,omitempty"`
-	VisualHTML        string            `json:"visualHtml,omitempty"`
-	VisualHTMLHash    string            `json:"visualHtmlHash,omitempty"`
-	Structured        map[string]any    `json:"structured,omitempty"`
-	Nonce             string            `json:"nonce,omitempty"`
-	Turns             []PreviewTurn     `json:"turns,omitempty"`
-	Upstream          map[string]any    `json:"upstream,omitempty"`
-	UpstreamHash      string            `json:"upstreamHash,omitempty"`
-	ReactSessionAlive *bool             `json:"reactSessionAlive,omitempty"`
-	SessionBusy       bool              `json:"sessionBusy,omitempty"`
-	Waiting           int               `json:"waiting,omitempty"`
+	Status            string             `json:"status"`
+	Kind              string             `json:"kind,omitempty"`
+	Title             string             `json:"title,omitempty"`
+	Description       string             `json:"description,omitempty"`
+	RemainingSec      *int64             `json:"remainingSec,omitempty"`
+	ExpiresAt         *time.Time         `json:"expiresAt,omitempty"`
+	Actions           map[string]string  `json:"actions,omitempty"`
+	VisualHTML        string             `json:"visualHtml,omitempty"`
+	VisualHTMLHash    string             `json:"visualHtmlHash,omitempty"`
+	Structured        map[string]any     `json:"structured,omitempty"`
+	StructuredHash    string             `json:"structuredHash,omitempty"`
+	Nonce             string             `json:"nonce,omitempty"`
+	Turns             []PreviewTurn      `json:"turns,omitempty"`
+	TurnsHash         string             `json:"turnsHash,omitempty"`
+	Upstream          map[string]any     `json:"upstream,omitempty"`
+	UpstreamHash      string             `json:"upstreamHash,omitempty"`
+	ReactSessionAlive *bool              `json:"reactSessionAlive,omitempty"`
+	SessionBusy       bool               `json:"sessionBusy,omitempty"`
+	Waiting           int                `json:"waiting,omitempty"`
 	QueueItems        []PreviewQueueItem `json:"queueItems,omitempty"`
 	ActiveItem        *PreviewActiveItem `json:"activeItem,omitempty"`
-	ProductKind       string            `json:"productKind,omitempty"`
-	ProductName       string            `json:"productName,omitempty"`
+	ProductKind       string             `json:"productKind,omitempty"`
+	ProductName       string             `json:"productName,omitempty"`
 }
 
 // PreviewExtras carries workbench fields that are optional on inactive links.
@@ -179,6 +187,8 @@ func applyPreviewArtifacts(dto *PreviewDTO, visualHTML, structuredName, structur
 	dto.SessionBusy = alive && (extras.SessionBusy || extras.Waiting > 0 || dto.ActiveItem != nil)
 	dto.VisualHTMLHash = ContentHash(dto.VisualHTML)
 	dto.UpstreamHash = HashUpstream(dto.Upstream)
+	dto.StructuredHash = HashStructured(dto.Structured)
+	dto.TurnsHash = HashTurns(dto.Turns)
 }
 
 // ContentHash returns a stable hex digest for sparse field comparison.
@@ -202,10 +212,35 @@ func HashUpstream(up map[string]any) string {
 	return ContentHash(string(b))
 }
 
+// HashStructured digests the sanitized structured map for sparse polls.
+func HashStructured(s map[string]any) string {
+	return HashUpstream(s)
+}
+
+// HashTurns digests sanitized turns for sparse polls.
+func HashTurns(turns []PreviewTurn) string {
+	if len(turns) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(turns)
+	if err != nil || len(b) == 0 {
+		return ""
+	}
+	return ContentHash(string(b))
+}
+
+// SparsePreviewKnown is the set of client-held hashes for ApplySparsePreview.
+type SparsePreviewKnown struct {
+	VisualHTML string
+	Upstream   string
+	Structured string
+	Turns      string
+}
+
 // ApplySparsePreview omits unchanged large fields when the client already holds
-// the same visualHtmlHash / upstreamHash. Hashes themselves are always returned
-// so clients can detect empty↔non-empty transitions even when bodies omit.
-func ApplySparsePreview(dto *PreviewDTO, knownVisualHash, knownUpstreamHash string) {
+// matching hashes. Hashes themselves are always returned so clients can detect
+// empty↔non-empty transitions even when bodies omit.
+func ApplySparsePreview(dto *PreviewDTO, known SparsePreviewKnown) {
 	if dto == nil {
 		return
 	}
@@ -215,12 +250,33 @@ func ApplySparsePreview(dto *PreviewDTO, knownVisualHash, knownUpstreamHash stri
 	if dto.UpstreamHash == "" {
 		dto.UpstreamHash = HashUpstream(dto.Upstream)
 	}
-	if knownVisualHash != "" && knownVisualHash == dto.VisualHTMLHash {
+	if dto.StructuredHash == "" {
+		dto.StructuredHash = HashStructured(dto.Structured)
+	}
+	if dto.TurnsHash == "" {
+		dto.TurnsHash = HashTurns(dto.Turns)
+	}
+	if known.VisualHTML != "" && known.VisualHTML == dto.VisualHTMLHash {
 		dto.VisualHTML = ""
 	}
-	if knownUpstreamHash != "" && knownUpstreamHash == dto.UpstreamHash {
+	if known.Upstream != "" && known.Upstream == dto.UpstreamHash {
 		dto.Upstream = nil
 	}
+	if known.Structured != "" && known.Structured == dto.StructuredHash {
+		dto.Structured = nil
+	}
+	if known.Turns != "" && known.Turns == dto.TurnsHash {
+		dto.Turns = nil
+	}
+}
+
+// WantPreviewNonce reports whether this public preview request should Issue a nonce.
+// Silent polls skip Issue unless the client explicitly asks (resume / near TTL).
+func WantPreviewNonce(silentPoll, issueNonce bool) bool {
+	if issueNonce {
+		return true
+	}
+	return !silentPoll
 }
 
 func inferProductKind(visualHTML, structuredName, hinted string) (kind, name string) {

--- a/server/internal/gateshare/sanitize_test.go
+++ b/server/internal/gateshare/sanitize_test.go
@@ -90,7 +90,7 @@ func TestApplySparsePreviewOmitsUnchangedLargeFields(t *testing.T) {
 		Upstream:       up,
 		UpstreamHash:   HashUpstream(up),
 	}
-	ApplySparsePreview(&dto, dto.VisualHTMLHash, dto.UpstreamHash)
+	ApplySparsePreview(&dto, SparsePreviewKnown{VisualHTML: dto.VisualHTMLHash, Upstream: dto.UpstreamHash})
 	if dto.VisualHTML != "" {
 		t.Fatalf("expected visualHtml omitted, got %q", dto.VisualHTML)
 	}
@@ -108,12 +108,60 @@ func TestApplySparsePreviewOmitsUnchangedLargeFields(t *testing.T) {
 		Upstream:       up,
 		UpstreamHash:   HashUpstream(up),
 	}
-	ApplySparsePreview(&dto2, ContentHash(html), dto.UpstreamHash)
+	ApplySparsePreview(&dto2, SparsePreviewKnown{VisualHTML: ContentHash(html), Upstream: dto.UpstreamHash})
 	if dto2.VisualHTML != "<p>new</p>" {
 		t.Fatalf("changed visual must be returned: %q", dto2.VisualHTML)
 	}
 	if dto2.Upstream != nil {
 		t.Fatalf("unchanged upstream still omitted: %+v", dto2.Upstream)
+	}
+}
+
+func TestApplySparsePreviewOmitsUnchangedStructuredAndTurns(t *testing.T) {
+	st := map[string]any{"name": "research.json", "title": "调研"}
+	turns := []PreviewTurn{{Role: "agent", Text: "请复审", At: "2026-08-01T00:00:00Z"}}
+	dto := PreviewDTO{
+		Status:         "active",
+		Structured:     st,
+		StructuredHash: HashStructured(st),
+		Turns:          turns,
+		TurnsHash:      HashTurns(turns),
+	}
+	ApplySparsePreview(&dto, SparsePreviewKnown{Structured: dto.StructuredHash, Turns: dto.TurnsHash})
+	if dto.Structured != nil {
+		t.Fatalf("expected structured omitted, got %+v", dto.Structured)
+	}
+	if dto.Turns != nil {
+		t.Fatalf("expected turns omitted, got %+v", dto.Turns)
+	}
+	if dto.StructuredHash == "" || dto.TurnsHash == "" {
+		t.Fatal("structured/turns hashes must remain")
+	}
+	dto2 := PreviewDTO{
+		Status:         "active",
+		Structured:     map[string]any{"name": "research.json", "title": "新调研"},
+		StructuredHash: HashStructured(map[string]any{"name": "research.json", "title": "新调研"}),
+		Turns:          append(turns, PreviewTurn{Role: "human", Text: "改摘要", At: "2026-08-01T00:01:00Z"}),
+	}
+	dto2.TurnsHash = HashTurns(dto2.Turns)
+	ApplySparsePreview(&dto2, SparsePreviewKnown{Structured: HashStructured(st), Turns: HashTurns(turns)})
+	if dto2.Structured == nil || dto2.Structured["title"] != "新调研" {
+		t.Fatalf("changed structured must return: %+v", dto2.Structured)
+	}
+	if len(dto2.Turns) != 2 {
+		t.Fatalf("changed turns must return: %+v", dto2.Turns)
+	}
+}
+
+func TestWantPreviewNonce(t *testing.T) {
+	if !WantPreviewNonce(false, false) {
+		t.Fatal("first/non-silent load must issue")
+	}
+	if WantPreviewNonce(true, false) {
+		t.Fatal("silent poll must not issue by default")
+	}
+	if !WantPreviewNonce(true, true) {
+		t.Fatal("silent + issueNonce must issue (resume / near TTL)")
 	}
 }
 
@@ -180,8 +228,8 @@ func TestBuildReviewPreviewDTOIncludesQueueState(t *testing.T) {
 		Waiting:           1,
 		QueueItems:        []map[string]any{{"id": "q1", "text": "请改标题，勿访问 http://10.1.2.3/api/runs/x"}},
 		ActiveItem: map[string]any{
-			"id":   "q1",
-			"text": "请改标题，勿访问 http://10.1.2.3/api/runs/x",
+			"id":     "q1",
+			"text":   "请改标题，勿访问 http://10.1.2.3/api/runs/x",
 			"images": []any{map[string]any{"url": "blob:http://127.0.0.1/abc"}},
 		},
 		ProductKind: ProductKindStructured,

--- a/server/internal/handlers/gate_share_public.go
+++ b/server/internal/handlers/gate_share_public.go
@@ -68,34 +68,44 @@ func (h *Handlers) PublicGatePreview(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"status": "invalid"})
 		return
 	}
-	nonce, err := h.GateShareNonces.Issue(lookup.Link.TokenHash)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "unavailable"})
-		return
+	silentPoll := strings.EqualFold(strings.TrimSpace(c.GetHeader(gateshare.HeaderSilentPoll)), "1")
+	issueNonce := strings.EqualFold(strings.TrimSpace(c.GetHeader(gateshare.HeaderIssueNonce)), "1")
+	nonce := ""
+	if gateshare.WantPreviewNonce(silentPoll, issueNonce) {
+		var err error
+		nonce, err = h.GateShareNonces.Issue(lookup.Link.TokenHash)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "unavailable"})
+			return
+		}
 	}
 	kind := publicShareKind(lookup)
 	if st != models.ShareLinkStateActive {
-		c.JSON(http.StatusOK, gin.H{"status": st, "kind": kind, "nonce": nonce})
+		out := gin.H{"status": st, "kind": kind}
+		if nonce != "" {
+			out["nonce"] = nonce
+		}
+		c.JSON(http.StatusOK, out)
 		return
+	}
+	known := gateshare.SparsePreviewKnown{
+		VisualHTML: strings.TrimSpace(c.GetHeader(gateshare.HeaderKnownVisualHTMLHash)),
+		Upstream:   strings.TrimSpace(c.GetHeader(gateshare.HeaderKnownUpstreamHash)),
+		Structured: strings.TrimSpace(c.GetHeader(gateshare.HeaderKnownStructuredHash)),
+		Turns:      strings.TrimSpace(c.GetHeader(gateshare.HeaderKnownTurnsHash)),
 	}
 	if kind == models.ShareLinkKindReview {
 		visual, structName, structContent := h.publicReviewArtifacts(lookup)
 		extras := h.publicReviewExtras(lookup, visual, structName)
 		dto := gateshare.BuildReviewPreviewDTO(st, lookup, visual, structName, structContent, nonce, extras)
-		gateshare.ApplySparsePreview(&dto,
-			strings.TrimSpace(c.GetHeader(gateshare.HeaderKnownVisualHTMLHash)),
-			strings.TrimSpace(c.GetHeader(gateshare.HeaderKnownUpstreamHash)),
-		)
+		gateshare.ApplySparsePreview(&dto, known)
 		c.JSON(http.StatusOK, dto)
 		return
 	}
 	visual, structName, structContent := h.publicGateArtifacts(lookup)
 	extras := h.publicGateExtras(lookup, visual, structName)
 	dto := gateshare.BuildPreviewDTO(st, lookup, visual, structName, structContent, nonce, extras)
-	gateshare.ApplySparsePreview(&dto,
-		strings.TrimSpace(c.GetHeader(gateshare.HeaderKnownVisualHTMLHash)),
-		strings.TrimSpace(c.GetHeader(gateshare.HeaderKnownUpstreamHash)),
-	)
+	gateshare.ApplySparsePreview(&dto, known)
 	c.JSON(http.StatusOK, dto)
 }
 

--- a/server/internal/handlers/gate_share_test.go
+++ b/server/internal/handlers/gate_share_test.go
@@ -836,9 +836,9 @@ func TestPublicGatePreviewOmitsUpstreamDocAndSupportsOnDemandUpstream(t *testing
 	}
 
 	sparse := parseJSON(t, h.doPublic(http.MethodGet, "/public/gate-approvals/preview", nil, map[string]string{
-		headerShareToken:                       token,
-		gateshare.HeaderKnownVisualHTMLHash:    vhHash,
-		gateshare.HeaderKnownUpstreamHash:      upHash,
+		headerShareToken:                    token,
+		gateshare.HeaderKnownVisualHTMLHash: vhHash,
+		gateshare.HeaderKnownUpstreamHash:   upHash,
 	}))
 	if sparse["visualHtml"] != nil && sparse["visualHtml"] != "" {
 		t.Fatalf("unchanged visualHtml must be omitted: %+v", sparse)
@@ -864,5 +864,54 @@ func TestPublicGatePreviewOmitsUpstreamDocAndSupportsOnDemandUpstream(t *testing
 	raw, _ := json.Marshal(fullUp)
 	if strings.Contains(string(raw), "should-hide") || strings.Contains(string(raw), "projectId") {
 		t.Fatalf("on-demand upstream leaked: %s", raw)
+	}
+}
+
+func countShareNonces(t *testing.T, h *harness) int64 {
+	t.Helper()
+	var n int64
+	if err := h.db.Model(&models.GateShareNonce{}).Count(&n).Error; err != nil {
+		t.Fatalf("count nonces: %v", err)
+	}
+	return n
+}
+
+func TestPublicGatePreviewSilentSkipsNonceUnlessRequested(t *testing.T) {
+	h := newHarness(t)
+	seedHumanGate(t, h, "run-share-nonce-idle", "hg-nonce-idle", nil)
+	created := parseJSON(t, h.do(http.MethodPost, "/api/runs/run-share-nonce-idle/gates/hg-nonce-idle/share-link", map[string]any{"ttlTier": "24h"}))
+	url, _ := created["url"].(string)
+	token := strings.TrimPrefix(url[strings.Index(url, "#t="):], "#t=")
+
+	first := parseJSON(t, h.doPublic(http.MethodGet, "/public/gate-approvals/preview", nil, map[string]string{headerShareToken: token}))
+	if first["nonce"] == nil || first["nonce"] == "" {
+		t.Fatalf("first preview must issue nonce: %+v", first)
+	}
+	afterFirst := countShareNonces(t, h)
+	if afterFirst < 1 {
+		t.Fatalf("expected at least one nonce row, got %d", afterFirst)
+	}
+
+	silent := parseJSON(t, h.doPublic(http.MethodGet, "/public/gate-approvals/preview", nil, map[string]string{
+		headerShareToken:           token,
+		gateshare.HeaderSilentPoll: "1",
+	}))
+	if silent["nonce"] != nil && silent["nonce"] != "" {
+		t.Fatalf("silent poll must omit nonce: %+v", silent)
+	}
+	if got := countShareNonces(t, h); got != afterFirst {
+		t.Fatalf("silent poll must not Issue, rows %d → %d", afterFirst, got)
+	}
+
+	refresh := parseJSON(t, h.doPublic(http.MethodGet, "/public/gate-approvals/preview", nil, map[string]string{
+		headerShareToken:           token,
+		gateshare.HeaderSilentPoll: "1",
+		gateshare.HeaderIssueNonce: "1",
+	}))
+	if refresh["nonce"] == nil || refresh["nonce"] == "" {
+		t.Fatalf("silent+issueNonce must return nonce: %+v", refresh)
+	}
+	if got := countShareNonces(t, h); got <= afterFirst {
+		t.Fatalf("issueNonce must Issue a new row, before=%d after=%d", afterFirst, got)
 	}
 }

--- a/web/src/components/run/ClarifyChat.vue
+++ b/web/src/components/run/ClarifyChat.vue
@@ -806,7 +806,7 @@ function applyQueueState(
   } | null,
 ) {
   if (waiting === 0 && !busy) {
-    queued.value = []
+    if (queued.value.length) queued.value = []
     if (liveAgentIdx.value < 0) thinking.value = false
   } else if (items) {
     const rebuilt: QueueItem[] = items.map((it) => {

--- a/web/src/lib/inbox/gateShareLink.test.ts
+++ b/web/src/lib/inbox/gateShareLink.test.ts
@@ -4,6 +4,8 @@ import {
   maskShareUrl,
   parseShareTokenFromHash,
   formatRemainingSec,
+  remainingSecFromExpiresAt,
+  publicGateContentKey,
   shareStatusLabel,
   canCreateGateShare,
   isGateShareActive,
@@ -158,5 +160,48 @@ describe('gateShareLink helpers', () => {
     })
     expect(changed.visualHtml).toBe('<p>new</p>')
     expect(changed.upstream?.summary).toBe('新摘要')
+
+    const withBodies = {
+      ...prev,
+      structured: { name: 'research.json', title: '旧' },
+      structuredHash: 'st-old',
+      turns: [{ role: 'agent', text: '请复审' }],
+      turnsHash: 'tn-old',
+      nonce: 'keep-me',
+    }
+    const sparseBodies = mergePublicGatePreview(withBodies, {
+      status: 'active',
+      structuredHash: 'st-old',
+      turnsHash: 'tn-old',
+      remainingSec: 10,
+    })
+    expect(sparseBodies.structured?.title).toBe('旧')
+    expect(sparseBodies.turns?.[0]?.text).toBe('请复审')
+    expect(sparseBodies.nonce).toBe('keep-me')
+  })
+
+  it('remainingSecFromExpiresAt prefers expiresAt over stale remainingSec (plan g2.1)', () => {
+    const now = Date.parse('2026-08-11T15:00:00.000Z')
+    expect(remainingSecFromExpiresAt('2026-08-11T16:30:00.000Z', 30, now)).toBe(90 * 60)
+    expect(remainingSecFromExpiresAt(undefined, 45, now)).toBe(45)
+    expect(remainingSecFromExpiresAt('2026-08-11T14:00:00.000Z', 99, now)).toBe(0)
+  })
+
+  it('publicGateContentKey ignores clock and nonce (plan g3.1)', () => {
+    const base = {
+      status: 'active' as const,
+      visualHtmlHash: 'vh',
+      structuredHash: 'st',
+      turnsHash: 'tn',
+      upstreamHash: 'up',
+      remainingSec: 100,
+      expiresAt: '2026-08-11T16:00:00.000Z',
+      nonce: 'n1',
+      turns: [{ role: 'agent', text: '请复审' }],
+    }
+    expect(publicGateContentKey({ ...base, remainingSec: 1, nonce: 'n2', expiresAt: '2026-08-11T17:00:00.000Z' })).toBe(
+      publicGateContentKey(base),
+    )
+    expect(publicGateContentKey({ ...base, turnsHash: 'tn-new' })).not.toBe(publicGateContentKey(base))
   })
 })

--- a/web/src/lib/inbox/gateShareLink.ts
+++ b/web/src/lib/inbox/gateShareLink.ts
@@ -126,6 +126,20 @@ export function canCreateGateShare(st?: GateShareInboxStatus | null): boolean {
   return st.state === 'none' || st.state === 'revoked' || st.state === 'expired'
 }
 
+/** Seconds left until expiresAt; falls back to remainingSec snapshot. */
+export function remainingSecFromExpiresAt(
+  expiresAt?: string,
+  remainingSec?: number,
+  nowMs: number = Date.now(),
+): number | undefined {
+  if (expiresAt) {
+    const ms = Date.parse(expiresAt)
+    if (!Number.isNaN(ms)) return Math.max(0, Math.floor((ms - nowMs) / 1000))
+  }
+  if (typeof remainingSec === 'number') return Math.max(0, Math.floor(remainingSec))
+  return undefined
+}
+
 export function formatRemainingSec(
   sec: number | undefined,
   t: (key: string, values?: Record<string, unknown>) => string,
@@ -192,6 +206,10 @@ export type PublicGatePreview = {
   visualHtml?: string
   /** Content hash for sparse silent poll; always present when server computed it. */
   visualHtmlHash?: string
+  /** Structured-doc hash for sparse silent poll (bodies may be omitted). */
+  structuredHash?: string
+  /** Turns hash for sparse silent poll (bodies may be omitted). */
+  turnsHash?: string
   structured?: {
     name?: string
     title?: string
@@ -253,6 +271,28 @@ async function readJson<T>(res: Response): Promise<T> {
   }
 }
 
+function keepSparseField<K extends keyof PublicGatePreview>(
+  merged: PublicGatePreview,
+  prev: PublicGatePreview,
+  next: PublicGatePreview,
+  bodyKey: K,
+  hashKey: 'visualHtmlHash' | 'upstreamHash' | 'structuredHash' | 'turnsHash',
+) {
+  const hashChanged = typeof next[hashKey] === 'string' && next[hashKey] !== (prev[hashKey] ?? '')
+  if (Object.prototype.hasOwnProperty.call(next, bodyKey)) {
+    merged[bodyKey] = next[bodyKey]
+  } else if (hashChanged) {
+    merged[bodyKey] = next[bodyKey]
+  } else if (prev[bodyKey] != null) {
+    merged[bodyKey] = prev[bodyKey]
+  }
+  if (typeof next[hashKey] === 'string') {
+    merged[hashKey] = next[hashKey]
+  } else if (prev[hashKey] != null) {
+    merged[hashKey] = prev[hashKey]
+  }
+}
+
 /** Merge sparse poll payloads: omitted large fields keep the previous client value. */
 export function mergePublicGatePreview(
   prev: PublicGatePreview | null,
@@ -260,37 +300,51 @@ export function mergePublicGatePreview(
 ): PublicGatePreview {
   if (!prev) return next
   const merged: PublicGatePreview = { ...prev, ...next }
-  const visualHashChanged =
-    typeof next.visualHtmlHash === 'string' &&
-    next.visualHtmlHash !== (prev.visualHtmlHash ?? '')
-  if (Object.prototype.hasOwnProperty.call(next, 'visualHtml')) {
-    merged.visualHtml = next.visualHtml
-  } else if (visualHashChanged) {
-    // Hash changed but body omitted (e.g. cleared) → drop stale HTML.
-    merged.visualHtml = next.visualHtml
-  } else if (prev.visualHtml != null) {
-    merged.visualHtml = prev.visualHtml
-  }
-  if (typeof next.visualHtmlHash === 'string') {
-    merged.visualHtmlHash = next.visualHtmlHash
-  } else if (prev.visualHtmlHash != null) {
-    merged.visualHtmlHash = prev.visualHtmlHash
-  }
-  const upstreamHashChanged =
-    typeof next.upstreamHash === 'string' && next.upstreamHash !== (prev.upstreamHash ?? '')
-  if (Object.prototype.hasOwnProperty.call(next, 'upstream')) {
-    merged.upstream = next.upstream
-  } else if (upstreamHashChanged) {
-    merged.upstream = next.upstream
-  } else if (prev.upstream != null) {
-    merged.upstream = prev.upstream
-  }
-  if (typeof next.upstreamHash === 'string') {
-    merged.upstreamHash = next.upstreamHash
-  } else if (prev.upstreamHash != null) {
-    merged.upstreamHash = prev.upstreamHash
-  }
+  keepSparseField(merged, prev, next, 'visualHtml', 'visualHtmlHash')
+  keepSparseField(merged, prev, next, 'upstream', 'upstreamHash')
+  keepSparseField(merged, prev, next, 'structured', 'structuredHash')
+  keepSparseField(merged, prev, next, 'turns', 'turnsHash')
+  // Silent polls may omit nonce; never drop the last usable one.
+  if (!next.nonce && prev.nonce) merged.nonce = prev.nonce
   return merged
+}
+
+/**
+ * Content fingerprint for silent-poll short-circuit.
+ * Excludes remainingSec / expiresAt clock drift and nonce rotation.
+ */
+export function publicGateContentKey(p: PublicGatePreview | null | undefined): string {
+  if (!p) return ''
+  return JSON.stringify({
+    status: p.status,
+    kind: p.kind || '',
+    title: p.title || '',
+    description: p.description || '',
+    actions: p.actions || null,
+    visualHtmlHash: p.visualHtmlHash || '',
+    visualHtml: p.visualHtmlHash ? '' : p.visualHtml || '',
+    structuredHash: p.structuredHash || '',
+    structured: p.structuredHash ? null : p.structured || null,
+    turnsHash: p.turnsHash || '',
+    turns: p.turnsHash ? null : p.turns || null,
+    upstreamHash: p.upstreamHash || '',
+    reactSessionAlive: !!p.reactSessionAlive,
+    sessionBusy: !!p.sessionBusy,
+    waiting: p.waiting || 0,
+    queueItems: p.queueItems || [],
+    activeItem: p.activeItem || null,
+    productKind: p.productKind || '',
+    productName: p.productName || '',
+  })
+}
+
+export type PublicGatePreviewKnown = {
+  visualHtmlHash?: string
+  upstreamHash?: string
+  structuredHash?: string
+  turnsHash?: string
+  silent?: boolean
+  issueNonce?: boolean
 }
 
 /** Unauthenticated public gate APIs. Token never goes in path/query. */
@@ -298,7 +352,7 @@ export const publicGateApi = {
   preview(
     token: string,
     signal?: AbortSignal,
-    known?: { visualHtmlHash?: string; upstreamHash?: string },
+    known?: PublicGatePreviewKnown,
   ): Promise<PublicGatePreview> {
     const headers: Record<string, string> = {
       [GATE_SHARE_TOKEN_HEADER]: token,
@@ -306,8 +360,14 @@ export const publicGateApi = {
     }
     const vh = known?.visualHtmlHash?.trim()
     const uh = known?.upstreamHash?.trim()
+    const sh = known?.structuredHash?.trim()
+    const th = known?.turnsHash?.trim()
     if (vh) headers['X-Gate-Known-Visual-Html-Hash'] = vh
     if (uh) headers['X-Gate-Known-Upstream-Hash'] = uh
+    if (sh) headers['X-Gate-Known-Structured-Hash'] = sh
+    if (th) headers['X-Gate-Known-Turns-Hash'] = th
+    if (known?.silent) headers['X-Gate-Silent-Poll'] = '1'
+    if (known?.issueNonce) headers['X-Gate-Issue-Nonce'] = '1'
     return fetch('/public/gate-approvals/preview', {
       method: 'GET',
       credentials: 'omit',

--- a/web/src/views/PublicGateApprovalView.test.ts
+++ b/web/src/views/PublicGateApprovalView.test.ts
@@ -41,6 +41,7 @@ vi.mock('@/lib/shared/locale', async () => {
 })
 
 import PublicGateApprovalView from './PublicGateApprovalView.vue'
+import ClarifyChat from '@/components/run/ClarifyChat.vue'
 import type { VueWrapper } from '@vue/test-utils'
 
 const mounted: VueWrapper[] = []
@@ -701,10 +702,14 @@ describe('PublicGateApprovalView workbench', () => {
     })
     await flushPromises()
     expect(w.get('[data-testid="public-gate-visual"]').html()).toContain('keep-me')
-    expect(mocks.preview.mock.calls[mocks.preview.mock.calls.length - 1]?.[2]).toEqual({
-      visualHtmlHash: 'vh1',
-      upstreamHash: 'up1',
-    })
+    expect(mocks.preview.mock.calls[mocks.preview.mock.calls.length - 1]?.[2]).toEqual(
+      expect.objectContaining({
+        visualHtmlHash: 'vh1',
+        upstreamHash: 'up1',
+        silent: true,
+        issueNonce: false,
+      }),
+    )
   })
 
   it('loads upstream doc on enlarge and retries on failure without blocking approve (plan g1.3)', async () => {
@@ -746,5 +751,200 @@ describe('PublicGateApprovalView workbench', () => {
     const docEl = document.body.querySelector('[data-testid="public-gate-upstream-doc"]')
     expect(docEl).toBeTruthy()
     expect(docEl?.textContent || '').toMatch(/g1|澄清/)
+  })
+
+  function setVisibility(state: DocumentVisibilityState) {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => state,
+    })
+    document.dispatchEvent(new Event('visibilitychange'))
+  }
+
+  it('stops polling while the tab is hidden and does not unmount preview (plan g1.1)', async () => {
+    window.location.hash = `#t=${'aa'.repeat(32)}`
+    mocks.preview.mockResolvedValue({
+      status: 'active',
+      kind: 'human_gate',
+      nonce: 'n-vis',
+      visualHtml: '<p>stay-mounted</p>',
+      visualHtmlHash: 'vh-stay',
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      remainingSec: 3600,
+      actions: { approve: 'approve', confirm: 'approve' },
+      productKind: 'visual',
+      productName: 'page.html',
+    })
+    const w = mountView()
+    await flushPromises()
+    expect(w.get('[data-testid="public-gate-visual"]').html()).toContain('stay-mounted')
+    const before = mocks.preview.mock.calls.length
+    setVisibility('hidden')
+    await flushPromises()
+    await new Promise((r) => setTimeout(r, 2500))
+    await flushPromises()
+    expect(mocks.preview.mock.calls.length).toBe(before)
+    expect(w.get('[data-testid="public-gate-visual"]').html()).toContain('stay-mounted')
+    expect(w.find('[data-testid="public-gate-workbench"]').exists()).toBe(true)
+    setVisibility('visible')
+  })
+
+  it('resumes with a silent refresh and keeps draft plus preview (plan g1.2 / g5.2)', async () => {
+    window.location.hash = `#t=${'aa'.repeat(32)}`
+    mocks.preview.mockResolvedValue({
+      status: 'active',
+      kind: 'human_gate',
+      nonce: 'n-resume',
+      visualHtml: '<p>keep-iframe</p>',
+      visualHtmlHash: 'vh-resume',
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      remainingSec: 3600,
+      reactSessionAlive: true,
+      actions: { approve: 'approve', confirm: 'approve', reply: 'reply' },
+      productKind: 'visual',
+      productName: 'page.html',
+      turns: [{ role: 'agent', text: '请审阅', at: '2026-08-01T00:00:00Z' }],
+    })
+    const w = mountView()
+    await flushPromises()
+    await w.get('[data-testid="clarify-input"]').setValue('未发送草稿')
+    setVisibility('hidden')
+    await flushPromises()
+    mocks.preview.mockResolvedValue({
+      status: 'active',
+      kind: 'human_gate',
+      nonce: 'n-resume-2',
+      visualHtmlHash: 'vh-resume',
+      remainingSec: 3500,
+      reactSessionAlive: true,
+      actions: { approve: 'approve', confirm: 'approve', reply: 'reply' },
+      productKind: 'visual',
+      productName: 'page.html',
+    })
+    const before = mocks.preview.mock.calls.length
+    setVisibility('visible')
+    await flushPromises()
+    expect(mocks.preview.mock.calls.length).toBeGreaterThan(before)
+    const lastKnown = mocks.preview.mock.calls[mocks.preview.mock.calls.length - 1]?.[2]
+    expect(lastKnown).toEqual(expect.objectContaining({ silent: true, issueNonce: true }))
+    expect(w.get('[data-testid="clarify-input"]').element).toHaveProperty('value', '未发送草稿')
+    expect(w.get('[data-testid="public-gate-visual"]').html()).toContain('keep-iframe')
+    expect(w.find('[data-testid="public-gate-loading"]').exists()).toBe(false)
+  })
+
+  it('shows remaining time from expiresAt, not stale remainingSec (plan g2.1)', async () => {
+    window.location.hash = `#t=${'aa'.repeat(32)}`
+    mocks.preview.mockResolvedValue({
+      status: 'active',
+      kind: 'human_gate',
+      nonce: 'n-clock',
+      remainingSec: 30,
+      expiresAt: new Date(Date.now() + 90 * 60 * 1000).toISOString(),
+      actions: { approve: 'approve', confirm: 'approve' },
+    })
+    const w = mountView()
+    await flushPromises()
+    expect(w.get('[data-testid="public-gate-remaining"]').text()).toContain('1 小时')
+    expect(w.get('[data-testid="public-gate-remaining"]').text()).not.toContain('1 分钟')
+  })
+
+  it('identical silent polls do not drop visual or idle-apply queue (plan g3.1 / g3.2)', async () => {
+    window.location.hash = `#t=${'aa'.repeat(32)}`
+    const base = {
+      status: 'active',
+      kind: 'human_gate',
+      visualHtml: '<p>stable</p>',
+      visualHtmlHash: 'vh-stable',
+      structuredHash: 'st-stable',
+      turnsHash: 'tn-stable',
+      upstreamHash: 'up-stable',
+      reactSessionAlive: true,
+      sessionBusy: false,
+      waiting: 0,
+      actions: { approve: 'approve', confirm: 'approve', reply: 'reply' },
+      productKind: 'visual',
+      productName: 'page.html',
+      turns: [{ role: 'agent', text: '请审阅', at: '2026-08-01T00:00:00Z' }],
+    }
+    mocks.preview.mockResolvedValue({ ...base, nonce: 'n0', remainingSec: 4000 })
+    const w = mountView()
+    await flushPromises()
+    await w.get('[data-testid="clarify-input"]').setValue('idle-draft')
+    const chat = w.getComponent(ClarifyChat)
+    const applySpy = vi.spyOn(chat.vm as unknown as { applyQueueState: (...args: unknown[]) => void }, 'applyQueueState')
+    for (let i = 1; i <= 8; i++) {
+      mocks.preview.mockResolvedValue({
+        ...base,
+        nonce: `n${i}`,
+        remainingSec: 4000 - i,
+      })
+      await (w.vm as unknown as { loadPreview: (opts?: { silent?: boolean }) => Promise<void> }).loadPreview({
+        silent: true,
+      })
+      await flushPromises()
+    }
+    expect(w.get('[data-testid="public-gate-visual"]').html()).toContain('stable')
+    expect(w.get('[data-testid="clarify-input"]').element).toHaveProperty('value', 'idle-draft')
+    expect(applySpy).not.toHaveBeenCalled()
+    applySpy.mockRestore()
+  })
+
+  it('retries nonce once on reject as well as confirm (plan g4.2)', async () => {
+    window.location.hash = `#t=${'aa'.repeat(32)}`
+    mocks.preview.mockResolvedValue({
+      status: 'active',
+      kind: 'human_gate',
+      nonce: 'n-old-rej',
+      actions: { approve: 'approve', reject: 'revise', confirm: 'approve' },
+    })
+    const w = mountView()
+    await flushPromises()
+    await w.get('[data-testid="public-gate-name"]').setValue('Jordan')
+    await w.get('[data-testid="public-gate-comment"]').setValue('需要驳回')
+    mocks.decide
+      .mockRejectedValueOnce(
+        Object.assign(new Error('nonce'), { status: 403, body: { error: 'nonce', message: 'nonce expired' } }),
+      )
+      .mockResolvedValueOnce({ status: 'rejected' })
+    mocks.preview.mockResolvedValue({
+      status: 'active',
+      kind: 'human_gate',
+      nonce: 'n-new-rej',
+      actions: { approve: 'approve', reject: 'revise', confirm: 'approve' },
+    })
+    await w.get('[data-testid="public-gate-reject"]').trigger('click')
+    await flushPromises()
+    expect(mocks.decide).toHaveBeenCalledTimes(2)
+    expect(mocks.decide.mock.calls[0][0]).toEqual(expect.objectContaining({ nonce: 'n-old-rej', action: 'revise' }))
+    expect(mocks.decide.mock.calls[1][0]).toEqual(expect.objectContaining({ nonce: 'n-new-rej', action: 'revise' }))
+    expect(w.get('[data-testid="public-gate-done"]').text()).toContain('已驳回')
+  })
+
+  it('silent 429 does not clear draft or leave the workbench (plan g5.2)', async () => {
+    window.location.hash = `#t=${'aa'.repeat(32)}`
+    mocks.preview.mockResolvedValue({
+      status: 'active',
+      kind: 'human_gate',
+      nonce: 'n-429',
+      visualHtml: '<p>ok</p>',
+      reactSessionAlive: true,
+      actions: { approve: 'approve', confirm: 'approve', reply: 'reply' },
+      productKind: 'visual',
+      productName: 'page.html',
+    })
+    const w = mountView()
+    await flushPromises()
+    await w.get('[data-testid="clarify-input"]').setValue('keep-on-429')
+    mocks.preview.mockRejectedValueOnce(
+      Object.assign(new Error('rate_limited'), { status: 429, body: { error: 'rate_limited' } }),
+    )
+    await (w.vm as unknown as { loadPreview: (opts?: { silent?: boolean }) => Promise<void> }).loadPreview({
+      silent: true,
+    })
+    await flushPromises()
+    expect(w.get('[data-testid="clarify-input"]').element).toHaveProperty('value', 'keep-on-429')
+    expect(w.find('[data-testid="public-gate-workbench"]').exists()).toBe(true)
+    expect(w.find('[data-testid="public-gate-network-error"]').exists()).toBe(false)
+    expect(w.get('[data-testid="public-gate-visual"]').html()).toContain('ok')
   })
 })

--- a/web/src/views/PublicGateApprovalView.vue
+++ b/web/src/views/PublicGateApprovalView.vue
@@ -17,9 +17,12 @@ import {
   mergePublicGatePreview,
   parseShareTokenFromHash,
   publicGateApi,
+  publicGateContentKey,
+  remainingSecFromExpiresAt,
   type PublicGateActiveItem,
   type PublicGateDecideResult,
   type PublicGatePreview,
+  type PublicGatePreviewKnown,
   type PublicGateQueueItem,
 } from '@/lib/inbox/gateShareLink'
 import type { ClarifyImage, ClarifyTurn, ReactAnnotation } from '@/lib/shared/types'
@@ -36,6 +39,10 @@ type PublicChatRef = {
 }
 
 const POLL_MS = 2000
+const IDLE_POLL_MS = 10_000
+const REMAINING_TICK_MS = 15_000
+const NONCE_TTL_MS = 15 * 60 * 1000
+const NONCE_REFRESH_BEFORE_MS = 2 * 60 * 1000
 
 const { t } = useI18n()
 const { isMobile } = useBreakpoint()
@@ -66,6 +73,12 @@ const chatRef = ref<PublicChatRef | null>(null)
 const replyInFlight = ref(false)
 const pendingReplyText = ref('')
 
+let lastKeptNonce = ''
+let nonceIssuedAt = 0
+let lastAppliedIdleQueue = false
+let pollIntervalMs = POLL_MS
+let remainingTimer: ReturnType<typeof setInterval> | null = null
+
 let previewGen = 0
 let previewAbort: AbortController | null = null
 let decideAbort: AbortController | null = null
@@ -89,7 +102,7 @@ function abortPreview() {
 const isReview = computed(() => preview.value?.kind === 'review')
 const status = computed(() => preview.value?.status || (token.value ? 'invalid' : 'invalid'))
 const isActive = computed(() => status.value === 'active')
-const remainingLabel = computed(() => formatRemainingSec(preview.value?.remainingSec, t))
+const remainingLabel = ref('')
 const reactAlive = computed(() => !!preview.value?.reactSessionAlive)
 const sessionBusy = computed(() => !!preview.value?.sessionBusy)
 const canReply = computed(() => isActive.value && reactAlive.value && !!preview.value?.actions?.reply)
@@ -171,7 +184,57 @@ function structuredFallbackDoc(): Record<string, unknown> | null {
   return Object.keys(out).length ? out : null
 }
 
-async function loadPreview(opts?: { silent?: boolean }) {
+function refreshRemainingLabel() {
+  const p = preview.value
+  const next = formatRemainingSec(remainingSecFromExpiresAt(p?.expiresAt, p?.remainingSec), t)
+  if (next !== remainingLabel.value) remainingLabel.value = next
+}
+
+function noteNonceIssued(nonce?: string) {
+  if (nonce) nonceIssuedAt = Date.now()
+}
+
+function shouldRefreshNonce(): boolean {
+  const have = !!(preview.value?.nonce || lastKeptNonce)
+  if (!have) return true
+  if (!nonceIssuedAt) return true
+  return Date.now() - nonceIssuedAt >= NONCE_TTL_MS - NONCE_REFRESH_BEFORE_MS
+}
+
+function patchClockAndNonce(prev: PublicGatePreview, next: PublicGatePreview) {
+  if (next.nonce) {
+    prev.nonce = next.nonce
+    lastKeptNonce = next.nonce
+    noteNonceIssued(next.nonce)
+  }
+  if (next.expiresAt) prev.expiresAt = next.expiresAt
+  if (typeof next.remainingSec === 'number') prev.remainingSec = next.remainingSec
+  refreshRemainingLabel()
+}
+
+function applyPreviewPayload(next: PublicGatePreview, silent: boolean) {
+  const prev = preview.value
+  if (silent && prev) {
+    const merged = mergePublicGatePreview(prev, next)
+    if (publicGateContentKey(merged) === publicGateContentKey(prev)) {
+      patchClockAndNonce(prev, next)
+      noteIdlePoll(true)
+      return false
+    }
+    preview.value = merged
+  } else {
+    preview.value = next
+  }
+  if (preview.value?.nonce) {
+    lastKeptNonce = preview.value.nonce
+    noteNonceIssued(preview.value.nonce)
+  }
+  refreshRemainingLabel()
+  noteIdlePoll(false)
+  return true
+}
+
+async function loadPreview(opts?: { silent?: boolean; issueNonce?: boolean }) {
   if (doneKind.value) return
   const attemptGen = ++previewGen
   abortPreview()
@@ -196,32 +259,44 @@ async function loadPreview(opts?: { silent?: boolean }) {
     preview.value = { status: 'invalid' }
     loading.value = false
     clearStuckTimer()
+    refreshRemainingLabel()
     return
   }
   try {
-    const known =
+    const known: PublicGatePreviewKnown | undefined =
       opts?.silent && preview.value
         ? {
             visualHtmlHash: preview.value.visualHtmlHash,
             upstreamHash: preview.value.upstreamHash,
+            structuredHash: preview.value.structuredHash,
+            turnsHash: preview.value.turnsHash,
+            silent: true,
+            issueNonce: !!opts.issueNonce || shouldRefreshNonce(),
           }
-        : undefined
+        : opts?.issueNonce
+          ? { issueNonce: true }
+          : undefined
     const next = await publicGateApi.preview(tok, signal, known)
     if (attemptGen !== previewGen) return
-    if (opts?.silent && preview.value) {
-      preview.value = mergePublicGatePreview(preview.value, next)
-    } else {
-      preview.value = next
-    }
+    const wroteTree = applyPreviewPayload(next, !!opts?.silent)
     if (next.status === 'active') workbenchSeen.value = true
     noteWorkbenchLinkInvalid(preview.value)
     if (!opts?.silent && !linkInvalid.value) errorText.value = ''
+    if (!wroteTree) {
+      if (attemptGen === previewGen) {
+        loading.value = false
+        clearStuckTimer()
+      }
+      return
+    }
   } catch (e) {
     if (attemptGen !== previewGen || isAbortError(e)) return
     if (!opts?.silent) {
       preview.value = null
       networkFailed.value = true
       errorText.value = t('pages.publicGate.networkError')
+    } else {
+      noteIdlePoll(true)
     }
   } finally {
     if (attemptGen === previewGen) {
@@ -302,6 +377,7 @@ function syncChatQueueFromPreview() {
   const busy = !!p.sessionBusy || waiting > 0 || !!activeItem
 
   if (busy) {
+    lastAppliedIdleQueue = false
     chat.applyQueueState?.(waiting, items.length ? items : null, true, activeItem)
     if (pendingReplyText.value && (turnsIncludeHumanText(pendingReplyText.value) || activeItem?.text?.trim() === pendingReplyText.value)) {
       pendingReplyText.value = ''
@@ -316,6 +392,8 @@ function syncChatQueueFromPreview() {
     chat.discardLastQueued?.()
     pendingReplyText.value = ''
   }
+  if (lastAppliedIdleQueue && !chat.isSessionBusy?.()) return
+  lastAppliedIdleQueue = true
   chat.applyQueueState?.(0, [], false, null)
 }
 
@@ -466,7 +544,7 @@ async function submitFinal(kind: 'confirm' | 'reject') {
   }
   if (!auditReady() && kind === 'reject') return
   if (!isReview.value && !auditReady()) return
-  if (!preview.value.nonce) {
+  if (!(preview.value.nonce || lastKeptNonce)) {
     errorText.value = t('pages.publicGate.unavailable')
     return
   }
@@ -486,13 +564,13 @@ async function submitFinal(kind: 'confirm' | 'reject') {
   try {
     let res: PublicGateDecideResult
     try {
-      res = await decideOnce(kind, preview.value.nonce, signal)
+      res = await decideOnce(kind, preview.value.nonce || lastKeptNonce, signal)
     } catch (e) {
       if (isAbortError(e)) return
-      if (kind !== 'confirm' || !isNonceError(e)) throw e
-      await loadPreview({ silent: true })
+      if (!isNonceError(e)) throw e
+      await loadPreview({ silent: true, issueNonce: true })
       if (signal.aborted) return
-      const nextNonce = preview.value?.nonce
+      const nextNonce = preview.value?.nonce || lastKeptNonce
       if (!nextNonce) throw e
       res = await decideOnce(kind, nextNonce, signal)
     }
@@ -552,16 +630,35 @@ function onHtmlPick(payload: { selector: string; tagName: string }) {
 }
 
 let pollTimer: ReturnType<typeof setInterval> | null = null
+function pageHidden(): boolean {
+  return typeof document !== 'undefined' && document.visibilityState === 'hidden'
+}
+function canPoll(): boolean {
+  return (
+    isActive.value &&
+    !doneKind.value &&
+    !submitting.value &&
+    !linkInvalid.value &&
+    !pageHidden()
+  )
+}
 function onHashChange() {
   if (doneKind.value || submitting.value) return
   void loadPreview()
 }
+function noteIdlePoll(sameContent: boolean) {
+  const next = sameContent ? IDLE_POLL_MS : POLL_MS
+  if (next === pollIntervalMs) return
+  pollIntervalMs = next
+  if (pollTimer && canPoll()) startPoll()
+}
 function startPoll() {
   stopPoll()
+  if (!canPoll()) return
   pollTimer = setInterval(() => {
-    if (!isActive.value || doneKind.value || !token.value || submitting.value || linkInvalid.value) return
+    if (!canPoll() || !token.value) return
     void loadPreview({ silent: true })
-  }, POLL_MS)
+  }, pollIntervalMs)
 }
 function stopPoll() {
   if (pollTimer) {
@@ -569,10 +666,41 @@ function stopPoll() {
     pollTimer = null
   }
 }
+function startRemainingTick() {
+  stopRemainingTick()
+  refreshRemainingLabel()
+  if (pageHidden() || !isActive.value || doneKind.value) return
+  remainingTimer = setInterval(refreshRemainingLabel, REMAINING_TICK_MS)
+}
+function stopRemainingTick() {
+  if (remainingTimer) {
+    clearInterval(remainingTimer)
+    remainingTimer = null
+  }
+}
+async function resumeFromForeground() {
+  if (!canPoll()) {
+    startRemainingTick()
+    return
+  }
+  startRemainingTick()
+  await loadPreview({ silent: true, issueNonce: true })
+  if (canPoll()) startPoll()
+}
+function onVisibilityChange() {
+  if (pageHidden()) {
+    stopPoll()
+    stopRemainingTick()
+    return
+  }
+  void resumeFromForeground()
+}
 
 watch([isActive, doneKind], () => {
-  if (isActive.value && !doneKind.value && !submitting.value && !linkInvalid.value) startPoll()
+  if (canPoll()) startPoll()
   else stopPoll()
+  if (isActive.value && !doneKind.value && !pageHidden()) startRemainingTick()
+  else stopRemainingTick()
 })
 
 watch(chatRef, (chat) => {
@@ -597,11 +725,15 @@ onMounted(async () => {
   ready.value = true
   await loadPreview()
   window.addEventListener('hashchange', onHashChange)
-  if (isActive.value) startPoll()
+  document.addEventListener('visibilitychange', onVisibilityChange)
+  startRemainingTick()
+  if (canPoll()) startPoll()
 })
 onUnmounted(() => {
   stopPoll()
+  stopRemainingTick()
   window.removeEventListener('hashchange', onHashChange)
+  document.removeEventListener('visibilitychange', onVisibilityChange)
   abortPreview()
   abortUpstream()
   decideAbort?.abort()


### PR DESCRIPTION
Stop hidden-tab polling, skip no-op preview writes, issue nonces less often, and back off idle polls so the workbench stays responsive without changing approve/reject semantics.

Co-authored-by: Cursor <cursoragent@cursor.com>
