### PR TITLE
fix/public gate chat stream

### DIFF
--- a/server/internal/gateshare/preview.go
+++ b/server/internal/gateshare/preview.go
@@ -59,6 +59,15 @@ type PreviewDTO struct {
 	// Kind stays "review" for ShareLinkKindReview; clients use NodeType to
 	// distinguish Inbox 待澄清 from 待复审 without leaking Run#.
 	NodeType string `json:"nodeType,omitempty"`
+	// LiveEvents is a leak-free in-flight ACP snapshot (message/thought only)
+	// while sessionBusy. Poll fallback when the public events WS is down.
+	LiveEvents []PreviewLiveEvent `json:"liveEvents,omitempty"`
+}
+
+// PreviewLiveEvent is a leak-free ACP rail for public streaming / poll seed.
+type PreviewLiveEvent struct {
+	Kind string `json:"kind"`
+	Text string `json:"text,omitempty"`
 }
 
 // PublicPreviewPort is the leak-free port entry for public app_preview remote / API iframe.
@@ -82,6 +91,7 @@ type PreviewExtras struct {
 	ProductKind       string
 	ProductName       string
 	Ports             []PublicPreviewPort
+	LiveEvents        []models.AcpEvent
 }
 
 // BuildPreviewDTO builds a whitelist human_gate preview from lookup + artifacts.
@@ -202,6 +212,11 @@ func applyPreviewArtifacts(dto *PreviewDTO, visualHTML, structuredName, structur
 		dto.Waiting = extras.Waiting
 	}
 	dto.SessionBusy = alive && (extras.SessionBusy || extras.Waiting > 0 || dto.ActiveItem != nil)
+	if dto.SessionBusy {
+		if ev := SanitizeLiveEvents(extras.LiveEvents); len(ev) > 0 {
+			dto.LiveEvents = ev
+		}
+	}
 	dto.VisualHTMLHash = ContentHash(dto.VisualHTML)
 	dto.UpstreamHash = HashUpstream(dto.Upstream)
 	dto.StructuredHash = HashStructured(dto.Structured)

