### PR TITLE
fix/output visual preview independence

### DIFF
--- a/server/internal/engine/build_output_card_test.go
+++ b/server/internal/engine/build_output_card_test.go
@@ -7,6 +7,15 @@ import (
 	"github.com/cocofhu/approving/internal/models"
 )
 
+func mustBuildCard(t *testing.T, e *Engine, c *execCtx, tmpl string) map[string]any {
+	t.Helper()
+	card, include := e.buildOutputCard(c, 1, tmpl)
+	if !include || card == nil {
+		t.Fatalf("expected card for %s, include=%v card=%v", tmpl, include, card)
+	}
+	return card
+}
+
 func TestBuildOutputCardBranches(t *testing.T) {
 	e, db := setupEngine(t)
 	run := &models.Run{ID: "run-card", WorkflowID: "wf", Status: "running", Graph: models.Graph{
@@ -33,30 +42,37 @@ func TestBuildOutputCardBranches(t *testing.T) {
 		},
 	}
 
-	// failed upstream
-	card := e.buildOutputCard(c, 1, "{{nodes.n1.outputs.content}}")
-	if card["status"] != "failed" {
+	// failed upstream — distinguishable failTitle (g1.2)
+	card := mustBuildCard(t, e, c, "{{nodes.n1.outputs.content}}")
+	if card["status"] != "failed" || card["failTitle"] != failTitleSourceFailed {
 		t.Fatalf("failed node: %+v", card)
 	}
-	// missing outputs
+	if strings.Contains(fmtSprint(card["errorReason"]), "上游节点无输出") {
+		t.Fatalf("must not use 上游节点无输出 for real failure: %+v", card)
+	}
+
+	// missing outputs on an executed node → still a fail card, missing-product title (g1.2 / g4.1)
 	c2 := &execCtx{run: run, graph: run.Graph, nodeOutputs: map[string]map[string]any{}}
-	card = e.buildOutputCard(c2, 1, "{{nodes.n2.outputs.content}}")
-	if card["status"] != "failed" {
+	card = mustBuildCard(t, e, c2, "{{nodes.n2.outputs.content}}")
+	if card["status"] != "failed" || card["failTitle"] != failTitleMissingOut {
 		t.Fatalf("no outs: %+v", card)
 	}
+	if card["errorReason"] == "上游节点无输出" {
+		t.Fatalf("deleted 上游节点无输出 copy: %+v", card)
+	}
 	// missing key
-	card = e.buildOutputCard(c, 1, "{{nodes.n2.outputs.missing}}")
-	if card["status"] != "failed" {
+	card = mustBuildCard(t, e, c, "{{nodes.n2.outputs.missing}}")
+	if card["status"] != "failed" || card["failTitle"] != failTitleMissingOut {
 		t.Fatalf("missing key: %+v", card)
 	}
 	// content ok
-	card = e.buildOutputCard(c, 1, "{{nodes.n2.outputs.content}}")
+	card = mustBuildCard(t, e, c, "{{nodes.n2.outputs.content}}")
 	if card["status"] != "ok" || card["typeTag"] != "Markdown" {
 		t.Fatalf("content: %+v", card)
 	}
-	// page is a custom HTML product (not structured); shape matches artifact("page.html")
-	card = e.buildOutputCard(c, 1, "{{nodes.n2.outputs.page}}")
-	if card["status"] != "ok" || card["typeTag"] != "自定义产物" || card["artifactName"] != "page.html" {
+	// page is a custom HTML product; artifactName is node-scoped (g2.2 / g4.1)
+	card = mustBuildCard(t, e, c, "{{nodes.n2.outputs.page}}")
+	if card["status"] != "ok" || card["typeTag"] != "自定义产物" || card["artifactName"] != "n2.page.html" {
 		t.Fatalf("page: %+v", card)
 	}
 	if card["structuredArtifactName"] != nil {
@@ -68,19 +84,19 @@ func TestBuildOutputCardBranches(t *testing.T) {
 	if md, _ := card["markdown"].(string); strings.TrimSpace(md) == "" {
 		t.Fatalf("page should keep markdown for HtmlPreview fallback: %+v", card)
 	}
-	card = e.buildOutputCard(c, 1, "{{nodes.n2.outputs.plan}}")
+	card = mustBuildCard(t, e, c, "{{nodes.n2.outputs.plan}}")
 	if card["typeTag"] != "结构化产物" {
 		t.Fatalf("plan: %+v", card)
 	}
-	card = e.buildOutputCard(c, 1, "{{nodes.n2.outputs.empty_custom}}")
-	if card["status"] != "failed" {
+	card = mustBuildCard(t, e, c, "{{nodes.n2.outputs.empty_custom}}")
+	if card["status"] != "failed" || card["failTitle"] != failTitleMissingOut {
 		t.Fatalf("empty custom: %+v", card)
 	}
-	card = e.buildOutputCard(c, 1, "{{nodes.n2.outputs.custom}}")
+	card = mustBuildCard(t, e, c, "{{nodes.n2.outputs.custom}}")
 	if card["status"] != "ok" {
 		t.Fatalf("custom: %+v", card)
 	}
-	card = e.buildOutputCard(c, 1, `{{artifact("missing.json")}}`)
+	card = mustBuildCard(t, e, c, "{{artifact(\"missing.json\")}}")
 	if card["status"] != "failed" {
 		t.Fatalf("artifact miss: %+v", card)
 	}
@@ -88,14 +104,14 @@ func TestBuildOutputCardBranches(t *testing.T) {
 	if _, err := e.store.Save(run.ID, "n2", "page.html", "html", "<html>artifact</html>"); err != nil {
 		t.Fatal(err)
 	}
-	card = e.buildOutputCard(c, 1, `{{artifact("page.html")}}`)
+	card = mustBuildCard(t, e, c, "{{artifact(\"page.html\")}}")
 	if card["status"] != "ok" || card["typeTag"] != "自定义产物" || card["artifactName"] != "page.html" {
 		t.Fatalf("artifact page.html: %+v", card)
 	}
 	if card["structuredArtifactName"] != nil {
 		t.Fatalf("artifact page.html must not be structured: %+v", card)
 	}
-	// empty page content → source failed (not structured-missing)
+	// empty page content → 缺少可展示产出 (g1.2 / g4.1)
 	cEmpty := &execCtx{
 		run:   run,
 		graph: run.Graph,
@@ -103,12 +119,81 @@ func TestBuildOutputCardBranches(t *testing.T) {
 			"n2": {"page": "  "},
 		},
 	}
-	card = e.buildOutputCard(cEmpty, 1, "{{nodes.n2.outputs.page}}")
-	if card["status"] != "failed" || card["typeTag"] != "来源失败" {
+	card = mustBuildCard(t, e, cEmpty, "{{nodes.n2.outputs.page}}")
+	if card["status"] != "failed" || card["typeTag"] != "来源失败" || card["failTitle"] != failTitleMissingOut {
 		t.Fatalf("empty page: %+v", card)
 	}
-	card = e.buildOutputCard(c, 1, "plain-text")
+	card = mustBuildCard(t, e, c, "plain-text")
 	if card["status"] != "ok" && card["status"] != "failed" {
 		t.Fatalf("unknown tmpl: %+v", card)
 	}
+}
+
+func TestBuildOutputCardHidesUnexecutedAndSkipped(t *testing.T) {
+	e, db := setupEngine(t)
+	run := &models.Run{ID: "run-hide", WorkflowID: "wf", Status: "running", Graph: models.Graph{
+		Nodes: []models.Node{
+			{ID: "visual_l6zc", Label: ""},
+			{ID: "skipped_n", Label: "Skipped"},
+			{ID: "running_n", Label: "Running"},
+		},
+	}}
+	if err := db.Create(run).Error; err != nil {
+		t.Fatal(err)
+	}
+	db.Create(&models.StateRun{RunID: run.ID, NodeID: "skipped_n", Status: "skipped", Iteration: 1})
+	db.Create(&models.StateRun{RunID: run.ID, NodeID: "running_n", Status: "running", Iteration: 1})
+
+	c := &execCtx{run: run, graph: run.Graph, nodeOutputs: map[string]map[string]any{}}
+
+	// screenshot case: no StateRun + missing nodeOutputs → hide (g1.1)
+	if card, include := e.buildOutputCard(c, 1, "{{nodes.visual_l6zc.outputs.page}}"); include || card != nil {
+		t.Fatalf("unexecuted visual_l6zc must hide, got include=%v card=%+v", include, card)
+	}
+	// skipped → hide, not a fail card (g1.1)
+	if card, include := e.buildOutputCard(c, 1, "{{nodes.skipped_n.outputs.research}}"); include || card != nil {
+		t.Fatalf("skipped must hide, got include=%v card=%+v", include, card)
+	}
+	// non-terminal + no output → hide (g1.1)
+	if card, include := e.buildOutputCard(c, 1, "{{nodes.running_n.outputs.content}}"); include || card != nil {
+		t.Fatalf("running without output must hide, got include=%v card=%+v", include, card)
+	}
+}
+
+func TestBuildOutputCardCancelledAndWaitingWithOutput(t *testing.T) {
+	e, db := setupEngine(t)
+	run := &models.Run{ID: "run-cancel", WorkflowID: "wf", Status: "running", Graph: models.Graph{
+		Nodes: []models.Node{{ID: "cn", Label: "C"}, {ID: "wh", Label: "W"}},
+	}}
+	if err := db.Create(run).Error; err != nil {
+		t.Fatal(err)
+	}
+	db.Create(&models.StateRun{RunID: run.ID, NodeID: "cn", Status: "cancelled", Iteration: 1})
+	db.Create(&models.StateRun{RunID: run.ID, NodeID: "wh", Status: "waiting_human", Iteration: 1})
+
+	c := &execCtx{
+		run:   run,
+		graph: run.Graph,
+		nodeOutputs: map[string]map[string]any{
+			"wh": {"page": "<html>live</html>"},
+		},
+	}
+	card := mustBuildCard(t, e, c, "{{nodes.cn.outputs.content}}")
+	if card["status"] != "failed" || card["failTitle"] != failTitleCancelled {
+		t.Fatalf("cancelled: %+v", card)
+	}
+	card = mustBuildCard(t, e, c, "{{nodes.wh.outputs.page}}")
+	if card["status"] != "ok" || card["artifactName"] != "wh.page.html" {
+		t.Fatalf("waiting_human with page should still show: %+v", card)
+	}
+}
+
+func fmtSprint(v any) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
 }

--- a/server/internal/engine/fakeprovider_test.go
+++ b/server/internal/engine/fakeprovider_test.go
@@ -68,6 +68,9 @@ type fakeProvider struct {
 	// visual control (test-only): when true a visual node finishes without
 	// writing page.html, so execVisual's contract-miss path is exercised.
 	visualSkipProduces bool
+	// visualBodyByNode optionally overrides the HTML written for a visual node
+	// so dual-visual independence tests can assert distinct pages.
+	visualBodyByNode map[string]string
 
 	// structuredSkipProduces (test-only): when true a framework node finishes
 	// without writing its reserved structured JSON, so finalizeStructured's
@@ -302,6 +305,11 @@ func (f *fakeProvider) RunAgent(ctx context.Context, req runtime.NodeReq) (runti
 	// the contract-miss path.
 	if req.NodeType == "visual" && !f.visualSkipProduces {
 		body := "<!doctype html><html><head><style>body{color:red}</style></head><body><h1>demo</h1></body></html>"
+		if f.visualBodyByNode != nil {
+			if custom, ok := f.visualBodyByNode[req.NodeID]; ok && custom != "" {
+				body = custom
+			}
+		}
 		id, err := f.host.WriteArtifact(req.RunID, req.Token, req.NodeID, visualPageName, body, "html")
 		if err != nil {
 			return runtime.NodeResult{}, err

--- a/server/internal/engine/node_agent.go
+++ b/server/internal/engine/node_agent.go
@@ -66,6 +66,12 @@ func (e *Engine) finalizeVisual(c *execCtx, node *models.Node, r runtime.NodeRes
 	if _, serr := e.store.Save(c.run.ID, node.ID, visualPageName, "html", content); serr != nil {
 		log.Warn().Err(serr).Str("node", node.ID).Msg("visual page re-save failed")
 	}
+	// Node-scoped physical copy so a later visual node cannot overwrite an
+	// earlier source when Save keys on (run_id, name). page.html stays the
+	// latest/single-visual alias for gates and the Agent contract.
+	if _, serr := e.store.Save(c.run.ID, node.ID, visualNodePageName(node.ID), "html", content); serr != nil {
+		log.Warn().Err(serr).Str("node", node.ID).Msg("visual node-scoped page save failed")
+	}
 	outputs := r.Outputs
 	if outputs == nil {
 		outputs = map[string]any{}

--- a/server/internal/engine/output.go
+++ b/server/internal/engine/output.go
@@ -112,7 +112,59 @@ func eNodeLabel(c *execCtx, nodeID string) string {
 	return nodeID
 }
 
-func (e *Engine) buildOutputCard(c *execCtx, idx int, tmpl string) map[string]any {
+const (
+	failTitleSourceFailed = "来源状态失败"
+	failTitleCancelled    = "来源已取消"
+	failTitleMissingOut   = "缺少可展示产出"
+)
+
+// visualNodePageName is the per-source physical copy of page.html so two visual
+// nodes in one run stay independently addressable. The logical alias page.html
+// is unchanged (Agent write_artifact + gate / single-visual fallback).
+func visualNodePageName(nodeID string) string {
+	return nodeID + "." + visualPageName
+}
+
+func markFailCard(card map[string]any, failTitle, reason string) map[string]any {
+	card["typeTag"] = "来源失败"
+	card["status"] = "failed"
+	card["failTitle"] = failTitle
+	card["errorReason"] = reason
+	return card
+}
+
+func isNonTerminalNodeStatus(st string) bool {
+	return st == "running" || st == "waiting_human"
+}
+
+func hasDisplayableNodeOutput(outs map[string]any, key string) bool {
+	if outs == nil {
+		return false
+	}
+	val, ok := outs[key]
+	if !ok {
+		return false
+	}
+	if strings.TrimSpace(models.VarDisplayText(val)) != "" {
+		return true
+	}
+	if artName := structuredArtifactForKey(key); artName != "" && key != "page" {
+		m := nodereg.BuildManifest()
+		if jsonKey, mapped := m.ArtifactToOutputJSON[artName]; mapped {
+			if snap, exists := outs[jsonKey]; exists {
+				if s, isStr := snap.(string); isStr && strings.TrimSpace(s) != "" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// buildOutputCard returns the card and whether execOutput should append it.
+// Unexecuted (no StateRun), skipped, and non-terminal sources with nothing to
+// show are hidden — they must not become failed cards.
+func (e *Engine) buildOutputCard(c *execCtx, idx int, tmpl string) (map[string]any, bool) {
 	ref := parseOutputSourceRef(tmpl)
 	card := map[string]any{
 		"index":    idx,
@@ -126,29 +178,29 @@ func (e *Engine) buildOutputCard(c *execCtx, idx int, tmpl string) map[string]an
 		card["outputKey"] = ref.outputKey
 		card["title"] = cardTitleForNodeRef(c, ref)
 		st := e.nodeLatestStatus(c, ref.nodeID)
-		if st == "failed" || st == "skipped" || st == "cancelled" {
-			card["typeTag"] = "来源失败"
-			card["status"] = "failed"
-			card["errorReason"] = fmt.Sprintf("上游节点状态：%s", st)
-			return card
-		}
 		outs := c.nodeOutputs[ref.nodeID]
+		if st == "" || st == "skipped" {
+			return nil, false
+		}
+		if isNonTerminalNodeStatus(st) && !hasDisplayableNodeOutput(outs, ref.outputKey) {
+			return nil, false
+		}
+		if st == "failed" {
+			return markFailCard(card, failTitleSourceFailed, fmt.Sprintf("上游节点状态：%s", st)), true
+		}
+		if st == "cancelled" {
+			return markFailCard(card, failTitleCancelled, fmt.Sprintf("上游节点状态：%s", st)), true
+		}
 		if outs == nil {
-			card["typeTag"] = "来源失败"
-			card["status"] = "failed"
-			card["errorReason"] = "上游节点无输出"
-			return card
+			return markFailCard(card, failTitleMissingOut, "来源已执行完成但没有可供展示的产出"), true
 		}
 		val, ok := outs[ref.outputKey]
 		if !ok {
-			card["typeTag"] = "来源失败"
-			card["status"] = "failed"
-			card["errorReason"] = fmt.Sprintf("上游输出键 %q 不存在", ref.outputKey)
-			return card
+			return markFailCard(card, failTitleMissingOut, fmt.Sprintf("上游输出键 %q 不存在", ref.outputKey)), true
 		}
 		// page→page.html is in OutputKeyToArtifact for artifact naming, but it is a
 		// custom HTML product (no *_json). Exclude it so the dedicated branch below
-		// is reachable and ends up as 自定义产物 + artifactName=page.html.
+		// is reachable and ends up as 自定义产物 + artifactName={nodeId}.page.html.
 		if artName := structuredArtifactForKey(ref.outputKey); artName != "" && ref.outputKey != "page" {
 			card["typeTag"] = "结构化产物"
 			card["structuredArtifactName"] = artName
@@ -166,66 +218,52 @@ func (e *Engine) buildOutputCard(c *execCtx, idx int, tmpl string) map[string]an
 				card["markdown"] = md
 			}
 			if card["jsonSnapshot"] == nil && (card["markdown"] == nil || card["markdown"] == "") {
-				card["typeTag"] = "来源失败"
-				card["status"] = "failed"
-				card["errorReason"] = "结构化产物缺失或为空"
+				return markFailCard(card, failTitleMissingOut, "结构化产物缺失或为空"), true
 			}
-			return card
+			return card, true
 		}
 		if ref.outputKey == "content" || ref.outputKey == "page" {
 			md := models.VarDisplayText(val)
 			if strings.TrimSpace(md) == "" {
-				card["typeTag"] = "来源失败"
-				card["status"] = "failed"
-				card["errorReason"] = "文本输出为空"
-				return card
+				return markFailCard(card, failTitleMissingOut, "来源已执行完成但没有可供展示的产出"), true
 			}
 			if ref.outputKey == "page" {
 				card["typeTag"] = "自定义产物"
-				card["artifactName"] = "page.html"
+				card["artifactName"] = visualNodePageName(ref.nodeID)
 				card["markdown"] = md
 			} else {
 				card["typeTag"] = "Markdown"
 				card["markdown"] = md
 			}
-			return card
+			return card, true
 		}
 		md := models.VarDisplayText(val)
 		if strings.TrimSpace(md) == "" {
-			card["typeTag"] = "来源失败"
-			card["status"] = "failed"
-			card["errorReason"] = "来源内容为空"
-			return card
+			return markFailCard(card, failTitleMissingOut, "来源已执行完成但没有可供展示的产出"), true
 		}
 		card["typeTag"] = "Markdown"
 		card["markdown"] = md
-		return card
+		return card, true
 
 	case "artifact":
 		card["title"] = "产物 · " + ref.artifact
 		card["artifactName"] = ref.artifact
 		content, ok := e.store.Get(c.run.ID, ref.artifact)
 		if !ok || strings.TrimSpace(content) == "" {
-			card["typeTag"] = "来源失败"
-			card["status"] = "failed"
-			card["errorReason"] = fmt.Sprintf("产物 %q 不存在或为空", ref.artifact)
-			return card
+			return markFailCard(card, failTitleMissingOut, fmt.Sprintf("产物 %q 不存在或为空", ref.artifact)), true
 		}
 		if isKnownStructuredArtifact(ref.artifact) {
 			card["typeTag"] = "结构化产物"
 			card["structuredArtifactName"] = ref.artifact
 			card["jsonSnapshot"] = content
-			return card
+			return card, true
 		}
 		card["typeTag"] = "自定义产物"
-		return card
+		return card, true
 
 	default:
 		card["title"] = "自定义 · " + tmpl
-		card["typeTag"] = "来源失败"
-		card["status"] = "failed"
-		card["errorReason"] = "无法解析的来源模板"
-		return card
+		return markFailCard(card, failTitleMissingOut, "无法解析的来源模板"), true
 	}
 }
 
@@ -238,8 +276,12 @@ func isKnownStructuredArtifact(name string) bool {
 func (e *Engine) execOutput(c *execCtx, node *models.Node) nodeOutcome {
 	templates := resolveOutputResults(node.Config)
 	cards := make([]map[string]any, 0, len(templates))
-	for i, tmpl := range templates {
-		cards = append(cards, e.buildOutputCard(c, i+1, tmpl))
+	for _, tmpl := range templates {
+		card, include := e.buildOutputCard(c, len(cards)+1, tmpl)
+		if !include {
+			continue
+		}
+		cards = append(cards, card)
 	}
 	outputs := map[string]any{
 		"outputCards": cards,

--- a/server/internal/engine/output_test.go
+++ b/server/internal/engine/output_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/cocofhu/approving/internal/models"
@@ -121,5 +122,142 @@ func TestExecOutputEmptyResults(t *testing.T) {
 	cards, _ := sr.Outputs["outputCards"].([]any)
 	if len(cards) != 0 {
 		t.Errorf("expected 0 cards, got %d", len(cards))
+	}
+}
+
+func TestExecOutputHidesUnexecutedAndStaysCompleted(t *testing.T) {
+	g := models.Graph{
+		Nodes: []models.Node{
+			{ID: "input", Type: "input"},
+			{ID: "agent", Type: "agent", Label: "代码实现", Config: map[string]any{"skill_profile": "ImplementAgent"}},
+			{ID: "visual_l6zc", Type: "visual", Label: ""},
+			{ID: "output", Type: "output", Config: map[string]any{
+				"results": []any{
+					"{{nodes.agent.outputs.content}}",
+					"{{nodes.visual_l6zc.outputs.page}}",
+				},
+			}},
+		},
+		Edges: []models.Edge{
+			{ID: "e1", Source: "input", Target: "agent"},
+			{ID: "e2", Source: "agent", Target: "output"},
+		},
+	}
+	eng, db, _ := setupEngineGraphP(t, g)
+	run, err := eng.StartRun("wf", nil, "test")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitRunStatus(t, db, run.ID, "completed")
+
+	var sr models.StateRun
+	if err := db.Where("run_id = ? AND node_id = ?", run.ID, "output").First(&sr).Error; err != nil {
+		t.Fatal(err)
+	}
+	if sr.Status != "completed" {
+		t.Fatalf("output status = %q, hide must not fail the node (g1.3)", sr.Status)
+	}
+	cards, _ := sr.Outputs["outputCards"].([]any)
+	if len(cards) != 1 {
+		t.Fatalf("expected only executed source card, got %#v", cards)
+	}
+	c0, _ := cards[0].(map[string]any)
+	if c0["nodeId"] != "agent" || c0["status"] != "ok" {
+		t.Fatalf("kept card = %#v", c0)
+	}
+}
+
+func TestExecOutputAllHiddenStaysCompleted(t *testing.T) {
+	g := models.Graph{
+		Nodes: []models.Node{
+			{ID: "input", Type: "input"},
+			{ID: "visual_l6zc", Type: "visual"},
+			{ID: "output", Type: "output", Config: map[string]any{
+				"results": []any{"{{nodes.visual_l6zc.outputs.page}}"},
+			}},
+		},
+		Edges: []models.Edge{{ID: "e1", Source: "input", Target: "output"}},
+	}
+	eng, db, _ := setupEngineGraphP(t, g)
+	run, err := eng.StartRun("wf", nil, "test")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitRunStatus(t, db, run.ID, "completed")
+	var sr models.StateRun
+	if err := db.Where("run_id = ? AND node_id = ?", run.ID, "output").First(&sr).Error; err != nil {
+		t.Fatal(err)
+	}
+	if sr.Status != "completed" {
+		t.Fatalf("all-hidden output status = %q (g1.3)", sr.Status)
+	}
+	cards, _ := sr.Outputs["outputCards"].([]any)
+	if len(cards) != 0 {
+		t.Fatalf("all hidden should yield empty cards, got %#v", cards)
+	}
+}
+
+func TestExecOutputDualVisualIndependentPages(t *testing.T) {
+	g := models.Graph{
+		Nodes: []models.Node{
+			{ID: "input", Type: "input"},
+			{ID: "visual_a", Type: "visual", Label: "视觉A"},
+			{ID: "visual_b", Type: "visual", Label: "视觉B"},
+			{ID: "output", Type: "output", Config: map[string]any{
+				"results": []any{
+					"{{nodes.visual_a.outputs.page}}",
+					"{{nodes.visual_b.outputs.page}}",
+				},
+			}},
+		},
+		Edges: []models.Edge{
+			{ID: "e1", Source: "input", Target: "visual_a"},
+			{ID: "e2", Source: "visual_a", Target: "visual_b"},
+			{ID: "e3", Source: "visual_b", Target: "output"},
+		},
+	}
+	eng, db, fp := setupEngineGraphP(t, g)
+	fp.visualBodyByNode = map[string]string{
+		"visual_a": "<!doctype html><html><body><h1>page-a</h1></body></html>",
+		"visual_b": "<!doctype html><html><body><h1>page-b</h1></body></html>",
+	}
+	run, err := eng.StartRun("wf", nil, "test")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitRunStatus(t, db, run.ID, "completed")
+
+	var sr models.StateRun
+	if err := db.Where("run_id = ? AND node_id = ?", run.ID, "output").First(&sr).Error; err != nil {
+		t.Fatal(err)
+	}
+	cards, ok := sr.Outputs["outputCards"].([]any)
+	if !ok || len(cards) != 2 {
+		t.Fatalf("outputCards = %#v", sr.Outputs["outputCards"])
+	}
+	c0, _ := cards[0].(map[string]any)
+	c1, _ := cards[1].(map[string]any)
+	if c0["status"] != "ok" || c1["status"] != "ok" {
+		t.Fatalf("both visual cards should be ok: %#v %#v", c0, c1)
+	}
+	if c0["artifactName"] != "visual_a.page.html" || c1["artifactName"] != "visual_b.page.html" {
+		t.Fatalf("artifactName a=%v b=%v", c0["artifactName"], c1["artifactName"])
+	}
+	md0, _ := c0["markdown"].(string)
+	md1, _ := c1["markdown"].(string)
+	if md0 == md1 || !strings.Contains(md0, "page-a") || !strings.Contains(md1, "page-b") {
+		t.Fatalf("markdown snapshots must differ: %q / %q", md0, md1)
+	}
+	aHTML, okA := eng.store.Get(run.ID, "visual_a.page.html")
+	bHTML, okB := eng.store.Get(run.ID, "visual_b.page.html")
+	alias, okAlias := eng.store.Get(run.ID, "page.html")
+	if !okA || !okB || !okAlias {
+		t.Fatalf("expected alias + node copies: a=%v b=%v alias=%v", okA, okB, okAlias)
+	}
+	if aHTML == bHTML || !strings.Contains(aHTML, "page-a") || !strings.Contains(bHTML, "page-b") {
+		t.Fatalf("node-scoped HTML must stay independent: %q / %q", aHTML, bHTML)
+	}
+	if alias != bHTML {
+		t.Fatalf("page.html alias should be the later visual, got %q", alias)
 	}
 }

--- a/server/internal/engine/visual_test.go
+++ b/server/internal/engine/visual_test.go
@@ -38,6 +38,13 @@ func TestVisualNode(t *testing.T) {
 	if art.Kind != "html" {
 		t.Fatalf("artifact kind = %q, want html", art.Kind)
 	}
+	var nodeCopy models.Artifact
+	if err := db.Where("run_id = ? AND name = ?", run.ID, "page.page.html").First(&nodeCopy).Error; err != nil {
+		t.Fatalf("node-scoped page.page.html not stored: %v", err)
+	}
+	if nodeCopy.Kind != "html" || nodeCopy.NodeID != "page" {
+		t.Fatalf("node copy = kind=%q node=%q", nodeCopy.Kind, nodeCopy.NodeID)
+	}
 
 	// Missing page.html -> failed (no failure edge -> routeFailure ends failed).
 	eng2, db2, p2 := setupEngineGraphP(t, visualGraph())

--- a/web/e2e/output-visual-independence.spec.ts
+++ b/web/e2e/output-visual-independence.spec.ts
@@ -1,0 +1,299 @@
+/**
+ * Browser acceptance for multi-visual independence + unexecuted hide + distinguishable fail copy.
+ * Uses the existing run-completed-output deep-link harness (mocked API).
+ */
+import { test, expect, type Page } from '@playwright/test'
+import type { Artifact, OutputCard } from '../src/lib/shared/types'
+
+const nodes = [
+  { id: 'start', type: 'input', label: '开始', position: { x: 0, y: 0 }, config: {} },
+  { id: 'visual_a', type: 'visual', label: '视觉网页', position: { x: 180, y: 0 }, config: {} },
+  { id: 'visual_l6zc', type: 'visual', label: '', position: { x: 360, y: 0 }, config: {} },
+  { id: 'end', type: 'output', label: '结束', position: { x: 540, y: 0 }, config: {} },
+]
+
+const pageA = `<!doctype html><html><body><h1 id="mark-a">page-a-workflow-shell</h1></body></html>`
+const pageB = `<!doctype html><html><body><h1 id="mark-b">page-b-artifact-density</h1></body></html>`
+
+function visualCard(partial: Partial<OutputCard> & Pick<OutputCard, 'index' | 'title' | 'artifactName' | 'nodeId'>): OutputCard {
+  return {
+    template: `{{nodes.${partial.nodeId}.outputs.page}}`,
+    typeTag: '自定义产物',
+    status: 'ok',
+    outputKey: 'page',
+    ...partial,
+  }
+}
+
+function mockRun(cards: OutputCard[], artifacts: Artifact[]) {
+  return {
+    id: 'run-completed-e2e',
+    workflowId: 'wf-completed-e2e',
+    workflowName: '自我迭代',
+    workflowVersion: 1,
+    status: 'completed',
+    trigger: 'manual',
+    startedAt: '2026-08-01T00:00:00Z',
+    durationSec: 120,
+    progress: 1,
+    nodeRuns: {
+      start: { nodeId: 'start', status: 'completed', startedAt: '2026-08-01T00:00:00Z', outputs: {} },
+      visual_a: {
+        nodeId: 'visual_a',
+        status: 'completed',
+        startedAt: '2026-08-01T00:01:00Z',
+        outputs: { page: pageA },
+      },
+      end: {
+        nodeId: 'end',
+        status: 'completed',
+        startedAt: '2026-08-01T00:02:00Z',
+        outputs: { outputCards: cards },
+      },
+    },
+    nodeExecutions: {},
+    artifacts,
+    trace: [],
+    vars: [],
+    nodes,
+    edges: [
+      { id: 'e1', source: 'start', target: 'visual_a' },
+      { id: 'e2', source: 'visual_a', target: 'end' },
+    ],
+  }
+}
+
+async function mockApi(
+  page: Page,
+  cards: OutputCard[],
+  artifacts: Artifact[],
+  contents: Record<string, string>,
+  fetchedIds?: string[],
+) {
+  const run = mockRun(cards, artifacts)
+  await page.route('**/api/runs/**', async (route) => {
+    const url = new URL(route.request().url())
+    if (url.pathname.endsWith('/events')) {
+      await route.fulfill({ json: { events: [], nextCursor: '', hasMore: false, live: false } })
+      return
+    }
+    if (url.pathname.endsWith('/sandbox-log') || url.pathname.includes('/sandbox')) {
+      await route.fulfill({ json: { content: '', live: false, found: false } })
+      return
+    }
+    if (url.pathname.includes('/runs/run-completed-e2e')) {
+      await route.fulfill({ json: run })
+      return
+    }
+    await route.fulfill({ status: 404, json: { error: 'not mocked' } })
+  })
+  await page.route('**/api/workflows/**', async (route) => {
+    await route.fulfill({
+      json: { id: 'wf-completed-e2e', name: '自我迭代', status: 'published', version: 1, nodes, edges: [] },
+    })
+  })
+  await page.route('**/api/artifacts/**', async (route) => {
+    const url = new URL(route.request().url())
+    const match = url.pathname.match(/\/artifacts\/([^/]+)\/content$/)
+    if (match) fetchedIds?.push(match[1])
+    if (match && contents[match[1]] != null) {
+      await route.fulfill({ json: { id: match[1], content: contents[match[1]] } })
+      return
+    }
+    await route.fulfill({ status: 404, json: { error: 'not mocked' } })
+  })
+}
+
+async function openOutput(
+  page: Page,
+  cards: OutputCard[],
+  artifacts: Artifact[] = [],
+  contents: Record<string, string> = {},
+  fetchedIds?: string[],
+) {
+  await page.setViewportSize({ width: 1280, height: 900 })
+  await mockApi(page, cards, artifacts, contents, fetchedIds)
+  await page.goto('/run-completed-output.html?node=end&tab=output')
+  await expect(page.getByTestId('run-detail-root')).toBeVisible({ timeout: 15_000 })
+}
+
+test.describe('运行产出：未执行隐藏 + 多视觉独立 + 可区分失败', () => {
+  test('未执行 visual_l6zc 不出卡，列表无误报失败文案', async ({ page }) => {
+    await openOutput(page, [
+      visualCard({
+        index: 1,
+        title: '网页预览 · 视觉网页',
+        artifactName: 'visual_a.page.html',
+        nodeId: 'visual_a',
+        markdown: pageA,
+      }),
+    ])
+    await expect(page.getByTestId('output-result-cards')).toBeVisible()
+    await expect(page.getByTestId('output-result-list')).toHaveCount(0)
+    await expect(page.getByTestId('output-result-detail-bar')).toContainText('网页预览 · 视觉网页')
+    await expect(page.getByTestId('run-detail-right-panel')).not.toContainText('网页预览 · visual_l6zc')
+    await expect(page.getByTestId('run-detail-right-panel')).not.toContainText('来源节点失败 / 无产物')
+    await expect(page.getByTestId('run-detail-right-panel')).not.toContainText('上游节点无输出')
+    await page.screenshot({ path: '/tmp/e2e-hide-unexecuted.png', fullPage: true })
+  })
+
+  test('全部隐藏时空态不算失败', async ({ page }) => {
+    await openOutput(page, [])
+    await expect(page.getByTestId('node-output-empty')).toBeVisible()
+    await expect(page.getByTestId('node-output-empty')).toContainText('本次没有可预览的结果卡')
+    await expect(page.getByTestId('node-output-empty')).toContainText('这不是加载失败')
+    await expect(page.getByTestId('run-detail-right-panel')).not.toContainText('来源节点失败 / 无产物')
+    await expect(page.getByTestId('run-detail-right-panel')).not.toContainText('上游节点无输出')
+    await page.screenshot({ path: '/tmp/e2e-all-hidden-empty.png', fullPage: true })
+  })
+
+  test('双视觉卡预览 HTML 不同且不读全局 page.html', async ({ page }) => {
+    const cards: OutputCard[] = [
+      visualCard({
+        index: 1,
+        title: '网页预览 · 视觉网页',
+        artifactName: 'visual_a.page.html',
+        nodeId: 'visual_a',
+        markdown: pageA,
+      }),
+      visualCard({
+        index: 2,
+        title: '网页预览 · visual_l6zc',
+        artifactName: 'visual_l6zc.page.html',
+        nodeId: 'visual_l6zc',
+        markdown: pageB,
+      }),
+    ]
+    const artifacts: Artifact[] = [
+      {
+        id: 'a-global',
+        name: 'page.html',
+        kind: 'html',
+        nodeId: 'visual_l6zc',
+        runId: 'run-completed-e2e',
+        workflowName: '自我迭代',
+        sizeBytes: pageB.length,
+        createdAt: '2026-08-01T00:00:00Z',
+      },
+      {
+        id: 'a-va',
+        name: 'visual_a.page.html',
+        kind: 'html',
+        nodeId: 'visual_a',
+        runId: 'run-completed-e2e',
+        workflowName: '自我迭代',
+        sizeBytes: pageA.length,
+        createdAt: '2026-08-01T00:00:00Z',
+      },
+      {
+        id: 'a-vb',
+        name: 'visual_l6zc.page.html',
+        kind: 'html',
+        nodeId: 'visual_l6zc',
+        runId: 'run-completed-e2e',
+        workflowName: '自我迭代',
+        sizeBytes: pageB.length,
+        createdAt: '2026-08-01T00:00:00Z',
+      },
+    ]
+    const fetched: string[] = []
+    await openOutput(page, cards, artifacts, { 'a-va': pageA, 'a-vb': pageB, 'a-global': '<html>WRONG-GLOBAL</html>' }, fetched)
+
+    await expect(page.getByTestId('output-result-list')).toBeVisible()
+    await expect(page.getByTestId('output-result-card-toggle-0')).toContainText('网页预览 · 视觉网页')
+    await expect(page.getByTestId('output-result-card-toggle-1')).toContainText('网页预览 · visual_l6zc')
+    await expect(page.getByTestId('output-result-list-kind-0')).toHaveText('HTML')
+    await expect(page.getByTestId('output-result-list-kind-1')).toHaveText('HTML')
+
+    const iframe0 = page.locator('iframe').first()
+    await expect(iframe0).toBeVisible()
+    await expect.poll(async () => iframe0.getAttribute('sandbox')).toBe('allow-scripts allow-forms')
+    await expect.poll(async () => iframe0.getAttribute('sandbox')).not.toContain('allow-same-origin')
+    await expect.poll(async () => {
+      return iframe0.evaluate((el) => (el as HTMLIFrameElement).srcdoc || '')
+    }).toContain('page-a-workflow-shell')
+    await expect.poll(async () => {
+      return iframe0.evaluate((el) => (el as HTMLIFrameElement).srcdoc || '')
+    }).not.toContain('page-b-artifact-density')
+    await expect.poll(async () => {
+      return iframe0.evaluate((el) => (el as HTMLIFrameElement).srcdoc || '')
+    }).not.toContain('WRONG-GLOBAL')
+    await page.screenshot({ path: '/tmp/e2e-dual-visual-a.png', fullPage: true })
+
+    await page.getByTestId('output-result-card-toggle-1').click()
+    const iframe1 = page.locator('iframe').first()
+    await expect.poll(async () => {
+      return iframe1.evaluate((el) => (el as HTMLIFrameElement).srcdoc || '')
+    }).toContain('page-b-artifact-density')
+    await expect.poll(async () => {
+      return iframe1.evaluate((el) => (el as HTMLIFrameElement).srcdoc || '')
+    }).not.toContain('page-a-workflow-shell')
+    await expect.poll(async () => iframe1.getAttribute('sandbox')).toBe('allow-scripts allow-forms')
+    await page.screenshot({ path: '/tmp/e2e-dual-visual-b.png', fullPage: true })
+
+    expect(fetched).toContain('a-va')
+    expect(fetched).toContain('a-vb')
+    expect(fetched).not.toContain('a-global')
+  })
+
+  test('真实缺页失败卡标题为缺少可展示产出', async ({ page }) => {
+    await openOutput(page, [
+      visualCard({
+        index: 1,
+        title: '网页预览 · 视觉网页',
+        artifactName: 'visual_a.page.html',
+        nodeId: 'visual_a',
+        markdown: pageA,
+      }),
+      {
+        index: 2,
+        template: '{{nodes.visual_l6zc.outputs.page}}',
+        title: '网页预览 · visual_l6zc',
+        typeTag: '来源失败',
+        status: 'failed',
+        nodeId: 'visual_l6zc',
+        outputKey: 'page',
+        failTitle: '缺少可展示产出',
+        errorReason: '来源已执行完成但没有可供展示的产出',
+      },
+    ])
+    await page.getByTestId('output-result-card-toggle-1').click()
+    await expect(page.getByTestId('output-result-fail-title')).toHaveText('缺少可展示产出')
+    await expect(page.getByTestId('output-result-card-body-1')).toContainText('来源已执行完成但没有可供展示的产出')
+    await expect(page.getByTestId('run-detail-right-panel')).not.toContainText('来源节点失败 / 无产物')
+    await expect(page.getByTestId('run-detail-right-panel')).not.toContainText('上游节点无输出')
+    await page.screenshot({ path: '/tmp/e2e-real-missing-page.png', fullPage: true })
+  })
+
+  test('来源状态失败与取消文案可区分', async ({ page }) => {
+    await openOutput(page, [
+      {
+        index: 1,
+        template: '{{nodes.visual_l6zc.outputs.page}}',
+        title: '网页预览 · visual_l6zc',
+        typeTag: '来源失败',
+        status: 'failed',
+        nodeId: 'visual_l6zc',
+        failTitle: '来源状态失败',
+        errorReason: '上游节点状态：failed',
+      },
+      {
+        index: 2,
+        template: '{{nodes.visual_a.outputs.page}}',
+        title: '网页预览 · 视觉网页',
+        typeTag: '来源失败',
+        status: 'failed',
+        nodeId: 'visual_a',
+        failTitle: '来源已取消',
+        errorReason: '上游节点状态：cancelled',
+      },
+    ])
+    await expect(page.getByTestId('output-result-fail-title')).toHaveText('来源状态失败')
+    await expect(page.getByTestId('output-result-card-body-0')).toContainText('上游节点状态：failed')
+    await page.screenshot({ path: '/tmp/e2e-source-failed.png', fullPage: true })
+    await page.getByTestId('output-result-card-toggle-1').click()
+    await expect(page.getByTestId('output-result-fail-title')).toHaveText('来源已取消')
+    await expect(page.getByTestId('output-result-card-body-1')).toContainText('上游节点状态：cancelled')
+    await page.screenshot({ path: '/tmp/e2e-source-cancelled.png', fullPage: true })
+  })
+})

--- a/web/src/components/run/OutputResultCardBody.vue
+++ b/web/src/components/run/OutputResultCardBody.vue
@@ -28,11 +28,17 @@ const isCustomHtml = computed(
   () => props.card.typeTag === '自定义产物' && isHtmlArtifact(props.card.artifactName),
 )
 
-/** Prefer fetched artifact body; fall back to inline markdown (HTML from node output). */
+/**
+ * Prefer the card's outputs.page snapshot for visual pages so two cards never
+ * share a stale global page.html fetch. Otherwise use the artifact loaded by
+ * artifactName + nodeId, then markdown.
+ */
 const htmlBody = computed(() => {
+  const fromMd = props.card.markdown?.trim() ?? ''
+  if (fromMd && props.card.outputKey === 'page') return fromMd
   const fromArt = props.artifactHtml?.trim() ?? ''
   if (fromArt) return fromArt
-  return props.card.markdown?.trim() ?? ''
+  return fromMd
 })
 
 /**
@@ -53,7 +59,9 @@ const htmlPreviewState = computed<'loading' | 'unavailable' | 'ready'>(() => {
 <template>
   <template v-if="card.status === 'failed'">
     <p class="text-[12px] text-txt2">
-      <strong class="text-err">{{ t('pages.nodeOutput.outputCards.sourceFailedTitle') }}</strong><br />
+      <strong class="text-err" data-testid="output-result-fail-title">{{
+        card.failTitle || t('pages.nodeOutput.outputCards.sourceFailedTitle')
+      }}</strong><br />
       {{ card.errorReason || t('pages.nodeOutput.outputCards.invalidSource') }}
     </p>
   </template>

--- a/web/src/components/run/OutputResultCards.test.ts
+++ b/web/src/components/run/OutputResultCards.test.ts
@@ -386,6 +386,124 @@ describe('OutputResultCards master-detail list + enlarge (g4.1)', () => {
     wrapper.unmount()
   })
 
+  it('failed card uses server failTitle instead of hardcoded 来源节点失败 / 无产物 (g3.1)', async () => {
+    const wrapper = mountCards([
+      {
+        index: 1,
+        template: '{{nodes.visual.outputs.page}}',
+        title: '网页预览 · 视觉网页',
+        status: 'failed',
+        typeTag: '来源失败',
+        failTitle: '缺少可展示产出',
+        errorReason: '来源已执行完成但没有可供展示的产出',
+      },
+    ])
+    await flushPromises()
+    expect(wrapper.get('[data-testid="output-result-fail-title"]').text()).toBe('缺少可展示产出')
+    expect(wrapper.text()).toContain('来源已执行完成但没有可供展示的产出')
+    expect(wrapper.text()).not.toContain('来源节点失败 / 无产物')
+    expect(wrapper.text()).not.toContain('上游节点无输出')
+    wrapper.unmount()
+  })
+
+  it('loads HTML by artifactName + nodeId; two visual cards stay independent (g3.2)', async () => {
+    apiMocks.artifactContent.mockImplementation(async (id: string) => {
+      if (id === 'a-va') return { content: '<html>from-art-a</html>' }
+      if (id === 'a-vb') return { content: '<html>from-art-b</html>' }
+      return { content: '<html>WRONG-GLOBAL</html>' }
+    })
+    const dualRun = {
+      ...run,
+      artifacts: [
+        {
+          id: 'a-global',
+          name: 'page.html',
+          kind: 'html',
+          nodeId: 'visual_b',
+          runId: 'run-1',
+          workflowName: 'wf',
+          sizeBytes: 8,
+          createdAt: '2026-07-18T00:00:00Z',
+        },
+        {
+          id: 'a-va',
+          name: 'visual_a.page.html',
+          kind: 'html',
+          nodeId: 'visual_a',
+          runId: 'run-1',
+          workflowName: 'wf',
+          sizeBytes: 8,
+          createdAt: '2026-07-18T00:00:00Z',
+        },
+        {
+          id: 'a-vb',
+          name: 'visual_b.page.html',
+          kind: 'html',
+          nodeId: 'visual_b',
+          runId: 'run-1',
+          workflowName: 'wf',
+          sizeBytes: 8,
+          createdAt: '2026-07-18T00:00:00Z',
+        },
+      ],
+    } as Run
+    const dual: OutputCard[] = [
+      {
+        index: 1,
+        template: '{{nodes.visual_a.outputs.page}}',
+        title: '网页预览 · 视觉A',
+        status: 'ok',
+        typeTag: '自定义产物',
+        artifactName: 'visual_a.page.html',
+        nodeId: 'visual_a',
+        outputKey: 'page',
+        markdown: '<!doctype html><html><body><h1>snap-a</h1></body></html>',
+      },
+      {
+        index: 2,
+        template: '{{nodes.visual_b.outputs.page}}',
+        title: '网页预览 · 视觉B',
+        status: 'ok',
+        typeTag: '自定义产物',
+        artifactName: 'visual_b.page.html',
+        nodeId: 'visual_b',
+        outputKey: 'page',
+        markdown: '<!doctype html><html><body><h1>snap-b</h1></body></html>',
+      },
+    ]
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const wrapper = mount(OutputResultCards, {
+      props: { cards: dual, run: dualRun },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          StructuredArtifactView: StructuredStub,
+          HtmlPreview: HtmlPreviewStub,
+          AppModal: AppModalStub,
+          Icon: true,
+        },
+      },
+    })
+    await flushPromises()
+    const first = wrapper.getComponent({ name: 'HtmlPreview' })
+    expect(first.props('html')).toContain('snap-a')
+    expect(first.props('html')).not.toContain('snap-b')
+    expect(first.props('html')).not.toContain('WRONG-GLOBAL')
+    await wrapper.get('[data-testid="output-result-card-toggle-1"]').trigger('click')
+    await flushPromises()
+    const second = wrapper.getComponent({ name: 'HtmlPreview' })
+    expect(second.props('html')).toContain('snap-b')
+    expect(second.props('html')).not.toContain('snap-a')
+    expect(apiMocks.artifactContent).toHaveBeenCalledWith('a-va')
+    expect(apiMocks.artifactContent).toHaveBeenCalledWith('a-vb')
+    expect(apiMocks.artifactContent).not.toHaveBeenCalledWith('a-global')
+    wrapper.unmount()
+  })
+
   it('custom HTML uses markdown fallback when artifact missing (no source leak)', async () => {
     const pageOnlyMd: OutputCard = {
       index: 1,

--- a/web/src/components/run/OutputResultCards.vue
+++ b/web/src/components/run/OutputResultCards.vue
@@ -20,23 +20,41 @@ const contentCache = ref<Record<string, string>>({})
 const loadErrors = ref<Record<string, boolean>>({})
 const loading = ref(false)
 
-async function loadArtifactContent(name: string) {
-  if (contentCache.value[name] !== undefined) return
-  const art = props.run.artifacts.find((a) => a.name === name)
+function artifactCacheKey(card: OutputCard): string {
+  return `${card.nodeId || ''}:${card.artifactName || ''}`
+}
+
+function findCardArtifact(card: OutputCard) {
+  const name = card.artifactName
+  if (!name) return undefined
+  const matches = props.run.artifacts.filter((a) => a.name === name)
+  if (card.nodeId) {
+    const scoped = matches.find((a) => a.nodeId === card.nodeId)
+    if (scoped) return scoped
+  }
+  return matches[0]
+}
+
+async function loadArtifactContent(card: OutputCard) {
+  const name = card.artifactName
+  if (!name) return
+  const key = artifactCacheKey(card)
+  if (contentCache.value[key] !== undefined) return
+  const art = findCardArtifact(card)
   if (!art) {
-    contentCache.value[name] = ''
+    contentCache.value[key] = ''
     // Not a fetch error — node markdown may still render via HtmlPreview.
-    loadErrors.value[name] = false
+    loadErrors.value[key] = false
     return
   }
   loading.value = true
   try {
     const full = await api.artifactContent(art.id)
-    contentCache.value[name] = full.content ?? ''
-    loadErrors.value[name] = false
+    contentCache.value[key] = full.content ?? ''
+    loadErrors.value[key] = false
   } catch {
-    contentCache.value[name] = ''
-    loadErrors.value[name] = true
+    contentCache.value[key] = ''
+    loadErrors.value[key] = true
   } finally {
     loading.value = false
   }
@@ -55,7 +73,7 @@ watch(
   () => {
     const c = props.cards[selectedIndex.value]
     if (c?.typeTag === '自定义产物' && c.artifactName && !c.structuredArtifactName) {
-      void loadArtifactContent(c.artifactName)
+      void loadArtifactContent(c)
     }
   },
   { immediate: true },
@@ -96,8 +114,9 @@ function hasRenderableBody(card: OutputCard | undefined): boolean {
 
 const canEnlarge = computed(() => hasRenderableBody(currentCard.value))
 
-function artifactContent(name: string): string {
-  return contentCache.value[name] ?? ''
+function artifactContent(card: OutputCard | undefined): string {
+  if (!card?.artifactName) return ''
+  return contentCache.value[artifactCacheKey(card)] ?? ''
 }
 
 function isHtmlArtifact(name?: string): boolean {
@@ -125,8 +144,9 @@ function detailKindLabel(card: OutputCard): string {
   return card.typeTag
 }
 
-function artifactLoadError(name?: string): boolean {
-  return !!name && !!loadErrors.value[name]
+function artifactLoadError(card: OutputCard | undefined): boolean {
+  if (!card?.artifactName) return false
+  return !!loadErrors.value[artifactCacheKey(card)]
 }
 
 function openEnlarge() {
@@ -221,8 +241,8 @@ function closeEnlarge() {
           :run="run"
           :doc="currentDoc"
           :loading="loading"
-          :artifact-html="currentCard.artifactName ? artifactContent(currentCard.artifactName) : ''"
-          :artifact-load-error="artifactLoadError(currentCard.artifactName)"
+          :artifact-html="artifactContent(currentCard)"
+          :artifact-load-error="artifactLoadError(currentCard)"
           variant="detail"
         />
       </div>
@@ -241,8 +261,8 @@ function closeEnlarge() {
           :run="run"
           :doc="currentDoc"
           :loading="loading"
-          :artifact-html="currentCard.artifactName ? artifactContent(currentCard.artifactName) : ''"
-          :artifact-load-error="artifactLoadError(currentCard.artifactName)"
+          :artifact-html="artifactContent(currentCard)"
+          :artifact-load-error="artifactLoadError(currentCard)"
           variant="enlarge"
         />
       </div>

--- a/web/src/components/run/UpstreamRequirementContext.test.ts
+++ b/web/src/components/run/UpstreamRequirementContext.test.ts
@@ -370,7 +370,7 @@ describe('UpstreamRequirementContext', () => {
     expect(wrapper.find('[data-testid="upstream-modal-callout"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="upstream-bar-hint"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="upstream-bar-hint"]').text()).toContain(
-      '本 run 已有澄清需求文档',
+      '本工作流已有澄清需求文档',
     )
     wrapper.unmount()
   })

--- a/web/src/lib/shared/types.ts
+++ b/web/src/lib/shared/types.ts
@@ -396,6 +396,8 @@ export interface OutputCard {
   typeTag: OutputCardTypeTag
   status: 'ok' | 'failed'
   errorReason?: string
+  /** Server-issued fail heading (e.g. 缺少可展示产出 / 来源状态失败). */
+  failTitle?: string
   /** Parsed JSON snapshot for structured framework products. */
   jsonSnapshot?: string
   /** Markdown body for agent content or rendered structured product. */


### PR DESCRIPTION
- **fix: hide unexecuted output sources and keep visual previews independent**
- **test: add browser e2e for independent visual previews**
