### PR TITLE
feat(web): open status run list modal from board column headers

### DIFF
--- a/web/e2e/board.spec.ts
+++ b/web/e2e/board.spec.ts
@@ -364,4 +364,231 @@ test.describe('需求进度看板（项目级）', () => {
     await viewMore.click()
     await expect(page.getByTestId('runs-page')).toBeVisible({ timeout: 5_000 })
   })
+
+  test('三主列列头打开状态列表模态：加载更多、关闭三件套、点行进详情、空态', async ({ page }) => {
+    test.setTimeout(60_000)
+    const listCalls: { status: string; page: string; pageSize: string }[] = []
+
+    await page.setViewportSize({ width: 1280, height: 800 })
+
+    await page.route('**/api/stats/dashboard', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ running: 5, waitingHuman: 0, failed: 0, completed: 45 }),
+        })
+        return
+      }
+      await route.continue()
+    })
+
+    await page.route('**/api/projects/*/token-stats**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          window: '30d',
+          bucketWidth: 'day',
+          timezone: 'UTC',
+          empty: true,
+          trend: [],
+          composition: {
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheWriteTokens: 0,
+            total: 0,
+          },
+          workflows: [],
+        }),
+      })
+    })
+
+    await page.route('**/api/runs**', async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.continue()
+        return
+      }
+      const url = new URL(route.request().url())
+      if (!url.searchParams.get('projectId')) {
+        await route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'projectId required in e2e mock' }),
+        })
+        return
+      }
+      const status = url.searchParams.get('status') || ''
+      const pageNum = Number(url.searchParams.get('page') || 1)
+      const pageSize = Number(url.searchParams.get('pageSize') || 20)
+      listCalls.push({ status, page: String(pageNum), pageSize: String(pageSize) })
+
+      // Modal lists always use pageSize=20; running/waiting columns use 100.
+      const isModalList =
+        pageSize === 20 && (status === 'running' || status === 'waiting_human' || (status === 'completed' && pageNum >= 1))
+
+      // Prefer modal-shaped payloads when pageSize=20 (column completed also uses 20 — shared OK).
+      if (status === 'completed' && pageSize === 20) {
+        const start = (pageNum - 1) * pageSize
+        const items = Array.from({ length: Math.min(20, Math.max(0, 45 - start)) }, (_, i) =>
+          stubRun({
+            id: `run-modal-done-${start + i}`,
+            status: 'completed',
+            title: `模态已完成-${start + i}`,
+            progress: 100,
+            durationSec: 90,
+          }),
+        )
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            items,
+            total: 45,
+            page: pageNum,
+            pageSize,
+            hasMore: start + items.length < 45,
+          }),
+        })
+        return
+      }
+
+      if (status === 'waiting_human' && pageSize === 20) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ items: [], total: 0, page: 1, pageSize, hasMore: false }),
+        })
+        return
+      }
+
+      if (status === 'running' && pageSize === 20) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            items: [
+              stubRun({ id: 'run-modal-running-1', status: 'running', title: '模态运行中-1', progress: 40 }),
+            ],
+            total: 1,
+            page: 1,
+            pageSize,
+            hasMore: false,
+          }),
+        })
+        return
+      }
+
+      void isModalList
+
+      // Column cache loads for the board itself (running/waiting pageSize=100).
+      let items: ReturnType<typeof stubRun>[] = []
+      let total = 0
+      if (status === 'running') {
+        items = Array.from({ length: 5 }, (_, i) =>
+          stubRun({ id: `run-running-${i}`, status: 'running', title: `看板运行中-${i}` }),
+        )
+        total = 5
+      } else if (status === 'waiting_human') {
+        items = []
+        total = 0
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items,
+          total,
+          page: 1,
+          pageSize,
+          hasMore: false,
+        }),
+      })
+    })
+
+    await page.goto('/board.html?start=project-board&memory=1&projectId=proj-1')
+    await expect(page.getByTestId('board-view')).toBeVisible({ timeout: 10_000 })
+
+    const headers = page.getByTestId('run-board-column-header')
+    await expect(headers).toHaveCount(3)
+
+    // --- completed: open + load more ---
+    await headers.nth(2).click()
+    await expect(page.getByTestId('board-status-list-body')).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await expect(page.getByTestId('board-status-list-subtitle')).toContainText('已完成')
+    await expect(page.getByTestId('board-status-list-row-run-modal-done-0')).toBeVisible()
+    await expect(page.getByTestId('board-status-list-range')).toContainText('已展示 20 / 45')
+    await page.getByTestId('board-status-list-load-more').click()
+    await expect(page.getByTestId('board-status-list-row-run-modal-done-20')).toBeVisible()
+    await expect(page.getByTestId('board-status-list-range')).toContainText('已展示 40 / 45')
+
+    // Esc closes and stays on board
+    await page.keyboard.press('Escape')
+    await expect(page.getByTestId('board-status-list-body')).toHaveCount(0)
+    await expect(page.getByTestId('board-view')).toBeVisible()
+    await expect(page.getByTestId('run-detail-page')).toHaveCount(0)
+
+    // --- running: open then backdrop close (click overlay corner, not dialog center) ---
+    await headers.nth(0).click()
+    await expect(page.getByTestId('board-status-list-row-run-modal-running-1')).toBeVisible()
+    await page.locator('.fixed.inset-0.z-50 > .absolute.inset-0').click({ position: { x: 8, y: 8 } })
+    await expect(page.getByTestId('board-status-list-body')).toHaveCount(0)
+    await expect(page.getByRole('dialog')).toHaveCount(0)
+    await expect(page.getByTestId('board-view')).toBeVisible()
+    await expect(page.getByTestId('run-detail-page')).toHaveCount(0)
+
+    // --- waiting_human empty state + explicit close button ---
+    await headers.nth(1).click()
+    await expect(page.getByTestId('board-status-list-empty')).toBeVisible()
+    await expect(page.getByTestId('board-status-list-empty')).toContainText('该状态暂无运行')
+    // AppModal chrome close (first button in the teleported shell)
+    await page.locator('.fixed.inset-0.z-50 button').first().click()
+    await expect(page.getByTestId('board-status-list-body')).toHaveCount(0)
+
+    // --- row click → detail (no drawer) ---
+    await headers.nth(2).click()
+    await expect(page.getByTestId('board-status-list-row-run-modal-done-0')).toBeVisible()
+    await page.getByTestId('board-status-list-row-run-modal-done-0').click()
+    await expect(page.getByTestId('run-detail-page')).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText('运行摘要')).toHaveCount(0)
+
+    // Modal list used pageSize=20 with page param (independent of column cache).
+    expect(listCalls.some((c) => c.status === 'completed' && c.pageSize === '20' && c.page === '1')).toBe(true)
+    expect(listCalls.some((c) => c.status === 'completed' && c.pageSize === '20' && c.page === '2')).toBe(true)
+  })
+
+  test('列头模态与侧滑互斥；Dashboard 列头不可激活', async ({ page }) => {
+    await gotoBoardHarness(page, { width: 1280, start: 'project-board', memory: '1', projectId: 'proj-1' })
+    await expect(page.getByTestId('board-view')).toBeVisible({ timeout: 10_000 })
+
+    // Open card drawer first
+    await page.getByText('看板需求-运行中').click()
+    await expect(page.getByText('运行摘要')).toBeVisible({ timeout: 5_000 })
+
+    // Drawer overlay blocks board chrome hit-testing; click the header element
+    // directly so openStatusList runs (closes drawer, opens list modal).
+    await page.getByTestId('run-board-column-header').nth(0).evaluate((el: HTMLElement) => el.click())
+    await expect(page.getByText('运行摘要')).toHaveCount(0)
+    await expect(page.getByTestId('board-status-list-body')).toBeVisible({ timeout: 5_000 })
+
+    // Close modal, open drawer again — modal must stay closed
+    await page.keyboard.press('Escape')
+    await expect(page.getByTestId('board-status-list-body')).toHaveCount(0)
+    await page.getByText('看板需求-运行中').click()
+    await expect(page.getByText('运行摘要')).toBeVisible()
+    await expect(page.getByTestId('board-status-list-body')).toHaveCount(0)
+
+    // Dismiss drawer, then confirm headers still work
+    await page.getByRole('button', { name: '继续浏览' }).click()
+    await expect(page.getByText('运行摘要')).toHaveCount(0)
+
+    // Dashboard mini board: headers not activatable
+    await gotoBoardHarness(page, { width: 1280, start: 'dashboard', memory: '1', projectId: 'proj-1' })
+    await expect(page.getByTestId('dashboard-view')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByTestId('run-board-column')).toHaveCount(2)
+    await expect(page.getByTestId('run-board-column-header')).toHaveCount(0)
+  })
 })