--- a/server/internal/gateshare/public_events.go
+++ b/server/internal/gateshare/public_events.go
@@ -1,0 +1,208 @@
+package gateshare
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/cocofhu/approving/internal/models"
+)
+
+// PublicDialogueNodeID is the leak-free node id rewritten onto public WS frames
+// so the unauthenticated workbench can consume review/ACP without host ids.
+const PublicDialogueNodeID = "public-gate"
+
+// SanitizeLiveEvents keeps only message/thought rails and redacts leaky URLs.
+func SanitizeLiveEvents(events []models.AcpEvent) []PreviewLiveEvent {
+	if len(events) == 0 {
+		return nil
+	}
+	out := make([]PreviewLiveEvent, 0, 2)
+	for _, ev := range events {
+		kind := strings.ToLower(strings.TrimSpace(ev.Kind))
+		if kind != "message" && kind != "thought" {
+			continue
+		}
+		text := capTurnText(SanitizeDescription(ev.Text))
+		if text == "" {
+			continue
+		}
+		out = append(out, PreviewLiveEvent{Kind: kind, Text: text})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// FilterPublicBrokerFrame rewrites a run-broker payload for the public
+// workbench: only review/acp for producerID, strip runId, rewrite nodeId,
+// drop tool_call/plan and images.
+func FilterPublicBrokerFrame(raw []byte, producerID string) ([]byte, bool) {
+	producerID = strings.TrimSpace(producerID)
+	if producerID == "" || len(raw) == 0 {
+		return nil, false
+	}
+	var m map[string]any
+	if json.Unmarshal(raw, &m) != nil {
+		return nil, false
+	}
+	typ, _ := m["type"].(string)
+	nodeID, _ := m["nodeId"].(string)
+	if strings.TrimSpace(nodeID) != producerID {
+		return nil, false
+	}
+	switch strings.ToLower(strings.TrimSpace(typ)) {
+	case "review":
+		return marshalPublicReviewFrame(m)
+	case "acp":
+		return marshalPublicAcpFrame(m)
+	default:
+		return nil, false
+	}
+}
+
+func marshalPublicReviewFrame(m map[string]any) ([]byte, bool) {
+	event, _ := m["event"].(string)
+	event = strings.TrimSpace(event)
+	if event == "" {
+		return nil, false
+	}
+	out := map[string]any{
+		"type":   "review",
+		"nodeId": PublicDialogueNodeID,
+		"event":  event,
+	}
+	if waiting, ok := jsonNumber(m["waiting"]); ok {
+		out["waiting"] = waiting
+	}
+	if busy, ok := m["busy"].(bool); ok {
+		out["busy"] = busy
+	}
+	if interrupted, ok := m["interrupted"].(bool); ok {
+		out["interrupted"] = interrupted
+	}
+	if msg, _ := m["message"].(string); strings.TrimSpace(msg) != "" {
+		out["message"] = capTurnText(SanitizeDescription(msg))
+	}
+	if items := queueItemsFromAny(m["items"]); len(items) > 0 {
+		out["items"] = items
+	}
+	if ai := activeItemFromAny(m["activeItem"]); ai != nil {
+		out["activeItem"] = ai
+	}
+	if item := activeItemFromAny(m["item"]); item != nil {
+		out["item"] = item
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		return nil, false
+	}
+	return b, true
+}
+
+func marshalPublicAcpFrame(m map[string]any) ([]byte, bool) {
+	events := acpEventsFromAny(m["events"])
+	rails := SanitizeLiveEvents(events)
+	if len(rails) == 0 {
+		return nil, false
+	}
+	out := map[string]any{
+		"type":   "acp",
+		"nodeId": PublicDialogueNodeID,
+		"events": rails,
+	}
+	if busy, ok := m["busy"].(bool); ok {
+		out["busy"] = busy
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		return nil, false
+	}
+	return b, true
+}
+
+func jsonNumber(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case json.Number:
+		f, err := n.Float64()
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func queueItemsFromAny(v any) []PreviewQueueItem {
+	switch items := v.(type) {
+	case []map[string]any:
+		return SanitizeQueueItems(items)
+	case []any:
+		parsed := make([]map[string]any, 0, len(items))
+		for _, raw := range items {
+			am, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			parsed = append(parsed, am)
+		}
+		return SanitizeQueueItems(parsed)
+	default:
+		return nil
+	}
+}
+
+func activeItemFromAny(v any) map[string]any {
+	switch item := v.(type) {
+	case map[string]any:
+		ai := SanitizeActiveItem(item)
+		return previewActiveItemMap(ai)
+	default:
+		return nil
+	}
+}
+
+func previewActiveItemMap(ai *PreviewActiveItem) map[string]any {
+	if ai == nil {
+		return nil
+	}
+	m := map[string]any{}
+	if ai.ID != "" {
+		m["id"] = ai.ID
+	}
+	if ai.Text != "" {
+		m["text"] = ai.Text
+	}
+	if len(ai.Annotations) > 0 {
+		m["annotations"] = ai.Annotations
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return m
+}
+
+func acpEventsFromAny(v any) []models.AcpEvent {
+	switch events := v.(type) {
+	case []models.AcpEvent:
+		return events
+	case []any:
+		out := make([]models.AcpEvent, 0, len(events))
+		for _, raw := range events {
+			am, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			kind, _ := am["kind"].(string)
+			text, _ := am["text"].(string)
+			out = append(out, models.AcpEvent{Kind: kind, Text: text})
+		}
+		return out
+	default:
+		return nil
+	}
+}

--- a/server/internal/gateshare/public_events_test.go
+++ b/server/internal/gateshare/public_events_test.go
@@ -1,0 +1,84 @@
+package gateshare
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/cocofhu/approving/internal/models"
+)
+
+func TestSanitizeLiveEventsKeepsRailsAndDropsTools(t *testing.T) {
+	ev := SanitizeLiveEvents([]models.AcpEvent{
+		{Kind: "thought", Text: "正在改 http://127.0.0.1/api/runs/secret"},
+		{Kind: "tool_call", Title: "write", Text: "should-drop"},
+		{Kind: "message", Text: "标题已改为绿色"},
+		{Kind: "plan", Text: "plan-secret"},
+	})
+	if len(ev) != 2 {
+		t.Fatalf("events=%d %+v", len(ev), ev)
+	}
+	if ev[0].Kind != "thought" || strings.Contains(ev[0].Text, "127.0.0.1") || strings.Contains(ev[0].Text, "/api/runs") {
+		t.Fatalf("thought leaked: %+v", ev[0])
+	}
+	if ev[1].Kind != "message" || ev[1].Text != "标题已改为绿色" {
+		t.Fatalf("message: %+v", ev[1])
+	}
+}
+
+func TestFilterPublicBrokerFrameStripsRunAndRewritesNode(t *testing.T) {
+	raw, _ := json.Marshal(map[string]any{
+		"type":   "acp",
+		"runId":  "run-secret",
+		"nodeId": "research1",
+		"busy":   true,
+		"events": []any{
+			map[string]any{"kind": "message", "text": "流式正文 http://10.1.2.3/api/x"},
+			map[string]any{"kind": "tool_call", "title": "write", "text": "leak"},
+		},
+	})
+	out, ok := FilterPublicBrokerFrame(raw, "research1")
+	if !ok {
+		t.Fatal("expected filtered frame")
+	}
+	s := string(out)
+	if strings.Contains(s, "run-secret") || strings.Contains(s, "research1") || strings.Contains(s, "tool_call") {
+		t.Fatalf("leaked: %s", s)
+	}
+	if !strings.Contains(s, PublicDialogueNodeID) || !strings.Contains(s, "流式正文") {
+		t.Fatalf("missing public payload: %s", s)
+	}
+	if strings.Contains(s, "10.1.2.3") {
+		t.Fatalf("url leak: %s", s)
+	}
+
+	other, ok := FilterPublicBrokerFrame(raw, "other-node")
+	if ok || other != nil {
+		t.Fatalf("other node must drop: ok=%v %s", ok, other)
+	}
+}
+
+func TestFilterPublicBrokerFrameReviewTurnBegin(t *testing.T) {
+	raw, _ := json.Marshal(map[string]any{
+		"type":   "review",
+		"runId":  "run-secret",
+		"nodeId": "research1",
+		"event":  "turn_begin",
+		"item": map[string]any{
+			"id":     "q1",
+			"text":   "改成绿的",
+			"images": []any{map[string]any{"data": "AAAA", "mimeType": "image/png"}},
+		},
+	})
+	out, ok := FilterPublicBrokerFrame(raw, "research1")
+	if !ok {
+		t.Fatal("expected review frame")
+	}
+	s := string(out)
+	if strings.Contains(s, "run-secret") || strings.Contains(s, "AAAA") || strings.Contains(s, "images") {
+		t.Fatalf("leaked: %s", s)
+	}
+	if !strings.Contains(s, `"event":"turn_begin"`) || !strings.Contains(s, "改成绿的") {
+		t.Fatalf("payload: %s", s)
+	}
+}

--- a/server/internal/handlers/gate_share_public.go
+++ b/server/internal/handlers/gate_share_public.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/url"
@@ -506,6 +507,9 @@ func (h *Handlers) publicReviewExtras(lookup *gateshare.LookupResult, visualHTML
 			ex.Waiting = waiting
 			ex.SessionBusy = thinking || waiting > 0 || !h.Eng.ReviewSessionReady(runID, nodeID)
 		}
+		if ex.SessionBusy {
+			ex.LiveEvents = h.publicLiveACP(runID, nodeID)
+		}
 	}
 	ex.UpstreamName, ex.UpstreamContent = h.publicUpstreamArtifact(runID, structName)
 	return ex
@@ -554,6 +558,9 @@ func (h *Handlers) publicGateExtras(lookup *gateshare.LookupResult, visualHTML, 
 			ex.Waiting = waiting
 			ex.SessionBusy = thinking || waiting > 0 || !h.Eng.ReviewSessionReady(runID, producerID)
 		}
+		if ex.SessionBusy {
+			ex.LiveEvents = h.publicLiveACP(runID, producerID)
+		}
 	}
 	ex.UpstreamName, ex.UpstreamContent = h.publicUpstreamArtifact(runID, structName)
 	return ex
@@ -568,6 +575,32 @@ func (h *Handlers) publicGateProducerID(lookup *gateshare.LookupResult) string {
 		return up
 	}
 	return ""
+}
+
+func (h *Handlers) publicDialogueProducerID(lookup *gateshare.LookupResult) string {
+	if lookup == nil {
+		return ""
+	}
+	if publicShareKind(lookup) == models.ShareLinkKindReview {
+		return strings.TrimSpace(lookup.Link.NodeID)
+	}
+	if h.Eng != nil {
+		if id, _ := h.Eng.GateReactInfo(lookup.Link.RunID, lookup.Link.NodeID); strings.TrimSpace(id) != "" {
+			return strings.TrimSpace(id)
+		}
+	}
+	return h.publicGateProducerID(lookup)
+}
+
+func (h *Handlers) publicLiveACP(runID, nodeID string) []models.AcpEvent {
+	if h.Eng == nil || strings.TrimSpace(runID) == "" || strings.TrimSpace(nodeID) == "" {
+		return nil
+	}
+	ev, ok, err := h.Eng.LiveNodeEvents(context.Background(), runID, nodeID)
+	if err != nil || !ok || len(ev) == 0 {
+		return nil
+	}
+	return ev
 }
 
 func (h *Handlers) publicConversation(runID, nodeID string) *models.ReactConversation {

--- a/server/internal/handlers/gate_share_public_events.go
+++ b/server/internal/handlers/gate_share_public_events.go
@@ -1,0 +1,155 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cocofhu/approving/internal/gateshare"
+	"github.com/cocofhu/approving/internal/models"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"github.com/rs/zerolog/log"
+)
+
+const publicEventsAuthTimeout = 5 * time.Second
+
+type publicEventsAuth struct {
+	Token string `json:"token"`
+}
+
+// PublicGateEvents streams leak-free review/ACP frames for the share-link
+// workbench. Token is sent as the first JSON message (never in the URL).
+func (h *Handlers) PublicGateEvents(c *gin.Context) {
+	applyPublicSecurityHeaders(c)
+	if !h.publicRateLimit(c, gateshare.RateBucketPreview) {
+		return
+	}
+	if h.GateShare == nil || h.Eng == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "unavailable"})
+		return
+	}
+	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		log.Debug().Err(err).Msg("public gate events websocket upgrade failed")
+		return
+	}
+	defer conn.Close()
+
+	_ = conn.SetReadDeadline(time.Now().Add(publicEventsAuthTimeout))
+	_, data, err := conn.ReadMessage()
+	if err != nil {
+		return
+	}
+	var auth publicEventsAuth
+	if json.Unmarshal(data, &auth) != nil {
+		_ = conn.WriteJSON(gin.H{"type": "error", "status": "invalid"})
+		return
+	}
+	token := strings.TrimSpace(auth.Token)
+	if token == "" || !gateshare.ValidTokenShape(token) {
+		_ = conn.WriteJSON(gin.H{"type": "error", "status": "invalid"})
+		return
+	}
+	lookup, st, err := h.GateShare.LookupByToken(token)
+	if err != nil || lookup == nil || st != models.ShareLinkStateActive {
+		status := st
+		if status == "" {
+			status = "invalid"
+		}
+		_ = conn.WriteJSON(gin.H{"type": "error", "status": status})
+		return
+	}
+	producerID := h.publicDialogueProducerID(lookup)
+	if producerID == "" {
+		producerID = strings.TrimSpace(lookup.Link.NodeID)
+	}
+	if producerID == "" {
+		_ = conn.WriteJSON(gin.H{"type": "error", "status": "invalid"})
+		return
+	}
+	_ = conn.SetReadDeadline(time.Time{})
+	if err := conn.WriteJSON(gin.H{"type": "ready"}); err != nil {
+		return
+	}
+
+	runID := lookup.Link.RunID
+	ch, unsub := h.Eng.Broker().Subscribe(runID)
+	defer unsub()
+	h.seedPublicDialogue(conn, lookup, producerID)
+
+	ping := time.NewTicker(25 * time.Second)
+	defer ping.Stop()
+
+	go func() {
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				_ = conn.Close()
+				return
+			}
+		}
+	}()
+
+	for {
+		select {
+		case msg, open := <-ch:
+			if !open {
+				return
+			}
+			out, ok := gateshare.FilterPublicBrokerFrame(msg, producerID)
+			if !ok {
+				continue
+			}
+			if err := conn.WriteMessage(websocket.TextMessage, out); err != nil {
+				return
+			}
+		case <-ping.C:
+			if err := conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(5*time.Second)); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func (h *Handlers) seedPublicDialogue(conn *websocket.Conn, lookup *gateshare.LookupResult, producerID string) {
+	if h.Eng == nil || lookup == nil || conn == nil {
+		return
+	}
+	runID := lookup.Link.RunID
+	if snap, ok := h.Eng.ReviewSessionSnapshotFor(runID, producerID); ok {
+		payload := map[string]any{
+			"type":    "review",
+			"runId":   runID,
+			"nodeId":  producerID,
+			"event":   "queue_state",
+			"waiting": snap.Waiting,
+			"items":   snap.Items,
+			"busy":    snap.Busy,
+		}
+		if snap.ActiveItem != nil {
+			payload["activeItem"] = snap.ActiveItem
+		}
+		raw, err := json.Marshal(payload)
+		if err == nil {
+			if out, ok := gateshare.FilterPublicBrokerFrame(raw, producerID); ok {
+				_ = conn.WriteMessage(websocket.TextMessage, out)
+			}
+		}
+	}
+	if ev := h.publicLiveACP(runID, producerID); len(ev) > 0 {
+		raw, err := json.Marshal(map[string]any{
+			"type":   "acp",
+			"runId":  runID,
+			"nodeId": producerID,
+			"events": ev,
+			"busy":   true,
+		})
+		if err == nil {
+			if out, ok := gateshare.FilterPublicBrokerFrame(raw, producerID); ok {
+				_ = conn.WriteMessage(websocket.TextMessage, out)
+			}
+		}
+	}
+}

--- a/server/internal/handlers/gate_share_public_events_test.go
+++ b/server/internal/handlers/gate_share_public_events_test.go
@@ -1,0 +1,121 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/gateshare"
+	"github.com/gorilla/websocket"
+)
+
+func TestPublicGateEventsWSStreamsSanitizedAcp(t *testing.T) {
+	h := newHarness(t)
+	seedInboxReview(t, h, "run-pub-ws", "research-ws", true)
+	created := parseJSON(t, h.do(http.MethodPost, "/api/runs/run-pub-ws/reviews/research-ws/share-link", map[string]any{"ttlTier": "24h"}))
+	url, _ := created["url"].(string)
+	token := strings.TrimPrefix(url[strings.Index(url, "#t="):], "#t=")
+	if !gateshare.ValidTokenShape(token) {
+		t.Fatalf("token: %s", token)
+	}
+
+	srv := httptest.NewServer(h.r)
+	defer srv.Close()
+
+	c, _, err := websocket.DefaultDialer.Dial(wsURL(srv.URL, "/public/gate-approvals/events"), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+	c.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if err := c.WriteJSON(map[string]any{"token": token}); err != nil {
+		t.Fatalf("auth: %v", err)
+	}
+	_, ready, err := c.ReadMessage()
+	if err != nil || !strings.Contains(string(ready), `"type":"ready"`) {
+		t.Fatalf("ready: %v %s", err, ready)
+	}
+
+	h.h.Eng.Broker().Publish("run-pub-ws", mustJSON(t, map[string]any{
+		"type":   "acp",
+		"runId":  "run-pub-ws",
+		"nodeId": "research-ws",
+		"busy":   true,
+		"events": []any{
+			map[string]any{"kind": "thought", "text": "思考 http://127.0.0.1/api/runs/x"},
+			map[string]any{"kind": "message", "text": "标题已改为绿色"},
+			map[string]any{"kind": "tool_call", "title": "write", "text": "secret"},
+		},
+	}))
+	h.h.Eng.Broker().Publish("run-pub-ws", mustJSON(t, map[string]any{
+		"type":   "acp",
+		"runId":  "run-pub-ws",
+		"nodeId": "other-node",
+		"events": []any{map[string]any{"kind": "message", "text": "should-not-leak"}},
+	}))
+	h.h.Eng.Broker().Publish("run-pub-ws", mustJSON(t, map[string]any{
+		"type":   "review",
+		"runId":  "run-pub-ws",
+		"nodeId": "research-ws",
+		"event":  "turn_begin",
+		"item":   map[string]any{"text": "改成绿的"},
+	}))
+
+	sawAcp, sawReview := false, false
+	for i := 0; i < 6; i++ {
+		_, msg, err := c.ReadMessage()
+		if err != nil {
+			break
+		}
+		s := string(msg)
+		if strings.Contains(s, "run-pub-ws") || strings.Contains(s, "research-ws") || strings.Contains(s, "should-not-leak") || strings.Contains(s, "tool_call") {
+			t.Fatalf("leaked: %s", s)
+		}
+		if strings.Contains(s, `"type":"acp"`) && strings.Contains(s, "标题已改为绿色") {
+			sawAcp = true
+			if strings.Contains(s, "127.0.0.1") {
+				t.Fatalf("url leak: %s", s)
+			}
+		}
+		if strings.Contains(s, `"event":"turn_begin"`) && strings.Contains(s, "改成绿的") {
+			sawReview = true
+		}
+	}
+	if !sawAcp || !sawReview {
+		t.Fatalf("sawAcp=%v sawReview=%v", sawAcp, sawReview)
+	}
+}
+
+func TestPublicGateEventsWSRejectsBadToken(t *testing.T) {
+	h := newHarness(t)
+	srv := httptest.NewServer(h.r)
+	defer srv.Close()
+	c, _, err := websocket.DefaultDialer.Dial(wsURL(srv.URL, "/public/gate-approvals/events"), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+	c.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if err := c.WriteJSON(map[string]any{"token": "ab"}); err != nil {
+		t.Fatalf("auth: %v", err)
+	}
+	_, msg, err := c.ReadMessage()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(msg), `"status":"invalid"`) {
+		t.Fatalf("want invalid, got %s", msg)
+	}
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}

--- a/server/internal/router/router.go
+++ b/server/internal/router/router.go
@@ -303,6 +303,7 @@ func New(h *handlers.Handlers) *gin.Engine {
 		pub.GET("/", h.PublicGateApprovalPage)
 		pub.GET("/preview", h.PublicGatePreview)
 		pub.GET("/upstream", h.PublicGateUpstream)
+		pub.GET("/events", h.PublicGateEvents)
 		pub.POST("/preview-ticket", h.PublicPreviewTicket)
 		pub.GET("/preview-vnc/ws", h.PublicPreviewVNC)
 		pub.Any("/preview-api/:ticket/*path", h.PublicPreviewAPIProxy)

--- a/web/e2e/gate-share-link-main.ts
+++ b/web/e2e/gate-share-link-main.ts
@@ -16,6 +16,36 @@ import HtmlPreview from '../src/components/ui/HtmlPreview.vue'
 installIdleScrollbar()
 setTheme('dark')
 
+/** Fixture WS: public workbench must not hit a real /events socket in e2e. */
+class E2ePublicWebSocket {
+  url: string
+  onopen: ((ev?: unknown) => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: ((ev?: unknown) => void) | null = null
+  readyState = 1
+  constructor(url: string) {
+    this.url = url
+    queueMicrotask(() => this.onopen?.())
+  }
+  send(data: string) {
+    try {
+      const m = JSON.parse(String(data || '')) as { token?: string }
+      if (m.token) {
+        queueMicrotask(() => this.onmessage?.({ data: JSON.stringify({ type: 'ready' }) }))
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+  close() {
+    this.readyState = 3
+    this.onclose?.()
+  }
+}
+;(window as unknown as { WebSocket: typeof WebSocket }).WebSocket =
+  E2ePublicWebSocket as unknown as typeof WebSocket
+
 const TOKEN = 'ab'.repeat(32)
 /** Non-loopback mint: covers auto-copy / clipboard assertions (g2.3 / g3.1). */
 const SHARE_URL_REACHABLE = `https://approving.example.com/public/gate-approvals#t=${TOKEN}`

--- a/web/src/components/run/ClarifyChat.test.ts
+++ b/web/src/components/run/ClarifyChat.test.ts
@@ -745,6 +745,57 @@ describe('ClarifyChat', () => {
       expect(wrapper.find('[data-testid="clarify-busy-placeholder"]').exists()).toBe(false)
       wrapper.unmount()
     })
+
+    it('does not duplicate human when persisted already completed the live turn', async () => {
+      const wrapper = mountChat({
+        reviewMode: true,
+        turns: [
+          { role: 'human', text: '改成绿的', at: '2026-08-01T00:01:00Z' },
+          { role: 'agent', text: '标题已改为绿色（#16a34a）', at: '2026-08-01T00:02:00Z' },
+        ],
+      })
+      const vm = wrapper.vm as unknown as {
+        applyQueueState: (
+          waiting: number,
+          items: unknown[] | null,
+          busy?: boolean,
+          activeItem?: { text?: string } | null,
+        ) => void
+      }
+      vm.applyQueueState(0, [], true, { text: '改成绿的' })
+      await flushPromises()
+      expect((wrapper.text().match(/改成绿的/g) || []).length).toBe(1)
+      expect(wrapper.find('[data-testid="clarify-busy-placeholder"]').exists()).toBe(false)
+      expect(wrapper.text()).toContain('标题已改为绿色')
+      wrapper.unmount()
+    })
+
+    it('tears down streaming placeholder when persisted catches up mid-stream', async () => {
+      const wrapper = mountChat({ reviewMode: true, turns: [{ role: 'agent', text: '请复审', at: 't0' }] })
+      const vm = wrapper.vm as unknown as {
+        applyQueueState: (
+          waiting: number,
+          items: unknown[] | null,
+          busy?: boolean,
+          activeItem?: { text?: string } | null,
+        ) => void
+      }
+      vm.applyQueueState(0, [], true, { text: '改成绿的' })
+      await flushPromises()
+      expect(wrapper.find('[data-testid="clarify-busy-placeholder"]').exists()).toBe(true)
+      await wrapper.setProps({
+        turns: [
+          { role: 'agent', text: '请复审', at: 't0' },
+          { role: 'human', text: '改成绿的', at: 't1' },
+          { role: 'agent', text: '标题已改为绿色', at: 't2' },
+        ],
+      })
+      await flushPromises()
+      expect((wrapper.text().match(/改成绿的/g) || []).length).toBe(1)
+      expect(wrapper.find('[data-testid="clarify-busy-placeholder"]').exists()).toBe(false)
+      expect(wrapper.text()).toContain('标题已改为绿色')
+      wrapper.unmount()
+    })
   })
 
   describe('busy status C-tier (no air bubble)', () => {

--- a/web/src/components/run/ClarifyChat.vue
+++ b/web/src/components/run/ClarifyChat.vue
@@ -8,7 +8,7 @@ import ClarifyDemoFrame from './ClarifyDemoFrame.vue'
 import { renderMarkdown } from '@/lib/shared/markdown'
 import { createStreamMarkdownPreview } from '@/lib/shared/streamMarkdownPreview'
 import { createStreamTextReveal } from '@/lib/run/streamTextReveal'
-import { mergePersistedAndLiveTurns } from '@/lib/inbox/mergeClarifyLiveTurns'
+import { mergePersistedAndLiveTurns, persistedCompletedLiveHuman } from '@/lib/inbox/mergeClarifyLiveTurns'
 import { relTime } from '@/lib/shared/format'
 import ThoughtSummaryStatus from './ThoughtSummaryStatus.vue'
 import {
@@ -390,8 +390,14 @@ watch(
     if (prevKey !== undefined && key === prevKey) return
     const turnList = props.turns
     pending.value = null
-    // Clear live bubbles once persisted transcript includes them (not while streaming).
-    if (liveTurns.value.length && !liveTurns.value.some((t) => t.streaming)) {
+    const liveHumanText = liveTurns.value[0]?.role === 'human' ? liveTurns.value[0].text || '' : ''
+    const persistedCaughtUp = persistedCompletedLiveHuman(turnList, liveHumanText)
+    // Clear live bubbles once persisted transcript includes them (not while streaming),
+    // or when poll/refresh already persisted the completed human+agent pair.
+    if (
+      liveTurns.value.length &&
+      (persistedCaughtUp || !liveTurns.value.some((t) => t.streaming))
+    ) {
       liveTurns.value = []
       liveAgentIdx.value = -1
       messageReveal.reset()
@@ -835,7 +841,14 @@ function applyQueueState(
     }
   }
   // Refresh resume: recreate streaming agent bubble from activeItem when busy.
-  if (busy && activeItem && liveAgentIdx.value < 0) {
+  // Skip when persisted turns already completed this human — otherwise poll
+  // resume duplicates the bubble and leaves a stuck「思考中…」placeholder.
+  if (
+    busy &&
+    activeItem &&
+    liveAgentIdx.value < 0 &&
+    !persistedCompletedLiveHuman(props.turns, activeItem.text ?? '')
+  ) {
     const text = activeItem.text ?? ''
     liveTurns.value = [
       {

--- a/web/src/lib/inbox/gateShareLink.test.ts
+++ b/web/src/lib/inbox/gateShareLink.test.ts
@@ -194,6 +194,12 @@ describe('gateShareLink helpers', () => {
     expect(sparseBodies.structured?.title).toBe('旧')
     expect(sparseBodies.turns?.[0]?.text).toBe('请复审')
     expect(sparseBodies.nonce).toBe('keep-me')
+
+    const idle = mergePublicGatePreview(
+      { ...prev, sessionBusy: true, liveEvents: [{ kind: 'message', text: '流式正文' }] },
+      { status: 'active', sessionBusy: false, remainingSec: 1 },
+    )
+    expect(idle.liveEvents).toBeUndefined()
   })
 
   it('remainingSecFromExpiresAt prefers expiresAt over stale remainingSec (plan g2.1)', () => {
@@ -219,5 +225,8 @@ describe('gateShareLink helpers', () => {
       publicGateContentKey(base),
     )
     expect(publicGateContentKey({ ...base, turnsHash: 'tn-new' })).not.toBe(publicGateContentKey(base))
+    expect(publicGateContentKey({ ...base, liveEvents: [{ kind: 'message', text: '流' }] })).not.toBe(
+      publicGateContentKey(base),
+    )
   })
 })

--- a/web/src/lib/inbox/gateShareLink.ts
+++ b/web/src/lib/inbox/gateShareLink.ts
@@ -275,6 +275,13 @@ export type PublicGatePreview = {
   ports?: PublicPreviewPort[]
   /** Graph node type from preview DTO; react ⇒ 待澄清. Kind stays review. */
   nodeType?: string
+  /** In-flight ACP rails (message/thought) while sessionBusy — poll fallback. */
+  liveEvents?: PublicGateLiveEvent[]
+}
+
+export type PublicGateLiveEvent = {
+  kind: 'message' | 'thought' | string
+  text?: string
 }
 
 export type PublicPreviewPort = {
@@ -362,6 +369,9 @@ export function mergePublicGatePreview(
   keepSparseField(merged, prev, next, 'turns', 'turnsHash')
   // Silent polls may omit nonce; never drop the last usable one.
   if (!next.nonce && prev.nonce) merged.nonce = prev.nonce
+  if (!next.sessionBusy) {
+    merged.liveEvents = undefined
+  }
   return merged
 }
 
@@ -392,6 +402,7 @@ export function publicGateContentKey(p: PublicGatePreview | null | undefined): s
     productKind: p.productKind || '',
     productName: p.productName || '',
     ports: (p.ports || []).map((x) => ({ port: x.port, label: x.label || '', mode: x.mode || '' })),
+    liveEvents: p.liveEvents || null,
   })
 }
 
@@ -406,6 +417,9 @@ export type PublicGatePreviewKnown = {
 
 /** Unauthenticated public gate APIs. Token never goes in path/query. */
 export const publicGateApi = {
+  eventsWsUrl(): string {
+    return window.location.origin.replace(/^http/, 'ws') + '/public/gate-approvals/events'
+  },
   preview(
     token: string,
     signal?: AbortSignal,

--- a/web/src/lib/inbox/mergeClarifyLiveTurns.test.ts
+++ b/web/src/lib/inbox/mergeClarifyLiveTurns.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { mergePersistedAndLiveTurns } from './mergeClarifyLiveTurns'
+import { mergePersistedAndLiveTurns, persistedCompletedLiveHuman } from './mergeClarifyLiveTurns'
 import type { ClarifyTurn } from '@/lib/shared/types'
 
 describe('mergePersistedAndLiveTurns', () => {
@@ -31,5 +31,37 @@ describe('mergePersistedAndLiveTurns', () => {
   it('returns persisted only when live empty', () => {
     const persisted: ClarifyTurn[] = [{ role: 'agent', text: 'x', at: 't0' }]
     expect(mergePersistedAndLiveTurns(persisted, [])).toEqual(persisted)
+  })
+
+  it('drops live when persisted already completed the same human turn', () => {
+    const persisted: ClarifyTurn[] = [
+      { role: 'human', text: '改成绿的', at: 't1' },
+      { role: 'agent', text: '标题已改为绿色（#16a34a）', at: 't2' },
+    ]
+    const live: ClarifyTurn[] = [
+      { role: 'human', text: '改成绿的', at: 't1-live' },
+      { role: 'agent', text: '', at: 't2-live', streaming: true },
+    ]
+    expect(persistedCompletedLiveHuman(persisted, '改成绿的')).toBe(true)
+    const merged = mergePersistedAndLiveTurns(persisted, live)
+    expect(merged.filter((t) => t.role === 'human' && t.text === '改成绿的')).toHaveLength(1)
+    expect(merged.some((t) => t.streaming)).toBe(false)
+    expect(merged[merged.length - 1].text).toContain('标题已改为绿色')
+  })
+
+  it('keeps live stream when a newer human is still in flight', () => {
+    const persisted: ClarifyTurn[] = [
+      { role: 'human', text: '改成绿的', at: 't1' },
+      { role: 'agent', text: '已改绿', at: 't2' },
+      { role: 'human', text: '改成绿的', at: 't3' },
+    ]
+    const live: ClarifyTurn[] = [
+      { role: 'human', text: '改成绿的', at: 't3-live' },
+      { role: 'agent', text: '流式中', at: 't4', streaming: true },
+    ]
+    expect(persistedCompletedLiveHuman(persisted, '改成绿的')).toBe(false)
+    const merged = mergePersistedAndLiveTurns(persisted, live)
+    expect(merged.filter((t) => t.role === 'human' && t.text === '改成绿的')).toHaveLength(2)
+    expect(merged[merged.length - 1].streaming).toBe(true)
   })
 })

--- a/web/src/lib/inbox/mergeClarifyLiveTurns.ts
+++ b/web/src/lib/inbox/mergeClarifyLiveTurns.ts
@@ -1,12 +1,42 @@
 import type { ClarifyTurn } from '@/lib/shared/types'
 
 /**
+ * True when `persisted` already has a completed agent reply after the in-flight
+ * live human (no later human). Public poll / refresh can persist the finished
+ * pair while liveTurns still hold a streaming placeholder — that must not
+ * double-render the human bubble.
+ */
+export function persistedCompletedLiveHuman(
+  persisted: ClarifyTurn[],
+  liveHumanText: string,
+): boolean {
+  const want = (liveHumanText || '').trim()
+  if (!want || persisted.length < 2) return false
+  for (let i = persisted.length - 2; i >= 0; i--) {
+    const human = persisted[i]
+    const agent = persisted[i + 1]
+    if (
+      human.role === 'human' &&
+      (human.text || '').trim() === want &&
+      agent.role === 'agent' &&
+      !agent.streaming &&
+      !!(agent.text || agent.thought)
+    ) {
+      return !persisted.slice(i + 2).some((t) => t.role === 'human')
+    }
+  }
+  return false
+}
+
+/**
  * Merge persisted transcript with in-flight liveTurns without duplicating
  * human/agent bubbles that softRefresh/loadRun already wrote into props.turns.
  *
  * Finds the longest prefix of `live` that matches the suffix of `persisted`
  * by role+text (streaming turns never match persisted), then appends only the
  * unmatched live tail (typically the streaming agent).
+ *
+ * If persisted already completed the live human's turn, live is dropped.
  */
 export function mergePersistedAndLiveTurns(
   persisted: ClarifyTurn[],
@@ -14,6 +44,11 @@ export function mergePersistedAndLiveTurns(
 ): ClarifyTurn[] {
   if (!live.length) return persisted
   if (!persisted.length) return [...persisted, ...live]
+
+  const liveHuman = live[0]?.role === 'human' ? live[0] : null
+  if (liveHuman && persistedCompletedLiveHuman(persisted, liveHuman.text || '')) {
+    return persisted
+  }
 
   const maxK = Math.min(live.length, persisted.length)
   let matched = 0

--- a/web/src/views/PublicGateApprovalView.test.ts
+++ b/web/src/views/PublicGateApprovalView.test.ts
@@ -18,6 +18,29 @@ const mocks = vi.hoisted(() => ({
   cancel: vi.fn(),
 }))
 
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = []
+  url: string
+  onopen: ((ev?: unknown) => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onclose: (() => void) | null = null
+  sent: string[] = []
+  constructor(url: string) {
+    this.url = url
+    FakeWebSocket.instances.push(this)
+    queueMicrotask(() => this.onopen?.())
+  }
+  send(data: string) {
+    this.sent.push(data)
+  }
+  close() {
+    this.onclose?.()
+  }
+  emit(obj: unknown) {
+    this.onmessage?.({ data: JSON.stringify(obj) })
+  }
+}
+
 vi.mock('@/lib/inbox/gateShareLink', async () => {
   const actual = await vi.importActual<typeof import('@/lib/inbox/gateShareLink')>('@/lib/inbox/gateShareLink')
   return {
@@ -28,6 +51,7 @@ vi.mock('@/lib/inbox/gateShareLink', async () => {
       decide: mocks.decide,
       reply: mocks.reply,
       cancel: mocks.cancel,
+      eventsWsUrl: () => 'ws://test/public/gate-approvals/events',
     },
   }
 })
@@ -66,6 +90,8 @@ beforeEach(() => {
   mocks.decide.mockReset()
   mocks.reply.mockReset()
   mocks.cancel.mockReset()
+  FakeWebSocket.instances = []
+  vi.stubGlobal('WebSocket', FakeWebSocket)
   window.location.hash = ''
   localStorage.clear()
   setTheme('dark')
@@ -74,6 +100,7 @@ beforeEach(() => {
 afterEach(() => {
   while (mounted.length) mounted.pop()?.unmount()
   document.documentElement.classList.remove('light')
+  vi.unstubAllGlobals()
 })
 
 describe('PublicGateApprovalView workbench', () => {
@@ -339,6 +366,82 @@ describe('PublicGateApprovalView workbench', () => {
     expect(w.find('[data-testid="clarify-review-cancel"]').exists()).toBe(true)
     expect(w.find('[data-testid="public-gate-confirm"]').exists()).toBe(false)
     expect(w.find('[data-testid="public-gate-done"]').exists()).toBe(false)
+  })
+
+  it('applies preview liveEvents as streaming agent text (poll fallback)', async () => {
+    window.location.hash = `#t=${'dd'.repeat(32)}`
+    mocks.preview.mockResolvedValue({
+      status: 'active',
+      kind: 'review',
+      nonce: 'n-live',
+      reactSessionAlive: true,
+      sessionBusy: true,
+      waiting: 0,
+      activeItem: { text: '改成绿的' },
+      actions: { confirm: 'confirm', reply: 'reply', cancel: 'cancel' },
+      turns: [{ role: 'agent', text: '请复审', at: '2026-08-01T00:00:00Z' }],
+      liveEvents: [{ kind: 'message', text: '标题已改为绿色（#16a34a）' }],
+    })
+    const w = mountView()
+    await flushPromises()
+    await flushPromises()
+    expect((w.text().match(/改成绿的/g) || []).length).toBe(1)
+    expect(w.text()).toContain('标题已改为绿色')
+    expect(w.find('[data-testid="clarify-stream-caret"]').exists()).toBe(true)
+    expect(w.find('[data-testid="clarify-busy-status"]').text()).toContain('输出中')
+  })
+
+  it('does not duplicate human when turns already completed the busy activeItem', async () => {
+    window.location.hash = `#t=${'dd'.repeat(32)}`
+    mocks.preview.mockResolvedValue({
+      status: 'active',
+      kind: 'review',
+      nonce: 'n-dup',
+      reactSessionAlive: true,
+      sessionBusy: true,
+      waiting: 0,
+      activeItem: { text: '改成绿的' },
+      actions: { confirm: 'confirm', reply: 'reply', cancel: 'cancel' },
+      turns: [
+        { role: 'human', text: '改成绿的', at: '2026-08-01T00:01:00Z' },
+        { role: 'agent', text: '标题已改为绿色（#16a34a）', at: '2026-08-01T00:02:00Z' },
+      ],
+    })
+    const w = mountView()
+    await flushPromises()
+    await flushPromises()
+    expect((w.text().match(/改成绿的/g) || []).length).toBe(1)
+    expect(w.find('[data-testid="clarify-busy-placeholder"]').exists()).toBe(false)
+    expect(w.text()).toContain('标题已改为绿色')
+  })
+
+  it('public events WS auth then ACP frame streams into the chat', async () => {
+    window.location.hash = `#t=${'dd'.repeat(32)}`
+    mocks.preview.mockResolvedValue({
+      status: 'active',
+      kind: 'review',
+      nonce: 'n-ws',
+      reactSessionAlive: true,
+      sessionBusy: true,
+      waiting: 0,
+      activeItem: { text: '改成绿的' },
+      actions: { confirm: 'confirm', reply: 'reply', cancel: 'cancel' },
+      turns: [{ role: 'agent', text: '请复审', at: '2026-08-01T00:00:00Z' }],
+    })
+    const w = mountView()
+    await flushPromises()
+    await flushPromises()
+    const sock = FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
+    expect(sock).toBeTruthy()
+    expect(sock.sent.some((s) => s.includes('dd'.repeat(32)))).toBe(true)
+    sock.emit({
+      type: 'acp',
+      nodeId: 'public-gate',
+      events: [{ kind: 'message', text: '流式产出正文' }],
+    })
+    await flushPromises()
+    expect(w.text()).toContain('流式产出正文')
+    expect(w.find('[data-testid="clarify-stream-caret"]').exists()).toBe(true)
   })
 
   it('unavailable states keep dark chrome without confirm/send', async () => {

--- a/web/src/views/PublicGateApprovalView.vue
+++ b/web/src/views/PublicGateApprovalView.vue
@@ -15,6 +15,7 @@ import { provideReviewAnnotate } from '@/lib/inbox/reviewAnnotate'
 import { previewPickLabel } from '@/lib/shared/previewPickUrl'
 import type { AppPreviewPickPayload } from '@/lib/shared/previewPickUrl'
 import { isAbortError } from '@/lib/run/liveLogRehydrate'
+import { createWsReconnectController } from '@/lib/run/wsReconnect'
 import {
   formatRemainingSec,
   mergePublicGatePreview,
@@ -28,7 +29,7 @@ import {
   type PublicGatePreviewKnown,
   type PublicGateQueueItem,
 } from '@/lib/inbox/gateShareLink'
-import type { ClarifyImage, ClarifyTurn, ReactAnnotation } from '@/lib/shared/types'
+import type { AcpEvent, ClarifyImage, ClarifyTurn, ReactAnnotation } from '@/lib/shared/types'
 
 type PublicChatRef = {
   discardLastQueued?: () => void
@@ -38,6 +39,8 @@ type PublicChatRef = {
     busy?: boolean,
     activeItem?: PublicGateActiveItem | null,
   ) => void
+  applyReviewFrame?: (frame: Record<string, unknown>) => boolean | void
+  applyAcpEvents?: (events: AcpEvent[] | undefined, nodeId?: string) => boolean | void
   isSessionBusy?: () => boolean
 }
 
@@ -392,19 +395,121 @@ function syncChatQueueFromPreview() {
     if (pendingReplyText.value && (turnsIncludeHumanText(pendingReplyText.value) || activeItem?.text?.trim() === pendingReplyText.value)) {
       pendingReplyText.value = ''
     }
+  } else if (!replyInFlight.value && !(pendingReplyText.value && !turnsIncludeHumanText(pendingReplyText.value))) {
+    if (pendingReplyText.value && turnsIncludeHumanText(pendingReplyText.value)) {
+      chat.discardLastQueued?.()
+      pendingReplyText.value = ''
+    }
+    if (!(lastAppliedIdleQueue && !chat.isSessionBusy?.())) {
+      lastAppliedIdleQueue = true
+      chat.applyQueueState?.(0, [], false, null)
+    }
+  }
+  applyPreviewLiveEvents()
+  flushPendingPublicAcp()
+}
+
+function toAcpEvents(
+  events: { kind?: string; text?: string }[] | undefined,
+): AcpEvent[] {
+  if (!events?.length) return []
+  return events
+    .filter((e) => (e.kind === 'message' || e.kind === 'thought') && e.text)
+    .map((e) => ({ t: 0, kind: e.kind as AcpEvent['kind'], text: e.text }))
+}
+
+let pendingPublicAcp: AcpEvent[] | null = null
+let publicWs: WebSocket | undefined
+
+function deliverPublicAcp(events: AcpEvent[] | undefined): boolean {
+  if (!events?.length) return true
+  const chat = chatRef.value
+  if (!chat?.applyAcpEvents) {
+    pendingPublicAcp = events
+    return false
+  }
+  if (chat.applyAcpEvents(events) === false) {
+    pendingPublicAcp = events
+    return false
+  }
+  pendingPublicAcp = null
+  return true
+}
+
+function flushPendingPublicAcp() {
+  if (pendingPublicAcp) deliverPublicAcp(pendingPublicAcp)
+}
+
+function applyPreviewLiveEvents() {
+  deliverPublicAcp(toAcpEvents(preview.value?.liveEvents))
+}
+
+function handlePublicWsMessage(raw: string) {
+  let m: Record<string, unknown>
+  try {
+    m = JSON.parse(raw) as Record<string, unknown>
+  } catch {
     return
   }
-
-  if (replyInFlight.value) return
-  if (pendingReplyText.value && !turnsIncludeHumanText(pendingReplyText.value)) return
-
-  if (pendingReplyText.value && turnsIncludeHumanText(pendingReplyText.value)) {
-    chat.discardLastQueued?.()
-    pendingReplyText.value = ''
+  const typ = String(m.type || '')
+  if (typ === 'ready' || typ === 'error') return
+  if (typ === 'review') {
+    chatRef.value?.applyReviewFrame?.(m)
+    flushPendingPublicAcp()
+    return
   }
-  if (lastAppliedIdleQueue && !chat.isSessionBusy?.()) return
-  lastAppliedIdleQueue = true
-  chat.applyQueueState?.(0, [], false, null)
+  if (typ === 'acp') {
+    const events = Array.isArray(m.events) ? (m.events as AcpEvent[]) : []
+    deliverPublicAcp(events)
+  }
+}
+
+const publicWsReconnect = createWsReconnectController({
+  connect: () => connectPublicEvents(),
+  shouldReconnect: () => isActive.value && !doneKind.value && !linkInvalid.value && !!token.value,
+})
+
+function connectPublicEvents() {
+  if (!isActive.value || doneKind.value || linkInvalid.value || !token.value) return
+  const prev = publicWs
+  if (prev) {
+    publicWsReconnect.markIntentionalClose()
+    prev.close()
+    if (publicWs === prev) publicWs = undefined
+  }
+  let socket: WebSocket
+  try {
+    socket = new WebSocket(publicGateApi.eventsWsUrl())
+    publicWs = socket
+  } catch {
+    publicWsReconnect.onClose()
+    return
+  }
+  socket.onopen = () => {
+    if (publicWs !== socket) return
+    publicWsReconnect.markOpened()
+    try {
+      socket.send(JSON.stringify({ token: token.value }))
+    } catch {
+      socket.close()
+    }
+  }
+  socket.onmessage = (ev) => {
+    if (publicWs !== socket) return
+    handlePublicWsMessage(String(ev.data || ''))
+  }
+  socket.onclose = () => {
+    if (publicWs !== socket) return
+    publicWs = undefined
+    publicWsReconnect.onClose()
+  }
+}
+
+function stopPublicEvents() {
+  publicWsReconnect.markIntentionalClose()
+  publicWs?.close()
+  publicWs = undefined
+  pendingPublicAcp = null
 }
 
 function clearHash() {
@@ -721,10 +826,19 @@ function onVisibilityChange() {
 }
 
 watch([isActive, doneKind], () => {
-  if (canPoll()) startPoll()
-  else stopPoll()
+  if (canPoll()) {
+    startPoll()
+    connectPublicEvents()
+  } else {
+    stopPoll()
+    stopPublicEvents()
+  }
   if (isActive.value && !doneKind.value && !pageHidden()) startRemainingTick()
   else stopRemainingTick()
+})
+
+watch(token, (tok, prev) => {
+  if (tok && tok !== prev && isActive.value && !doneKind.value && !linkInvalid.value) connectPublicEvents()
 })
 
 watch(chatRef, (chat) => {
@@ -752,10 +866,12 @@ onMounted(async () => {
   document.addEventListener('visibilitychange', onVisibilityChange)
   startRemainingTick()
   if (canPoll()) startPoll()
+  connectPublicEvents()
 })
 onUnmounted(() => {
   stopPoll()
   stopRemainingTick()
+  stopPublicEvents()
   window.removeEventListener('hashchange', onHashChange)
   document.removeEventListener('visibilitychange', onVisibilityChange)
   abortPreview()


### PR DESCRIPTION
## Summary
- 外部复审侧栏在回合已完成后仍叠一层「思考中」气泡，同一条用户消息会重复显示。
- 公开页补上脱敏对话 WebSocket（token 放在首帧，不进 URL），Agent 回复按内部复审同样流式输出；WS 不可用时 preview `liveEvents` 作为轮询兜底。
- 历史里已有对应完整回复时，不再重建进行中气泡。

## Test plan
- [ ] 打开外部复审链接，发送一条修订意见：用户气泡只出现一次，Agent 回复带「输出中」和流式光标，而不是整段突然出现。
- [ ] 回复完成后不应再残留「思考中…」或第二条相同用户消息。
- [ ] 刷新进行中的复审页，应能续上当前流式正文。
- [ ] 确认分享 token 不出现在 WS URL / 查询参数；ACP 帧不含 runId、工具调用等内部字段。


Made with [Cursor](https://cursor.com)