### PR TITLE
fix(runtime): harden feedback agent summaries

### DIFF
--- a/server/internal/runtime/acp_react.go
+++ b/server/internal/runtime/acp_react.go
@@ -169,6 +169,7 @@ func (c *acpProvider) ReactReply(ctx context.Context, req NodeReq, history []mod
 	var events []models.AcpEvent
 	absorbChat(&usage, &usageByModel, &events, res)
 	narration, agentSummary := applyDualWrite(res.Narration)
+	logDualWriteMiss(req, res.Narration, agentSummary)
 
 	qs := c.host.TakePendingQuestions(req.RunID, req.NodeID)
 
@@ -241,6 +242,7 @@ func (c *acpProvider) ReviseInPlace(ctx context.Context, req NodeReq, history []
 	var events []models.AcpEvent
 	absorbChat(&usage, &usageByModel, &events, res)
 	narration, agentSummary := applyDualWrite(res.Narration)
+	logDualWriteMiss(req, res.Narration, agentSummary)
 
 	c.host.TakePendingQuestions(req.RunID, req.NodeID)
 
@@ -276,6 +278,17 @@ func (c *acpProvider) CancelSessionTurn(runID, nodeID string) {
 	if sess != nil && sess.acp != nil {
 		_ = sess.acp.Cancel()
 	}
+}
+
+// logDualWriteMiss records a parse miss without logging the agent response,
+// which can contain user feedback. It gives operators a denominator for the
+// non-empty agentSummary rate on review and clarify human turns.
+func logDualWriteMiss(req NodeReq, raw, agentSummary string) {
+	if strings.TrimSpace(raw) == "" || strings.TrimSpace(agentSummary) != "" {
+		return
+	}
+	log.Debug().Str("run", req.RunID).Str("node", req.NodeID).Str("node_type", req.NodeType).
+		Msg("dual-write agentSummary missing or unparseable")
 }
 
 // enforceOpenQuestionsGate implements the clarification gate: when the agent

--- a/server/internal/runtime/turn_dual_write.go
+++ b/server/internal/runtime/turn_dual_write.go
@@ -21,12 +21,14 @@ const dualWriteTurnContract = `
 规则:
 - agentSummary 是供反馈账本卡片最前展示的「Agent 总结」,须归纳本轮反馈意图/要点,与叙述分离。
 - 禁止把索引规则 gist、正文首行或对话气泡原文原样当作 agentSummary。
-- 若无法归纳,可省略该 JSON 代码块(平台将隐藏总结区);不要写空字符串占位。
+- 除非确实无法归纳,请始终产出一段非空的 agentSummary；它应确认用户本轮反馈意图,而非复述叙述回复。
+- 仅在确实无法归纳时才省略整个 JSON 代码块(平台将隐藏总结区);禁止输出空键、空字符串或模板占位。
 - JSON 只出现在文末代码块中,不要把 JSON 写进叙述正文。
 `
 
-// Match the last fenced code block (optional language tag) at end of text.
-var dualWriteJSONFence = regexp.MustCompile("(?s)```(?:json)?\\s*\\n(\\{[\\s\\S]*?\\})\\s*\\n```\\s*$")
+// Match fenced JSON objects so we can recover the final valid dual-write
+// payload when an agent appends harmless prose after its contract fence.
+var dualWriteJSONFence = regexp.MustCompile("(?s)```(?:json)?\\s*\\n(\\{[\\s\\S]*?\\})\\s*\\n```")
 
 type dualWritePayload struct {
 	AgentSummary string `json:"agentSummary"`
@@ -55,17 +57,27 @@ func splitTurnDualWrite(raw string) (narration, agentSummary string) {
 		return "", ""
 	}
 
-	if loc := dualWriteJSONFence.FindStringSubmatchIndex(raw); len(loc) >= 4 {
-		jsonBody := raw[loc[2]:loc[3]]
-		prefix := strings.TrimSpace(raw[:loc[0]])
-		if sum, narr, ok := parseDualWriteJSON(jsonBody); ok {
-			if narr != "" {
-				return narr, sum
-			}
-			return prefix, sum
+	matches := dualWriteJSONFence.FindAllStringSubmatchIndex(raw, -1)
+	var emptyNarration string
+	for i := len(matches) - 1; i >= 0; i-- {
+		loc := matches[i]
+		sum, narr, ok := parseDualWriteJSON(raw[loc[2]:loc[3]])
+		if !ok || !hasLightweightTrailingNoise(raw[loc[1]:]) {
+			continue
 		}
-		// Fence present but not our dual-write shape: keep raw intact.
-		return raw, ""
+		if sum == "" {
+			if emptyNarration == "" {
+				emptyNarration = withoutDualWriteFence(raw, loc)
+			}
+			continue
+		}
+		if narr != "" {
+			return narr, sum
+		}
+		return withoutDualWriteFence(raw, loc), sum
+	}
+	if emptyNarration != "" {
+		return emptyNarration, ""
 	}
 
 	if strings.HasPrefix(raw, "{") && strings.HasSuffix(raw, "}") {
@@ -78,6 +90,26 @@ func splitTurnDualWrite(raw string) (narration, agentSummary string) {
 		}
 	}
 	return raw, ""
+}
+
+// hasLightweightTrailingNoise permits a short, plain-text postscript after a
+// valid final fence. It deliberately rejects another fence or a long body so
+// an unrelated JSON example in the middle of narration cannot be absorbed.
+func hasLightweightTrailingNoise(suffix string) bool {
+	suffix = strings.TrimSpace(suffix)
+	return len(suffix) <= 160 && !strings.Contains(suffix, "```")
+}
+
+func withoutDualWriteFence(raw string, loc []int) string {
+	prefix := strings.TrimSpace(raw[:loc[0]])
+	suffix := strings.TrimSpace(raw[loc[1]:])
+	if prefix == "" {
+		return suffix
+	}
+	if suffix == "" {
+		return prefix
+	}
+	return prefix + "\n\n" + suffix
 }
 
 func parseDualWriteJSON(body string) (summary, narration string, ok bool) {

--- a/server/internal/runtime/turn_dual_write_test.go
+++ b/server/internal/runtime/turn_dual_write_test.go
@@ -51,9 +51,64 @@ func TestSplitTurnDualWriteUnrelatedFenceKept(t *testing.T) {
 	}
 }
 
+func TestSplitTurnDualWriteRecoversFinalValidFenceWithLightweightNoise(t *testing.T) {
+	raw := "已完成调整。\n\n```json\n{\"agentSummary\":\"用户要求收紧总结输出契约。\"}\n```\n\n以上为本轮处理说明。"
+	narr, sum := splitTurnDualWrite(raw)
+	if narr != "已完成调整。\n\n以上为本轮处理说明。" {
+		t.Fatalf("narration = %q", narr)
+	}
+	if sum != "用户要求收紧总结输出契约。" {
+		t.Fatalf("summary = %q", sum)
+	}
+}
+
+func TestSplitTurnDualWriteUsesLastValidSummaryFence(t *testing.T) {
+	raw := "先前草稿。\n\n```json\n{\"agentSummary\":\"旧总结\"}\n```\n\n最终回复。\n\n```json\n{\"agentSummary\":\"用户确认最终方案。\"}\n```"
+	narr, sum := splitTurnDualWrite(raw)
+	if narr != "先前草稿。\n\n```json\n{\"agentSummary\":\"旧总结\"}\n```\n\n最终回复。" {
+		t.Fatalf("narration = %q", narr)
+	}
+	if sum != "用户确认最终方案。" {
+		t.Fatalf("summary = %q", sum)
+	}
+}
+
+func TestSplitTurnDualWriteDoesNotAbsorbMidNarrationFence(t *testing.T) {
+	raw := "示例：\n```json\n{\"agentSummary\":\"这不是本轮总结\"}\n```\n" + strings.Repeat("后续叙述内容。", 30)
+	narr, sum := splitTurnDualWrite(raw)
+	if narr != raw || sum != "" {
+		t.Fatalf("mid-narration fence must stay untouched; got narr=%q sum=%q", narr, sum)
+	}
+}
+
+func TestSplitTurnDualWriteBaselineFixtures(t *testing.T) {
+	// This fixture set is the f3/n1 baseline: valid summary recovery must
+	// improve without accepting empty keys, unrelated JSON, or raw narration.
+	tests := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{"terminal valid fence", "回复\n```json\n{\"agentSummary\":\"有效总结\"}\n```", true},
+		{"whitespace after fence", "回复\n```json\n{\"agentSummary\":\"有效总结\"}\n```\n \t", true},
+		{"lightweight postscript", "回复\n```json\n{\"agentSummary\":\"有效总结\"}\n```\n完成。", true},
+		{"empty summary", "回复\n```json\n{\"agentSummary\":\" \"}\n```", false},
+		{"unrelated fence", "回复\n```json\n{\"foo\":\"bar\"}\n```", false},
+		{"no fence", "回复正文不能被当作总结。", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, sum := splitTurnDualWrite(tt.raw)
+			if (sum != "") != tt.want {
+				t.Fatalf("summary = %q, want present=%v", sum, tt.want)
+			}
+		})
+	}
+}
+
 func TestWithDualWriteContractAppends(t *testing.T) {
 	got := withDualWriteContract("请改标题")
-	for _, part := range []string{"请改标题", "agentSummary", "本轮输出契约"} {
+	for _, part := range []string{"请改标题", "agentSummary", "本轮输出契约", "始终产出", "空字符串"} {
 		if !strings.Contains(got, part) {
 			t.Fatalf("contract missing %q in: %s", part, got)
 		}


### PR DESCRIPTION
Recover valid trailing dual-write summaries despite minor output noise while preserving the no-fallback contract, and emit parse-miss telemetry for success-rate monitoring.

Co-authored-by: Cursor <cursoragent@cursor.com>
