### PR TITLE
fix(web): stop year-1 startedAt from inflating multi-run avg wall

### DIFF
--- a/web/src/components/run/ExecutionStatsPanel.test.ts
+++ b/web/src/components/run/ExecutionStatsPanel.test.ts
@@ -414,8 +414,8 @@ describe('ExecutionStatsPanel', () => {
     await multiBtn!.trigger('click')
     await flushPromises()
 
-    // avg wall of 120 + 90 = 105s → 1.8m; tip exact clock
-    expect(wrapper.find('[data-testid="stats-kpi-avg-wall-value"]').text()).toBe('1.8m')
+    // avg wall of 120 + 90 = 105s → 01:45 (F2 mm:ss, not compact 1.8m)
+    expect(wrapper.find('[data-testid="stats-kpi-avg-wall-value"]').text()).toBe('01:45')
     await wrapper.find('[data-testid="stats-kpi-avg-wall-value"]').trigger('mouseenter')
     expect(wrapper.find('[data-testid="stats-kpi-avg-wall-tip"]').text()).toContain('01:45')
     await wrapper.find('[data-testid="stats-kpi-avg-wall-value"]').trigger('mouseleave')
@@ -432,6 +432,149 @@ describe('ExecutionStatsPanel', () => {
     expect(wrapper.text()).toContain('合计')
     expect(wrapper.text()).toContain('对所选 Run 中同一维度的条目合计耗时')
     expect(wrapper.text()).not.toContain('Σ')
+    wrapper.unmount()
+  })
+
+  it('F7: queued+0001 does not inflate avg wall; list wall equals KPI; unknown time (g2/g3/g5.1)', async () => {
+    const goZero = '0001-01-01T00:00:00Z'
+    const queued = {
+      ...baseRun(false),
+      id: 'run-1',
+      status: 'queued',
+      startedAt: goZero,
+      durationSec: 0,
+      nodeExecutions: {},
+    } as Run
+    const doneA = {
+      ...baseRun(true),
+      id: 'run-2',
+      status: 'completed',
+      startedAt: '2026-08-12T02:00:00Z',
+      durationSec: 744,
+    } as Run
+    const doneB = {
+      ...baseRun(false),
+      id: 'run-3',
+      status: 'completed',
+      startedAt: '2026-08-12T03:00:00Z',
+      durationSec: 120,
+    } as Run
+    apiMocks.listRuns.mockResolvedValue({
+      items: [
+        { id: 'run-1', status: 'queued', durationSec: 0, startedAt: goZero },
+        { id: 'run-2', status: 'completed', durationSec: 744, startedAt: '2026-08-12T02:00:00Z' },
+        { id: 'run-3', status: 'completed', durationSec: 120, startedAt: '2026-08-12T03:00:00Z' },
+      ],
+      total: 3,
+    })
+    apiMocks.getRun.mockImplementation(async (id: string) => {
+      if (id === 'run-2') return doneA
+      if (id === 'run-3') return doneB
+      return queued
+    })
+
+    const wrapper = mount(ExecutionStatsPanel, {
+      props: {
+        run: queued,
+        nodes,
+        wallSec: 63_922_000_000,
+        nowMs: Date.parse('2026-08-12T04:00:00Z'),
+      },
+      global: {
+        plugins: [
+          createI18n({
+            legacy: false,
+            locale: 'zh-CN',
+            messages: { 'zh-CN': { ...common, ...pages } },
+          }),
+        ],
+        stubs: { Icon: true, TruncatedTextTooltip: true, StatsPieChart: false },
+      },
+    })
+    await flushPromises()
+    const multiBtn = wrapper.findAll('button').find((b) => b.text().includes('多次执行聚合'))
+    await multiBtn!.trigger('click')
+    await flushPromises()
+
+    const avgText = wrapper.find('[data-testid="stats-kpi-avg-wall-value"]').text()
+    expect(avgText).not.toMatch(/h$/)
+    expect(avgText).toBe('04:48')
+    const avgHours = 288 / 3600
+    expect(avgHours).toBeLessThan(1_000_000)
+
+    const queuedCell = wrapper.find('[data-testid="stats-multi-compare-cell"][data-run-id="run-1"]')
+    expect(queuedCell.text()).toContain('时间未知')
+    expect(queuedCell.text()).toContain('耗时 00:00')
+    expect(queuedCell.text()).not.toMatch(/1-01-01|0001|1 月 1 日/)
+
+    const doneCell = wrapper.find('[data-testid="stats-multi-compare-cell"][data-run-id="run-2"]')
+    expect(doneCell.text()).toContain('耗时 12:24')
+    expect(doneCell.text()).not.toContain('时间未知')
+
+    await wrapper.find('[data-testid="stats-multi-picker-toggle"]').trigger('click')
+    await flushPromises()
+    const groupText = wrapper
+      .findAll('[data-testid="stats-multi-day-group"]')
+      .map((g) => g.text())
+      .join(' | ')
+    expect(groupText).toContain('时间未知')
+    expect(groupText).not.toMatch(/1 月 1 日/)
+
+    const rate = wrapper.find('[data-testid="stats-kpi-multi-token-rate-value"]').text()
+    expect(rate).toMatch(/\/s/)
+    expect(rate).not.toBe('0.00/s')
+    expect(rate).not.toBe('—')
+
+    expect(wrapper.find('[data-testid="stats-kpi-selected"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="stats-kpi-avg-wall"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="stats-kpi-process-count"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="stats-kpi-sum-tokens"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="stats-kpi-avg-tokens"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="stats-kpi-multi-token-rate"]').exists()).toBe(true)
+    expect(wrapper.text()).not.toContain('修复前')
+    expect(wrapper.text()).not.toContain('修复后')
+    expect(wrapper.text()).not.toContain('验收要点')
+    wrapper.unmount()
+  })
+
+  it('F7: all-zero validated walls show 00:00 and 0.00/s; waiting_human tokens still count', async () => {
+    const goZero = '0001-01-01T00:00:00Z'
+    const waiting = {
+      ...baseRun(true),
+      id: 'run-1',
+      status: 'waiting_human',
+      startedAt: goZero,
+      durationSec: 0,
+    } as Run
+    const queued = {
+      ...baseRun(false),
+      id: 'run-2',
+      status: 'queued',
+      startedAt: goZero,
+      durationSec: 0,
+      nodeExecutions: {},
+    } as Run
+    apiMocks.listRuns.mockResolvedValue({
+      items: [
+        { id: 'run-1', status: 'waiting_human', durationSec: 0, startedAt: goZero },
+        { id: 'run-2', status: 'queued', durationSec: 0, startedAt: goZero },
+      ],
+      total: 2,
+    })
+    apiMocks.getRun.mockImplementation(async (id: string) => (id === 'run-2' ? queued : waiting))
+
+    const wrapper = mountPanel(waiting)
+    await wrapper.setProps({ wallSec: 99_999_999, nowMs: Date.parse('2026-08-12T04:00:00Z') })
+    await flushPromises()
+    const multiBtn = wrapper.findAll('button').find((b) => b.text().includes('多次执行聚合'))
+    await multiBtn!.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="stats-kpi-avg-wall-value"]').text()).toBe('00:00')
+    expect(wrapper.find('[data-testid="stats-kpi-multi-token-rate-value"]').text()).toBe('0.00/s')
+    expect(wrapper.find('[data-testid="stats-kpi-sum-tokens-value"]').text()).toContain('token')
+    expect(wrapper.find('[data-testid="stats-kpi-avg-tokens-value"]').text()).toContain('token')
+    expect(wrapper.text()).toContain('时间未知')
     wrapper.unmount()
   })
 })

