### PR TITLE
feat(engine): prefer remaining human_gate within same claim priority

### DIFF
--- a/server/internal/engine/admission_test.go
+++ b/server/internal/engine/admission_test.go
@@ -128,6 +128,27 @@ func gateThenWorkGraph() models.Graph {
 	}
 }
 
+// workThenGateGraph keeps the run on blocked "work" after claim while still
+// having a remaining human_gate ahead — so admission tests can observe claim
+// order without waiting_human releasing the slot.
+func workThenGateGraph() models.Graph {
+	return models.Graph{
+		Nodes: []models.Node{
+			{ID: "input", Type: "input"},
+			{ID: "work", Type: "agent", Config: map[string]any{"skill_profile": "t", "prompt": "work"}},
+			{ID: "gate", Type: "human_gate", Config: map[string]any{
+				"actions": []any{map[string]any{"id": "ok", "label": "OK"}},
+			}},
+			{ID: "output", Type: "output"},
+		},
+		Edges: []models.Edge{
+			{ID: "e1", Source: "input", Target: "work"},
+			{ID: "e2", Source: "work", Target: "gate", Kind: models.EdgeSuccess},
+			{ID: "e3", Source: "gate", Target: "output", Kind: models.EdgeSuccess},
+		},
+	}
+}
+
 func countRunsByStatus(t *testing.T, db *gorm.DB, status string) int64 {
 	t.Helper()
 	var n int64
@@ -157,6 +178,14 @@ func setupBlockingEngineDual(t *testing.T, maxRuns int) (*Engine, *gorm.DB, *blo
 	}
 	if err := db.Create(&models.WorkflowVersion{WorkflowID: "wf-gate", Version: 1, Graph: gateThenWorkGraph()}).Error; err != nil {
 		t.Fatalf("create gate version: %v", err)
+	}
+	if err := db.Create(&models.WorkflowDef{
+		ID: "wf-work-gate", Name: "wf-work-gate", Status: "published", Version: 1, Graph: workThenGateGraph(),
+	}).Error; err != nil {
+		t.Fatalf("create work-then-gate workflow: %v", err)
+	}
+	if err := db.Create(&models.WorkflowVersion{WorkflowID: "wf-work-gate", Version: 1, Graph: workThenGateGraph()}).Error; err != nil {
+		t.Fatalf("create work-then-gate version: %v", err)
 	}
 	p := newBlockingFake(eng.host)
 	p.blockNode("work")
@@ -567,4 +596,219 @@ func TestStartRunFromPublishedForcesNormal(t *testing.T) {
 		t.Fatalf("trigger = %q, want api", run.Trigger)
 	}
 	p.ReleaseAll()
+}
+
+// Demo s1: same-band claim prefers remaining human_gate over earlier FIFO no-gate.
+func TestAdmissionSamePriorityHumanGatePreferred(t *testing.T) {
+	eng, db, p := setupBlockingEngineDual(t, 1)
+
+	hold, err := eng.StartRun("wf", nil, "test")
+	if err != nil {
+		t.Fatalf("StartRun hold: %v", err)
+	}
+	waitRunStatus(t, db, hold.ID, "running")
+
+	earlyNoGate, err := eng.StartRun("wf", nil, "test")
+	if err != nil {
+		t.Fatalf("StartRun early no-gate: %v", err)
+	}
+	// work→gate keeps the claimed run running (blocked on work) so the slot is
+	// not freed by waiting_human before we observe claim order.
+	lateWithGate, err := eng.StartRun("wf-work-gate", nil, "test")
+	if err != nil {
+		t.Fatalf("StartRun late with-gate: %v", err)
+	}
+	waitAdmissionUntil(t, func() bool {
+		return countRunsByStatus(t, db, "queued") == 2
+	}, 3*time.Second)
+
+	p.releaseRun(hold.ID)
+	waitAdmissionUntil(t, func() bool {
+		var r models.Run
+		db.First(&r, "id = ?", hold.ID)
+		return r.Status == "completed"
+	}, 5*time.Second)
+	waitAdmissionUntil(t, func() bool {
+		var r models.Run
+		db.First(&r, "id = ?", lateWithGate.ID)
+		return r.Status == "running"
+	}, 5*time.Second)
+
+	var early models.Run
+	db.First(&early, "id = ?", earlyNoGate.ID)
+	if early.Status != "queued" {
+		t.Fatalf("early no-gate status = %q, want queued (late with-gate claimed first)", early.Status)
+	}
+	if early.Priority != models.PriorityNormal {
+		t.Fatalf("priority mutated: %d", early.Priority)
+	}
+	p.ReleaseAll()
+}
+
+// Demo s2: higher Priority band still wins even when lower band has remaining human_gate.
+func TestAdmissionCrossPriorityIgnoresHumanGate(t *testing.T) {
+	eng, db, p := setupBlockingEngineDual(t, 1)
+
+	hold, err := eng.StartRun("wf", nil, "test")
+	if err != nil {
+		t.Fatalf("StartRun hold: %v", err)
+	}
+	waitRunStatus(t, db, hold.ID, "running")
+
+	normalGate, err := eng.StartRunWithPriority("wf-gate", nil, "test", "normal")
+	if err != nil {
+		t.Fatalf("StartRun normal gate: %v", err)
+	}
+	highNoGate, err := eng.StartRunWithPriority("wf", nil, "test", "high")
+	if err != nil {
+		t.Fatalf("StartRun high no-gate: %v", err)
+	}
+	waitAdmissionUntil(t, func() bool {
+		return countRunsByStatus(t, db, "queued") == 2
+	}, 3*time.Second)
+
+	p.releaseRun(hold.ID)
+	waitAdmissionUntil(t, func() bool {
+		var r models.Run
+		db.First(&r, "id = ?", hold.ID)
+		return r.Status == "completed"
+	}, 5*time.Second)
+	waitAdmissionUntil(t, func() bool {
+		var r models.Run
+		db.First(&r, "id = ?", highNoGate.ID)
+		return r.Status == "running"
+	}, 5*time.Second)
+
+	var normal models.Run
+	db.First(&normal, "id = ?", normalGate.ID)
+	if normal.Status != "queued" {
+		t.Fatalf("normal+gate status = %q, want queued (high band first)", normal.Status)
+	}
+	p.ReleaseAll()
+}
+
+// Demo s3: after human_gate passes and requeues with no remaining gate, yield to
+// same-band queued runs that still have a remaining human_gate.
+func TestAdmissionYieldAfterHumanGatePassed(t *testing.T) {
+	eng, db, p := setupBlockingEngineDual(t, 1)
+
+	pastGate, err := eng.StartRun("wf-gate", nil, "test")
+	if err != nil {
+		t.Fatalf("StartRun past-gate: %v", err)
+	}
+	waitRunStatus(t, db, pastGate.ID, "waiting_human")
+
+	hold, err := eng.StartRun("wf", nil, "test")
+	if err != nil {
+		t.Fatalf("StartRun hold: %v", err)
+	}
+	waitRunStatus(t, db, hold.ID, "running")
+
+	if err := eng.ResumeGate(pastGate.ID, "gate", "ok", nil); err != nil {
+		t.Fatalf("ResumeGate: %v", err)
+	}
+	waitAdmissionUntil(t, func() bool {
+		var r models.Run
+		db.First(&r, "id = ?", pastGate.ID)
+		return r.Status == "queued"
+	}, 3*time.Second)
+	if from := admissionFromInDB(t, db, pastGate.ID); from != "work" {
+		t.Fatalf("admission from = %q, want work", from)
+	}
+
+	stillHasGate, err := eng.StartRun("wf-work-gate", nil, "test")
+	if err != nil {
+		t.Fatalf("StartRun still-has-gate: %v", err)
+	}
+	waitAdmissionUntil(t, func() bool {
+		return countRunsByStatus(t, db, "queued") == 2
+	}, 3*time.Second)
+
+	p.releaseRun(hold.ID)
+	waitAdmissionUntil(t, func() bool {
+		var r models.Run
+		db.First(&r, "id = ?", hold.ID)
+		return r.Status == "completed"
+	}, 5*time.Second)
+	waitAdmissionUntil(t, func() bool {
+		var r models.Run
+		db.First(&r, "id = ?", stillHasGate.ID)
+		return r.Status == "running"
+	}, 5*time.Second)
+
+	var past models.Run
+	db.First(&past, "id = ?", pastGate.ID)
+	if past.Status != "queued" {
+		t.Fatalf("past-gate status = %q, want queued (yielded to remaining gate)", past.Status)
+	}
+	p.ReleaseAll()
+}
+
+// Demo s4/s5 constraints: Priority/list semantics unchanged; empty-slot passthrough;
+// running not kicked back to queued when a gated peer arrives.
+func TestAdmissionHumanGateConstraintsNoPreemptNoStarve(t *testing.T) {
+	eng, db, p := setupBlockingEngineDual(t, 2)
+
+	noGate, err := eng.StartRun("wf", nil, "test")
+	if err != nil {
+		t.Fatalf("StartRun no-gate: %v", err)
+	}
+	waitRunStatus(t, db, noGate.ID, "running")
+
+	withGate, err := eng.StartRun("wf-gate", nil, "test")
+	if err != nil {
+		t.Fatalf("StartRun with-gate: %v", err)
+	}
+	// Empty slot: gated run must admit immediately (no intentional idle wait).
+	waitAdmissionUntil(t, func() bool {
+		var r models.Run
+		db.First(&r, "id = ?", withGate.ID)
+		return r.Status == "running" || r.Status == "waiting_human"
+	}, 3*time.Second)
+
+	var hold models.Run
+	db.First(&hold, "id = ?", noGate.ID)
+	if hold.Status != "running" {
+		t.Fatalf("running no-gate status = %q, want running (must not preempt)", hold.Status)
+	}
+	if hold.Priority != models.PriorityNormal {
+		t.Fatalf("stored priority mutated: %d", hold.Priority)
+	}
+	if models.PriorityLabel(hold.Priority) != models.PriorityLabelNormal {
+		t.Fatalf("badge label mutated: %q", models.PriorityLabel(hold.Priority))
+	}
+	p.ReleaseAll()
+}
+
+func TestPickQueuedByRemainingHumanGate(t *testing.T) {
+	noGate := models.Run{
+		ID: "a", Priority: models.PriorityNormal,
+		Graph: slowGraph(),
+	}
+	withGate := models.Run{
+		ID: "b", Priority: models.PriorityNormal,
+		Graph: workThenGateGraph(),
+	}
+	// FIFO order: noGate first; picker must still prefer withGate.
+	got := pickQueuedByRemainingHumanGate([]models.Run{noGate, withGate})
+	if got.ID != "b" {
+		t.Fatalf("pick = %q, want b (remaining human_gate)", got.ID)
+	}
+	// Both no-gate → FIFO head.
+	got = pickQueuedByRemainingHumanGate([]models.Run{noGate, {ID: "c", Graph: slowGraph()}})
+	if got.ID != "a" {
+		t.Fatalf("pick = %q, want a (FIFO when gate tie)", got.ID)
+	}
+	// Past gate via admission-from → yield to remaining gate.
+	past := models.Run{
+		ID: "past", Priority: models.PriorityNormal,
+		Graph: gateThenWorkGraph(),
+		Checkpoints: map[string]map[string]any{
+			admissionFromCheckpoint: {"node": "work"},
+		},
+	}
+	got = pickQueuedByRemainingHumanGate([]models.Run{past, withGate})
+	if got.ID != "b" {
+		t.Fatalf("pick = %q, want b after past-gate yield", got.ID)
+	}
 }

