### PR TITLE
fix(web): keep CompositeImageStrip terminal state across poll refreshes

### DIFF
--- a/web/src/components/run/UpstreamRequirementContext.test.ts
+++ b/web/src/components/run/UpstreamRequirementContext.test.ts
@@ -370,7 +370,7 @@ describe('UpstreamRequirementContext', () => {
     expect(wrapper.find('[data-testid="upstream-modal-callout"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="upstream-bar-hint"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="upstream-bar-hint"]').text()).toContain(
-      '本 run 已有澄清需求文档',
+      '本工作流已有澄清需求文档',
     )
     wrapper.unmount()
   })

--- a/web/src/components/ui/CompositeImageStrip.test.ts
+++ b/web/src/components/ui/CompositeImageStrip.test.ts
@@ -1,9 +1,12 @@
 // @vitest-environment happy-dom
 import { createI18n } from 'vue-i18n'
-import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import common from '@/locales/zh-CN/common.json'
 import CompositeImageStrip from './CompositeImageStrip.vue'
+
+/** Must match LOAD_TIMEOUT_MS in CompositeImageStrip.vue (8–15s band). */
+const LOAD_TIMEOUT_MS = 12_000
 
 function mountStrip(value: unknown, size?: 'sm' | 'md' | 'lg') {
   const i18n = createI18n({
@@ -22,7 +25,17 @@ function mountStrip(value: unknown, size?: 'sm' | 'md' | 'lg') {
   })
 }
 
+const blobImg = (id: string, name = 'a.png') => ({
+  mime: 'image/png',
+  ref: `blob:${id}`,
+  name,
+})
+
 describe('CompositeImageStrip', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('renders images from composite value (g1.1 success path)', async () => {
     const wrapper = mountStrip({
       text: 'hi',
@@ -99,6 +112,125 @@ describe('CompositeImageStrip', () => {
     expect(wrapper.text()).toContain('附件不可用')
     // Successful thumb still present; failures are independent placeholders
     expect(wrapper.find('[data-testid="composite-image-ok"] img').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('same src value replace keeps ok (poll refresh / g1.1)', async () => {
+    const wrapper = mountStrip({
+      text: 'feature',
+      images: [blobImg('same-id')],
+    })
+    await wrapper.find('img').trigger('load')
+    expect(wrapper.find('[data-testid="composite-image-ok"]').exists()).toBe(true)
+
+    // Simulate Run detail 2s poll: new object graph, identical blob src
+    await wrapper.setProps({
+      value: {
+        text: 'feature',
+        images: [blobImg('same-id')],
+      },
+    })
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="composite-image-ok"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="composite-image-loading"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('src change leaves previous ok for a new loading/terminal (g1.2)', async () => {
+    const wrapper = mountStrip({
+      text: 'feature',
+      images: [blobImg('first')],
+    })
+    await wrapper.find('img').trigger('load')
+    expect(wrapper.find('[data-testid="composite-image-ok"]').exists()).toBe(true)
+
+    await wrapper.setProps({
+      value: {
+        text: 'feature',
+        images: [blobImg('second')],
+      },
+    })
+    await flushPromises()
+
+    // Must not keep the prior ok; happy-dom may @error the new URL immediately → failed.
+    expect(wrapper.find('[data-testid="composite-image-ok"]').exists()).toBe(false)
+    const loading = wrapper.find('[data-testid="composite-image-loading"]').exists()
+    const failed = wrapper.find('[data-testid="composite-image-failed"]').exists()
+    expect(loading || failed).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('one failed slot does not reset sibling ok on same-src poll (g1.2)', async () => {
+    const wrapper = mountStrip({
+      text: 'multi',
+      images: [blobImg('ok-slot', 'ok.png'), blobImg('bad-slot', 'bad.png')],
+    })
+    const imgs = wrapper.findAll('img')
+    await imgs[0]!.trigger('load')
+    await imgs[1]!.trigger('error')
+    expect(wrapper.findAll('[data-testid="composite-image-ok"]').length).toBe(1)
+    expect(wrapper.findAll('[data-testid="composite-image-failed"]').length).toBe(1)
+
+    await wrapper.setProps({
+      value: {
+        text: 'multi',
+        images: [blobImg('ok-slot', 'ok.png'), blobImg('bad-slot', 'bad.png')],
+      },
+    })
+    await flushPromises()
+
+    expect(wrapper.findAll('[data-testid="composite-image-ok"]').length).toBe(1)
+    expect(wrapper.findAll('[data-testid="composite-image-failed"]').length).toBe(1)
+    expect(wrapper.find('[data-testid="composite-image-loading"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('complete+naturalWidth syncs to ok without @load (g2.1)', async () => {
+    const completeDesc = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, 'complete')
+    const widthDesc = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, 'naturalWidth')
+    Object.defineProperty(HTMLImageElement.prototype, 'complete', {
+      configurable: true,
+      get: () => true,
+    })
+    Object.defineProperty(HTMLImageElement.prototype, 'naturalWidth', {
+      configurable: true,
+      get: () => 64,
+    })
+    try {
+      const wrapper = mountStrip({
+        text: 'cached',
+        images: [blobImg('cached')],
+      })
+      await flushPromises()
+      expect(wrapper.find('[data-testid="composite-image-ok"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="composite-image-loading"]').exists()).toBe(false)
+      wrapper.unmount()
+    } finally {
+      if (completeDesc) Object.defineProperty(HTMLImageElement.prototype, 'complete', completeDesc)
+      else delete (HTMLImageElement.prototype as { complete?: unknown }).complete
+      if (widthDesc) Object.defineProperty(HTMLImageElement.prototype, 'naturalWidth', widthDesc)
+      else delete (HTMLImageElement.prototype as { naturalWidth?: unknown }).naturalWidth
+    }
+  })
+
+  it('loading timeout enters failed placeholder without retry (g2.2)', async () => {
+    vi.useFakeTimers()
+    const wrapper = mountStrip({
+      text: 'slow',
+      images: [blobImg('hang')],
+    })
+    expect(wrapper.find('[data-testid="composite-image-loading"]').exists()).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(LOAD_TIMEOUT_MS)
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="composite-image-failed"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="composite-image-loading"]').exists()).toBe(false)
+    expect(wrapper.text()).toContain('无法显示')
+    expect(wrapper.text()).toContain('附件不可用')
+    expect(wrapper.text()).not.toContain('重试')
+    expect(wrapper.find('button').exists()).toBe(false)
     wrapper.unmount()
   })
 })

--- a/web/src/components/ui/CompositeImageStrip.vue
+++ b/web/src/components/ui/CompositeImageStrip.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
-import { computed, reactive, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, reactive, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import AppSpinner from './AppSpinner.vue'
 import { compositeImages, imgSrc } from '@/lib/shared/compositeText'
 
 type ThumbStatus = 'loading' | 'ok' | 'failed'
+
+/** Loading must reach a terminal state; 12s is within the agreed 8–15s band. */
+const LOAD_TIMEOUT_MS = 12_000
 
 const props = withDefaults(
   defineProps<{
@@ -33,43 +36,146 @@ const images = computed(() => compositeImages(props.value))
 const sizeClass = computed(() => SIZE_CLS[props.size] ?? SIZE_CLS.sm)
 const cardClass = computed(() => CARD_CLS[props.size] ?? CARD_CLS.sm)
 
-/** Per-index status after mount; empty src never enters loading. */
-const statuses = reactive<Record<number, ThumbStatus>>({})
+type SlotState = { src: string; status: ThumbStatus }
+
+/** Per-index slot keyed by last known src so same-src poll refreshes keep ok/failed. */
+const slots = reactive<Record<number, SlotState>>({})
+const loadTimers = new Map<number, ReturnType<typeof setTimeout>>()
+const imgEls = new Map<number, HTMLImageElement>()
 
 const items = computed(() =>
   images.value.map((im, index) => {
     const src = imgSrc(im)
-    const status: ThumbStatus = !src ? 'failed' : (statuses[index] ?? 'loading')
+    const slot = slots[index]
+    const status: ThumbStatus = !src
+      ? 'failed'
+      : (slot?.status ?? 'loading')
     return { index, src, status }
   }),
 )
 
+function clearTimer(index: number) {
+  const timer = loadTimers.get(index)
+  if (timer != null) {
+    clearTimeout(timer)
+    loadTimers.delete(index)
+  }
+}
+
+function clearAllTimers() {
+  for (const timer of loadTimers.values()) clearTimeout(timer)
+  loadTimers.clear()
+}
+
+function setStatus(index: number, status: ThumbStatus) {
+  const slot = slots[index]
+  if (!slot) return
+  if (status === 'ok' || status === 'failed') clearTimer(index)
+  slot.status = status
+}
+
+function startLoadTimeout(index: number) {
+  clearTimer(index)
+  loadTimers.set(
+    index,
+    setTimeout(() => {
+      loadTimers.delete(index)
+      if (slots[index]?.status === 'loading') {
+        slots[index].status = 'failed'
+      }
+    }, LOAD_TIMEOUT_MS),
+  )
+}
+
+/** Cache hit / sync decode: leave loading without waiting for a late @load. */
+function syncFromImg(index: number, img: HTMLImageElement) {
+  const slot = slots[index]
+  if (!slot || slot.status !== 'loading' || !slot.src) return
+  // Ignore stale complete from a previous src on the same element (before remount).
+  const shown = img.getAttribute('src') || ''
+  if (shown && shown !== slot.src) return
+  if (!img.complete) return
+  if (img.naturalWidth > 0) {
+    setStatus(index, 'ok')
+    return
+  }
+  // complete with no dimensions → broken resource
+  setStatus(index, 'failed')
+}
+
+function bindImg(el: unknown, index: number) {
+  if (el instanceof HTMLImageElement) {
+    imgEls.set(index, el)
+    syncFromImg(index, el)
+    return
+  }
+  imgEls.delete(index)
+}
+
 watch(
   images,
   (imgs) => {
-    for (const key of Object.keys(statuses)) {
-      delete statuses[Number(key)]
-    }
+    const alive = new Set<number>()
     imgs.forEach((im, index) => {
-      statuses[index] = imgSrc(im) ? 'loading' : 'failed'
+      alive.add(index)
+      const src = imgSrc(im)
+      const prev = slots[index]
+
+      if (!src) {
+        clearTimer(index)
+        slots[index] = { src: '', status: 'failed' }
+        return
+      }
+
+      // Same src: keep terminal ok/failed (Run detail 2s poll replaces value objects).
+      if (prev && prev.src === src) {
+        if (prev.status === 'loading' && !loadTimers.has(index)) {
+          startLoadTimeout(index)
+        }
+        return
+      }
+
+      // Empty→src or src change: new loading transition.
+      slots[index] = { src, status: 'loading' }
+      startLoadTimeout(index)
+    })
+
+    for (const key of Object.keys(slots)) {
+      const index = Number(key)
+      if (!alive.has(index)) {
+        clearTimer(index)
+        imgEls.delete(index)
+        delete slots[index]
+      }
+    }
+
+    void nextTick(() => {
+      for (const [index, img] of imgEls) {
+        syncFromImg(index, img)
+      }
     })
   },
   { immediate: true, deep: true },
 )
 
+onBeforeUnmount(() => {
+  clearAllTimers()
+  imgEls.clear()
+})
+
 function onLoad(index: number) {
-  statuses[index] = 'ok'
+  setStatus(index, 'ok')
 }
 
 function onError(index: number) {
-  statuses[index] = 'failed'
+  setStatus(index, 'failed')
 }
 </script>
 
 <template>
   <div v-if="items.length" class="flex flex-wrap gap-1.5" data-testid="composite-image-strip">
     <template v-for="item in items" :key="item.index">
-      <!-- Permanent failure: empty src or blob/@error; no retry, no HTTP/path details -->
+      <!-- Permanent failure: empty src or blob/@error/timeout; no retry, no HTTP/path details -->
       <div
         v-if="item.status === 'failed'"
         class="flex flex-col items-center justify-center gap-1 border border-err/35 bg-err/[0.06] px-2 py-2 text-center"
@@ -87,7 +193,7 @@ function onError(index: number) {
         </div>
       </div>
 
-      <!-- Has src: loading overlay until @load; @error → failed -->
+      <!-- Has src: loading overlay until load/complete/timeout; @error → failed -->
       <div
         v-else
         class="relative overflow-hidden border border-line"
@@ -105,6 +211,8 @@ function onError(index: number) {
           <span>{{ t('common.compositeImage.loading') }}</span>
         </div>
         <img
+          :key="item.src"
+          :ref="(el) => bindImg(el, item.index)"
           :src="item.src"
           class="h-full w-full object-cover"
           :class="item.status === 'loading' ? 'opacity-0' : ''"


### PR DESCRIPTION
Same-src value replacements no longer reset ok/failed to loading; sync from img.complete and time out hung loads into the existing failure placeholder so run detail input images leave the permanent spinner.

Co-authored-by: Cursor <cursoragent@cursor.com>
