### PR TITLE
fix(public): subscribe before ready on gate events WS

### DIFF
--- a/server/internal/handlers/gate_share_public_events.go
+++ b/server/internal/handlers/gate_share_public_events.go
@@ -71,13 +71,14 @@ func (h *Handlers) PublicGateEvents(c *gin.Context) {
 		return
 	}
 	_ = conn.SetReadDeadline(time.Time{})
-	if err := conn.WriteJSON(gin.H{"type": "ready"}); err != nil {
-		return
-	}
-
+	// Subscribe before advertising ready so events published right after the
+	// client sees ready are not lost to a subscribe race.
 	runID := lookup.Link.RunID
 	ch, unsub := h.Eng.Broker().Subscribe(runID)
 	defer unsub()
+	if err := conn.WriteJSON(gin.H{"type": "ready"}); err != nil {
+		return
+	}
 	h.seedPublicDialogue(conn, lookup, producerID)
 
 	ping := time.NewTicker(25 * time.Second)

--- a/server/internal/handlers/gate_share_public_events_test.go
+++ b/server/internal/handlers/gate_share_public_events_test.go
@@ -64,8 +64,10 @@ func TestPublicGateEventsWSStreamsSanitizedAcp(t *testing.T) {
 		"item":   map[string]any{"text": "改成绿的"},
 	}))
 
+	deadline := time.Now().Add(3 * time.Second)
 	sawAcp, sawReview := false, false
-	for i := 0; i < 6; i++ {
+	for time.Now().Before(deadline) && (!sawAcp || !sawReview) {
+		_ = c.SetReadDeadline(time.Now().Add(time.Until(deadline) + 50*time.Millisecond))
 		_, msg, err := c.ReadMessage()
 		if err != nil {
 			break


### PR DESCRIPTION
## Summary
- Subscribe to the run broker **before** sending the public gate events `ready` frame, so frames published right after auth are not lost.
- Harden `TestPublicGateEventsWSStreamsSanitizedAcp` to wait until both acp/review frames arrive (or deadline), instead of a fixed 6 reads.

This addresses main `ci-server` follow-on flakes after #305 (e.g. PR #306 failing with `sawAcp=false sawReview=false`). The earlier main failure on run 31618951947 was a transient golangci-lint download `socket hang up`; this PR also re-triggers `ci-server` on merge.

## Test plan
- [x] `go test ./internal/handlers/ -count=20 -run TestPublicGateEventsWS`
- [ ] CI `ci-server` green on this PR
- [ ] Merge then confirm `main` `ci-server` green


Made with [Cursor](https://cursor.com)