--- a/server/internal/engine/dispatcher.go
+++ b/server/internal/engine/dispatcher.go
@@ -22,8 +22,9 @@ const dispatchPoll = 5 * time.Second
 const admissionFromCheckpoint = "__admission_from__"
 
 // dispatch is the single scheduler goroutine. It admits queued runs up to the
-// concurrency limit (priority DESC, then FIFO), blocking on the wake channel
-// between drains. Being the sole admitter keeps admission strictly ordered.
+// concurrency limit (Priority DESC → remaining human_gate → FIFO), blocking on
+// the wake channel between drains. Being the sole admitter keeps admission
+// strictly ordered.
 func (e *Engine) dispatch() {
 	for {
 		e.drainQueue()
@@ -37,8 +38,8 @@ func (e *Engine) dispatch() {
 }
 
 // drainQueue admits as many queued runs as free concurrency slots allow, in
-// priority-then-FIFO order, then returns (either at capacity or with the queue
-// empty).
+// Priority DESC → hasRemainingHumanGate DESC → created_at ASC → id ASC order,
+// then returns (either at capacity or with the queue empty).
 func (e *Engine) drainQueue() {
 	if e.IsHalted() {
 		return
@@ -57,17 +58,23 @@ func (e *Engine) drainQueue() {
 }
 
 // claimNextQueued atomically promotes the next queued run to running and
-// returns its start node. Selection order: higher Priority first, then FIFO
-// (created_at ASC, id ASC) within the same priority — covering first enqueue
-// and re-queue after waiting_human / execute early-exit. The claim is a guarded
-// UPDATE so a run cancelled (or otherwise moved off "queued") between the read
-// and the write is skipped (RowsAffected == 0) rather than double-run. Returns
-// ok=false when there is nothing to admit; the caller then releases the
+// returns its continue node. Selection order (do NOT rewrite Run.Priority to
+// implement same-band tilt — Priority is the stored/badge band):
+//
+//	Priority DESC → hasRemainingHumanGate DESC → created_at ASC → id ASC
+//
+// Implementation: load all queued runs in the current highest Priority band,
+// score remaining human_gate reachability in memory (from __admission_from__
+// or StartNode), pick the head, then CAS UPDATE queued→running. Covering first
+// enqueue and re-queue after waiting_human / execute early-exit. The claim is a
+// guarded UPDATE so a run cancelled (or otherwise moved off "queued") between
+// the read and the write is skipped (RowsAffected == 0) rather than double-run.
+// Returns ok=false when there is nothing to admit; the caller then releases the
 // tentatively-taken slot.
 func (e *Engine) claimNextQueued() (runID, fromNodeID string, ok bool) {
-	var run models.Run
+	var head models.Run
 	if err := e.db.Where("status = ?", "queued").
-		Order("priority desc, created_at asc, id asc").First(&run).Error; err != nil {
+		Order("priority desc, created_at asc, id asc").First(&head).Error; err != nil {
 		// ErrRecordNotFound simply means the queue is empty (expected, silent).
 		// Any other error is a transient DB fault: the run stays "queued" and
 		// the 5s poll retries, but surface it so a persistent fault (which would
@@ -77,6 +84,18 @@ func (e *Engine) claimNextQueued() (runID, fromNodeID string, ok bool) {
 		}
 		return "", "", false
 	}
+
+	var candidates []models.Run
+	if err := e.db.Where("status = ? AND priority = ?", "queued", head.Priority).
+		Order("created_at asc, id asc").Find(&candidates).Error; err != nil {
+		log.Error().Err(err).Msg("dispatcher: load same-priority queued runs failed (will retry)")
+		return "", "", false
+	}
+	if len(candidates) == 0 {
+		return "", "", false
+	}
+
+	run := pickQueuedByRemainingHumanGate(candidates)
 	updates := map[string]any{"status": "running"}
 	if run.StartedAt.IsZero() {
 		updates["started_at"] = time.Now()
@@ -109,10 +128,35 @@ func (e *Engine) claimNextQueued() (runID, fromNodeID string, ok bool) {
 	return run.ID, fromNodeID, true
 }
 
+// pickQueuedByRemainingHumanGate chooses among same-priority queued candidates
+// (already ordered created_at ASC, id ASC): prefer the first with remaining
+// human_gate reachability; otherwise the FIFO head. Does not mutate Priority.
+func pickQueuedByRemainingHumanGate(candidates []models.Run) models.Run {
+	var fallback models.Run
+	haveFallback := false
+	for i := range candidates {
+		from, ok := continueFromNodeID(candidates[i])
+		hasGate := ok && hasRemainingHumanGate(&candidates[i].Graph, from)
+		if hasGate {
+			return candidates[i]
+		}
+		if !haveFallback {
+			fallback = candidates[i]
+			haveFallback = true
+		}
+	}
+	if haveFallback {
+		return fallback
+	}
+	return candidates[0]
+}
+
 // scheduleRunAdmission is the unified entry for resuming or re-driving a run
-// from a specific node. It TryAcquires a slot synchronously; when at capacity
-// the run is persisted as queued (with fromNodeID) and the dispatcher promotes
-// it later by priority then FIFO — never writing "running" before a slot is held.
+// from a specific node. It TryAcquires a slot synchronously (admitRunDirect —
+// empty-slot passthrough; does not wait for a future human_gate run). When at
+// capacity the run is persisted as queued (with fromNodeID) and the dispatcher
+// promotes it later by Priority → remaining human_gate → FIFO — never writing
+// "running" before a slot is held. Already-running runs are never preempted.
 func (e *Engine) scheduleRunAdmission(runID, fromNodeID string) {
 	if !e.sem.TryAcquire() {
 		e.queueForAdmission(runID, fromNodeID)

--- a/server/internal/engine/human_gate_reachability.go
+++ b/server/internal/engine/human_gate_reachability.go
@@ -1,0 +1,136 @@
+package engine
+
+import (
+	"strings"
+
+	"github.com/cocofhu/approving/internal/models"
+)
+
+// hasRemainingHumanGate reports whether a node with Type=="human_gate" is
+// reachable forward from fromNodeID (inclusive) on the given graph snapshot.
+//
+// Reachability neighbors are OutEdges targets plus config goto targets
+// (branch.cases[].goto, human_gate.actions[].goto, structured exits.*.goto).
+// Only human_gate counts — proposal_select, ReAct review waits, and platform
+// auto gates do not. Missing/empty graph, missing from node, or unresolvable
+// structure returns false (conservative: avoid falsely prioritizing).
+// Cycles terminate via a visited set.
+func hasRemainingHumanGate(graph *models.Graph, fromNodeID string) bool {
+	if graph == nil || fromNodeID == "" {
+		return false
+	}
+	start := graph.FindNode(fromNodeID)
+	if start == nil {
+		return false
+	}
+	if start.Type == "human_gate" {
+		return true
+	}
+	visited := map[string]bool{fromNodeID: true}
+	queue := []string{fromNodeID}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		node := graph.FindNode(cur)
+		if node == nil {
+			continue
+		}
+		for _, next := range remainingPathNeighbors(graph, node) {
+			if visited[next] {
+				continue
+			}
+			visited[next] = true
+			gn := graph.FindNode(next)
+			if gn != nil && gn.Type == "human_gate" {
+				return true
+			}
+			queue = append(queue, next)
+		}
+	}
+	return false
+}
+
+// remainingPathNeighbors returns forward destinations from node: OutEdges
+// targets union config goto targets, de-duplicated while preserving discovery
+// order (edges first, then config gotos).
+func remainingPathNeighbors(graph *models.Graph, node *models.Node) []string {
+	if graph == nil || node == nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	add := func(id string) {
+		id = strings.TrimSpace(id)
+		if id == "" || seen[id] {
+			return
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	for _, ed := range graph.OutEdges(node.ID) {
+		add(ed.Target)
+	}
+	for _, g := range configGotoTargets(node) {
+		add(g)
+	}
+	return out
+}
+
+// configGotoTargets extracts static goto destinations from node config that
+// runtime routing may take without a corresponding OutEdge.
+func configGotoTargets(node *models.Node) []string {
+	if node == nil || node.Config == nil {
+		return nil
+	}
+	var out []string
+	appendGoto := func(v any) {
+		if g := strings.TrimSpace(str(v)); g != "" {
+			out = append(out, g)
+		}
+	}
+	if cases, ok := node.Config["cases"].([]any); ok {
+		for _, ci := range cases {
+			m, ok := ci.(map[string]any)
+			if !ok {
+				continue
+			}
+			appendGoto(m["goto"])
+		}
+	}
+	if actions, ok := node.Config["actions"].([]any); ok {
+		for _, ai := range actions {
+			m, ok := ai.(map[string]any)
+			if !ok {
+				continue
+			}
+			appendGoto(m["goto"])
+		}
+	}
+	if exits, ok := node.Config["exits"].(map[string]any); ok {
+		for _, side := range exits {
+			m, ok := side.(map[string]any)
+			if !ok {
+				continue
+			}
+			appendGoto(m["goto"])
+		}
+	}
+	return out
+}
+
+// continueFromNodeID resolves the admission continue point for a queued run:
+// Checkpoints[__admission_from__].node when present, else Graph.StartNode().
+// Returns ("", false) when neither is available.
+func continueFromNodeID(run models.Run) (string, bool) {
+	if run.Checkpoints != nil {
+		if cp, ok := run.Checkpoints[admissionFromCheckpoint]; ok {
+			if node, _ := cp["node"].(string); strings.TrimSpace(node) != "" {
+				return node, true
+			}
+		}
+	}
+	if start := run.Graph.StartNode(); start != nil {
+		return start.ID, true
+	}
+	return "", false
+}

--- a/server/internal/engine/human_gate_reachability_test.go
+++ b/server/internal/engine/human_gate_reachability_test.go
@@ -1,0 +1,211 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cocofhu/approving/internal/models"
+)
+
+func TestHasRemainingHumanGate_EdgeOnly(t *testing.T) {
+	g := models.Graph{
+		Nodes: []models.Node{
+			{ID: "in", Type: "input"},
+			{ID: "work", Type: "agent"},
+			{ID: "gate", Type: "human_gate"},
+			{ID: "out", Type: "output"},
+		},
+		Edges: []models.Edge{
+			{ID: "e1", Source: "in", Target: "work"},
+			{ID: "e2", Source: "work", Target: "gate"},
+			{ID: "e3", Source: "gate", Target: "out"},
+		},
+	}
+	if !hasRemainingHumanGate(&g, "in") {
+		t.Fatal("want true via OutEdges from in")
+	}
+	if hasRemainingHumanGate(&g, "out") {
+		t.Fatal("want false from out")
+	}
+}
+
+func TestHasRemainingHumanGate_GotoOnly(t *testing.T) {
+	g := models.Graph{
+		Nodes: []models.Node{
+			{ID: "in", Type: "input"},
+			{ID: "branch", Type: "branch", Config: map[string]any{
+				"cases": []any{
+					map[string]any{"when": "true", "goto": "gate"},
+					map[string]any{"when": "false", "goto": "out"},
+				},
+			}},
+			{ID: "gate", Type: "human_gate"},
+			{ID: "out", Type: "output"},
+		},
+		Edges: []models.Edge{
+			{ID: "e1", Source: "in", Target: "branch"},
+			// no OutEdge to gate — only config goto
+		},
+	}
+	if !hasRemainingHumanGate(&g, "in") {
+		t.Fatal("want true via branch.cases[].goto")
+	}
+
+	g2 := models.Graph{
+		Nodes: []models.Node{
+			{ID: "in", Type: "input"},
+			{ID: "work", Type: "agent", Config: map[string]any{
+				"exits": map[string]any{
+					"pass": map[string]any{"goto": "gate"},
+					"fail": map[string]any{"goto": "out"},
+				},
+			}},
+			{ID: "gate", Type: "human_gate"},
+			{ID: "out", Type: "output"},
+		},
+		Edges: []models.Edge{
+			{ID: "e1", Source: "in", Target: "work"},
+		},
+	}
+	if !hasRemainingHumanGate(&g2, "in") {
+		t.Fatal("want true via structured exits.*.goto")
+	}
+
+	g3 := models.Graph{
+		Nodes: []models.Node{
+			{ID: "in", Type: "input"},
+			{ID: "gateA", Type: "human_gate", Config: map[string]any{
+				"actions": []any{
+					map[string]any{"id": "ok", "label": "OK", "goto": "gateB"},
+				},
+			}},
+			{ID: "gateB", Type: "human_gate"},
+			{ID: "out", Type: "output"},
+		},
+		Edges: []models.Edge{
+			{ID: "e1", Source: "in", Target: "gateA"},
+		},
+	}
+	// from gateA itself is human_gate → true; from after gateA via action goto also true
+	if !hasRemainingHumanGate(&g3, "gateA") {
+		t.Fatal("want true when start is human_gate")
+	}
+	if !hasRemainingHumanGate(&g3, "in") {
+		t.Fatal("want true reaching gateA via edge")
+	}
+}
+
+func TestHasRemainingHumanGate_CycleTerminates(t *testing.T) {
+	g := models.Graph{
+		Nodes: []models.Node{
+			{ID: "a", Type: "agent"},
+			{ID: "b", Type: "agent"},
+			{ID: "c", Type: "agent"},
+		},
+		Edges: []models.Edge{
+			{ID: "e1", Source: "a", Target: "b"},
+			{ID: "e2", Source: "b", Target: "c"},
+			{ID: "e3", Source: "c", Target: "a"},
+		},
+	}
+	if hasRemainingHumanGate(&g, "a") {
+		t.Fatal("cycle with no human_gate must return false and terminate")
+	}
+}
+
+func TestHasRemainingHumanGate_StartIsGate(t *testing.T) {
+	g := models.Graph{
+		Nodes: []models.Node{
+			{ID: "gate", Type: "human_gate"},
+			{ID: "out", Type: "output"},
+		},
+		Edges: []models.Edge{
+			{ID: "e1", Source: "gate", Target: "out"},
+		},
+	}
+	if !hasRemainingHumanGate(&g, "gate") {
+		t.Fatal("start node that is human_gate must be true")
+	}
+}
+
+func TestHasRemainingHumanGate_AnyBranchReachable(t *testing.T) {
+	g := models.Graph{
+		Nodes: []models.Node{
+			{ID: "in", Type: "input"},
+			{ID: "br", Type: "branch", Config: map[string]any{
+				"cases": []any{
+					map[string]any{"when": "x", "goto": "auto"},
+					map[string]any{"when": "y", "goto": "gate"},
+				},
+			}},
+			{ID: "auto", Type: "agent"},
+			{ID: "gate", Type: "human_gate"},
+			{ID: "out", Type: "output"},
+		},
+		Edges: []models.Edge{
+			{ID: "e1", Source: "in", Target: "br"},
+			{ID: "e2", Source: "auto", Target: "out"},
+			{ID: "e3", Source: "gate", Target: "out"},
+		},
+	}
+	if !hasRemainingHumanGate(&g, "in") {
+		t.Fatal("any reachable branch to human_gate must count as remaining")
+	}
+}
+
+func TestHasRemainingHumanGate_BadGraphFalse(t *testing.T) {
+	if hasRemainingHumanGate(nil, "in") {
+		t.Fatal("nil graph → false")
+	}
+	empty := models.Graph{}
+	if hasRemainingHumanGate(&empty, "in") {
+		t.Fatal("empty graph missing from → false")
+	}
+	g := models.Graph{Nodes: []models.Node{{ID: "a", Type: "agent"}}}
+	if hasRemainingHumanGate(&g, "") {
+		t.Fatal("empty from → false")
+	}
+	if hasRemainingHumanGate(&g, "missing") {
+		t.Fatal("missing from node → false")
+	}
+}
+
+func TestHasRemainingHumanGate_ReactAndProposalSelectNotGate(t *testing.T) {
+	g := models.Graph{
+		Nodes: []models.Node{
+			{ID: "in", Type: "input"},
+			{ID: "react", Type: "react"},
+			{ID: "select", Type: "proposal_select"},
+			{ID: "out", Type: "output"},
+		},
+		Edges: []models.Edge{
+			{ID: "e1", Source: "in", Target: "react"},
+			{ID: "e2", Source: "react", Target: "select"},
+			{ID: "e3", Source: "select", Target: "out"},
+		},
+	}
+	if hasRemainingHumanGate(&g, "in") {
+		t.Fatal("react / proposal_select must not count as human_gate")
+	}
+}
+
+func TestContinueFromNodeID(t *testing.T) {
+	g := models.Graph{
+		Nodes: []models.Node{
+			{ID: "in", Type: "input"},
+			{ID: "work", Type: "agent"},
+		},
+		Edges: []models.Edge{{ID: "e1", Source: "in", Target: "work"}},
+	}
+	run := models.Run{Graph: g}
+	from, ok := continueFromNodeID(run)
+	if !ok || from != "in" {
+		t.Fatalf("StartNode continue = %q ok=%v, want in true", from, ok)
+	}
+	run.Checkpoints = map[string]map[string]any{
+		admissionFromCheckpoint: {"node": "work"},
+	}
+	from, ok = continueFromNodeID(run)
+	if !ok || from != "work" {
+		t.Fatalf("admission-from continue = %q ok=%v, want work true", from, ok)
+	}
+}

--- a/server/internal/models/models.go
+++ b/server/internal/models/models.go
@@ -117,7 +117,9 @@ type Run struct {
 	Inputs          map[string]any `gorm:"serializer:json" json:"inputs"`
 	Tags            []string       `gorm:"serializer:json" json:"tags"`
 	// Priority is the admission weight: high=3, normal=2, low=1 (default 2).
-	// API/frontend expose string labels; claim sorts by Priority DESC then FIFO.
+	// API/frontend expose string labels; claim sorts by Priority DESC then
+	// remaining-human_gate then FIFO (see engine.claimNextQueued). List UI order
+	// is independent and must not follow the claim secondary key.
 	Priority int `gorm:"not null;default:2;index" json:"-"`
 	// McpToken is the run-scoped artifact-store MCP token, persisted so a run
 	// paused for human input (gate / react) can be resumed after a server

--- a/server/internal/services/run.go
+++ b/server/internal/services/run.go
@@ -14,6 +14,8 @@ import (
 
 // defaultRunListOrder is the production default: hybrid time DESC + id DESC.
 // Queued runs use created_at; all others use started_at.
+// Claim order (Priority → remaining human_gate → FIFO) is independent — do not
+// change this clause to mirror claim (Demo s4 / clarified f7).
 const defaultRunListOrder = "CASE WHEN status = 'queued' THEN created_at ELSE started_at END DESC, id DESC"
 
 // runListOrderBy maps whitelist sort/order to a fixed ORDER BY clause.

--- a/server/internal/services/run_list_page_test.go
+++ b/server/internal/services/run_list_page_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,5 +31,23 @@ func TestRunListPage(t *testing.T) {
 	page2, total2 := s.ListPage(nil, "wf", "", 2, 2)
 	if total2 != 3 || len(page2) != 1 {
 		t.Fatalf("page2=%d total2=%d", len(page2), total2)
+	}
+}
+
+// Demo s4: claim remaining-human_gate tie-break must not alter list ORDER BY.
+func TestRunListOrderIndependentOfClaimHumanGate(t *testing.T) {
+	got := runListOrderBy("", "")
+	if got != defaultRunListOrder {
+		t.Fatalf("default list order = %q, want %q", got, defaultRunListOrder)
+	}
+	if !strings.Contains(defaultRunListOrder, "created_at") {
+		t.Fatalf("expected created_at in list order: %q", defaultRunListOrder)
+	}
+	if strings.Contains(strings.ToLower(defaultRunListOrder), "human_gate") {
+		t.Fatalf("list order must not include claim human_gate key: %q", defaultRunListOrder)
+	}
+	// Whitelist still only started_at|priority — no gate secondary key.
+	if got := runListOrderBy("priority", "desc"); got != "priority DESC, id DESC" {
+		t.Fatalf("priority sort = %q", got)
 	}
 }


### PR DESCRIPTION
Same-band queued runs with a reachable human_gate from the continue point
are claimed before no-gate peers without rewriting stored Priority or list order.

Co-authored-by: Cursor <cursoragent@cursor.com>
