### PR TITLE
fix(web): align upstream bar hint test with locale copy

### DIFF
--- a/web/src/components/run/UpstreamRequirementContext.test.ts
+++ b/web/src/components/run/UpstreamRequirementContext.test.ts
@@ -370,7 +370,7 @@ describe('UpstreamRequirementContext', () => {
     expect(wrapper.find('[data-testid="upstream-modal-callout"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="upstream-bar-hint"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="upstream-bar-hint"]').text()).toContain(
-      '本 run 已有澄清需求文档',
+      '本工作流已有澄清需求文档',
     )
     wrapper.unmount()
   })


### PR DESCRIPTION
## Summary
- #274 将 `upstreamBarHint` 改为「本工作流…」，但 `UpstreamRequirementContext.test.ts` 仍有一处断言「本 run…」，导致 main 与大量开放 PR 的 `ci-web`/`web-gate` 失败。
- 将过期断言与 locale / 同用例前半段对齐。

## Test plan
- [ ] `ci-web` green on this PR
- [ ] Confirm no other assertions still expect `本 run 已有澄清需求文档`


Made with [Cursor](https://cursor.com)