### PR TITLE
fix(web): keep public review confirm visible when busy

### DIFF
--- a/web/src/views/PublicGateApprovalView.test.ts
+++ b/web/src/views/PublicGateApprovalView.test.ts
@@ -343,8 +343,10 @@ describe('PublicGateApprovalView workbench', () => {
     resolveReply?.({ status: 'accepted' })
     await flushPromises()
     expect(w.find('[data-testid="clarify-review-queue"]').exists()).toBe(true)
-    // f3: confirm follows local sessionBusy — optimistic queue keeps confirm gated.
-    expect(w.find('[data-testid="public-gate-confirm"]').exists()).toBe(false)
+    // plan g1/g2: busy keeps confirm mounted and disabled (not unmounted).
+    const confirmBusy = w.find('[data-testid="public-gate-confirm"]')
+    expect(confirmBusy.exists()).toBe(true)
+    expect((confirmBusy.element as HTMLButtonElement).disabled).toBe(true)
     expect(w.find('[data-testid="clarify-review-cancel"]').exists()).toBe(true)
   })
 
@@ -366,7 +368,10 @@ describe('PublicGateApprovalView workbench', () => {
     await flushPromises()
     expect(w.find('[data-testid="clarify-busy-placeholder"]').exists()).toBe(true)
     expect(w.find('[data-testid="clarify-review-cancel"]').exists()).toBe(true)
-    expect(w.find('[data-testid="public-gate-confirm"]').exists()).toBe(false)
+    // plan g1/g2: sessionBusy resume keeps confirm visible + disabled.
+    const confirmResume = w.find('[data-testid="public-gate-confirm"]')
+    expect(confirmResume.exists()).toBe(true)
+    expect((confirmResume.element as HTMLButtonElement).disabled).toBe(true)
     expect(w.find('[data-testid="public-gate-done"]').exists()).toBe(false)
   })
 
@@ -1071,7 +1076,10 @@ describe('PublicGateApprovalView workbench', () => {
     await flushPromises()
     expect(w.find('[data-testid="clarify-busy-placeholder"]').exists()).toBe(true)
     expect(w.find('[data-testid="clarify-review-cancel"]').exists()).toBe(true)
-    expect(w.find('[data-testid="public-gate-confirm"]').exists()).toBe(false)
+    // plan g1/g2: sticky busy keeps confirm visible + disabled until idle.
+    const confirmSticky = w.find('[data-testid="public-gate-confirm"]')
+    expect(confirmSticky.exists()).toBe(true)
+    expect((confirmSticky.element as HTMLButtonElement).disabled).toBe(true)
 
     // Authoritative idle poll — clear stale activeItem explicitly (sparse merge).
     mocks.preview.mockResolvedValue({

--- a/web/src/views/PublicGateApprovalView.vue
+++ b/web/src/views/PublicGateApprovalView.vue
@@ -118,13 +118,21 @@ function refreshLocalChatBusy() {
 }
 const canReply = computed(() => isActive.value && reactAlive.value && !!preview.value?.actions?.reply)
 const canReject = computed(() => !isReview.value && !!preview.value?.actions?.reject)
-const canConfirm = computed(() => {
+/** Business mountability only — busy/submitting must not hide the confirm control. */
+const showConfirm = computed(() => {
   if (!isActive.value || doneKind.value) return false
-  // f3: confirm gated on local !sessionBusy, not lagged preview.sessionBusy.
-  if (localChatBusy.value || replyInFlight.value) return false
   if (isReview.value) return !!preview.value?.actions?.confirm
   return !!preview.value?.actions?.approve || !!preview.value?.actions?.confirm
 })
+/** Clickability: busy / in-flight / submitting / linkInvalid disable (align GateApproval). */
+const confirmDisabled = computed(
+  () =>
+    submitting.value ||
+    localChatBusy.value ||
+    replyInFlight.value ||
+    linkInvalid.value ||
+    !showConfirm.value,
+)
 const productKind = computed(() => preview.value?.productKind || inferProductKind())
 const productName = computed(() => preview.value?.productName || preview.value?.structured?.name || '')
 const inspectable = computed(
@@ -1155,11 +1163,11 @@ defineExpose({ loadPreview, loadUpstreamFull, openUpstreamModal })
             {{ submitting ? t('pages.publicGate.submitting') : t('pages.publicGate.reject') }}
           </button>
           <button
-            v-if="canConfirm || linkInvalid"
+            v-if="showConfirm || linkInvalid"
             type="button"
             class="inline-flex min-h-9 min-w-[8rem] items-center justify-center gap-2 bg-ok px-4 text-sm font-medium text-white disabled:opacity-45"
             data-testid="public-gate-confirm"
-            :disabled="submitting || localChatBusy || replyInFlight || linkInvalid || !canConfirm"
+            :disabled="confirmDisabled"
             :aria-busy="pendingKind === 'confirm' && submitting ? 'true' : 'false'"
             :aria-label="t('pages.publicGate.confirmAria')"
             @click="submitFinal('confirm')"


### PR DESCRIPTION
Split showConfirm from confirmDisabled in PublicGateApprovalView so
Agent output / session busy only disables「确认并流转」instead of
unmounting it, matching GateApproval semantics. Update unit tests for
queue, sessionBusy resume, and sticky busy.

Co-authored-by: Cursor <cursoragent@cursor.com>
