### PR TITLE
fix(web): align project audit panel presentation with the approved demo.

### DIFF
--- a/web/e2e/project-audit-dual-mode.spec.ts
+++ b/web/e2e/project-audit-dual-mode.spec.ts
@@ -15,6 +15,8 @@ const MOCK_PROJECT = {
 
 const RUN_A = 'run-8f2a1111'
 const RUN_B = 'run-3c911111'
+const RUN_C = 'run-aa11cccc'
+const RUN_D = 'run-bb22dddd'
 
 const MOCK_EVENTS = [
   {
@@ -161,6 +163,96 @@ const MOCK_EVENTS = [
     summary: '修改可见性',
     payload: {},
   },
+  {
+    id: 'e10',
+    projectId: 'proj-1',
+    occurredAt: '2026-07-26T08:10:00Z',
+    actor: 'system',
+    actorDisplay: '系统',
+    unattributable: true,
+    callerKind: 'system',
+    action: 'run.start',
+    resourceType: 'run',
+    resourceId: RUN_C,
+    resource: `run/${RUN_C}`,
+    runId: RUN_C,
+    nodeId: '',
+    outcome: 'ok',
+    summary: 'Run C 开始',
+    payload: { runId: RUN_C },
+  },
+  {
+    id: 'e11',
+    projectId: 'proj-1',
+    occurredAt: '2026-07-26T08:10:08Z',
+    actor: 'system',
+    actorDisplay: '系统',
+    unattributable: true,
+    callerKind: 'system',
+    action: 'mcp.call',
+    resourceType: 'mcp',
+    resourceId: 'read_artifact',
+    resource: 'mcp/read_artifact',
+    runId: RUN_C,
+    nodeId: 'research_2wn4',
+    outcome: 'ok',
+    summary: '读取产物 research.json',
+    payload: { tool: 'read_artifact', runId: RUN_C },
+  },
+  {
+    id: 'e12',
+    projectId: 'proj-1',
+    occurredAt: '2026-07-26T08:10:16Z',
+    actor: 'system',
+    actorDisplay: '系统',
+    unattributable: true,
+    callerKind: 'system',
+    action: 'mcp.call',
+    resourceType: 'mcp',
+    resourceId: 'write_artifact',
+    resource: 'mcp/write_artifact',
+    runId: RUN_C,
+    nodeId: 'visual_bqc5',
+    outcome: 'ok',
+    summary: '写入产物 page.html',
+    payload: { tool: 'write_artifact' },
+  },
+  {
+    id: 'e20',
+    projectId: 'proj-1',
+    occurredAt: '2026-07-26T09:00:00Z',
+    actor: 'system',
+    actorDisplay: '系统',
+    unattributable: true,
+    callerKind: 'system',
+    action: 'run.start',
+    resourceType: 'run',
+    resourceId: RUN_D,
+    resource: `run/${RUN_D}`,
+    runId: RUN_D,
+    nodeId: '',
+    outcome: 'ok',
+    summary: 'Run D 开始',
+    payload: { runId: RUN_D },
+  },
+  {
+    id: 'e21',
+    projectId: 'proj-1',
+    occurredAt: '2026-07-26T09:00:04Z',
+    actor: 'system',
+    actorDisplay: '系统',
+    unattributable: true,
+    callerKind: 'system',
+    action: 'project.config',
+    resourceType: 'project',
+    resourceId: 'proj-1',
+    resource: 'project/proj-1',
+    runId: RUN_D,
+    nodeId: '',
+    outcome: 'ok',
+    summary: '单分组配置变更',
+    payload: {},
+  },
 ]
 
 function facetsFor(runId?: string | null) {
@@ -174,6 +266,16 @@ function facetsFor(runId?: string | null) {
       runId: RUN_B,
       label: '2026-07-26 14:05 · 3c911111',
       sub: '失败 · 含 MCP',
+    },
+    {
+      runId: RUN_C,
+      label: '2026-07-26 16:10 · aa11cccc',
+      sub: '成功 · 含 MCP',
+    },
+    {
+      runId: RUN_D,
+      label: '2026-07-26 17:00 · bb22dddd',
+      sub: '成功',
     },
   ]
   const inRun = runId
@@ -345,8 +447,8 @@ test.describe('审计 Tab 双模式 Demo 验收', () => {
     await expect(page.locator('body')).not.toContainText('动作类型')
     await expect(page.locator('body')).not.toContainText('旧摘要')
 
-    // Run mode hides event pagination; shows run count instead
-    await expect(page.getByTestId('project-audit-run-count')).toBeVisible()
+    // Run mode hides event pagination; count lives on the toolbar (not a dedicated strip)
+    await expect(page.getByTestId('project-audit-stats')).toBeVisible()
     await expect(page.getByTestId('project-audit-page-size')).toHaveCount(0)
     await expect(panel.locator('select')).toHaveCount(0)
 
@@ -364,8 +466,11 @@ test.describe('审计 Tab 双模式 Demo 验收', () => {
     await expect(page.getByTestId('project-audit-stats')).toContainText('成功')
 
     await expect(page.getByTestId('project-audit-run')).toContainText('Run')
+    await expect(page.getByTestId('project-audit-run')).toContainText('2026-07-26 18:42 · 8f2a1111')
     await expect(page.getByTestId('project-audit-resource')).toContainText('资源')
     await expect(page.getByTestId('project-audit-time')).toContainText('时间')
+    await expect(panel.locator('h4')).toHaveCount(0)
+    await expect(panel.locator('.chip').filter({ hasText: /^Run\b/ })).toHaveCount(0)
 
     const exportBtn = page.getByTestId('project-audit-export')
     await expect(exportBtn).toHaveText('导出')
@@ -377,10 +482,11 @@ test.describe('审计 Tab 双模式 Demo 验收', () => {
     const resPanel = page.locator('.audit-dd-panel').filter({ visible: true })
     await expect(resPanel).toBeVisible()
     await resPanel.locator('.audit-dd-opt', { hasText: 'mcp/read_artifact' }).first().click()
-    await page.getByTestId('project-audit-group-head-research_2wn4').click()
+    await expect(page.getByTestId('project-audit-group-research_2wn4')).toHaveAttribute('data-open', 'true')
     await expect(page.getByTestId('project-audit-list').locator('tbody tr.row')).toHaveCount(1)
     await expect(page.getByText('读取产物 research.json')).toBeVisible()
-    await expect(page.getByText('mcp/read_artifact').first()).toBeVisible()
+    await expect(page.getByText('mcp / read_artifact').first()).toBeVisible()
+    await expect(page.getByTestId('project-audit-chips')).toContainText('mcp/read_artifact')
 
     await page.getByTestId('project-audit-event-e2').click()
     await expect(page.getByTestId('project-audit-payload')).toBeVisible()
@@ -578,5 +684,63 @@ test.describe('审计 Tab 双模式 Demo 验收', () => {
     await page.getByTestId('project-audit-mode-run').click()
     await expect(page.getByTestId('project-audit-list')).toHaveAttribute('data-layout', 'groups')
     await expect(page.getByTestId('project-audit-export')).toBeVisible()
+  })
+
+  test('全成功 Run：单分组与多分组均默认全展开且事件行可见', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await stubProjectApis(page)
+    await page.goto('/project-detail.html?tab=audit&theme=light')
+    await dismissOnboardingIfOpen(page)
+    await expect(page.getByTestId('project-audit-panel')).toBeVisible({ timeout: 15_000 })
+
+    async function pickRun(label: string) {
+      await page.getByTestId('project-audit-run').locator('button.audit-dd-trig').click()
+      const panel = page.locator('.audit-dd-panel').filter({ visible: true })
+      await expect(panel).toBeVisible()
+      await panel.locator('.audit-dd-opt', { hasText: label }).first().click()
+    }
+
+    await pickRun('2026-07-26 16:10 · aa11cccc')
+    await expect(page.getByTestId('project-audit-group-_system')).toHaveAttribute('data-open', 'true')
+    await expect(page.getByTestId('project-audit-group-research_2wn4')).toHaveAttribute('data-open', 'true')
+    await expect(page.getByTestId('project-audit-group-visual_bqc5')).toHaveAttribute('data-open', 'true')
+    await expect(page.getByTestId('project-audit-event-e10')).toBeVisible()
+    await expect(page.getByTestId('project-audit-event-e11')).toBeVisible()
+    await expect(page.getByTestId('project-audit-event-e12')).toBeVisible()
+    await expect(page.getByText('Run C 开始')).toBeVisible()
+
+    await pickRun('2026-07-26 17:00 · bb22dddd')
+    await expect(page.getByTestId('project-audit-group-_system')).toHaveAttribute('data-open', 'true')
+    await expect(page.getByTestId('project-audit-event-e20')).toBeVisible()
+    await expect(page.getByTestId('project-audit-event-e21')).toBeVisible()
+    await expect(page.getByText('单分组配置变更')).toBeVisible()
+    await expect(page.getByTestId('project-audit-panel').locator('h4')).toHaveCount(0)
+    await expect(page.getByTestId('project-audit-panel').locator('.chip').filter({ hasText: /^Run\b/ })).toHaveCount(0)
+  })
+
+  test('有权但 0 条事件时空态可切全部日志', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await stubProjectApis(page)
+    await page.route('**/api/projects/proj-1/audit?**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items: [],
+          total: 0,
+          page: 1,
+          pageSize: 10,
+          hasMore: false,
+          stats: { total: 0, mcp: 0, fail: 0 },
+        }),
+      })
+    })
+    await page.goto('/project-detail.html?tab=audit&theme=light')
+    await dismissOnboardingIfOpen(page)
+    await expect(page.getByTestId('project-audit-empty')).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByTestId('project-audit-empty-all')).toBeVisible()
+    await expect(page.getByTestId('project-audit-list')).toHaveCount(0)
+    await page.getByTestId('project-audit-empty-all').click()
+    await expect(page.getByTestId('project-audit-mode-all')).toHaveClass(/on/)
   })
 })

