### PR TITLE
fix: use 本工作流 in upstream bar hint instead of 本 run

### DIFF
--- a/web/src/components/run/UpstreamRequirementContext.test.ts
+++ b/web/src/components/run/UpstreamRequirementContext.test.ts
@@ -352,7 +352,7 @@ describe('UpstreamRequirementContext', () => {
     expect(wrapper.find('[data-testid="upstream-context-body"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="upstream-bar-hint"]').text()).toContain('上游上下文')
     expect(wrapper.find('[data-testid="upstream-bar-hint"]').text()).toContain(
-      '本 run 已有澄清需求文档',
+      '本工作流已有澄清需求文档',
     )
     expect(wrapper.find('[data-testid="upstream-enlarge"]').text()).toContain('放大上游上下文')
     expect(apiMocks.artifactContent).not.toHaveBeenCalled()

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -2282,7 +2282,7 @@
       "upstreamRetry": "Retry",
       "upstreamViewStructured": "Structured",
       "upstreamViewRaw": "Raw JSON",
-      "upstreamBarHint": "This run has a clarified requirement — open it to review against the current product",
+      "upstreamBarHint": "This workflow has a clarified requirement — open it to review against the current product",
       "primaryBadge": "Primary",
       "readonlyBadge": "Read-only",
       "readonlyHint": "Non-text artifact · read-only reference",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -2282,7 +2282,7 @@
       "upstreamRetry": "重试",
       "upstreamViewStructured": "结构化",
       "upstreamViewRaw": "原始 JSON",
-      "upstreamBarHint": "本 run 已有澄清需求文档，可对照审阅当前主产物",
+      "upstreamBarHint": "本工作流已有澄清需求文档，可对照审阅当前主产物",
       "primaryBadge": "主产物",
       "readonlyBadge": "只读",
       "readonlyHint": "非文本产物 · 只读引用",


### PR DESCRIPTION
Align the persistent upstream-context copy with workflow-scoped clarified requirements so reviewers are not pointed at the current run.

Co-authored-by: Cursor <cursoragent@cursor.com>
