### PR TITLE
fix(web): lock PublicGate root viewport so chat scrolls independently

### DIFF
--- a/web/src/views/PublicGateApprovalView.layout.test.ts
+++ b/web/src/views/PublicGateApprovalView.layout.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+/**
+ * PublicGateApproval viewport lock + sidebar/chat scroll chain (g1 / g2 / g3.1).
+ * Source-structure assertions prevent the long-chat whole-page scroll regression.
+ */
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const viewsDir = dirname(fileURLToPath(import.meta.url))
+const viewSrc = readFileSync(join(viewsDir, 'PublicGateApprovalView.vue'), 'utf8')
+const shellSrc = readFileSync(join(viewsDir, '../components/run/ReviewShell.vue'), 'utf8')
+const chatSrc = readFileSync(join(viewsDir, '../components/run/ClarifyChat.vue'), 'utf8')
+
+function publicGateRootClass(): string {
+  const rootIdx = viewSrc.indexOf('data-testid="public-gate-root"')
+  expect(rootIdx, 'missing public-gate-root').toBeGreaterThanOrEqual(0)
+  const block = viewSrc.slice(Math.max(0, rootIdx - 160), rootIdx + 80)
+  const cls = block.match(/class="([^"]+)"/)
+  expect(cls?.[1], 'missing public-gate-root class').toBeTruthy()
+  return cls![1]
+}
+
+describe('PublicGateApproval root viewport lock (g1.1)', () => {
+  it('locks root to viewport height with overflow-hidden (not min-h-screen alone)', () => {
+    const cls = publicGateRootClass()
+    expect(cls).toMatch(/\bh-screen\b|\bh-dvh\b|\bh-\[100dvh\]\b/)
+    expect(cls).toMatch(/\boverflow-hidden\b/)
+    expect(cls).toMatch(/\bflex\b/)
+    expect(cls).toMatch(/\bflex-col\b/)
+    expect(cls).not.toMatch(/\bmin-h-screen\b/)
+    expect(viewSrc).not.toMatch(/class="flex min-h-screen flex-col/)
+  })
+})
+
+describe('PublicGateApproval height chain to clarify-scroller (g1.2 / g2)', () => {
+  it('workbench and sidebar keep min-h-0 flex chain', () => {
+    expect(viewSrc).toMatch(/data-testid="public-gate-workbench"/)
+    expect(viewSrc).toMatch(/class="flex min-h-0 flex-1 flex-col"[^>]*data-testid="public-gate-workbench"/)
+    expect(viewSrc).toMatch(/ReviewShell class="min-h-0 flex-1"/)
+    expect(viewSrc).toMatch(/data-testid="public-gate-sidebar"/)
+    expect(viewSrc).toMatch(/class="flex h-full min-h-0 flex-col"[^>]*data-testid="public-gate-sidebar"/)
+    // Chat host wrapper (ClarifyChat is multi-root; fallthrough class is ignored)
+    expect(viewSrc).toMatch(/data-testid="public-gate-chat-host"/)
+    expect(viewSrc).toMatch(/class="flex min-h-0 flex-1 flex-col"[^>]*data-testid="public-gate-chat-host"/)
+  })
+
+  it('footer stays shrink-0 in workbench (confirm stays in page footer, g2.1)', () => {
+    const footerIdx = viewSrc.indexOf('data-testid="public-gate-footer"')
+    expect(footerIdx).toBeGreaterThanOrEqual(0)
+    const footerOpen = viewSrc.slice(Math.max(0, footerIdx - 200), footerIdx + 40)
+    expect(footerOpen).toMatch(/\bshrink-0\b/)
+    expect(viewSrc).toMatch(/data-testid="public-gate-confirm"/)
+    expect(viewSrc).toMatch(/hide-finish/)
+  })
+
+  it('stage keeps bounded height with internal scroll for tall content (g2.3)', () => {
+    expect(viewSrc).toMatch(/data-testid="public-gate-stage"/)
+    expect(viewSrc).toMatch(/class="flex min-h-0 flex-1 flex-col"[^>]*data-testid="public-gate-stage"/)
+    expect(viewSrc).toMatch(/class="min-h-0 flex-1 overflow-hidden"/)
+    const structuredIdx = viewSrc.indexOf('data-testid="public-gate-structured"')
+    expect(structuredIdx).toBeGreaterThanOrEqual(0)
+    const structuredBlock = viewSrc.slice(Math.max(0, structuredIdx - 160), structuredIdx + 40)
+    expect(structuredBlock).toMatch(/\boverflow-y-auto\b/)
+  })
+
+  it('ReviewShell sidebar/stage preserve min-h-0 overflow chain (g1.2 / g2.2)', () => {
+    expect(shellSrc).toMatch(/class="flex h-full min-h-0"/)
+    expect(shellSrc).toMatch(/data-testid="review-shell-stage"/)
+    expect(shellSrc).toMatch(/flex min-h-0 flex-1 flex-col overflow-hidden/)
+    expect(shellSrc).toMatch(/data-testid="review-shell-sidebar"/)
+    expect(shellSrc).toMatch(/class="flex min-h-0 flex-1 flex-col overflow-hidden"/)
+  })
+
+  it('ClarifyChat clarify-scroller remains the overflow-y-auto list (g2.2 / g3.1)', () => {
+    const scrollerIdx = chatSrc.indexOf('data-testid="clarify-scroller"')
+    expect(scrollerIdx).toBeGreaterThanOrEqual(0)
+    const scrollerBlock = chatSrc.slice(Math.max(0, scrollerIdx - 160), scrollerIdx + 40)
+    expect(scrollerBlock).toMatch(/\boverflow-y-auto\b/)
+    expect(chatSrc).toMatch(/border-t border-line p-3/)
+  })
+})

--- a/web/src/views/PublicGateApprovalView.vue
+++ b/web/src/views/PublicGateApprovalView.vue
@@ -886,7 +886,7 @@ defineExpose({ loadPreview, loadUpstreamFull, openUpstreamModal })
 
 <template>
   <div
-    class="flex min-h-screen flex-col bg-base text-txt"
+    class="flex h-screen flex-col overflow-hidden bg-base text-txt"
     data-testid="public-gate-root"
     :aria-busy="(!ready || loading || submitting) ? 'true' : 'false'"
   >
@@ -1051,24 +1051,26 @@ defineExpose({ loadPreview, loadUpstreamFull, openUpstreamModal })
             >
               {{ isReview ? t('pages.publicGate.sessionEndedHint') : t('pages.publicGate.sessionEndedHintGate') }}
             </p>
-            <ClarifyChat
-              ref="chatRef"
-              class="min-h-0 flex-1"
-              run-id="public-share"
-              node-id="public-gate"
-              :iteration="1"
-              v-model:draft="draft"
-              v-model:attachments="attachments"
-              v-model:annotations="annotations"
-              :turns="turns"
-              :done="false"
-              :active="canReply"
-              review-mode
-              annotate-enabled
-              hide-finish
-              @send="onSend"
-              @cancel="onCancel"
-            />
+            <!-- Wrapper supplies min-h-0 flex-1: ClarifyChat is multi-root so fallthrough class is ignored. -->
+            <div class="flex min-h-0 flex-1 flex-col" data-testid="public-gate-chat-host">
+              <ClarifyChat
+                ref="chatRef"
+                run-id="public-share"
+                node-id="public-gate"
+                :iteration="1"
+                v-model:draft="draft"
+                v-model:attachments="attachments"
+                v-model:annotations="annotations"
+                :turns="turns"
+                :done="false"
+                :active="canReply"
+                review-mode
+                annotate-enabled
+                hide-finish
+                @send="onSend"
+                @cancel="onCancel"
+              />
+            </div>
           </div>
         </template>
       </ReviewShell>


### PR DESCRIPTION
Bare PublicGateApproval used min-h-screen, so long chat stretched the whole
document. Use h-screen + overflow-hidden and host ClarifyChat in a min-h-0
flex wrapper so only clarify-scroller scrolls; footer/composer stay reachable.

Co-authored-by: Cursor <cursoragent@cursor.com>
