### PR TITLE
fix(web): hide spec callout in enlarge-upstream modal

### DIFF
--- a/web/src/components/run/UpstreamRequirementContext.test.ts
+++ b/web/src/components/run/UpstreamRequirementContext.test.ts
@@ -61,6 +61,7 @@ const AppModalStub = defineComponent({
         data-testid="modal-backdrop"
         @click="closeOnBackdrop && $emit('close')"
       />
+      <h2 data-testid="upstream-enlarge-modal-title">{{ title }}</h2>
       <button data-testid="modal-close" type="button" @click="$emit('close')">close</button>
       <slot />
       <slot name="footer" />
@@ -228,14 +229,16 @@ describe('UpstreamRequirementContext', () => {
     await flushPromises()
 
     expect(wrapper.find('[data-testid="upstream-enlarge-modal"]').exists()).toBe(true)
-    // Modal title stays 「上游上下文」; only the trigger button uses the new enlarge label.
-    expect(wrapper.find('[data-testid="upstream-enlarge-modal"]').text()).toContain('上游上下文')
+    // Modal title stays 「上游上下文」; enlarge label remains on the trigger, not a spec callout.
+    expect(wrapper.find('[data-testid="upstream-enlarge-modal-title"]').text()).toBe('上游上下文')
+    expect(wrapper.findComponent(AppModalStub).props('title')).toBe('上游上下文')
     expect(wrapper.find('[data-testid="upstream-context-body"]').exists()).toBe(false)
     expect(apiMocks.artifactContent).toHaveBeenCalledWith('a-req')
-    expect(wrapper.find('[data-testid="upstream-modal-callout"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="upstream-modal-callout"]').text()).toContain(
-      '放大上游上下文',
+    expect(wrapper.find('[data-testid="upstream-modal-callout"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="upstream-modal-body"]').text()).not.toContain(
+      '应用内模态大视口',
     )
+    expect(wrapper.find('[data-testid="upstream-modal-mode-structured"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="upstream-modal-readonly-footer"]').text()).toContain(
       '只读对照',
     )
@@ -364,6 +367,11 @@ describe('UpstreamRequirementContext', () => {
     expect(wrapper.find('[data-testid="upstream-enlarge-modal"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="upstream-context-body"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="structured-view"]').text()).toContain('需求')
+    expect(wrapper.find('[data-testid="upstream-modal-callout"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="upstream-bar-hint"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="upstream-bar-hint"]').text()).toContain(
+      '本 run 已有澄清需求文档',
+    )
     wrapper.unmount()
   })
 

--- a/web/src/components/run/UpstreamRequirementContext.vue
+++ b/web/src/components/run/UpstreamRequirementContext.vue
@@ -275,13 +275,6 @@ watch(visible, (isVisible) => {
       @close="closeModal"
     >
       <div class="space-y-3" data-testid="upstream-modal-body">
-        <div
-          class="rounded-md border border-accent/25 bg-accent-dim/45 px-3 py-2 text-[11px] leading-relaxed text-txt2"
-          data-testid="upstream-modal-callout"
-        >
-          <strong class="font-semibold text-accent-2">{{ enlargeLabel }}</strong>
-          {{ t('pages.gateApproval.upstreamEnlargeHint') }}
-        </div>
         <div class="flex flex-wrap gap-1">
           <button
             type="button"

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -2276,7 +2276,6 @@
       "reviewingUpstreamFallback": "Snapshot miss; showing run artifact store",
       "upstreamContext": "Upstream context",
       "upstreamEnlarge": "Enlarge upstream context",
-      "upstreamEnlargeHint": " — In-app modal with a larger viewport than the ~40vh inline area; closing returns to approval without changing the review target or form.",
       "upstreamReadonlyFooter": "Read-only reference · does not change the approval target",
       "upstreamLoadFailed": "Failed to load upstream context: {error}",
       "upstreamRetry": "Retry",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -2276,7 +2276,6 @@
       "reviewingUpstreamFallback": "快照未命中，已回落产物库",
       "upstreamContext": "上游上下文",
       "upstreamEnlarge": "放大上游上下文",
-      "upstreamEnlargeHint": " — 应用内模态大视口，视口显著大于内联约 40vh 限高区；关闭后回到审批页，主产物与表单状态不变。",
       "upstreamReadonlyFooter": "只读对照 · 不改变审批对象",
       "upstreamLoadFailed": "上游上下文读取失败：{error}",
       "upstreamRetry": "重试",


### PR DESCRIPTION
Approvers already have a large read-only viewport; the modal hint restating that spec is noise. Removing the shared callout (and its i18n key) keeps the title, enlarge entry, footer, and review-bar business hint unchanged.

Co-authored-by: Cursor <cursoragent@cursor.com>