--- a/web/src/components/project/AuditFilterDropdown.vue
+++ b/web/src/components/project/AuditFilterDropdown.vue
@@ -52,7 +52,7 @@ const displayValue = computed(() => {
   if (!c || c.value === '') {
     return c?.label || props.emptyLabel || '全部'
   }
-  return c.short || c.label
+  return c.label
 })
 
 const muted = computed(() => !current.value || current.value.value === '')
@@ -220,7 +220,7 @@ defineExpose({ close })
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  max-width: 220px;
+  max-width: 280px;
   border: 1px solid rgb(var(--c-line));
   background: rgb(var(--c-surface));
   padding: 0 8px 0 10px;
@@ -262,7 +262,7 @@ defineExpose({ close })
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 500;
-  max-width: 140px;
+  max-width: 200px;
 }
 .audit-dd.block .audit-dd-trig .v {
   flex: 1 1 auto;
@@ -294,30 +294,31 @@ defineExpose({ close })
   display: flex;
   flex-direction: column;
   max-width: calc(100vw - 24px);
-  background: #fff;
-  border: 1px solid #e4e4e7;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.06), 0 12px 32px rgba(0, 0, 0, 0.12);
+  background: rgb(var(--c-surface));
+  border: 1px solid rgb(var(--c-line));
+  box-shadow: 0 0 0 1px rgb(var(--c-line) / 0.6), 0 12px 32px rgba(0, 0, 0, 0.12);
   border-radius: 0;
 }
 .audit-dd-find {
   padding: 8px;
-  border-bottom: 1px solid #ececef;
+  border-bottom: 1px solid rgb(var(--c-line));
   flex: 0 0 auto;
 }
 .audit-dd-find input {
   width: 100%;
   height: 30px;
-  border: 1px solid #e4e4e7;
+  border: 1px solid rgb(var(--c-line));
   padding: 0 9px;
   font: inherit;
   font-size: 12px;
   outline: none;
-  background: #fafafa;
+  background: rgb(var(--c-elevated));
+  color: rgb(var(--c-txt));
   border-radius: 0;
 }
 .audit-dd-find input:focus {
-  border-color: #c4b5fd;
-  background: #fff;
+  border-color: rgb(var(--c-accent));
+  background: rgb(var(--c-surface));
 }
 .audit-dd-list {
   overflow: auto;
@@ -329,7 +330,7 @@ defineExpose({ close })
   padding: 8px 8px 4px;
   font-size: 10px;
   font-weight: 650;
-  color: #a1a1aa;
+  color: rgb(var(--c-txt3));
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
@@ -345,39 +346,39 @@ defineExpose({ close })
   font-size: 12px;
   text-align: left;
   cursor: pointer;
-  color: #18181b;
+  color: rgb(var(--c-txt));
   border-radius: 0;
 }
 .audit-dd-opt:hover {
-  background: #f4f4f5;
+  background: rgb(var(--c-elevated));
 }
 .audit-dd-opt.on {
-  background: #f5f3ff;
-  color: #7c3aed;
+  background: rgb(var(--c-accent-dim));
+  color: rgb(var(--c-accent));
 }
 .audit-dd-opt .dot {
   width: 6px;
   height: 6px;
   flex: 0 0 auto;
-  background: #d4d4d8;
+  background: rgb(var(--c-txt3));
 }
 .audit-dd-opt .dot.mcp {
-  background: #8b5cf6;
+  background: rgb(var(--c-accent));
 }
 .audit-dd-opt .dot.run {
-  background: #71717a;
+  background: rgb(var(--c-txt2));
 }
 .audit-dd-opt .dot.gate {
-  background: #d97706;
+  background: rgb(var(--c-warn));
 }
 .audit-dd-opt .dot.wf {
-  background: #2563eb;
+  background: rgb(var(--c-info));
 }
 .audit-dd-opt .dot.prj {
-  background: #16a34a;
+  background: rgb(var(--c-ok));
 }
 .audit-dd-opt .dot.aud {
-  background: #db2777;
+  background: rgb(var(--c-err));
 }
 .audit-dd-opt .main {
   flex: 1;
@@ -393,7 +394,7 @@ defineExpose({ close })
 .audit-dd-opt .main .s {
   display: block;
   font-size: 11px;
-  color: #71717a;
+  color: rgb(var(--c-txt3));
   margin-top: 1px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -402,7 +403,7 @@ defineExpose({ close })
 .audit-dd-opt .tick {
   width: 14px;
   opacity: 0;
-  color: #7c3aed;
+  color: rgb(var(--c-accent));
   font-size: 12px;
   font-weight: 700;
 }
@@ -412,7 +413,7 @@ defineExpose({ close })
 .audit-dd-empty {
   padding: 20px 12px;
   text-align: center;
-  color: #a1a1aa;
+  color: rgb(var(--c-txt3));
   font-size: 12px;
 }
 </style>

--- a/web/src/components/project/ProjectAuditPanel.vue
+++ b/web/src/components/project/ProjectAuditPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import AuditFilterDropdown, { type AuditDdOption } from '@/components/project/AuditFilterDropdown.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
@@ -39,7 +39,7 @@ const pageSize = ref(10)
 const openId = ref<string | null>(null)
 const mode = ref<Mode>('run')
 const initialized = ref(false)
-/** User overrides for Run group expand; missing key = default (fail groups open). */
+/** User overrides for Run group expand; missing key = Demo defaultOpen. */
 const groupOpen = ref<Record<string, boolean>>({})
 const runCapped = ref(false)
 const runFetched = ref(0)
@@ -75,7 +75,6 @@ const runDdOptions = computed<AuditDdOption[]>(() =>
     value: r.runId,
     label: r.label,
     sub: r.sub,
-    short: r.runId.replace(/^run-/, '').slice(0, 8),
     dot: 'run',
   })),
 )
