### PR TITLE
Simplify StatusMetrics hover tips to label: value.

### DIFF
--- a/web/e2e/status-metrics-topbar.spec.ts
+++ b/web/e2e/status-metrics-topbar.spec.ts
@@ -39,9 +39,26 @@ test.describe('StatusMetrics topbar E2E', () => {
     expect(smIdx).toBeGreaterThanOrEqual(0)
     expect(langIdx).toBeGreaterThan(smIdx)
 
+    const tokensTip = page.getByTestId('status-metrics-tokens').locator('.sm-tip')
     await page.getByTestId('status-metrics-tokens').hover()
-    await expect(page.getByTestId('status-metrics-tokens').locator('.sm-tip')).toBeVisible()
-    await expect(page.getByTestId('status-metrics-tokens').locator('.sm-tip')).toContainText('累计')
+    await expect(tokensTip).toBeVisible()
+    await expect(tokensTip).toContainText('累计')
+    await expect(tokensTip).toContainText('1,240,582')
+    await expect(tokensTip).not.toContainText('完整值')
+    await expect(tokensTip).not.toContainText('/5m')
+
+    const rateTip = page.getByTestId('status-metrics-rate').locator('.sm-tip')
+    await page.getByTestId('status-metrics-rate').hover()
+    await expect(rateTip).toBeVisible()
+    await expect(rateTip).toContainText('速率')
+    await expect(rateTip).toContainText('4,812')
+    await expect(rateTip).not.toContainText('/5m')
+
+    // Click pin (tip-open) still works.
+    await page.getByTestId('status-metrics-running').click()
+    await expect(page.getByTestId('status-metrics-running')).toHaveClass(/tip-open/)
+    await expect(page.getByTestId('status-metrics-running').locator('.sm-tip')).toBeVisible()
+    await expect(page.getByTestId('status-metrics-running').locator('.sm-tip')).toContainText(/执行中:\s*3/)
 
     const shot = path.join(testInfo.outputDir, 'desktop-five-metrics.png')
     await page.locator('header').screenshot({ path: shot })
@@ -51,7 +68,7 @@ test.describe('StatusMetrics topbar E2E', () => {
     })
   })
 
