### PR TITLE
fix(preview): 直连预览取点脚本用 ready/ping 握手判定

### DIFF
--- a/sandbox-gateway/sandbox/cmd/preview-inject/main.go
+++ b/sandbox-gateway/sandbox/cmd/preview-inject/main.go
@@ -51,8 +51,8 @@ func parseOptions(args []string, getenv func(string) string) (options, error) {
 	}
 
 	opt := options{
-		Listen:    firstNonEmpty(*listen, getenv("PREVIEW_INJECT_LISTEN"), fmt.Sprintf(":%d", previewinject.ListenPort)),
-		Upstream:  firstNonEmpty(*upstream, getenv("PREVIEW_INJECT_UPSTREAM")),
+		Listen:   firstNonEmpty(*listen, getenv("PREVIEW_INJECT_LISTEN"), fmt.Sprintf(":%d", previewinject.ListenPort)),
+		Upstream: firstNonEmpty(*upstream, getenv("PREVIEW_INJECT_UPSTREAM")),
 		// Always default to the same-origin path. PREVIEW_PICK_SCRIPT_URL is
 		// for the Agent HTML fallback; Approving often sets it to
 		// http://localhost:8080/preview-pick.js, which the reviewer's

--- a/sandbox-gateway/sandbox/docs/PROTOCOL.md
+++ b/sandbox-gateway/sandbox/docs/PROTOCOL.md
@@ -264,6 +264,10 @@ IP 直连预览时审批页 iframe 的 origin 是 `http://<sandbox-ip>:$PREVIEW_
   `<script src="/__approving/preview-pick.js">`。不得注入
   `http://localhost:8080/preview-pick.js`:审批人浏览器 origin 是
   `http://IP:PREVIEW_PORT/`,打不开 Approving 的 loopback。
+- 脚本用 `postMessage` 向父页发 `direct-preview-ready`(每次文档加载一次,
+  经典 `<script>` 早于 iframe `load` 事件),SPA 跳转再发 `direct-preview-url`。
+  父页可发 `direct-preview-ping` 要求重播 ready;判定「未加载脚本」须以
+  ping 也无应答为准,不能只看 `load` 时序。
 - 回环(应用 ← 注入进程)走 OUTPUT,不进 PREROUTING,不会环。
 - 注入进程**不得**听 `PREVIEW_PORT`(平台 `KeepalivePort` 按该口找应用进程)。
 - 进程挂了必须拆规则或立刻拉起:箱外 `ProbeHTTPPort` 打的是发布口,会走 REDIRECT;

--- a/sandbox-gateway/sandbox/internal/previewinject/preview-pick.js
+++ b/sandbox-gateway/sandbox/internal/previewinject/preview-pick.js
@@ -6,6 +6,7 @@
   var CANCELED = 'direct-preview-canceled';
   var INSPECT = 'direct-preview-inspect';
   var NAV = 'direct-preview-nav';
+  var PING = 'direct-preview-ping';
   var enabled = false;
   var hoverEl = null;
   var styleEl = null;
@@ -133,6 +134,10 @@
   window.addEventListener('message', function (ev) {
     var data = ev.data;
     if (!data || typeof data !== 'object') return;
+    if (data.type === PING) {
+      postUrl(READY);
+      return;
+    }
     if (data.type === INSPECT) {
       setEnabled(!!data.on);
       return;

--- a/sandbox-gateway/sandbox/internal/previewinject/preview-pick.js
+++ b/sandbox-gateway/sandbox/internal/previewinject/preview-pick.js
@@ -10,21 +10,13 @@
   var hoverEl = null;
   var styleEl = null;
 
-  function parentOrigin() {
-    try {
-      if (document.referrer) return new URL(document.referrer).origin;
-    } catch (e) {}
-    return '*';
-  }
-
   function post(msg) {
+    // Always '*' : HTTPS Approving embedding http://IP:port often strips
+    // document.referrer (strict-origin-when-cross-origin), and a wrong
+    // targetOrigin fails silently with no exception.
     try {
-      parent.postMessage(msg, parentOrigin());
-    } catch (e) {
-      try {
-        parent.postMessage(msg, '*');
-      } catch (e2) {}
-    }
+      parent.postMessage(msg, '*');
+    } catch (e) {}
   }
 
   function currentUrl() {
@@ -181,4 +173,13 @@
   } catch (e) {}
 
   postUrl(READY);
+  // Parent may arm its wait on iframe "load", which fires after this script.
+  // Re-announce so a late listener still clears the missing-script tip.
+  if (document.readyState === 'complete') {
+    postUrl(READY);
+  } else {
+    window.addEventListener('load', function () {
+      postUrl(READY);
+    });
+  }
 })();

--- a/server/internal/handlers/preview-pick.js
+++ b/server/internal/handlers/preview-pick.js
@@ -6,6 +6,7 @@
   var CANCELED = 'direct-preview-canceled';
   var INSPECT = 'direct-preview-inspect';
   var NAV = 'direct-preview-nav';
+  var PING = 'direct-preview-ping';
   var enabled = false;
   var hoverEl = null;
   var styleEl = null;
@@ -133,6 +134,10 @@
   window.addEventListener('message', function (ev) {
     var data = ev.data;
     if (!data || typeof data !== 'object') return;
+    if (data.type === PING) {
+      postUrl(READY);
+      return;
+    }
     if (data.type === INSPECT) {
       setEnabled(!!data.on);
       return;

--- a/server/internal/handlers/preview-pick.js
+++ b/server/internal/handlers/preview-pick.js
@@ -10,21 +10,13 @@
   var hoverEl = null;
   var styleEl = null;
 
-  function parentOrigin() {
-    try {
-      if (document.referrer) return new URL(document.referrer).origin;
-    } catch (e) {}
-    return '*';
-  }
-
   function post(msg) {
+    // Always '*' : HTTPS Approving embedding http://IP:port often strips
+    // document.referrer (strict-origin-when-cross-origin), and a wrong
+    // targetOrigin fails silently with no exception.
     try {
-      parent.postMessage(msg, parentOrigin());
-    } catch (e) {
-      try {
-        parent.postMessage(msg, '*');
-      } catch (e2) {}
-    }
+      parent.postMessage(msg, '*');
+    } catch (e) {}
   }
 
   function currentUrl() {
@@ -181,4 +173,13 @@
   } catch (e) {}
 
   postUrl(READY);
+  // Parent may arm its wait on iframe "load", which fires after this script.
+  // Re-announce so a late listener still clears the missing-script tip.
+  if (document.readyState === 'complete') {
+    postUrl(READY);
+  } else {
+    window.addEventListener('load', function () {
+      postUrl(READY);
+    });
+  }
 })();

--- a/server/internal/handlers/preview_pick_test.go
+++ b/server/internal/handlers/preview_pick_test.go
@@ -1,8 +1,12 @@
 package handlers
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -37,9 +41,32 @@ func TestPreviewPickScript(t *testing.T) {
 		"direct-preview-canceled",
 		"direct-preview-inspect",
 		"direct-preview-nav",
+		"direct-preview-ping",
 	} {
 		if !strings.Contains(body, needle) {
 			t.Fatalf("script missing %q", needle)
+		}
+	}
+}
+
+// The script is embedded three times: here, in the web dev/static bundle, and
+// in the sandbox injector. Drift means one preview surface silently loses pick.
+func TestPreviewPickScriptCopiesInSync(t *testing.T) {
+	_, self, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller")
+	}
+	root := filepath.Join(filepath.Dir(self), "..", "..", "..")
+	for _, rel := range []string{
+		filepath.Join("web", "public", "preview-pick.js"),
+		filepath.Join("sandbox-gateway", "sandbox", "internal", "previewinject", "preview-pick.js"),
+	} {
+		copyBytes, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if !bytes.Equal(copyBytes, previewPickJS) {
+			t.Errorf("%s drifted from server/internal/handlers/preview-pick.js", rel)
 		}
 	}
 }

