### PR TITLE
feat(feedback): persist every human feedback round as its own product

### DIFF
--- a/server/internal/engine/feedback.go
+++ b/server/internal/engine/feedback.go
@@ -1,0 +1,375 @@
+package engine
+
+import (
+	"errors"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cocofhu/approving/internal/mcp"
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/services"
+
+	"github.com/rs/zerolog/log"
+)
+
+// recordFeedback appends one round of human feedback and renders it into
+// products: a brand-new per-round file that is never touched again, plus a
+// full rewrite of feedback_index.json.
+//
+// It writes nothing at all when the event carries no human input — no opinion,
+// no annotation, no attachment, no ReAct turn. A gate approval clicked through
+// with an empty form is exactly that case, and flooding a run with empty shells
+// would make the ledger useless.
+//
+// Best-effort, like persistRunErrorArtifact: every failure is logged and
+// swallowed, because losing a feedback product must never stall the FSM.
+func (e *Engine) recordFeedback(ev models.FeedbackEvent) {
+	if e.db == nil || strings.TrimSpace(ev.RunID) == "" {
+		return
+	}
+	if !ev.HasSubstance() {
+		return
+	}
+
+	// A key distinct from the callers' runID+":"+nodeID resume locks: those are
+	// already held on every path that lands here, so sharing one would deadlock.
+	unlock := e.lockResume(ev.RunID + ":feedback")
+	defer unlock()
+
+	svc := services.NewFeedbackService(e.db)
+	if err := svc.Append(&ev); err != nil {
+		if !errors.Is(err, services.ErrFeedbackNoSubstance) {
+			log.Warn().Str("run_id", ev.RunID).Str("node_id", ev.NodeID).Err(err).
+				Msg("append feedback event failed")
+		}
+		return
+	}
+	e.renderFeedbackProducts(ev.RunID, svc)
+}
+
+// renderFeedbackProducts rewrites the index from the table and backfills any
+// per-round product the index references but the store is missing.
+//
+// Deriving the index from the table on every round makes it self-healing: a
+// write that failed once is picked up by the next round's rewrite. Per-round
+// files do not heal on their own, hence the explicit backfill pass here.
+func (e *Engine) renderFeedbackProducts(runID string, svc *services.FeedbackService) {
+	if e.store == nil {
+		return
+	}
+	events := svc.Events(runID)
+	if len(events) == 0 {
+		return
+	}
+
+	labels, types := e.nodeMeta(runID)
+	for i, ev := range events {
+		if ev.ArtifactName == "" {
+			continue
+		}
+		if _, ok := e.store.Get(runID, ev.ArtifactName); ok {
+			continue
+		}
+		body, err := services.MarshalRoundJSON(ev, priorRoundsFor(events, i), runID,
+			services.NodeRef{Label: labels[ev.NodeID], Type: types[ev.NodeID]})
+		if err != nil {
+			log.Warn().Str("run_id", runID).Str("artifact", ev.ArtifactName).Err(err).
+				Msg("marshal feedback round failed")
+			continue
+		}
+		// The real node id keeps the product grouped under its node in the UI;
+		// captureDeliverable skips feedback.* so this cannot suppress the
+		// node's own deliverable capture.
+		if _, err := e.store.Save(runID, ev.NodeID, ev.ArtifactName, "json", body); err != nil {
+			log.Warn().Str("run_id", runID).Str("artifact", ev.ArtifactName).Err(err).
+				Msg("save feedback round failed")
+		}
+	}
+
+	body, err := services.MarshalIndexJSON(runID, events)
+	if err != nil {
+		log.Warn().Str("run_id", runID).Err(err).Msg("marshal feedback index failed")
+		return
+	}
+	// The index spans the whole run, so it is deliberately unattributed to any
+	// single node.
+	if _, err := e.store.Save(runID, "", services.FeedbackIndexArtifactName, "json", body); err != nil {
+		log.Warn().Str("run_id", runID).Err(err).Msg("save feedback index failed")
+	}
+}
+
+// priorRoundsFor returns the rounds of the same node+iteration that precede
+// index i, which is the chain a single product summarizes.
+func priorRoundsFor(events []models.FeedbackEvent, i int) []models.FeedbackEvent {
+	cur := events[i]
+	out := make([]models.FeedbackEvent, 0, i)
+	for _, ev := range events[:i] {
+		if ev.NodeID == cur.NodeID && ev.Iteration == cur.Iteration {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+// reviewFeedbackEvent assembles one in-place-revision round.
+//
+// The enqueue path (WS review_chat) carries no identity today, so the round is
+// recorded as unattributable rather than inventing a reviewer name.
+func (e *Engine) reviewFeedbackEvent(s *reviewSession, item *reviewQueueItem, iteration int,
+	human, agent models.ReactMessage, targets []models.FeedbackTarget, interrupted bool) models.FeedbackEvent {
+	ev := models.FeedbackEvent{
+		RunID:          s.runID,
+		Kind:           models.FeedbackKindReview,
+		NodeID:         s.producerID,
+		Iteration:      iteration,
+		CallerKind:     models.CallerKindPM,
+		Unattributable: true,
+		Action:         "revise",
+		Text:           item.Text,
+		Annotations:    item.Annotations,
+		Attachments:    item.Images,
+		Turns:          []models.ReactMessage{human, agent},
+		Targets:        targets,
+		Interrupted:    interrupted,
+		OccurredAt:     time.Now(),
+	}
+	if item.Source != "" {
+		ev.Detail = map[string]any{"source": item.Source}
+		if item.GateNodeID != "" {
+			ev.Detail["gateNodeId"] = item.GateNodeID
+		}
+	}
+	return ev
+}
+
+// clarifyFeedbackEvent assembles one human answer in a clarification dialogue.
+// The questions being answered ride along in Detail so the round is readable on
+// its own instead of as a dangling reply.
+func (e *Engine) clarifyFeedbackEvent(s *reviewSession, item *reviewQueueItem, iteration int,
+	answered []models.ReactQuestion, human, agent models.ReactMessage, interrupted bool) models.FeedbackEvent {
+	ev := models.FeedbackEvent{
+		RunID:          s.runID,
+		Kind:           models.FeedbackKindClarify,
+		NodeID:         s.producerID,
+		Iteration:      iteration,
+		CallerKind:     models.CallerKindPM,
+		Unattributable: true,
+		Action:         "answer",
+		Text:           item.Text,
+		Annotations:    item.Annotations,
+		Attachments:    item.Images,
+		Turns:          []models.ReactMessage{human, agent},
+		Interrupted:    interrupted,
+		OccurredAt:     time.Now(),
+	}
+	if len(answered) > 0 {
+		ev.Detail = map[string]any{"questions": answered}
+	}
+	return ev
+}
+
+// recordAutoClarifyRound logs a platform auto-answered clarify round.
+//
+// It is index-only: the round shaped the requirement and later rounds need that
+// context, but there is no human prose to warrant a file of its own.
+func (e *Engine) recordAutoClarifyRound(runID, nodeID string, iteration int, human, agent models.ReactMessage) {
+	e.recordFeedback(models.FeedbackEvent{
+		RunID:      runID,
+		Kind:       models.FeedbackKindClarify,
+		NodeID:     nodeID,
+		Iteration:  iteration,
+		CallerKind: models.CallerKindSystem,
+		Actor:      "system",
+		Action:     "auto_answer",
+		Text:       human.Text,
+		Turns:      []models.ReactMessage{human, agent},
+		IndexOnly:  true,
+		OccurredAt: time.Now(),
+	})
+}
+
+// lastAgentQuestions returns the structured questions from the most recent
+// agent turn, i.e. the ones the next human turn is answering.
+func lastAgentQuestions(msgs []models.ReactMessage) []models.ReactQuestion {
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role == "agent" {
+			return msgs[i].Questions
+		}
+	}
+	return nil
+}
+
+// recordGateFeedback records a gate decision, but only when the reviewer
+// actually wrote something.
+//
+// A decision with an empty form is a click, not feedback: recording it would
+// turn a batch sign-off into a pile of empty products and bury the rounds that
+// carry real reasoning. HasSubstance enforces this downstream too; the explicit
+// text extraction here is what gives the round its body.
+func (e *Engine) recordGateFeedback(c *execCtx, node *models.Node, gate models.Gate,
+	action string, form map[string]any, reviewer string, opts resumeGateOpts) {
+	if c == nil || node == nil {
+		return
+	}
+	actor := services.ActorFromUsername(reviewer)
+	ev := models.FeedbackEvent{
+		RunID:          c.run.ID,
+		Kind:           models.FeedbackKindGate,
+		NodeID:         node.ID,
+		Iteration:      gate.Iteration,
+		Actor:          actor.Username,
+		Unattributable: actor.Unattributable,
+		CallerKind:     firstNonEmptyStr(opts.callerKind, models.CallerKindPM),
+		Action:         action,
+		Text:           gateFormText(form),
+		OccurredAt:     time.Now(),
+	}
+	detail := map[string]any{}
+	if len(form) > 0 {
+		detail["form"] = form
+	}
+	if opts.externalName != "" {
+		detail["externalName"] = opts.externalName
+		detail["external"] = true
+	}
+	for _, a := range parseActions(node.Config["actions"]) {
+		if a.ID == action && a.Goto != "" {
+			detail["goto"] = a.Goto
+		}
+	}
+	if len(detail) > 0 {
+		ev.Detail = detail
+	}
+	e.recordFeedback(ev)
+}
+
+// gateFormText joins the reviewer's written form values into the round's body.
+// Non-text values are skipped: a checkbox is a decision, not an opinion.
+func gateFormText(form map[string]any) string {
+	keys := make([]string, 0, len(form))
+	for k := range form {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var parts []string
+	for _, k := range keys {
+		s, ok := form[k].(string)
+		if !ok {
+			continue
+		}
+		if s = strings.TrimSpace(s); s == "" {
+			continue
+		}
+		parts = append(parts, k+": "+s)
+	}
+	return strings.Join(parts, "\n")
+}
+
+// recordPreviewFeedback records a batch of preview issues as one round: the
+// reviewer filed them as one pass over the page, and splitting them would lose
+// that grouping. An empty snapshot records nothing.
+//
+// Screenshots are carried as blob refs only — PromptImage.Data is dropped
+// before persistence, so no base64 reaches the ledger.
+func (e *Engine) recordPreviewFeedback(c *execCtx, nodeID string, issues []models.PreviewIssue) {
+	if c == nil || len(issues) == 0 {
+		return
+	}
+	var texts []string
+	var images []models.PromptImage
+	items := make([]map[string]any, 0, len(issues))
+	for _, is := range issues {
+		body := strings.TrimSpace(is.Body)
+		if body != "" {
+			texts = append(texts, body)
+		}
+		images = append(images, is.Images...)
+		item := map[string]any{"body": body}
+		if s := strings.TrimSpace(is.Selector); s != "" {
+			item["selector"] = s
+		}
+		if is.Port > 0 {
+			item["port"] = is.Port
+		}
+		if n := len(is.Images); n > 0 {
+			item["attachments"] = n
+		}
+		items = append(items, item)
+	}
+	e.recordFeedback(models.FeedbackEvent{
+		RunID:       c.run.ID,
+		Kind:        models.FeedbackKindPreview,
+		NodeID:      nodeID,
+		Iteration:   c.iter[nodeID],
+		CallerKind:  models.CallerKindPM,
+		Action:      "snapshot",
+		Text:        strings.Join(texts, "\n"),
+		Attachments: images,
+		Detail:      map[string]any{"issues": items},
+		OccurredAt:  time.Now(),
+	})
+}
+
+// artifactDigests snapshots the content digests of a node's products, keyed by
+// name. Ledger products and the outcome marker are excluded: they are platform
+// bookkeeping, and listing them as "changed by this feedback" would be noise.
+func (e *Engine) artifactDigests(runID, nodeID string) map[string]string {
+	out := map[string]string{}
+	if e.store == nil {
+		return out
+	}
+	for _, a := range e.store.List(runID) {
+		if a.Node != nodeID || a.Name == mcp.NodeOutcomeArtifactName ||
+			services.IsFeedbackArtifactName(a.Name) {
+			continue
+		}
+		content, ok := e.store.Get(runID, a.Name)
+		if !ok {
+			continue
+		}
+		out[a.Name] = services.FeedbackDigest(content)
+	}
+	return out
+}
+
+// diffDigests turns two snapshots into the per-product before/after record that
+// answers "what did this round of feedback actually change".
+func diffDigests(before, after map[string]string) []models.FeedbackTarget {
+	names := make([]string, 0, len(after))
+	for n := range after {
+		names = append(names, n)
+	}
+	for n := range before {
+		if _, ok := after[n]; !ok {
+			names = append(names, n)
+		}
+	}
+	sort.Strings(names)
+
+	out := make([]models.FeedbackTarget, 0, len(names))
+	for _, n := range names {
+		b, a := before[n], after[n]
+		out = append(out, models.FeedbackTarget{Name: n, Before: b, After: a, Changed: b != a})
+	}
+	return out
+}
+
+// nodeMeta reads label/type per node id from the run's stored graph so the
+// products are readable without a graph lookup. Callers reach this helper from
+// paths that have no execCtx, so the graph comes from the run row.
+func (e *Engine) nodeMeta(runID string) (labels, types map[string]string) {
+	labels, types = map[string]string{}, map[string]string{}
+	var run models.Run
+	if err := e.db.Select("graph").First(&run, "id = ?", runID).Error; err != nil {
+		return labels, types
+	}
+	for _, n := range run.Graph.Nodes {
+		if lbl := strings.TrimSpace(n.Label); lbl != "" {
+			labels[n.ID] = lbl
+		}
+		types[n.ID] = n.Type
+	}
+	return labels, types
+}

--- a/server/internal/engine/feedback_test.go
+++ b/server/internal/engine/feedback_test.go
@@ -1,0 +1,324 @@
+package engine
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/mcp"
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/services"
+
+	"gorm.io/gorm"
+)
+
+func feedbackArtifacts(db *gorm.DB, runID string) []models.Artifact {
+	var all []models.Artifact
+	db.Where("run_id = ?", runID).Order("name").Find(&all)
+	out := make([]models.Artifact, 0, len(all))
+	for _, a := range all {
+		if strings.HasPrefix(a.Name, services.FeedbackArtifactPrefix) {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+func decodeIndex(t *testing.T, db *gorm.DB, runID string) map[string]any {
+	t.Helper()
+	a, ok := arts(db, runID, services.FeedbackIndexArtifactName)
+	if !ok {
+		t.Fatalf("%s missing", services.FeedbackIndexArtifactName)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(a.Content), &doc); err != nil {
+		t.Fatalf("index is not valid JSON: %v", err)
+	}
+	return doc
+}
+
+// Three push-backs on one execution must leave three separate products behind.
+// Overwriting would erase the reasoning of the earlier rounds, which is the
+// whole reason the ledger exists.
+func TestReviseRoundsEachProduceTheirOwnArtifact(t *testing.T) {
+	eng, db, _ := setupReviewEngine(t, true)
+
+	run, err := eng.StartRun("review-wf", map[string]any{"idea": "登录"}, "test")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitReactPause(t, db, run.ID, "prop")
+	waitRunStatus(t, db, run.ID, "waiting_human")
+
+	opinions := []string{"第一条要补证据", "第二条图表改柱状图", "第三条补上原始链接"}
+	anns := []models.ReactAnnotation{{JSONPath: "proposals[p2]", Note: "更具体"}}
+	for _, text := range opinions {
+		if err := eng.ReactReply(run.ID, "prop", text, nil, anns, false); err != nil {
+			t.Fatalf("revise %q: %v", text, err)
+		}
+		if err := eng.waitReviewReadyForTest(run.ID, "prop", 5*time.Second); err != nil {
+			t.Fatalf("wait revise %q: %v", text, err)
+		}
+	}
+
+	rounds := feedbackArtifacts(db, run.ID)
+	if len(rounds) != 3 {
+		t.Fatalf("want 3 per-round products, got %d: %+v", len(rounds), rounds)
+	}
+	seen := map[string]bool{}
+	for i, a := range rounds {
+		if seen[a.Name] {
+			t.Fatalf("duplicate product name %q", a.Name)
+		}
+		seen[a.Name] = true
+		if !strings.Contains(a.Content, opinions[i]) {
+			t.Fatalf("%s does not carry its own round's opinion:\n%s", a.Name, a.Content)
+		}
+		if a.NodeID != "prop" {
+			t.Fatalf("%s should hang off the producer node, got %q", a.Name, a.NodeID)
+		}
+	}
+	// Each round only carries its own body; earlier rounds are one-line refs.
+	if strings.Contains(rounds[0].Content, opinions[2]) {
+		t.Fatalf("round 1 must not contain round 3's body:\n%s", rounds[0].Content)
+	}
+
+	idx := decodeIndex(t, db, run.ID)
+	list, _ := idx["rounds"].([]any)
+	if len(list) != 3 {
+		t.Fatalf("index must list all 3 rounds, got %d", len(list))
+	}
+	for _, r := range list {
+		m := r.(map[string]any)
+		if m["artifact"] == "" || m["artifact"] == nil {
+			t.Fatalf("index row missing artifact pointer: %+v", m)
+		}
+	}
+	// The producer's own deliverable survived: feedback products must not be
+	// mistaken for "this node already produced something".
+	if _, ok := arts(db, run.ID, mcp.ProposalsArtifactName); !ok {
+		t.Fatal("proposals.json missing — feedback products suppressed the deliverable")
+	}
+}
+
+// A reviewer who clicks through without writing anything has not given
+// feedback; recording it would flood the run with empty shells.
+func TestEmptyGateApprovalWritesNoFeedbackProduct(t *testing.T) {
+	eng, db := setupEngine(t)
+	run := runToGate(t, eng, db)
+
+	if err := eng.ResumeGate(run.ID, "approve", "approve", map[string]any{}); err != nil {
+		t.Fatalf("resume gate: %v", err)
+	}
+	waitRunStatus(t, db, run.ID, "completed")
+
+	if got := feedbackArtifacts(db, run.ID); len(got) != 0 {
+		t.Fatalf("empty approval must not produce feedback files, got %+v", got)
+	}
+	if _, ok := arts(db, run.ID, services.FeedbackIndexArtifactName); ok {
+		t.Fatal("no index should exist when nothing was recorded")
+	}
+	var n int64
+	db.Model(&models.FeedbackEvent{}).Where("run_id = ?", run.ID).Count(&n)
+	if n != 0 {
+		t.Fatalf("no row should be written either, got %d", n)
+	}
+}
+
+// The same click WITH a written comment is real feedback and must be kept,
+// attributed to the reviewer who wrote it.
+func TestGateApprovalWithCommentRecordsOneRound(t *testing.T) {
+	eng, db := setupEngine(t)
+	run := runToGate(t, eng, db)
+
+	form := map[string]any{"comment": "同意，但下轮请补上压测数据", "checked": true}
+	if err := eng.ResumeGateAs(run.ID, "approve", "approve", form, "alice"); err != nil {
+		t.Fatalf("resume gate: %v", err)
+	}
+	waitRunStatus(t, db, run.ID, "completed")
+
+	rounds := feedbackArtifacts(db, run.ID)
+	if len(rounds) != 1 {
+		t.Fatalf("want exactly one gate round, got %d: %+v", len(rounds), rounds)
+	}
+	body := rounds[0].Content
+	for _, want := range []string{"压测数据", "alice", "\"kind\": \"gate\""} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("gate round missing %q:\n%s", want, body)
+		}
+	}
+	// A boolean checkbox is a decision, not an opinion — it stays out of the body.
+	var doc struct {
+		Feedback struct {
+			Text string `json:"text"`
+		} `json:"feedback"`
+	}
+	if err := json.Unmarshal([]byte(body), &doc); err != nil {
+		t.Fatalf("round is not valid JSON: %v", err)
+	}
+	if strings.Contains(doc.Feedback.Text, "checked") {
+		t.Fatalf("non-text form values must not enter the opinion body: %q", doc.Feedback.Text)
+	}
+
+	idx := decodeIndex(t, db, run.ID)
+	if got := idx["totalRounds"]; got != float64(1) {
+		t.Fatalf("index totalRounds = %v", got)
+	}
+}
+
+// runToGate drives the standard test workflow up to its pending human gate.
+func runToGate(t *testing.T, eng *Engine, db *gorm.DB) models.Run {
+	t.Helper()
+	run, err := eng.StartRun("clarify-to-design", map[string]any{"idea": "做个登录"}, "test")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitReactPause(t, db, run.ID, "clarify")
+	if err := eng.ReactReply(run.ID, "clarify", "就这样", nil, nil, true); err != nil {
+		t.Fatalf("finish clarify: %v", err)
+	}
+	waitGatePending(t, db, run.ID, "approve")
+	return *run
+}
+
+// Attachments are blob references. Inlining base64 into a text product would
+// bloat every read of the ledger and duplicate bytes the blob store already
+// holds, so the payload must never make it to disk.
+func TestFeedbackAttachmentsStayReferences(t *testing.T) {
+	eng, db := setupEngine(t)
+	run := runToGate(t, eng, db)
+
+	const payload = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk"
+	eng.recordFeedback(models.FeedbackEvent{
+		RunID: run.ID, Kind: models.FeedbackKindReview, NodeID: "review_design",
+		Iteration: 1, Actor: "alice", Action: "revise", Text: "看截图里的这处",
+		Attachments: []models.PromptImage{{
+			Ref: "blob:abc123", Name: "shot.png", MimeType: "image/png",
+			SizeBytes: 48213, Data: payload,
+		}},
+		Turns: []models.ReactMessage{{Role: "human", Text: "看截图",
+			Images: []models.PromptImage{{Ref: "blob:abc123", Data: payload}}}},
+	})
+
+	rounds := feedbackArtifacts(db, run.ID)
+	if len(rounds) != 1 {
+		t.Fatalf("want one round, got %d", len(rounds))
+	}
+	body := rounds[0].Content
+	if strings.Contains(body, payload) || strings.Contains(body, "data:image") {
+		t.Fatalf("attachment bytes leaked into the product:\n%s", body)
+	}
+	if !strings.Contains(body, "blob:abc123") || !strings.Contains(body, "shot.png") {
+		t.Fatalf("attachment reference missing from the product:\n%s", body)
+	}
+
+	var row models.FeedbackEvent
+	if err := db.Where("run_id = ?", run.ID).First(&row).Error; err != nil {
+		t.Fatalf("load row: %v", err)
+	}
+	if row.Attachments[0].Data != "" || row.Turns[0].Images[0].Data != "" {
+		t.Fatal("base64 must be stripped before the row is written")
+	}
+}
+
+// The ledger is evidence of what a human actually said. Letting a reviewer edit
+// it through the gate product editor — the same path a share-link holder uses —
+// would make it unciteable.
+func TestFeedbackProductsAreNotGateEditable(t *testing.T) {
+	eng, db := setupEngine(t)
+	run := runToGate(t, eng, db)
+
+	eng.recordFeedback(models.FeedbackEvent{
+		RunID: run.ID, Kind: models.FeedbackKindGate, NodeID: "approve",
+		Iteration: 1, Actor: "alice", Action: "revise", Text: "补上压测数据",
+	})
+	rounds := feedbackArtifacts(db, run.ID)
+	if len(rounds) != 1 {
+		t.Fatalf("want one round, got %d", len(rounds))
+	}
+
+	names := []string{rounds[0].Name, services.FeedbackIndexArtifactName}
+	for _, name := range names {
+		if _, err := eng.SaveGateArtifact(run.ID, "approve", name, `{"x":1}`, ""); err == nil {
+			t.Fatalf("%s must not be editable through the gate editor", name)
+		}
+	}
+
+	// It is also absent from what a share-link holder is offered at all.
+	items, err := eng.ListGatePrimaryProducts(run.ID, "approve")
+	if err != nil {
+		t.Fatalf("list primaries: %v", err)
+	}
+	for _, it := range items {
+		if services.IsFeedbackArtifactName(it.Name) {
+			t.Fatalf("feedback product exposed as a gate primary: %q", it.Name)
+		}
+	}
+}
+
+func TestRecordFeedbackIgnoresEventsWithoutSubstance(t *testing.T) {
+	eng, db := setupEngine(t)
+	// No run row needed: the guard must reject before any write happens.
+	eng.recordFeedback(models.FeedbackEvent{RunID: "run-x", Kind: models.FeedbackKindGate,
+		NodeID: "approve", Iteration: 1, Action: "pass"})
+	eng.recordFeedback(models.FeedbackEvent{})
+
+	var n int64
+	db.Model(&models.FeedbackEvent{}).Count(&n)
+	if n != 0 {
+		t.Fatalf("substance-free events must never reach the table, got %d", n)
+	}
+}
+
+func TestDiffDigestsMarksOnlyRealChanges(t *testing.T) {
+	before := map[string]string{"a.json": "1", "gone.json": "9"}
+	after := map[string]string{"a.json": "2", "new.json": "3"}
+	got := diffDigests(before, after)
+	if len(got) != 3 {
+		t.Fatalf("want 3 targets, got %+v", got)
+	}
+	byName := map[string]models.FeedbackTarget{}
+	for _, tg := range got {
+		byName[tg.Name] = tg
+	}
+	if !byName["a.json"].Changed || byName["a.json"].Before != "1" || byName["a.json"].After != "2" {
+		t.Fatalf("edited product = %+v", byName["a.json"])
+	}
+	if !byName["new.json"].Changed || byName["new.json"].Before != "" {
+		t.Fatalf("added product = %+v", byName["new.json"])
+	}
+	if !byName["gone.json"].Changed || byName["gone.json"].After != "" {
+		t.Fatalf("removed product = %+v", byName["gone.json"])
+	}
+	// Identical snapshots report no change.
+	same := diffDigests(map[string]string{"a.json": "1"}, map[string]string{"a.json": "1"})
+	if len(same) != 1 || same[0].Changed {
+		t.Fatalf("unchanged product must not be marked changed: %+v", same)
+	}
+}
+
+func TestGateFormTextJoinsOnlyWrittenValues(t *testing.T) {
+	if got := gateFormText(map[string]any{"ok": true, "n": 3, "blank": "  "}); got != "" {
+		t.Fatalf("no written text should yield an empty body, got %q", got)
+	}
+	got := gateFormText(map[string]any{"b": "第二", "a": "第一", "ok": true})
+	if got != "a: 第一\nb: 第二" {
+		t.Fatalf("form body = %q", got)
+	}
+}
+
+func TestLastAgentQuestionsPicksMostRecentTurn(t *testing.T) {
+	msgs := []models.ReactMessage{
+		{Role: "agent", Questions: []models.ReactQuestion{{ID: "q1"}}},
+		{Role: "human", Text: "答"},
+		{Role: "agent", Questions: []models.ReactQuestion{{ID: "q2"}}},
+	}
+	got := lastAgentQuestions(msgs)
+	if len(got) != 1 || got[0].ID != "q2" {
+		t.Fatalf("want the latest agent turn's questions, got %+v", got)
+	}
+	if lastAgentQuestions([]models.ReactMessage{{Role: "human"}}) != nil {
+		t.Fatal("no agent turn ⇒ no questions")
+	}
+}

--- a/server/internal/engine/node_gate.go
+++ b/server/internal/engine/node_gate.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cocofhu/approving/internal/models"
 	gatenode "github.com/cocofhu/approving/internal/models/nodereg"
 	"github.com/cocofhu/approving/internal/runtime"
+	"github.com/cocofhu/approving/internal/services"
 	"github.com/rs/zerolog/log"
 )
 
@@ -71,7 +72,12 @@ func (e *Engine) captureDeliverable(c *execCtx, node *models.Node, res runtime.N
 		return
 	}
 	for _, a := range e.store.List(c.run.ID) {
-		if a.Node == node.ID && a.Name != mcp.NodeOutcomeArtifactName {
+		// Feedback ledger products hang off the real node id so the UI can group
+		// them, but they are platform-written side records — treating one as
+		// "this node already produced something" would suppress the node's
+		// actual deliverable the moment a reviewer pushes back.
+		if a.Node == node.ID && a.Name != mcp.NodeOutcomeArtifactName &&
+			!services.IsFeedbackArtifactName(a.Name) {
 			return
 		}
 	}

--- a/server/internal/engine/node_react.go
+++ b/server/internal/engine/node_react.go
@@ -86,15 +86,18 @@ func (e *Engine) autoAdvanceReact(c *execCtx, node *models.Node, conv *models.Re
 		if humanText == "" {
 			break
 		}
-		conv.Messages = append(conv.Messages, models.ReactMessage{Role: "human", Text: humanText,
-			At: time.Now().Format(time.RFC3339)})
+		humanMsg := models.ReactMessage{Role: "human", Text: humanText,
+			At: time.Now().Format(time.RFC3339)}
+		conv.Messages = append(conv.Messages, humanMsg)
 		t = e.provider.ReactReply(context.Background(), req, conv.Messages, humanText, nil, false)
 		acc = models.AddTokenUsage(acc, t.Usage)
 		accBy = models.AddTokenUsageByModel(accBy, t.UsageByModel)
-		conv.Messages = append(conv.Messages, models.ReactMessage{Role: "agent", Text: t.Msg,
-			At: time.Now().Format(time.RFC3339), Questions: t.Questions})
+		agentMsg := models.ReactMessage{Role: "agent", Text: t.Msg,
+			At: time.Now().Format(time.RFC3339), Questions: t.Questions}
+		conv.Messages = append(conv.Messages, agentMsg)
 		conv.Done = t.Done
 		logDB(e.db.Save(conv), c.run.ID, "auto react round")
+		e.recordAutoClarifyRound(c.run.ID, node.ID, conv.Iteration, humanMsg, agentMsg)
 	}
 	t.Usage = acc
 	t.UsageByModel = accBy

--- a/server/internal/engine/resume.go
+++ b/server/internal/engine/resume.go
@@ -211,6 +211,8 @@ func (e *Engine) resumeGateLocked(runID, nodeID, action string, form map[string]
 		e.recordAudit(rec)
 	}
 
+	e.recordGateFeedback(c, node, gate, action, form, reviewer, opts)
+
 	if e.shareRevoker != nil && node.Type == "human_gate" {
 		e.shareRevoker.RevokeUnusedForGate(runID, nodeID, gate.Iteration)
 	}
@@ -345,6 +347,8 @@ func (e *Engine) snapshotPreviewIssues(c *execCtx, runID, nodeID string) error {
 	e.persistVar(runID, "preview_issues", value)
 	c.setVar("preview_issues_count", len(issues))
 	e.persistVar(runID, "preview_issues_count", len(issues))
+
+	e.recordPreviewFeedback(c, nodeID, issues)
 
 	// Snapshot succeeded — close the lifecycle for this node's open issues.
 	return e.markPreviewIssuesResolvedByNode(runID, nodeID)

--- a/server/internal/engine/review_session.go
+++ b/server/internal/engine/review_session.go
@@ -476,12 +476,17 @@ func (e *Engine) executeClarifyTurn(ctx context.Context, s *reviewSession, item 
 		return false, errors.New("react already done")
 	}
 
+	// The questions this answer responds to, captured before the human turn is
+	// appended — without them the recorded answer reads as a bare fragment.
+	answered := lastAgentQuestions(conv.Messages)
+
 	now := time.Now().Format(time.RFC3339)
 	conv.Messages = append(conv.Messages, models.ReactMessage{
 		Role: "human", Text: item.Text, At: now,
 		Images: item.Images, Annotations: item.Annotations,
 	})
 	logDB(e.db.Save(&conv), s.runID, "save clarify human turn (turn_begin)")
+	humanMsg := conv.Messages[len(conv.Messages)-1]
 	e.broker.Publish(s.runID, jsonMsg("react", s.runID, s.producerID))
 
 	req := e.nodeReq(c, node)
@@ -503,6 +508,7 @@ func (e *Engine) executeClarifyTurn(ctx context.Context, s *reviewSession, item 
 		agentMsg.Text = "(已中断)"
 	}
 	conv.Messages = append(conv.Messages, agentMsg)
+	e.recordFeedback(e.clarifyFeedbackEvent(s, item, conv.Iteration, answered, humanMsg, agentMsg, interrupted))
 
 	if interrupted {
 		logDB(e.db.Save(&conv), s.runID, "save clarify agent turn (interrupted)")
@@ -620,11 +626,17 @@ func (e *Engine) executeReviewTurn(ctx context.Context, s *reviewSession, item *
 	})
 	logDB(e.db.Save(&conv), s.runID, "save review human turn (turn_begin)")
 
+	humanMsg := conv.Messages[len(conv.Messages)-1]
+
 	req := e.nodeReq(c, producer)
 	e.host.SetActiveReview(s.runID, true)
 
 	// Publish react so UIs that refetch on turn_begin see the human bubble.
 	e.broker.Publish(s.runID, jsonMsg("react", s.runID, s.producerID))
+
+	// Snapshot before the agent edits so the ledger can state which products
+	// this specific push-back moved.
+	beforeDigests := e.artifactDigests(s.runID, s.producerID)
 
 	t := rp.ReviseInPlace(ctx, req, conv.Messages, item.Effective, item.Images)
 
@@ -658,11 +670,16 @@ func (e *Engine) executeReviewTurn(ctx context.Context, s *reviewSession, item *
 			log.Warn().Err(t.Err).Str("run_id", s.runID).Str("producer", s.producerID).
 				Msg("review revise turn failed (session kept for retry)")
 		}
+		// The opinion was still given, so the round is recorded — only without
+		// targets, because nothing landed.
+		e.recordFeedback(e.reviewFeedbackEvent(s, item, iter, humanMsg, agentMsg, nil, true))
 		e.broker.Publish(s.runID, jsonMsg("react", s.runID, s.producerID))
 		return true, nil
 	}
 
 	e.refreshProducerOutputs(c, producer)
+	e.recordFeedback(e.reviewFeedbackEvent(s, item, iter, humanMsg, agentMsg,
+		diffDigests(beforeDigests, e.artifactDigests(s.runID, s.producerID)), false))
 	if item.Source == "gate" && item.GateNodeID != "" {
 		e.refreshGateBodyAfterRevise(c, item.GateNodeID)
 		e.appendTrace(c, models.TraceEntry{NodeID: item.GateNodeID, Event: "resume",

--- a/server/internal/mcp/feedback_history_test.go
+++ b/server/internal/mcp/feedback_history_test.go
@@ -1,0 +1,318 @@
+package mcp
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cocofhu/approving/internal/models"
+)
+
+func reviewEvent(node string, iter, round int, text, artifact string) models.FeedbackEvent {
+	return models.FeedbackEvent{
+		RunID: "r", Seq: round, Round: round, Kind: models.FeedbackKindReview,
+		NodeID: node, Iteration: iter, Text: text, ArtifactName: artifact,
+	}
+}
+
+// Every round in scope must show up, each citing its own product — that pointer
+// is what makes the overview a table of contents instead of a summary.
+func TestRunHistoryListsEveryFeedbackRoundWithArtifactCitation(t *testing.T) {
+	fh := twoGateRun()
+	fh.feedback = []models.FeedbackEvent{
+		reviewEvent("design", 2, 1, "证据不足", "feedback.review.design.i2r1.json"),
+		reviewEvent("design", 2, 2, "图表改柱状图", "feedback.review.design.i2r2.json"),
+		reviewEvent("design", 2, 3, "补上原始链接", "feedback.review.design.i2r3.json"),
+	}
+	h := NewHost(&memStore{})
+	h.SetHistoryProvider(fh)
+
+	out, err := h.RunHistory("r", "design", false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"证据不足", "图表改柱状图", "补上原始链接"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("round %q missing from overview:\n%s", want, out)
+		}
+	}
+	for i := 1; i <= 3; i++ {
+		cite := fmt.Sprintf("read_artifact feedback.review.design.i2r%d.json", i)
+		if !strings.Contains(out, cite) {
+			t.Fatalf("missing drill-down %q:\n%s", cite, out)
+		}
+	}
+	if !strings.Contains(out, "#2.3") {
+		t.Fatalf("rounds must be addressable as iteration.round:\n%s", out)
+	}
+}
+
+// A design-stage push-back must not reach the coding stage.
+func TestRunHistoryFeedbackScopeIsolation(t *testing.T) {
+	fh := twoGateRun()
+	fh.feedback = []models.FeedbackEvent{
+		reviewEvent("design", 1, 1, "设计要用直角", "feedback.review.design.i1r1.json"),
+		{RunID: "r", Seq: 2, Round: 1, Kind: models.FeedbackKindGate, NodeID: "gate1", Iteration: 1,
+			Text: "门禁意见:配色偏暗", ArtifactName: "feedback.gate.gate1.i1r1.json"},
+	}
+	h := NewHost(&memStore{})
+	h.SetHistoryProvider(fh)
+
+	design, _ := h.RunHistory("r", "design", false, false)
+	if !strings.Contains(design, "设计要用直角") || !strings.Contains(design, "配色偏暗") {
+		t.Fatalf("design must see its own round and its gate's round:\n%s", design)
+	}
+	code, _ := h.RunHistory("r", "code", false, false)
+	if strings.Contains(code, "设计要用直角") || strings.Contains(code, "配色偏暗") {
+		t.Fatalf("design-stage feedback leaked into the coding stage:\n%s", code)
+	}
+	all, _ := h.RunHistory("r", "code", true, false)
+	if !strings.Contains(all, "设计要用直角") {
+		t.Fatalf("all=true must drop the scope:\n%s", all)
+	}
+}
+
+// The rollback entries were always in the trace; the reader simply ignored
+// them, leaving a re-run node blind to the fact that it was sent back.
+func TestRunHistorySurfacesRollbackToTargetNode(t *testing.T) {
+	fh := twoGateRun()
+	fh.run.Trace = []models.TraceEntry{
+		{NodeID: "gate2", Event: "rollback", To: "code", Kind: models.EdgeRollback,
+			Detail: "attempt=2 携带 [last_error] 回滚到 checkpoint"},
+	}
+	h := NewHost(&memStore{})
+	h.SetHistoryProvider(fh)
+
+	code, _ := h.RunHistory("r", "code", false, false)
+	if !strings.Contains(code, "回退") || !strings.Contains(code, "attempt=2") {
+		t.Fatalf("the rolled-back node must see why it is running again:\n%s", code)
+	}
+	design, _ := h.RunHistory("r", "design", false, false)
+	if strings.Contains(design, "attempt=2") {
+		t.Fatalf("rollback belongs to its target node only:\n%s", design)
+	}
+	// A rollback is a machine decision, not human feedback.
+	onlyFb, _ := h.RunHistory("r", "code", false, true)
+	if strings.Contains(onlyFb, "attempt=2") {
+		t.Fatalf("only_feedback must exclude rollbacks:\n%s", onlyFb)
+	}
+}
+
+func TestRunHistoryOnlyFeedbackKeepsHumanRounds(t *testing.T) {
+	fh := twoGateRun()
+	fh.feedback = []models.FeedbackEvent{
+		reviewEvent("design", 1, 1, "人工打回意见", "feedback.review.design.i1r1.json"),
+	}
+	h := NewHost(&memStore{})
+	h.SetHistoryProvider(fh)
+
+	out, _ := h.RunHistory("r", "design", false, true)
+	if !strings.Contains(out, "人工打回意见") {
+		t.Fatalf("only_feedback now means all human feedback:\n%s", out)
+	}
+	if strings.Contains(out, "初版设计") {
+		t.Fatalf("only_feedback must drop plain node executions:\n%s", out)
+	}
+}
+
+func TestExecutionDetailRendersFeedbackRounds(t *testing.T) {
+	fh := twoGateRun()
+	fh.feedback = []models.FeedbackEvent{
+		reviewEvent("design", 2, 1, "第二版仍需调整", "feedback.review.design.i2r1.json"),
+		reviewEvent("design", 1, 1, "第一次的意见", "feedback.review.design.i1r1.json"),
+	}
+	h := NewHost(&memStore{})
+	h.SetHistoryProvider(fh)
+
+	d, err := h.ExecutionDetail("r", "design", 2, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(d, "第二版仍需调整") || !strings.Contains(d, "feedback.review.design.i2r1.json") {
+		t.Fatalf("detail must show the rounds of that execution:\n%s", d)
+	}
+	if strings.Contains(d, "第一次的意见") {
+		t.Fatalf("detail is scoped to one execution:\n%s", d)
+	}
+}
+
+// The prompt clause exists so an agent actually reads the ledger; injecting it
+// when there is nothing to read would be pure noise.
+func TestFeedbackBriefOnlyReportsInScopeRounds(t *testing.T) {
+	fh := twoGateRun()
+	fh.feedback = []models.FeedbackEvent{
+		reviewEvent("design", 1, 1, "用直角", "feedback.review.design.i1r1.json"),
+		{RunID: "r", Seq: 2, Round: 1, Kind: models.FeedbackKindClarify, NodeID: "design", Iteration: 1,
+			Text: "自动采纳", IndexOnly: true},
+	}
+	h := NewHost(&memStore{})
+	h.SetHistoryProvider(fh)
+
+	n, cites := h.FeedbackBrief("r", "design")
+	if n != 2 {
+		t.Fatalf("count = %d, want 2", n)
+	}
+	if len(cites) != 1 || !strings.Contains(cites[0], "feedback.review.design.i1r1.json") {
+		t.Fatalf("only rounds with products can be cited: %v", cites)
+	}
+	if n, _ := h.FeedbackBrief("r", "code"); n != 0 {
+		t.Fatalf("out-of-scope node must report zero, got %d", n)
+	}
+	if n, _ := h.FeedbackBrief("r", ""); n != 0 {
+		t.Fatalf("unknown node must report zero, got %d", n)
+	}
+}
+
+func TestFoldHistoryLinesKeepsHeadAndTail(t *testing.T) {
+	line := strings.Repeat("x", 500)
+	lines := make([]string, 80)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("%02d-%s", i, line)
+	}
+	got := foldHistoryLines(lines)
+	if len(got) >= len(lines) {
+		t.Fatalf("oversized overview must fold, got %d lines", len(got))
+	}
+	if got[0] != lines[0] {
+		t.Fatal("the earliest constraint must survive")
+	}
+	if got[len(got)-1] != lines[len(lines)-1] {
+		t.Fatal("the newest instruction must survive")
+	}
+	marker := 0
+	for _, l := range got {
+		if strings.Contains(l, "省略") {
+			marker++
+		}
+	}
+	if marker != 1 {
+		t.Fatalf("exactly one fold marker expected, got %d", marker)
+	}
+	// Small inputs pass through untouched.
+	small := []string{"a", "b", "c"}
+	if len(foldHistoryLines(small)) != 3 {
+		t.Fatal("within budget must not fold")
+	}
+}
+
+func TestFoldFeedbackArtifactsCollapsesRounds(t *testing.T) {
+	in := []ArtifactInfo{
+		{Name: "research.json", Node: "design", Size: 10},
+		{Name: "feedback.review.design.i1r1.json", Node: "design", Size: 20},
+		{Name: "feedback.review.design.i1r2.json", Node: "design", Size: 30},
+		{Name: FeedbackIndexArtifactName, Size: 40},
+	}
+	out := foldFeedbackArtifacts(in)
+	if len(out) != 2 {
+		t.Fatalf("rounds must fold behind the index, got %d: %+v", len(out), out)
+	}
+	var index *ArtifactInfo
+	for i := range out {
+		if out[i].Name == FeedbackIndexArtifactName {
+			index = &out[i]
+		}
+		if strings.HasPrefix(out[i].Name, FeedbackArtifactPrefix) {
+			t.Fatalf("per-round product still listed: %q", out[i].Name)
+		}
+	}
+	if index == nil || !strings.Contains(index.Note, "2") {
+		t.Fatalf("the index entry must say how many rounds it stands for: %+v", index)
+	}
+	// Rounds present without an index still get a pointer to read.
+	out2 := foldFeedbackArtifacts([]ArtifactInfo{{Name: "feedback.gate.g1.i1r1.json"}})
+	if len(out2) != 1 || out2[0].Name != FeedbackIndexArtifactName {
+		t.Fatalf("missing index must be synthesized: %+v", out2)
+	}
+	// Nothing to fold ⇒ list unchanged.
+	plain := []ArtifactInfo{{Name: "plan.json"}}
+	if got := foldFeedbackArtifacts(plain); len(got) != 1 || got[0].Name != "plan.json" {
+		t.Fatalf("plain list changed: %+v", got)
+	}
+}
+
+// The overview line is often all an agent reads about a round, so each kind and
+// action has to name itself in plain words rather than leak a raw enum.
+func TestFeedbackLineLabelsAndGist(t *testing.T) {
+	kinds := map[string]string{
+		models.FeedbackKindClarify: "澄清",
+		models.FeedbackKindReview:  "复审",
+		models.FeedbackKindGate:    "门禁",
+		models.FeedbackKindPreview: "预览问题单",
+		"something-else":           "反馈",
+	}
+	for kind, want := range kinds {
+		if got := feedbackKindLabel(kind); got != want {
+			t.Errorf("kind %q → %q, want %q", kind, got, want)
+		}
+	}
+
+	actions := []struct {
+		name string
+		ev   models.FeedbackEvent
+		want string
+	}{
+		{"auto answer", models.FeedbackEvent{Kind: models.FeedbackKindClarify, Action: "auto_answer"}, "自动采纳推荐项"},
+		{"review", models.FeedbackEvent{Kind: models.FeedbackKindReview}, "人工打回"},
+		{"clarify", models.FeedbackEvent{Kind: models.FeedbackKindClarify}, "人工回答"},
+		{"gate", models.FeedbackEvent{Kind: models.FeedbackKindGate, Action: "revise"}, "人工决定 action=revise"},
+		{"preview", models.FeedbackEvent{Kind: models.FeedbackKindPreview}, "人工问题单"},
+		{"unknown", models.FeedbackEvent{Kind: "x"}, "人工反馈"},
+	}
+	for _, c := range actions {
+		if got := feedbackActionLabel(c.ev); got != c.want {
+			t.Errorf("%s: got %q want %q", c.name, got, c.want)
+		}
+	}
+
+	gists := []struct {
+		name string
+		ev   models.FeedbackEvent
+		want string
+	}{
+		{"text first", models.FeedbackEvent{Text: "\n第一行\n第二行"}, "第一行"},
+		{"annotation note", models.FeedbackEvent{
+			Annotations: []models.ReactAnnotation{{Note: ""}, {Note: "补链接"}}}, "补链接"},
+		{"human turn", models.FeedbackEvent{
+			Turns: []models.ReactMessage{{Role: "agent", Text: "机器"}, {Role: "human", Text: "人说的"}}}, "人说的"},
+		{"nothing", models.FeedbackEvent{}, "(无正文)"},
+	}
+	for _, c := range gists {
+		if got := feedbackGist(c.ev); got != c.want {
+			t.Errorf("%s: got %q want %q", c.name, got, c.want)
+		}
+	}
+}
+
+// A round whose node no longer exists in the graph must not become visible
+// everywhere — an unresolvable scope is a closed scope.
+func TestFeedbackInScopeRequiresAKnownNode(t *testing.T) {
+	g := twoGateRun().run.Graph
+	ev := reviewEvent("design", 1, 1, "意见", "")
+	if feedbackInScope(g, ev, "") {
+		t.Fatal("no current node ⇒ nothing is in scope")
+	}
+	if !feedbackInScope(g, ev, "design") {
+		t.Fatal("a node sees its own rounds")
+	}
+	if feedbackInScope(g, ev, "code") {
+		t.Fatal("a review round belongs to its own node only")
+	}
+	orphan := models.FeedbackEvent{Kind: models.FeedbackKindGate, NodeID: "ghost-gate"}
+	if feedbackInScope(g, orphan, "code") {
+		t.Fatal("a gate that is not in the graph reviews nothing")
+	}
+}
+
+// The ledger records what humans said; it must not be rewritable through the
+// human-edit path, or it stops being evidence.
+func TestFeedbackProductsRejectHumanEdit(t *testing.T) {
+	for _, name := range []string{FeedbackIndexArtifactName, "feedback.review.design.i1r1.json"} {
+		if _, err := ValidateHumanArtifactContent(name, `{"a":1}`); err == nil {
+			t.Fatalf("%s must not be human-editable", name)
+		}
+	}
+	if _, err := ValidateHumanArtifactContent("research.json",
+		`{"summary":"s","findings":[{"title":"t","detail":"d"}]}`); err != nil {
+		t.Fatalf("a normal product must stay editable: %v", err)
+	}
+}

--- a/server/internal/mcp/history.go
+++ b/server/internal/mcp/history.go
@@ -11,12 +11,19 @@ import (
 )
 
 // HistoryProvider is the read-only source the run-history tools read from. It is
-// satisfied by services.RunService (States + Get) and injected via
-// SetHistoryProvider so the mcp package stays free of a service dependency.
+// satisfied by services.RunService (States + Get + FeedbackEvents) and injected
+// via SetHistoryProvider so the mcp package stays free of a service dependency.
 type HistoryProvider interface {
 	States(runID string) []models.StateRun
 	Get(runID string) (models.Run, bool)
+	FeedbackEvents(runID string) []models.FeedbackEvent
 }
+
+// historyBudgetBytes caps the overview. Breadth is never trimmed by count —
+// every round in scope gets a line — so only a genuinely huge run hits this,
+// and then the middle is folded while the earliest constraints and the latest
+// instructions both survive.
+const historyBudgetBytes = 16 * 1024
 
 // gateFeedback extracts the human's chosen action and any form input (e.g. a
 // review comment like "改用直角") from a resolved gate's persisted outputs.
@@ -130,13 +137,15 @@ func reviewedLabel(g models.Graph, ids []string) string {
 
 // RunHistory renders the progressive-disclosure overview of a run's execution
 // history. By default it is scoped to currentNode: that node's own past
-// executions plus any resolved-gate feedback whose segment covers currentNode.
-// all=true drops the scope (full timeline); onlyFeedback=true keeps only gate
-// feedback. Each line is self-labeled with the gate + reviewed stage + iteration
-// so an agent can never confuse which gate/stage a piece of feedback came from.
+// executions, any resolved-gate feedback whose segment covers currentNode, the
+// human feedback rounds recorded against it, and any rollback that landed on
+// it. all=true drops the scope (full timeline); onlyFeedback=true keeps only
+// human feedback. Each line is self-labeled with the node + iteration so an
+// agent can never confuse which gate/stage a piece of feedback came from.
 //
-// Human primary-artifact edits (trace event artifact_edit) are appended as
-// feedback-scoped lines so agents and the UI timeline can see「人改产物」.
+// Depth is what stays on demand: every feedback round cites its own product, so
+// the verbatim text, annotations, attachments and product diff are one
+// read_artifact away instead of being inlined here.
 func (h *Host) RunHistory(runID, currentNode string, all, onlyFeedback bool) (string, error) {
 	if h.history == nil {
 		return "", errors.New("history unavailable")
@@ -145,8 +154,7 @@ func (h *Host) RunHistory(runID, currentNode string, all, onlyFeedback bool) (st
 	g := run.Graph
 	states := h.history.States(runID)
 
-	var b strings.Builder
-	n := 0
+	var lines []string
 	for _, s := range states {
 		gate := isGateType(s.NodeType)
 		if onlyFeedback && !gate {
@@ -161,50 +169,215 @@ func (h *Host) RunHistory(runID, currentNode string, all, onlyFeedback bool) (st
 				continue
 			}
 		}
-		n++
 		if gate {
 			action, comment := gateFeedback(s)
 			reviewed := reviewedLabel(g, incomingSources(g, s.NodeID))
-			b.WriteString(fmt.Sprintf("- #%d [门禁 %s「%s」→ 审阶段 %s] 人工意见: action=%s",
-				s.Iteration, s.NodeID, gateTitle(g, s.NodeID), reviewed, action))
+			line := fmt.Sprintf("- #%d [门禁 %s「%s」→ 审阶段 %s] 人工意见: action=%s",
+				s.Iteration, s.NodeID, gateTitle(g, s.NodeID), reviewed, action)
 			if comment != "" {
-				b.WriteString(" · \"" + trunc(comment, 240) + "\"")
+				line += " · \"" + trunc(comment, 240) + "\""
 			}
-			b.WriteString(fmt.Sprintf("  (细节: get_history_detail node_id=%s iteration=%d)\n", s.NodeID, s.Iteration))
-		} else {
-			b.WriteString(fmt.Sprintf("- #%d [节点 %s「%s」] %s", s.Iteration, s.NodeID, nodeLabel(g, s.NodeID), s.Status))
-			if s.Error != "" {
-				b.WriteString(" · 错误: " + trunc(s.Error, 160))
-			} else if sum := firstLine(s.OutputMd); sum != "" {
-				b.WriteString(" — " + trunc(sum, 140))
-			}
-			b.WriteString("\n")
-		}
-	}
-	// Surface human artifact-edit audit events from the run trace (same scope
-	// rules as gate feedback: gate reviews currentNode, or all=true).
-	for _, te := range run.Trace {
-		if te.Event != "artifact_edit" {
+			lines = append(lines, line+fmt.Sprintf("  (细节: get_history_detail node_id=%s iteration=%d)",
+				s.NodeID, s.Iteration))
 			continue
 		}
-		if !all {
-			if currentNode == "" || (te.NodeID != currentNode && !gateReviewScope(g, te.NodeID)[currentNode]) {
-				continue
-			}
+		line := fmt.Sprintf("- #%d [节点 %s「%s」] %s", s.Iteration, s.NodeID, nodeLabel(g, s.NodeID), s.Status)
+		if s.Error != "" {
+			line += " · 错误: " + trunc(s.Error, 160)
+		} else if sum := firstLine(s.OutputMd); sum != "" {
+			line += " — " + trunc(sum, 140)
 		}
-		n++
-		b.WriteString(fmt.Sprintf("- [门禁 %s「%s」] 人改产物: %s\n",
-			te.NodeID, gateTitle(g, te.NodeID), trunc(te.Detail, 240)))
+		lines = append(lines, line)
 	}
-	if n == 0 {
+
+	lines = append(lines, traceHistoryLines(run, g, currentNode, all, onlyFeedback)...)
+	lines = append(lines, h.feedbackLines(runID, g, currentNode, all)...)
+
+	if len(lines) == 0 {
 		return "(暂无相关历史)", nil
 	}
 	scope := "当前阶段相关"
 	if all {
 		scope = "全部"
 	}
-	header := fmt.Sprintf("运行历史(%s,共 %d 条;历次人工反馈务必遵守,不要回退已确认的意见):\n", scope, n)
-	return header + b.String(), nil
+	header := fmt.Sprintf("运行历史(%s,共 %d 条;历次人工反馈务必遵守,不要回退已确认的意见):\n", scope, len(lines))
+	return header + strings.Join(foldHistoryLines(lines), "\n") + "\n", nil
+}
+
+// traceHistoryLines renders the run-trace entries that carry history an agent
+// needs: human product edits, and rollbacks.
+//
+// Rollback entries have always been written to the trace; they were simply
+// never read here, so a node re-run after a rollback had no way to learn that
+// it was sent back, on which attempt, or why. Scope follows the rollback
+// target, because that is the node about to run again.
+func traceHistoryLines(run models.Run, g models.Graph, currentNode string, all, onlyFeedback bool) []string {
+	var out []string
+	for _, te := range run.Trace {
+		switch te.Event {
+		case "artifact_edit":
+			if !all {
+				if currentNode == "" || (te.NodeID != currentNode && !gateReviewScope(g, te.NodeID)[currentNode]) {
+					continue
+				}
+			}
+			out = append(out, fmt.Sprintf("- [门禁 %s「%s」] 人改产物: %s",
+				te.NodeID, gateTitle(g, te.NodeID), trunc(te.Detail, 240)))
+		case "rollback":
+			// A rollback is a machine routing decision, not human feedback.
+			if onlyFeedback {
+				continue
+			}
+			if !all && (currentNode == "" || te.To != currentNode) {
+				continue
+			}
+			out = append(out, fmt.Sprintf("- [回退 %s「%s」→ %s「%s」] %s",
+				te.NodeID, nodeLabel(g, te.NodeID), te.To, nodeLabel(g, te.To), trunc(te.Detail, 240)))
+		}
+	}
+	return out
+}
+
+// feedbackLines renders one line per recorded feedback round, each citing the
+// product that holds its full body.
+func (h *Host) feedbackLines(runID string, g models.Graph, currentNode string, all bool) []string {
+	var out []string
+	for _, ev := range h.history.FeedbackEvents(runID) {
+		if !all && !feedbackInScope(g, ev, currentNode) {
+			continue
+		}
+		line := fmt.Sprintf("- #%d.%d [%s %s「%s」] %s: \"%s\"",
+			ev.Iteration, ev.Round, feedbackKindLabel(ev.Kind), ev.NodeID, nodeLabel(g, ev.NodeID),
+			feedbackActionLabel(ev), trunc(feedbackGist(ev), 240))
+		if n := len(ev.Annotations); n > 0 {
+			line += fmt.Sprintf(" · 标注%d", n)
+		}
+		if n := len(ev.Attachments); n > 0 {
+			line += fmt.Sprintf(" 附件%d", n)
+		}
+		if ev.Interrupted {
+			line += " · (该轮修改被中断,未落地)"
+		}
+		if ev.ArtifactName != "" {
+			line += "\n      (细节: read_artifact " + ev.ArtifactName + ")"
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+// feedbackInScope decides whether a round is relevant to currentNode.
+//
+// Node-bound rounds (clarify / review) belong to the node that was revised.
+// Gate-bound rounds (gate / preview) reach the stages the gate reviews, using
+// the same backward BFS as gate feedback so a design gate's opinion never leaks
+// into a later coding stage.
+func feedbackInScope(g models.Graph, ev models.FeedbackEvent, currentNode string) bool {
+	if currentNode == "" {
+		return false
+	}
+	if ev.NodeID == currentNode {
+		return true
+	}
+	switch ev.Kind {
+	case models.FeedbackKindGate, models.FeedbackKindPreview:
+		return gateReviewScope(g, ev.NodeID)[currentNode]
+	default:
+		return false
+	}
+}
+
+func feedbackKindLabel(kind string) string {
+	switch kind {
+	case models.FeedbackKindClarify:
+		return "澄清"
+	case models.FeedbackKindReview:
+		return "复审"
+	case models.FeedbackKindGate:
+		return "门禁"
+	case models.FeedbackKindPreview:
+		return "预览问题单"
+	default:
+		return "反馈"
+	}
+}
+
+func feedbackActionLabel(ev models.FeedbackEvent) string {
+	switch {
+	case ev.Action == "auto_answer":
+		return "自动采纳推荐项"
+	case ev.Kind == models.FeedbackKindReview:
+		return "人工打回"
+	case ev.Kind == models.FeedbackKindClarify:
+		return "人工回答"
+	case ev.Kind == models.FeedbackKindGate:
+		return "人工决定 action=" + ev.Action
+	case ev.Kind == models.FeedbackKindPreview:
+		return "人工问题单"
+	default:
+		return "人工反馈"
+	}
+}
+
+// feedbackGist picks the one-line body for an overview row.
+func feedbackGist(ev models.FeedbackEvent) string {
+	if s := firstLine(ev.Text); s != "" {
+		return s
+	}
+	for _, a := range ev.Annotations {
+		if n := strings.TrimSpace(a.Note); n != "" {
+			return n
+		}
+	}
+	for _, t := range ev.Turns {
+		if t.Role == "human" {
+			if s := firstLine(t.Text); s != "" {
+				return s
+			}
+		}
+	}
+	return "(无正文)"
+}
+
+// foldHistoryLines keeps the overview under the byte budget by dropping a
+// contiguous middle run of lines rather than a suffix: the earliest constraints
+// and the newest instructions are the two things an agent must not miss, and a
+// plain truncation would always sacrifice one of them.
+func foldHistoryLines(lines []string) []string {
+	total := 0
+	for _, l := range lines {
+		total += len(l) + 1
+	}
+	if total <= historyBudgetBytes || len(lines) <= 2 {
+		return lines
+	}
+
+	head, tail := 1, 1
+	used := len(lines[0]) + len(lines[len(lines)-1]) + 2
+	for head+tail < len(lines) {
+		// Grow from the tail first: recent instructions supersede older ones.
+		if next := len(lines) - tail - 1; used+len(lines[next])+1 <= historyBudgetBytes {
+			used += len(lines[next]) + 1
+			tail++
+			continue
+		}
+		if used+len(lines[head])+1 <= historyBudgetBytes {
+			used += len(lines[head]) + 1
+			head++
+			continue
+		}
+		break
+	}
+	omitted := len(lines) - head - tail
+	if omitted <= 0 {
+		return lines
+	}
+	marker := fmt.Sprintf("- …省略第 %d–%d 条,用 read_artifact 或 get_history_detail 逐条查看",
+		head+1, head+omitted)
+	out := make([]string, 0, head+tail+1)
+	out = append(out, lines[:head]...)
+	out = append(out, marker)
+	return append(out, lines[len(lines)-tail:]...)
 }
 
 // ExecutionDetail renders the drill-down for one node execution. iteration<=0
@@ -264,6 +437,9 @@ func (h *Host) ExecutionDetail(runID, nodeID string, iteration int, includeLog b
 	if len(chosen.VarsSnapshot) > 0 {
 		b.WriteString("变量快照: " + truncJSON(chosen.VarsSnapshot, 1000) + "\n")
 	}
+	if fb := renderExecutionFeedback(h.history.FeedbackEvents(runID), nodeID, chosen.Iteration); fb != "" {
+		b.WriteString("\n" + fb)
+	}
 	if includeLog && len(chosen.Events) > 0 {
 		b.WriteString("\n事件日志:\n")
 		for _, e := range chosen.Events {
@@ -278,6 +454,55 @@ func (h *Host) ExecutionDetail(runID, nodeID string, iteration int, includeLog b
 		}
 	}
 	return b.String(), nil
+}
+
+// FeedbackBrief returns the number of feedback rounds in scope for a node and
+// a one-line citation per round that has a product.
+//
+// This is what puts the ledger in front of an agent: list_run_history existed
+// long before anything told an agent to call it, so a node re-run after a
+// push-back saw only the original prompt. The prompt clause built from this is
+// injected only when the count is non-zero.
+func (h *Host) FeedbackBrief(runID, nodeID string) (int, []string) {
+	if h.history == nil || strings.TrimSpace(nodeID) == "" {
+		return 0, nil
+	}
+	run, _ := h.history.Get(runID)
+	count := 0
+	var lines []string
+	for _, ev := range h.history.FeedbackEvents(runID) {
+		if !feedbackInScope(run.Graph, ev, nodeID) {
+			continue
+		}
+		count++
+		if ev.ArtifactName == "" {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("`%s` — 第%d次执行第%d轮 %s: %s",
+			ev.ArtifactName, ev.Iteration, ev.Round, feedbackKindLabel(ev.Kind),
+			trunc(feedbackGist(ev), 120)))
+	}
+	return count, lines
+}
+
+// renderExecutionFeedback lists the feedback rounds recorded against one node
+// execution, pointing at each round's product for the full text.
+func renderExecutionFeedback(events []models.FeedbackEvent, nodeID string, iteration int) string {
+	var b strings.Builder
+	for _, ev := range events {
+		if ev.NodeID != nodeID || ev.Iteration != iteration {
+			continue
+		}
+		fmt.Fprintf(&b, "- 第%d轮 %s %s: %s\n", ev.Round, feedbackKindLabel(ev.Kind),
+			feedbackActionLabel(ev), trunc(feedbackGist(ev), 400))
+		if ev.ArtifactName != "" {
+			b.WriteString("  (完整内容: read_artifact " + ev.ArtifactName + ")\n")
+		}
+	}
+	if b.Len() == 0 {
+		return ""
+	}
+	return "人工反馈轮次(务必遵守,不要回退已确认的意见):\n" + b.String()
 }
 
 // --- shared string helpers -------------------------------------------------

--- a/server/internal/mcp/history_test.go
+++ b/server/internal/mcp/history_test.go
@@ -9,12 +9,16 @@ import (
 
 // fakeHistory is an in-memory HistoryProvider for the run-history tools.
 type fakeHistory struct {
-	states []models.StateRun
-	run    models.Run
+	states   []models.StateRun
+	run      models.Run
+	feedback []models.FeedbackEvent
 }
 
 func (f *fakeHistory) States(runID string) []models.StateRun { return f.states }
 func (f *fakeHistory) Get(runID string) (models.Run, bool)   { return f.run, true }
+func (f *fakeHistory) FeedbackEvents(runID string) []models.FeedbackEvent {
+	return f.feedback
+}
 
 // twoGateRun builds a pipeline: input → design → gate1(revise→design) →
 // code → gate2(revise→code) → output, with one resolved feedback per gate.

--- a/server/internal/mcp/host.go
+++ b/server/internal/mcp/host.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/cocofhu/approving/internal/models"
@@ -27,6 +28,22 @@ type ArtifactInfo struct {
 	Name string `json:"name"`
 	Node string `json:"node"`
 	Size int    `json:"size"`
+	// Note explains a synthesized entry (currently only the folded feedback
+	// ledger), so a listing that stands in for many products says so.
+	Note string `json:"note,omitempty"`
+}
+
+// Feedback ledger product names. Per-round products are written by the
+// platform, never by an agent, and are folded behind the index in listings.
+const (
+	FeedbackIndexArtifactName = "feedback_index.json"
+	FeedbackArtifactPrefix    = "feedback."
+)
+
+// IsFeedbackArtifactName reports whether name belongs to the feedback ledger.
+func IsFeedbackArtifactName(name string) bool {
+	name = strings.TrimSpace(name)
+	return name == FeedbackIndexArtifactName || strings.HasPrefix(name, FeedbackArtifactPrefix)
 }
 
 // Store is the persistence backend the MCP writes through. Implemented by
@@ -425,12 +442,48 @@ func (h *Host) ReadArtifact(runID, token, name string) (string, error) {
 	return content, nil
 }
 
-// ListArtifacts lists products of the current run only.
+// ListArtifacts lists products of the current run only, with the per-round
+// feedback ledger folded behind its index.
 func (h *Host) ListArtifacts(runID, token string) ([]ArtifactInfo, error) {
 	if !h.authorize(runID, token) {
 		return nil, ErrUnauthorized
 	}
-	return h.store.List(runID), nil
+	return foldFeedbackArtifacts(h.store.List(runID)), nil
+}
+
+// foldFeedbackArtifacts collapses feedback.* into the index entry.
+//
+// A long review can produce dozens of rounds; listing each one would bury the
+// actual deliverables in bookkeeping. The index is the documented entry point,
+// and it names every round for read_artifact, so nothing becomes unreachable.
+func foldFeedbackArtifacts(in []ArtifactInfo) []ArtifactInfo {
+	out := make([]ArtifactInfo, 0, len(in))
+	folded, indexAt := 0, -1
+	for _, a := range in {
+		switch {
+		case a.Name == FeedbackIndexArtifactName:
+			indexAt = len(out)
+			out = append(out, a)
+		case strings.HasPrefix(a.Name, FeedbackArtifactPrefix):
+			folded++
+		default:
+			out = append(out, a)
+		}
+	}
+	if folded == 0 {
+		return out
+	}
+	entry := ArtifactInfo{
+		Name: FeedbackIndexArtifactName,
+		Note: fmt.Sprintf("人工反馈台账:已折叠 %d 轮单轮产物,读本索引取轮次清单与产物名", folded),
+	}
+	if indexAt >= 0 {
+		entry.Node = out[indexAt].Node
+		entry.Size = out[indexAt].Size
+		out[indexAt] = entry
+		return out
+	}
+	return append(out, entry)
 }
 
 // PlanIncomplete returns descriptions of the run plan's not-yet-done leaf items

--- a/server/internal/mcp/human_artifact.go
+++ b/server/internal/mcp/human_artifact.go
@@ -32,6 +32,12 @@ func ValidateHumanArtifactContent(name, content string) (HumanArtifactNormalized
 	if strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") {
 		return HumanArtifactNormalized{}, errors.New("产物名非法")
 	}
+	// The feedback ledger is an append-only record of what humans actually said.
+	// Letting it be edited through the human-artifact path would make it
+	// unciteable evidence, so it is platform-written only.
+	if IsFeedbackArtifactName(name) {
+		return HumanArtifactNormalized{}, fmt.Errorf("产物 %q 为人工反馈台账，由平台自动记录，不可编辑", name)
+	}
 	kind := gatenode.InferArtifactKind(name)
 	out := HumanArtifactNormalized{Name: name, Kind: kind, Content: content, OutKey: gatenode.ArtifactToOutputKey[name]}
 

--- a/server/internal/mcp/tools.go
+++ b/server/internal/mcp/tools.go
@@ -469,27 +469,30 @@ func artifactTools() []map[string]any {
 			},
 		},
 		{
-			"name":        "list_artifacts",
-			"description": "列出本次运行已有产物清单([{name,node,size}])。",
+			"name": "list_artifacts",
+			"description": "列出本次运行已有产物清单([{name,node,size}])。" +
+				"人工反馈产物(feedback.*)会折叠成 feedback_index.json 一条,先读索引再按需 read_artifact 取单轮详情。",
 			"inputSchema": map[string]any{"type": "object", "properties": map[string]any{}},
 		},
 		{
 			"name": "list_run_history",
-			"description": "回看本次运行的执行历史概览(渐进式披露)。默认只返回与当前阶段相关的记录:本节点的历次执行 + 指向本节点的门禁人工反馈;" +
-				"每条都标注了来自哪个门禁、评审哪个阶段、第几次,便于对齐。**历次人工反馈务必遵守,不要在新一轮里回退已确认的意见(如之前要求的样式)。**" +
-				"需要某条的完整内容时用 get_history_detail 下钻。",
+			"description": "回看本次运行的执行历史概览(渐进式披露)。默认只返回与当前阶段相关的记录:本节点的历次执行、指向本节点的门禁人工反馈、" +
+				"本节点收到的每一轮人工反馈(澄清/复审/门禁/预览问题单),以及回退到本节点的记录;" +
+				"每条都标注了来自哪个节点、第几次执行、第几轮,便于对齐。**历次人工反馈务必遵守,不要在新一轮里回退已确认的意见(如之前要求的样式)。**" +
+				"每轮反馈都带有独立产物名,用 read_artifact 读取该轮的完整原文、标注与附件;执行细节则用 get_history_detail 下钻。",
 			"inputSchema": map[string]any{
 				"type": "object",
 				"properties": map[string]any{
 					"all":           map[string]any{"type": "boolean", "description": "可选:true 则返回整条时间线(忽略当前阶段作用域)"},
-					"only_feedback": map[string]any{"type": "boolean", "description": "可选:true 则只返回门禁人工反馈"},
+					"only_feedback": map[string]any{"type": "boolean", "description": "可选:true 则只返回人工反馈(门禁决定、各轮打回/回答/问题单、人改产物),不含机器回退与普通执行"},
 					"node_id":       strProp("可选:指定节点 id 作为作用域,默认当前执行节点"),
 				},
 			},
 		},
 		{
-			"name":        "get_history_detail",
-			"description": "下钻查看某次执行/门禁的完整细节(状态、错误、输出摘要、关键输出、变量快照;门禁则含人工的动作与填写)。配合 list_run_history 使用。",
+			"name": "get_history_detail",
+			"description": "下钻查看某次执行/门禁的完整细节(状态、错误、输出摘要、关键输出、变量快照;门禁则含人工的动作与填写;" +
+				"并列出该次执行收到的各轮人工反馈及其产物名)。配合 list_run_history 使用。",
 			"inputSchema": map[string]any{
 				"type": "object",
 				"properties": map[string]any{

--- a/server/internal/models/feedback.go
+++ b/server/internal/models/feedback.go
@@ -1,0 +1,111 @@
+package models
+
+import (
+	"strings"
+	"time"
+)
+
+// Feedback event kinds. Only human-originated events are recorded: rollback /
+// auto-retry / resume-from are machine routing decisions and stay out of this
+// table entirely (the run trace already carries them).
+const (
+	FeedbackKindClarify = "clarify"
+	FeedbackKindReview  = "review"
+	FeedbackKindGate    = "gate"
+	FeedbackKindPreview = "preview"
+)
+
+// FeedbackEvent is one round of human feedback on a run, persisted append-only.
+//
+// It is the source of truth from which the per-round feedback artifacts and
+// feedback_index.json are rendered, mirroring how run_error.json is derived
+// from StateRun. Rows are only ever INSERTed: a node visited N times with M
+// revise turns each keeps every one of them, because losing a round loses the
+// reviewer's reasoning for that round.
+//
+// Two ordinals are carried on purpose. Seq is the run-global order. Round is
+// the ordinal within (NodeID, Iteration) — one execution can hold many revise
+// turns, so Iteration alone cannot address "the 3rd push-back of the 2nd run".
+// Round is what makes the artifact name unique, and therefore what makes the
+// artifact store's (run_id, name) upsert non-destructive.
+type FeedbackEvent struct {
+	ID    uint   `gorm:"primaryKey" json:"-"`
+	RunID string `gorm:"index" json:"runId"`
+	Seq   int    `json:"seq"`
+	Round int    `json:"round"`
+	Kind  string `json:"kind"`
+
+	NodeID    string `json:"nodeId"`
+	Iteration int    `json:"iteration"`
+
+	Actor          string `json:"actor,omitempty"`
+	Unattributable bool   `json:"unattributable,omitempty"`
+	CallerKind     string `json:"callerKind,omitempty"` // pm | apikey | system | external
+
+	// Action is the kind-specific verb: revise | answer | auto_answer |
+	// snapshot, or the gate action id for a gate decision.
+	Action string `json:"action,omitempty"`
+	// Text is the human's verbatim opinion.
+	Text string `json:"text,omitempty"`
+	// Interrupted marks a revise turn whose agent reply was cancelled or
+	// failed. The opinion was still given, so the round is kept — only its
+	// Targets are absent because nothing landed.
+	Interrupted bool `json:"interrupted,omitempty"`
+
+	// ArtifactName is the per-round product this event rendered to. Empty when
+	// IndexOnly is set.
+	ArtifactName string `json:"artifactName,omitempty"`
+	// IndexOnly marks a round that is listed in the index but gets no
+	// standalone product. Used for platform auto-answered clarify rounds: they
+	// shape the requirement and later rounds need that context, but there is no
+	// human prose worth a file of its own.
+	IndexOnly bool `json:"indexOnly,omitempty"`
+
+	Annotations []ReactAnnotation `gorm:"serializer:json" json:"annotations,omitempty"`
+	// Attachments must only carry blob refs; PromptImage.Data is cleared before
+	// persistence so base64 never reaches the DB or the rendered artifact.
+	Attachments []PromptImage `gorm:"serializer:json" json:"attachments,omitempty"`
+	// Turns is this round's incremental dialogue, not the whole conversation.
+	Turns   []ReactMessage   `gorm:"serializer:json" json:"turns,omitempty"`
+	Targets []FeedbackTarget `gorm:"serializer:json" json:"targets,omitempty"`
+	// Detail carries kind-specific fields: gate stores form / goto / external;
+	// preview stores each issue's selector / port.
+	Detail map[string]any `gorm:"serializer:json" json:"detail,omitempty"`
+
+	OccurredAt time.Time `json:"at"`
+}
+
+// FeedbackTarget records the before/after digest of a product a round of
+// feedback changed, so "what did this push-back actually alter" is answerable
+// without diffing the artifact store by hand.
+type FeedbackTarget struct {
+	Name    string `json:"name"`
+	Before  string `json:"before,omitempty"` // sha256[:16]
+	After   string `json:"after,omitempty"`
+	Changed bool   `json:"changed"`
+}
+
+// WantsArtifact reports whether this round gets its own product file.
+func (e FeedbackEvent) WantsArtifact() bool { return !e.IndexOnly }
+
+// HasSubstance reports whether the event carries actual human input worth
+// persisting: an opinion, an annotation, an attachment, or a ReAct turn.
+//
+// This is the single gate on the whole feature. A gate approval clicked through
+// with an empty form has none of the four and must not produce a row or a
+// product — otherwise bulk sign-off floods the run with empty shells.
+func (e FeedbackEvent) HasSubstance() bool {
+	if strings.TrimSpace(e.Text) != "" {
+		return true
+	}
+	if len(e.Annotations) > 0 || len(e.Attachments) > 0 {
+		return true
+	}
+	for _, t := range e.Turns {
+		if strings.TrimSpace(t.Text) != "" || len(t.Questions) > 0 ||
+			len(t.Annotations) > 0 || len(t.Images) > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/server/internal/models/feedback_test.go
+++ b/server/internal/models/feedback_test.go
@@ -1,0 +1,55 @@
+package models
+
+import (
+	"strings"
+	"testing"
+)
+
+// HasSubstance is the single gate deciding whether a round is recorded at all,
+// so each of the four qualifying inputs is pinned individually.
+func TestFeedbackEventHasSubstance(t *testing.T) {
+	cases := []struct {
+		name string
+		ev   FeedbackEvent
+		want bool
+	}{
+		{"empty gate approval", FeedbackEvent{Kind: FeedbackKindGate, Action: "pass"}, false},
+		{"blank text only", FeedbackEvent{Text: "   \n\t "}, false},
+		{"empty turns", FeedbackEvent{Turns: []ReactMessage{{Role: "agent", Text: "  "}}}, false},
+		{"opinion text", FeedbackEvent{Text: "证据不足"}, true},
+		{"annotation", FeedbackEvent{Annotations: []ReactAnnotation{{JSONPath: "$.a"}}}, true},
+		{"attachment", FeedbackEvent{Attachments: []PromptImage{{Ref: "blob:x"}}}, true},
+		{"react turn", FeedbackEvent{Turns: []ReactMessage{{Role: "human", Text: "改这里"}}}, true},
+		{"turn with questions only", FeedbackEvent{
+			Turns: []ReactMessage{{Role: "agent", Questions: []ReactQuestion{{Prompt: "选哪个?"}}}}}, true},
+		{"turn with image only", FeedbackEvent{
+			Turns: []ReactMessage{{Role: "human", Images: []PromptImage{{Ref: "blob:x"}}}}}, true},
+	}
+	for _, c := range cases {
+		if got := c.ev.HasSubstance(); got != c.want {
+			t.Errorf("%s: HasSubstance() = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestFeedbackEventWantsArtifact(t *testing.T) {
+	if !(FeedbackEvent{}).WantsArtifact() {
+		t.Error("a normal round gets its own product")
+	}
+	if (FeedbackEvent{IndexOnly: true}).WantsArtifact() {
+		t.Error("an index-only round must not claim a product")
+	}
+}
+
+func TestFeedbackHeaderForSubstitutesCount(t *testing.T) {
+	got := FeedbackHeaderFor(3)
+	if want := "已收到 3 轮人工反馈"; !strings.Contains(got, want) {
+		t.Fatalf("FeedbackHeaderFor(3) missing %q:\n%s", want, got)
+	}
+	if strings.Contains(got, "{n}") {
+		t.Fatal("placeholder left unsubstituted")
+	}
+	if !strings.Contains(got, "list_run_history") || !strings.Contains(got, "read_artifact") {
+		t.Fatal("the clause must name both tools an agent needs to act on it")
+	}
+}

--- a/server/internal/models/models.go
+++ b/server/internal/models/models.go
@@ -691,7 +691,7 @@ func AllModels() []any {
 		&WorkflowDef{}, &WorkflowVersion{}, &Run{}, &StateRun{},
 		&RunVariable{}, &Artifact{}, &Gate{}, &ReactConversation{},
 		&Sandbox{}, &SandboxLog{}, &Setting{}, &Session{}, &WorkflowAPIKey{},
-		&RunPreviewPort{}, &PreviewIssue{},
+		&RunPreviewPort{}, &PreviewIssue{}, &FeedbackEvent{},
 		&ProjectMemoryItem{}, &ChatThread{}, &ChatMessage{}, &ChatTurnDraft{},
 		&AgentCronJob{}, &AgentCronRun{}, &ChannelConfig{},
 		&ProjectAuditEvent{},

--- a/server/internal/models/prompts.go
+++ b/server/internal/models/prompts.go
@@ -1,6 +1,9 @@
 package models
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+)
 
 // AgentPrompts holds a per-Agent override of the platform-injected prompt text
 // and sandbox rule files. It is persisted in the Agent's agent.json under the
@@ -103,7 +106,18 @@ const (
 	DefaultPreviewRetry                 = "【必须完成】你尚未成功调用 `set_preview` 注册**可达**的预览端口。请在沙箱内用 `setsid`/`nohup` **真后台**原生启动应用(不要用 docker、不要前台占会话),监听 `0.0.0.0:<port>`(不能只绑 127.0.0.1;服务在根路径 `/`),确认端口可访问后再调用 `set_preview(port, label?)`。端口不可达时 set_preview 会失败,修复后可重试。"
 	DefaultOutcomeContract              = "\n\n## 完成标记契约(强制)\n结束本节点前**必须**调用 `node_complete` 标记结果:`status` 取 `success` 或 `failed`;可选 `summary` / `error` / `outputs` / `checks`。写完产物(`set_*` / `write_artifact`)后再调用。未标记将被判定为节点失败。平台先做默认校验(产物/门禁等),通过后才可能做业务 RPC 校验。\n"
 	DefaultOutcomeRetry                 = "【必须完成】你尚未调用 `node_complete` 标记本节点完成结果,这是强制要求。现在立即调用 `node_complete(status=\"success\"|\"failed\", summary?, error?, outputs?)`,不要再提问或输出其它内容——只需完成这次调用。\n"
+
+	// DefaultFeedbackHeader is injected only when this node actually has human
+	// feedback in scope. Storing feedback that no agent ever reads is the same
+	// as not storing it, and a node's first execution has nothing to read, so
+	// the clause must not appear there as noise.
+	DefaultFeedbackHeader = "\n\n## 历史人工反馈(强制先读)\n本节点此前已收到 {n} 轮人工反馈。**开工前必须先调用 `list_run_history` 通读**,再用 `read_artifact` 逐个读取下列反馈产物的完整内容(含原文、标注与附件)。历次已确认的意见务必遵守,不得在新一轮里回退:\n"
 )
+
+// FeedbackHeaderFor renders the history-feedback clause for n rounds.
+func FeedbackHeaderFor(n int) string {
+	return strings.ReplaceAll(DefaultFeedbackHeader, "{n}", strconv.Itoa(n))
+}
 
 // UpstreamHeader returns the configured upstream-artifacts header or the
 // built-in default. Nil-safe.

--- a/server/internal/runtime/acp_prompt.go
+++ b/server/internal/runtime/acp_prompt.go
@@ -22,6 +22,12 @@ func (c *acpProvider) buildAgentPrompt(req NodeReq, seeded []string) string {
 			fmt.Fprintf(&b, "- `%s`\n", n)
 		}
 	}
+	if n, cites := c.host.FeedbackBrief(req.RunID, req.NodeID); n > 0 {
+		b.WriteString(models.FeedbackHeaderFor(n))
+		for _, cite := range cites {
+			fmt.Fprintf(&b, "- %s\n", cite)
+		}
+	}
 
 	source, target := mrBranches(req)
 	if clause := nodereg.PromptContractText(prompts, req.NodeType, source, mrTargetDisplay(target)); clause != "" {

--- a/server/internal/runtime/acp_unit_test.go
+++ b/server/internal/runtime/acp_unit_test.go
@@ -162,6 +162,62 @@ func TestBuildAgentPromptPerType(t *testing.T) {
 	}
 }
 
+// stubHistory feeds the host the two run-scoped reads FeedbackBrief needs.
+type stubHistory struct {
+	run      models.Run
+	feedback []models.FeedbackEvent
+}
+
+func (s *stubHistory) States(string) []models.StateRun { return nil }
+func (s *stubHistory) Get(string) (models.Run, bool)   { return s.run, true }
+func (s *stubHistory) FeedbackEvents(string) []models.FeedbackEvent {
+	return s.feedback
+}
+
+// Stored feedback an agent is never told to read is the same as no feedback, so
+// the clause must appear when — and only when — the node has rounds in scope.
+func TestBuildAgentPromptInjectsFeedbackOnlyWhenInScope(t *testing.T) {
+	host := mcp.NewHost(newMemStore())
+	host.SetHistoryProvider(&stubHistory{
+		run: models.Run{ID: "r1", Graph: models.Graph{
+			Nodes: []models.Node{{ID: "impl", Type: "implement"}, {ID: "other", Type: "implement"}},
+		}},
+		feedback: []models.FeedbackEvent{{
+			RunID: "r1", Kind: models.FeedbackKindReview, NodeID: "impl", Iteration: 2, Round: 3,
+			Text:         "第 3 条证据不足," + strings.Repeat("请补上原始链接。", 40),
+			ArtifactName: "feedback.review.impl.i2r3.json",
+		}},
+	})
+	p := newACPProvider(host, Options{}).(*acpProvider)
+
+	got := p.buildAgentPrompt(NodeReq{
+		RunID: "r1", NodeID: "impl", NodeType: "implement",
+		Config: map[string]any{"prompt": "P"},
+	}, nil)
+	if !strings.Contains(got, "历史人工反馈") || !strings.Contains(got, "list_run_history") {
+		t.Fatalf("node with feedback must be told to read it:\n%s", got)
+	}
+	if !strings.Contains(got, "feedback.review.impl.i2r3.json") {
+		t.Fatalf("the round's product must be cited by name:\n%s", got)
+	}
+	// One line per round, not the body — a long push-back must not push the
+	// node's own instructions out of the context window.
+	if !strings.Contains(got, "第 3 条证据不足") {
+		t.Fatalf("the round needs a readable gist:\n%s", got)
+	}
+	if strings.Contains(got, strings.Repeat("请补上原始链接。", 40)) {
+		t.Fatalf("full opinion text must not be inlined into the prompt:\n%s", got)
+	}
+
+	clean := p.buildAgentPrompt(NodeReq{
+		RunID: "r1", NodeID: "other", NodeType: "implement",
+		Config: map[string]any{"prompt": "P"},
+	}, nil)
+	if strings.Contains(clean, "历史人工反馈") {
+		t.Fatalf("a node with no feedback in scope must not carry the clause:\n%s", clean)
+	}
+}
+
 func TestTestNodePromptExtras(t *testing.T) {
 	host := mcp.NewHost(newMemStore())
 	p := newACPProvider(host, Options{}).(*acpProvider)

--- a/server/internal/services/feedback.go
+++ b/server/internal/services/feedback.go
@@ -1,0 +1,341 @@
+package services
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+
+	"gorm.io/gorm"
+)
+
+// Budgets for rendered feedback products. A reviewer can paste a lot; the row
+// keeps what they wrote, the product keeps a bounded version so one verbose
+// round cannot dominate the ledger or an Agent's context window.
+const (
+	feedbackTextMax    = 8 * 1024
+	feedbackTurnMax    = 4 * 1024
+	feedbackSummaryMax = 240
+)
+
+// ErrFeedbackNoSubstance is returned by Append when the event carries no human
+// input at all. Callers treat it as a no-op, not a failure.
+var ErrFeedbackNoSubstance = errors.New("feedback event has no substance")
+
+// FeedbackService persists human feedback rounds and renders them into
+// products. The table is the source of truth; the artifacts are derived, the
+// same split run_error.json uses over StateRun.
+type FeedbackService struct{ db *gorm.DB }
+
+// NewFeedbackService builds the service.
+func NewFeedbackService(db *gorm.DB) *FeedbackService { return &FeedbackService{db: db} }
+
+// Append assigns the two ordinals and inserts the event.
+//
+// Seq is run-global; Round is scoped to (NodeID, Iteration) and is what makes
+// the per-round artifact name unique. Both are allocated inside one
+// transaction so two concurrent rounds cannot claim the same name and
+// overwrite each other in the artifact store.
+//
+// Events without substance are rejected with ErrFeedbackNoSubstance and never
+// reach the table.
+func (s *FeedbackService) Append(ev *models.FeedbackEvent) error {
+	if ev == nil {
+		return errors.New("nil feedback event")
+	}
+	if !ev.HasSubstance() {
+		return ErrFeedbackNoSubstance
+	}
+	normalizeFeedbackEvent(ev)
+
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		var maxSeq struct{ V int }
+		if err := tx.Model(&models.FeedbackEvent{}).
+			Select("COALESCE(MAX(seq), 0) AS v").
+			Where("run_id = ?", ev.RunID).Scan(&maxSeq).Error; err != nil {
+			return err
+		}
+		var maxRound struct{ V int }
+		if err := tx.Model(&models.FeedbackEvent{}).
+			Select("COALESCE(MAX(round), 0) AS v").
+			Where("run_id = ? AND node_id = ? AND iteration = ?", ev.RunID, ev.NodeID, ev.Iteration).
+			Scan(&maxRound).Error; err != nil {
+			return err
+		}
+		ev.Seq = maxSeq.V + 1
+		ev.Round = maxRound.V + 1
+		if ev.OccurredAt.IsZero() {
+			ev.OccurredAt = time.Now()
+		}
+		if ev.WantsArtifact() {
+			ev.ArtifactName = FeedbackArtifactName(ev.Kind, ev.NodeID, ev.Iteration, ev.Round)
+		}
+		return tx.Create(ev).Error
+	})
+}
+
+// Events returns a run's feedback rounds in chronological order.
+func (s *FeedbackService) Events(runID string) []models.FeedbackEvent {
+	var out []models.FeedbackEvent
+	s.db.Where("run_id = ?", runID).Order("seq asc, id asc").Find(&out)
+	return out
+}
+
+// normalizeFeedbackEvent enforces the storage invariants: attachments carry
+// refs only (never base64), and free text is bounded.
+func normalizeFeedbackEvent(ev *models.FeedbackEvent) {
+	ev.Text = truncateStr(strings.TrimSpace(ev.Text), feedbackTextMax)
+	ev.Attachments = stripAttachmentData(ev.Attachments)
+	for i := range ev.Turns {
+		ev.Turns[i].Text = truncateStr(strings.TrimSpace(ev.Turns[i].Text), feedbackTurnMax)
+		ev.Turns[i].Images = stripAttachmentData(ev.Turns[i].Images)
+	}
+}
+
+// stripAttachmentData clears inline base64 so only blob refs are persisted and
+// rendered. Inlining images into a text product is forbidden platform-wide.
+func stripAttachmentData(in []models.PromptImage) []models.PromptImage {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]models.PromptImage, len(in))
+	for i, im := range in {
+		im.Data = ""
+		out[i] = im
+	}
+	return out
+}
+
+// FeedbackSummary renders the one-line gist used by the index, the MCP history
+// overview and the UI collapsed row.
+func FeedbackSummary(ev models.FeedbackEvent) string {
+	if t := strings.TrimSpace(ev.Text); t != "" {
+		return truncateStr(firstNonEmptyLine(t), feedbackSummaryMax)
+	}
+	for _, a := range ev.Annotations {
+		if n := strings.TrimSpace(a.Note); n != "" {
+			return truncateStr(n, feedbackSummaryMax)
+		}
+	}
+	for _, t := range ev.Turns {
+		if t.Role == "human" && strings.TrimSpace(t.Text) != "" {
+			return truncateStr(firstNonEmptyLine(t.Text), feedbackSummaryMax)
+		}
+	}
+	if len(ev.Attachments) > 0 {
+		return "(仅附件)"
+	}
+	return "(无正文)"
+}
+
+func firstNonEmptyLine(s string) string {
+	for _, ln := range strings.Split(s, "\n") {
+		if t := strings.TrimSpace(ln); t != "" {
+			return t
+		}
+	}
+	return strings.TrimSpace(s)
+}
+
+// FeedbackDigest is the short content hash used for product before/after
+// comparison in FeedbackTarget.
+func FeedbackDigest(content string) string {
+	if content == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+// MarshalRoundJSON renders one round's standalone product.
+//
+// The body holds only this round's increment. Prior rounds appear as one-line
+// summaries plus a pointer to the previous product, so the file is
+// self-describing without duplicating earlier bodies — reading the whole
+// history stays a deliberate, incremental choice rather than a fixed cost.
+func MarshalRoundJSON(ev models.FeedbackEvent, prior []models.FeedbackEvent, runID string, node NodeRef) (string, error) {
+	payload := map[string]any{
+		"runId":     runID,
+		"kind":      ev.Kind,
+		"node":      node.toMap(ev.NodeID),
+		"iteration": ev.Iteration,
+		"round":     ev.Round,
+		"seq":       ev.Seq,
+		"at":        ev.OccurredAt.Format(time.RFC3339),
+		"actor":     feedbackActor(ev),
+		"index":     FeedbackIndexArtifactName,
+	}
+	if ev.Action != "" {
+		payload["action"] = ev.Action
+	}
+	if ev.Interrupted {
+		payload["interrupted"] = true
+	}
+
+	fb := map[string]any{"text": ev.Text}
+	if len(ev.Annotations) > 0 {
+		fb["annotations"] = ev.Annotations
+	}
+	if len(ev.Attachments) > 0 {
+		fb["attachments"] = ev.Attachments
+	}
+	payload["feedback"] = fb
+
+	if len(ev.Turns) > 0 {
+		payload["transcript"] = renderFeedbackTurns(ev.Turns)
+	}
+	if len(ev.Targets) > 0 {
+		payload["targets"] = ev.Targets
+	}
+	if len(ev.Detail) > 0 {
+		payload["detail"] = ev.Detail
+	}
+
+	if rounds := priorRoundSummaries(prior); len(rounds) > 0 {
+		payload["priorRounds"] = rounds
+	}
+	if prev := prevRoundArtifact(prior); prev != "" {
+		payload["prev"] = prev
+	}
+
+	b, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// NodeRef carries the display metadata for the node a round belongs to.
+type NodeRef struct {
+	Label string
+	Type  string
+}
+
+func (n NodeRef) toMap(id string) map[string]any {
+	m := map[string]any{"id": id}
+	if n.Label != "" {
+		m["label"] = n.Label
+	}
+	if n.Type != "" {
+		m["type"] = n.Type
+	}
+	return m
+}
+
+func feedbackActor(ev models.FeedbackEvent) map[string]any {
+	m := map[string]any{}
+	if ev.Actor != "" {
+		m["name"] = ev.Actor
+	}
+	if ev.CallerKind != "" {
+		m["callerKind"] = ev.CallerKind
+	}
+	if ev.Unattributable {
+		m["unattributable"] = true
+	}
+	return m
+}
+
+func renderFeedbackTurns(turns []models.ReactMessage) []map[string]any {
+	out := make([]map[string]any, 0, len(turns))
+	for _, t := range turns {
+		m := map[string]any{"role": t.Role, "text": t.Text}
+		if t.At != "" {
+			m["at"] = t.At
+		}
+		if len(t.Annotations) > 0 {
+			m["annotations"] = t.Annotations
+		}
+		if len(t.Images) > 0 {
+			m["attachments"] = t.Images
+		}
+		if len(t.Questions) > 0 {
+			m["questions"] = t.Questions
+		}
+		if t.Interrupted {
+			m["interrupted"] = true
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// priorRoundSummaries condenses the rounds that came before into one line each.
+func priorRoundSummaries(prior []models.FeedbackEvent) []map[string]any {
+	out := make([]map[string]any, 0, len(prior))
+	for _, p := range prior {
+		out = append(out, map[string]any{
+			"round":   p.Round,
+			"kind":    p.Kind,
+			"at":      p.OccurredAt.Format(time.RFC3339),
+			"summary": FeedbackSummary(p),
+		})
+	}
+	return out
+}
+
+// prevRoundArtifact returns the most recent prior round that has a standalone
+// product, so the chain skips index-only rounds instead of dangling.
+func prevRoundArtifact(prior []models.FeedbackEvent) string {
+	for i := len(prior) - 1; i >= 0; i-- {
+		if prior[i].ArtifactName != "" {
+			return prior[i].ArtifactName
+		}
+	}
+	return ""
+}
+
+// MarshalIndexJSON renders the run-level index over every recorded round.
+// Rounds with no standalone product (platform auto-answers) appear without an
+// "artifact" field but are still listed — the breadth is never trimmed.
+func MarshalIndexJSON(runID string, events []models.FeedbackEvent) (string, error) {
+	counts := map[string]int{}
+	rounds := make([]map[string]any, 0, len(events))
+	for _, ev := range events {
+		counts[ev.Kind]++
+		r := map[string]any{
+			"seq":       ev.Seq,
+			"kind":      ev.Kind,
+			"node":      ev.NodeID,
+			"iteration": ev.Iteration,
+			"round":     ev.Round,
+			"at":        ev.OccurredAt.Format(time.RFC3339),
+			"summary":   FeedbackSummary(ev),
+		}
+		if ev.Actor != "" {
+			r["actor"] = ev.Actor
+		}
+		if ev.Action != "" {
+			r["action"] = ev.Action
+		}
+		if n := len(ev.Attachments); n > 0 {
+			r["attachments"] = n
+		}
+		if len(ev.Annotations) > 0 {
+			r["annotations"] = len(ev.Annotations)
+		}
+		if ev.Interrupted {
+			r["interrupted"] = true
+		}
+		if ev.ArtifactName != "" {
+			r["artifact"] = ev.ArtifactName
+		}
+		rounds = append(rounds, r)
+	}
+	payload := map[string]any{
+		"runId":       runID,
+		"generatedAt": time.Now().Format(time.RFC3339),
+		"totalRounds": len(events),
+		"counts":      counts,
+		"rounds":      rounds,
+	}
+	b, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/server/internal/services/feedback_name.go
+++ b/server/internal/services/feedback_name.go
@@ -1,0 +1,122 @@
+package services
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/cocofhu/approving/internal/mcp"
+)
+
+// Reserved names for the feedback ledger products. Defined in mcp alongside the
+// other product-name constants and re-exported here so callers on this side do
+// not need the mcp import.
+const (
+	// FeedbackIndexArtifactName is the run-level index every round links back
+	// to; it is the single entry point for both the Agent and the UI.
+	FeedbackIndexArtifactName = mcp.FeedbackIndexArtifactName
+	// FeedbackArtifactPrefix marks per-round feedback products. Callers match
+	// on it to exclude the ledger from deliverable capture, share links and
+	// artifact lists.
+	FeedbackArtifactPrefix = mcp.FeedbackArtifactPrefix
+)
+
+// feedbackSlugMax caps the node-id segment so a long id cannot push the
+// artifact name past what UIs and citation shapes handle comfortably.
+const feedbackSlugMax = 40
+
+// IsFeedbackArtifactName reports whether name is part of the feedback ledger
+// (a per-round product or the index).
+func IsFeedbackArtifactName(name string) bool { return mcp.IsFeedbackArtifactName(name) }
+
+// FeedbackArtifactName builds the per-round product name.
+//
+// Uniqueness is the whole point: the artifact store upserts on (run_id, name),
+// so a name that varies per round is what keeps every round's feedback instead
+// of overwriting the previous one. The shape stays flat and dotted because
+// gateshare.safeArtifactName truncates at the last "/" — a path-style name
+// would collapse to its basename and start colliding.
+//
+// The result always satisfies the citation name shape
+// ^[a-z0-9][a-z0-9._-]*\.[a-z0-9]{1,16}$.
+func FeedbackArtifactName(kind, nodeID string, iteration, round int) string {
+	if iteration < 1 {
+		iteration = 1
+	}
+	if round < 1 {
+		round = 1
+	}
+	return fmt.Sprintf("%s%s.%s.i%dr%d.json",
+		FeedbackArtifactPrefix, feedbackKindSlug(kind), feedbackNodeSlug(nodeID), iteration, round)
+}
+
+// feedbackKindSlug keeps the kind segment inside the known set so a malformed
+// caller cannot inject separators into the name.
+func feedbackKindSlug(kind string) string {
+	switch strings.TrimSpace(strings.ToLower(kind)) {
+	case "clarify", "review", "gate", "preview":
+		return strings.TrimSpace(strings.ToLower(kind))
+	default:
+		return "other"
+	}
+}
+
+// feedbackNodeSlug renders a node id as a name-safe segment.
+//
+// Any lossy transform (case folding, character replacement, truncation) appends
+// a digest of the original id, so two different node ids can never slug to the
+// same segment — without that, "Foo" and "foo", or "a/b" and "a-b", would share
+// one artifact and silently overwrite each other's rounds.
+func feedbackNodeSlug(nodeID string) string {
+	raw := strings.TrimSpace(nodeID)
+	var b strings.Builder
+	mangled := false
+	for _, r := range raw {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '_':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + ('a' - 'A'))
+			mangled = true
+		default:
+			b.WriteByte('-')
+			mangled = true
+		}
+	}
+	slug := collapseDashes(b.String())
+	if len(slug) > feedbackSlugMax {
+		slug = strings.Trim(slug[:feedbackSlugMax], "-")
+		mangled = true
+	}
+	if slug == "" {
+		slug = "node"
+		mangled = true
+	}
+	if mangled {
+		slug += "-" + shortDigest(raw)
+	}
+	return slug
+}
+
+func collapseDashes(s string) string {
+	var b strings.Builder
+	prevDash := false
+	for _, r := range s {
+		if r == '-' {
+			if prevDash {
+				continue
+			}
+			prevDash = true
+		} else {
+			prevDash = false
+		}
+		b.WriteRune(r)
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func shortDigest(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])[:6]
+}

--- a/server/internal/services/feedback_test.go
+++ b/server/internal/services/feedback_test.go
@@ -1,0 +1,319 @@
+package services
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+)
+
+// nameShape mirrors pmArtifactNameRe: every ledger name must satisfy the
+// platform's citation name shape or it cannot be cited or read back.
+var nameShape = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*\.[a-z0-9]{1,16}$`)
+
+func TestFeedbackArtifactNameShapeAndUniqueness(t *testing.T) {
+	cases := []struct{ kind, node string }{
+		{"review", "research-1"},
+		{"clarify", "clarify_1"},
+		{"gate", "Gate/One"},
+		{"preview", "  "},
+		{"weird", strings.Repeat("x", 80)},
+	}
+	seen := map[string]string{}
+	for _, c := range cases {
+		got := FeedbackArtifactName(c.kind, c.node, 2, 3)
+		if !nameShape.MatchString(got) {
+			t.Fatalf("name %q does not match the citation shape", got)
+		}
+		if prev, dup := seen[got]; dup {
+			t.Fatalf("name collision: %q from %q and %q", got, prev, c.node)
+		}
+		seen[got] = c.node
+		if !IsFeedbackArtifactName(got) {
+			t.Fatalf("%q should be recognized as a ledger name", got)
+		}
+	}
+
+	// The readable case stays readable — no digest suffix when nothing is lost.
+	if got := FeedbackArtifactName("review", "research-1", 2, 3); got != "feedback.review.research-1.i2r3.json" {
+		t.Fatalf("clean node id should not be mangled, got %q", got)
+	}
+	// Case folding and separator replacement must not merge distinct ids.
+	if FeedbackArtifactName("review", "Foo", 1, 1) == FeedbackArtifactName("review", "foo", 1, 1) {
+		t.Fatal("Foo and foo must not share an artifact name")
+	}
+	if FeedbackArtifactName("review", "a/b", 1, 1) == FeedbackArtifactName("review", "a-b", 1, 1) {
+		t.Fatal("a/b and a-b must not share an artifact name")
+	}
+}
+
+func TestFeedbackArtifactNameNormalizesOrdinals(t *testing.T) {
+	if got := FeedbackArtifactName("review", "n", 0, 0); got != "feedback.review.n.i1r1.json" {
+		t.Fatalf("non-positive ordinals should floor to 1, got %q", got)
+	}
+	if !IsFeedbackArtifactName(FeedbackIndexArtifactName) {
+		t.Fatal("index must be recognized as a ledger name")
+	}
+	if IsFeedbackArtifactName("research.json") {
+		t.Fatal("a normal product must not be treated as ledger")
+	}
+}
+
+func TestAppendRejectsEventsWithoutSubstance(t *testing.T) {
+	svc := NewFeedbackService(newTestDB(t))
+	// A gate approval clicked through with an empty form.
+	ev := models.FeedbackEvent{RunID: "r1", Kind: models.FeedbackKindGate, NodeID: "gate1", Iteration: 1, Action: "pass"}
+	if err := svc.Append(&ev); err != ErrFeedbackNoSubstance {
+		t.Fatalf("empty approval should be rejected, got %v", err)
+	}
+	if got := svc.Events("r1"); len(got) != 0 {
+		t.Fatalf("no row should exist, got %d", len(got))
+	}
+	if err := svc.Append(nil); err == nil {
+		t.Fatal("nil event should error")
+	}
+}
+
+func TestAppendAssignsSeqAndRoundPerNodeIteration(t *testing.T) {
+	svc := NewFeedbackService(newTestDB(t))
+	mk := func(node string, iter int, text string) models.FeedbackEvent {
+		return models.FeedbackEvent{RunID: "r1", Kind: models.FeedbackKindReview,
+			NodeID: node, Iteration: iter, Text: text}
+	}
+	for _, text := range []string{"一", "二", "三"} {
+		ev := mk("research-1", 2, text)
+		if err := svc.Append(&ev); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+	}
+	other := mk("impl-1", 1, "别的节点")
+	if err := svc.Append(&other); err != nil {
+		t.Fatalf("append other: %v", err)
+	}
+
+	events := svc.Events("r1")
+	if len(events) != 4 {
+		t.Fatalf("want 4 events, got %d", len(events))
+	}
+	// Seq is run-global and monotonic; Round restarts per (node, iteration).
+	names := map[string]bool{}
+	for i, ev := range events {
+		if ev.Seq != i+1 {
+			t.Fatalf("event %d has seq %d", i, ev.Seq)
+		}
+		names[ev.ArtifactName] = true
+	}
+	for i, want := range []int{1, 2, 3} {
+		if events[i].Round != want {
+			t.Fatalf("round %d = %d, want %d", i, events[i].Round, want)
+		}
+	}
+	if events[3].Round != 1 {
+		t.Fatalf("a different node starts a fresh round counter, got %d", events[3].Round)
+	}
+	// Three consecutive rounds must produce three distinct products, all kept.
+	if len(names) != 4 {
+		t.Fatalf("want 4 distinct artifact names, got %d: %v", len(names), names)
+	}
+}
+
+func TestAppendKeepsIndexOnlyRoundsWithoutArtifact(t *testing.T) {
+	svc := NewFeedbackService(newTestDB(t))
+	ev := models.FeedbackEvent{RunID: "r1", Kind: models.FeedbackKindClarify, NodeID: "c1",
+		Iteration: 1, Action: "auto_answer", Text: "缓存=Redis", IndexOnly: true}
+	if err := svc.Append(&ev); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if ev.ArtifactName != "" {
+		t.Fatalf("index-only round must not claim a product, got %q", ev.ArtifactName)
+	}
+	if ev.Round != 1 || ev.Seq != 1 {
+		t.Fatalf("ordinals still assigned: seq=%d round=%d", ev.Seq, ev.Round)
+	}
+}
+
+func TestAppendStripsInlineAttachmentData(t *testing.T) {
+	svc := NewFeedbackService(newTestDB(t))
+	ev := models.FeedbackEvent{
+		RunID: "r1", Kind: models.FeedbackKindReview, NodeID: "n1", Iteration: 1,
+		Text:        "看截图",
+		Attachments: []models.PromptImage{{Ref: "blob:abc", Name: "s.png", MimeType: "image/png", Data: "AAAABBBB"}},
+		Turns: []models.ReactMessage{
+			{Role: "human", Text: "看截图", Images: []models.PromptImage{{Ref: "blob:abc", Data: "AAAABBBB"}}},
+		},
+	}
+	if err := svc.Append(&ev); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	stored := svc.Events("r1")[0]
+	if stored.Attachments[0].Data != "" || stored.Turns[0].Images[0].Data != "" {
+		t.Fatal("inline base64 must never be persisted; only blob refs")
+	}
+	if stored.Attachments[0].Ref != "blob:abc" {
+		t.Fatalf("ref lost: %+v", stored.Attachments[0])
+	}
+
+	body, err := MarshalRoundJSON(stored, nil, "r1", NodeRef{})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(body, "AAAABBBB") || strings.Contains(body, "data:image") {
+		t.Fatalf("rendered product must not inline attachment bytes:\n%s", body)
+	}
+}
+
+func TestAppendTruncatesOversizeText(t *testing.T) {
+	svc := NewFeedbackService(newTestDB(t))
+	ev := models.FeedbackEvent{RunID: "r1", Kind: models.FeedbackKindReview, NodeID: "n1", Iteration: 1,
+		Text:  strings.Repeat("x", feedbackTextMax+500),
+		Turns: []models.ReactMessage{{Role: "human", Text: strings.Repeat("y", feedbackTurnMax+500)}},
+	}
+	if err := svc.Append(&ev); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	stored := svc.Events("r1")[0]
+	if len(stored.Text) > feedbackTextMax+8 {
+		t.Fatalf("text not truncated: %d", len(stored.Text))
+	}
+	if len(stored.Turns[0].Text) > feedbackTurnMax+8 {
+		t.Fatalf("turn not truncated: %d", len(stored.Turns[0].Text))
+	}
+}
+
+func TestMarshalRoundJSONCarriesPriorRoundsAndPrevPointer(t *testing.T) {
+	at := time.Date(2026, 8, 13, 15, 7, 22, 0, time.UTC)
+	prior := []models.FeedbackEvent{
+		{Round: 1, Kind: "review", Text: "要求补充竞品对比", OccurredAt: at, ArtifactName: "feedback.review.r1.i2r1.json"},
+		{Round: 2, Kind: "clarify", Text: "图表改用柱状图", OccurredAt: at, IndexOnly: true},
+	}
+	cur := models.FeedbackEvent{
+		RunID: "run-1", Kind: models.FeedbackKindReview, NodeID: "research-1", Iteration: 2, Round: 3, Seq: 7,
+		OccurredAt: at, Actor: "alice", CallerKind: "pm", Action: "revise",
+		Text:        "第 3 条结论证据不足",
+		Annotations: []models.ReactAnnotation{{JSONPath: "$.findings[2]", Note: "补链接"}},
+		Targets:     []models.FeedbackTarget{{Name: "research.json", Before: "ab", After: "cd", Changed: true}},
+		Detail:      map[string]any{"source": "gate"},
+		Turns:       []models.ReactMessage{{Role: "human", Text: "补链接"}, {Role: "agent", Text: "已补充"}},
+	}
+	body, err := MarshalRoundJSON(cur, prior, "run-1", NodeRef{Label: "调研", Type: "research"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(body), &doc); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	// prev must skip the index-only round rather than dangle on it.
+	if doc["prev"] != "feedback.review.r1.i2r1.json" {
+		t.Fatalf("prev = %v", doc["prev"])
+	}
+	if got := doc["priorRounds"].([]any); len(got) != 2 {
+		t.Fatalf("priorRounds = %v", got)
+	}
+	node := doc["node"].(map[string]any)
+	if node["id"] != "research-1" || node["label"] != "调研" {
+		t.Fatalf("node = %v", node)
+	}
+	if doc["index"] != FeedbackIndexArtifactName {
+		t.Fatalf("index pointer = %v", doc["index"])
+	}
+	for _, k := range []string{"feedback", "transcript", "targets", "detail", "actor"} {
+		if _, ok := doc[k]; !ok {
+			t.Fatalf("missing %q in:\n%s", k, body)
+		}
+	}
+}
+
+func TestMarshalIndexJSONListsEveryRound(t *testing.T) {
+	at := time.Now()
+	events := []models.FeedbackEvent{
+		{Seq: 1, Round: 1, Kind: models.FeedbackKindClarify, NodeID: "c1", Iteration: 1, OccurredAt: at,
+			Action: "auto_answer", Actor: "system", Text: "缓存=Redis"},
+		{Seq: 2, Round: 1, Kind: models.FeedbackKindReview, NodeID: "r1", Iteration: 1, OccurredAt: at,
+			Text: "证据不足", ArtifactName: "feedback.review.r1.i1r1.json",
+			Attachments: []models.PromptImage{{Ref: "blob:x"}}, Interrupted: true},
+	}
+	body, err := MarshalIndexJSON("run-1", events)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var doc struct {
+		TotalRounds int            `json:"totalRounds"`
+		Counts      map[string]int `json:"counts"`
+		Rounds      []struct {
+			Kind        string `json:"kind"`
+			Summary     string `json:"summary"`
+			Artifact    string `json:"artifact"`
+			Attachments int    `json:"attachments"`
+			Interrupted bool   `json:"interrupted"`
+		} `json:"rounds"`
+	}
+	if err := json.Unmarshal([]byte(body), &doc); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if doc.TotalRounds != 2 || len(doc.Rounds) != 2 {
+		t.Fatalf("index must list every round, got %d", doc.TotalRounds)
+	}
+	if doc.Counts["clarify"] != 1 || doc.Counts["review"] != 1 {
+		t.Fatalf("counts = %v", doc.Counts)
+	}
+	// The auto-answered round is listed but carries no product pointer.
+	if doc.Rounds[0].Artifact != "" {
+		t.Fatalf("index-only round must not cite an artifact: %q", doc.Rounds[0].Artifact)
+	}
+	if doc.Rounds[1].Artifact == "" || doc.Rounds[1].Attachments != 1 || !doc.Rounds[1].Interrupted {
+		t.Fatalf("round 2 = %+v", doc.Rounds[1])
+	}
+	if doc.Rounds[1].Summary != "证据不足" {
+		t.Fatalf("summary = %q", doc.Rounds[1].Summary)
+	}
+}
+
+func TestFeedbackSummaryFallsBackThroughSources(t *testing.T) {
+	cases := []struct {
+		name string
+		ev   models.FeedbackEvent
+		want string
+	}{
+		{"text wins", models.FeedbackEvent{Text: "\n\n第一行\n第二行"}, "第一行"},
+		{"annotation note", models.FeedbackEvent{
+			Annotations: []models.ReactAnnotation{{Note: "补链接"}}}, "补链接"},
+		{"human turn", models.FeedbackEvent{
+			Turns: []models.ReactMessage{{Role: "agent", Text: "机器"}, {Role: "human", Text: "人说的"}}}, "人说的"},
+		{"attachment only", models.FeedbackEvent{
+			Attachments: []models.PromptImage{{Ref: "blob:x"}}}, "(仅附件)"},
+		{"nothing", models.FeedbackEvent{}, "(无正文)"},
+	}
+	for _, c := range cases {
+		if got := FeedbackSummary(c.ev); got != c.want {
+			t.Errorf("%s: got %q want %q", c.name, got, c.want)
+		}
+	}
+}
+
+func TestFeedbackDigestDetectsChange(t *testing.T) {
+	if FeedbackDigest("") != "" {
+		t.Fatal("empty content has no digest")
+	}
+	a, b := FeedbackDigest("x"), FeedbackDigest("y")
+	if a == b || len(a) != 16 {
+		t.Fatalf("digest a=%q b=%q", a, b)
+	}
+	if FeedbackDigest("x") != a {
+		t.Fatal("digest must be stable")
+	}
+}
+
+func TestRunServiceFeedbackEventsSatisfiesHistoryProvider(t *testing.T) {
+	db := newTestDB(t)
+	ev := models.FeedbackEvent{RunID: "r1", Kind: models.FeedbackKindReview, NodeID: "n1", Iteration: 1, Text: "改"}
+	if err := NewFeedbackService(db).Append(&ev); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if got := NewRunService(db).FeedbackEvents("r1"); len(got) != 1 || got[0].Text != "改" {
+		t.Fatalf("provider read = %+v", got)
+	}
+}

--- a/server/internal/services/run.go
+++ b/server/internal/services/run.go
@@ -155,6 +155,12 @@ func (s *RunService) States(runID string) []models.StateRun {
 	return states
 }
 
+// FeedbackEvents returns the run's human feedback rounds in order, satisfying
+// the run-history tools' provider contract.
+func (s *RunService) FeedbackEvents(runID string) []models.FeedbackEvent {
+	return NewFeedbackService(s.db).Events(runID)
+}
+
 // StateRun returns one node's persisted record (used as the event-log fallback
 // once the live sandbox is gone).
 func (s *RunService) StateRun(runID, nodeID string) (models.StateRun, bool) {

--- a/web/src/components/run/ArtifactList.test.ts
+++ b/web/src/components/run/ArtifactList.test.ts
@@ -72,4 +72,35 @@ describe('ArtifactList', () => {
     expect(wrapper.text()).toMatch(/暂无|没有/)
     wrapper.unmount()
   })
+
+  // A long review produces one product per round; listing them all inline would
+  // bury the deliverables the list exists to show.
+  it('folds the feedback ledger into one collapsed group', async () => {
+    const wrapper = mountList({
+      artifacts: [
+        artifact('research.json'),
+        artifact('feedback_index.json', 'f0'),
+        artifact('feedback.review.research.i1r1.json', 'f1'),
+        artifact('feedback.review.research.i1r2.json', 'f2'),
+      ],
+    })
+    const rowFor = (name: string) =>
+      wrapper.findAll('button').find((b) => b.text().includes(name))!
+    const ledgerRows = () => wrapper.get('[data-testid="artifact-feedback-group"] + div')
+
+    expect(rowFor('research.json').isVisible()).toBe(true)
+    expect(ledgerRows().attributes('style')).toContain('display: none')
+
+    const group = wrapper.get('[data-testid="artifact-feedback-group"]')
+    expect(group.text()).toContain('3')
+
+    await group.trigger('click')
+    expect(ledgerRows().attributes('style') || '').not.toContain('display: none')
+    expect(ledgerRows().text()).toContain('feedback_index.json')
+    expect(ledgerRows().text()).toContain('feedback.review.research.i1r2.json')
+
+    await rowFor('feedback_index.json').trigger('click')
+    expect((wrapper.emitted('select')![0][0] as Artifact).name).toBe('feedback_index.json')
+    wrapper.unmount()
+  })
 })

--- a/web/src/components/run/ArtifactList.vue
+++ b/web/src/components/run/ArtifactList.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import Icon from '../ui/Icon.vue'
 import { fmtTime } from '@/lib/shared/format'
 import { runSectionTitle } from '@/lib/run/artifactGroups'
+import { isFeedbackArtifactName } from './StructuredArtifactView.vue'
 import type { Artifact } from '@/lib/shared/types'
 import type { RunSection } from '@/lib/run/artifactGroups'
 
@@ -45,6 +46,12 @@ const { t } = useI18n()
 const artFilter = ref('')
 const collapsedRuns = ref<Set<string>>(new Set())
 const scrollEl = ref<HTMLElement | null>(null)
+// A long review produces one product per round; left flat they would bury the
+// actual deliverables, so the ledger gets its own collapsed group.
+const feedbackOpen = ref(false)
+
+const feedbackItems = computed(() => props.artifacts.filter((a) => isFeedbackArtifactName(a.name)))
+const plainItems = computed(() => props.artifacts.filter((a) => !isFeedbackArtifactName(a.name)))
 
 const kindIcon: Record<string, string> = { markdown: 'doc', json: 'doc', yaml: 'doc', html: 'dashboard' }
 
@@ -290,7 +297,7 @@ watch(
 
       <template v-else>
         <button
-          v-for="a in artifacts"
+          v-for="a in plainItems"
           :key="a.id"
           class="mb-1.5 flex w-full items-center gap-2.5 rounded-md border px-2.5 py-2 text-left transition"
           :class="activeId === a.id ? 'border-accent/50 bg-accent-dim/40' : 'border-line hover:bg-elevated'"
@@ -308,6 +315,42 @@ watch(
           </div>
           <Icon name="chevron-right" :size="14" class="text-txt3" />
         </button>
+
+        <div v-if="feedbackItems.length" class="mb-1.5">
+          <button
+            type="button"
+            class="flex w-full items-center gap-1.5 px-2 py-1 text-left text-[12px] font-normal text-txt3 transition hover:text-txt2"
+            data-testid="artifact-feedback-group"
+            @click="feedbackOpen = !feedbackOpen"
+          >
+            <Icon
+              name="chevron-down"
+              :size="12"
+              class="shrink-0 text-txt3 transition-transform"
+              :class="feedbackOpen ? '' : '-rotate-90'"
+            />
+            <span class="min-w-0 flex-1 truncate">{{ t('pages.artifactList.feedbackGroup') }}</span>
+            <span class="shrink-0 text-[10px] tabular-nums text-txt3">{{ feedbackItems.length }}</span>
+          </button>
+          <div v-show="feedbackOpen" class="mt-1">
+            <button
+              v-for="a in feedbackItems"
+              :key="a.id"
+              class="mb-1.5 flex w-full items-center gap-2.5 rounded-md border px-2.5 py-2 text-left transition"
+              :class="activeId === a.id ? 'border-accent/50 bg-accent-dim/40' : 'border-line hover:bg-elevated'"
+              @click="emit('select', a)"
+            >
+              <div class="flex h-8 w-8 items-center justify-center rounded-md bg-n-artifact/15 text-n-artifact">
+                <Icon name="doc" :size="16" />
+              </div>
+              <div class="min-w-0 flex-1">
+                <div class="truncate text-[13px] font-medium text-txt">{{ a.name }}</div>
+                <div class="truncate text-[10px] text-txt3">{{ a.nodeId }} · {{ fmtTime(a.createdAt) }}</div>
+              </div>
+              <Icon name="chevron-right" :size="14" class="text-txt3" />
+            </button>
+          </div>
+        </div>
       </template>
     </div>
   </div>

--- a/web/src/components/run/StructuredArtifactView.test.ts
+++ b/web/src/components/run/StructuredArtifactView.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isStructuredArtifactName } from './StructuredArtifactView.vue'
+import { isFeedbackArtifactName, isStructuredArtifactName } from './StructuredArtifactView.vue'
 
 describe('isStructuredArtifactName', () => {
   it('matches the 8 reserved structured JSON artifact names', () => {
@@ -23,5 +23,22 @@ describe('isStructuredArtifactName', () => {
     expect(isStructuredArtifactName('page.html')).toBe(false)
     expect(isStructuredArtifactName('design.md')).toBe(false)
     expect(isStructuredArtifactName('result.json')).toBe(false)
+  })
+
+  // Round names are generated per node and iteration, so the ledger can only be
+  // recognized by prefix — an exact-name whitelist would drop every round into
+  // the raw JSON fallback.
+  it('recognizes the ledger by prefix, not by an exact name', () => {
+    const names = [
+      'feedback_index.json',
+      'feedback.review.research-1.i2r3.json',
+      'feedback.gate.approve.i1r1.json',
+    ]
+    for (const name of names) {
+      expect(isFeedbackArtifactName(name)).toBe(true)
+      expect(isStructuredArtifactName(name)).toBe(true)
+    }
+    expect(isFeedbackArtifactName('feedbackish.json')).toBe(false)
+    expect(isFeedbackArtifactName('research.json')).toBe(false)
   })
 })

--- a/web/src/components/run/StructuredArtifactView.vue
+++ b/web/src/components/run/StructuredArtifactView.vue
@@ -10,8 +10,18 @@ const STRUCTURED_ARTIFACT_NAMES = new Set([
   'review.json',
 ])
 
+// Feedback ledger products are matched by prefix, not by exact name: each round
+// gets its own file (feedback.<kind>.<node>.i<n>r<n>.json) so rounds never
+// overwrite each other, which makes the set of names unbounded.
+const FEEDBACK_INDEX_NAME = 'feedback_index.json'
+const FEEDBACK_PREFIX = 'feedback.'
+
+export function isFeedbackArtifactName(name: string): boolean {
+  return name === FEEDBACK_INDEX_NAME || name.startsWith(FEEDBACK_PREFIX)
+}
+
 export function isStructuredArtifactName(name: string): boolean {
-  return STRUCTURED_ARTIFACT_NAMES.has(name)
+  return STRUCTURED_ARTIFACT_NAMES.has(name) || isFeedbackArtifactName(name)
 }
 </script>
 
@@ -24,6 +34,7 @@ import ResearchView from './product/ResearchView.vue'
 import TestResultView from './product/TestResultView.vue'
 import ReviewView from './product/ReviewView.vue'
 import ImplementationResultView from './product/ImplementationResultView.vue'
+import FeedbackLedgerView from './product/FeedbackLedgerView.vue'
 
 import type { Artifact } from '@/lib/shared/types'
 
@@ -43,6 +54,7 @@ const props = defineProps<{
 // proposal.json is a single accepted proposal; adapt it to the proposals card
 // list (one item) and highlight it as the selected one.
 const asProposals = computed(() => ({ context: props.doc?.context, proposals: props.doc ? [props.doc] : [] }))
+const isFeedback = computed(() => isFeedbackArtifactName(props.name))
 </script>
 
 <template>
@@ -61,4 +73,11 @@ const asProposals = computed(() => ({ context: props.doc?.context, proposals: pr
   <ReviewView v-else-if="name === 'review.json'" :doc="doc" />
   <ProposalSelectView v-else-if="name === 'proposals.json'" :doc="doc" readonly />
   <ProposalSelectView v-else-if="name === 'proposal.json'" :doc="asProposals" :resolved-id="doc?.id" readonly />
+  <FeedbackLedgerView
+    v-else-if="isFeedback"
+    :name="name"
+    :doc="doc"
+    :run-id="runId"
+    :artifacts="artifacts"
+  />
 </template>

--- a/web/src/components/run/product/FeedbackLedgerView.test.ts
+++ b/web/src/components/run/product/FeedbackLedgerView.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment happy-dom
+import { createI18n } from 'vue-i18n'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import common from '@/locales/zh-CN/common.json'
+import pages from '@/locales/zh-CN/pages.json'
+import type { Artifact } from '@/lib/shared/types'
+import ChatImageThumb from '../../ui/ChatImageThumb.vue'
+import FeedbackLedgerView from './FeedbackLedgerView.vue'
+
+const artifactContent = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/api/api', () => ({
+  api: { artifactContent },
+  blobContentUrl: (ref: string) => `/api/blobs/${String(ref).replace(/^blob:/, '')}`,
+}))
+
+function mountLedger(name: string, doc: unknown, artifacts: Artifact[] = []) {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common, ...pages } },
+  })
+  return mount(FeedbackLedgerView, {
+    props: { name, doc, runId: 'run-1', artifacts },
+    global: { plugins: [i18n], stubs: { Icon: true, ChatImageThumb: true } },
+  })
+}
+
+const indexDoc = {
+  runId: 'run-1',
+  totalRounds: 2,
+  counts: { review: 1, clarify: 1 },
+  rounds: [
+    {
+      seq: 1, kind: 'clarify', node: 'clarify-1', iteration: 1, round: 1,
+      at: '2026-08-13T15:00:00+08:00', actor: 'system', action: 'auto_answer',
+      summary: '自动采纳推荐项:缓存 = Redis',
+    },
+    {
+      seq: 2, kind: 'review', node: 'research-1', iteration: 2, round: 3,
+      at: '2026-08-13T15:07:22+08:00', actor: 'alice', action: 'revise',
+      annotations: 2, attachments: 1, summary: '第 3 条结论证据不足',
+      artifact: 'feedback.review.research-1.i2r3.json',
+    },
+  ],
+}
+
+const roundDoc = {
+  runId: 'run-1',
+  kind: 'review',
+  node: { id: 'research-1', label: '调研', type: 'research' },
+  iteration: 2,
+  round: 3,
+  at: '2026-08-13T15:07:22+08:00',
+  actor: { name: 'alice', callerKind: 'pm' },
+  feedback: {
+    text: '第 3 条结论证据不足,请补上原始链接。',
+    annotations: [{ jsonPath: '$.findings[2].evidence', note: '补链接' }],
+    attachments: [{ ref: 'blob:9f2c', name: 'screenshot.png', mimeType: 'image/png' }],
+  },
+  transcript: [
+    { role: 'human', at: '2026-08-13T15:07:22+08:00', text: '补上原始链接' },
+    { role: 'agent', at: '2026-08-13T15:08:02+08:00', text: '已补充 3 处引用' },
+  ],
+  targets: [
+    { name: 'research.json', before: 'ab3f1c9d', after: 'cd91e4b7', changed: true },
+    { name: 'plan.json', before: 'ee11', after: 'ee11', changed: false },
+  ],
+  priorRounds: [{ round: 1, kind: 'review', summary: '要求补充竞品对比' }],
+  index: 'feedback_index.json',
+}
+
+describe('FeedbackLedgerView', () => {
+  beforeEach(() => {
+    artifactContent.mockReset()
+  })
+
+  it('renders the index as a timeline of every round', () => {
+    const w = mountLedger('feedback_index.json', indexDoc)
+    expect(w.text()).toContain('第 3 条结论证据不足')
+    expect(w.text()).toContain('自动采纳推荐项')
+    expect(w.findAll('li')).toHaveLength(2)
+    // Bodies stay collapsed until asked for.
+    expect(w.text()).not.toContain('已补充 3 处引用')
+    w.unmount()
+  })
+
+  // Depth on demand is the whole point of one file per round: expanding is what
+  // fetches the body, so a long ledger costs nothing until it is read.
+  it('fetches a round product only when its row is expanded', async () => {
+    artifactContent.mockResolvedValue({ content: JSON.stringify(roundDoc) })
+    const artifacts = [
+      { id: 'art-9', name: 'feedback.review.research-1.i2r3.json' } as Artifact,
+    ]
+    const w = mountLedger('feedback_index.json', indexDoc, artifacts)
+    expect(artifactContent).not.toHaveBeenCalled()
+
+    await w.get('[data-testid="feedback-round-2"]').trigger('click')
+    await new Promise((r) => setTimeout(r, 0))
+    await w.vm.$nextTick()
+
+    expect(artifactContent).toHaveBeenCalledWith('art-9')
+    expect(w.text()).toContain('已补充 3 处引用')
+    expect(w.text()).toContain('research.json')
+    // Unchanged products are not listed as touched by this round.
+    expect(w.text()).not.toContain('plan.json')
+
+    // Collapsing and re-expanding reuses the loaded body.
+    await w.get('[data-testid="feedback-round-2"]').trigger('click')
+    await w.get('[data-testid="feedback-round-2"]').trigger('click')
+    expect(artifactContent).toHaveBeenCalledTimes(1)
+    w.unmount()
+  })
+
+  it('says so when a round has no standalone product', async () => {
+    const w = mountLedger('feedback_index.json', indexDoc)
+    await w.get('[data-testid="feedback-round-1"]').trigger('click')
+    expect(w.text()).toContain(pages.pages.product.feedback.indexOnly)
+    expect(artifactContent).not.toHaveBeenCalled()
+    w.unmount()
+  })
+
+  it('reports a round that cannot be fetched instead of rendering blank', async () => {
+    artifactContent.mockRejectedValueOnce(new Error('boom'))
+    const artifacts = [
+      { id: 'art-9', name: 'feedback.review.research-1.i2r3.json' } as Artifact,
+    ]
+    const w = mountLedger('feedback_index.json', indexDoc, artifacts)
+    await w.get('[data-testid="feedback-round-2"]').trigger('click')
+    await new Promise((r) => setTimeout(r, 0))
+    await w.vm.$nextTick()
+    expect(w.text()).toContain('feedback.review.research-1.i2r3.json')
+    w.unmount()
+  })
+
+  it('renders a single round product on its own', () => {
+    const w = mountLedger('feedback.review.research-1.i2r3.json', roundDoc)
+    expect(w.text()).toContain('research-1')
+    expect(w.text()).toContain('第 3 条结论证据不足')
+    expect(w.text()).toContain('已补充 3 处引用')
+    expect(w.text()).toContain('要求补充竞品对比')
+    // Attachments are references, never inlined bytes.
+    expect(w.findComponent(ChatImageThumb).props('src')).toBe('/api/blobs/9f2c')
+    w.unmount()
+  })
+
+  it('shows an empty ledger without rows', () => {
+    const w = mountLedger('feedback_index.json', { runId: 'run-1', totalRounds: 0, rounds: [] })
+    expect(w.text()).toContain(pages.pages.product.feedback.empty)
+    expect(w.findAll('li')).toHaveLength(0)
+    w.unmount()
+  })
+})

--- a/web/src/components/run/product/FeedbackLedgerView.vue
+++ b/web/src/components/run/product/FeedbackLedgerView.vue
@@ -1,0 +1,226 @@
+<script lang="ts">
+export type FeedbackIndexRound = {
+  seq?: number
+  kind?: string
+  node?: string
+  iteration?: number
+  round?: number
+  at?: string
+  actor?: string
+  action?: string
+  summary?: string
+  attachments?: number
+  annotations?: number
+  interrupted?: boolean
+  artifact?: string
+}
+
+export type FeedbackIndexDoc = {
+  runId?: string
+  generatedAt?: string
+  totalRounds?: number
+  counts?: Record<string, number>
+  rounds?: FeedbackIndexRound[]
+}
+</script>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Icon from '../../ui/Icon.vue'
+import FeedbackRoundCard, { type FeedbackRoundDoc } from './FeedbackRoundCard.vue'
+import { api } from '@/lib/api/api'
+import { fmtTime } from '@/lib/shared/format'
+import type { Artifact } from '@/lib/shared/types'
+
+// Renders the human-feedback ledger. The same component handles both shapes the
+// ledger produces: feedback_index.json (a timeline over every round) and a
+// single feedback.<kind>.<node>.i<n>r<n>.json round. Rows start collapsed and
+// fetch their round product on demand — the point of one file per round is that
+// depth stays optional.
+const props = defineProps<{
+  name: string
+  doc: any
+  runId?: string
+  artifacts?: Artifact[]
+}>()
+
+const { t } = useI18n()
+
+const isIndex = computed(() => Array.isArray(props.doc?.rounds))
+const index = computed<FeedbackIndexDoc>(() => (props.doc || {}) as FeedbackIndexDoc)
+const rounds = computed<FeedbackIndexRound[]>(() => index.value.rounds || [])
+
+const KIND_META: Record<string, { icon: string; cls: string; labelKey: string }> = {
+  clarify: { icon: 'chat', cls: 'text-info border-info/40 bg-info/10', labelKey: 'pages.product.feedback.kind.clarify' },
+  review: { icon: 'edit', cls: 'text-accent-2 border-accent/40 bg-accent-dim', labelKey: 'pages.product.feedback.kind.review' },
+  gate: { icon: 'gate', cls: 'text-ok border-ok/40 bg-ok/10', labelKey: 'pages.product.feedback.kind.gate' },
+  preview: { icon: 'dashboard', cls: 'text-warn border-warn/40 bg-warn/10', labelKey: 'pages.product.feedback.kind.preview' },
+}
+
+function kindMeta(kind?: string) {
+  return KIND_META[kind || ''] || KIND_META.review
+}
+
+/** Gate rejections read as errors, not approvals. */
+function badgeClass(r: FeedbackIndexRound): string {
+  if (r.kind === 'gate' && r.action && !['pass', 'approve'].includes(r.action)) {
+    return 'text-err border-err/40 bg-err/10'
+  }
+  return kindMeta(r.kind).cls
+}
+
+const expanded = ref<Set<number>>(new Set())
+const loaded = ref<Record<string, FeedbackRoundDoc>>({})
+const loading = ref<Record<string, boolean>>({})
+const failed = ref<Record<string, boolean>>({})
+
+function artifactId(name: string): string | null {
+  return (props.artifacts || []).find((a) => a.name === name)?.id ?? null
+}
+
+async function loadRound(name: string) {
+  if (loaded.value[name] || loading.value[name]) return
+  const id = artifactId(name)
+  if (!id) {
+    failed.value = { ...failed.value, [name]: true }
+    return
+  }
+  loading.value = { ...loading.value, [name]: true }
+  try {
+    const art = await api.artifactContent(id)
+    loaded.value = { ...loaded.value, [name]: JSON.parse(art.content || '{}') as FeedbackRoundDoc }
+    failed.value = { ...failed.value, [name]: false }
+  } catch {
+    failed.value = { ...failed.value, [name]: true }
+  } finally {
+    loading.value = { ...loading.value, [name]: false }
+  }
+}
+
+function toggle(i: number, r: FeedbackIndexRound) {
+  const next = new Set(expanded.value)
+  if (next.has(i)) next.delete(i)
+  else {
+    next.add(i)
+    if (r.artifact) void loadRound(r.artifact)
+  }
+  expanded.value = next
+}
+
+// A re-render for a different product must not keep the previous one's rows open.
+watch(
+  () => props.name,
+  () => {
+    expanded.value = new Set()
+  },
+)
+
+const countEntries = computed(() =>
+  Object.entries(index.value.counts || {}).filter(([, n]) => n > 0),
+)
+</script>
+
+<template>
+  <div v-if="!isIndex" class="space-y-3">
+    <div class="flex flex-wrap items-center gap-2">
+      <span
+        class="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium"
+        :class="kindMeta(doc?.kind).cls"
+      >
+        <Icon :name="kindMeta(doc?.kind).icon" :size="10" />
+        {{ t(kindMeta(doc?.kind).labelKey) }}
+      </span>
+      <code v-if="doc?.node?.id" class="font-mono text-[12px] text-txt">{{ doc.node.id }}</code>
+      <span class="text-[11px] text-txt3">
+        {{ t('pages.product.feedback.iterRound', { i: doc?.iteration, r: doc?.round }) }}
+      </span>
+      <span v-if="doc?.actor?.name" class="text-[11px] text-txt3">{{ doc.actor.name }}</span>
+      <span v-if="doc?.at" class="ml-auto text-[10px] text-txt3">{{ fmtTime(doc.at) }}</span>
+    </div>
+    <FeedbackRoundCard :doc="doc as FeedbackRoundDoc" />
+    <div v-if="doc?.index" class="text-[11px] text-txt3">
+      {{ t('pages.product.feedback.seeIndex', { name: doc.index }) }}
+    </div>
+  </div>
+
+  <div v-else class="space-y-3">
+    <div class="flex flex-wrap items-center gap-2 text-[11px] text-txt3">
+      <span class="text-[12px] font-medium text-txt2">
+        {{ t('pages.product.feedback.total', { n: index.totalRounds ?? rounds.length }) }}
+      </span>
+      <span
+        v-for="[kind, n] in countEntries"
+        :key="kind"
+        class="rounded-full border px-1.5 py-px text-[10px]"
+        :class="kindMeta(kind).cls"
+      >
+        {{ t(kindMeta(kind).labelKey) }} {{ n }}
+      </span>
+    </div>
+
+    <div v-if="!rounds.length" class="py-6 text-center text-[12px] text-txt3">
+      {{ t('pages.product.feedback.empty') }}
+    </div>
+
+    <ol v-else class="relative space-y-3 border-l border-line pl-5">
+      <li v-for="(r, i) in rounds" :key="r.seq ?? i" class="relative">
+        <span
+          class="absolute -left-[27px] flex h-5 w-5 items-center justify-center rounded-full border"
+          :class="badgeClass(r)"
+        >
+          <Icon :name="kindMeta(r.kind).icon" :size="11" />
+        </span>
+        <button
+          type="button"
+          class="flex w-full items-start gap-2 text-left"
+          :data-testid="`feedback-round-${r.seq ?? i}`"
+          @click="toggle(i, r)"
+        >
+          <div class="min-w-0 flex-1">
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="text-[10px] font-medium uppercase tracking-wide" :class="badgeClass(r).split(' ')[0]">
+                {{ t(kindMeta(r.kind).labelKey) }}
+              </span>
+              <code class="font-mono text-[12px] text-txt">{{ r.node }}</code>
+              <span class="text-[10px] text-txt3">
+                {{ t('pages.product.feedback.iterRound', { i: r.iteration, r: r.round }) }}
+              </span>
+              <span v-if="r.actor" class="text-[10px] text-txt3">{{ r.actor }}</span>
+              <span v-if="r.annotations" class="text-[10px] text-txt3">
+                {{ t('pages.product.feedback.annotationCount', { n: r.annotations }) }}
+              </span>
+              <span v-if="r.attachments" class="text-[10px] text-txt3">
+                {{ t('pages.product.feedback.attachmentCount', { n: r.attachments }) }}
+              </span>
+              <span v-if="r.interrupted" class="text-[10px] text-warn">
+                {{ t('pages.product.feedback.interrupted') }}
+              </span>
+              <span v-if="r.at" class="ml-auto text-[10px] text-txt3">{{ fmtTime(r.at) }}</span>
+            </div>
+            <div class="mt-0.5 truncate text-[11px] text-txt2">{{ r.summary }}</div>
+          </div>
+          <Icon
+            name="chevron-down"
+            :size="12"
+            class="mt-0.5 shrink-0 text-txt3 transition-transform"
+            :class="expanded.has(i) ? '' : '-rotate-90'"
+          />
+        </button>
+
+        <div v-if="expanded.has(i)" class="mt-2 border-l border-line pl-3">
+          <div v-if="!r.artifact" class="text-[11px] text-txt3">
+            {{ t('pages.product.feedback.indexOnly') }}
+          </div>
+          <div v-else-if="loading[r.artifact]" class="text-[11px] text-txt3">
+            {{ t('pages.product.feedback.loading') }}
+          </div>
+          <div v-else-if="failed[r.artifact]" class="text-[11px] text-err">
+            {{ t('pages.product.feedback.loadFailed', { name: r.artifact }) }}
+          </div>
+          <FeedbackRoundCard v-else-if="loaded[r.artifact]" :doc="loaded[r.artifact]" />
+        </div>
+      </li>
+    </ol>
+  </div>
+</template>

--- a/web/src/components/run/product/FeedbackRoundCard.vue
+++ b/web/src/components/run/product/FeedbackRoundCard.vue
@@ -1,0 +1,163 @@
+<script lang="ts">
+export type FeedbackAttachment = {
+  ref?: string
+  name?: string
+  mimeType?: string
+  sizeBytes?: number
+}
+
+export type FeedbackAnnotation = {
+  jsonPath?: string
+  selector?: string
+  url?: string
+  label?: string
+  note?: string
+  quote?: string
+  truncated?: boolean
+}
+
+export type FeedbackTurn = {
+  role?: string
+  text?: string
+  at?: string
+  annotations?: FeedbackAnnotation[]
+  attachments?: FeedbackAttachment[]
+  interrupted?: boolean
+}
+
+export type FeedbackTarget = {
+  name?: string
+  before?: string
+  after?: string
+  changed?: boolean
+}
+
+export type FeedbackRoundDoc = {
+  runId?: string
+  kind?: string
+  node?: { id?: string; label?: string; type?: string }
+  iteration?: number
+  round?: number
+  seq?: number
+  at?: string
+  actor?: { name?: string; callerKind?: string; unattributable?: boolean }
+  action?: string
+  interrupted?: boolean
+  feedback?: {
+    text?: string
+    annotations?: FeedbackAnnotation[]
+    attachments?: FeedbackAttachment[]
+  }
+  transcript?: FeedbackTurn[]
+  targets?: FeedbackTarget[]
+  priorRounds?: { round?: number; kind?: string; at?: string; summary?: string }[]
+  prev?: string
+  index?: string
+}
+</script>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import AnnotationChip from '../AnnotationChip.vue'
+import ChatImageThumb from '../../ui/ChatImageThumb.vue'
+import { blobContentUrl } from '@/lib/api/api'
+import { fmtTime } from '@/lib/shared/format'
+import type { ReactAnnotation } from '@/lib/shared/types'
+
+const props = defineProps<{ doc: FeedbackRoundDoc }>()
+
+const { t } = useI18n()
+
+const body = computed(() => (props.doc.feedback?.text || '').trim())
+const annotations = computed(() => props.doc.feedback?.annotations || [])
+const attachments = computed(() => props.doc.feedback?.attachments || [])
+const transcript = computed(() => props.doc.transcript || [])
+/** Only changed products are worth showing: unchanged rows are noise. */
+const changedTargets = computed(() => (props.doc.targets || []).filter((x) => x.changed))
+
+function attachmentSrc(a: FeedbackAttachment): string {
+  return a.ref ? blobContentUrl(a.ref) : ''
+}
+
+function attachmentLabel(a: FeedbackAttachment, i: number): string {
+  return a.name || `#${i + 1}`
+}
+
+/** AnnotationChip takes the platform ReactAnnotation shape; the JSON matches it. */
+function asAnnotation(a: FeedbackAnnotation): ReactAnnotation {
+  return a as ReactAnnotation
+}
+</script>
+
+<template>
+  <div class="space-y-3">
+    <p v-if="body" class="whitespace-pre-wrap text-[12px] leading-relaxed text-txt">{{ body }}</p>
+
+    <div v-if="annotations.length" class="flex flex-wrap gap-1.5">
+      <AnnotationChip v-for="(a, i) in annotations" :key="i" :ann="asAnnotation(a)" />
+    </div>
+
+    <section v-if="attachments.length">
+      <div class="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-txt3">
+        {{ t('pages.product.feedback.attachments', { n: attachments.length }) }}
+      </div>
+      <div class="flex flex-wrap gap-1.5">
+        <ChatImageThumb
+          v-for="(a, i) in attachments"
+          :key="i"
+          mode="previewable"
+          :src="attachmentSrc(a)"
+          :label="attachmentLabel(a, i)"
+        />
+      </div>
+    </section>
+
+    <section v-if="changedTargets.length">
+      <div class="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-txt3">
+        {{ t('pages.product.feedback.targets') }}
+      </div>
+      <ul class="space-y-1">
+        <li v-for="(x, i) in changedTargets" :key="i" class="flex flex-wrap items-center gap-1.5 text-[11px] text-txt2">
+          <code class="font-mono text-[12px] text-txt">{{ x.name }}</code>
+          <span class="text-txt3">{{ x.before || '—' }} → {{ x.after || '—' }}</span>
+        </li>
+      </ul>
+    </section>
+
+    <section v-if="transcript.length">
+      <div class="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-txt3">
+        {{ t('pages.product.feedback.transcript') }}
+      </div>
+      <div class="space-y-1.5">
+        <div
+          v-for="(turn, i) in transcript"
+          :key="i"
+          class="rounded-md border p-2"
+          :class="turn.role === 'human' ? 'border-accent/40 bg-accent-dim/25' : 'border-line bg-base/40'"
+        >
+          <div class="mb-0.5 flex items-center gap-2">
+            <span class="text-[10px] font-medium uppercase tracking-wide" :class="turn.role === 'human' ? 'text-accent-2' : 'text-txt3'">
+              {{ turn.role === 'human' ? t('pages.product.feedback.roleHuman') : t('pages.product.feedback.roleAgent') }}
+            </span>
+            <span v-if="turn.interrupted" class="text-[10px] text-warn">{{ t('pages.product.feedback.interrupted') }}</span>
+            <span v-if="turn.at" class="ml-auto text-[10px] text-txt3">{{ fmtTime(turn.at) }}</span>
+          </div>
+          <p class="whitespace-pre-wrap text-[11px] leading-relaxed text-txt2">{{ turn.text }}</p>
+        </div>
+      </div>
+    </section>
+
+    <section v-if="doc.priorRounds?.length">
+      <div class="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-txt3">
+        {{ t('pages.product.feedback.priorRounds') }}
+      </div>
+      <ul class="space-y-1">
+        <li v-for="(p, i) in doc.priorRounds" :key="i" class="flex items-start gap-1.5 text-[11px] leading-5 text-txt3">
+          <span class="shrink-0 text-txt3">{{ t('pages.product.feedback.roundN', { n: p.round }) }}</span>
+          <span class="min-w-0 flex-1">{{ p.summary }}</span>
+        </li>
+      </ul>
+    </section>
+  </div>
+</template>

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -2909,7 +2909,8 @@
       "matchCount": "({n} runs matched)",
       "noMatchingArtifacts": "No matching artifacts",
       "expandAll": "Expand",
-      "collapseAll": "Collapse"
+      "collapseAll": "Collapse",
+      "feedbackGroup": "Human feedback ledger"
     },
     "artifactPreview": {
       "emptyHint": "Select an artifact on the left to view (platform storage, downloadable)",
@@ -2986,6 +2987,31 @@
         "tests": "Tests",
         "breakingChanges": "Breaking changes",
         "followUps": "Follow-ups"
+      },
+      "feedback": {
+        "total": "{n} rounds of human feedback",
+        "empty": "No human feedback yet",
+        "iterRound": "Run {i} · round {r}",
+        "roundN": "Round {n}",
+        "annotationCount": "{n} annotations",
+        "attachmentCount": "{n} attachments",
+        "attachments": "Attachments ({n})",
+        "targets": "Affected artifacts",
+        "transcript": "Dialogue this round",
+        "priorRounds": "Earlier rounds",
+        "roleHuman": "Human",
+        "roleAgent": "Agent",
+        "interrupted": "Not applied",
+        "indexOnly": "Auto-accepted by the platform; no standalone artifact",
+        "loading": "Loading…",
+        "loadFailed": "Cannot load {name}",
+        "seeIndex": "All rounds are listed in {name}",
+        "kind": {
+          "clarify": "Clarify",
+          "review": "Revise",
+          "gate": "Gate",
+          "preview": "Preview issues"
+        }
       },
       "review": {
         "verdict": "Review verdict",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -2909,7 +2909,8 @@
       "matchCount": "（匹配 {n} 个 Run）",
       "noMatchingArtifacts": "无匹配产物",
       "expandAll": "展开",
-      "collapseAll": "折叠"
+      "collapseAll": "折叠",
+      "feedbackGroup": "人工反馈台账"
     },
     "artifactPreview": {
       "emptyHint": "选择左侧产物查看内容(平台存储,可下载)",
@@ -2986,6 +2987,31 @@
         "tests": "测试",
         "breakingChanges": "破坏性变更",
         "followUps": "后续"
+      },
+      "feedback": {
+        "total": "共 {n} 轮人工反馈",
+        "empty": "暂无人工反馈",
+        "iterRound": "第 {i} 次执行 · 第 {r} 轮",
+        "roundN": "第 {n} 轮",
+        "annotationCount": "标注 {n}",
+        "attachmentCount": "附件 {n}",
+        "attachments": "附件 ({n})",
+        "targets": "受影响产物",
+        "transcript": "本轮对话",
+        "priorRounds": "此前各轮",
+        "roleHuman": "人工",
+        "roleAgent": "Agent",
+        "interrupted": "本轮未落地",
+        "indexOnly": "该轮为平台自动采纳，无独立产物",
+        "loading": "加载中…",
+        "loadFailed": "无法加载 {name}",
+        "seeIndex": "全部轮次见 {name}",
+        "kind": {
+          "clarify": "澄清",
+          "review": "复审",
+          "gate": "门禁",
+          "preview": "预览问题单"
+        }
       },
       "review": {
         "verdict": "评审结论",


### PR DESCRIPTION
## 背景

正向产出这条线一直很完整（`clarified_requirement.json` / `research.json` / `plan.json` 等），**反馈这条线一个产物都没有**：人的打回原文、标注、附件只活在 `react_conversations.messages` 这个 JSON blob 里，门禁审批意见散落在 `run_variables` / `state_runs.outputs` / `project_audit_events.payload` 三处。后果是门禁打回后节点重跑时，agent 拿到的还是原始需求。

## 改动

**一轮一个产物，永不覆盖。** 新增 `feedback_events` 表作真相来源，产物由它渲染（与 `run_error.json` 由 `state_runs` 派生同一范式）。`Seq`（run 全局）与 `Round`（`(node, iteration)` 内）两个序号在同一事务里分配，并发轮次不会撞名互相覆盖。每轮渲染成 `feedback.<kind>.<nodeSlug>.i<n>r<n>.json`，外加一个每轮从表全量重渲染的 `feedback_index.json`——某次写失败，下一轮会把漏掉的补回来。

**没有意见就不存。** `HasSubstance()` 是唯一判定：意见正文、标注、附件、ReAct 轮次，四者有其一才落。一路点"通过"不填表单的空审批产物数为零。`autoAdvanceReact` 的自动轮次只进索引不出文件——它决定了需求内容，但没有值得单独成文的正文。

**四个采集点。** 复审就地修改（前后取产物 sha256 组成 `targets`，说明这轮打回具体动了哪些产品；中断路径也记，标 `interrupted` 且不带 targets）、澄清问答（连同它所回应的 `questions`）、门禁决策（仅当表单有意见文本）、预览问题单（空快照不落）。回退没有造新数据：`runs.trace` 里 `Event: "rollback"` 的条目**本来就有**，只是 `history.go` 那个循环只认 `artifact_edit`，改成也渲染 rollback 并按回退目标节点收敛作用域即可。

**推到 agent 眼前。** 这是缺了就前功尽弃的一步：`list_run_history` 早就存在，但 `prompts.go` 里零处提到它。新增 `DefaultFeedbackHeader`，**仅在作用域内确有反馈时注入**，只列产物名与一行摘要，正文让 agent 自己 `read_artifact` 拉。作用域与 `list_run_history` 共用 `gateReviewScope`，不会出现"prompt 里列了但查不到"的错位。

**广度全留、深度按需。** 概览层不按条数裁剪，作用域内每一轮都一行；只有总字节超预算时才折叠中间段，首尾始终保留——最早的约束和最新的意见都不能丢。`list_artifacts` 与前端 `ArtifactList` 都把 `feedback.*` 折叠成一行指向索引，`FeedbackLedgerView` 以索引为入口渲染轨道时间线，展开才按名拉取单轮产物。

**隔离约束（均有测试守）。** 反馈产物不可经人工编辑路径改写；不是门禁主产物，分享链持有者读不到审批人姓名与原文；附件落库前清空 base64 只留 blob ref；`captureDeliverable` 忽略反馈产物，不会因为有人打回就把节点真正的交付物吞掉。

## 测试

- `server`：lint 0 issues、`go vet` 干净、`gen-configdoc -check` 无 diff、`go test ./...` 全绿、核心覆盖率 **90.5%**（门槛 90）、runtime ReAct 子集通过
- `web`：lint 0 errors、`vue-tsc` 干净、1965 tests 全过、lines **86.07%**（门槛 85）、`npm run build` 成功、42 条 critical-path Playwright 全过

> 本机 Node 25 会暴露一个缺 `clear` 的全局 `localStorage`，盖掉 happy-dom 的，导致 96 个无关测试失败；加 `NODE_OPTIONS=--no-experimental-webstorage` 复现 CI 的 Node 24 环境后全绿。仓库无需改动。

## 明确不做

不回填历史运行；不为回退 / 自动重试 / ResumeFrom 造反馈数据；不改 `react_conversations` 现有存储（产物是旁路沉淀，不是替代）；不新增 HTTP 端点与配置项。

Made with [Cursor](https://cursor.com)