### PR TITLE
feat(web): paginate the notifications inbox at 20 items per page

### DIFF
--- a/web/e2e/notifications-center-main.ts
+++ b/web/e2e/notifications-center-main.ts
@@ -208,11 +208,24 @@ const cappedItems = Array.from({ length: 7 }, (_, i) =>
   }),
 )
 
+/** 25 post-baseline items → independent page has 2 pages (20 + 5). */
+const pagedItems = Array.from({ length: 25 }, (_, i) =>
+  makeRun({
+    id: `run-page-${i}`,
+    status: i === 0 ? 'failed' : 'completed',
+    title: `分页条目 ${i}`,
+    workflowName: '自我迭代',
+    startedAt: `2026-08-10T${String(8 + Math.floor(i / 10)).padStart(2, '0')}:${String((i * 2) % 60).padStart(2, '0')}:00Z`,
+    durationSec: 30,
+  }),
+)
+
 function poolForScene() {
   if (scene === 'empty') return []
   if (scene === 'history-only') return historyItems
   if (scene === 'post-enable') return [...postEnableItems, ...historyItems]
   if (scene === 'capped') return cappedItems
+  if (scene === 'paged') return pagedItems
   return postEnableItems
 }
 
@@ -292,7 +305,7 @@ async function bootstrap() {
 
   // Seed enable baseline: for post-enable / with-items / capped, baseline in past so items unread;
   // for history-only, leave unset so first enable treats history as read.
-  if (scene === 'post-enable' || scene === 'with-items' || scene === 'capped') {
+  if (scene === 'post-enable' || scene === 'with-items' || scene === 'capped' || scene === 'paged') {
     localStorage.setItem(
       'approving.notifications.prefs.e2e',
       JSON.stringify({ enabledAt: '2020-01-01T00:00:00Z', readIds: [] }),

--- a/web/e2e/notifications-center.spec.ts
+++ b/web/e2e/notifications-center.spec.ts
@@ -113,13 +113,12 @@ test.describe('shell notification center (IA separation)', () => {
   test('completed click opens output without marking read; mark-as-read then clears badge', async ({
     page,
   }) => {
-    await page.goto('/notifications-center.html?scene=with-items')
-    await expect(page.getByTestId('shell-main-dashboard')).toBeVisible({ timeout: 15_000 })
+    await page.goto('/notifications-center.html?scene=with-items&start=notifications')
+    await expect(page.getByTestId('notifications-page')).toBeVisible({ timeout: 15_000 })
     await settleAuth(page)
     await expect(page.getByTestId('run-notifications-badge')).toHaveText('3')
-    await page.getByTestId('run-notifications-bell').click()
     await page
-      .locator('[data-testid="run-notifications-item"][data-status="completed"]')
+      .locator('[data-testid="notifications-item"][data-status="completed"]')
       .first()
       .click()
     // run-new-ok has outputCards → result-cards path (not legacy artifact deck)
@@ -140,13 +139,12 @@ test.describe('shell notification center (IA separation)', () => {
   test('completed without outputCards shows empty dual exits, not full artifact list', async ({
     page,
   }) => {
-    await page.goto('/notifications-center.html?scene=with-items')
-    await expect(page.getByTestId('shell-main-dashboard')).toBeVisible({ timeout: 15_000 })
+    await page.goto('/notifications-center.html?scene=with-items&start=notifications')
+    await expect(page.getByTestId('notifications-page')).toBeVisible({ timeout: 15_000 })
     await settleAuth(page)
-    await page.getByTestId('run-notifications-bell').click()
     // Second completed item is run-clean (empty cards)
     await page
-      .locator('[data-testid="run-notifications-item"][data-status="completed"]')
+      .locator('[data-testid="notifications-item"][data-status="completed"]')
       .nth(1)
       .click()
     const empty = page.getByTestId('run-output-empty')
@@ -168,5 +166,47 @@ test.describe('shell notification center (IA separation)', () => {
     await expect(page.getByText('e2e', { exact: true })).toBeVisible({ timeout: 15_000 })
     // Must not under-count until focus/15s poll — auth watch rehydrates prefs sync.
     await expect(page.getByTestId('run-notifications-badge')).toHaveText('3', { timeout: 5_000 })
+  })
+
+  test('independent page paginates at 20; filter and topbar entry reset to page 1 (g4.3)', async ({
+    page,
+  }) => {
+    await page.goto('/notifications-center.html?scene=paged&start=notifications')
+    await expect(page.getByTestId('notifications-page')).toBeVisible({ timeout: 15_000 })
+    await settleAuth(page)
+
+    await expect(page.getByTestId('notifications-item')).toHaveCount(20)
+    await expect(page.getByTestId('notifications-page-range')).toContainText('第 1 页 · 1–20 / 25')
+    const pager = page.getByTestId('notifications-pagination')
+    await expect(pager).toBeVisible()
+    await expect(page.getByTestId('notifications-pager-summary')).toHaveText('共 25 条 · 每页 20')
+
+    await pager.getByRole('button', { name: '下一页' }).click()
+    await expect(page.getByTestId('notifications-item')).toHaveCount(5)
+    await expect(page.getByTestId('notifications-page-range')).toContainText('第 2 页 · 21–25 / 25')
+    await expect(page).not.toHaveURL(/[?&]page=/)
+
+    await page.getByTestId('notifications-filter-read').click()
+    await expect(page.getByTestId('notifications-pagination')).toHaveCount(0)
+    await expect(page.getByTestId('notifications-page-range')).toHaveCount(0)
+
+    await page.getByTestId('notifications-filter-all').click()
+    await expect(page.getByTestId('notifications-item')).toHaveCount(20)
+    await expect(page.getByTestId('notifications-page-range')).toContainText('第 1 页')
+
+    await pager.getByRole('button', { name: '下一页' }).click()
+    await expect(page.getByTestId('notifications-page-range')).toContainText('第 2 页')
+    await page.getByTestId('run-notifications-bell').click()
+    await expect(page.getByTestId('run-notifications-item')).toHaveCount(5)
+    await page.getByTestId('run-notifications-view-all').click()
+    await expect(page.getByTestId('notifications-page-range')).toContainText('第 1 页 · 1–20 / 25')
+    await expect(page.getByTestId('notifications-item')).toHaveCount(20)
+
+    await pager.getByRole('button', { name: '下一页' }).click()
+    await page.getByTestId('run-notifications-bell').click()
+    await page.getByTestId('run-notifications-item').first().click()
+    await expect(page.getByTestId('notifications-page')).toBeVisible()
+    await expect(page.getByTestId('notifications-page-range')).toContainText('第 1 页')
+    await expect(page.getByTestId('notifications-item')).toHaveCount(20)
   })
 })

--- a/web/src/components/run/UpstreamRequirementContext.test.ts
+++ b/web/src/components/run/UpstreamRequirementContext.test.ts
@@ -370,7 +370,7 @@ describe('UpstreamRequirementContext', () => {
     expect(wrapper.find('[data-testid="upstream-modal-callout"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="upstream-bar-hint"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="upstream-bar-hint"]').text()).toContain(
-      '本 run 已有澄清需求文档',
+      '本工作流已有澄清需求文档',
     )
     wrapper.unmount()
   })

--- a/web/src/components/shell/AppTopbar.test.ts
+++ b/web/src/components/shell/AppTopbar.test.ts
@@ -38,6 +38,7 @@ vi.mock('@/lib/api/api', () => ({
 }))
 
 import { api } from '@/lib/api/api'
+import { __resetNotificationsPageEntryForTests } from '@/lib/composables/useNotificationsPageEntry'
 import {
   __resetRunTerminalNotificationsForTests,
   prefsKeyForUser,
@@ -92,6 +93,7 @@ describe('AppTopbar notifications', () => {
   beforeEach(() => {
     localStorage.clear()
     __resetRunTerminalNotificationsForTests()
+    __resetNotificationsPageEntryForTests()
     push.mockReset()
     vi.mocked(api.listRuns).mockReset()
     vi.mocked(api.getRun).mockReset()
@@ -113,6 +115,7 @@ describe('AppTopbar notifications', () => {
 
   afterEach(() => {
     __resetRunTerminalNotificationsForTests()
+    __resetNotificationsPageEntryForTests()
   })
 
   it('renders header with theme toggle and bell aria titled 通知', async () => {
@@ -208,24 +211,26 @@ describe('AppTopbar notifications', () => {
     wrapper.unmount()
   })
 
-  it('clicking failed item marks read and navigates to run detail without output modal', async () => {
+  it('clicking a preview item enters /notifications page 1 without locating (g3.2)', async () => {
     seedBaseline()
     vi.mocked(api.listRuns).mockResolvedValue(
       paged([run({ id: 'fail-1', status: 'failed', title: 'boom' })]),
     )
     const wrapper = mountTopbar()
     await flushPromises()
+    expect(wrapper.find('[data-testid="run-notifications-badge"]').text()).toBe('1')
     await wrapper.find('[data-testid="run-notifications-bell"]').trigger('click')
     await nextTick()
     await wrapper.find('[data-testid="run-notifications-item"]').trigger('click')
     await flushPromises()
-    expect(push).toHaveBeenCalledWith('/runs/fail-1')
-    expect(wrapper.find('[data-testid="run-notifications-badge"]').exists()).toBe(false)
+    expect(push).toHaveBeenCalledWith({ path: '/notifications' })
+    expect(push).not.toHaveBeenCalledWith('/runs/fail-1')
+    expect(wrapper.find('[data-testid="run-notifications-badge"]').text()).toBe('1')
     expect(wrapper.find('[data-testid="run-output-empty"]').exists()).toBe(false)
     wrapper.unmount()
   })
 
-  it('clicking completed item opens output modal without marking read (g2.1)', async () => {
+  it('clicking completed preview also goes to /notifications and does not open output modal (g3.2)', async () => {
     seedBaseline()
     vi.mocked(api.listRuns).mockResolvedValue(
       paged([run({ id: 'ok-1', status: 'completed', title: 'done' })]),
@@ -260,175 +265,10 @@ describe('AppTopbar notifications', () => {
     await wrapper.find('[data-testid="run-notifications-item"]').trigger('click')
     await flushPromises()
     await nextTick()
-    expect(push).not.toHaveBeenCalled()
-    expect(api.getRun).toHaveBeenCalledWith('ok-1')
-    expect(wrapper.vm.outputOpen).toBe(true)
-    expect(wrapper.vm.outputRunId).toBe('ok-1')
-    await vi.waitFor(() => {
-      expect(document.body.querySelector('[data-testid="run-output-empty"]')).toBeTruthy()
-    })
-    const emptyText = document.body.querySelector('[data-testid="run-output-empty"]')?.textContent || ''
-    expect(emptyText).toContain('暂无最终结果可预览')
-    expect(emptyText).not.toContain('node_complete.json')
-    expect(document.body.querySelector('[data-testid="run-output-empty-open-artifacts"]')).toBeTruthy()
-    expect(document.body.querySelector('[data-testid="run-output-list"]')).toBeNull()
-    // Opening must NOT clear unread (g2.1 / f3)
-    expect(wrapper.find('[data-testid="run-notifications-badge"]').exists()).toBe(true)
+    expect(push).toHaveBeenCalledWith({ path: '/notifications' })
+    expect(api.getRun).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="run-output-empty"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="run-notifications-badge"]').text()).toBe('1')
-    wrapper.unmount()
-  })
-
-  it('mark-as-read marks read and closes modal; Esc close keeps unread (g3.2)', async () => {
-    seedBaseline()
-    vi.mocked(api.listRuns).mockResolvedValue(
-      paged([run({ id: 'ok-1', status: 'completed', title: 'done' })]),
-    )
-    vi.mocked(api.getRun).mockResolvedValue(
-      run({ id: 'ok-1', status: 'completed', artifacts: [] }),
-    )
-    const wrapper = mountTopbar()
-    await flushPromises()
-    await wrapper.find('[data-testid="run-notifications-bell"]').trigger('click')
-    await nextTick()
-    await wrapper.find('[data-testid="run-notifications-item"]').trigger('click')
-    await flushPromises()
-    await vi.waitFor(() => {
-      expect(document.body.querySelector('[data-testid="run-output-mark-read"]')).toBeTruthy()
-    })
-    expect(wrapper.find('[data-testid="run-notifications-badge"]').text()).toBe('1')
-
-    // Passive close via AppModal close (Esc/X/mask) keeps unread
-    const modal = wrapper.findComponent({ name: 'AppModal' })
-    modal.vm.$emit('close')
-    await nextTick()
-    expect(wrapper.vm.outputOpen).toBe(false)
-    expect(wrapper.find('[data-testid="run-notifications-badge"]').text()).toBe('1')
-
-    // Re-open and mark as read
-    await wrapper.find('[data-testid="run-notifications-bell"]').trigger('click')
-    await nextTick()
-    await wrapper.find('[data-testid="run-notifications-item"]').trigger('click')
-    await flushPromises()
-    await vi.waitFor(() => {
-      expect(document.body.querySelector('[data-testid="run-output-mark-read"]')).toBeTruthy()
-    })
-    const markBtn = document.body.querySelector(
-      '[data-testid="run-output-mark-read"]',
-    ) as HTMLButtonElement
-    markBtn.click()
-    await nextTick()
-    expect(wrapper.vm.outputOpen).toBe(false)
-    expect(wrapper.find('[data-testid="run-notifications-badge"]').exists()).toBe(false)
-    wrapper.unmount()
-  })
-
-  it('completed with outputCards shows focus bar + OutputResultCards, not artifact list', async () => {
-    seedBaseline()
-    vi.mocked(api.listRuns).mockResolvedValue(
-      paged([run({ id: 'ok-2', status: 'completed', title: 'done' })]),
-    )
-    vi.mocked(api.getRun).mockResolvedValue(
-      run({
-        id: 'ok-2',
-        status: 'completed',
-        nodes: [{ id: 'out-1', type: 'output', label: '输出', position: { x: 0, y: 0 }, config: {} }],
-        nodeRuns: {
-          'out-1': {
-            nodeId: 'out-1',
-            status: 'completed',
-            startedAt: '2026-08-10T12:01:00Z',
-            outputs: {
-              outputCards: [
-                {
-                  index: 1,
-                  template: 'artifact("summary.md")',
-                  title: '摘要',
-                  typeTag: '自定义产物',
-                  status: 'ok',
-                  artifactName: 'summary.md',
-                },
-                {
-                  index: 2,
-                  template: 'artifact("result.json")',
-                  title: '结果 JSON',
-                  typeTag: '自定义产物',
-                  status: 'ok',
-                  artifactName: 'result.json',
-                },
-              ],
-            },
-          },
-        },
-        artifacts: [
-          {
-            id: 'a1',
-            name: 'summary.md',
-            kind: 'markdown',
-            nodeId: 'n1',
-            runId: 'ok-2',
-            workflowName: 'demo-wf',
-            sizeBytes: 10,
-            createdAt: '2026-08-10T12:00:00Z',
-          },
-          {
-            id: 'a2',
-            name: 'result.json',
-            kind: 'json',
-            nodeId: 'n1',
-            runId: 'ok-2',
-            workflowName: 'demo-wf',
-            sizeBytes: 20,
-            createdAt: '2026-08-10T12:00:00Z',
-          },
-          {
-            id: 'a-nc',
-            name: 'node_complete.json',
-            kind: 'json',
-            nodeId: 'submit_mr',
-            runId: 'ok-2',
-            workflowName: 'demo-wf',
-            sizeBytes: 40,
-            createdAt: '2026-08-10T12:00:00Z',
-          },
-        ],
-      }),
-    )
-    vi.mocked(api.artifactContent).mockResolvedValue({
-      id: 'a1',
-      name: 'summary.md',
-      kind: 'markdown',
-      nodeId: 'n1',
-      runId: 'ok-2',
-      workflowName: 'demo-wf',
-      sizeBytes: 10,
-      createdAt: '2026-08-10T12:00:00Z',
-      content: '# summary',
-    })
-    const wrapper = mountTopbar()
-    await flushPromises()
-    await wrapper.find('[data-testid="run-notifications-bell"]').trigger('click')
-    await nextTick()
-    await wrapper.find('[data-testid="run-notifications-item"]').trigger('click')
-    await flushPromises()
-    await nextTick()
-    expect(wrapper.vm.outputOpen).toBe(true)
-    await vi.waitFor(() => {
-      expect(document.body.querySelector('[data-testid="run-output-result-cards"]')).toBeTruthy()
-    })
-    expect(document.body.querySelector('[data-testid="run-output-focus-bar"]')).toBeTruthy()
-    expect(document.body.querySelector('[data-testid="output-result-cards"]')).toBeTruthy()
-    expect(document.body.querySelector('[data-testid="run-output-list"]')).toBeNull()
-    expect(document.body.querySelectorAll('[data-testid="run-output-row"]')).toHaveLength(0)
-    expect(document.body.textContent || '').toContain('摘要')
-    expect(document.body.textContent || '').not.toContain('node_complete.json')
-    expect(document.body.querySelector('[data-testid="run-output-open-run"]')).toBeNull()
-    expect(document.body.querySelector('[data-testid="run-output-done"]')).toBeNull()
-    const markBtn = document.body.querySelector('[data-testid="run-output-mark-read"]')
-    expect(markBtn).toBeTruthy()
-    expect(markBtn?.textContent).toContain('标记已读')
-    // Opening completed item must keep unread badge (g2.1)
-    expect(wrapper.find('[data-testid="run-notifications-badge"]').exists()).toBe(true)
-    expect(document.body.textContent || '').not.toMatch(/PPT|幻灯片|16:9/)
     wrapper.unmount()
   })
 

--- a/web/src/components/shell/AppTopbar.vue
+++ b/web/src/components/shell/AppTopbar.vue
@@ -4,9 +4,9 @@ import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import Icon from '../ui/Icon.vue'
 import LangSelect from '../ui/LangSelect.vue'
-import RunOutputPptModal from './RunOutputPptModal.vue'
 import { theme, toggleTheme } from '@/lib/shared/theme'
 import { isDraining } from '@/lib/composables/useShutdownState'
+import { requestNotificationsPageReset } from '@/lib/composables/useNotificationsPageEntry'
 import { locale, setLocale, type AppLocale } from '@/lib/shared/locale'
 import { relTime } from '@/lib/shared/format'
 import { useRunTerminalNotifications } from '@/lib/run/useRunTerminalNotifications'
@@ -26,15 +26,10 @@ const {
   unreadCount,
   hasUnreadFailed,
   badgeLabel,
-  markRead,
   markAllRead,
   startPolling,
   stopPolling,
 } = useRunTerminalNotifications()
-
-const outputOpen = ref(false)
-const outputRunId = ref<string | null>(null)
-const outputContext = ref('')
 
 const themeTitle = computed(() =>
   t(theme.value === 'dark' ? 'shell.theme.toLight' : 'shell.theme.toDark'),
@@ -105,33 +100,11 @@ function itemContext(item: { workflowName: string; runId: string; title: string 
   return wf ? `${wf} · ${item.runId}` : item.runId
 }
 
-async function onItemClick(item: {
-  runId: string
-  status: 'completed' | 'failed'
-  title: string
-  workflowName: string
-}) {
+async function onItemClick() {
+  // Demo / f5: preview click enters /notifications page 1, no locate/highlight.
   closePanel()
-  if (item.status === 'failed') {
-    markRead(item.runId)
-    await router.push(`/runs/${item.runId}`)
-    return
-  }
-  // completed: defer markRead until user clicks「标记已读」in the output modal
-  outputContext.value = itemContext(item)
-  outputRunId.value = item.runId
-  outputOpen.value = true
-}
-
-function closeOutputModal() {
-  outputOpen.value = false
-  outputRunId.value = null
-  outputContext.value = ''
-}
-
-function onOutputMarkRead() {
-  if (outputRunId.value) markRead(outputRunId.value)
-  closeOutputModal()
+  requestNotificationsPageReset()
+  await router.push({ path: '/notifications' })
 }
 
 function onMarkAllRead() {
@@ -141,6 +114,7 @@ function onMarkAllRead() {
 function viewAll() {
   // Opening "view all" must NOT batch-mark read; goes to independent notifications page.
   closePanel()
+  requestNotificationsPageReset()
   void router.push({ path: '/notifications' })
 }
 
@@ -161,8 +135,6 @@ defineExpose({
   toggleMenu,
   panelOpen,
   togglePanel,
-  outputOpen,
-  outputRunId,
 })
 </script>
 
@@ -259,7 +231,7 @@ defineExpose({
             :data-status="item.status"
             :data-unread="item.unread ? 'true' : 'false'"
             :data-before-baseline="item.beforeBaseline ? 'true' : 'false'"
-            @click="onItemClick(item)"
+            @click="onItemClick()"
           >
             <span
               v-if="item.unread"
@@ -316,12 +288,5 @@ defineExpose({
       </div>
     </div>
 
-    <RunOutputPptModal
-      :open="outputOpen"
-      :run-id="outputRunId"
-      :context-label="outputContext"
-      @close="closeOutputModal"
-      @mark-read="onOutputMarkRead"
-    />
   </header>
 </template>

--- a/web/src/components/ui/Pagination.test.ts
+++ b/web/src/components/ui/Pagination.test.ts
@@ -26,6 +26,7 @@ function mountPager(
     loading: boolean
     disabled: boolean
     pageSizeOptions: number[]
+    summaryOverride: string
     summaryTestId: string
     pageSizeTestId: string
   }> = {},

--- a/web/src/components/ui/Pagination.test.ts
+++ b/web/src/components/ui/Pagination.test.ts
@@ -166,6 +166,45 @@ describe('Pagination', () => {
     wrapper.unmount()
   })
 
+  it('keeps default rangeSummary when summaryOverride is omitted (g4.2)', () => {
+    const wrapper = mountPager({ page: 2, pageSize: 10, total: 50 })
+    expect(wrapper.text()).toContain('11–20 / 50')
+    expect(wrapper.text()).not.toContain('共 50 条 · 每页 10')
+    wrapper.unmount()
+  })
+
+  it('uses summaryOverride when provided and still supports summary slot (g2.2 / g4.2)', async () => {
+    const overridden = mountPager({
+      page: 1,
+      pageSize: 20,
+      total: 21,
+      summaryOverride: '共 21 条 · 每页 20',
+      summaryTestId: 'notifications-pager-summary',
+    })
+    expect(overridden.find('[data-testid="notifications-pager-summary"]').text()).toBe(
+      '共 21 条 · 每页 20',
+    )
+    expect(overridden.text()).not.toContain('1–20 / 21')
+    overridden.unmount()
+
+    const slotted = mount(Pagination, {
+      props: { page: 1, pageSize: 20, total: 21 },
+      slots: { summary: 'slot-summary' },
+      global: {
+        plugins: [
+          createI18n({
+            legacy: false,
+            locale: 'zh-CN',
+            messages: { 'zh-CN': { ...commonZh } },
+          }),
+        ],
+      },
+    })
+    expect(slotted.text()).toContain('slot-summary')
+    expect(slotted.text()).not.toContain('1–20 / 21')
+    slotted.unmount()
+  })
+
   it('forwards summary test id', () => {
     const wrapper = mountPager({
       total: 50,

--- a/web/src/components/ui/Pagination.vue
+++ b/web/src/components/ui/Pagination.vue
@@ -13,6 +13,8 @@ const props = withDefaults(
     disabled?: boolean
     /** When provided (non-empty), render per-page elevated select. */
     pageSizeOptions?: number[]
+    /** Optional summary text; omit to keep common.pagination.rangeSummary. */
+    summaryOverride?: string
     summaryTestId?: string
     pageSizeTestId?: string
   }>(),
@@ -20,6 +22,7 @@ const props = withDefaults(
     loading: false,
     disabled: false,
     pageSizeOptions: undefined,
+    summaryOverride: undefined,
     summaryTestId: undefined,
     pageSizeTestId: undefined,
   },
@@ -48,6 +51,7 @@ const rangeTo = computed(() => {
 })
 
 const summaryText = computed(() => {
+  if (props.summaryOverride !== undefined) return props.summaryOverride
   if (props.total <= 0) return t('common.pagination.emptySummary')
   return t('common.pagination.rangeSummary', {
     from: rangeFrom.value,
@@ -96,7 +100,7 @@ function onPageSizeChange(event: Event) {
     :aria-busy="loading ? 'true' : undefined"
   >
     <div class="pg-summary" :data-testid="summaryTestId || undefined">
-      {{ summaryText }}
+      <slot name="summary">{{ summaryText }}</slot>
     </div>
     <div class="pg-nav">
       <button

--- a/web/src/lib/composables/useNotificationsPageEntry.test.ts
+++ b/web/src/lib/composables/useNotificationsPageEntry.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import {
+  __resetNotificationsPageEntryForTests,
+  requestNotificationsPageReset,
+  useNotificationsPageEntry,
+} from './useNotificationsPageEntry'
+
+describe('useNotificationsPageEntry', () => {
+  it('increments a shared nonce so same-route view-all can reset (g3.1)', () => {
+    __resetNotificationsPageEntryForTests()
+    const a = useNotificationsPageEntry()
+    const b = useNotificationsPageEntry()
+    expect(a.enterNonce.value).toBe(0)
+    requestNotificationsPageReset()
+    expect(a.enterNonce.value).toBe(1)
+    expect(b.enterNonce.value).toBe(1)
+    __resetNotificationsPageEntryForTests()
+    expect(a.enterNonce.value).toBe(0)
+  })
+})

--- a/web/src/lib/composables/useNotificationsPageEntry.ts
+++ b/web/src/lib/composables/useNotificationsPageEntry.ts
@@ -1,0 +1,20 @@
+import { ref } from 'vue'
+
+/**
+ * Same-route entry signal for /notifications.
+ * Incrementing while already on the page resets filter=all and page=1
+ * without writing page into the URL.
+ */
+const enterNonce = ref(0)
+
+export function requestNotificationsPageReset() {
+  enterNonce.value += 1
+}
+
+export function useNotificationsPageEntry() {
+  return { enterNonce }
+}
+
+export function __resetNotificationsPageEntryForTests() {
+  enterNonce.value = 0
+}

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -1097,6 +1097,8 @@
       "loading": "Loading notifications…",
       "filterEmpty": "No notifications match this filter",
       "filterEmptyHint": "Try All / Unread / Read",
+      "pageRange": "Page {page} · {from}–{to} / {total}",
+      "pagerSummary": "{total} items · {pageSize} per page",
       "filter": {
         "all": "All",
         "unread": "Unread",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -1097,6 +1097,8 @@
       "loading": "正在加载通知…",
       "filterEmpty": "没有符合筛选的通知",
       "filterEmptyHint": "试试切换全部 / 未读 / 已读",
+      "pageRange": "第 {page} 页 · {from}–{to} / {total}",
+      "pagerSummary": "共 {total} 条 · 每页 {pageSize}",
       "filter": {
         "all": "全部",
         "unread": "未读",

--- a/web/src/views/NotificationsView.pagination.test.ts
+++ b/web/src/views/NotificationsView.pagination.test.ts
@@ -1,0 +1,283 @@
+// @vitest-environment happy-dom
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createI18n } from 'vue-i18n'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+import common from '@/locales/zh-CN/common.json'
+import pages from '@/locales/zh-CN/pages.json'
+import shell from '@/locales/zh-CN/shell.json'
+import type { Run } from '@/lib/shared/types'
+import { requestNotificationsPageReset, __resetNotificationsPageEntryForTests } from '@/lib/composables/useNotificationsPageEntry'
+
+vi.mock('@/lib/composables/useBreakpoint', () => ({
+  useBreakpoint: () => ({ isMobile: ref(false) }),
+}))
+
+vi.mock('@/lib/composables/useAuth', () => ({
+  useAuth: () => ({
+    user: ref({ username: 'tester', expiresAt: 't' }),
+    ready: ref(true),
+  }),
+}))
+
+vi.mock('@/lib/api/api', () => ({
+  api: {
+    listRuns: vi.fn(),
+    getRun: vi.fn(),
+    artifactContent: vi.fn(),
+    artifactDownloadUrl: vi.fn((id: string) => `http://test/api/artifacts/${id}/download`),
+  },
+  isPaginated: (data: unknown): data is { items: unknown[]; total: number } =>
+    data != null && typeof data === 'object' && !Array.isArray(data) && 'items' in data,
+}))
+
+import { api } from '@/lib/api/api'
+import {
+  __resetRunTerminalNotificationsForTests,
+  prefsKeyForUser,
+  RUN_TERMINAL_PANEL_LIMIT,
+  RUN_TERMINAL_POOL_SIZE,
+  useRunTerminalNotifications,
+} from '@/lib/run/useRunTerminalNotifications'
+import NotificationsView from './NotificationsView.vue'
+
+const viewSrc = readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'NotificationsView.vue'), 'utf8')
+const poolSrc = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), '../lib/run/useRunTerminalNotifications.ts'),
+  'utf8',
+)
+
+function run(partial: Partial<Run> & Pick<Run, 'id' | 'status'>): Run {
+  return {
+    workflowId: 'wf',
+    workflowName: 'demo-wf',
+    title: partial.title ?? `Run ${partial.id}`,
+    trigger: 'manual',
+    startedAt: partial.startedAt ?? '2026-08-10T12:00:00Z',
+    durationSec: 1,
+    progress: 100,
+    nodeRuns: {},
+    artifacts: [],
+    ...partial,
+  }
+}
+
+function paged(items: Run[], total = items.length) {
+  return { items, total, page: 1, pageSize: RUN_TERMINAL_POOL_SIZE, hasMore: false }
+}
+
+function seedBaseline(enabledAt = '2020-01-01T00:00:00Z', readIds: string[] = []) {
+  localStorage.setItem(prefsKeyForUser('tester'), JSON.stringify({ enabledAt, readIds }))
+}
+
+function makeItems(n: number, unreadCount = n) {
+  return Array.from({ length: n }, (_, i) =>
+    run({
+      id: `n-${String(i).padStart(2, '0')}`,
+      status: i % 7 === 0 ? 'failed' : 'completed',
+      startedAt: `2026-08-10T${String(10 + Math.floor(i / 60)).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}:00Z`,
+      title: `通知 ${i}`,
+    }),
+  ).map((item, i) => {
+    if (i >= unreadCount) {
+      return item
+    }
+    return item
+  })
+}
+
+async function mountView(items: Run[], readIds: string[] = []) {
+  seedBaseline('2020-01-01T00:00:00Z', readIds)
+  vi.mocked(api.listRuns).mockResolvedValue(paged(items, items.length))
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common, ...pages, ...shell } },
+  })
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/notifications', component: NotificationsView },
+      { path: '/runs/:id', component: { template: '<div data-testid="run-detail" />' } },
+    ],
+  })
+  await router.push('/notifications')
+  await router.isReady()
+  const wrapper = mount(NotificationsView, {
+    global: {
+      plugins: [i18n, router],
+      stubs: { Icon: true, Transition: false },
+    },
+  })
+  await flushPromises()
+  return { wrapper, router }
+}
+
+describe('NotificationsView pagination (g1/g2/g4)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    __resetRunTerminalNotificationsForTests()
+    __resetNotificationsPageEntryForTests()
+    vi.mocked(api.listRuns).mockReset()
+    vi.mocked(api.listRuns).mockResolvedValue(paged([]))
+  })
+
+  afterEach(() => {
+    __resetRunTerminalNotificationsForTests()
+    __resetNotificationsPageEntryForTests()
+  })
+
+  it('N=20 has no pager and shows page-1 range 1–20 / 20 (g1.2 / g2.1 / g4.1)', async () => {
+    const { wrapper } = await mountView(makeItems(20))
+    expect(wrapper.findAll('[data-testid="notifications-item"]')).toHaveLength(20)
+    expect(wrapper.find('[data-testid="notifications-pagination"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="notifications-page-range"]').text()).toBe('第 1 页 · 1–20 / 20')
+    wrapper.unmount()
+  })
+
+  it('N=21 shows two pages and slices 20+1 (g1.1 / g1.2 / g4.1)', async () => {
+    const { wrapper } = await mountView(makeItems(21))
+    expect(wrapper.findAll('[data-testid="notifications-item"]')).toHaveLength(20)
+    const pager = wrapper.find('[data-testid="notifications-pagination"]')
+    expect(pager.exists()).toBe(true)
+    expect(wrapper.find('[data-testid="notifications-pager-summary"]').text()).toBe('共 21 条 · 每页 20')
+    expect(wrapper.find('[data-testid="notifications-page-range"]').text()).toBe('第 1 页 · 1–20 / 21')
+
+    const next = pager.findAll('button.pg-btn')[1]!
+    await next.trigger('click')
+    await nextTick()
+    expect(wrapper.findAll('[data-testid="notifications-item"]')).toHaveLength(1)
+    expect(wrapper.find('[data-testid="notifications-page-range"]').text()).toBe('第 2 页 · 21–21 / 21')
+    wrapper.unmount()
+  })
+
+  it('switching filter resets to page 1 and may hide pager (g1.3 / g4.1)', async () => {
+    const items = makeItems(21)
+    const { wrapper } = await mountView(items, items.slice(0, 18).map((r) => r.id))
+    await wrapper.find('[data-testid="notifications-pagination"]').findAll('button.pg-btn')[1]!.trigger('click')
+    await nextTick()
+    expect(wrapper.find('[data-testid="notifications-page-range"]').text()).toMatch(/第 2 页/)
+
+    await wrapper.find('[data-testid="notifications-filter-unread"]').trigger('click')
+    await nextTick()
+    expect(wrapper.find('[data-testid="notifications-page-range"]').text()).toMatch(/第 1 页/)
+    expect(wrapper.find('[data-testid="notifications-pagination"]').exists()).toBe(false)
+    expect(wrapper.findAll('[data-testid="notifications-item"]').length).toBeLessThanOrEqual(20)
+    wrapper.unmount()
+  })
+
+  it('clamps to last data page when current unread page becomes empty (g1.4 / g4.1)', async () => {
+    const items = makeItems(21)
+    const { wrapper } = await mountView(items)
+    await wrapper.find('[data-testid="notifications-filter-unread"]').trigger('click')
+    await wrapper.find('[data-testid="notifications-pagination"]').findAll('button.pg-btn')[1]!.trigger('click')
+    await nextTick()
+    expect(wrapper.findAll('[data-testid="notifications-item"]')).toHaveLength(1)
+    const lastId = wrapper.find('[data-testid="notifications-item"]').attributes('data-run-id')!
+    useRunTerminalNotifications().markRead(lastId)
+    await nextTick()
+    await nextTick()
+    expect(wrapper.find('[data-testid="notifications-pagination"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="notifications-page-range"]').text()).toMatch(/第 1 页/)
+    expect(wrapper.findAll('[data-testid="notifications-item"]')).toHaveLength(20)
+    wrapper.unmount()
+  })
+
+  it('keeps page on non-filter data change when still valid (g1.4)', async () => {
+    const items = makeItems(25)
+    const { wrapper } = await mountView(items)
+    await wrapper.find('[data-testid="notifications-pagination"]').findAll('button.pg-btn')[1]!.trigger('click')
+    await nextTick()
+    expect(wrapper.find('[data-testid="notifications-page-range"]').text()).toBe('第 2 页 · 21–25 / 25')
+    const firstOnPage = wrapper.find('[data-testid="notifications-item"]').attributes('data-run-id')!
+    useRunTerminalNotifications().markRead(firstOnPage)
+    await nextTick()
+    expect(wrapper.find('[data-testid="notifications-page-range"]').text()).toMatch(/第 2 页/)
+    expect(wrapper.findAll('[data-testid="notifications-item"]').length).toBeGreaterThan(0)
+    wrapper.unmount()
+  })
+
+  it('paging does not change unread badge or preview slice / fetchPool (g1.5 / g4.1)', async () => {
+    const items = makeItems(25)
+    const { wrapper } = await mountView(items)
+    const callsAfterMount = vi.mocked(api.listRuns).mock.calls.length
+    const n = useRunTerminalNotifications()
+    expect(n.unreadCount.value).toBe(25)
+    expect(n.previewItems.value).toHaveLength(RUN_TERMINAL_PANEL_LIMIT)
+    const previewIds = n.previewItems.value.map((x) => x.runId)
+
+    await wrapper.find('[data-testid="notifications-pagination"]').findAll('button.pg-btn')[1]!.trigger('click')
+    await nextTick()
+    expect(n.unreadCount.value).toBe(25)
+    expect(wrapper.find('[data-testid="notifications-unread-count"]').text()).toContain('25')
+    expect(n.previewItems.value.map((x) => x.runId)).toEqual(previewIds)
+    expect(vi.mocked(api.listRuns).mock.calls.length).toBe(callsAfterMount)
+    expect(api.listRuns).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 1, pageSize: RUN_TERMINAL_POOL_SIZE }),
+    )
+    wrapper.unmount()
+  })
+
+  it('does not write page into the URL (g3.3 / g4.1)', async () => {
+    const { wrapper, router } = await mountView(makeItems(21))
+    await wrapper.find('[data-testid="notifications-pagination"]').findAll('button.pg-btn')[1]!.trigger('click')
+    await nextTick()
+    expect(router.currentRoute.value.query.page).toBeUndefined()
+    expect(router.currentRoute.value.fullPath).not.toContain('page=')
+    wrapper.unmount()
+  })
+
+  it('empty list hides range and pager (g1.4 / g2.1)', async () => {
+    const { wrapper } = await mountView([])
+    expect(wrapper.find('[data-testid="notifications-page-range"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="notifications-pagination"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('topbar entry signal resets filter and page without query (g3.1)', async () => {
+    const { wrapper, router } = await mountView(makeItems(21))
+    await wrapper.find('[data-testid="notifications-pagination"]').findAll('button.pg-btn')[1]!.trigger('click')
+    await wrapper.find('[data-testid="notifications-filter-unread"]').trigger('click')
+    await nextTick()
+    requestNotificationsPageReset()
+    await nextTick()
+    expect(wrapper.find('[data-testid="notifications-page-range"]').text()).toMatch(/第 1 页/)
+    expect(wrapper.find('[data-testid="notifications-filter-all"]').classes().join(' ')).toMatch(/border-accent/)
+    expect(router.currentRoute.value.fullPath).not.toContain('page=')
+    wrapper.unmount()
+  })
+
+  it('mark-all-read still clears the whole pool unread count (g1.5)', async () => {
+    const { wrapper } = await mountView(makeItems(25))
+    await wrapper.find('[data-testid="notifications-pagination"]').findAll('button.pg-btn')[1]!.trigger('click')
+    await wrapper.find('[data-testid="notifications-mark-all"]').trigger('click')
+    await nextTick()
+    expect(useRunTerminalNotifications().unreadCount.value).toBe(0)
+    wrapper.unmount()
+  })
+})
+
+describe('NotificationsView pagination conventions (g4.4 / g1.5)', () => {
+  it('keeps min-h-11 on filter and mark-all', () => {
+    expect(viewSrc).toMatch(/min-h-11 border border-line bg-transparent/)
+    expect(viewSrc).toMatch(/min-h-11 border px-2.5/)
+  })
+
+  it('gates Pagination on filteredTotal > PAGE_SIZE with shrink-0 and no pageSizeOptions', () => {
+    expect(viewSrc).toMatch(/const PAGE_SIZE = 20/)
+    expect(viewSrc).toMatch(/<Pagination[\s\S]*v-if="filteredTotal > PAGE_SIZE"/)
+    expect(viewSrc).toMatch(/class="shrink-0"/)
+    expect(viewSrc).not.toMatch(/page-size-options/)
+    expect(viewSrc).not.toMatch(/pageSizeOptions/)
+  })
+
+  it('does not change fetchPool page=1 / pageSize=50', () => {
+    expect(poolSrc).toMatch(/page:\s*1/)
+    expect(poolSrc).toMatch(/pageSize:\s*RUN_TERMINAL_POOL_SIZE/)
+    expect(poolSrc).toMatch(/export const RUN_TERMINAL_POOL_SIZE = 50/)
+  })
+})

--- a/web/src/views/NotificationsView.vue
+++ b/web/src/views/NotificationsView.vue
@@ -1,16 +1,21 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import EmptyState from '@/components/ui/EmptyState.vue'
+import Pagination from '@/components/ui/Pagination.vue'
 import RunOutputPptModal from '@/components/shell/RunOutputPptModal.vue'
+import { useNotificationsPageEntry } from '@/lib/composables/useNotificationsPageEntry'
 import { relTime } from '@/lib/shared/format'
 import { useRunTerminalNotifications } from '@/lib/run/useRunTerminalNotifications'
 
 type ReadFilter = 'all' | 'unread' | 'read'
 
+const PAGE_SIZE = 20
+
 const { t } = useI18n()
 const router = useRouter()
+const { enterNonce } = useNotificationsPageEntry()
 
 const {
   listItems,
@@ -23,6 +28,7 @@ const {
 } = useRunTerminalNotifications()
 
 const filter = ref<ReadFilter>('all')
+const page = ref(1)
 const outputOpen = ref(false)
 const outputRunId = ref<string | null>(null)
 const outputContext = ref('')
@@ -32,6 +38,56 @@ const filteredItems = computed(() => {
   if (filter.value === 'unread') return items.filter((n) => n.unread)
   if (filter.value === 'read') return items.filter((n) => !n.unread)
   return items
+})
+
+const filteredTotal = computed(() => filteredItems.value.length)
+
+const pagedItems = computed(() => {
+  const start = (page.value - 1) * PAGE_SIZE
+  return filteredItems.value.slice(start, start + PAGE_SIZE)
+})
+
+const pageRangeText = computed(() => {
+  const n = filteredTotal.value
+  if (n <= 0) return ''
+  const k = page.value
+  const from = (k - 1) * PAGE_SIZE + 1
+  const to = Math.min(k * PAGE_SIZE, n)
+  return t('pages.notifications.pageRange', { page: k, from, to, total: n })
+})
+
+const pagerSummary = computed(() =>
+  t('pages.notifications.pagerSummary', { total: filteredTotal.value, pageSize: PAGE_SIZE }),
+)
+
+function setFilter(next: ReadFilter) {
+  filter.value = next
+  page.value = 1
+}
+
+function resetToAllFirstPage() {
+  filter.value = 'all'
+  page.value = 1
+}
+
+function clampPage() {
+  const n = filteredTotal.value
+  if (n <= 0) {
+    page.value = 1
+    return
+  }
+  const last = Math.ceil(n / PAGE_SIZE)
+  if (page.value > last || pagedItems.value.length === 0) {
+    page.value = last
+  }
+}
+
+watch(enterNonce, () => {
+  resetToAllFirstPage()
+})
+
+watch(filteredTotal, () => {
+  clampPage()
 })
 
 function statusLabel(status: string) {
@@ -91,6 +147,12 @@ onMounted(() => {
   ensureUsername()
   void refresh({ source: 'manual' })
 })
+
+defineExpose({
+  page,
+  filter,
+  PAGE_SIZE,
+})
 </script>
 
 <template>
@@ -99,9 +161,16 @@ onMounted(() => {
       <div>
         <h1 class="m-0 text-base font-semibold text-txt">{{ t('pages.notifications.title') }}</h1>
         <p class="mt-1 text-xs text-txt3">{{ t('pages.notifications.subtitle') }}</p>
+        <p
+          v-if="pageRangeText"
+          class="mt-1 text-xs text-txt3"
+          data-testid="notifications-page-range"
+        >
+          {{ pageRangeText }}
+        </p>
       </div>
       <div class="flex flex-wrap items-center gap-2">
-        <span class="text-xs text-txt3">
+        <span class="text-xs text-txt3" data-testid="notifications-unread-count">
           {{ t('shell.runNotifications.unreadCount', { n: unreadCount }) }}
         </span>
         <button
@@ -128,7 +197,7 @@ onMounted(() => {
             : 'border-line bg-transparent text-txt2 hover:border-line-strong hover:text-txt'
         "
         :data-testid="`notifications-filter-${opt}`"
-        @click="filter = opt"
+        @click="setFilter(opt)"
       >
         {{ t(`pages.notifications.filter.${opt}`) }}
       </button>
@@ -155,7 +224,7 @@ onMounted(() => {
         :desc="t('pages.notifications.filterEmptyHint')"
       />
       <button
-        v-for="item in filteredItems"
+        v-for="item in pagedItems"
         :key="item.runId"
         type="button"
         class="relative block w-full border-b border-line px-4 py-3.5 text-left hover:bg-elevated md:px-6"
@@ -199,6 +268,17 @@ onMounted(() => {
         </div>
       </button>
     </div>
+
+    <Pagination
+      v-if="filteredTotal > PAGE_SIZE"
+      v-model:page="page"
+      class="shrink-0"
+      data-testid="notifications-pagination"
+      :page-size="PAGE_SIZE"
+      :total="filteredTotal"
+      :summary-override="pagerSummary"
+      summary-test-id="notifications-pager-summary"
+    />
 
     <RunOutputPptModal
       :open="outputOpen"


### PR DESCRIPTION
Slice filtered results on /notifications so long pools stay scannable without changing fetchPool, badges, or shared Pagination defaults.

Co-authored-by: Cursor <cursoragent@cursor.com>
