### PR TITLE
fix(web): restore RunLaunchModal success phase after start

### DIFF
--- a/web/e2e/run-sandbox-env-harness.spec.ts
+++ b/web/e2e/run-sandbox-env-harness.spec.ts
@@ -55,9 +55,17 @@ test('RunLaunchModal 与 Run 快照面板浏览器验收', async ({ page }) => {
   await row.locator('input').nth(0).fill('LOG_LEVEL')
   await row.locator('input').nth(1).fill('debug')
   await page.getByRole('button', { name: /开始运行|Start/i }).click()
+  // plan g2.2: sandbox env start still lands on success phase before navigation
+  await expect(page.getByText(/工作流已启动|Workflow started/)).toBeVisible()
+  await expect(page.getByRole('button', { name: /查看运行|View run/i })).toBeVisible()
+  await expect(page.getByRole('button', { name: /留在当前页|Stay on this page/i })).toBeVisible()
+  await expect(page.getByTestId('last-start')).toContainText('started:run-env-e2e')
+  await page.screenshot({ path: path.join(OUT, '03-success-phase.png'), fullPage: true })
+
+  await page.getByRole('button', { name: /查看运行|View run/i }).click()
   await expect(page.getByTestId('last-start')).toContainText('view-run:run-env-e2e')
   await expect(page.getByTestId('run-sandbox-env-panel')).toBeVisible()
   await expect(page.getByText('••••••••')).toBeVisible()
   await expect(page.getByText('编辑')).toHaveCount(0)
-  await page.screenshot({ path: path.join(OUT, '03-run-detail-snapshot.png'), fullPage: true })
+  await page.screenshot({ path: path.join(OUT, '04-run-detail-snapshot.png'), fullPage: true })
 })

--- a/web/src/components/workflow/RunLaunchModal.test.ts
+++ b/web/src/components/workflow/RunLaunchModal.test.ts
@@ -55,7 +55,7 @@ function mountModal(open = true, extraProps: Record<string, unknown> = {}) {
           props: ['open', 'title'],
           emits: ['close'],
           template:
-            '<div v-if="open" data-testid="modal"><button data-testid="modal-close" @click="$emit(\'close\')" /><slot /><slot name="footer" /></div>',
+            '<div v-if="open" data-testid="modal"><button data-testid="modal-close" @click="$emit(\'close\')" /><slot name="header" /><slot /><slot name="footer" /></div>',
         },
         ParagraphInput: {
           props: ['text'],
@@ -129,7 +129,7 @@ describe('RunLaunchModal', () => {
     wrapper.unmount()
   })
 
-  it('calls startRun and navigates to run detail', async () => {
+  it('calls startRun and switches to success phase', async () => {
     apiMocks.startRun.mockResolvedValue({ id: 'run-99' })
     const wrapper = mountModal(true)
     await flushPromises()
@@ -145,8 +145,12 @@ describe('RunLaunchModal', () => {
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     )
     expect(wrapper.emitted('started')?.[0]?.[0]).toBe('run-99')
-    expect(wrapper.emitted('view-run')?.[0]?.[0]).toBe('run-99')
-    expect(wrapper.emitted('close')).toBeTruthy()
+    // plan g2.1: success phase first — no auto view-run/close
+    expect(wrapper.emitted('view-run')).toBeFalsy()
+    expect(wrapper.emitted('close')).toBeFalsy()
+    expect(wrapper.text()).toMatch(/工作流已启动|Workflow started/)
+    expect(wrapper.text()).toMatch(/查看运行|View run/)
+    expect(wrapper.text()).toMatch(/留在当前页|Stay on this page/)
     wrapper.unmount()
   })
 
@@ -193,6 +197,11 @@ describe('RunLaunchModal', () => {
         env: [{ key: 'LOG_LEVEL', value: 'debug', secret: false }],
       }),
     )
+    // plan g1.3 / g2.1: sandbox env start still reaches success phase (no auto navigate)
+    expect(wrapper.emitted('view-run')).toBeFalsy()
+    expect(wrapper.emitted('close')).toBeFalsy()
+    expect(wrapper.text()).toMatch(/工作流已启动|Workflow started/)
+    expect(wrapper.text()).toMatch(/查看运行|View run/)
     wrapper.unmount()
   })
 

--- a/web/src/components/workflow/RunLaunchModal.vue
+++ b/web/src/components/workflow/RunLaunchModal.vue
@@ -352,9 +352,7 @@ async function startRun() {
     if (gen !== startGen) return
     successRunId.value = res.id
     emit('started', res.id)
-    // Clarified UX: close modal and navigate to Run detail (skip stay-on-page success).
-    emit('view-run', res.id)
-    emit('close')
+    phase.value = 'success'
   } catch (e: any) {
     if (gen !== startGen || isAbortError(e) || startAbort.signal.aborted) return
     phase.value = 'error'


### PR DESCRIPTION
PR #295 auto-navigated on start success and skipped the stay-on-page confirm dialog; restore phase='success' while keeping sandbox env, and realign unit/e2e assertions.

Co-authored-by: Cursor <cursoragent@cursor.com>
