### PR TITLE
fix(engine): stop CAPA A7 false empty-MCP kills after flush/Clear

### DIFF
--- a/server/internal/engine/auto_retry_test.go
+++ b/server/internal/engine/auto_retry_test.go
@@ -165,7 +165,8 @@ func TestAutoRetryDisabledByDefault(t *testing.T) {
 
 // TestStaleNodeCompleteNotReusedAfterRunAgentError: a failed attempt that
 // already called node_complete must not let the next attempt complete without
-// a fresh mark (nodeReq clears the buffer before each RunAgent).
+// a fresh mark (startNodeRun ClearOutcome drops Host mark + audit artifact
+// before each new visit/iteration).
 func TestStaleNodeCompleteNotReusedAfterRunAgentError(t *testing.T) {
 	autoRetryBackoff = 0
 	eng, db, p := setupEngineGraphP(t, autoRetryGraph())

--- a/server/internal/engine/execute.go
+++ b/server/internal/engine/execute.go
@@ -67,6 +67,9 @@ func (e *Engine) startNodeRun(c *execCtx, node *models.Node) {
 	for k, v := range c.vars {
 		before[k] = v
 	}
+	// New visit / new iteration: drop stale Host outcome + audit artifact so a
+	// prior attempt's mark cannot satisfy this visit (CAPA A7 / FR4).
+	e.host.ClearOutcome(c.run.ID, node.ID)
 	logDB(e.db.Create(&models.StateRun{
 		RunID: c.run.ID, NodeID: node.ID, NodeType: node.Type,
 		Iteration: c.iter[node.ID], Status: "running", StartedAt: &now, Attempt: c.run.Attempt,

--- a/server/internal/engine/finish.go
+++ b/server/internal/engine/finish.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"time"
@@ -235,12 +236,19 @@ func (e *Engine) finish(runID, status string) bool {
 
 // persistRunErrorArtifact writes run_error.json via the artifact store so empty
 // product failures remain queryable. Best-effort: store failures are logged and
-// do not change finish control flow.
+// do not change finish control flow. Before aggregating, forces sandbox log
+// archive/pull so CAPA mis-fires after retire still get logs or a degrade note.
 func (e *Engine) persistRunErrorArtifact(runID string) {
 	if e.store == nil {
 		return
 	}
-	info := services.NewRunService(e.db).AggregateRunFailure(runID)
+	degrade := ""
+	if a, ok := e.provider.(runtime.RunSandboxLogArchiver); ok {
+		if n, note := a.ArchiveRunSandboxLogs(context.Background(), runID); n == 0 && note != "" {
+			degrade = note
+		}
+	}
+	info := services.NewRunService(e.db).AggregateRunFailure(runID, degrade)
 	body, err := services.MarshalRunErrorJSON(info)
 	if err != nil {
 		log.Warn().Str("run_id", runID).Err(err).Msg("marshal run_error.json failed")

--- a/server/internal/engine/node_req.go
+++ b/server/internal/engine/node_req.go
@@ -68,7 +68,10 @@ func (e *Engine) nodeReq(c *execCtx, node *models.Node) runtime.NodeReq {
 
 	e.host.SetActiveNode(c.run.ID, node.ID, node.Type)
 
-	e.host.ClearOutcome(c.run.ID, node.ID)
+	// ClearOutcome is intentionally NOT called here: same-visit react multi-round
+	// replies rebuild NodeReq via this helper and must keep a legal Host mark.
+	// New visit/iteration clears in startNodeRun; sandbox retries clear in
+	// ReactOpen / runAgentOnce.
 	if node.Type == "app_preview" {
 		e.host.ResetPreviewReady(c.run.ID, node.ID)
 	}

--- a/server/internal/engine/outcome.go
+++ b/server/internal/engine/outcome.go
@@ -8,18 +8,33 @@ import (
 	"github.com/cocofhu/approving/internal/models"
 	"github.com/cocofhu/approving/internal/nodereg"
 	"github.com/cocofhu/approving/internal/runtime"
+	"github.com/rs/zerolog/log"
+)
+
+// CAPA A7 failure reasons (Demo S2/S3/S4) — keep wording stable for tests/UI.
+const (
+	errMCPSurfaceEmpty     = "MCP 工具面为空/不可达，无法完成 node_complete"
+	errMissingNodeComplete = "未调用 node_complete 标记完成"
+	errOutcomeMarkLost     = "node_complete 标记丢失/不可用（产物无法解析或无法采纳）"
 )
 
 // consumeNodeOutcome drains the agent's node_complete mark and merges its
 // outputs into res. Missing mark or status=failed yields a failed nodeOutcome.
 //
-// CAPA A7: when the mark is missing, distinguish "MCP tool surface empty /
-// unreachable" (expected MCP traffic but zero host calls) from "tools were
-// reachable but agent never called node_complete".
+// CAPA A7: when the Host memory mark is missing, adopt a parseable
+// node_complete.json when present; otherwise classify failure with the evidence
+// triple Host Peek ∪ current-iteration StateRun.McpCalls ∪ artifact state —
+// never treat "Host buffer currently empty" alone as "tool surface unreachable".
 func (e *Engine) consumeNodeOutcome(c *execCtx, node *models.Node, res *runtime.NodeResult) (nodeOutcome, bool) {
 	o, ok := e.host.TakeOutcome(c.run.ID, node.ID)
 	if !ok {
-		errMsg := missingOutcomeErr(e.host.PeekMcpCalls(c.run.ID, node.ID))
+		if adopted, adoptedOK := e.adoptOutcomeArtifact(c, node); adoptedOK {
+			o = adopted
+			ok = true
+		}
+	}
+	if !ok {
+		errMsg := e.missingOutcomeErr(c, node)
 		return nodeOutcome{
 			status:   "failed",
 			err:      errMsg,
@@ -52,6 +67,43 @@ func (e *Engine) consumeNodeOutcome(c *execCtx, node *models.Node, res *runtime.
 		}, false
 	}
 	return nodeOutcome{}, true
+}
+
+// adoptOutcomeArtifact restores a parseable node_complete.json into the Host
+// buffer and returns it for immediate consume. success and failed marks both
+// count as "normally finalized" (differ only in result).
+func (e *Engine) adoptOutcomeArtifact(c *execCtx, node *models.Node) (mcp.NodeOutcome, bool) {
+	if e == nil || e.host == nil || c == nil || node == nil {
+		return mcp.NodeOutcome{}, false
+	}
+	o, state := e.host.PeekOutcomeArtifact(c.run.ID)
+	if state != mcp.OutcomeArtifactAdoptable {
+		return mcp.NodeOutcome{}, false
+	}
+	e.host.RestoreOutcomeFromArtifact(c.run.ID, node.ID)
+	// Restore leaves the mark in the buffer; drain so callers mirror TakeOutcome.
+	taken, ok := e.host.TakeOutcome(c.run.ID, node.ID)
+	if !ok {
+		taken = o
+	}
+	log.Info().Str("run_id", c.run.ID).Str("node_id", node.ID).
+		Str("status", taken.Status).
+		Msg("adopted node_complete.json after Host mark missing")
+	return taken, true
+}
+
+// currentIterationMcpCalls returns StateRun.McpCalls for the node's latest
+// (current) iteration row — durable evidence after flushMcpCalls.
+func (e *Engine) currentIterationMcpCalls(runID, nodeID string) []models.McpCall {
+	if e == nil || e.db == nil || runID == "" || nodeID == "" {
+		return nil
+	}
+	var sr models.StateRun
+	if err := e.db.Where("run_id = ? AND node_id = ?", runID, nodeID).
+		Order("iteration desc, id desc").First(&sr).Error; err != nil {
+		return nil
+	}
+	return sr.McpCalls
 }
 
 // afterDefaultChecks runs the optional business RPC validator only after
@@ -154,11 +206,34 @@ func agentExecNeedsOutcome(k nodereg.ExecKind) bool {
 	}
 }
 
-// missingOutcomeErr (CAPA A7) picks the failure reason when node_complete is absent.
-// Zero MCP host calls ⇒ tool surface empty/unreachable; any traffic ⇒ agent forgot mark.
-func missingOutcomeErr(calls []models.McpCall) string {
-	if len(calls) == 0 {
-		return "MCP 工具面为空/不可达，无法完成 node_complete"
+// missingOutcomeErr (CAPA A7) picks the failure reason when no adoptable mark
+// exists. Evidence triple: Host Peek ∪ StateRun.McpCalls ∪ artifact presence.
+// ① true-zero MCP + no artifact → empty surface
+// ② MCP evidence but no usable mark → forgot node_complete
+// ③ artifact present but corrupt/unadoptable → mark lost
+func (e *Engine) missingOutcomeErr(c *execCtx, node *models.Node) string {
+	hostCalls := e.host.PeekMcpCalls(c.run.ID, node.ID)
+	stateCalls := e.currentIterationMcpCalls(c.run.ID, node.ID)
+	_, artState := e.host.PeekOutcomeArtifact(c.run.ID)
+	return missingOutcomeErr(hostCalls, stateCalls, artState)
+}
+
+// missingOutcomeErr is the pure classifier (testable without Engine).
+func missingOutcomeErr(hostCalls, stateCalls []models.McpCall, artState mcp.OutcomeArtifactState) string {
+	if artState == mcp.OutcomeArtifactCorrupt {
+		return errOutcomeMarkLost
 	}
-	return "未调用 node_complete 标记完成"
+	hasMCP := len(hostCalls) > 0 || len(stateCalls) > 0
+	if !hasMCP && artState == mcp.OutcomeArtifactAbsent {
+		return errMCPSurfaceEmpty
+	}
+	// Adoptable artifacts are handled before this helper; if we still see
+	// Adoptable here it means adoption failed unexpectedly — treat as mark lost.
+	if artState == mcp.OutcomeArtifactAdoptable {
+		return errOutcomeMarkLost
+	}
+	if hasMCP {
+		return errMissingNodeComplete
+	}
+	return errMCPSurfaceEmpty
 }

--- a/server/internal/engine/outcome_test.go
+++ b/server/internal/engine/outcome_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cocofhu/approving/internal/mcp"
 	"github.com/cocofhu/approving/internal/models"
 	"github.com/cocofhu/approving/internal/runtime"
+	"github.com/cocofhu/approving/internal/services"
 )
 
 type countingRPC struct {
@@ -51,8 +53,8 @@ func TestAfterDefaultChecksRunsRPCOnSuccess(t *testing.T) {
 	}
 }
 
-// TestConsumeNodeOutcomeEmptyMCPSurface (CAPA A7): expected MCP + zero calls +
-// missing outcome ⇒ distinct "工具面为空/不可达" failure (not node_complete).
+// TestConsumeNodeOutcomeEmptyMCPSurface (CAPA A7): true-zero MCP evidence +
+// missing outcome + no artifact ⇒ distinct "工具面为空/不可达" failure.
 func TestConsumeNodeOutcomeEmptyMCPSurface(t *testing.T) {
 	eng, _ := setupEngine(t)
 	runID := "r-empty-mcp"
@@ -67,17 +69,16 @@ func TestConsumeNodeOutcomeEmptyMCPSurface(t *testing.T) {
 	if ok {
 		t.Fatal("want missing outcome failure")
 	}
-	want := "MCP 工具面为空/不可达，无法完成 node_complete"
-	if fail.err != want {
-		t.Fatalf("err=%q want %q", fail.err, want)
+	if fail.err != errMCPSurfaceEmpty {
+		t.Fatalf("err=%q want %q", fail.err, errMCPSurfaceEmpty)
 	}
-	if !strings.Contains(fail.outputMd, want) {
+	if !strings.Contains(fail.outputMd, errMCPSurfaceEmpty) {
 		t.Fatalf("outputMd=%q", fail.outputMd)
 	}
 }
 
 // TestConsumeNodeOutcomeMissingNodeComplete (CAPA A7): MCP traffic present but
-// no mark ⇒ keep classic「未调用 node_complete」wording.
+// no mark ⇒ classic「未调用 node_complete」wording (not empty surface).
 func TestConsumeNodeOutcomeMissingNodeComplete(t *testing.T) {
 	eng, _ := setupEngine(t)
 	runID := "r-has-mcp"
@@ -85,7 +86,6 @@ func TestConsumeNodeOutcomeMissingNodeComplete(t *testing.T) {
 	tok := eng.host.RegisterRun(runID)
 	eng.host.SetActiveNode(runID, nodeID, "research")
 
-	// One built-in MCP call proves the tool surface was reachable.
 	st, resp := eng.host.ServeRPC(runID, tok, []byte(
 		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"write_artifact","arguments":{"name":"note.md","content":"x","kind":"markdown"}}}`))
 	if st != 200 {
@@ -102,20 +102,233 @@ func TestConsumeNodeOutcomeMissingNodeComplete(t *testing.T) {
 	if ok {
 		t.Fatal("want missing outcome failure")
 	}
-	want := "未调用 node_complete 标记完成"
-	if fail.err != want {
-		t.Fatalf("err=%q want %q", fail.err, want)
+	if fail.err != errMissingNodeComplete {
+		t.Fatalf("err=%q want %q", fail.err, errMissingNodeComplete)
 	}
 	if strings.Contains(fail.err, "工具面为空") {
 		t.Fatalf("must not use empty-surface wording when MCP traffic exists: %q", fail.err)
 	}
 }
 
-func TestMissingOutcomeErrBranches(t *testing.T) {
-	if got := missingOutcomeErr(nil); got != "MCP 工具面为空/不可达，无法完成 node_complete" {
-		t.Fatalf("nil calls: %q", got)
+// TestConsumeNodeOutcomeAdoptsArtifactAfterFlush: Host Peek empty after flush
+// but node_complete.json(success) exists → adopt, not empty-surface (Demo S1).
+func TestConsumeNodeOutcomeAdoptsArtifactAfterFlush(t *testing.T) {
+	eng, db := setupEngine(t)
+	runID := "r-adopt"
+	nodeID := "react_rlze"
+	tok := eng.host.RegisterRun(runID)
+	eng.host.SetActiveNode(runID, nodeID, "react")
+
+	// Business call then node_complete (writes Host mark + artifact).
+	st, resp := eng.host.ServeRPC(runID, tok, []byte(
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"write_artifact","arguments":{"name":"clarified_requirement.json","content":"{\"title\":\"t\"}","kind":"json"}}}`))
+	if st != 200 {
+		t.Fatalf("write_artifact status=%d resp=%s", st, resp)
 	}
-	if got := missingOutcomeErr([]models.McpCall{{Tool: "write_artifact"}}); got != "未调用 node_complete 标记完成" {
-		t.Fatalf("with calls: %q", got)
+	st, resp = eng.host.ServeRPC(runID, tok, []byte(
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"node_complete","arguments":{"status":"success","summary":"done"}}}`))
+	if st != 200 || strings.Contains(string(resp), `"error"`) {
+		t.Fatalf("node_complete status=%d resp=%s", st, resp)
+	}
+
+	// Persist calls then clear Host buffer (flushMcpCalls shape) + Clear Host mark
+	// (same-visit mis-clear repro before FR4 fix — evidence still in store/StateRun).
+	now := time.Now()
+	calls := eng.host.TakeMcpCalls(runID, nodeID)
+	if len(calls) < 2 {
+		t.Fatalf("want buffered calls before flush, got %d", len(calls))
+	}
+	if err := db.Create(&models.StateRun{
+		RunID: runID, NodeID: nodeID, NodeType: "react", Iteration: 1,
+		Status: "running", McpCalls: calls, StartedAt: &now,
+	}).Error; err != nil {
+		t.Fatalf("state_run: %v", err)
+	}
+	eng.host.ClearOutcome(runID, nodeID) // clears memory only path for this test:
+	// re-write artifact because ClearOutcome deletes audit via ArtifactDeleter
+	if _, err := eng.store.Save(runID, nodeID, mcp.NodeOutcomeArtifactName, "json",
+		mcp.OutcomeJSON(mcp.NodeOutcome{Status: mcp.OutcomeSuccess, Summary: "done"})); err != nil {
+		t.Fatalf("restore artifact: %v", err)
+	}
+	if n := len(eng.host.PeekMcpCalls(runID, nodeID)); n != 0 {
+		t.Fatalf("Peek after flush want 0, got %d", n)
+	}
+	if eng.host.HasOutcome(runID, nodeID) {
+		t.Fatal("Host mark should be cleared")
+	}
+
+	c := &execCtx{run: &models.Run{ID: runID}, token: tok}
+	node := &models.Node{ID: nodeID, Type: "react"}
+	res := &runtime.NodeResult{Outputs: map[string]any{}}
+	fail, ok := eng.consumeNodeOutcome(c, node, res)
+	if !ok {
+		t.Fatalf("want adopt success, got fail err=%q", fail.err)
+	}
+	if res.Outputs["outcome_status"] != "success" {
+		t.Fatalf("outputs=%v", res.Outputs)
+	}
+}
+
+// TestConsumeNodeOutcomeStateRunOnlyNotEmptySurface: Peek empty but StateRun
+// has MCP calls and no mark → 未调用, not 工具面为空 (Demo S2).
+func TestConsumeNodeOutcomeStateRunOnlyNotEmptySurface(t *testing.T) {
+	eng, db := setupEngine(t)
+	runID := "r-state-only"
+	nodeID := "research"
+	eng.host.RegisterRun(runID)
+	eng.host.SetActiveNode(runID, nodeID, "research")
+
+	now := time.Now()
+	if err := db.Create(&models.StateRun{
+		RunID: runID, NodeID: nodeID, NodeType: "research", Iteration: 1,
+		Status: "running", StartedAt: &now,
+		McpCalls: []models.McpCall{{Tool: "write_artifact"}, {Tool: "set_research"}},
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	c := &execCtx{run: &models.Run{ID: runID}}
+	node := &models.Node{ID: nodeID, Type: "research"}
+	fail, ok := eng.consumeNodeOutcome(c, node, &runtime.NodeResult{})
+	if ok {
+		t.Fatal("want failure")
+	}
+	if fail.err != errMissingNodeComplete {
+		t.Fatalf("err=%q want %q", fail.err, errMissingNodeComplete)
+	}
+}
+
+// TestConsumeNodeOutcomeCorruptArtifact: artifact exists but unparseable →
+// mark lost wording (Demo S4), not empty surface.
+func TestConsumeNodeOutcomeCorruptArtifact(t *testing.T) {
+	eng, _ := setupEngine(t)
+	runID := "r-corrupt"
+	nodeID := "test"
+	tok := eng.host.RegisterRun(runID)
+	eng.host.SetActiveNode(runID, nodeID, "test")
+	if _, err := eng.store.Save(runID, nodeID, mcp.NodeOutcomeArtifactName, "json", "{not-json"); err != nil {
+		t.Fatal(err)
+	}
+	st, resp := eng.host.ServeRPC(runID, tok, []byte(
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"write_artifact","arguments":{"name":"x.md","content":"x","kind":"markdown"}}}`))
+	if st != 200 {
+		t.Fatalf("status=%d resp=%s", st, resp)
+	}
+
+	fail, ok := eng.consumeNodeOutcome(&execCtx{run: &models.Run{ID: runID}}, &models.Node{ID: nodeID, Type: "test"}, &runtime.NodeResult{})
+	if ok {
+		t.Fatal("want failure")
+	}
+	if fail.err != errOutcomeMarkLost {
+		t.Fatalf("err=%q want %q", fail.err, errOutcomeMarkLost)
+	}
+}
+
+// TestConsumeNodeOutcomeAdoptsFailedArtifact: status=failed mark is normal
+// finalize (failed result), not empty-surface / 未调用.
+func TestConsumeNodeOutcomeAdoptsFailedArtifact(t *testing.T) {
+	eng, _ := setupEngine(t)
+	runID := "r-failed-mark"
+	nodeID := "implement"
+	eng.host.RegisterRun(runID)
+	eng.host.SetActiveNode(runID, nodeID, "implement")
+	if _, err := eng.store.Save(runID, nodeID, mcp.NodeOutcomeArtifactName, "json",
+		mcp.OutcomeJSON(mcp.NodeOutcome{Status: mcp.OutcomeFailed, Error: "plan incomplete"})); err != nil {
+		t.Fatal(err)
+	}
+
+	fail, ok := eng.consumeNodeOutcome(&execCtx{run: &models.Run{ID: runID}},
+		&models.Node{ID: nodeID, Type: "implement"}, &runtime.NodeResult{})
+	if ok {
+		t.Fatal("want failed outcome (agent-reported)")
+	}
+	if fail.err != "plan incomplete" {
+		t.Fatalf("err=%q", fail.err)
+	}
+	if strings.Contains(fail.err, "工具面") || strings.Contains(fail.err, "未调用") {
+		t.Fatalf("must not remap failed mark: %q", fail.err)
+	}
+}
+
+// TestNodeReqDoesNotClearOutcome: same-visit NodeReq rebuild must keep mark.
+func TestNodeReqDoesNotClearOutcome(t *testing.T) {
+	eng, _ := setupEngine(t)
+	runID := "r-keep-mark"
+	nodeID := "react"
+	tok := eng.host.RegisterRun(runID)
+	eng.host.SetActiveNode(runID, nodeID, "react")
+	st, resp := eng.host.ServeRPC(runID, tok, []byte(
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"node_complete","arguments":{"status":"success","summary":"ok"}}}`))
+	if st != 200 {
+		t.Fatalf("node_complete: %s", resp)
+	}
+	if !eng.host.HasOutcome(runID, nodeID) {
+		t.Fatal("want mark")
+	}
+	c := &execCtx{run: &models.Run{ID: runID}, token: tok, vars: map[string]any{}}
+	_ = eng.nodeReq(c, &models.Node{ID: nodeID, Type: "react", Config: map[string]any{}})
+	if !eng.host.HasOutcome(runID, nodeID) {
+		t.Fatal("nodeReq must not ClearOutcome on same visit")
+	}
+}
+
+// TestStartNodeRunClearsOutcome: new visit clears Host mark + artifact.
+func TestStartNodeRunClearsOutcome(t *testing.T) {
+	eng, _ := setupEngine(t)
+	runID := "r-clear-visit"
+	nodeID := "research"
+	tok := eng.host.RegisterRun(runID)
+	eng.host.SetActiveNode(runID, nodeID, "research")
+	_, _ = eng.host.ServeRPC(runID, tok, []byte(
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"node_complete","arguments":{"status":"success"}}}`))
+	if !eng.host.HasOutcome(runID, nodeID) {
+		t.Fatal("want mark")
+	}
+	if _, ok := eng.store.Get(runID, mcp.NodeOutcomeArtifactName); !ok {
+		t.Fatal("want artifact")
+	}
+	c := &execCtx{run: &models.Run{ID: runID}, iter: map[string]int{nodeID: 2}, vars: map[string]any{}}
+	eng.startNodeRun(c, &models.Node{ID: nodeID, Type: "research"})
+	if eng.host.HasOutcome(runID, nodeID) {
+		t.Fatal("startNodeRun must ClearOutcome")
+	}
+	if _, ok := eng.store.Get(runID, mcp.NodeOutcomeArtifactName); ok {
+		t.Fatal("startNodeRun must delete node_complete.json")
+	}
+}
+
+func TestMissingOutcomeErrBranches(t *testing.T) {
+	if got := missingOutcomeErr(nil, nil, mcp.OutcomeArtifactAbsent); got != errMCPSurfaceEmpty {
+		t.Fatalf("zero evidence: %q", got)
+	}
+	if got := missingOutcomeErr([]models.McpCall{{Tool: "write_artifact"}}, nil, mcp.OutcomeArtifactAbsent); got != errMissingNodeComplete {
+		t.Fatalf("host calls: %q", got)
+	}
+	if got := missingOutcomeErr(nil, []models.McpCall{{Tool: "set_research"}}, mcp.OutcomeArtifactAbsent); got != errMissingNodeComplete {
+		t.Fatalf("state calls: %q", got)
+	}
+	if got := missingOutcomeErr(nil, nil, mcp.OutcomeArtifactCorrupt); got != errOutcomeMarkLost {
+		t.Fatalf("corrupt: %q", got)
+	}
+	if got := missingOutcomeErr([]models.McpCall{{Tool: "x"}}, nil, mcp.OutcomeArtifactCorrupt); got != errOutcomeMarkLost {
+		t.Fatalf("corrupt with MCP: %q", got)
+	}
+}
+
+func TestAggregateRunFailureDegradeNote(t *testing.T) {
+	_, db := setupEngine(t)
+	s := services.NewRunService(db)
+	db.Create(&models.Run{ID: "rf-degrade", Status: "failed"})
+	db.Create(&models.StateRun{RunID: "rf-degrade", NodeID: "research", Status: "failed", Error: "boom"})
+	info := s.AggregateRunFailure("rf-degrade", "容器已销毁，未能拉取 live logs")
+	if !info.NoSandboxLog {
+		t.Fatal("expected noSandboxLog")
+	}
+	if info.SandboxLogNote != "容器已销毁，未能拉取 live logs" {
+		t.Fatalf("note=%q", info.SandboxLogNote)
+	}
+	display := info.DisplayReason()
+	if !strings.Contains(display, "容器已销毁") {
+		t.Fatalf("display=%q", display)
 	}
 }

--- a/server/internal/engine/review.go
+++ b/server/internal/engine/review.go
@@ -252,7 +252,7 @@ func (e *Engine) reviewReply(c *execCtx, node *models.Node, conv *models.ReactCo
 	runID, nodeID := c.run.ID, node.ID
 	_ = human
 	_ = images
-	_ = e.nodeReq(c, node) // SetActiveNode + KeepAliveForReview + ClearOutcome
+	_ = e.nodeReq(c, node) // SetActiveNode + KeepAliveForReview (no ClearOutcome)
 	e.host.SetActiveReview(runID, true)
 
 	if !force {

--- a/server/internal/mcp/host.go
+++ b/server/internal/mcp/host.go
@@ -54,6 +54,12 @@ type Store interface {
 	List(runID string) []ArtifactInfo
 }
 
+// ArtifactDeleter is an optional Store capability used to drop stale
+// node_complete.json when ClearOutcome runs for a new attempt/iteration.
+type ArtifactDeleter interface {
+	Delete(runID, name string) error
+}
+
 // Host manages per-run scoped endpoints and tokens.
 type Host struct {
 	mu         sync.RWMutex

--- a/server/internal/mcp/outcome.go
+++ b/server/internal/mcp/outcome.go
@@ -168,8 +168,11 @@ func (h *Host) TakeOutcome(runID, nodeID string) (NodeOutcome, bool) {
 }
 
 // ClearOutcome drops any buffered node_complete mark for (runID, nodeID).
-// Call at the start of each agent attempt so a mark from a failed/retried
-// turn cannot satisfy ensureOutcome or TakeOutcome on a later attempt.
+// Call only at a new attempt / new iteration (or equivalent fresh node visit)
+// so a mark from a failed/retried turn cannot satisfy ensureOutcome or
+// TakeOutcome later. Same-visit react multi-round replies must NOT call this.
+// Best-effort: also deletes the audit node_complete.json so artifact adoption
+// cannot revive a stale mark across attempts.
 func (h *Host) ClearOutcome(runID, nodeID string) {
 	h.mu.Lock()
 	var (
@@ -188,6 +191,82 @@ func (h *Host) ClearOutcome(runID, nodeID string) {
 			Str("status", o.Status).Str("summary", o.Summary).
 			Msg("cleared stale node_complete mark before new attempt")
 	}
+	h.clearOutcomeArtifact(runID)
+}
+
+// clearOutcomeArtifact drops the audit node_complete.json when the store
+// supports deletion (production ArtifactService). No-op for stores that do not.
+func (h *Host) clearOutcomeArtifact(runID string) {
+	if h == nil || h.store == nil || runID == "" {
+		return
+	}
+	d, ok := h.store.(ArtifactDeleter)
+	if !ok {
+		return
+	}
+	if err := d.Delete(runID, NodeOutcomeArtifactName); err != nil {
+		log.Warn().Err(err).Str("run_id", runID).
+			Msg("clear node_complete.json before new attempt failed")
+	}
+}
+
+// PeekOutcomeArtifact reads and classifies the audit node_complete.json for a
+// run without authorizing a token (engine / ensure paths). Missing → absent.
+func (h *Host) PeekOutcomeArtifact(runID string) (NodeOutcome, OutcomeArtifactState) {
+	if h == nil || h.store == nil || runID == "" {
+		return NodeOutcome{}, OutcomeArtifactAbsent
+	}
+	content, ok := h.store.Get(runID, NodeOutcomeArtifactName)
+	if !ok {
+		return NodeOutcome{}, OutcomeArtifactAbsent
+	}
+	return ClassifyOutcomeArtifact(content)
+}
+
+// RestoreOutcomeFromArtifact adopts a parseable node_complete.json into the
+// Host outcome buffer when memory mark is missing. Returns true when restored.
+func (h *Host) RestoreOutcomeFromArtifact(runID, nodeID string) bool {
+	o, state := h.PeekOutcomeArtifact(runID)
+	if state != OutcomeArtifactAdoptable {
+		return false
+	}
+	if nodeID == "" {
+		nodeID = h.ActiveNode(runID)
+	}
+	if nodeID == "" || nodeID == "mcp" {
+		return false
+	}
+	h.storeOutcome(runID, nodeID, o)
+	log.Info().Str("run_id", runID).Str("node_id", nodeID).
+		Str("status", o.Status).
+		Msg("restored node_complete mark from artifact")
+	return true
+}
+
+// OutcomeArtifactState classifies node_complete.json for CAPA A7 evidence.
+type OutcomeArtifactState int
+
+const (
+	OutcomeArtifactAbsent OutcomeArtifactState = iota
+	OutcomeArtifactAdoptable
+	OutcomeArtifactCorrupt
+)
+
+// ClassifyOutcomeArtifact parses audit JSON. Only status success|failed is adoptable.
+func ClassifyOutcomeArtifact(content string) (NodeOutcome, OutcomeArtifactState) {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return NodeOutcome{}, OutcomeArtifactAbsent
+	}
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(content), &raw); err != nil {
+		return NodeOutcome{}, OutcomeArtifactCorrupt
+	}
+	o, err := ParseNodeOutcome(raw)
+	if err != nil {
+		return NodeOutcome{}, OutcomeArtifactCorrupt
+	}
+	return o, OutcomeArtifactAdoptable
 }
 
 // HasOutcome reports whether a non-cleared outcome exists for the node.

--- a/server/internal/mcp/outcome_test.go
+++ b/server/internal/mcp/outcome_test.go
@@ -26,6 +26,12 @@ func (m *memOutcomeStore) Get(runID, name string) (string, bool) {
 	return c, ok
 }
 func (m *memOutcomeStore) List(runID string) []ArtifactInfo { return nil }
+func (m *memOutcomeStore) Delete(runID, name string) error {
+	if m.data != nil && m.data[runID] != nil {
+		delete(m.data[runID], name)
+	}
+	return nil
+}
 
 type countingValidator struct {
 	calls  int
@@ -156,7 +162,8 @@ func TestNodeCompleteTool(t *testing.T) {
 }
 
 func TestClearOutcome(t *testing.T) {
-	h := NewHost(&memOutcomeStore{})
+	store := &memOutcomeStore{}
+	h := NewHost(store)
 	tok := h.RegisterRun("r1")
 	h.SetActiveNode("r1", "n1", "agent")
 	if msg, isErr := h.runTool("r1", tok, "node_complete", map[string]any{
@@ -167,11 +174,44 @@ func TestClearOutcome(t *testing.T) {
 	if !h.HasOutcome("r1", "n1") {
 		t.Fatal("expected buffered outcome")
 	}
+	if _, ok := store.Get("r1", NodeOutcomeArtifactName); !ok {
+		t.Fatal("expected audit artifact")
+	}
 	h.ClearOutcome("r1", "n1")
 	if h.HasOutcome("r1", "n1") {
 		t.Fatal("ClearOutcome should drop the mark")
 	}
+	if _, ok := store.Get("r1", NodeOutcomeArtifactName); ok {
+		t.Fatal("ClearOutcome should delete audit artifact")
+	}
 	h.ClearOutcome("r1", "n1") // idempotent
+}
+
+func TestClassifyAndRestoreOutcomeArtifact(t *testing.T) {
+	store := &memOutcomeStore{}
+	h := NewHost(store)
+	h.RegisterRun("r1")
+	h.SetActiveNode("r1", "n1", "agent")
+	_, _ = store.Save("r1", "n1", NodeOutcomeArtifactName, "json",
+		OutcomeJSON(NodeOutcome{Status: OutcomeSuccess, Summary: "from art"}))
+	if h.HasOutcome("r1", "n1") {
+		t.Fatal("memory should be empty before restore")
+	}
+	if !h.RestoreOutcomeFromArtifact("r1", "n1") {
+		t.Fatal("restore failed")
+	}
+	o, ok := h.PeekOutcome("r1", "n1")
+	if !ok || o.Status != OutcomeSuccess || o.Summary != "from art" {
+		t.Fatalf("restored=%v ok=%v", o, ok)
+	}
+	_, st := ClassifyOutcomeArtifact("{bad")
+	if st != OutcomeArtifactCorrupt {
+		t.Fatalf("corrupt state=%v", st)
+	}
+	_, st = ClassifyOutcomeArtifact(`{"status":"nope"}`)
+	if st != OutcomeArtifactCorrupt {
+		t.Fatalf("bad status state=%v", st)
+	}
 }
 
 func TestSetRPCOutcomeValidator(t *testing.T) {

--- a/server/internal/runtime/acp_ensure.go
+++ b/server/internal/runtime/acp_ensure.go
@@ -13,15 +13,23 @@ import (
 
 // ensureOutcome re-prompts the agent to call node_complete when the mark is
 // still missing (best-effort; engine fails closed if ultimately absent).
+// Aligns with ensureStructured: when Host memory HasOutcome is false, first
+// adopt a parseable node_complete.json before re-prompting / fail-closed.
 // For react nodes, a pending ask_question raised during the re-prompt aborts
 // the completion push and returns those questions (caller must not discard).
 // Non-react callers keep the prior discard-and-continue semantics.
 func (c *acpProvider) ensureOutcome(ctx context.Context, req NodeReq, acp *sandbox.ACPClient, events *[]models.AcpEvent, usage **models.TokenUsage, byModel *models.TokenUsageByModel) ([]models.ReactQuestion, error) {
-	if c.host.HasOutcome(req.RunID, req.NodeID) {
+	outcomeReady := func() bool {
+		if c.host.HasOutcome(req.RunID, req.NodeID) {
+			return true
+		}
+		return c.host.RestoreOutcomeFromArtifact(req.RunID, req.NodeID)
+	}
+	if outcomeReady() {
 		return nil, nil
 	}
 	for i := 0; i <= producesRetry; i++ {
-		if c.host.HasOutcome(req.RunID, req.NodeID) {
+		if outcomeReady() {
 			return nil, nil
 		}
 		if i == producesRetry {

--- a/server/internal/runtime/acp_sandbox.go
+++ b/server/internal/runtime/acp_sandbox.go
@@ -107,6 +107,19 @@ func (c *acpProvider) SetSandboxRegistry(r SandboxRegistry) {
 	c.registry = r
 }
 
+// ArchiveRunSandboxLogs best-effort archives live logs via the platform
+// SandboxService when wired as registry.
+func (c *acpProvider) ArchiveRunSandboxLogs(ctx context.Context, runID string) (int, string) {
+	if c == nil || c.registry == nil {
+		return 0, "未接线沙箱注册表，未能拉取 live logs"
+	}
+	a, ok := c.registry.(RunSandboxLogArchiver)
+	if !ok {
+		return 0, "沙箱注册表不支持归档 live logs"
+	}
+	return a.ArchiveRunSandboxLogs(ctx, runID)
+}
+
 // beginRunSandbox records a "creating" placeholder row for a node sandbox before
 // the (slow) gateway provisioning, so it shows up in the sandbox list / node
 // live log as "starting" instead of a 404. No-op when the registry is absent or

--- a/server/internal/runtime/provider.go
+++ b/server/internal/runtime/provider.go
@@ -279,6 +279,13 @@ type RunSandboxRetirer interface {
 	RetireRunSandbox(name string)
 }
 
+// RunSandboxLogArchiver is an optional capability (SandboxService / provider
+// forwarder): before AggregateRunFailure, best-effort archive live container
+// logs so CAPA failures after retire still have sandbox_logs.
+type RunSandboxLogArchiver interface {
+	ArchiveRunSandboxLogs(ctx context.Context, runID string) (archived int, degradeNote string)
+}
+
 // SandboxRegistrar is the optional provider capability used to inject the
 // registry after construction (the SandboxService is built after the
 // provider in main). main type-asserts the provider for it.

--- a/server/internal/runtime/registry.go
+++ b/server/internal/runtime/registry.go
@@ -190,3 +190,14 @@ func (r *ProviderRegistry) SetSandboxRegistry(reg SandboxRegistry) {
 		}
 	}
 }
+
+// ArchiveRunSandboxLogs forwards to the shared sandbox registry when it
+// implements RunSandboxLogArchiver (production SandboxService).
+func (r *ProviderRegistry) ArchiveRunSandboxLogs(ctx context.Context, runID string) (int, string) {
+	for _, p := range r.providers {
+		if a, ok := p.(RunSandboxLogArchiver); ok {
+			return a.ArchiveRunSandboxLogs(ctx, runID)
+		}
+	}
+	return 0, "执行后端未暴露沙箱日志归档"
+}

--- a/server/internal/services/artifact.go
+++ b/server/internal/services/artifact.go
@@ -99,6 +99,17 @@ func (s *ArtifactService) List(runID string) []mcp.ArtifactInfo {
 	return out
 }
 
+// Delete removes a named artifact within a run (idempotent). Used to drop stale
+// node_complete.json when ClearOutcome starts a new attempt/iteration.
+func (s *ArtifactService) Delete(runID, name string) error {
+	if runID == "" || name == "" {
+		return nil
+	}
+	return s.db.Where("run_id = ? AND name = ?", runID, name).Delete(&models.Artifact{}).Error
+}
+
+var _ mcp.ArtifactDeleter = (*ArtifactService)(nil)
+
 // ByRun returns artifact records for a run (for the API). Content is omitted.
 func (s *ArtifactService) ByRun(runID string) []models.Artifact {
 	var arts []models.Artifact

--- a/server/internal/services/run_failure.go
+++ b/server/internal/services/run_failure.go
@@ -16,6 +16,9 @@ const RunErrorArtifactName = "run_error.json"
 const (
 	DefaultRunFailureReason = "运行失败，未记录具体错误原因"
 	NoSandboxLogMarker      = "无可用沙箱日志"
+	// SandboxLogDegradeMarker distinguishes "archive/pull failed" from a bare
+	// no-log flag so operators know why logs are missing (FR6 / Demo S5).
+	SandboxLogDegradeMarker = "无可用沙箱日志（未能归档或拉取 live logs）"
 )
 
 // Log summary caps for run_error.json (tail of archived sandbox logs).
@@ -31,6 +34,9 @@ type RunFailureInfo struct {
 	FailedNode      string `json:"failedNode,omitempty"`
 	LogSummaryOrRef string `json:"logSummaryOrRef,omitempty"`
 	NoSandboxLog    bool   `json:"noSandboxLog,omitempty"`
+	// SandboxLogNote explains why logs are missing when NoSandboxLog is true
+	// (archive/pull degrade). Empty when logs are present or never attempted.
+	SandboxLogNote string `json:"sandboxLogNote,omitempty"`
 }
 
 // AggregateRunFailure builds RunFailureInfo from the latest non-empty failed
@@ -38,11 +44,16 @@ type RunFailureInfo struct {
 // empty: early-exit / panic paths without StateRun.error fall back to a
 // human-readable default. Call after finalizeActiveStateRuns when possible so
 // in-flight nodes that were force-failed contribute their error text.
-func (s *RunService) AggregateRunFailure(runID string) RunFailureInfo {
+//
+// optDegradeNote, when non-empty and no archived log is found, is stored on
+// SandboxLogNote so DisplayReason can distinguish archive failure from "never
+// produced logs".
+func (s *RunService) AggregateRunFailure(runID string, optDegradeNote ...string) RunFailureInfo {
 	info := RunFailureInfo{}
 	if runID == "" || s == nil || s.db == nil {
 		info.Reason = DefaultRunFailureReason
 		info.NoSandboxLog = true
+		info.SandboxLogNote = SandboxLogDegradeMarker
 		return info
 	}
 
@@ -72,6 +83,15 @@ func (s *RunService) AggregateRunFailure(runID string) RunFailureInfo {
 		info.NoSandboxLog = false
 	} else {
 		info.NoSandboxLog = true
+		note := ""
+		if len(optDegradeNote) > 0 {
+			note = strings.TrimSpace(optDegradeNote[0])
+		}
+		if note != "" {
+			info.SandboxLogNote = note
+		} else {
+			info.SandboxLogNote = SandboxLogDegradeMarker
+		}
 	}
 	return info
 }
@@ -86,8 +106,14 @@ func (info RunFailureInfo) DisplayReason() string {
 	if info.FailedNode != "" && !strings.Contains(reason, info.FailedNode) {
 		reason = fmt.Sprintf("%s（节点 %s）", reason, info.FailedNode)
 	}
-	if info.NoSandboxLog && !strings.Contains(reason, NoSandboxLogMarker) {
-		reason = reason + " · " + NoSandboxLogMarker
+	if info.NoSandboxLog {
+		marker := strings.TrimSpace(info.SandboxLogNote)
+		if marker == "" {
+			marker = SandboxLogDegradeMarker
+		}
+		if !strings.Contains(reason, NoSandboxLogMarker) && !strings.Contains(reason, marker) {
+			reason = reason + " · " + marker
+		}
 	}
 	return reason
 }
@@ -110,6 +136,9 @@ func MarshalRunErrorJSON(info RunFailureInfo) (string, error) {
 	}
 	if info.LogSummaryOrRef != "" {
 		payload["logSummaryOrRef"] = info.LogSummaryOrRef
+	}
+	if info.NoSandboxLog && strings.TrimSpace(info.SandboxLogNote) != "" {
+		payload["sandboxLogNote"] = info.SandboxLogNote
 	}
 	b, err := json.MarshalIndent(payload, "", "  ")
 	if err != nil {

--- a/server/internal/services/run_failure_test.go
+++ b/server/internal/services/run_failure_test.go
@@ -29,6 +29,9 @@ func TestAggregateRunFailureFromStateRun(t *testing.T) {
 	if !strings.Contains(display, "research") || !strings.Contains(display, NoSandboxLogMarker) {
 		t.Fatalf("display=%q", display)
 	}
+	if info.SandboxLogNote == "" {
+		t.Fatal("expected SandboxLogNote degrade explanation")
+	}
 }
 
 func TestAggregateRunFailureLastErrorFallback(t *testing.T) {
@@ -70,7 +73,7 @@ func TestAggregateRunFailureWithSandboxLog(t *testing.T) {
 	}
 	db.Create(&models.SandboxLog{
 		Name: "sbx-rf4", RunID: "rf4", NodeID: "research",
-		Content: strings.Join(lines, "\n") + "\nTAIL_MARKER",
+		Content:   strings.Join(lines, "\n") + "\nTAIL_MARKER",
 		CreatedAt: time.Now(), UpdatedAt: time.Now(),
 	})
 

--- a/server/internal/services/sandbox.go
+++ b/server/internal/services/sandbox.go
@@ -285,10 +285,15 @@ func (s *SandboxService) RegisterRunSandbox(info runtime.RunSandboxInfo) {
 // an idle deadline so the sweeper reclaims it later, while it remains browsable
 // (terminal / IDE / ACP / container logs) in the sandbox UI. Implements
 // runtime.RunSandboxRetirer.
+//
+// Always best-effort archives container logs before idle retention so a later
+// CAPA / AggregateRunFailure path still has sandbox_logs even when the engine
+// mis-fires after retire (eliminates noSandboxLog:true with no explanation).
 func (s *SandboxService) RetireRunSandbox(name string) {
 	if name == "" {
 		return
 	}
+	s.archiveLog(context.Background(), name)
 	s.mu.Lock()
 	delete(s.runActive, name)
 	s.mu.Unlock()
@@ -299,6 +304,46 @@ func (s *SandboxService) RetireRunSandbox(name string) {
 		return
 	}
 	log.Info().Str("name", name).Dur("ttl", s.RunTTL()).Msg("run sandbox retired for debugging (idle ttl)")
+}
+
+// ArchiveRunSandboxLogs best-effort archives live logs for every per-run node
+// sandbox still recorded for runID. Returns how many containers were archived
+// and a non-empty note when none could be captured (for DisplayReason degrade).
+func (s *SandboxService) ArchiveRunSandboxLogs(ctx context.Context, runID string) (archived int, degradeNote string) {
+	if s == nil || runID == "" {
+		return 0, "无沙箱服务，未能拉取 live logs"
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var rows []models.Sandbox
+	if err := s.db.Where("run_id = ? AND purpose = ?", runID, "run").Find(&rows).Error; err != nil {
+		return 0, "查询沙箱失败，未能拉取 live logs"
+	}
+	if len(rows) == 0 {
+		return 0, "无存活沙箱记录，未能拉取 live logs"
+	}
+	for _, row := range rows {
+		s.archiveLog(ctx, row.Name)
+		if s.hasArchivedLog(row.Name) {
+			archived++
+		}
+	}
+	if archived == 0 {
+		return 0, "容器已销毁或日志为空，未能归档 live logs"
+	}
+	return archived, ""
+}
+
+func (s *SandboxService) hasArchivedLog(name string) bool {
+	if name == "" || s == nil || s.db == nil {
+		return false
+	}
+	var rec models.SandboxLog
+	if err := s.db.Where("name = ?", name).First(&rec).Error; err != nil {
+		return false
+	}
+	return strings.TrimSpace(rec.Content) != ""
 }
 
 // UnregisterRunSandbox clears a per-run node sandbox record once the runtime


### PR DESCRIPTION
Adopt durable node_complete.json and StateRun.McpCalls in outcome
judgement, clear marks only on new visit/attempt, archive sandbox
logs on retire/failure, and keep three distinct failure wordings.

Co-authored-by: Cursor <cursoragent@cursor.com>