-  test('narrow: Token·RUN/Q summary; rate/peak via tip', async ({ page }) => {
+  test('narrow: Token·RUN/Q summary; compact tip five label:value rows', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 })
     await page.goto('/status-metrics-topbar.html')
     await expect(page.getByTestId('status-metrics-compact')).toBeVisible({ timeout: 15_000 })
@@ -62,8 +79,15 @@ test.describe('StatusMetrics topbar E2E', () => {
     await expect(compact).toContainText('5')
 
     await compact.click()
-    await expect(compact.locator('.sm-tip')).toBeVisible()
-    await expect(compact.locator('.sm-tip')).toContainText('/5m')
+    const tip = compact.locator('.sm-tip')
+    await expect(tip).toBeVisible()
+    await expect(tip).toContainText(/累计 Token:\s*1,240,582/)
+    await expect(tip).toContainText(/速率:\s*4,812/)
+    await expect(tip).toContainText(/峰值:\s*12,104/)
+    await expect(tip).toContainText(/执行中:\s*3/)
+    await expect(tip).toContainText(/排队:\s*5/)
+    await expect(tip).not.toContainText('/5m')
+    await expect(tip).not.toContainText('完整值')
 
     await page.screenshot({
       path: path.join(OUT, '02-narrow-status-metrics.png'),

--- a/web/src/components/shell/StatusMetrics.test.ts
+++ b/web/src/components/shell/StatusMetrics.test.ts
@@ -134,4 +134,66 @@ describe('StatusMetrics', () => {
     expect(text).toMatch(/5/)
     w.unmount()
   })
+
+  it('desktop tips are single-line label: value with exact counts (plan g1.1/g1.2)', async () => {
+    const w = mountMetrics()
+    await flushPromises()
+    const tips = {
+      tokens: w.find('[data-testid="status-metrics-tokens"] .sm-tip').text(),
+      rate: w.find('[data-testid="status-metrics-rate"] .sm-tip').text(),
+      peak: w.find('[data-testid="status-metrics-peak"] .sm-tip').text(),
+      running: w.find('[data-testid="status-metrics-running"] .sm-tip').text(),
+      queued: w.find('[data-testid="status-metrics-queued"] .sm-tip').text(),
+    }
+    expect(tips.tokens).toMatch(/累计 Token:\s*1,240,582/)
+    expect(tips.rate).toMatch(/当前 5 分钟速率:\s*4,812/)
+    expect(tips.peak).toMatch(/今日 5 分钟峰值:\s*12,104/)
+    expect(tips.running).toMatch(/执行中:\s*3/)
+    expect(tips.queued).toMatch(/排队:\s*5/)
+    for (const tip of Object.values(tips)) {
+      expect(tip).not.toMatch(/完整值/)
+      expect(tip).not.toMatch(/totalTokens/i)
+      expect(tip).not.toContain('/5m')
+      expect(tip).not.toMatch(/\d{2}:\d{2}/)
+    }
+    expect(w.find('[data-testid="status-metrics-tokens"] .sm-tip').classes()).not.toContain('min-w-[210px]')
+    w.unmount()
+  })
+
+  it('compact tip is five label: value rows aligned with desktop (plan g1.3)', async () => {
+    isMobile.value = true
+    const w = mountMetrics()
+    await flushPromises()
+    const tip = w.find('[data-testid="status-metrics-compact"] .sm-tip')
+    const lines = tip.findAll('div').map((d) => d.text())
+    expect(lines).toHaveLength(5)
+    expect(lines[0]).toMatch(/累计 Token:\s*1,240,582/)
+    expect(lines[1]).toMatch(/当前 5 分钟速率:\s*4,812/)
+    expect(lines[2]).toMatch(/今日 5 分钟峰值:\s*12,104/)
+    expect(lines[3]).toMatch(/执行中:\s*3/)
+    expect(lines[4]).toMatch(/排队:\s*5/)
+    const tipText = tip.text()
+    expect(tipText).not.toMatch(/完整值/)
+    expect(tipText).not.toContain('/5m')
+    expect(tipText).not.toMatch(/窄屏摘要|完整值|totalTokens/i)
+    w.unmount()
+  })
+
+  it('zero counts still show label: 0 in tip', async () => {
+    platformStatus.mockResolvedValue({
+      cumulativeTokens: 0,
+      current5mBucketTokens: 0,
+      todayMaxCompleted5mTokens: 0,
+      runningCount: 0,
+      queuedCount: 0,
+      asOf: '2026-08-12T00:00:00Z',
+      timezone: 'UTC',
+    })
+    const w = mountMetrics()
+    await flushPromises()
+    expect(w.find('[data-testid="status-metrics-running"] .sm-tip').text()).toMatch(/执行中:\s*0/)
+    expect(w.find('[data-testid="status-metrics-queued"] .sm-tip').text()).toMatch(/排队:\s*0/)
+    expect(w.find('[data-testid="status-metrics-tokens"] .sm-tip').text()).toMatch(/累计 Token:\s*0/)
+    w.unmount()
+  })
 })

--- a/web/src/components/shell/StatusMetrics.vue
+++ b/web/src/components/shell/StatusMetrics.vue
@@ -23,28 +23,11 @@ function fmtFiveMinuteRate(n: number | null | undefined): string {
   return `${fmtCompactTokenCount(n)}/5m`
 }
 
-function fmtBucketRange(start?: string | null, end?: string | null): string {
-  if (!start || !end) return ''
-  const a = new Date(start)
-  const b = new Date(end)
-  if (Number.isNaN(a.getTime()) || Number.isNaN(b.getTime())) return ''
-  const p = (d: Date) =>
-    `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
-  return `${p(a)}–${p(b)}`
-}
-
 const cumulative = computed(() => metrics.value?.cumulativeTokens ?? null)
 const rate = computed(() => metrics.value?.current5mBucketTokens ?? null)
 const peak = computed(() => metrics.value?.todayMaxCompleted5mTokens ?? null)
 const running = computed(() => metrics.value?.runningCount ?? 0)
 const queued = computed(() => metrics.value?.queuedCount ?? 0)
-
-const rateBucketLabel = computed(() =>
-  fmtBucketRange(metrics.value?.currentBucketStart, metrics.value?.currentBucketEnd),
-)
-const peakBucketLabel = computed(() =>
-  fmtBucketRange(metrics.value?.peakBucketStart, metrics.value?.peakBucketEnd),
-)
 
 function toggleTip(id: string, ev: Event) {
   ev.preventDefault()
@@ -83,13 +66,10 @@ function onBlurTip(id: string) {
         </svg>
         <span class="sm-val text-xs leading-none text-txt">{{ fmtCompactTokenCount(cumulative) }}</span>
         <span
-          class="sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden min-w-[210px] max-w-[290px] -translate-x-1/2 border border-line-strong bg-overlay px-2.5 py-2 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
+          class="sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden -translate-x-1/2 whitespace-nowrap border border-line-strong bg-overlay px-2.5 py-1.5 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
           role="tooltip"
         >
-          <strong class="mb-1 block font-semibold text-txt">{{ t('shell.statusMetrics.tokens') }}</strong>
-          {{ t('shell.statusMetrics.tokensTip') }}
-          {{ t('shell.statusMetrics.fullValue') }}
-          <span class="font-mono">{{ fmtFull(cumulative) }}</span>
+          {{ t('shell.statusMetrics.tokens') }}: <span class="font-mono">{{ fmtFull(cumulative) }}</span>
         </span>
       </button>
       <span class="mx-0.5 h-3.5 w-px shrink-0 bg-line-strong" aria-hidden="true" />
@@ -108,14 +88,10 @@ function onBlurTip(id: string) {
         </svg>
         <span class="sm-val text-xs leading-none text-txt">{{ fmtFiveMinuteRate(rate) }}</span>
         <span
-          class="sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden min-w-[210px] max-w-[290px] -translate-x-1/2 border border-line-strong bg-overlay px-2.5 py-2 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
+          class="sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden -translate-x-1/2 whitespace-nowrap border border-line-strong bg-overlay px-2.5 py-1.5 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
           role="tooltip"
         >
-          <strong class="mb-1 block font-semibold text-txt">{{ t('shell.statusMetrics.rate') }}</strong>
-          {{ t('shell.statusMetrics.rateTip') }}
-          {{ t('shell.statusMetrics.fullValue') }}
-          <span class="font-mono">{{ fmtFull(rate) }}</span>
-          <template v-if="rateBucketLabel"> · {{ t('shell.statusMetrics.bucket') }} {{ rateBucketLabel }}</template>
+          {{ t('shell.statusMetrics.rate') }}: <span class="font-mono">{{ fmtFull(rate) }}</span>
         </span>
       </button>
       <span class="mx-0.5 h-3.5 w-px shrink-0 bg-line-strong" aria-hidden="true" />
@@ -135,14 +111,10 @@ function onBlurTip(id: string) {
         </svg>
         <span class="sm-val text-xs leading-none text-txt">{{ fmtCompactTokenCount(peak) }}</span>
         <span
-          class="sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden min-w-[210px] max-w-[290px] -translate-x-1/2 border border-line-strong bg-overlay px-2.5 py-2 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
+          class="sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden -translate-x-1/2 whitespace-nowrap border border-line-strong bg-overlay px-2.5 py-1.5 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
           role="tooltip"
         >
-          <strong class="mb-1 block font-semibold text-txt">{{ t('shell.statusMetrics.peak') }}</strong>
-          {{ t('shell.statusMetrics.peakTip') }}
-          {{ t('shell.statusMetrics.fullValue') }}
-          <span class="font-mono">{{ fmtFull(peak) }}</span>
-          <template v-if="peakBucketLabel"> · {{ peakBucketLabel }}</template>
+          {{ t('shell.statusMetrics.peak') }}: <span class="font-mono">{{ fmtFull(peak) }}</span>
         </span>
       </button>
       <span class="mx-0.5 h-3.5 w-px shrink-0 bg-line-strong" aria-hidden="true" />
@@ -162,11 +134,10 @@ function onBlurTip(id: string) {
         </svg>
         <span class="sm-val text-xs leading-none text-txt">{{ running }}</span>
         <span
-          class="sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden min-w-[210px] max-w-[290px] -translate-x-1/2 border border-line-strong bg-overlay px-2.5 py-2 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
+          class="sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden -translate-x-1/2 whitespace-nowrap border border-line-strong bg-overlay px-2.5 py-1.5 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
           role="tooltip"
         >
-          <strong class="mb-1 block font-semibold text-txt">{{ t('shell.statusMetrics.running') }}</strong>
-          {{ t('shell.statusMetrics.runningTip') }}
+          {{ t('shell.statusMetrics.running') }}: <span class="font-mono">{{ running }}</span>
         </span>
       </button>
       <span class="mx-0.5 h-3.5 w-px shrink-0 bg-line-strong" aria-hidden="true" />
@@ -185,11 +156,10 @@ function onBlurTip(id: string) {
         </svg>
         <span class="sm-val text-xs leading-none text-txt">{{ queued }}</span>
         <span
-          class="sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden min-w-[210px] max-w-[290px] -translate-x-1/2 border border-line-strong bg-overlay px-2.5 py-2 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
+          class="sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden -translate-x-1/2 whitespace-nowrap border border-line-strong bg-overlay px-2.5 py-1.5 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
           role="tooltip"
         >
-          <strong class="mb-1 block font-semibold text-txt">{{ t('shell.statusMetrics.queued') }}</strong>
-          {{ t('shell.statusMetrics.queuedTip') }}
+          {{ t('shell.statusMetrics.queued') }}: <span class="font-mono">{{ queued }}</span>
         </span>
       </button>
     </template>
@@ -226,16 +196,14 @@ function onBlurTip(id: string) {
         <span class="sm-val text-xs leading-none text-txt">{{ queued }}</span>
       </span>
       <span
-        class="sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden min-w-[210px] max-w-[290px] -translate-x-1/2 border border-line-strong bg-overlay px-2.5 py-2 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
+        class="sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden min-w-[180px] -translate-x-1/2 border border-line-strong bg-overlay px-2.5 py-2 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
         role="tooltip"
       >
-        <strong class="mb-1 block font-semibold text-txt">{{ t('shell.statusMetrics.compactTitle') }}</strong>
-        {{ t('shell.statusMetrics.compactTip') }}
-        <br />
-        {{ t('shell.statusMetrics.rate') }}
-        <span class="font-mono">{{ fmtFiveMinuteRate(rate) }}</span>
-        · {{ t('shell.statusMetrics.peak') }}
-        <span class="font-mono">{{ fmtCompactTokenCount(peak) }}</span>
+        <div>{{ t('shell.statusMetrics.tokens') }}: <span class="font-mono">{{ fmtFull(cumulative) }}</span></div>
+        <div>{{ t('shell.statusMetrics.rate') }}: <span class="font-mono">{{ fmtFull(rate) }}</span></div>
+        <div>{{ t('shell.statusMetrics.peak') }}: <span class="font-mono">{{ fmtFull(peak) }}</span></div>
+        <div>{{ t('shell.statusMetrics.running') }}: <span class="font-mono">{{ running }}</span></div>
+        <div>{{ t('shell.statusMetrics.queued') }}: <span class="font-mono">{{ queued }}</span></div>
       </span>
     </button>
   </div>

--- a/web/src/locales/en/shell.json
+++ b/web/src/locales/en/shell.json
@@ -56,20 +56,11 @@
     "statusMetrics": {
       "aria": "Platform status metrics",
       "tokens": "Cumulative tokens",
-      "tokensTip": "Platform-wide totalTokens.",
       "rate": "Current 5-minute rate",
-      "rateTip": "Aligned-bucket cumulative (not token/s).",
       "peak": "Today's 5-minute peak",
-      "peakTip": "Max of today's completed buckets.",
       "running": "Running",
-      "runningTip": "runs.status = running (excludes waiting_human).",
       "queued": "Queued",
-      "queuedTip": "runs.status = queued (pre-admission).",
-      "fullValue": "Exact: ",
-      "bucket": "bucket",
-      "compactAria": "Platform status summary",
-      "compactTitle": "Compact summary",
-      "compactTip": "Cumulative tokens · running / queued."
+      "compactAria": "Platform status summary"
     }
   }
 }

--- a/web/src/locales/zh-CN/shell.json
+++ b/web/src/locales/zh-CN/shell.json
@@ -56,20 +56,11 @@
     "statusMetrics": {
       "aria": "平台状态指标",
       "tokens": "累计 Token",
-      "tokensTip": "全平台 totalTokens。",
       "rate": "当前 5 分钟速率",
-      "rateTip": "对齐桶内累计（非 token/s）。",
       "peak": "今日 5 分钟峰值",
-      "peakTip": "今日已完整桶 max。",
       "running": "执行中",
-      "runningTip": "runs.status = running（不含 waiting_human）。",
       "queued": "排队",
-      "queuedTip": "runs.status = queued（引擎准入前）。",
-      "fullValue": "完整值：",
-      "bucket": "桶",
-      "compactAria": "平台状态摘要",
-      "compactTitle": "窄屏摘要",
-      "compactTip": "累计 Token · 执行中 / 排队。"
+      "compactAria": "平台状态摘要"
     }
   }
 }


### PR DESCRIPTION
Cut multi-line jargon, full-value prefixes, and bucket ranges so desktop and compact tips match the approved demo density.

Co-authored-by: Cursor <cursoragent@cursor.com>
