### PR TITLE
fix(web): shrink MCP quick-add buttons to 11px

### DIFF
--- a/web/src/components/run/UpstreamRequirementContext.test.ts
+++ b/web/src/components/run/UpstreamRequirementContext.test.ts
@@ -370,7 +370,7 @@ describe('UpstreamRequirementContext', () => {
     expect(wrapper.find('[data-testid="upstream-modal-callout"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="upstream-bar-hint"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="upstream-bar-hint"]').text()).toContain(
-      '本 run 已有澄清需求文档',
+      '本工作流已有澄清需求文档',
     )
     wrapper.unmount()
   })

--- a/web/src/views/AgentStudioView.test.ts
+++ b/web/src/views/AgentStudioView.test.ts
@@ -247,6 +247,27 @@ describe('AgentStudio MCP PM leader prefills', () => {
     await flushPromises()
   }
 
+  it('keeps mcp quick-add buttons at text-[11px] including artifact store', async () => {
+    mocks.listAgents.mockResolvedValue([agent()])
+    const wrapper = await mountStudio()
+    await flushPromises()
+    await openMcpTab(wrapper)
+
+    const selectors = ['mcp-add-artifact', 'mcp-add-memory', 'mcp-add-context', 'mcp-add-scheduler'] as const
+    for (const testId of selectors) {
+      const btn = wrapper.get(`[data-test="${testId}"]`)
+      expect(btn.classes()).toContain('text-[11px]')
+      expect(btn.classes()).toContain('px-2')
+      expect(btn.classes()).toContain('py-1')
+      expect(btn.classes()).not.toContain('text-xs')
+      expect(btn.classes()).not.toContain('py-0.5')
+    }
+    expect(wrapper.get('[data-test="mcp-add-artifact"]').text()).toBe('+ 添加产物存储')
+    expect(wrapper.get('[data-test="mcp-add-memory"]').text()).toBe('+ 添加长期记忆')
+    expect(wrapper.get('[data-test="mcp-add-context"]').text()).toBe('+ 添加对话上下文')
+    expect(wrapper.get('[data-test="mcp-add-scheduler"]').text()).toBe('+ 添加定时任务')
+  })
+
   it('adds memory-store from the agent platform card without changing artifact-store', async () => {
     mocks.listAgents.mockResolvedValue([
       {
@@ -271,6 +292,10 @@ describe('AgentStudio MCP PM leader prefills', () => {
     expect(wrapper.text()).not.toContain('运行级变量(运行时替换')
     expect(wrapper.get('[data-test="mcp-help-link"]').text()).toBe('帮助')
     expect(wrapper.get('[data-test="mcp-add-memory"]').text()).toContain('添加长期记忆')
+    expect(wrapper.get('[data-test="mcp-add-memory"]').classes()).toContain('text-[11px]')
+    expect(wrapper.get('[data-test="mcp-add-context"]').classes()).toContain('text-[11px]')
+    expect(wrapper.get('[data-test="mcp-add-scheduler"]').classes()).toContain('text-[11px]')
+    expect(wrapper.find('[data-test="mcp-add-artifact"]').exists()).toBe(false)
     expect(wrapper.get('[data-mcp-name="artifact-store"] [data-test="mcp-display-name"]').text()).toBe('产物存储')
     expect(wrapper.get('[data-mcp-name="artifact-store"] [data-test="mcp-preset-key"]').text()).toBe('artifact-store')
     expect(wrapper.get('[data-mcp-name="artifact-store"] [data-test="mcp-scope-note"]').text()).toContain('本次运行隔离的产物服务')

--- a/web/src/views/AgentStudioView.vue
+++ b/web/src/views/AgentStudioView.vue
@@ -2963,27 +2963,27 @@ onBeforeUnmount(() => {
               <span class="mr-1 text-[11px] text-txt3">{{ t('pages.agentStudio.mcp.quickAddLabel') }}</span>
               <button
                 v-if="!hasArtifactStore"
-                class="rounded border border-accent/40 px-2 py-1 text-accent-2 hover:bg-accent-dim"
+                class="rounded border border-accent/40 px-2 py-1 text-[11px] text-accent-2 hover:bg-accent-dim"
                 type="button"
                 data-test="mcp-add-artifact"
                 @click="addArtifactStore"
               >{{ t('pages.agentStudio.mcp.addArtifactStore') }}</button>
               <button
-                class="rounded border border-accent/40 px-2 py-1 text-accent-2 hover:bg-accent-dim disabled:cursor-not-allowed disabled:opacity-40"
+                class="rounded border border-accent/40 px-2 py-1 text-[11px] text-accent-2 hover:bg-accent-dim disabled:cursor-not-allowed disabled:opacity-40"
                 type="button"
                 data-test="mcp-add-memory"
                 :disabled="!isProjectBound"
                 @click="addAgentPlatformMcp('memory-store')"
               >{{ t('pages.agentStudio.mcp.addMemoryStore') }}</button>
               <button
-                class="rounded border border-accent/40 px-2 py-1 text-accent-2 hover:bg-accent-dim disabled:cursor-not-allowed disabled:opacity-40"
+                class="rounded border border-accent/40 px-2 py-1 text-[11px] text-accent-2 hover:bg-accent-dim disabled:cursor-not-allowed disabled:opacity-40"
                 type="button"
                 data-test="mcp-add-context"
                 :disabled="!isProjectBound"
                 @click="addAgentPlatformMcp('context-store')"
               >{{ t('pages.agentStudio.mcp.addContextStore') }}</button>
               <button
-                class="rounded border border-accent/40 px-2 py-1 text-accent-2 hover:bg-accent-dim disabled:cursor-not-allowed disabled:opacity-40"
+                class="rounded border border-accent/40 px-2 py-1 text-[11px] text-accent-2 hover:bg-accent-dim disabled:cursor-not-allowed disabled:opacity-40"
                 type="button"
                 data-test="mcp-add-scheduler"
                 :disabled="!isProjectBound"


### PR DESCRIPTION
Match the existing Raw JSON control so the four shortcut buttons no longer inherit the 14px body size.

Co-authored-by: Cursor <cursoragent@cursor.com>