--- a/web/src/components/board/RunBoardColumn.test.ts
+++ b/web/src/components/board/RunBoardColumn.test.ts
@@ -123,4 +123,32 @@ describe('RunBoardColumn', () => {
 
     wrapper.unmount()
   })
+
+  it('keeps non-activatable header as a plain div (Dashboard default)', () => {
+    const wrapper = mountColumn()
+    expect(wrapper.find('[data-testid="run-board-column-header"]').exists()).toBe(false)
+    const header = wrapper.find('[data-testid="run-board-column"] > div')
+    expect(header.element.tagName.toLowerCase()).toBe('div')
+    expect(header.attributes('aria-haspopup')).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  it('activatable header is a focusable button that emits activate-header with status', async () => {
+    const wrapper = mountColumn({
+      headerActivatable: true,
+      status: 'completed',
+      items: [stubRun({ id: 'run-1', status: 'completed', title: '完成-1' })],
+      total: 1,
+    })
+    const header = wrapper.find('[data-testid="run-board-column-header"]')
+    expect(header.exists()).toBe(true)
+    expect(header.element.tagName.toLowerCase()).toBe('button')
+    expect(header.attributes('type')).toBe('button')
+    expect(header.attributes('aria-haspopup')).toBe('dialog')
+
+    await header.trigger('click')
+    expect(wrapper.emitted('activate-header')).toEqual([['completed']])
+    expect(wrapper.emitted('select')).toBeUndefined()
+    wrapper.unmount()
+  })
 })