--- a/web/public/preview-pick.js
+++ b/web/public/preview-pick.js
@@ -6,6 +6,7 @@
   var CANCELED = 'direct-preview-canceled';
   var INSPECT = 'direct-preview-inspect';
   var NAV = 'direct-preview-nav';
+  var PING = 'direct-preview-ping';
   var enabled = false;
   var hoverEl = null;
   var styleEl = null;
@@ -133,6 +134,10 @@
   window.addEventListener('message', function (ev) {
     var data = ev.data;
     if (!data || typeof data !== 'object') return;
+    if (data.type === PING) {
+      postUrl(READY);
+      return;
+    }
     if (data.type === INSPECT) {
       setEnabled(!!data.on);
       return;

--- a/web/public/preview-pick.js
+++ b/web/public/preview-pick.js
@@ -10,21 +10,13 @@
   var hoverEl = null;
   var styleEl = null;
 
-  function parentOrigin() {
-    try {
-      if (document.referrer) return new URL(document.referrer).origin;
-    } catch (e) {}
-    return '*';
-  }
-
   function post(msg) {
+    // Always '*' : HTTPS Approving embedding http://IP:port often strips
+    // document.referrer (strict-origin-when-cross-origin), and a wrong
+    // targetOrigin fails silently with no exception.
     try {
-      parent.postMessage(msg, parentOrigin());
-    } catch (e) {
-      try {
-        parent.postMessage(msg, '*');
-      } catch (e2) {}
-    }
+      parent.postMessage(msg, '*');
+    } catch (e) {}
   }
 
   function currentUrl() {
@@ -181,4 +173,13 @@
   } catch (e) {}
 
   postUrl(READY);
+  // Parent may arm its wait on iframe "load", which fires after this script.
+  // Re-announce so a late listener still clears the missing-script tip.
+  if (document.readyState === 'complete') {
+    postUrl(READY);
+  } else {
+    window.addEventListener('load', function () {
+      postUrl(READY);
+    });
+  }
 })();

