### PR TITLE
fix(preview): 取点开启后可取消，按钮改为「取消标注」

### DIFF
--- a/server/internal/browser/inspect_cancel.go
+++ b/server/internal/browser/inspect_cancel.go
@@ -1,0 +1,78 @@
+package browser
+
+import (
+	"sync"
+	"time"
+)
+
+// Overlay.setInspectMode(searchForNode) often emits inspectModeCanceled for the
+// previous mode. If that event reaches the UI, the toggle looks off while
+// Overlay is still on — the next click re-enters inspect and cancel never sticks.
+const inspectCancelSkip = 300 * time.Millisecond
+
+// inspectCancelFilter decides whether Overlay.inspectModeCanceled should notify
+// the UI. It swallows the side-effect cancel from enabling inspect.
+type inspectCancelFilter struct {
+	mu     sync.Mutex
+	wanted bool
+	skip   bool
+	gen    int
+	timer  *time.Timer
+}
+
+func (f *inspectCancelFilter) set(on bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.wanted = on
+	f.gen++
+	if f.timer != nil {
+		f.timer.Stop()
+		f.timer = nil
+	}
+	if !on {
+		f.skip = false
+		return
+	}
+	f.skip = true
+	gen := f.gen
+	f.timer = time.AfterFunc(inspectCancelSkip, func() {
+		f.expireSkip(gen)
+	})
+}
+
+func (f *inspectCancelFilter) expireSkip(gen int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.gen == gen {
+		f.skip = false
+	}
+}
+
+func (f *inspectCancelFilter) expireSkipNow() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.skip = false
+}
+
+func (f *inspectCancelFilter) onCanceled() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.skip {
+		f.skip = false
+		return false
+	}
+	if !f.wanted {
+		return false
+	}
+	f.wanted = false
+	return true
+}
+
+func (f *inspectCancelFilter) stop() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.timer != nil {
+		f.timer.Stop()
+		f.timer = nil
+	}
+}

--- a/server/internal/browser/inspect_cancel_test.go
+++ b/server/internal/browser/inspect_cancel_test.go
@@ -1,0 +1,52 @@
+package browser
+
+import "testing"
+
+func TestInspectCancelFilterEscAfterEnableSideEffect(t *testing.T) {
+	var f inspectCancelFilter
+	f.set(true)
+	if f.onCanceled() {
+		t.Fatal("enable-side inspectModeCanceled must not notify UI")
+	}
+	if !f.onCanceled() {
+		t.Fatal("Esc after the skipped enable-side cancel must notify UI")
+	}
+}
+
+func TestInspectCancelFilterNotifiesEscAfterSkipExpires(t *testing.T) {
+	var f inspectCancelFilter
+	f.set(true)
+	f.expireSkipNow()
+	if !f.onCanceled() {
+		t.Fatal("Esc after skip window must notify UI")
+	}
+	if f.onCanceled() {
+		t.Fatal("second cancel after Esc must not notify again")
+	}
+}
+
+func TestInspectCancelFilterDisableDoesNotNotify(t *testing.T) {
+	var f inspectCancelFilter
+	f.set(true)
+	f.set(false)
+	if f.onCanceled() {
+		t.Fatal("toolbar off already cleared UI; Overlay cancel must not echo")
+	}
+}
+
+func TestInspectCancelFilterNeverEnabled(t *testing.T) {
+	var f inspectCancelFilter
+	if f.onCanceled() {
+		t.Fatal("cancel with inspect never wanted must not notify")
+	}
+}
+
+func TestInspectCancelFilterReenterArmsNewSkip(t *testing.T) {
+	var f inspectCancelFilter
+	f.set(true)
+	_ = f.onCanceled()
+	f.set(true)
+	if f.onCanceled() {
+		t.Fatal("re-enter must skip the next enable-side cancel")
+	}
+}