--- a/web/src/components/board/RunBoardColumn.vue
+++ b/web/src/components/board/RunBoardColumn.vue
@@ -16,11 +16,21 @@ const props = withDefaults(
     loadingText?: string
     /** Fill parent height without max-height cap (dashboard preview only). */
     fill?: boolean
+    /**
+     * When true, column header is a focusable control that emits activate-header
+     * (project full board only; Dashboard leaves this off).
+     */
+    headerActivatable?: boolean
+    /** Status key emitted with activate-header when headerActivatable. */
+    status?: string
   }>(),
-  { accent: 'extra', total: 0, loading: false, fill: false },
+  { accent: 'extra', total: 0, loading: false, fill: false, headerActivatable: false },
 )
 
-const emit = defineEmits<{ (e: 'select', run: Run): void }>()
+const emit = defineEmits<{
+  (e: 'select', run: Run): void
+  (e: 'activate-header', status: string): void
+}>()
 
 const accentClass: Record<string, string> = {
   active: 'border-t-2 border-t-accent-2',
@@ -37,6 +47,11 @@ function badgeLabel(): string {
   if (total > n) return String(total)
   return String(n)
 }
+
+function onActivateHeader() {
+  if (!props.headerActivatable) return
+  emit('activate-header', props.status || '')
+}
 </script>
 
 <template>
@@ -45,7 +60,19 @@ function badgeLabel(): string {
     :class="[accentClass[accent] || accentClass.extra, fill ? 'h-full' : '']"
     data-testid="run-board-column"
   >
-    <div class="flex items-center gap-2 border-b border-line bg-surface px-3 py-2.5">
+    <component
+      :is="headerActivatable ? 'button' : 'div'"
+      :type="headerActivatable ? 'button' : undefined"
+      class="flex w-full items-center gap-2 border-b border-line bg-surface px-3 py-2.5 text-left"
+      :class="
+        headerActivatable
+          ? 'cursor-pointer transition hover:bg-elevated focus-visible:bg-elevated focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-[-1px] focus-visible:outline-accent'
+          : ''
+      "
+      :aria-haspopup="headerActivatable ? 'dialog' : undefined"
+      :data-testid="headerActivatable ? 'run-board-column-header' : undefined"
+      @click="headerActivatable ? onActivateHeader() : undefined"
+    >
       <span class="text-[13px] font-semibold text-txt">{{ title }}</span>
       <span v-if="hint" class="text-[11px] text-txt3">{{ hint }}</span>
       <span
@@ -54,7 +81,7 @@ function badgeLabel(): string {
       >
         {{ badgeLabel() }}
       </span>
-    </div>
+    </component>
     <div
       class="scroll-area flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-2.5"
       :style="fill ? undefined : { maxHeight: 'min(52vh, 420px)' }"

--- a/web/src/components/board/RunBoardStatusListModal.test.ts
+++ b/web/src/components/board/RunBoardStatusListModal.test.ts
@@ -1,0 +1,260 @@
+// @vitest-environment happy-dom
+import { createI18n } from 'vue-i18n'
+import { defineComponent, h } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import common from '@/locales/zh-CN/common.json'
+import pages from '@/locales/zh-CN/pages.json'
+import type { Run } from '@/lib/shared/types'
+
+const listRuns = vi.fn()
+
+vi.mock('@/lib/api/api', () => ({
+  api: {
+    listRuns: (...args: unknown[]) => listRuns(...args),
+  },
+}))
+
+import RunBoardStatusListModal from './RunBoardStatusListModal.vue'
+
+const AppModalStub = defineComponent({
+  name: 'AppModal',
+  props: {
+    open: Boolean,
+    title: String,
+    width: Number,
+    closeOnEsc: Boolean,
+  },
+  setup(props, { slots }) {
+    return () =>
+      props.open
+        ? h('div', { role: 'dialog', 'data-testid': 'stub-modal' }, [
+            h('div', slots.header?.()),
+            h('div', slots.default?.()),
+            h('div', slots.footer?.()),
+          ])
+        : null
+  },
+})
+
+function stubRun(partial: Partial<Run> & Pick<Run, 'id' | 'status'>): Run {
+  return {
+    workflowId: 'wf',
+    workflowName: 'Pipeline',
+    trigger: 'manual',
+    startedAt: '2026-07-18T12:00:00Z',
+    durationSec: 60,
+    progress: 40,
+    currentNodeLabel: '实现',
+    priority: 'normal',
+    nodeRuns: {},
+    artifacts: [],
+    ...partial,
+  }
+}
+
+function mountModal(props: Record<string, unknown> = {}) {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common, ...pages } },
+  })
+  return mount(RunBoardStatusListModal, {
+    props: {
+      open: true,
+      projectId: 'proj-1',
+      status: 'completed',
+      title: '已完成',
+      ...props,
+    },
+    global: {
+      plugins: [i18n],
+      stubs: {
+        AppModal: AppModalStub,
+        AppButton: defineComponent({
+          name: 'AppButton',
+          inheritAttrs: false,
+          emits: ['click'],
+          setup(_, { slots, emit, attrs }) {
+            return () =>
+              h(
+                'button',
+                {
+                  type: 'button',
+                  ...attrs,
+                  onClick: (e: MouseEvent) => emit('click', e),
+                },
+                slots.default?.(),
+              )
+          },
+        }),
+        PriorityBadge: { template: '<span data-testid="priority-badge" />' },
+      },
+    },
+    attachTo: document.body,
+  })
+}
+
+describe('RunBoardStatusListModal', () => {
+  beforeEach(() => {
+    listRuns.mockReset()
+  })
+
+  it('loads first page with pageSize 20 and shows rows + range', async () => {
+    listRuns.mockResolvedValue({
+      items: [
+        stubRun({ id: 'run-1', status: 'completed', title: '完成-1', progress: 100 }),
+        stubRun({ id: 'run-2', status: 'completed', title: '完成-2', progress: 100 }),
+      ],
+      total: 45,
+      page: 1,
+      pageSize: 20,
+      hasMore: true,
+    })
+
+    const wrapper = mountModal()
+    await flushPromises()
+
+    expect(listRuns).toHaveBeenCalledWith({
+      projectId: 'proj-1',
+      status: 'completed',
+      page: 1,
+      pageSize: 20,
+    })
+    expect(wrapper.find('[data-testid="board-status-list-row-run-1"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('完成-1')
+    expect(wrapper.text()).toContain('实现 · 100% ·')
+    expect(wrapper.find('[data-testid="board-status-list-range"]').text()).toContain('已展示 2 / 45')
+    expect(wrapper.find('[data-testid="board-status-list-load-more"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('appends on load more and hides button when hasMore is false', async () => {
+    listRuns
+      .mockResolvedValueOnce({
+        items: [stubRun({ id: 'run-1', status: 'completed', title: '完成-1' })],
+        total: 2,
+        page: 1,
+        pageSize: 20,
+        hasMore: true,
+      })
+      .mockResolvedValueOnce({
+        items: [stubRun({ id: 'run-2', status: 'completed', title: '完成-2' })],
+        total: 2,
+        page: 2,
+        pageSize: 20,
+        hasMore: false,
+      })
+
+    const wrapper = mountModal()
+    await flushPromises()
+    await wrapper.find('[data-testid="board-status-list-load-more"]').trigger('click')
+    await flushPromises()
+
+    expect(listRuns).toHaveBeenNthCalledWith(2, {
+      projectId: 'proj-1',
+      status: 'completed',
+      page: 2,
+      pageSize: 20,
+    })
+    expect(wrapper.find('[data-testid="board-status-list-row-run-2"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="board-status-list-load-more"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="board-status-list-range"]').text()).toMatch(/已全部加载/)
+    wrapper.unmount()
+  })
+
+  it('shows empty state when total is 0 (not an error)', async () => {
+    listRuns.mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+      hasMore: false,
+    })
+    const wrapper = mountModal({ status: 'waiting_human', title: '等待人工' })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="board-status-list-empty"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('该状态暂无运行')
+    expect(wrapper.find('[data-testid="board-status-list-error"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="board-status-list-load-more"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('shows initial failure distinctly from empty and allows retry', async () => {
+    listRuns.mockRejectedValueOnce(new Error('network')).mockResolvedValueOnce({
+      items: [stubRun({ id: 'run-ok', status: 'completed', title: '恢复' })],
+      total: 1,
+      page: 1,
+      pageSize: 20,
+      hasMore: false,
+    })
+    const wrapper = mountModal()
+    await flushPromises()
+    expect(wrapper.find('[data-testid="board-status-list-error"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('加载失败')
+    expect(wrapper.find('[data-testid="board-status-list-empty"]').exists()).toBe(false)
+
+    await wrapper.find('[data-testid="board-status-list-retry"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="board-status-list-row-run-ok"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('keeps shown rows when load-more fails and retries next page', async () => {
+    listRuns
+      .mockResolvedValueOnce({
+        items: [stubRun({ id: 'run-1', status: 'completed', title: '完成-1' })],
+        total: 40,
+        page: 1,
+        pageSize: 20,
+        hasMore: true,
+      })
+      .mockRejectedValueOnce(new Error('more failed'))
+      .mockResolvedValueOnce({
+        items: [stubRun({ id: 'run-2', status: 'completed', title: '完成-2' })],
+        total: 40,
+        page: 2,
+        pageSize: 20,
+        hasMore: false,
+      })
+
+    const wrapper = mountModal()
+    await flushPromises()
+    await wrapper.find('[data-testid="board-status-list-load-more"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="board-status-list-row-run-1"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="board-status-list-retry"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="board-status-list-range"]').text()).toMatch(/下一批失败/)
+
+    await wrapper.find('[data-testid="board-status-list-retry"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="board-status-list-row-run-2"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('emits select when a row is clicked', async () => {
+    listRuns.mockResolvedValue({
+      items: [stubRun({ id: 'run-9', status: 'running', title: '点我' })],
+      total: 1,
+      page: 1,
+      pageSize: 20,
+      hasMore: false,
+    })
+    const wrapper = mountModal({ status: 'running', title: '运行中' })
+    await flushPromises()
+    await wrapper.find('[data-testid="board-status-list-row-run-9"]').trigger('click')
+    expect(wrapper.emitted('select')?.[0]?.[0]).toMatchObject({ id: 'run-9' })
+    wrapper.unmount()
+  })
+
+  it('enables Esc close and ~720 width on AppModal', async () => {
+    listRuns.mockResolvedValue({ items: [], total: 0, page: 1, pageSize: 20, hasMore: false })
+    const wrapper = mountModal()
+    await flushPromises()
+    const modal = wrapper.getComponent(AppModalStub)
+    expect(modal.props('closeOnEsc')).toBe(true)
+    expect(modal.props('width')).toBe(720)
+    wrapper.unmount()
+  })
+})

--- a/web/src/components/board/RunBoardStatusListModal.vue
+++ b/web/src/components/board/RunBoardStatusListModal.vue
@@ -1,0 +1,267 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import AppModal from '@/components/ui/AppModal.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import PriorityBadge from '@/components/ui/PriorityBadge.vue'
+import { api, type PaginatedResponse } from '@/lib/api/api'
+import { fmtDuration } from '@/lib/shared/format'
+import { runBoardTitle, runIdShort } from '@/lib/run/runBoard'
+import type { Run } from '@/lib/shared/types'
+
+const PAGE_SIZE = 20
+
+const props = defineProps<{
+  open: boolean
+  projectId: string
+  /** Run status filter matching the activated board column. */
+  status: string
+  /** Localized column title for the modal heading. */
+  title: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'select', run: Run): void
+}>()
+
+const { t } = useI18n()
+
+const items = ref<Run[]>([])
+const total = ref(0)
+const page = ref(0)
+const hasMore = ref(false)
+const loading = ref(false)
+/** True while the very first page is in flight (empty body). */
+const initialLoading = ref(false)
+const loadFailed = ref(false)
+/** Distinguishes first-page failure from append failure. */
+const failKind = ref<'initial' | 'more' | null>(null)
+
+let requestSeq = 0
+
+const shownCount = computed(() => items.value.length)
+
+const rangeText = computed(() => {
+  if (loadFailed.value && failKind.value === 'initial') {
+    return t('pages.board.statusList.rangeInitialFailed')
+  }
+  if (loadFailed.value && failKind.value === 'more') {
+    return t('pages.board.statusList.rangeMoreFailed', {
+      shown: shownCount.value,
+      total: total.value,
+    })
+  }
+  if (!loading.value && !hasMore.value && shownCount.value > 0) {
+    return t('pages.board.statusList.rangeComplete', {
+      shown: shownCount.value,
+      total: total.value,
+    })
+  }
+  return t('pages.board.statusList.range', {
+    shown: shownCount.value,
+    total: total.value,
+  })
+})
+
+const subtitle = computed(() => {
+  if (loadFailed.value) {
+    return t('pages.board.statusList.subtitleFailed', { title: props.title })
+  }
+  return t('pages.board.statusList.subtitle', {
+    title: props.title,
+    total: total.value,
+  })
+})
+
+function resetState() {
+  items.value = []
+  total.value = 0
+  page.value = 0
+  hasMore.value = false
+  loading.value = false
+  initialLoading.value = false
+  loadFailed.value = false
+  failKind.value = null
+  requestSeq += 1
+}
+
+async function fetchPage(nextPage: number, mode: 'initial' | 'more') {
+  if (!props.projectId || !props.status) return
+  const seq = ++requestSeq
+  loading.value = true
+  if (mode === 'initial') {
+    initialLoading.value = true
+    loadFailed.value = false
+    failKind.value = null
+  } else {
+    loadFailed.value = false
+    failKind.value = null
+  }
+
+  try {
+    const data = (await api.listRuns({
+      projectId: props.projectId,
+      status: props.status,
+      page: nextPage,
+      pageSize: PAGE_SIZE,
+    })) as PaginatedResponse<Run>
+
+    if (seq !== requestSeq) return
+
+    const batch = data.items || []
+    if (mode === 'initial') {
+      items.value = batch
+    } else {
+      items.value = [...items.value, ...batch]
+    }
+    total.value = data.total ?? items.value.length
+    page.value = data.page ?? nextPage
+    hasMore.value = Boolean(data.hasMore)
+    loadFailed.value = false
+    failKind.value = null
+  } catch {
+    if (seq !== requestSeq) return
+    loadFailed.value = true
+    failKind.value = mode
+    // Keep already-shown items on more-failure (n5).
+  } finally {
+    if (seq === requestSeq) {
+      loading.value = false
+      initialLoading.value = false
+    }
+  }
+}
+
+function loadInitial() {
+  resetState()
+  void fetchPage(1, 'initial')
+}
+
+function loadMore() {
+  if (loading.value || !hasMore.value) return
+  void fetchPage(page.value + 1, 'more')
+}
+
+function retry() {
+  if (loading.value) return
+  if (failKind.value === 'more' && items.value.length > 0) {
+    void fetchPage(page.value + 1, 'more')
+    return
+  }
+  loadInitial()
+}
+
+function rowMeta(run: Run): string {
+  const node = run.currentNodeLabel || '—'
+  const prog = run.progress != null ? `${run.progress}%` : '—'
+  const dur = fmtDuration(run.durationSec ?? 0)
+  return `${node} · ${prog} · ${dur}`
+}
+
+function onSelect(run: Run) {
+  emit('select', run)
+}
+
+watch(
+  () => [props.open, props.projectId, props.status] as const,
+  ([open]) => {
+    if (open) {
+      loadInitial()
+    } else {
+      resetState()
+    }
+  },
+  { immediate: true },
+)
+</script>
+
+<template>
+  <AppModal
+    :open="open"
+    :title="title"
+    :width="720"
+    :close-on-esc="true"
+    @close="emit('close')"
+  >
+    <template #header>
+      <div class="min-w-0">
+        <div class="text-[15px] font-semibold text-txt">{{ title }}</div>
+        <p class="mt-0.5 truncate text-xs text-txt2" data-testid="board-status-list-subtitle">
+          {{ subtitle }}
+        </p>
+      </div>
+    </template>
+
+    <div class="-m-5" data-testid="board-status-list-body">
+      <div v-if="initialLoading" class="px-5 py-10 text-center text-sm text-txt2" data-testid="board-status-list-loading">
+        {{ t('pages.board.statusList.loading') }}
+      </div>
+
+      <div
+        v-else-if="loadFailed && failKind === 'initial'"
+        class="px-5 py-10 text-center text-sm"
+        data-testid="board-status-list-error"
+      >
+        <strong class="mb-1 block text-txt">{{ t('pages.board.statusList.errorTitle') }}</strong>
+        <p class="text-err">{{ t('pages.board.statusList.errorHint') }}</p>
+      </div>
+
+      <div
+        v-else-if="!items.length"
+        class="px-5 py-10 text-center text-sm text-txt2"
+        data-testid="board-status-list-empty"
+      >
+        <strong class="mb-1 block text-txt">{{ t('pages.board.statusList.emptyTitle') }}</strong>
+        <p>{{ t('pages.board.statusList.emptyHint', { title }) }}</p>
+      </div>
+
+      <div v-else class="flex flex-col" data-testid="board-status-list-rows">
+        <button
+          v-for="run in items"
+          :key="run.id"
+          type="button"
+          class="grid w-full grid-cols-[92px_minmax(0,1fr)_auto] items-center gap-2.5 border-b border-line px-4 py-2.5 text-left transition hover:bg-elevated focus-visible:bg-elevated focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-[-1px] focus-visible:outline-accent"
+          :data-testid="`board-status-list-row-${run.id}`"
+          @click="onSelect(run)"
+        >
+          <span class="font-mono text-[11px] text-txt3">#{{ runIdShort(run.id) }}</span>
+          <span class="min-w-0">
+            <span class="block truncate text-[13px] font-semibold text-txt">{{ runBoardTitle(run) }}</span>
+            <span class="mt-0.5 block truncate text-[11px] text-txt3">{{ rowMeta(run) }}</span>
+          </span>
+          <PriorityBadge :priority="run.priority" />
+        </button>
+      </div>
+    </div>
+
+    <template #footer>
+      <div class="flex w-full items-center justify-between gap-2" data-testid="board-status-list-footer">
+        <span class="text-xs text-txt3" data-testid="board-status-list-range">{{ rangeText }}</span>
+        <div class="flex items-center gap-2">
+          <AppButton
+            v-if="loadFailed"
+            variant="outline"
+            size="sm"
+            data-testid="board-status-list-retry"
+            :disabled="loading"
+            @click="retry"
+          >
+            {{ t('pages.board.statusList.retry') }}
+          </AppButton>
+          <AppButton
+            v-else-if="hasMore"
+            variant="primary"
+            size="sm"
+            data-testid="board-status-list-load-more"
+            :loading="loading"
+            :disabled="loading"
+            @click="loadMore"
+          >
+            {{ t('pages.board.statusList.loadMore') }}
+          </AppButton>
+        </div>
+      </div>
+    </template>
+  </AppModal>
+</template>

--- a/web/src/components/run/UpstreamRequirementContext.test.ts
+++ b/web/src/components/run/UpstreamRequirementContext.test.ts
@@ -370,7 +370,7 @@ describe('UpstreamRequirementContext', () => {
     expect(wrapper.find('[data-testid="upstream-modal-callout"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="upstream-bar-hint"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="upstream-bar-hint"]').text()).toContain(
-      '本 run 已有澄清需求文档',
+      '本工作流已有澄清需求文档',
     )
     wrapper.unmount()
   })

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -110,6 +110,21 @@
         "hint": "Cards open a summary first; open the full run detail when ready. Closing keeps you on the board.",
         "dismiss": "Keep browsing",
         "openDetail": "Open run detail"
+      },
+      "statusList": {
+        "subtitle": "This project · {title} · {total} total",
+        "subtitleFailed": "{title} · Failed to load — retry available",
+        "range": "Showing {shown} / {total}",
+        "rangeComplete": "All loaded {shown} / {total} · no more",
+        "rangeInitialFailed": "First page not loaded",
+        "rangeMoreFailed": "Showing {shown} / {total} · next page failed",
+        "loadMore": "Load more",
+        "loading": "Loading…",
+        "retry": "Retry",
+        "emptyTitle": "No runs in this status",
+        "emptyHint": "There are no \"{title}\" runs in this project. This is not a load failure.",
+        "errorTitle": "Failed to load",
+        "errorHint": "Could not fetch runs for this status. This is not an empty list."
       }
     },
     "projectList": {

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -110,6 +110,21 @@
         "hint": "点击卡片先预览摘要，确认后再进入完整运行详情；关闭后仍停留在原看板视图。",
         "dismiss": "继续浏览",
         "openDetail": "进入运行详情"
+      },
+      "statusList": {
+        "subtitle": "当前项目 · {title} · 共 {total} 条",
+        "subtitleFailed": "{title} · 加载失败，可重试",
+        "range": "已展示 {shown} / {total}",
+        "rangeComplete": "已全部加载 {shown} / {total} · 没有更多",
+        "rangeInitialFailed": "首批未载入",
+        "rangeMoreFailed": "已展示 {shown} / {total} · 下一批失败",
+        "loadMore": "加载更多",
+        "loading": "加载中…",
+        "retry": "重试",
+        "emptyTitle": "该状态暂无运行",
+        "emptyHint": "当前项目下没有「{title}」的运行。这不是加载失败。",
+        "errorTitle": "加载失败",
+        "errorHint": "无法拉取该状态运行列表。这不是空列表。"
       }
     },
     "projectList": {

--- a/web/src/views/BoardView.vue
+++ b/web/src/views/BoardView.vue
@@ -4,6 +4,7 @@ import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import RunBoardColumn from '@/components/board/RunBoardColumn.vue'
 import RunBoardPreviewDrawer from '@/components/board/RunBoardPreviewDrawer.vue'
+import RunBoardStatusListModal from '@/components/board/RunBoardStatusListModal.vue'
 import TokenStatsPanel from '@/components/board/token-stats/TokenStatsPanel.vue'
 import { serializeStatusQuery } from '@/lib/composables/useStatusFilter'
 import { useRunBoard, type BoardColumnKey } from '@/lib/run/useRunBoard'
@@ -47,6 +48,11 @@ watch(projectIdRef, () => {
 const selected = ref<Run | null>(null)
 const drawerOpen = ref(false)
 
+/** Column-header status list modal (independent of useRunBoard column cache). */
+const listModalOpen = ref(false)
+const listModalStatus = ref<string>('')
+const listModalTitle = ref('')
+
 const mainCols: { key: BoardColumnKey; accent: 'running' | 'waiting' | 'done'; titleKey: string; hintKey: string; emptyKey: string }[] = [
   { key: 'running', accent: 'running', titleKey: 'pages.board.columns.running', hintKey: 'pages.board.hints.inProgress', emptyKey: 'pages.board.empty.running' },
   { key: 'waiting_human', accent: 'waiting', titleKey: 'pages.board.columns.waitingHuman', hintKey: 'pages.board.hints.inReview', emptyKey: 'pages.board.empty.waitingHuman' },
@@ -72,7 +78,13 @@ function truncatedHint(key: BoardColumnKey): string {
   return ''
 }
 
+function closeListModal() {
+  listModalOpen.value = false
+}
+
 function openPreview(run: Run) {
+  // Mutual exclusion with column-header list modal (f6).
+  closeListModal()
   selected.value = run
   drawerOpen.value = true
 }
@@ -80,6 +92,21 @@ function openPreview(run: Run) {
 function closePreview() {
   drawerOpen.value = false
   selected.value = null
+}
+
+function openStatusList(status: string) {
+  const col = mainCols.find((c) => c.key === status)
+  if (!col) return
+  // Mutual exclusion with card preview drawer (f6).
+  closePreview()
+  listModalStatus.value = status
+  listModalTitle.value = t(col.titleKey)
+  listModalOpen.value = true
+}
+
+function onListSelect(run: Run) {
+  closeListModal()
+  router.push('/runs/' + run.id)
 }
 
 function goMoreCompleted() {
@@ -185,7 +212,10 @@ onUnmounted(() => {
         :loading-text="t('pages.board.loading')"
         :empty-text="t(col.emptyKey)"
         :truncated-hint="truncatedHint(col.key)"
+        header-activatable
+        :status="col.key"
         @select="openPreview"
+        @activate-header="openStatusList"
       >
         <template v-if="col.key === 'completed'" #footer>
           <button
@@ -222,5 +252,14 @@ onUnmounted(() => {
     </div>
 
     <RunBoardPreviewDrawer :open="drawerOpen" :run="selected" @close="closePreview" />
+
+    <RunBoardStatusListModal
+      :open="listModalOpen"
+      :project-id="projectId"
+      :status="listModalStatus"
+      :title="listModalTitle"
+      @close="closeListModal"
+      @select="onListSelect"
+    />
   </div>
 </template>


### PR DESCRIPTION
Allow project board column headers to open an AppModal with independent
listRuns pagination (load more, empty/error retry), mutually exclusive
with the card preview drawer, so users can browse full status lists
without leaving the board.

Co-authored-by: Cursor <cursoragent@cursor.com>