--- a/web/src/components/run/DirectPreviewFrame.test.ts
+++ b/web/src/components/run/DirectPreviewFrame.test.ts
@@ -86,6 +86,20 @@ describe('DirectPreviewFrame', () => {
     wrapper.unmount()
   })
 
+  it('keeps ready after iframe load that races past the script', async () => {
+    const { wrapper } = mountFrame()
+    dispatchFromPreview({ type: 'direct-preview-ready', url: DIRECT })
+    await flushPromises()
+    await wrapper.get('[data-testid="app-preview-direct-frame"]').trigger('load')
+    await flushPromises()
+    vi.advanceTimersByTime(2500)
+    await flushPromises()
+    expect(wrapper.find('[data-testid="direct-preview-tip"]').exists()).toBe(false)
+    await wrapper.get('[data-testid="direct-preview-inspect"]').trigger('click')
+    expect(wrapper.find('[data-testid="direct-preview-tip"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
   it('ignores pick messages from other origins', async () => {
     const { wrapper } = mountFrame()
     dispatchFromPreview(

--- a/web/src/components/run/DirectPreviewFrame.test.ts
+++ b/web/src/components/run/DirectPreviewFrame.test.ts
@@ -8,7 +8,7 @@ import DirectPreviewFrame from './DirectPreviewFrame.vue'
 
 const DIRECT = 'http://127.0.0.1:18081/'
 
-function mountFrame() {
+function mountFrame(opts: { answerPing?: boolean } = {}) {
   const i18n = createI18n({
     legacy: false,
     locale: 'zh-CN',
@@ -18,6 +18,9 @@ function mountFrame() {
   const fakeWin = {
     postMessage: (msg: unknown) => {
       posted.push(msg)
+      if (opts.answerPing && (msg as { type?: string })?.type === 'direct-preview-ping') {
+        dispatchFromPreview({ type: 'direct-preview-ready', url: DIRECT })
+      }
     },
   }
   const wrapper = mount(DirectPreviewFrame, {
@@ -86,17 +89,62 @@ describe('DirectPreviewFrame', () => {
     wrapper.unmount()
   })
 
-  it('keeps ready after iframe load that races past the script', async () => {
+  it('keeps ready across iframe load without needing a ping', async () => {
+    const { wrapper, posted } = mountFrame()
+    dispatchFromPreview({ type: 'direct-preview-ready', url: DIRECT })
+    await flushPromises()
+    await wrapper.get('[data-testid="app-preview-direct-frame"]').trigger('load')
+    await flushPromises()
+    vi.advanceTimersByTime(3000)
+    await flushPromises()
+    expect(posted).toEqual([])
+    expect(wrapper.find('[data-testid="direct-preview-tip"]').exists()).toBe(false)
+    await wrapper.get('[data-testid="direct-preview-inspect"]').trigger('click')
+    expect(wrapper.find('[data-testid="direct-preview-tip"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('recovers via ping when the announcement was missed', async () => {
+    const { wrapper, posted } = mountFrame({ answerPing: true })
+    await wrapper.get('[data-testid="app-preview-direct-frame"]').trigger('load')
+    await flushPromises()
+    expect(posted).toEqual([{ type: 'direct-preview-ping' }])
+    vi.advanceTimersByTime(3000)
+    await flushPromises()
+    expect(wrapper.find('[data-testid="direct-preview-tip"]').exists()).toBe(false)
+    await wrapper.get('[data-testid="direct-preview-inspect"]').trigger('click')
+    expect(posted).toContainEqual({ type: 'direct-preview-inspect', on: true })
+    wrapper.unmount()
+  })
+
+  it('pings again before reporting a missing script', async () => {
+    const { wrapper, posted } = mountFrame()
+    vi.advanceTimersByTime(2500)
+    await flushPromises()
+    expect(posted).toEqual([{ type: 'direct-preview-ping' }])
+    expect(wrapper.find('[data-testid="direct-preview-tip"]').exists()).toBe(false)
+    dispatchFromPreview({ type: 'direct-preview-ready', url: DIRECT })
+    await flushPromises()
+    vi.advanceTimersByTime(500)
+    await flushPromises()
+    expect(wrapper.find('[data-testid="direct-preview-tip"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('drops stale ready when a later page has no script', async () => {
     const { wrapper } = mountFrame()
     dispatchFromPreview({ type: 'direct-preview-ready', url: DIRECT })
     await flushPromises()
     await wrapper.get('[data-testid="app-preview-direct-frame"]').trigger('load')
     await flushPromises()
-    vi.advanceTimersByTime(2500)
+    await wrapper.get('[data-testid="direct-preview-address"]').setValue('/no-script')
+    await wrapper.get('form').trigger('submit')
     await flushPromises()
-    expect(wrapper.find('[data-testid="direct-preview-tip"]').exists()).toBe(false)
-    await wrapper.get('[data-testid="direct-preview-inspect"]').trigger('click')
-    expect(wrapper.find('[data-testid="direct-preview-tip"]').exists()).toBe(false)
+    await wrapper.get('[data-testid="app-preview-direct-frame"]').trigger('load')
+    await flushPromises()
+    vi.advanceTimersByTime(3000)
+    await flushPromises()
+    expect(wrapper.get('[data-testid="direct-preview-tip"]').text()).toMatch(/未加载取点脚本/)
     wrapper.unmount()
   })
 
@@ -130,7 +178,7 @@ describe('DirectPreviewFrame', () => {
 
   it('shows script-missing tip after wait without ready', async () => {
     const { wrapper } = mountFrame()
-    vi.advanceTimersByTime(2500)
+    vi.advanceTimersByTime(3000)
     await flushPromises()
     expect(wrapper.get('[data-testid="direct-preview-tip"]').text()).toMatch(/未加载取点脚本/)
     wrapper.unmount()

--- a/web/src/components/run/DirectPreviewFrame.vue
+++ b/web/src/components/run/DirectPreviewFrame.vue
@@ -67,6 +67,13 @@ function armScriptWait() {
 }
 
 function onIframeLoad() {
+  // Classic <script> runs before the iframe "load" event, so ready may already
+  // have arrived. Resetting here races and leaves the tip stuck forever.
+  if (scriptReady.value) {
+    scriptTip.value = false
+    clearWait()
+    return
+  }
   armScriptWait()
 }
 

--- a/web/src/components/run/DirectPreviewFrame.vue
+++ b/web/src/components/run/DirectPreviewFrame.vue
@@ -5,6 +5,7 @@ import type { AppPreviewPickPayload } from '@/lib/shared/previewPickUrl'
 import {
   DIRECT_PREVIEW_INSPECT,
   DIRECT_PREVIEW_NAV,
+  DIRECT_PREVIEW_PING,
   iframeOrigin,
   isDirectPreviewOrigin,
   parseDirectPreviewMessage,
@@ -13,6 +14,7 @@ import {
 } from '@/lib/shared/directPreviewPick'
 
 const SCRIPT_WAIT_MS = 2500
+const PING_GRACE_MS = 500
 
 const props = withDefaults(
   defineProps<{
@@ -37,6 +39,8 @@ const inlineTip = ref<string | null>(null)
 const picked = ref<AppPreviewPickPayload | null>(null)
 const iframeRef = ref<HTMLIFrameElement | null>(null)
 let waitTimer: ReturnType<typeof setTimeout> | null = null
+let readySeq = 0
+let loadedSeq = 0
 
 function originOf(): string {
   return iframeOrigin(props.directUrl)
@@ -56,25 +60,43 @@ function clearWait() {
   }
 }
 
+function pingFrame() {
+  postToFrame({ type: DIRECT_PREVIEW_PING })
+}
+
 function armScriptWait() {
   clearWait()
-  scriptReady.value = false
+  // Anything announced from here on belongs to the document being waited for.
+  loadedSeq = readySeq
   scriptTip.value = false
   inspect.value = false
+  const armed = readySeq
   waitTimer = setTimeout(() => {
-    if (!scriptReady.value) scriptTip.value = true
+    if (readySeq !== armed) return
+    pingFrame()
+    waitTimer = setTimeout(() => {
+      if (readySeq !== armed) return
+      scriptReady.value = false
+      scriptTip.value = true
+    }, PING_GRACE_MS)
   }, SCRIPT_WAIT_MS)
 }
 
+// A classic <script> runs before the iframe "load" event, so a page carrying
+// the script has already announced by now. Comparing against the previous load
+// tells announced-for-this-document apart from a stale flag left by the page we
+// just navigated away from.
 function onIframeLoad() {
-  // Classic <script> runs before the iframe "load" event, so ready may already
-  // have arrived. Resetting here races and leaves the tip stuck forever.
-  if (scriptReady.value) {
+  if (readySeq > loadedSeq) {
+    loadedSeq = readySeq
+    scriptReady.value = true
     scriptTip.value = false
     clearWait()
     return
   }
+  scriptReady.value = false
   armScriptWait()
+  pingFrame()
 }
 
 function onMessage(event: MessageEvent) {
@@ -82,6 +104,7 @@ function onMessage(event: MessageEvent) {
   const parsed = parseDirectPreviewMessage(event.data)
   if (!parsed) return
   if (parsed.type === 'direct-preview-ready' || parsed.type === 'direct-preview-url') {
+    readySeq += 1
     scriptReady.value = true
     scriptTip.value = false
     clearWait()

--- a/web/src/lib/shared/directPreviewPick.ts
+++ b/web/src/lib/shared/directPreviewPick.ts
@@ -6,6 +6,8 @@ export const DIRECT_PREVIEW_PICKED = 'direct-preview-picked'
 export const DIRECT_PREVIEW_CANCELED = 'direct-preview-canceled'
 export const DIRECT_PREVIEW_INSPECT = 'direct-preview-inspect'
 export const DIRECT_PREVIEW_NAV = 'direct-preview-nav'
+/** Parent asks the page to re-announce ready; answers with DIRECT_PREVIEW_READY. */
+export const DIRECT_PREVIEW_PING = 'direct-preview-ping'
 
 export type DirectPreviewNavAction = 'back' | 'forward' | 'reload'
 


### PR DESCRIPTION
## Summary
- #329 之后审批页仍稳定提示「未加载取点脚本」。实测 HTML 已含 `<script src="/__approving/preview-pick.js">` 且返回 200：脚本其实加载了，是父页判定错。
- 取点脚本每次文档只发一次 `direct-preview-ready`，而经典 `<script>` 早于 iframe `load` 事件。父页在 `@load` 里重置 `scriptReady` 并重新计时，把已收到的 ready 冲掉，之后不会有第二次 → 刷新后红条一直挂着。
- 改为按「本次文档是否 announce 过」判定（对比上一次 load 的计数），并在报错前主动发 `direct-preview-ping` 让脚本重播 ready。旧沙箱镜像的脚本不认 ping，但走 announce 分支照样正常。
- 脚本 `postMessage` 改为固定 `'*'`：HTTPS 父页嵌 http 预览时 `document.referrer` 常被 referrer policy 剥掉，targetOrigin 猜错会静默失败。
- 三份 `preview-pick.js`（server embed / web public / 沙箱注入层）加防漂移测试，避免以后某个预览面悄悄失去取点。

## Test plan
- [x] `npm test -- --run src/components/run/DirectPreviewFrame.test.ts`（14 passed：load 不冲掉 ready、ping 补救、页面换到无脚本页要报错、旧脚本无需 ping）
- [x] `npx vue-tsc --noEmit`
- [x] `npm run lint`（0 error）
- [x] `go test ./internal/handlers ./internal/runtime`（含三份脚本一致性）
- [x] `go test ./internal/previewinject ./cmd/preview-inject` + `gofmt`
- [x] 线上沙箱实测：`curl http://IP:18080/` HTML 已含同域 script，`/__approving/preview-pick.js` 200 且 `application/javascript`
- [ ] 部署前端后刷新审批页：红条消失，「取点标注」可用；应用内跳转、地址栏跳转后仍可用

只需更新 Approving 前端，本次不必重打沙箱镜像。

Made with [Cursor](https://cursor.com)