--- a/web/src/components/run/ExecutionStatsPanel.vue
+++ b/web/src/components/run/ExecutionStatsPanel.vue
@@ -6,13 +6,14 @@ import Icon from '../ui/Icon.vue'
 import TruncatedTextTooltip from '../ui/TruncatedTextTooltip.vue'
 import { api, isPaginated } from '@/lib/api/api'
 import { NODE_DEFS } from '@/data/nodeRegistry'
-import { fmtCompactDuration, fmtDuration, fmtTime } from '@/lib/shared/format'
+import { fmtCompactDuration, fmtDuration, fmtMultiAvgDuration, fmtTime } from '@/lib/shared/format'
 import { resolveNodeDisplayLabel } from '@/lib/run/resolveNodeDisplayLabel'
 import {
   aggregateMultiRuns,
   aggregateSingleRun,
   bottleneckDisplayName,
   flattenProcesses,
+  isInvalidStart,
   resolveRunWallSec,
   type MultiDimension,
   type SingleDimension,
@@ -180,6 +181,13 @@ function compactRateMain(totalTokens: number | null, wallSec: number): string {
   return fmtCompactTokenRate(totalTokens, wallSec)
 }
 
+/** Multi token/s main: same formula as compactRateMain, but 0 wall → 0.00/s (F3). */
+function multiRateMain(totalTokens: number | null, wallSec: number): string {
+  if (totalTokens == null) return t('pages.executionStats.dash')
+  if (wallSec <= 0) return '0.00/s'
+  return fmtCompactTokenRate(totalTokens, wallSec)
+}
+
 function tokenRateTipText(totalTokens: number | null, wallSec: number): string {
   if (wallSec <= 0) return t('pages.executionStats.tipTokenRateZeroWall')
   const tokens = totalTokens ?? 0
@@ -210,6 +218,7 @@ interface Candidate {
   label: string
   listWallSec: number
   startedAt: string
+  status?: Run['status']
 }
 
 const candidates = ref<Candidate[]>([])
@@ -234,21 +243,27 @@ function localYmd(d: Date): string {
 }
 
 function startedAtYmd(iso: string): string | null {
-  if (!iso) return null
+  if (isInvalidStart(iso)) return null
   const d = new Date(iso)
   if (Number.isNaN(d.getTime())) return null
   return localYmd(d)
 }
 
-/** Large start clock HH:mm from startedAt (local); missing → —. */
+/** Large start clock HH:mm from startedAt (local); invalid / missing → 时间未知. */
 function fmtStartHm(iso: string): string {
-  if (!iso) return t('pages.executionStats.dash')
+  if (isInvalidStart(iso)) return t('pages.executionStats.unknownTime')
   const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return t('pages.executionStats.dash')
+  if (Number.isNaN(d.getTime())) return t('pages.executionStats.unknownTime')
   return `${pad2(d.getHours())}:${pad2(d.getMinutes())}`
 }
 
+function fmtCandidateTime(iso: string): string {
+  if (isInvalidStart(iso)) return t('pages.executionStats.unknownTime')
+  return fmtTime(iso)
+}
+
 function fmtOlderDateLabel(iso: string): string {
+  if (isInvalidStart(iso)) return t('pages.executionStats.unknownTime')
   const d = new Date(iso)
   if (Number.isNaN(d.getTime())) return t('pages.executionStats.unknownTime')
   const loc = String(locale.value || 'zh-CN')
@@ -270,8 +285,23 @@ function dayGroupLabel(iso: string): string {
   return fmtOlderDateLabel(iso)
 }
 
+function wallSourceForId(id: string): Pick<Run, 'status' | 'startedAt' | 'durationSec'> {
+  if (id === props.run.id) return props.run
+  const cached = detailCache.value[id]
+  if (cached) return cached
+  const c = candidates.value.find((item) => item.id === id)
+  return {
+    status: c?.status ?? 'completed',
+    startedAt: c?.startedAt ?? '',
+    durationSec: c?.listWallSec ?? 0,
+  }
+}
+
+/** Candidate / list duration uses the same validated wall as KPI contribution. */
 function candidateWallSec(c: Candidate): number {
-  return c.id === props.run.id ? props.wallSec : c.listWallSec
+  const wall = resolveRunWallSec(wallSourceForId(c.id), props.nowMs)
+  if (wall > 0) return wall
+  return c.listWallSec > 0 ? c.listWallSec : 0
 }
 
 function durationWithPrefix(sec: number): string {
@@ -307,7 +337,8 @@ async function loadCandidates() {
       id: r.id,
       label: '#' + r.id.replace(/^run-/, ''),
       listWallSec: r.durationSec || 0,
-      startedAt: r.startedAt || r.createdAt || '',
+      startedAt: r.startedAt || '',
+      status: r.status,
     }))
     // If current run missing from page, still keep it selected.
     if (!nextCandidates.some((c) => c.id === props.run.id)) {
@@ -315,8 +346,9 @@ async function loadCandidates() {
         {
           id: props.run.id,
           label: '#' + props.run.id.replace(/^run-/, ''),
-          listWallSec: props.wallSec,
+          listWallSec: props.run.durationSec || 0,
           startedAt: props.run.startedAt,
+          status: props.run.status,
         },
         ...nextCandidates,
       ].slice(0, 20)
@@ -465,14 +497,16 @@ const multiInputs = computed(() => {
   const out: { run: Run; wallSec: number; nodes?: WFNode[] }[] = []
   for (const id of selectedIds.value) {
     if (id === props.run.id) {
-      out.push({ run: props.run, wallSec: props.wallSec, nodes: props.nodes })
+      // Never trust props.wallSec (elapsedSec) — clamp year-1 / unset starts to 0.
+      out.push({ run: props.run, wallSec: resolveRunWallSec(props.run, props.nowMs), nodes: props.nodes })
       continue
     }
     const r = detailCache.value[id]
     if (!r) continue
     let wall = resolveRunWallSec(r, props.nowMs)
     if (wall <= 0) {
-      wall = candidates.value.find((c) => c.id === id)?.listWallSec || r.durationSec || 0
+      const listWall = candidates.value.find((c) => c.id === id)?.listWallSec || 0
+      if (listWall > 0) wall = listWall
     }
     out.push({ run: r, wallSec: wall, nodes: r.nodes })
   }
@@ -1128,7 +1162,7 @@ html.light .stats-panel {
               <span class="block text-[22px] font-semibold tabular-nums tracking-tight text-txt sm:text-[24px]">
                 {{ fmtStartHm(c.startedAt) }}
               </span>
-              <div class="mt-1 text-[12px] text-txt3">{{ c.startedAt ? fmtTime(c.startedAt) : t('pages.executionStats.dash') }}</div>
+              <div class="mt-1 text-[12px] text-txt3">{{ fmtCandidateTime(c.startedAt) }}</div>
               <div class="stats-kpi-time mt-0.5 text-[12px]">{{ durationWithPrefix(candidateWallSec(c)) }}</div>
               <span class="mt-1.5 block font-mono text-[11px] text-txt3">{{ c.label }}</span>
             </div>
@@ -1167,7 +1201,7 @@ html.light .stats-panel {
                   {{ isCurrentRun(c.id) ? t('pages.executionStats.current') : '' }}
                 </span>
                 <span class="truncate tabular-nums">
-                  {{ c.startedAt ? fmtTime(c.startedAt) : t('pages.executionStats.dash') }}
+                  {{ fmtCandidateTime(c.startedAt) }}
                 </span>
                 <span class="stats-kpi-time truncate">{{ durationWithPrefix(candidateWallSec(c)) }}</span>
                 <span class="font-mono text-[11px] text-txt3">{{ c.label }}</span>
@@ -1211,7 +1245,7 @@ html.light .stats-panel {
               >
                 {{
                   multiReady && multiSummary.selectedCount
-                    ? fmtCompactDuration(multiAvgWallSec)
+                    ? fmtMultiAvgDuration(multiAvgWallSec)
                     : t('pages.executionStats.dash')
                 }}
               </div>
@@ -1315,7 +1349,7 @@ html.light .stats-panel {
               >
                 {{
                   multiReady
-                    ? compactRateMain(multiSummary.totalTokens, multiSummary.wallSumSec)
+                    ? multiRateMain(multiSummary.totalTokens, multiSummary.wallSumSec)
                     : t('pages.executionStats.dash')
                 }}
               </div>

--- a/web/src/components/run/UpstreamRequirementContext.test.ts
+++ b/web/src/components/run/UpstreamRequirementContext.test.ts
@@ -370,7 +370,7 @@ describe('UpstreamRequirementContext', () => {
     expect(wrapper.find('[data-testid="upstream-modal-callout"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="upstream-bar-hint"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="upstream-bar-hint"]').text()).toContain(
-      '本 run 已有澄清需求文档',
+      '本工作流已有澄清需求文档',
     )
     wrapper.unmount()
   })

--- a/web/src/lib/run/runStats.test.ts
+++ b/web/src/lib/run/runStats.test.ts
@@ -4,6 +4,7 @@ import {
   aggregateSingleRun,
   flattenProcesses,
   hasHumanWait,
+  isInvalidStart,
   mergeByNode,
   mergeByType,
   pickDefaultTimelineNodeId,
@@ -87,6 +88,68 @@ describe('resolveProcessDuration / hasHumanWait', () => {
         now,
       ),
     ).toBe(42)
+  })
+})
+
+describe('isInvalidStart / resolveRunWallSec sentinels (F1/F7)', () => {
+  const now = Date.parse('2026-08-11T21:17:00Z')
+  const goZero = '0001-01-01T00:00:00Z'
+
+  it('treats empty, unparseable, pre-epoch, and year-1 as invalid', () => {
+    expect(isInvalidStart(undefined)).toBe(true)
+    expect(isInvalidStart(null)).toBe(true)
+    expect(isInvalidStart('')).toBe(true)
+    expect(isInvalidStart('   ')).toBe(true)
+    expect(isInvalidStart('not-a-date')).toBe(true)
+    expect(isInvalidStart('1969-12-31T23:59:59Z')).toBe(true)
+    expect(isInvalidStart(goZero)).toBe(true)
+    expect(isInvalidStart('0001-01-01T00:00:00+00:00')).toBe(true)
+    expect(isInvalidStart('2026-07-18T00:00:00Z')).toBe(false)
+    expect(isInvalidStart('1970-01-01T00:00:00Z')).toBe(false)
+  })
+
+  it('queued / running / waiting_human with Go-zero start contribute 0 (no now-start)', () => {
+    for (const status of ['queued', 'running', 'waiting_human'] as const) {
+      expect(resolveRunWallSec({ status, startedAt: goZero, durationSec: 0 }, now)).toBe(0)
+      expect(resolveRunWallSec({ status, startedAt: '', durationSec: 99 }, now)).toBe(0)
+      expect(resolveRunWallSec({ status, startedAt: 'bogus', durationSec: 0 }, now)).toBe(0)
+    }
+  })
+
+  it('does not zero a running run with a recent valid startedAt', () => {
+    const start = '2026-08-11T21:16:00Z'
+    expect(
+      resolveRunWallSec({ status: 'running', startedAt: start, durationSec: 0 }, now),
+    ).toBe(60)
+  })
+
+  it('keeps terminal duration even when startedAt is Go zero', () => {
+    expect(
+      resolveRunWallSec(
+        { status: 'completed', startedAt: goZero, durationSec: 744 },
+        now,
+      ),
+    ).toBe(744)
+  })
+
+  it('queued+0001 mean stays minute-scale, not million hours (F7 inflation lock)', () => {
+    const queued = resolveRunWallSec(
+      { status: 'queued', startedAt: goZero, durationSec: 0 },
+      now,
+    )
+    const a = resolveRunWallSec(
+      { status: 'completed', startedAt: '2026-08-12T00:00:00Z', durationSec: 744 },
+      now,
+    )
+    const b = resolveRunWallSec(
+      { status: 'completed', startedAt: '2026-08-12T01:00:00Z', durationSec: 1936 },
+      now,
+    )
+    const avg = (queued + queued + a + b) / 4
+    expect(queued).toBe(0)
+    expect(avg).toBe((744 + 1936) / 4)
+    expect(avg).toBeLessThan(3600)
+    expect(avg / 3600).toBeLessThan(1_000_000)
   })
 })
 

--- a/web/src/lib/run/runStats.ts
+++ b/web/src/lib/run/runStats.ts
@@ -91,6 +91,23 @@ const TERMINAL_DUR: ReadonlySet<string> = new Set([
   'skipped',
   'cancelled',
 ])
+const UNIX_EPOCH_MS = Date.parse('1970-01-01T00:00:00Z')
+
+/**
+ * Demo-aligned sentinel for a missing run start.
+ * Treats empty values, unparseable strings, pre-Unix timestamps, and Go
+ * zero-time (0001-01-01 / UTC year ≤ 1) as unset — never a real origin.
+ */
+export function isInvalidStart(startedAt?: string | null): boolean {
+  if (startedAt == null) return true
+  const raw = String(startedAt).trim()
+  if (!raw) return true
+  const ms = Date.parse(raw)
+  if (Number.isNaN(ms)) return true
+  if (ms < UNIX_EPOCH_MS) return true
+  if (new Date(ms).getUTCFullYear() <= 1) return true
+  return false
+}
 
 /** Share = duration / max(denominator, 1); null when denominator ≤ 0. */
 export function sharePct(durationSec: number, denominatorSec: number): number | null {
@@ -121,20 +138,21 @@ export function resolveProcessDuration(
   return ex.durationSec != null ? Math.max(0, Math.floor(ex.durationSec)) : 0
 }
 
-/** Wall-clock for a run: live elapsed from startedAt, else durationSec. */
+/**
+ * Wall-clock for a run: live elapsed from a valid startedAt, else durationSec.
+ * Invalid / Go-zero starts never use now-start (queued and active alike → 0).
+ */
 export function resolveRunWallSec(
   run: Pick<Run, 'status' | 'startedAt' | 'durationSec'>,
   nowMs: number,
 ): number {
-  const start = Date.parse(run.startedAt)
-  if (ACTIVE_NODE.has(run.status) || run.status === 'queued') {
-    if (!isNaN(start)) return Math.max(0, Math.floor((nowMs - start) / 1000))
+  const live = ACTIVE_NODE.has(run.status) || run.status === 'queued'
+  if (live) {
+    if (isInvalidStart(run.startedAt)) return 0
+    const start = Date.parse(run.startedAt)
+    return Math.max(0, Math.floor((nowMs - start) / 1000))
   }
   if (run.durationSec > 0) return Math.floor(run.durationSec)
-  if (!isNaN(start)) {
-    // Fallback already handled by callers via elapsedSec; keep 0 here.
-    return 0
-  }
   return 0
 }
 

--- a/web/src/lib/shared/format.test.ts
+++ b/web/src/lib/shared/format.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { formatTrigger, fmtCompactDuration, fmtDuration, relTime } from './format'
+import { formatTrigger, fmtCompactDuration, fmtDuration, fmtMultiAvgDuration, relTime } from './format'
 import { i18n } from './i18n'
 import { loadLocaleMessages } from './loadLocaleMessages'
 
@@ -30,6 +30,22 @@ describe('fmtCompactDuration', () => {
     expect(fmtDuration(3458)).toBe('57:38')
     expect(fmtDuration(245)).toBe('04:05')
     expect(fmtDuration(0)).toBe('00:00')
+  })
+})
+
+describe('fmtMultiAvgDuration', () => {
+  it('uses mm:ss under 1h, x.xxh at/above 1h, and 00:00 for zero (F2)', () => {
+    expect(fmtMultiAvgDuration(0)).toBe('00:00')
+    expect(fmtMultiAvgDuration(105)).toBe('01:45')
+    expect(fmtMultiAvgDuration(715)).toBe('11:55')
+    expect(fmtMultiAvgDuration(3600)).toBe('1.00h')
+    expect(fmtMultiAvgDuration(3703)).toBe('1.03h')
+    expect(fmtMultiAvgDuration(Number.NaN)).toBe('00:00')
+  })
+
+  it('does not reuse compact x.xm / 0s for the multi avg main', () => {
+    expect(fmtMultiAvgDuration(105)).not.toBe(fmtCompactDuration(105))
+    expect(fmtMultiAvgDuration(0)).not.toBe('0s')
   })
 })
 

--- a/web/src/lib/shared/format.ts
+++ b/web/src/lib/shared/format.ts
@@ -43,6 +43,18 @@ export function fmtCompactDuration(sec: number): string {
   return `${(n / 60).toFixed(1)}m`
 }
 
+/**
+ * Multi-run「平均总耗时」main value (F2): under 1h → mm:ss; ≥1h → x.xxh; 0 → 00:00.
+ * Do not reuse fmtCompactDuration (x.xm / 0s) for this KPI.
+ */
+export function fmtMultiAvgDuration(sec: number): string {
+  if (sec == null || !Number.isFinite(sec)) return '00:00'
+  const n = Math.max(0, sec)
+  if (n <= 0) return '00:00'
+  if (n >= 3600) return `${(n / 3600).toFixed(2)}h`
+  return fmtDuration(Math.round(n))
+}
+
 export function truncateText(s: string, maxLen: number): string {
   if (!s || s.length <= maxLen) return s
   return s.slice(0, maxLen) + '…'


### PR DESCRIPTION
Treat Go-zero and pre-epoch starts as unset so queued/active runs contribute 0s, and format multi avg / token/s from the same validated wall sum.

Co-authored-by: Cursor <cursoragent@cursor.com>
