### PR TITLE
fix(shell): 移除运行产出弹窗顶部 outputHint 说明句

### DIFF
--- a/web/e2e/notifications-center.spec.ts
+++ b/web/e2e/notifications-center.spec.ts
@@ -128,6 +128,10 @@ test.describe('shell notification center (IA separation)', () => {
     await expect(page.getByTestId('run-output-result-cards')).toContainText('视觉 Demo')
     await expect(page.getByTestId('run-output-result-cards')).not.toContainText('node_complete.json')
     await expect(page.getByTestId('run-output-list')).toHaveCount(0)
+    // plan g3.1: removed outputHint must not reappear
+    await expect(page.getByRole('dialog')).not.toContainText(
+      '展示聚焦输出节点的最终结果卡；与 Run 详情输出 Tab 一致，不是全量产物列表。',
+    )
     // Opening alone must NOT drop unread (3 stays 3)
     await expect(page.getByTestId('run-notifications-badge')).toHaveText('3')
     await page.getByTestId('run-output-mark-read').click()
@@ -156,6 +160,10 @@ test.describe('shell notification center (IA separation)', () => {
     await expect(empty).not.toContainText('node_complete.json')
     await expect(empty).not.toContainText('plan.json')
     await expect(page.getByTestId('run-output-list')).toHaveCount(0)
+    // plan g3.1: removed outputHint must not reappear on empty path
+    await expect(page.getByRole('dialog')).not.toContainText(
+      '展示聚焦输出节点的最终结果卡；与 Run 详情输出 Tab 一致，不是全量产物列表。',
+    )
   })
 
   test('legacy structured page card: iframe visible, no source leak, kind=自定义产物 · HTML (g4.3)', async ({

--- a/web/src/components/shell/RunOutputPptModal.test.ts
+++ b/web/src/components/shell/RunOutputPptModal.test.ts
@@ -39,6 +39,12 @@ vi.mock('@/lib/composables/useToast', () => ({
 
 import RunOutputPptModal from './RunOutputPptModal.vue'
 
+/** Removed outputHint full sentence — must not reappear in modal (plan g3.1). */
+const FORBIDDEN_OUTPUT_HINT_ZH =
+  '展示聚焦输出节点的最终结果卡；与 Run 详情输出 Tab 一致，不是全量产物列表。'
+const FORBIDDEN_OUTPUT_HINT_EN =
+  'Shows final result cards from the focused output node — same as the run detail Output tab, not the full artifact browser.'
+
 function artifact(partial: Partial<Artifact> & Pick<Artifact, 'id' | 'name' | 'kind'>): Artifact {
   return {
     nodeId: partial.nodeId ?? 'out-1',
@@ -160,6 +166,9 @@ describe('RunOutputPptModal output result cards (g1/g2)', () => {
     expect(wrapper.findAll('[data-testid="run-output-row"]')).toHaveLength(0)
     expect(wrapper.text()).not.toContain('node_complete.json')
     expect(wrapper.text()).not.toContain('plan.json')
+    // plan g3.1: no removed outputHint on empty path
+    expect(wrapper.text()).not.toContain(FORBIDDEN_OUTPUT_HINT_ZH)
+    expect(wrapper.text()).not.toContain(FORBIDDEN_OUTPUT_HINT_EN)
 
     await wrapper.find('[data-testid="run-output-empty-open-artifacts"]').trigger('click')
     expect(push).toHaveBeenCalledWith({ path: '/runs/run-1', query: { detail: 'artifacts' } })
@@ -237,6 +246,7 @@ describe('RunOutputPptModal output result cards (g1/g2)', () => {
     expect(wrapper.find('[data-testid="run-output-focus-bar"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="run-output-focus-bar"]').text()).toContain('聚焦输出节点')
     expect(wrapper.find('[data-testid="run-output-focus-bar"]').text()).toContain('type: output')
+    expect(wrapper.find('[data-testid="run-output-focus-bar"]').text()).toContain('与 Run 详情一致')
     expect(wrapper.find('[data-testid="output-result-cards"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="output-result-list"]').exists()).toBe(true)
     expect(wrapper.text()).toContain('视觉 Demo')
@@ -246,6 +256,9 @@ describe('RunOutputPptModal output result cards (g1/g2)', () => {
     expect(wrapper.findAll('[data-testid="run-output-row"]')).toHaveLength(0)
     expect(wrapper.text()).not.toContain('node_complete.json')
     expect(wrapper.text()).not.toMatch(/PPT|幻灯片|16:9/)
+    // plan g3.1: no removed outputHint on cards path (full sentence only)
+    expect(wrapper.text()).not.toContain(FORBIDDEN_OUTPUT_HINT_ZH)
+    expect(wrapper.text()).not.toContain(FORBIDDEN_OUTPUT_HINT_EN)
 
     expect(wrapper.find('[data-testid="run-output-open-run"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="run-output-mark-read"]').exists()).toBe(true)

--- a/web/src/components/shell/RunOutputPptModal.vue
+++ b/web/src/components/shell/RunOutputPptModal.vue
@@ -136,7 +136,6 @@ function openArtifacts() {
     @close="close"
   >
     <p class="mb-2 text-xs text-txt3">{{ subtitle || '—' }}</p>
-    <p class="mb-3 text-xs text-txt2">{{ t('shell.runNotifications.outputHint') }}</p>
 
     <div v-if="loading" class="py-10 text-center text-sm text-txt2" data-testid="run-output-loading">
       {{ t('shell.runNotifications.loadingOutputs') }}

--- a/web/src/locales/en/shell.json
+++ b/web/src/locales/en/shell.json
@@ -35,7 +35,6 @@
       "clickForDetail": "Click to view details",
       "neutralTitle": "{name} · {status}",
       "outputTitle": "Run outputs",
-      "outputHint": "Shows final result cards from the focused output node — same as the run detail Output tab, not the full artifact browser.",
       "noArtifacts": "This run has no outputs",
       "noArtifactsHint": "Open the run detail to inspect execution",
       "markAsRead": "Mark as read",

--- a/web/src/locales/zh-CN/shell.json
+++ b/web/src/locales/zh-CN/shell.json
@@ -35,7 +35,6 @@
       "clickForDetail": "点击查看详情",
       "neutralTitle": "{name} · {status}",
       "outputTitle": "运行产出",
-      "outputHint": "展示聚焦输出节点的最终结果卡；与 Run 详情输出 Tab 一致，不是全量产物列表。",
       "noArtifacts": "本次运行暂无产出",
       "noArtifactsHint": "可打开 Run 详情查看执行过程",
       "markAsRead": "标记已读",


### PR DESCRIPTION
对齐 Demo「改后」：标题/副标题下不再展示实现说明文案，同步删除中英文死键，并在有卡/空态路径增加完整原句负向断言防回归。

Co-authored-by: Cursor <cursoragent@cursor.com>
