### PR TITLE
fix(token-stats): hide unknown badge and gray when display name is set

### DIFF
--- a/web/e2e/unknown-model-display-name.spec.ts
+++ b/web/e2e/unknown-model-display-name.spec.ts
@@ -180,7 +180,7 @@ test.describe('未知模型显示名', () => {
     await expect(input).toHaveValue('')
   })
 
-  test('看板排行/构成：别名 + 未知角标，同名两行不合并', async ({ page }) => {
+  test('看板排行/构成：别名无未知角标、非未知灰，同名两行不合并', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 900 })
     await seedOnboardingDismissed(page, 'proj-1')
 
@@ -218,24 +218,84 @@ test.describe('未知模型显示名', () => {
     await expect(rank).toBeVisible()
     const rankRows = rank.locator('> li')
     await expect(rankRows).toHaveCount(2)
-    // 两行都显示 gpt-5（真实桶 + 未知别名），未知行带角标
+    // 两行都显示 gpt-5（真实桶 + 未知别名）；已设名后未知行无「未知」角标
     await expect(rank).toContainText('gpt-5')
-    await expect(rank.getByTestId('unknown-model-badge')).toHaveCount(1)
+    await expect(rank.getByTestId('unknown-model-badge')).toHaveCount(0)
     await expect(rank).not.toContainText('未知/未分桶')
+    const unkRank = rank.locator('[data-unknown="1"]')
+    await expect(unkRank).toHaveCount(1)
+    // 条色非未知灰 #71717A
+    await expect(unkRank.locator('.h-full')).not.toHaveCSS('background-color', 'rgb(113, 113, 122)')
 
     const legend = page.getByTestId('token-model-legend')
     await expect(legend).toBeVisible()
     await expect(legend).toContainText('gpt-5')
-    await expect(legend.getByTestId('unknown-model-badge')).toHaveCount(1)
+    await expect(legend.getByTestId('unknown-model-badge')).toHaveCount(0)
     await expect(legend).not.toContainText('未知/未分桶')
 
     await page.screenshot({
-      path: path.join(shotDir, '03-board-alias-badge.png'),
+      path: path.join(shotDir, '03-board-alias-no-badge.png'),
       fullPage: false,
     })
   })
 
-  test('Run 按模型明细：显示别名 + 未知角标，来源列仍为未知/未分桶', async ({ page }) => {
+  test('看板：未设显示名时未知桶仍有角标与灰色', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await seedOnboardingDismissed(page, 'proj-1')
+
+    const unnamedStats = {
+      ...aliasedTokenStats(),
+      modelComposition: [
+        { modelKey: 'gpt-5', name: 'gpt-5', total: 100 },
+        { modelKey: '未知/未分桶', name: '未知/未分桶', total: 80, unknown: true },
+      ],
+      modelRanking: [
+        { modelKey: 'gpt-5', name: 'gpt-5', total: 100 },
+        { modelKey: '未知/未分桶', name: '未知/未分桶', total: 80, unknown: true },
+      ],
+    }
+
+    await page.route('**/api/stats/dashboard', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ running: 0, waitingHuman: 0, failed: 0, completed: 1 }),
+      })
+    })
+    await page.route('**/api/runs**', async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.continue()
+        return
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: [], total: 0, page: 1, pageSize: 20, hasMore: false }),
+      })
+    })
+    await page.route('**/api/projects/*/token-stats**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(unnamedStats),
+      })
+    })
+
+    await page.goto('/board.html?start=project-board&memory=1&projectId=proj-1')
+    await expect(page.getByTestId('token-model-rank')).toBeVisible({ timeout: 15_000 })
+
+    const rank = page.getByTestId('token-model-rank')
+    const unkRank = rank.locator('[data-unknown="1"]')
+    await expect(unkRank).toContainText('未知/未分桶')
+    await expect(unkRank.getByTestId('unknown-model-badge')).toHaveCount(1)
+    await expect(unkRank.locator('.h-full')).toHaveCSS('background-color', 'rgb(113, 113, 122)')
+
+    const legend = page.getByTestId('token-model-legend')
+    await expect(legend.getByTestId('unknown-model-badge')).toHaveCount(1)
+    await expect(legend).toContainText('未知/未分桶')
+  })
+
+  test('Run 按模型明细：显示别名且无未知角标，来源列仍为未知/未分桶', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 900 })
 
     const nodes = [
@@ -370,7 +430,8 @@ test.describe('未知模型显示名', () => {
     const unkRow = table.locator('tr[data-unknown="1"]')
     await expect(unkRow).toHaveCount(1)
     await expect(unkRow).toContainText('gpt-5')
-    await expect(unkRow.getByTestId('unknown-model-badge')).toBeVisible()
+    // 已设名：模型列无「未知」角标
+    await expect(unkRow.getByTestId('unknown-model-badge')).toHaveCount(0)
     // 来源列属性标签不随显示名改变
     await expect(unkRow).toContainText('未知/未分桶')
     // 模型列不显示默认桶名（已被别名覆盖）

--- a/web/src/components/board/token-stats/TokenModelComposition.test.ts
+++ b/web/src/components/board/token-stats/TokenModelComposition.test.ts
@@ -188,20 +188,48 @@ describe('TokenModelComposition hides filledTag (g2.1)', () => {
     wrapper.unmount()
   })
 
-  it('alias name still shows unknown badge and grey color via unknown flag', () => {
+  it('configured alias: no unknown badge and not #71717A; same-name rows stay distinct (g4.1)', () => {
     const models = [
       { modelKey: '未知/未分桶', name: 'gpt-5', total: 100, unknown: true },
       { modelKey: 'gpt-5', name: 'gpt-5', total: 80 },
     ]
-    expect(colorForModel(models[0]!, 0)).toBe('#71717A')
+    expect(colorForModel(models[0]!, 0)).toBe('#7B61FF')
+    expect(colorForModel(models[0]!, 0)).not.toBe('#71717A')
     const wrapper = mount(TokenModelComposition, {
       props: { models },
       global: { plugins: [i18n()] },
     })
     const legend = wrapper.find('[data-testid="token-model-legend"]')
     expect(legend.text()).toContain('gpt-5')
-    expect(legend.find('[data-testid="unknown-model-badge"]').exists()).toBe(true)
+    expect(legend.find('[data-testid="unknown-model-badge"]').exists()).toBe(false)
+    const nameSpan = legend.findAll('li')[0]!.findAll('span')[1]!
+    expect(nameSpan.classes()).not.toContain('text-txt3')
+    expect(nameSpan.classes()).toContain('text-txt')
+    const fills = wrapper.findAll('[data-testid="token-model-pie-slice"]').map((p) => p.attributes('fill'))
+    expect(fills[0]).toBe('#7B61FF')
+    expect(fills[0]).not.toBe('#71717A')
     expect(legend.findAll('li')).toHaveLength(2)
+    wrapper.unmount()
+  })
+
+  it('configured alias + filled: sector/legend #34D399 and no badge (g4.1)', () => {
+    const models = [
+      { modelKey: '未知/未分桶', name: 'Auto', total: 100, unknown: true, filled: true },
+      { modelKey: 'cursor-grok', name: 'cursor-grok-4.5-high-fast', total: 80, filled: true },
+    ]
+    expect(colorForModel(models[0]!, 0)).toBe('#34D399')
+    const wrapper = mount(TokenModelComposition, {
+      props: { models },
+      global: { plugins: [i18n()] },
+    })
+    const legend = wrapper.find('[data-testid="token-model-legend"]')
+    expect(legend.text()).toContain('Auto')
+    expect(legend.find('[data-testid="unknown-model-badge"]').exists()).toBe(false)
+    const nameSpan = legend.findAll('li')[0]!.findAll('span')[1]!
+    expect(nameSpan.classes()).toContain('text-ok')
+    expect(nameSpan.classes()).not.toContain('text-txt3')
+    const fills = wrapper.findAll('[data-testid="token-model-pie-slice"]').map((p) => p.attributes('fill'))
+    expect(fills).toEqual(['#34D399', '#34D399'])
     wrapper.unmount()
   })
 

--- a/web/src/components/board/token-stats/TokenModelComposition.vue
+++ b/web/src/components/board/token-stats/TokenModelComposition.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { TokenStatsModel } from '@/lib/shared/types'
-import { fmtCompactTokenCount, fmtTokenCount } from '@/lib/run/tokenUsage'
+import { fmtCompactTokenCount, fmtTokenCount, shouldShowUnknownVisual } from '@/lib/run/tokenUsage'
 import { MODEL_PALETTE, colorForModel } from './tokenModelColors'
 import UnknownModelBadge from '@/components/ui/UnknownModelBadge.vue'
 
@@ -122,11 +122,11 @@ const slices = computed(() => {
         <span class="h-2.5 w-2.5" :style="{ background: r.color || MODEL_PALETTE[0] }" />
         <span
           class="flex min-w-0 items-center gap-1.5 truncate"
-          :class="r.unknown ? 'text-txt3' : r.filled ? 'text-ok' : 'text-txt'"
+          :class="shouldShowUnknownVisual(r.unknown, r.name) ? 'text-txt3' : r.filled ? 'text-ok' : 'text-txt'"
           :title="r.name"
         >
           <span class="min-w-0 truncate">{{ r.name }}</span>
-          <UnknownModelBadge v-if="r.unknown" />
+          <UnknownModelBadge v-if="shouldShowUnknownVisual(r.unknown, r.name)" />
         </span>
         <span class="tabular-nums text-txt3" :title="fmtTokenCount(r.total)">
           {{ r.pct }}% · {{ fmtCompactTokenCount(r.total) }}

--- a/web/src/components/board/token-stats/TokenModelRank.test.ts
+++ b/web/src/components/board/token-stats/TokenModelRank.test.ts
@@ -156,12 +156,14 @@ describe('TokenModelRank unknown vs other (g3.3)', () => {
     wrapper.unmount()
   })
 
-  it('shows configured alias with unknown badge; color uses unknown flag not name literal', () => {
+  it('configured alias: no unknown badge and not #71717A; data-unknown keeps distinction (g4.1)', () => {
     const models = [
       { modelKey: 'gpt-5', name: 'gpt-5', total: 100 },
       { modelKey: '未知/未分桶', name: 'gpt-5', total: 80, unknown: true },
     ]
-    expect(colorForModel(models[1]!, 1)).toBe('#71717A')
+    // Alias removes unknown-gray; falls through to palette (idx 1 → #60A5FA).
+    expect(colorForModel(models[1]!, 1)).toBe('#60A5FA')
+    expect(colorForModel(models[1]!, 1)).not.toBe('#71717A')
     expect(colorForModel({ name: 'gpt-5', unknown: false }, 0)).not.toBe('#71717A')
 
     const wrapper = mount(TokenModelRank, {
@@ -170,10 +172,35 @@ describe('TokenModelRank unknown vs other (g3.3)', () => {
     })
     const unk = wrapper.find('[data-unknown="1"]')
     expect(unk.text()).toContain('gpt-5')
-    expect(unk.find('[data-testid="unknown-model-badge"]').exists()).toBe(true)
-    expect(unk.find('.h-full').attributes('style')).toMatch(/#71717A/i)
+    expect(unk.find('[data-testid="unknown-model-badge"]').exists()).toBe(false)
+    const nameRow = unk.find('.flex.min-w-0.items-center')
+    expect(nameRow.classes()).not.toContain('text-txt3')
+    expect(nameRow.classes()).toContain('text-txt')
+    expect(unk.find('.h-full').attributes('style')).not.toMatch(/#71717A/i)
+    expect(unk.find('.h-full').attributes('style')).toMatch(/#60A5FA/i)
     // Two rows with same display text stay distinct via data-unknown.
     expect(wrapper.findAll('[data-testid="token-model-rank"] > li')).toHaveLength(2)
+    wrapper.unmount()
+  })
+
+  it('configured alias + filled: main name and bar use #34D399, no badge (g4.1)', () => {
+    const models = [
+      { modelKey: '未知/未分桶', name: 'Auto', total: 400, unknown: true, filled: true },
+      { modelKey: 'cursor-grok-4.5-high-fast', name: 'cursor-grok-4.5-high-fast', total: 200, filled: true },
+    ]
+    expect(colorForModel(models[0]!, 0)).toBe('#34D399')
+
+    const wrapper = mount(TokenModelRank, {
+      props: { models },
+      global: { plugins: [i18nZh()] },
+    })
+    const unk = wrapper.find('[data-unknown="1"]')
+    expect(unk.text()).toContain('Auto')
+    expect(unk.text()).not.toContain('未知/未分桶')
+    expect(unk.find('[data-testid="unknown-model-badge"]').exists()).toBe(false)
+    expect(unk.find('.text-ok').exists()).toBe(true)
+    expect(unk.find('.h-full').attributes('style')).toMatch(/#34D399/i)
+    expect(unk.find('.h-full').attributes('style')).not.toMatch(/#71717A/i)
     wrapper.unmount()
   })
 })

--- a/web/src/components/board/token-stats/TokenModelRank.vue
+++ b/web/src/components/board/token-stats/TokenModelRank.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { TokenStatsModel } from '@/lib/shared/types'
-import { fmtCompactTokenCount, fmtTokenCount } from '@/lib/run/tokenUsage'
+import { fmtCompactTokenCount, fmtTokenCount, shouldShowUnknownVisual } from '@/lib/run/tokenUsage'
 import UnknownModelBadge from '@/components/ui/UnknownModelBadge.vue'
 import { colorForModel } from './tokenModelColors'
 
@@ -36,11 +36,11 @@ function barWidth(total: number): string {
       <div class="min-w-0">
         <div
           class="flex min-w-0 items-center gap-1.5 text-xs font-medium"
-          :class="m.unknown ? 'text-txt3' : m.filled ? 'text-ok' : 'text-txt'"
+          :class="shouldShowUnknownVisual(m.unknown, displayName(m)) ? 'text-txt3' : m.filled ? 'text-ok' : 'text-txt'"
           :title="displayName(m)"
         >
           <span class="min-w-0 truncate">{{ displayName(m) }}</span>
-          <UnknownModelBadge v-if="m.unknown" />
+          <UnknownModelBadge v-if="shouldShowUnknownVisual(m.unknown, displayName(m))" />
         </div>
         <div class="mt-1 h-2 overflow-hidden bg-elevated">
           <div

--- a/web/src/components/board/token-stats/tokenModelColors.ts
+++ b/web/src/components/board/token-stats/tokenModelColors.ts
@@ -1,4 +1,5 @@
 import type { TokenStatsModel } from '@/lib/shared/types'
+import { shouldShowUnknownVisual } from '@/lib/run/tokenUsage'
 
 export const MODEL_PALETTE = [
   '#7B61FF',
@@ -18,7 +19,9 @@ const OTHER = '#A1A1AA'
 const FILLED = '#34D399'
 
 export function colorForModel(m: Pick<TokenStatsModel, 'name' | 'unknown' | 'other' | 'filled'>, idx: number): string {
-  if (m.unknown) return UNK
+  // Unknown gray only when display name is still the default 「未知/未分桶」.
+  // Configured alias keeps Unknown=true for identity but uses filled/palette colors.
+  if (shouldShowUnknownVisual(m.unknown, m.name)) return UNK
   if (m.other || m.name === 'other') return OTHER
   if (m.filled) return FILLED
   return MODEL_PALETTE[idx % MODEL_PALETTE.length]!

--- a/web/src/components/run/TokenUsageByModelTable.vue
+++ b/web/src/components/run/TokenUsageByModelTable.vue
@@ -5,6 +5,7 @@ import {
   effectiveModelUsageRows,
   fmtTokenCount,
   mergeTokenUsageByModel,
+  shouldShowUnknownVisual,
   TOKEN_USAGE_SOURCE_BRIDGE,
   tokenUsageTotal,
   unknownDisplayName,
@@ -63,6 +64,10 @@ function modelLabel(modelKey: string, unknown: boolean): string {
   if (!unknown) return modelKey
   return unknownDisplayName(modelKey, props.unknownModelDisplayName)
 }
+
+function showUnknownVisual(modelKey: string, unknown: boolean): boolean {
+  return shouldShowUnknownVisual(unknown, modelLabel(modelKey, unknown))
+}
 </script>
 
 <template>
@@ -98,11 +103,11 @@ function modelLabel(modelKey: string, unknown: boolean): string {
           >
             <td
               class="px-3 py-2 font-medium"
-              :class="row.unknown ? 'text-txt3' : row.filled ? 'text-ok' : 'text-txt'"
+              :class="showUnknownVisual(row.modelKey, row.unknown) ? 'text-txt3' : row.filled ? 'text-ok' : 'text-txt'"
             >
               <span class="inline-flex max-w-full items-center gap-1.5">
                 <span class="min-w-0 truncate">{{ modelLabel(row.modelKey, row.unknown) }}</span>
-                <UnknownModelBadge v-if="row.unknown" />
+                <UnknownModelBadge v-if="showUnknownVisual(row.modelKey, row.unknown)" />
               </span>
             </td>
             <td class="px-3 py-2 text-txt3">{{ sourceLabel(row.source, row.filled) }}</td>

--- a/web/src/components/ui/TokenUsageByModelTip.vue
+++ b/web/src/components/ui/TokenUsageByModelTip.vue
@@ -9,6 +9,7 @@ import {
   effectiveModelUsageRows,
   fmtCompactTokenCount,
   fmtTokenCount,
+  shouldShowUnknownVisual,
   TOKEN_USAGE_SOURCE_BRIDGE,
   tokenUsageTotal,
   unknownDisplayName,
@@ -76,6 +77,10 @@ function modelLabel(modelKey: string, unknown: boolean): string {
   return unknownDisplayName(modelKey, props.unknownModelDisplayName)
 }
 
+function showUnknownVisual(modelKey: string, unknown: boolean): boolean {
+  return shouldShowUnknownVisual(unknown, modelLabel(modelKey, unknown))
+}
+
 defineExpose({ toggle, close, isOpen })
 </script>
 
@@ -125,7 +130,7 @@ defineExpose({ toggle, close, isOpen })
           <div class="mb-1 flex items-center justify-between gap-2 text-xs">
             <strong
               class="min-w-0 truncate font-semibold"
-              :class="row.unknown ? 'text-[#a1a1aa]' : row.filled ? 'text-[#6ee7b7]' : 'text-[#f9fafb]'"
+              :class="showUnknownVisual(row.modelKey, row.unknown) ? 'text-[#a1a1aa]' : row.filled ? 'text-[#6ee7b7]' : 'text-[#f9fafb]'"
             >{{ modelLabel(row.modelKey, row.unknown) }}</strong>
             <span class="shrink-0 font-mono tabular-nums text-[#c7cbd4]">{{ fmtTokenCount(row.total) }}</span>
           </div>

--- a/web/src/lib/run/tokenUsage.test.ts
+++ b/web/src/lib/run/tokenUsage.test.ts
@@ -13,6 +13,7 @@ import {
   TOKEN_USAGE_UNKNOWN_MODEL,
   tokenUsageTotal,
   totalTokensOrNull,
+  shouldShowUnknownVisual,
   unknownDisplayName,
 } from './tokenUsage'
 
@@ -187,6 +188,15 @@ describe('tokenUsage', () => {
     )
     expect(unknownDisplayName(TOKEN_USAGE_UNKNOWN_MODEL, null)).toBe(TOKEN_USAGE_UNKNOWN_MODEL)
     expect(unknownDisplayName('gpt-5', 'alias')).toBe('gpt-5')
+  })
+
+  it('shouldShowUnknownVisual: only unknown + default label', () => {
+    expect(shouldShowUnknownVisual(true, TOKEN_USAGE_UNKNOWN_MODEL)).toBe(true)
+    expect(shouldShowUnknownVisual(true, ' 未知/未分桶 ')).toBe(true)
+    expect(shouldShowUnknownVisual(true, 'Auto')).toBe(false)
+    expect(shouldShowUnknownVisual(true, 'gpt-5')).toBe(false)
+    expect(shouldShowUnknownVisual(false, TOKEN_USAGE_UNKNOWN_MODEL)).toBe(false)
+    expect(shouldShowUnknownVisual(undefined, 'Auto')).toBe(false)
   })
 
   it('normalizeUnknownModelDisplayNameInput trims, clears default, rejects >64', () => {

--- a/web/src/lib/run/tokenUsage.ts
+++ b/web/src/lib/run/tokenUsage.ts
@@ -18,6 +18,20 @@ export function unknownDisplayName(modelKey: string, alias?: string | null): str
 }
 
 /**
+ * Whether to apply unknown-bucket visuals (「未知」badge + unknown-gray).
+ * Only when the row is an unknown bucket AND the resolved display name is still
+ * the default 「未知/未分桶」. A configured alias (e.g. Auto) keeps Unknown=true
+ * for identity but must not show the unknown badge or #71717A gray.
+ */
+export function shouldShowUnknownVisual(
+  unknown: boolean | undefined,
+  displayName: string | null | undefined,
+): boolean {
+  if (!unknown) return false
+  return (displayName ?? '').trim() === TOKEN_USAGE_UNKNOWN_MODEL
+}
+
+/**
  * Client-side normalize for save: trim; empty/default → ''; over max → error message.
  * Returns { value, error } where error is a user-facing message when invalid.
  */


### PR DESCRIPTION
Use shouldShowUnknownVisual so aliased unknown buckets no longer show the
未知 badge or #71717A; filled aliases take #34D399 like the approved demo.

Co-authored-by: Cursor <cursoragent@cursor.com>
