### PR TITLE
fix(i18n): localize onboarding shell workflow name and featureHint

### DIFF
--- a/web/e2e/onboarding-wizard-main.ts
+++ b/web/e2e/onboarding-wizard-main.ts
@@ -7,7 +7,8 @@ import OnboardingWizard from '../src/components/onboarding/OnboardingWizard.vue'
 
 async function boot() {
   await initLocale()
-  await setLocale('zh-CN')
+  const params = new URLSearchParams(window.location.search)
+  await setLocale(params.get('lang') === 'en' ? 'en' : 'zh-CN')
   setTheme('dark')
 
   const open = ref(true)
@@ -15,6 +16,12 @@ async function boot() {
     setup() {
       return () =>
         h('div', [
+          // Mirrors ProjectDetailView empty CTA copy for shell i18n e2e assertions.
+          h(
+            'p',
+            { 'data-testid': 'onboarding-empty-desc' },
+            String(i18n.global.t('pages.onboarding.emptyDesc')),
+          ),
           h(OnboardingWizard, {
             open: open.value,
             projectId: 'e2e-project',

--- a/web/e2e/onboarding-wizard.spec.ts
+++ b/web/e2e/onboarding-wizard.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 import path from 'node:path'
 import fs from 'node:fs'
 
@@ -8,7 +8,7 @@ test.beforeAll(() => {
   fs.mkdirSync(OUT, { recursive: true })
 })
 
-test('空项目上手引导五步向导浏览器验收', async ({ page }) => {
+async function mockOnboardingApi(page: Page) {
   await page.route('**/api/**', async (route) => {
     // Skip Vite module URLs like /@fs/.../src/lib/api/api.ts (pathname is not /api/...)
     if (!new URL(route.request().url()).pathname.startsWith('/api/')) {
@@ -17,9 +17,17 @@ test('空项目上手引导五步向导浏览器验收', async ({ page }) => {
     }
     const url = new URL(route.request().url())
     if (url.pathname.includes('/bootstrap-onboarding') && route.request().method() === 'POST') {
-      const body = route.request().postDataJSON() as { apiKey?: string; repos?: string }
+      const body = route.request().postDataJSON() as {
+        apiKey?: string
+        repos?: string
+        featureHint?: string
+      }
       if (!body?.apiKey?.trim()) {
-        await route.fulfill({ status: 400, contentType: 'application/json', body: JSON.stringify({ error: 'apiKey required' }) })
+        await route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'apiKey required' }),
+        })
         return
       }
       await route.fulfill({
@@ -29,7 +37,7 @@ test('空项目上手引导五步向导浏览器验收', async ({ page }) => {
           agentIds: ['ClarifyAgent', 'VisualAgent', 'ImplementAgent', 'TestAgent', 'PreviewAgent'],
           workflowId: 'wf-onboard-1',
           repos: body.repos || 'demo|https://github.com/heroku/nodejs-getting-started.git|main',
-          feature: '把首页欢迎文案与主按钮文案改得更清晰友好',
+          feature: body.featureHint || '把首页欢迎文案与主按钮文案改得更清晰友好',
           published: true,
         }),
       })
@@ -45,9 +53,25 @@ test('空项目上手引导五步向导浏览器验收', async ({ page }) => {
     }
     await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
   })
+}
+
+async function walkWizardToSuccess(page: Page, opts: { generateLabel: string; apiKey: string }) {
+  await page.getByTestId('onboarding-next').click() // overview -> acp
+  await page.getByTestId('onboarding-next').click() // acp -> apiKey
+  await page.getByTestId('onboarding-api-key').fill(opts.apiKey)
+  await page.getByTestId('onboarding-next').click() // apiKey -> git
+  await page.getByTestId('onboarding-next').click() // git -> review
+  await expect(page.getByText(opts.generateLabel)).toBeVisible()
+  await page.getByTestId('onboarding-next').click() // generate
+  await expect(page.getByTestId('onboarding-success')).toBeVisible()
+}
+
+test('空项目上手引导五步向导浏览器验收（zh）', async ({ page }) => {
+  await mockOnboardingApi(page)
 
   await page.goto('/onboarding-wizard.html', { waitUntil: 'networkidle' })
   await expect(page.getByTestId('onboarding-wizard-root')).toBeVisible()
+  await expect(page.getByTestId('onboarding-empty-desc')).toContainText('快速上手·轻量')
   await expect(page.getByText('概览').first()).toBeVisible()
   await expect(page.getByText(/Heroku 官方 Node Getting Started/)).toBeVisible()
   await expect(page.getByText('GitHub').first()).toBeVisible()
@@ -75,13 +99,14 @@ test('空项目上手引导五步向导浏览器验收', async ({ page }) => {
 
   await page.getByTestId('onboarding-next').click()
   await expect(page.getByText('生成配置')).toBeVisible()
+  await expect(page.getByText('工作流 · 快速上手·轻量')).toBeVisible()
   await page.screenshot({ path: path.join(OUT, '05-review.png'), fullPage: true })
 
   await page.getByTestId('onboarding-next').click()
   await expect(page.getByTestId('onboarding-success')).toBeVisible()
   await expect(page.getByText('VisualAgent')).toBeVisible()
   await expect(page.getByText('PreviewAgent')).toBeVisible()
-  await expect(page.getByText('快速上手·轻量（published）')).toBeVisible()
+  await expect(page.getByText('快速上手·轻量（已发布）')).toBeVisible()
   const successRepo = page.getByTestId('onboarding-success-repo')
   await expect(successRepo).toBeVisible()
   await expect(successRepo).toContainText('heroku/nodejs-getting-started')
@@ -89,4 +114,69 @@ test('空项目上手引导五步向导浏览器验收', async ({ page }) => {
   await expect(successRepo).not.toContainText('demo|https://')
   await expect(page.getByTestId('onboarding-start-run')).toBeVisible()
   await page.screenshot({ path: path.join(OUT, '06-success.png'), fullPage: true })
+})
+
+test('onboarding wizard English shell copy (Demo gold)', async ({ page }) => {
+  let bootstrapBody: { featureHint?: string } | null = null
+  await page.route('**/api/**', async (route) => {
+    if (!new URL(route.request().url()).pathname.startsWith('/api/')) {
+      await route.continue()
+      return
+    }
+    const url = new URL(route.request().url())
+    if (url.pathname.includes('/bootstrap-onboarding') && route.request().method() === 'POST') {
+      bootstrapBody = route.request().postDataJSON() as { featureHint?: string; apiKey?: string; repos?: string }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          agentIds: ['ClarifyAgent', 'VisualAgent', 'ImplementAgent', 'TestAgent', 'PreviewAgent'],
+          workflowId: 'wf-onboard-en',
+          repos: bootstrapBody?.repos || 'demo|https://github.com/heroku/nodejs-getting-started.git|main',
+          feature: bootstrapBody?.featureHint || '',
+          published: true,
+        }),
+      })
+      return
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  })
+
+  await page.goto('/onboarding-wizard.html?lang=en', { waitUntil: 'networkidle' })
+  await expect(page.getByTestId('onboarding-wizard-root')).toBeVisible()
+  await expect(page.getByText('Overview').first()).toBeVisible()
+
+  await walkWizardToSuccess(page, { generateLabel: 'Generate setup', apiKey: 'crsr_e2e_en' })
+
+  await expect(page.getByText('Quick Start · Light (published)')).toBeVisible()
+  await expect(page.getByText('快速上手·轻量')).toHaveCount(0)
+  // Review chip was visible before generate; re-open path is heavy — assert from prior review via regenerate
+  // After success we already left review; assert chip was in DOM during walk by checking bootstrap featureHint
+  expect(bootstrapBody?.featureHint).toBe(
+    'Add a lightweight quick-start sample so the team can walk the clarify → gate → agent path.',
+  )
+  await page.screenshot({ path: path.join(OUT, 'en-success.png'), fullPage: true })
+})
+
+test('onboarding English empty CTA / review chip gold sample', async ({ page }) => {
+  await mockOnboardingApi(page)
+  await page.goto('/onboarding-wizard.html?lang=en', { waitUntil: 'networkidle' })
+  await expect(page.getByTestId('onboarding-wizard-root')).toBeVisible()
+
+  const emptyDesc = page.getByTestId('onboarding-empty-desc')
+  await expect(emptyDesc).toHaveText('Publishes Quick Start · Light workflow and starts a sample run.')
+  await expect(emptyDesc).not.toContainText('快速上手·轻量')
+
+  await page.getByTestId('onboarding-next').click() // acp
+  await page.getByTestId('onboarding-next').click() // apiKey
+  await page.getByTestId('onboarding-api-key').fill('crsr_chip')
+  await page.getByTestId('onboarding-next').click() // git
+  await page.getByTestId('onboarding-next').click() // review
+
+  await expect(page.getByText('Workflow · Quick Start · Light')).toBeVisible()
+  await expect(page.getByText('快速上手·轻量')).toHaveCount(0)
+  const pane = await page.locator('[data-testid="onboarding-wizard-root"]').innerText()
+  expect(pane).not.toContain('快速上手·轻量')
+  expect(pane).toContain('Quick Start · Light')
+  await page.screenshot({ path: path.join(OUT, 'en-review-chip.png'), fullPage: true })
 })

--- a/web/src/components/onboarding/OnboardingWizard.test.ts
+++ b/web/src/components/onboarding/OnboardingWizard.test.ts
@@ -26,11 +26,15 @@ vi.mock('@/lib/composables/useToast', () => ({
   useToast: () => ({ success: vi.fn(), error: vi.fn(), warn: vi.fn(), show: vi.fn() }),
 }))
 
-vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (k: string) => k,
-  }),
-}))
+vi.mock('vue-i18n', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-i18n')>()
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (k: string) => k,
+    }),
+  }
+})
 
 describe('OnboardingWizard', () => {
   beforeEach(() => {

--- a/web/src/components/onboarding/OnboardingWizard.vue
+++ b/web/src/components/onboarding/OnboardingWizard.vue
@@ -12,7 +12,6 @@ import {
   DEFAULT_ONBOARDING_REPO,
   ONBOARDING_AGENT_NAMES,
   ONBOARDING_STEPS,
-  ONBOARDING_WORKFLOW_NAME,
   assembleBootstrapBody,
   dismissOnboarding,
   encodeReposLiteral,
@@ -219,7 +218,7 @@ async function startSampleRun() {
           <p class="mt-2 text-[13px] text-txt2">{{ t('pages.onboarding.success.desc') }}</p>
           <ul class="mt-4 space-y-1.5 text-[13px] text-txt2">
             <li v-for="n in ONBOARDING_AGENT_NAMES" :key="n">· {{ n }}</li>
-            <li>· {{ ONBOARDING_WORKFLOW_NAME }}（published）</li>
+            <li>· {{ t('pages.onboarding.success.publishedLine') }}</li>
           </ul>
           <div
             class="mt-4 border border-line bg-elevated px-3 py-3 text-[13px] text-txt2"

--- a/web/src/lib/pm/onboardingWizard.test.ts
+++ b/web/src/lib/pm/onboardingWizard.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { describe, expect, it, beforeEach } from 'vitest'
+import { describe, expect, it, beforeEach, beforeAll } from 'vitest'
 import {
   DEFAULT_ONBOARDING_REPOS_LITERAL,
   assembleBootstrapBody,
@@ -13,10 +13,23 @@ import {
   reposInputFromFields,
   shouldAutoOpenOnboarding,
 } from './onboardingWizard'
+import { i18n } from '@/lib/shared/i18n'
+import { loadLocaleMessages } from '@/lib/shared/loadLocaleMessages'
+
+const EN_FEATURE_HINT =
+  'Add a lightweight quick-start sample so the team can walk the clarify → gate → agent path.'
+const ZH_FEATURE_HINT = '用轻量快速上手示例走完澄清 → 门禁 → Agent 路径。'
+
+beforeAll(async () => {
+  const [zh, en] = await Promise.all([loadLocaleMessages('zh-CN'), loadLocaleMessages('en')])
+  i18n.global.setLocaleMessage('zh-CN', zh)
+  i18n.global.setLocaleMessage('en', en)
+})
 
 describe('onboardingWizard', () => {
   beforeEach(() => {
     localStorage.clear()
+    i18n.global.locale.value = 'zh-CN'
   })
 
   it('encodes default heroku well-known repos literal', () => {
@@ -50,6 +63,19 @@ describe('onboardingWizard', () => {
     expect(body.apiKey).toBe('cb-key')
     expect(body.region).toBe('public')
     expect(body.repos).toContain('heroku/nodejs-getting-started')
+  })
+
+  it('assembles featureHint from zh locale (Demo gold)', () => {
+    i18n.global.locale.value = 'zh-CN'
+    const body = assembleBootstrapBody(freshOnboardingDraft())
+    expect(body.featureHint).toBe(ZH_FEATURE_HINT)
+  })
+
+  it('assembles featureHint from en locale (Demo gold)', () => {
+    i18n.global.locale.value = 'en'
+    const body = assembleBootstrapBody(freshOnboardingDraft())
+    expect(body.featureHint).toBe(EN_FEATURE_HINT)
+    expect(body.featureHint).not.toContain('快速上手·轻量')
   })
 
   it('detects empty project by 0 workflows and 0 bound agents', () => {

--- a/web/src/lib/pm/onboardingWizard.ts
+++ b/web/src/lib/pm/onboardingWizard.ts
@@ -1,5 +1,6 @@
 import type { BackendId } from '@/lib/shared/regionPolicy'
 import { getRegionPolicy } from '@/lib/shared/regionPolicy'
+import { i18n } from '@/lib/shared/i18n'
 
 export const ONBOARDING_WORKFLOW_NAME = '快速上手·轻量'
 
@@ -58,6 +59,8 @@ export type OnboardingBootstrapBody = {
   apiKey: string
   region?: string
   repos?: string
+  /** Locale-aware sample feature; server falls back to Chinese default when omitted. */
+  featureHint?: string
 }
 
 export type OnboardingBootstrapResult = {
@@ -173,10 +176,14 @@ export function reposInputFromFields(repo: OnboardingRepoFields): Array<{ name: 
 }
 
 export function assembleBootstrapBody(draft: OnboardingDraft): OnboardingBootstrapBody {
+  const featureHint = String(i18n.global.t('pages.onboarding.review.featureHint')).trim()
   const body: OnboardingBootstrapBody = {
     acpBackend: draft.acpBackend,
     apiKey: draft.apiKey.trim(),
     repos: encodeReposLiteral(draft.repo),
+  }
+  if (featureHint && !featureHint.startsWith('pages.onboarding.')) {
+    body.featureHint = featureHint
   }
   const policy = getRegionPolicy(draft.acpBackend)
   if (policy && draft.region.trim()) {

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -155,7 +155,8 @@
       "startRun": "Start sample Run",
       "cta": "Start onboarding",
       "emptyTitle": "Empty project — start onboarding",
-      "emptyDesc": "Configure backend + API Key to create 5 Agents and the published「快速上手·轻量」workflow. Default git is the public Heroku sample.",
+      "emptyDesc": "Publishes Quick Start · Light workflow and starts a sample run.",
+      "workflowName": "Quick Start · Light",
       "head": {
         "overview": "What you will get",
         "acp": "Choose ACP backend",
@@ -200,16 +201,17 @@
       "review": {
         "meta": "Confirm below. Existing same-named resources are reused/updated (idempotent).",
         "needKey": "API Key is missing — go back and fill it in.",
-        "featureHint": "Sample feature (no input needed): make the homepage welcome copy and primary button clearer.",
+        "featureHint": "Add a lightweight quick-start sample so the team can walk the clarify → gate → agent path.",
         "agentsChip": "Agents · 5",
-        "wfChip": "Workflow · 快速上手·轻量"
+        "wfChip": "Workflow · Quick Start · Light"
       },
       "success": {
         "title": "Setup ready",
         "desc": "Project auth written; 5 Agents and the published light workflow are ready.",
         "repo": "Sample repository",
         "limit": "Public repos usually cannot be pushed; Preview may not show Implement changes. Success means Agents/workflow were created.",
-        "runStarted": "Sample Run started"
+        "runStarted": "Sample Run started",
+        "publishedLine": "Quick Start · Light (published)"
       },
       "toastOk": "Generated — Run not started automatically",
       "toastNeedKey": "Please enter an API Key",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -155,7 +155,8 @@
       "startRun": "启动示例 Run",
       "cta": "开始上手引导",
       "emptyTitle": "空项目，开始上手引导",
-      "emptyDesc": "配置后端与 API Key，一键生成 5 个 Agent 与「快速上手·轻量」工作流。默认使用 Heroku 公开示例仓。",
+      "emptyDesc": "将发布「快速上手·轻量」工作流并启动示例 Run。",
+      "workflowName": "快速上手·轻量",
       "head": {
         "overview": "看看这次会生成什么",
         "acp": "选择运行后端",
@@ -200,7 +201,7 @@
       "review": {
         "meta": "确认下列信息。若项目中已有同名资源，将复用并更新，不会重复创建。",
         "needKey": "尚未配置 API Key，请返回上一步填写后再生成。",
-        "featureHint": "示例需求（无需填写）：把首页欢迎文案与主按钮改得更清晰友好。",
+        "featureHint": "用轻量快速上手示例走完澄清 → 门禁 → Agent 路径。",
         "agentsChip": "Agents · 5",
         "wfChip": "工作流 · 快速上手·轻量"
       },
@@ -209,7 +210,8 @@
         "desc": "已写入项目鉴权，并生成 5 个 Agent 与已发布的「快速上手·轻量」工作流。",
         "repo": "示例代码仓",
         "limit": "公开仓通常无法 push；Preview 未必看到 Implement 改动。引导成败以 Agent/工作流是否生成为准。",
-        "runStarted": "已启动示例 Run"
+        "runStarted": "已启动示例 Run",
+        "publishedLine": "快速上手·轻量（已发布）"
       },
       "toastOk": "生成成功，未自动开跑",
       "toastNeedKey": "请先填写 API Key",


### PR DESCRIPTION
Show Quick Start · Light on English empty CTA / review chip / success;
keep 快速上手·轻量 for zh-CN and canonical bootstrap idempotency.
Pass locale-aware featureHint on bootstrap without renaming the stored workflow.

Co-authored-by: Cursor <cursoragent@cursor.com>