--- a/server/internal/browser/rod.go
+++ b/server/internal/browser/rod.go
@@ -169,6 +169,7 @@ type rodPage struct {
 	onPick            func(Pick)
 	onInspectCanceled func()
 	onDescribeFailed  func()
+	inspectCancel     inspectCancelFilter
 }
 
 func (rp *rodPage) OnPick(cb func(Pick)) {
@@ -285,6 +286,7 @@ func (rp *rodPage) SetViewport(width, height int, dpr float64) error {
 
 func (rp *rodPage) SetInspect(on bool) error {
 	if !on {
+		rp.inspectCancel.set(false)
 		_ = proto.OverlayHideHighlight{}.Call(rp.page)
 		err := proto.OverlaySetInspectMode{Mode: proto.OverlayInspectModeNone}.Call(rp.page)
 		if err != nil {
@@ -298,6 +300,7 @@ func (rp *rodPage) SetInspect(on bool) error {
 	if err := rp.presentDesktop(); err != nil {
 		return err
 	}
+	rp.inspectCancel.set(true)
 	_ = proto.DOMEnable{}.Call(rp.page)
 	_ = proto.OverlayEnable{}.Call(rp.page)
 	content, border := 0.4, 1.0
@@ -329,6 +332,7 @@ func (rp *rodPage) Goto(url string) error {
 }
 
 func (rp *rodPage) Close() error {
+	rp.inspectCancel.stop()
 	err := rp.page.Close()
 	// Dispose the isolated browser context so it doesn't leak in a long-lived
 	// container.
@@ -359,7 +363,11 @@ func (rp *rodPage) installPickListener() {
 			cb(pick)
 		},
 		func(_ *proto.OverlayInspectModeCanceled) {
-			// User Esc (or equivalent) canceled SearchForNode — notify UI to clear sticky toggle.
+			// Enabling inspect often fires this for the previous mode; ignore that
+			// or the UI toggle desyncs and cancel never sticks.
+			if !rp.inspectCancel.onCanceled() {
+				return
+			}
 			if cb := rp.getInspectCanceled(); cb != nil {
 				cb()
 			}

--- a/server/internal/browser/types.go
+++ b/server/internal/browser/types.go
@@ -40,12 +40,12 @@ type KeyEvent struct {
 
 // Pick is a DOM element the user selected in inspect mode.
 type Pick struct {
-	Selector  string     `json:"selector"`
-	TagName   string     `json:"tagName"`
-	OuterHTML string     `json:"outerHTML"`
+	Selector  string `json:"selector"`
+	TagName   string `json:"tagName"`
+	OuterHTML string `json:"outerHTML"`
 	// URL is location.href at pick time (SPA navigations included).
-	URL       string     `json:"url,omitempty"`
-	Box       [4]float64 `json:"box"` // x, y, width, height (CSS px)
+	URL string     `json:"url,omitempty"`
+	Box [4]float64 `json:"box"` // x, y, width, height (CSS px)
 }
 
 // Engine is one Chromium instance (one container) we can open tabs in.
@@ -72,6 +72,8 @@ type Page interface {
 	OnPick(func(Pick))
 	// OnInspectCanceled is invoked when the user cancels CDP inspect mode
 	// (e.g. Esc → Overlay.inspectModeCanceled). Callers sync UI button state.
+	// Enabling inspect may itself emit inspectModeCanceled for the previous
+	// mode; implementations must not invoke this callback for that side effect.
 	// Describe/recognition failures use OnDescribeFailed instead.
 	OnInspectCanceled(func())
 	// OnDescribeFailed is invoked when Overlay pick fires but describing the

--- a/web/src/components/run/NovncPreviewPanel.test.ts
+++ b/web/src/components/run/NovncPreviewPanel.test.ts
@@ -154,25 +154,26 @@ describe('NovncPreviewPanel', () => {
     consoleWrap.unmount()
   })
 
-  it('toggles inspect with stable label and aria-pressed; second click sends on:false', async () => {
+  it('toggles inspect label to 取消标注; second click sends on:false', async () => {
     const wrapper = mountNovnc()
     await flushPromises()
     const btn = inspectButton(wrapper)
     expect(btn.attributes('aria-pressed')).toBe('false')
     expect(btn.text()).toContain('取点标注')
-    expect(wrapper.text()).not.toContain('取消取点')
+    expect(wrapper.text()).not.toContain('取消标注')
 
     await btn.trigger('click')
     await flushPromises()
     expect(btn.attributes('aria-pressed')).toBe('true')
-    expect(btn.text()).toContain('取点标注')
-    expect(wrapper.text()).not.toContain('取消取点')
+    expect(btn.text()).toContain('取消标注')
+    expect(btn.text()).not.toContain('取点标注')
     expect(lastInspectCtrl()).toEqual({ type: 'inspect', on: true })
 
     await btn.trigger('click')
     await flushPromises()
     expect(btn.attributes('aria-pressed')).toBe('false')
     expect(btn.text()).toContain('取点标注')
+    expect(wrapper.text()).not.toContain('取消标注')
     expect(lastInspectCtrl()).toEqual({ type: 'inspect', on: false })
     wrapper.unmount()
   })

--- a/web/src/components/run/NovncPreviewPanel.vue
+++ b/web/src/components/run/NovncPreviewPanel.vue
@@ -53,6 +53,9 @@ const previewStuck = ref(false)
 let previewWarnTimer: ReturnType<typeof setTimeout> | null = null
 const PREVIEW_STUCK_MS = 20_000
 const inspect = ref(false)
+const inspectToggleLabel = computed(() =>
+  t(inspect.value ? 'pages.appPreview.novnc.cancelInspect' : 'pages.appPreview.novnc.inspect'),
+)
 const picked = ref<AppPreviewPickPayload | null>(null)
 const address = ref('about:blank')
 /** Toolbar inline tip (Demo S2/S3): not-ready warn vs describe-failed err. */
@@ -463,12 +466,12 @@ onBeforeUnmount(() => {
         type="button"
         class="rounded px-2 py-0.5 text-[11px] transition"
         :class="inspect ? 'bg-ok/20 text-ok' : 'text-txt2 hover:bg-overlay'"
-        :title="t('pages.appPreview.novnc.inspect')"
+        :title="inspectToggleLabel"
         :aria-pressed="inspect ? 'true' : 'false'"
         data-testid="novnc-inspect-toggle"
         @click="toggleInspect"
       >
-        {{ t('pages.appPreview.novnc.inspect') }}
+        {{ inspectToggleLabel }}
       </button>
       <button
         type="button"

--- a/web/src/components/ui/HtmlPreview.test.ts
+++ b/web/src/components/ui/HtmlPreview.test.ts
@@ -347,7 +347,7 @@ describe('HtmlPreview inspect toggle', () => {
     vi.unstubAllGlobals()
   })
 
-  it('toggles with stable 取点标注 label and aria-pressed round-trip', async () => {
+  it('toggles label to 取消标注 and aria-pressed round-trip', async () => {
     const wrapper = mountPreview({
       mode: 'inline',
       fitContent: false,
@@ -360,18 +360,19 @@ describe('HtmlPreview inspect toggle', () => {
     expect(btn.exists()).toBe(true)
     expect(btn.text()).toContain('取点标注')
     expect(btn.attributes('aria-pressed')).toBe('false')
-    expect(wrapper.text()).not.toContain('取消取点')
+    expect(wrapper.text()).not.toContain('取消标注')
 
     await btn.trigger('click')
     await nextTick()
     expect(btn.attributes('aria-pressed')).toBe('true')
-    expect(btn.text()).toContain('取点标注')
-    expect(wrapper.text()).not.toContain('取消取点')
+    expect(btn.text()).toContain('取消标注')
+    expect(btn.text()).not.toContain('取点标注')
 
     await btn.trigger('click')
     await nextTick()
     expect(btn.attributes('aria-pressed')).toBe('false')
     expect(btn.text()).toContain('取点标注')
+    expect(wrapper.text()).not.toContain('取消标注')
     wrapper.unmount()
   })
 

--- a/web/src/components/ui/HtmlPreview.vue
+++ b/web/src/components/ui/HtmlPreview.vue
@@ -92,6 +92,9 @@ const heightStable = ref(false)
 /** First inline/content-fit convergence from fallback height. */
 const isFirstHeightConvergence = ref(true)
 const inspecting = ref(false)
+const inspectToggleLabel = computed(() =>
+  t(inspecting.value ? 'pages.appPreview.novnc.cancelInspect' : 'pages.appPreview.novnc.inspect'),
+)
 const instanceId = createInstanceId()
 let resizeTimeout: ReturnType<typeof setTimeout> | undefined
 let pendingResizeHeight: number | null = null
@@ -427,12 +430,12 @@ watch(needsMessageListener, (enabled, wasEnabled) => {
             : 'border-line text-txt2 hover:text-txt'
         "
         :aria-pressed="inspecting ? 'true' : 'false'"
-        :title="t('pages.appPreview.novnc.inspect')"
+        :title="inspectToggleLabel"
         data-testid="html-preview-inspect-toggle"
         @click="toggleInspect"
       >
         <Icon name="crosshair" :size="13" />
-        {{ t('pages.appPreview.novnc.inspect') }}
+        {{ inspectToggleLabel }}
       </button>
       <button
         v-if="showGateShare"
@@ -543,12 +546,12 @@ watch(needsMessageListener, (enabled, wasEnabled) => {
             : 'border-line text-txt2 hover:text-txt'
         "
         :aria-pressed="inspecting ? 'true' : 'false'"
-        :title="t('pages.appPreview.novnc.inspect')"
+        :title="inspectToggleLabel"
         data-testid="html-preview-inspect-toggle"
         @click="toggleInspect"
       >
         <Icon name="crosshair" :size="13" />
-        {{ t('pages.appPreview.novnc.inspect') }}
+        {{ inspectToggleLabel }}
       </button>
       <button
         v-if="showGateShare"

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -2449,7 +2449,7 @@
         "fullscreen": "Fullscreen",
         "exitFullscreen": "Exit fullscreen",
         "inspect": "Pick to annotate",
-        "cancelInspect": "Cancel pick",
+        "cancelInspect": "Cancel annotation",
         "usePick": "Add to chat ⤴",
         "clearPick": "Clear",
         "pickedLabel": "Picked",

--- a/web/src/locales/userFacingCopy.test.ts
+++ b/web/src/locales/userFacingCopy.test.ts
@@ -265,6 +265,12 @@ describe('user-facing copy remediation keys', () => {
     expect(en.global.t('pages.board.tokenStats.workflow')).not.toBe('workflow')
     expect(en.global.t('pages.projectDetail.tokenTipWorkflow')).not.toBe('workflow')
 
+    expect(zh.global.t('pages.appPreview.novnc.inspect')).toBe('取点标注')
+    expect(zh.global.t('pages.appPreview.novnc.cancelInspect')).toBe('取消标注')
+    expect(en.global.t('pages.appPreview.novnc.inspect')).toBe('Pick to annotate')
+    expect(en.global.t('pages.appPreview.novnc.cancelInspect')).toBe('Cancel annotation')
+    expect(zh.global.t('pages.appPreview.novnc.cancelInspect')).not.toMatch(/取消取点/)
+
     const tokenSourceNoPmKeys = [
       'pages.board.tokenStats.workflow',
       'pages.projectDetail.tokenTipWorkflow',

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -2449,7 +2449,7 @@
         "fullscreen": "全屏",
         "exitFullscreen": "退出全屏",
         "inspect": "取点标注",
-        "cancelInspect": "取消取点",
+        "cancelInspect": "取消标注",
         "usePick": "添加到聊天 ⤴",
         "clearPick": "清除",
         "pickedLabel": "已选出",


### PR DESCRIPTION
## Summary
- 开启 Overlay inspect 时 Chrome 会误发 `inspectModeCanceled`（取消上一次模式），前端把按钮当成已退出，画面里取点还在；再点等于重新打开，所以「永远取消不了」。
- 过滤这次副作用，只把真正的 Esc / 点取消同步到 UI。
- 开关文案改为 **取点标注 / 取消标注**（不再一直显示「取点标注」，也不再用「取消取点」）。

## Test plan
- [ ] 应用预览 noVNC：点「取点标注」→ 文案变为「取消标注」、十字光标仍在 → 再点「取消标注」应退出取点，页面可正常点击
- [ ] 取点过程中按 Esc，按钮应回到「取点标注」，已选出的标注仍保留
- [ ] HTML 预览「取点标注」同样切换为「取消标注」，再点可退出
- [x] `go test ./internal/browser/ -count=1`
- [x] `npx vitest run`（NovncPreviewPanel / HtmlPreview / userFacingCopy）


Made with [Cursor](https://cursor.com)