@@ -122,15 +121,6 @@ type Chip = { key: string; label: string; value: string; clearable: boolean }
 const chips = computed<Chip[]>(() => {
   const list: Chip[] = []
   if (mode.value === 'run') {
-    if (runId.value) {
-      const hit = runOptions.value.find((r) => r.runId === runId.value)
-      list.push({
-        key: 'run',
-        label: 'Run',
-        value: hit?.label || shortRun(runId.value),
-        clearable: false,
-      })
-    }
     if (nodeId.value) {
       list.push({
         key: 'node',
@@ -242,9 +232,18 @@ function nodeLabel(id?: string) {
   return formatAuditNodeTitle(id)
 }
 
+/** Demo「类别 / 标识」辅行；缺字段则空，不回退到 action。 */
 function resourceAux(ev: ProjectAuditEvent) {
-  const res = resourceText(ev)
-  return res && res !== '—' ? res : ev.action
+  const type = (ev.resourceType || '').trim()
+  const id = (ev.resourceId || '').trim()
+  if (type && id) return `${type} / ${id}`
+  const raw = (ev.resource || '').trim()
+  if (!raw || raw === '—') return ''
+  const i = raw.indexOf('/')
+  if (i > 0 && i < raw.length - 1) {
+    return `${raw.slice(0, i)} / ${raw.slice(i + 1)}`
+  }
+  return ''
 }
 
 type RunGroup = {
@@ -291,11 +290,36 @@ const runGroups = computed<RunGroup[]>(() => {
 
 const statOk = computed(() => Math.max(0, (stats.value.total || 0) - (stats.value.fail || 0)))
 
+const listFailCount = computed(
+  () => events.value.filter((e) => e.outcome === 'fail').length,
+)
+
+function defaultGroupOpen(g: RunGroup) {
+  if (runGroups.value.length === 1 || listFailCount.value === 0) return true
+  return g.fail > 0
+}
+
 function isGroupOpen(g: RunGroup) {
   if (Object.prototype.hasOwnProperty.call(groupOpen.value, g.id)) {
     return groupOpen.value[g.id]
   }
-  return g.fail > 0
+  return defaultGroupOpen(g)
+}
+
+function pruneGroupOpen() {
+  const ids = new Set(runGroups.value.map((g) => g.id))
+  const cur = groupOpen.value
+  const keys = Object.keys(cur)
+  if (!keys.some((k) => !ids.has(k))) return
+  const next: Record<string, boolean> = {}
+  for (const k of keys) {
+    if (ids.has(k)) next[k] = cur[k]!
+  }
+  groupOpen.value = next
+}
+
+function resetGroupOpen() {
+  groupOpen.value = {}
 }
 
 function toggleGroup(id: string) {
@@ -416,7 +440,7 @@ async function load(resetPage = false) {
     stats.value = { total: 0, mcp: 0, fail: 0 }
     runCapped.value = false
     runFetched.value = 0
-    groupOpen.value = {}
+    resetGroupOpen()
     loading.value = false
     return
   }
@@ -462,6 +486,7 @@ async function load(resetPage = false) {
 }
 
 async function bootstrap() {
+  resetGroupOpen()
   if (props.forceDenied) {
     denied.value = true
     initialized.value = true
@@ -486,7 +511,7 @@ async function setMode(next: Mode) {
   if (mode.value === next) return
   mode.value = next
   openId.value = null
-  groupOpen.value = {}
+  resetGroupOpen()
   page.value = 1
   nodeId.value = ''
   callerKind.value = ''
@@ -508,14 +533,13 @@ async function onRunChange(v: string) {
   nodeId.value = ''
   resource.value = ''
   openId.value = null
-  groupOpen.value = {}
+  resetGroupOpen()
   await loadFacets(v)
   await load(true)
 }
 
 function onFilterChange() {
   openId.value = null
-  groupOpen.value = {}
   void load(true)
 }
 
@@ -600,13 +624,19 @@ function onPageSizeChange(size: number) {
 async function onTimeChange(v: string) {
   timeWindow.value = v as '24h' | '7d' | '30d'
   openId.value = null
+  const prevRun = runId.value
   await loadFacets(mode.value === 'run' ? runId.value : undefined)
   if (mode.value === 'run' && runId.value && !runOptions.value.some((r) => r.runId === runId.value)) {
     runId.value = runOptions.value[0]?.runId || ''
     if (runId.value) await loadFacets(runId.value)
   }
+  if (runId.value !== prevRun) resetGroupOpen()
   await load(true)
 }
+
+watch(runGroups, () => {
+  pruneGroupOpen()
+})
 
 watch(
   () => [props.projectId, props.forceDenied],
@@ -618,6 +648,10 @@ watch(
 
 onMounted(() => {
   void bootstrap()
+})
+
+onUnmounted(() => {
+  resetGroupOpen()
 })
 </script>
 
@@ -633,28 +667,6 @@ onMounted(() => {
     </div>
 
     <template v-else>
-      <div class="panel-hd">
-        <h4>{{ t('pages.projectDetail.audit.title') }}</h4>
-        <div class="seg" role="tablist" data-testid="project-audit-mode">
-          <button
-            type="button"
-            :class="{ on: mode === 'run' }"
-            data-testid="project-audit-mode-run"
-            @click="setMode('run')"
-          >
-            {{ t('pages.projectDetail.audit.modeRun') }}
-          </button>
-          <button
-            type="button"
-            :class="{ on: mode === 'all' }"
-            data-testid="project-audit-mode-all"
-            @click="setMode('all')"
-          >
-            {{ t('pages.projectDetail.audit.modeAll') }}
-          </button>
-        </div>
-      </div>
-
       <div class="filters" :class="{ 'filters-mobile': isMobile }" data-testid="project-audit-filters">
         <!-- Mobile: collapsible filter summary (plan g2); search/export stay outside fold -->
         <template v-if="isMobile">
@@ -747,7 +759,33 @@ onMounted(() => {
               @input="onSearchInput"
             />
           </div>
-          <div class="filters-actions">
+          <div class="seg" role="tablist" data-testid="project-audit-mode">
+            <button
+              type="button"
+              :class="{ on: mode === 'run' }"
+              data-testid="project-audit-mode-run"
+              @click="setMode('run')"
+            >
+              {{ t('pages.projectDetail.audit.modeRun') }}
+            </button>
+            <button
+              type="button"
+              :class="{ on: mode === 'all' }"
+              data-testid="project-audit-mode-all"
+              @click="setMode('all')"
+            >
+              {{ t('pages.projectDetail.audit.modeAll') }}
+            </button>
+          </div>
+          <div class="toolbar-end">
+            <div class="toolbar-stats" data-testid="project-audit-stats">
+              <span class="stat-chip" data-testid="project-audit-run-count">
+                {{ t('pages.projectDetail.audit.statTotal') }} <b>{{ stats.total }}</b>
+              </span>
+              <span class="stat-chip ok">{{ t('pages.projectDetail.audit.statOk') }} <b>{{ statOk }}</b></span>
+              <span class="stat-chip" :class="{ fail: stats.fail }">{{ t('pages.projectDetail.audit.statFail') }} <b>{{ stats.fail }}</b></span>
+              <span class="stat-chip">MCP <b>{{ stats.mcp }}</b></span>
+            </div>
             <button type="button" class="btn" data-testid="project-audit-export" @click="exportAudit">
               {{ t('pages.projectDetail.audit.export') }}
             </button>
@@ -820,7 +858,33 @@ onMounted(() => {
             @update:model-value="onTimeChange"
           />
 
-          <div class="filters-actions">
+          <div class="seg" role="tablist" data-testid="project-audit-mode">
+            <button
+              type="button"
+              :class="{ on: mode === 'run' }"
+              data-testid="project-audit-mode-run"
+              @click="setMode('run')"
+            >
+              {{ t('pages.projectDetail.audit.modeRun') }}
+            </button>
+            <button
+              type="button"
+              :class="{ on: mode === 'all' }"
+              data-testid="project-audit-mode-all"
+              @click="setMode('all')"
+            >
+              {{ t('pages.projectDetail.audit.modeAll') }}
+            </button>
+          </div>
+          <div class="toolbar-end">
+            <div class="toolbar-stats" data-testid="project-audit-stats">
+              <span class="stat-chip" data-testid="project-audit-run-count">
+                {{ t('pages.projectDetail.audit.statTotal') }} <b>{{ stats.total }}</b>
+              </span>
+              <span class="stat-chip ok">{{ t('pages.projectDetail.audit.statOk') }} <b>{{ statOk }}</b></span>
+              <span class="stat-chip" :class="{ fail: stats.fail }">{{ t('pages.projectDetail.audit.statFail') }} <b>{{ stats.fail }}</b></span>
+              <span class="stat-chip">MCP <b>{{ stats.mcp }}</b></span>
+            </div>
             <button type="button" class="btn" data-testid="project-audit-export" @click="exportAudit">
               {{ t('pages.projectDetail.audit.export') }}
             </button>
@@ -853,23 +917,6 @@ onMounted(() => {
         </button>
       </div>
 
-      <div v-if="!isMobile" class="meta">
-        <div class="meta-l" data-testid="project-audit-stats">
-          <span class="stat-chip">{{ t('pages.projectDetail.audit.statTotal') }} <b>{{ stats.total }}</b></span>
-          <span class="stat-chip ok">{{ t('pages.projectDetail.audit.statOk') }} <b>{{ statOk }}</b></span>
-          <span class="stat-chip" :class="{ fail: stats.fail }">{{ t('pages.projectDetail.audit.statFail') }} <b>{{ stats.fail }}</b></span>
-          <span class="stat-chip">MCP <b>{{ stats.mcp }}</b></span>
-          <span v-if="mode === 'run' && runId">Run <b>{{ shortRun(runId) }}</b></span>
-        </div>
-        <div>{{ t('pages.projectDetail.audit.expandHint') }}</div>
-      </div>
-      <div v-else class="meta meta-mobile" data-testid="project-audit-stats">
-        <span class="stat-chip">{{ t('pages.projectDetail.audit.statTotal') }} <b>{{ stats.total }}</b></span>
-        <span class="stat-chip ok">{{ t('pages.projectDetail.audit.statOk') }} <b>{{ statOk }}</b></span>
-        <span class="stat-chip" :class="{ fail: stats.fail }">{{ t('pages.projectDetail.audit.statFail') }} <b>{{ stats.fail }}</b></span>
-        <span class="stat-chip">MCP <b>{{ stats.mcp }}</b></span>
-        <span v-if="mode === 'run' && runId">Run <b>{{ shortRun(runId) }}</b></span>
-      </div>
       <p v-if="mode === 'run' && runCapped && !loading" class="cap-hint" data-testid="project-audit-capped">
         {{ t('pages.projectDetail.audit.runCapped', { n: runFetched }) }}
       </p>
@@ -896,7 +943,17 @@ onMounted(() => {
         data-testid="project-audit-empty"
         :title="t('pages.projectDetail.audit.emptyTitle')"
         :desc="t('pages.projectDetail.audit.emptyDesc')"
-      />
+      >
+        <button
+          v-if="mode === 'run'"
+          type="button"
+          class="linkish"
+          data-testid="project-audit-empty-all"
+          @click="setMode('all')"
+        >
+          {{ t('pages.projectDetail.audit.modeAll') }}
+        </button>
+      </EmptyState>
       <!-- Mobile event cards (plan g3); shared by run + all modes -->
       <div
         v-else-if="isMobile"
@@ -921,7 +978,7 @@ onMounted(() => {
           <div class="ec-row">
             <span class="k">{{ t('pages.projectDetail.audit.colNode') }}</span>
             {{ nodeLabel(ev.nodeId) }}
-            <span class="ec-aux">{{ resourceAux(ev) }}</span>
+            <span v-if="resourceAux(ev)" class="ec-aux">{{ resourceAux(ev) }}</span>
           </div>
           <div v-if="openId === ev.id" class="ec-detail" @click.stop>
             <div>
@@ -1014,7 +1071,7 @@ onMounted(() => {
                     </td>
                     <td class="summary">
                       <div class="summary-main">{{ ev.summary }}</div>
-                      <div class="summary-aux">{{ resourceAux(ev) }}</div>
+                      <div v-if="resourceAux(ev)" class="summary-aux">{{ resourceAux(ev) }}</div>
                     </td>
                     <td>
                       <span :class="ev.outcome === 'fail' ? 'bad' : 'ok'">{{ outcomeLabel(ev) }}</span>
@@ -1075,7 +1132,7 @@ onMounted(() => {
                 </td>
                 <td class="summary">
                   <div class="summary-main">{{ ev.summary }}</div>
-                  <div class="summary-aux">{{ resourceAux(ev) }}</div>
+                  <div v-if="resourceAux(ev)" class="summary-aux">{{ resourceAux(ev) }}</div>
                 </td>
                 <td>
                   <span :class="ev.outcome === 'fail' ? 'bad' : 'ok'">{{ outcomeLabel(ev) }}</span>
@@ -1104,13 +1161,6 @@ onMounted(() => {
         </table>
       </div>
 
-      <div
-        v-if="mode === 'run' && !noRuns && !loading"
-        class="run-count shrink-0"
-        data-testid="project-audit-run-count"
-      >
-        {{ t('pages.projectDetail.audit.runCount', { n: stats.total }) }}
-      </div>
       <Pagination
         v-if="mode === 'all' && !noRuns"
         class="shrink-0"
@@ -1137,23 +1187,6 @@ onMounted(() => {
   overflow: hidden;
   border: 1px solid rgb(var(--c-line));
   background: rgb(var(--c-surface));
-}
-.panel-hd {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  flex-wrap: wrap;
-  flex-shrink: 0;
-  padding: 14px 16px 12px;
-  border-bottom: 1px solid rgb(var(--c-line));
-}
-.panel-hd h4 {
-  margin: 0;
-  font-size: 15px;
-  font-weight: 650;
-  letter-spacing: -0.02em;
-  color: rgb(var(--c-txt));
 }
 .seg {
   display: inline-flex;
@@ -1198,17 +1231,18 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: 8px;
-  border: 1px solid #e4e4e7;
-  background: #fff;
+  border: 1px solid rgb(var(--c-line));
+  background: rgb(var(--c-surface));
   padding: 0 10px;
 }
 .search:focus-within {
-  border-color: #c4b5fd;
-  box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.1);
+  border-color: rgb(var(--c-accent));
+  box-shadow: 0 0 0 3px rgb(var(--c-accent) / 0.12);
 }
 .search svg {
   opacity: 0.4;
   flex: 0 0 auto;
+  color: rgb(var(--c-txt2));
 }
 .search input {
   flex: 1;
@@ -1219,21 +1253,29 @@ onMounted(() => {
   min-width: 0;
   height: 30px;
   font-size: 12px;
+  color: rgb(var(--c-txt));
 }
 .search input::placeholder {
-  color: #a1a1aa;
+  color: rgb(var(--c-txt3));
 }
-.filters-actions {
+.toolbar-end {
   display: flex;
   align-items: center;
   gap: 8px;
   margin-left: auto;
+  flex-wrap: wrap;
+}
+.toolbar-stats {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
 }
 .btn {
   height: 32px;
   padding: 0 12px;
-  border: 1px solid #e4e4e7;
-  background: #fff;
+  border: 1px solid rgb(var(--c-line));
+  background: rgb(var(--c-surface));
   color: rgb(var(--c-txt));
   font: inherit;
   font-size: 12px;
@@ -1242,8 +1284,8 @@ onMounted(() => {
   white-space: nowrap;
 }
 .btn:hover:not(:disabled) {
-  background: #fafafa;
-  border-color: #d4d4d8;
+  background: rgb(var(--c-elevated));
+  border-color: rgb(var(--c-line-strong));
 }
 .btn:disabled {
   opacity: 0.35;
@@ -1264,8 +1306,8 @@ onMounted(() => {
   gap: 4px;
   height: 24px;
   padding: 0 4px 0 8px;
-  background: #f4f4f5;
-  border: 1px solid #e4e4e7;
+  background: rgb(var(--c-elevated));
+  border: 1px solid rgb(var(--c-line));
   font-size: 11px;
   color: rgb(var(--c-txt));
 }
@@ -1289,7 +1331,7 @@ onMounted(() => {
 }
 .chip .x:hover {
   color: rgb(var(--c-txt));
-  background: #e4e4e7;
+  background: rgb(var(--c-overlay));
 }
 .linkish {
   border: 0;
@@ -1302,29 +1344,6 @@ onMounted(() => {
 }
 .linkish:hover {
   color: rgb(var(--c-accent));
-}
-.meta {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-  flex-shrink: 0;
-  padding: 8px 16px;
-  font-size: 12px;
-  color: rgb(var(--c-txt2));
-  border-bottom: 1px solid rgb(var(--c-line));
-}
-.meta b {
-  color: rgb(var(--c-txt));
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
-}
-.meta-l {
-  display: flex;
-  gap: 8px 12px;
-  flex-wrap: wrap;
-  align-items: center;
 }
 .stat-chip {
   display: inline-flex;
@@ -1347,7 +1366,7 @@ onMounted(() => {
 }
 .stat-chip.fail b,
 .stat-chip.fail strong {
-  color: #f87171;
+  color: rgb(var(--c-err));
 }
 .cap-hint {
   margin: 0;
@@ -1357,21 +1376,6 @@ onMounted(() => {
   border-bottom: 1px dashed rgb(var(--c-line-strong));
   background: rgb(var(--c-accent-dim));
   flex-shrink: 0;
-}
-.run-count {
-  padding: 10px 16px;
-  font-size: 12px;
-  color: rgb(var(--c-txt3));
-  border-top: 1px solid rgb(var(--c-line));
-}
-.meta-mobile {
-  gap: 10px;
-  padding: 6px 16px;
-}
-.meta-mobile b {
-  color: rgb(var(--c-txt));
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
 }
 .table-wrap {
   flex: 1;
@@ -1415,7 +1419,7 @@ onMounted(() => {
 }
 .group.open .chev {
   transform: rotate(90deg);
-  border-left-color: #7b61ff;
+  border-left-color: rgb(var(--c-accent));
 }
 .group-meta {
   display: flex;
@@ -1442,31 +1446,34 @@ onMounted(() => {
   flex-shrink: 0;
   background: rgb(var(--c-txt3));
 }
-.node-dot.research {
-  background: #22d3ee;
+.node-dot.research,
+.node-dot.react,
+.node-dot.input,
+.node-dot.output {
+  background: rgb(var(--c-info));
 }
 .node-dot.proposal,
-.node-dot.proposal_select {
-  background: #60a5fa;
-}
-.node-dot.gate,
-.node-dot.human_gate {
-  background: #fbbf24;
-}
-.node-dot.visual {
-  background: #f59e0b;
-}
-.node-dot.react {
-  background: #22d3ee;
-}
+.node-dot.proposal_select,
 .node-dot.implement,
 .node-dot.plan,
 .node-dot.test,
-.node-dot.review {
-  background: #60a5fa;
+.node-dot.review,
+.node-dot.submit_mr {
+  background: rgb(var(--c-info));
 }
+.node-dot.gate,
+.node-dot.human_gate,
+.node-dot.visual,
 .node-dot.app_preview {
-  background: #f59e0b;
+  background: rgb(var(--c-warn));
+}
+.node-dot.agent,
+.node-dot.branch,
+.node-dot.set_var {
+  background: rgb(var(--c-accent));
+}
+.node-dot.system {
+  background: rgb(var(--c-ok));
 }
 .group-sub {
   font-size: 11.5px;
@@ -1519,17 +1526,17 @@ tr.row {
   cursor: pointer;
 }
 tr.row:hover td {
-  background: #fafafa;
+  background: rgb(var(--c-elevated));
 }
 tr.row.open td {
-  background: #f5f3ff;
+  background: rgb(var(--c-accent-dim));
 }
 tr.row.fail td:first-child {
-  box-shadow: inset 2px 0 0 #dc2626;
+  box-shadow: inset 2px 0 0 rgb(var(--c-err));
 }
 tr.detail td {
   padding: 0;
-  background: #fafafa;
+  background: rgb(var(--c-elevated));
   border-bottom: 1px solid rgb(var(--c-line));
 }
 .detail-inner {
@@ -1549,7 +1556,7 @@ tr.detail td {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 11px;
   color: rgb(var(--c-txt));
-  background: #fff;
+  background: rgb(var(--c-surface));
   border: 1px solid rgb(var(--c-line));
   padding: 1px 5px;
 }
@@ -1557,21 +1564,21 @@ tr.detail td {
   margin: 0;
   padding: 10px 12px;
   border: 1px solid rgb(var(--c-line));
-  background: #fff;
+  background: rgb(var(--c-surface));
   font: 11px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   white-space: pre-wrap;
   word-break: break-word;
-  color: #3f3f46;
+  color: rgb(var(--c-txt2));
   overflow-x: auto;
 }
 .mono {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 12px;
-  color: #52525b;
+  color: rgb(var(--c-txt2));
 }
 .time-main {
   font-variant-numeric: tabular-nums;
-  color: #3f3f46;
+  color: rgb(var(--c-txt));
   font-size: 12px;
 }
 .who {
@@ -1607,17 +1614,17 @@ tr.detail td {
   font-size: 12px;
 }
 .ok {
-  color: #16a34a;
+  color: rgb(var(--c-ok));
   font-size: 12px;
   font-weight: 500;
 }
 .bad {
-  color: #dc2626;
+  color: rgb(var(--c-err));
   font-size: 12px;
   font-weight: 500;
 }
 .summary {
-  color: #3f3f46;
+  color: rgb(var(--c-txt));
 }
 .list-placeholder {
   flex: 1;
@@ -1652,8 +1659,8 @@ tr.detail td {
   gap: 8px;
   width: 100%;
   min-height: 44px;
-  border: 1px solid #e4e4e7;
-  background: #fafafa;
+  border: 1px solid rgb(var(--c-line));
+  background: rgb(var(--c-elevated));
   padding: 10px 12px;
   font: inherit;
   text-align: left;
@@ -1683,9 +1690,9 @@ tr.detail td {
   width: 100%;
   /* 与搜索同宽（f1/g2.3）：仅纵向内边距，避免左右 inset 缩窄触发器 */
   padding: 10px 0;
-  border-top: 1px solid #eee;
-  border-bottom: 1px solid #eee;
-  background: #fcfcfc;
+  border-top: 1px solid rgb(var(--c-line));
+  border-bottom: 1px solid rgb(var(--c-line));
+  background: rgb(var(--c-base));
 }
 .filters-mobile {
   flex-direction: column;
@@ -1701,16 +1708,19 @@ tr.detail td {
 .filters-mobile .search input {
   height: 42px;
 }
-.filters-mobile .filters-actions {
+.filters-mobile .toolbar-end {
   margin-left: 0;
   width: 100%;
   flex: 0 0 auto;
 }
-.filters-mobile .filters-actions .btn {
+.filters-mobile .toolbar-end .btn {
   flex: 1;
   width: 100%;
   min-height: 44px;
   height: auto;
+}
+.filters-mobile .toolbar-stats {
+  width: 100%;
 }
 .filters-mobile .filter-summary {
   flex: 0 0 auto;
@@ -1727,8 +1737,8 @@ tr.detail td {
 .event-card {
   display: block;
   width: 100%;
-  border: 1px solid #e5e5e5;
-  background: #fff;
+  border: 1px solid rgb(var(--c-line));
+  background: rgb(var(--c-surface));
   padding: 10px;
   text-align: left;
   font: inherit;
@@ -1737,14 +1747,14 @@ tr.detail td {
   transition: border-color 0.15s ease, background 0.15s ease;
 }
 .event-card:hover {
-  border-color: #c4b5fd;
+  border-color: rgb(var(--c-accent));
 }
 .event-card.open {
   border-color: rgb(var(--c-accent));
-  background: #faf8ff;
+  background: rgb(var(--c-accent-dim));
 }
 .event-card.fail {
-  box-shadow: inset 2px 0 0 #dc2626;
+  box-shadow: inset 2px 0 0 rgb(var(--c-err));
 }
 .ec-top {
   display: flex;
@@ -1815,11 +1825,11 @@ tr.detail td {
     max-width: none;
     width: 100%;
   }
-  .filters:not(.filters-mobile) .filters-actions {
+  .filters:not(.filters-mobile) .toolbar-end {
     margin-left: 0;
     width: 100%;
   }
-  .filters:not(.filters-mobile) .filters-actions .btn {
+  .filters:not(.filters-mobile) .toolbar-end .btn {
     flex: 1;
     width: 100%;
   }

--- a/web/src/components/run/UpstreamRequirementContext.test.ts
+++ b/web/src/components/run/UpstreamRequirementContext.test.ts
@@ -370,7 +370,7 @@ describe('UpstreamRequirementContext', () => {
     expect(wrapper.find('[data-testid="upstream-modal-callout"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="upstream-bar-hint"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="upstream-bar-hint"]').text()).toContain(
-      '本 run 已有澄清需求文档',
+      '本工作流已有澄清需求文档',
     )
     wrapper.unmount()
   })

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -348,7 +348,7 @@
         "statFail": "Failed",
         "runCount": "{n} events in this run",
         "runCapped": "Showing the first {n} events. Narrow filters or switch to All logs.",
-        "groupEvents": "{n} events · click to expand/collapse",
+        "groupEvents": "{n}",
         "expandHint": "Click a row to expand",
         "expandHintCard": "Tap a card to expand",
         "filterExpand": "Expand filters",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -348,7 +348,7 @@
         "statFail": "失败",
         "runCount": "该 Run 共 {n} 条",
         "runCapped": "仅展示前 {n} 条，请用筛选或全部日志",
-        "groupEvents": "{n} 条事件 · 点击展开/折叠",
+        "groupEvents": "{n} 条",
         "expandHint": "点击行展开",
         "expandHintCard": "点击卡片展开",
         "filterExpand": "展开筛选",

--- a/web/src/views/ProjectDetailView.auditLayout.test.ts
+++ b/web/src/views/ProjectDetailView.auditLayout.test.ts
@@ -48,16 +48,24 @@ describe('ProjectAuditPanel fill layout + sticky header + tokens (g1.2–g4.2 / 
     expect(cards).toMatch(/min-height:\s*0/)
     expect(cards).toMatch(/overflow:\s*auto/)
 
-    expect(cssBlock(panelSrc, '.panel-hd')).toMatch(/flex-shrink:\s*0/)
     expect(cssBlock(panelSrc, '.filters')).toMatch(/flex-shrink:\s*0/)
     expect(cssBlock(panelSrc, '.chips')).toMatch(/flex-shrink:\s*0/)
-    expect(cssBlock(panelSrc, '.meta')).toMatch(/flex-shrink:\s*0/)
+    expect(cssBlock(panelSrc, '.groups-wrap')).toMatch(/flex:\s*1/)
+    expect(cssBlock(panelSrc, '.groups-wrap')).toMatch(/min-height:\s*0/)
+    expect(cssBlock(panelSrc, '.groups-wrap')).toMatch(/overflow:\s*auto/)
 
     expect(panelSrc).toMatch(/<Pagination[\s\S]*?class="shrink-0"/)
     expect(panelSrc).toMatch(/v-if="mode === 'all' && !noRuns"/)
     expect(panelSrc).toMatch(/AUDIT_PAGE_SIZE_OPTIONS = \[5, 10, 20\]/)
     expect(panelSrc).toMatch(/data-layout="groups"/)
+    expect(panelSrc).toMatch(/class="toolbar-end"/)
+    expect(panelSrc).toMatch(/class="toolbar-stats"/)
     expect(panelSrc).toMatch(/project-audit-run-count/)
+    expect(panelSrc).not.toMatch(/<h4>/)
+    expect(panelSrc).not.toMatch(/class="meta/)
+    expect(panelSrc).not.toMatch(/class="run-count/)
+    expect(panelSrc).not.toMatch(/class="panel-hd/)
+    expect(panelSrc).not.toMatch(/class="filters-actions"/)
   })
 
   it('desktop thead sticks with elevated bg and txt2 (not Demo txt3 / #fafafa)', () => {
@@ -72,9 +80,12 @@ describe('ProjectAuditPanel fill layout + sticky header + tokens (g1.2–g4.2 / 
     expect(cssBlock(panelSrc, 'table')).toMatch(/border-spacing:\s*0/)
   })
 
-  it('title / stats / filter trigger use global --c-* tokens', () => {
-    expect(cssBlock(panelSrc, '.panel-hd h4')).toMatch(/color:\s*rgb\(var\(--c-txt\)\)/)
-    expect(cssBlock(panelSrc, '.meta')).toMatch(/color:\s*rgb\(var\(--c-txt2\)\)/)
+  it('toolbar / stats / filter trigger use global --c-* tokens', () => {
+    expect(cssBlock(panelSrc, '.filters')).toMatch(/border-bottom:\s*1px solid rgb\(var\(--c-line\)\)/)
+    expect(cssBlock(panelSrc, '.search')).toMatch(/background:\s*rgb\(var\(--c-surface\)\)/)
+    expect(cssBlock(panelSrc, '.search')).toMatch(/border:\s*1px solid rgb\(var\(--c-line\)\)/)
+    expect(cssBlock(panelSrc, '.btn')).toMatch(/background:\s*rgb\(var\(--c-surface\)\)/)
+    expect(cssBlock(panelSrc, '.chip')).toMatch(/background:\s*rgb\(var\(--c-elevated\)\)/)
     expect(cssBlock(panelSrc, '.audit-panel')).toMatch(/background:\s*rgb\(var\(--c-surface\)\)/)
     expect(cssBlock(panelSrc, '.audit-panel')).toMatch(/border:\s*1px solid rgb\(var\(--c-line\)\)/)
     expect(cssBlock(panelSrc, '.seg')).toMatch(/background:\s*rgb\(var\(--c-elevated\)\)/)
@@ -92,6 +103,9 @@ describe('ProjectAuditPanel fill layout + sticky header + tokens (g1.2–g4.2 / 
     expect(filterSrc).not.toMatch(/var\(--card/)
     expect(filterSrc).not.toMatch(/var\(--line/)
     expect(filterSrc).not.toMatch(/var\(--accent/)
+    expect(filterSrc).not.toMatch(/background:\s*#fff/)
+    expect(filterSrc).not.toMatch(/#e4e4e7/)
+    expect(filterSrc).not.toMatch(/#fafafa/)
   })
 
   it('loading / noRuns / empty / denied occupy remaining slot and center', () => {


### PR DESCRIPTION
Default-open groups when a run has one group or no failures, drop the misleading Run chip, and collapse the toolbar so events are visible on first paint.

Co-authored-by: Cursor <cursoragent@cursor.com>
