### PR TITLE
fix(web): show Inbox first-load skeleton and fail state

### DIFF
--- a/web/e2e/inbox-empty-fill.spec.ts
+++ b/web/e2e/inbox-empty-fill.spec.ts
@@ -19,7 +19,10 @@ const MOCK_WORKFLOWS = [
   },
 ]
 
-async function mockApi(page: Page, opts: { filterEmpty?: boolean } = {}) {
+async function mockApi(
+  page: Page,
+  opts: { filterEmpty?: boolean; gatesDelayMs?: number; failGates?: { current: boolean } } = {},
+) {
   await page.route('**/api/**', async (route) => {
     // Skip Vite module URLs like /@fs/.../src/lib/api/api.ts (pathname is not /api/...)
     if (!new URL(route.request().url()).pathname.startsWith('/api/')) {
@@ -29,6 +32,13 @@ async function mockApi(page: Page, opts: { filterEmpty?: boolean } = {}) {
     const url = new URL(route.request().url())
     const p = url.pathname
     if (p.includes('/gates')) {
+      if (opts.failGates?.current) {
+        await route.fulfill({ status: 500, json: { error: 'gates boom' } })
+        return
+      }
+      if (opts.gatesDelayMs) {
+        await new Promise((resolve) => setTimeout(resolve, opts.gatesDelayMs))
+      }
       const filtered = opts.filterEmpty || !!url.searchParams.get('wf')
       await route.fulfill({
         json: filtered ? { items: [], total: 5 } : { items: [], total: 0 },
@@ -203,5 +213,44 @@ test.describe('Inbox empty fill layout (plan g2.3)', () => {
     expect(m.cardBox!.top).toBeGreaterThan(m.headingBox!.bottom - 1)
     // overflow-auto allows internal scroll when EmptyState exceeds card height.
     expect(['auto', 'overlay', 'scroll']).toContain(m.cardOverflow)
+  })
+})
+
+test.describe('Inbox first-load skeleton / fail (plan g3.3)', () => {
+  test('delayed GET /gates shows 6 skeletons and never flashes empty copy (g3.3)', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await mockApi(page, { gatesDelayMs: 1800 })
+    await page.goto('/inbox-empty-fill.html?theme=light')
+    await expect(page.getByRole('heading', { name: '待审批' })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByTestId('inbox-list-skeleton')).toBeVisible()
+    await expect(page.getByTestId('inbox-pending-card-skeleton')).toHaveCount(6)
+    await expect(page.getByText('列表加载后可选择一项')).toBeVisible()
+    await expect(page.getByText('没有待审批项')).toHaveCount(0)
+    await expect(page.getByText('该流水线没有待审批项')).toHaveCount(0)
+    await expect(page.getByRole('heading', { name: '待审批' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '刷新' })).toBeVisible()
+
+    await expect(page.getByText('没有待审批项')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByTestId('inbox-list-skeleton')).toHaveCount(0)
+    await expectEmptyCardClasses(page)
+  })
+
+  test('first GET /gates 500 shows load-failed + retry, not empty copy (g3.3)', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    const failGates = { current: true }
+    await mockApi(page, { failGates })
+    await page.goto('/inbox-empty-fill.html?theme=light')
+    await expect(page.getByRole('heading', { name: '待审批' })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByTestId('inbox-list-failed')).toBeVisible()
+    await expect(page.getByText('加载失败')).toBeVisible()
+    await expect(page.getByText('无法获取列表，请稍后重试')).toBeVisible()
+    await expect(page.getByTestId('inbox-list-retry')).toBeVisible()
+    await expect(page.getByText('没有待审批项')).toHaveCount(0)
+
+    failGates.current = false
+    await page.getByTestId('inbox-list-retry').click()
+    await expect(page.getByText('没有待审批项')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByTestId('inbox-list-failed')).toHaveCount(0)
+    await expectEmptyCardClasses(page)
   })
 })

--- a/web/src/components/run/UpstreamRequirementContext.test.ts
+++ b/web/src/components/run/UpstreamRequirementContext.test.ts
@@ -370,7 +370,7 @@ describe('UpstreamRequirementContext', () => {
     expect(wrapper.find('[data-testid="upstream-modal-callout"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="upstream-bar-hint"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="upstream-bar-hint"]').text()).toContain(
-      '本 run 已有澄清需求文档',
+      '本工作流已有澄清需求文档',
     )
     wrapper.unmount()
   })

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -972,6 +972,8 @@
       "reviewType": "Needs review",
       "previewType": "App Preview",
       "loadingRun": "Loading run details…",
+      "listLoadingHint": "Select an item after the list loads",
+      "detailPane": "Details",
       "reviewFinished": "Confirmed and advanced",
       "reviewFinishedPending": "Confirmed and advanced; list not updated yet — refresh shortly",
       "reviewFinishFailed": "Failed to confirm and advance; please retry",

--- a/web/src/locales/userFacingCopy.test.ts
+++ b/web/src/locales/userFacingCopy.test.ts
@@ -66,6 +66,23 @@ describe('user-facing copy remediation keys', () => {
     expect(zh.global.t('pages.workflowEditor.canvas.humanGateSubtitle')).not.toMatch(/ReAct/)
   })
 
+  it('inbox first-load hint is distinct from empty and run-loading copy', () => {
+    expect(zh.global.t('pages.gatesInbox.listLoadingHint')).toBe('列表加载后可选择一项')
+    expect(en.global.t('pages.gatesInbox.listLoadingHint')).toBe('Select an item after the list loads')
+    expect(zh.global.t('pages.gatesInbox.listLoadingHint')).not.toBe(zh.global.t('common.empty.noPendingGates'))
+    expect(zh.global.t('pages.gatesInbox.listLoadingHint')).not.toBe(zh.global.t('pages.gatesInbox.loadingRun'))
+    expect(zh.global.t('pages.gatesInbox.detailPane')).toBe('详情')
+    expect(en.global.t('pages.gatesInbox.detailPane')).toBe('Details')
+    expect(zh.global.t('common.empty.noPendingGates')).toBe('没有待审批项')
+    expect(zh.global.t('common.empty.noPendingGatesForPipeline')).toBe('该流水线没有待审批项')
+    expect(zh.global.t('common.empty.noPendingGatesDesc')).toBe(
+      '当工作流到达人工门禁或需求澄清节点时会出现在这里',
+    )
+    expect(zh.global.t('common.empty.noPendingGatesPipelineDesc')).toBe(
+      '试试选择其他流水线,或查看全部流水线',
+    )
+  })
+
   it('gate share-link copy is bilingual without hardcoded jargon', () => {
     expect(zh.global.t('pages.gatesInbox.share.copyLink')).toBe('复制临时链接')
     expect(en.global.t('pages.gatesInbox.share.copyLink')).toBe('Copy temp link')

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -972,6 +972,8 @@
       "reviewType": "待复审",
       "previewType": "应用预览",
       "loadingRun": "加载运行详情…",
+      "listLoadingHint": "列表加载后可选择一项",
+      "detailPane": "详情",
       "reviewFinished": "已确认并流转",
       "reviewFinishedPending": "已提交确认并流转，列表尚未更新，请稍后刷新",
       "reviewFinishFailed": "确认并流转失败，请重试",

--- a/web/src/views/GatesInboxView.mobileFill.test.ts
+++ b/web/src/views/GatesInboxView.mobileFill.test.ts
@@ -95,6 +95,53 @@ describe('GatesInboxView empty inbox fill (plan g1 / g2.1 / g1.3)', () => {
   })
 })
 
+describe('GatesInboxView list first-load tri-state (plan g1 / g2 / g3.2)', () => {
+  it('listLoading starts true and template consumes listLoading + listLoadFailed', () => {
+    expect(src).toMatch(/const listLoading = ref\(true\)/)
+    expect(src).toMatch(/const listLoadFailed = ref\(false\)/)
+    expect(src).toMatch(/showListSkeleton/)
+    expect(src).toMatch(/showListError/)
+    expect(src).toMatch(/listLoadFailed\.value = true/)
+    expect(src).toMatch(/listLoadFailed\.value = false/)
+    expect(src).toMatch(/retryListLoad/)
+    expect(src).toMatch(/t\('pages\.gatesInbox\.listLoadingHint'\)/)
+    expect(src).toMatch(/t\('common\.asyncState\.loadFailedTitle'\)/)
+    expect(src).toMatch(/t\('common\.asyncState\.loadFailedDesc'\)/)
+    expect(src).toMatch(/t\('common\.buttons\.retry'\)/)
+    expect(src).toMatch(/data-testid="inbox-list-skeleton"/)
+    expect(src).toMatch(/data-testid="inbox-list-failed"/)
+    expect(src).toMatch(/data-testid="inbox-pending-card-skeleton"/)
+    expect(src).toMatch(/aria-busy="true"/)
+    expect(src).toMatch(/LIST_SKELETON_COUNT = 6/)
+    expect(src).toMatch(/app-skeleton__block h-9 w-9/)
+    expect(src).not.toMatch(/<AppSkeleton/)
+    expect(src).not.toMatch(/InboxPendingCardSkeleton/)
+  })
+
+  it('branch order is loading∧empty → error∧empty → EmptyState; empty wrappers stay two', () => {
+    const mobileList = src.slice(src.indexOf('<!-- Mobile list view -->'), src.indexOf('<!-- Mobile detail view -->'))
+    expect(mobileList.indexOf('v-else-if="showListSkeleton"')).toBeGreaterThan(-1)
+    expect(mobileList.indexOf('v-else-if="showListError"')).toBeGreaterThan(
+      mobileList.indexOf('v-else-if="showListSkeleton"'),
+    )
+    expect(mobileList.indexOf('v-else class="card flex min-h-0 flex-1 flex-col items-center justify-center overflow-auto"')).toBeGreaterThan(
+      mobileList.indexOf('v-else-if="showListError"'),
+    )
+
+    const desktop = src.slice(src.indexOf('<!-- Desktop loading'))
+    expect(desktop.indexOf('v-else-if="!isMobile && showListSkeleton"')).toBeGreaterThan(-1)
+    expect(desktop.indexOf('v-else-if="!isMobile && showListError"')).toBeGreaterThan(
+      desktop.indexOf('v-else-if="!isMobile && showListSkeleton"'),
+    )
+    expect(desktop.indexOf('v-else-if="!isMobile && listItems.length"')).toBeGreaterThan(
+      desktop.indexOf('v-else-if="!isMobile && showListError"'),
+    )
+    expect(desktop).toMatch(/grid-cols-\[320px_1fr\] items-stretch/)
+    expect(src).toMatch(/loadList\(\{ showLoading: listItems\.value\.length === 0 \}\)/)
+    expect(src).toMatch(/void loadList\(\{ showLoading: true \}\)/)
+  })
+})
+
 describe('GatesInboxView app_preview stage (g2.2)', () => {
   it('mounts AppPreviewPanel with fill + pick wiring on both ReviewShell stages', () => {
     expect(src).toMatch(/import AppPreviewPanel/)

--- a/web/src/views/GatesInboxView.vue
+++ b/web/src/views/GatesInboxView.vue
@@ -73,14 +73,25 @@ const {
   itemKey,
 } = usePendingGates()
 const PAGE_SIZE = 20
+/** InboxPendingCard-density placeholders; only when list is empty and still fetching. */
+const LIST_SKELETON_COUNT = 6
 const listItems = ref<InboxItem[]>([])
 /** Snapshot before the latest list mutation — used for neighbor active selection. */
 let listSnapshotForNeighbor: InboxItem[] = []
 const listTotal = ref(0)
 const listPage = ref(1)
-const listLoading = ref(false)
+/** true on first frame so mount cannot flash EmptyState before onMounted loadList. */
+const listLoading = ref(true)
+/** Set only by the current listLoadGeneration; cleared when a new request starts. */
+const listLoadFailed = ref(false)
 /** Monotonic generation: stale listGates responses must not overwrite local converge. */
 let listLoadGeneration = 0
+const showListSkeleton = computed(
+  () => listLoading.value && listItems.value.length === 0,
+)
+const showListError = computed(
+  () => !listLoading.value && listLoadFailed.value && listItems.value.length === 0,
+)
 const { isMobile } = useBreakpoint()
 const active = ref<InboxItem | null>(null)
 const mobileView = ref<'list' | 'detail'>('list')
@@ -320,6 +331,7 @@ function handleLeftInboxContext(it: InboxItem) {
 
 async function loadList({ showLoading = false }: { showLoading?: boolean } = {}) {
   const gen = ++listLoadGeneration
+  listLoadFailed.value = false
   if (showLoading) listLoading.value = true
   try {
     const data = await api.listGates({
@@ -343,10 +355,17 @@ async function loadList({ showLoading = false }: { showLoading?: boolean } = {})
     // Independent loadList success path: repair invalid selection (no Run # - shell).
     if (!processingLock.value) ensureValidActive()
   } catch {
+    // Stale failure must not flip a newer loading/empty/error state.
+    if (gen !== listLoadGeneration) return
+    listLoadFailed.value = true
     /* keep previous list on transient failure */
   } finally {
     if (gen === listLoadGeneration) listLoading.value = false
   }
+}
+
+function retryListLoad() {
+  void loadList({ showLoading: true })
 }
 
 watch(selected, () => {
@@ -1149,7 +1168,7 @@ async function onManualRefresh() {
     } else {
       const prevKey = active.value ? itemKey(active.value) : null
       await refresh({ source: 'manual', mode: 'force' })
-      await loadList()
+      await loadList({ showLoading: listItems.value.length === 0 })
       syncActiveAfterApply(listItems.value, prevKey)
       await loadActiveRun(isEditing.value ? false : true)
       checkProcessedWhileEditing()
@@ -1498,6 +1517,47 @@ function itemSecondary(it: InboxItem) {
         </div>
         <Pagination v-if="listTotal > PAGE_SIZE" v-model:page="listPage" :page-size="PAGE_SIZE" :total="listTotal" />
       </div>
+      <div
+        v-else-if="showListSkeleton"
+        class="flex min-h-0 flex-1 flex-col"
+        data-testid="inbox-list-skeleton"
+        aria-busy="true"
+      >
+        <div class="scroll-area flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
+          <div
+            v-for="n in LIST_SKELETON_COUNT"
+            :key="'inbox-skel-m-' + n"
+            class="flex w-full shrink-0 items-start gap-3 border border-line bg-surface p-3"
+            data-testid="inbox-pending-card-skeleton"
+            aria-hidden="true"
+          >
+            <div class="app-skeleton__block h-9 w-9 shrink-0" />
+            <div class="flex min-w-0 flex-1 flex-col gap-2">
+              <div class="app-skeleton__block h-2.5 w-4/5" />
+              <div class="app-skeleton__block h-2.5 w-[55%]" />
+              <div class="app-skeleton__block h-2 w-[30%]" />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        v-else-if="showListError"
+        class="card flex min-h-0 flex-1 flex-col items-center justify-center overflow-auto px-5 py-10 text-center"
+        role="status"
+        data-testid="inbox-list-failed"
+      >
+        <Icon name="alert" :size="22" class="mb-3 text-err" />
+        <h3 class="text-sm font-semibold text-txt">{{ t('common.asyncState.loadFailedTitle') }}</h3>
+        <p class="mt-1 text-xs text-txt2">{{ t('common.asyncState.loadFailedDesc') }}</p>
+        <button
+          type="button"
+          class="mt-4 inline-flex items-center rounded-md border border-line bg-surface px-3.5 py-2 text-sm font-medium text-txt transition hover:border-line-strong hover:bg-elevated"
+          data-testid="inbox-list-retry"
+          @click="retryListLoad"
+        >
+          {{ t('common.buttons.retry') }}
+        </button>
+      </div>
       <div v-else class="card flex min-h-0 flex-1 flex-col items-center justify-center overflow-auto">
         <EmptyState
           icon="gate"
@@ -1610,6 +1670,63 @@ function itemSecondary(it: InboxItem) {
           @retry="retryActiveRun"
         />
       </div>
+    </div>
+
+    <!-- Desktop loading∧empty: keep 320px list + weak detail hint (no EmptyState, no detail skeleton). -->
+    <div
+      v-else-if="!isMobile && showListSkeleton"
+      class="grid min-h-0 flex-1 grid-cols-[320px_1fr] items-stretch gap-4"
+      data-testid="inbox-list-skeleton"
+      aria-busy="true"
+    >
+      <div class="flex h-full min-h-0 flex-col overflow-hidden">
+        <div class="scroll-area flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
+          <div
+            v-for="n in LIST_SKELETON_COUNT"
+            :key="'inbox-skel-d-' + n"
+            class="flex w-full shrink-0 items-start gap-3 border border-line bg-surface p-3"
+            data-testid="inbox-pending-card-skeleton"
+            aria-hidden="true"
+          >
+            <div class="app-skeleton__block h-9 w-9 shrink-0" />
+            <div class="flex min-w-0 flex-1 flex-col gap-2">
+              <div class="app-skeleton__block h-2.5 w-4/5" />
+              <div class="app-skeleton__block h-2.5 w-[55%]" />
+              <div class="app-skeleton__block h-2 w-[30%]" />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="flex h-full min-h-0 min-w-0 flex-col">
+        <div class="card flex h-full min-h-0 w-full flex-col overflow-hidden">
+          <div class="flex shrink-0 items-center justify-between border-b border-line px-4 py-2.5">
+            <span class="text-xs text-txt3">{{ t('pages.gatesInbox.detailPane') }}</span>
+          </div>
+          <div class="flex min-h-0 flex-1 flex-col items-center justify-center px-6 text-center">
+            <p class="text-sm text-txt2">{{ t('pages.gatesInbox.listLoadingHint') }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Desktop error∧empty: single-column retry fills former list+detail area. -->
+    <div
+      v-else-if="!isMobile && showListError"
+      class="card flex min-h-0 flex-1 flex-col items-center justify-center overflow-auto px-5 py-10 text-center"
+      role="status"
+      data-testid="inbox-list-failed"
+    >
+      <Icon name="alert" :size="22" class="mb-3 text-err" />
+      <h3 class="text-sm font-semibold text-txt">{{ t('common.asyncState.loadFailedTitle') }}</h3>
+      <p class="mt-1 text-xs text-txt2">{{ t('common.asyncState.loadFailedDesc') }}</p>
+      <button
+        type="button"
+        class="mt-4 inline-flex items-center rounded-md border border-line bg-surface px-3.5 py-2 text-sm font-medium text-txt transition hover:border-line-strong hover:bg-elevated"
+        data-testid="inbox-list-retry"
+        @click="retryListLoad"
+      >
+        {{ t('common.buttons.retry') }}
+      </button>
     </div>
 
     <!-- Desktop three-zone: list | product stage + review sidebar (via GateApproval/ReviewShell).


### PR DESCRIPTION
Avoid flashing the empty copy on /gates by keeping listLoading true on mount and branching loading/error before EmptyState.

Co-authored-by: Cursor <cursoragent@cursor.com>
