### PR TITLE
feat(sidebar): persist quick pipeline ordering

### DIFF
--- a/web/e2e/workflow-favorites-main.ts
+++ b/web/e2e/workflow-favorites-main.ts
@@ -119,7 +119,11 @@ for (let i = 0; i < WORKFLOW_FAVORITES_MAX; i++) {
 
 function seedFavorites() {
   const key = `approving.workflowFavorites.${username}`
+  const seedKey = `workflow-favorites.seeded.${scene}.${username}`
+  if (sessionStorage.getItem(seedKey) === '1') return
   localStorage.removeItem(key)
+  localStorage.removeItem(`${key}.order-v2`)
+  sessionStorage.setItem(seedKey, '1')
   if (scene === 'empty') {
     localStorage.setItem(key, JSON.stringify([]))
     return
@@ -142,7 +146,7 @@ function seedFavorites() {
     )
     return
   }
-  // with-items / launch: newest first when hydrated
+  // Legacy source data: hydrate migrates this once to newest-first initial manual order.
   localStorage.setItem(
     key,
     JSON.stringify([

--- a/web/e2e/workflow-favorites.spec.ts
+++ b/web/e2e/workflow-favorites.spec.ts
@@ -24,7 +24,7 @@ test.describe('workflow favorites quick-launch', () => {
     await expect(page.getByTestId('nav-quick-pipeline-item').first()).toBeVisible({ timeout: 15_000 })
     const items = page.getByTestId('nav-quick-pipeline-item')
     await expect(items).toHaveCount(3)
-    // Newest favoritedAt first: wf-night
+    // Legacy favorites migrate once to newest-first as the initial manual order.
     await expect(items.nth(0)).toContainText('夜间回归')
     await expect(items.nth(0)).toContainText('checkout-service')
     await expect(items.nth(0)).toContainText('草稿')
@@ -49,6 +49,30 @@ test.describe('workflow favorites quick-launch', () => {
     await expect(page.getByTestId('nav-quick-pipeline-item')).toHaveCount(2)
     await expect(page.getByTestId('nav-quick-pipeline-item').first()).not.toContainText('夜间回归')
     await page.screenshot({ path: path.join(shotDir, 'fav-unfavorite.png'), fullPage: true })
+  })
+
+  test('desktop handle pointer drag reorders and survives reload without a toast', async ({ page }) => {
+    await page.goto('/workflow-favorites.html?scene=with-items')
+    const items = page.getByTestId('nav-quick-pipeline-item')
+    await expect(items).toHaveCount(3)
+    const handles = page.getByTestId('nav-quick-pipeline-drag-handle')
+    await expect(handles).toHaveCount(3)
+    const firstBox = await handles.nth(0).boundingBox()
+    const lastBox = await handles.nth(2).boundingBox()
+    if (!firstBox || !lastBox) throw new Error('quick-pipeline drag handles are not visible')
+
+    await page.mouse.move(firstBox.x + firstBox.width / 2, firstBox.y + firstBox.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(lastBox.x + lastBox.width / 2, lastBox.y + lastBox.height + 12, { steps: 4 })
+    await expect(page.getByTestId('nav-quick-pipeline-placeholder')).toBeVisible()
+    await page.mouse.up()
+
+    await expect(items.nth(0)).toContainText('热修回滚')
+    await expect(items.nth(2)).toContainText('夜间回归')
+    await expect(page.getByTestId('toast-host')).not.toContainText('已调整')
+    await page.reload()
+    await expect(page.getByTestId('nav-quick-pipeline-item').nth(2)).toContainText('夜间回归')
+    await page.screenshot({ path: path.join(shotDir, 'fav-reorder.png'), fullPage: true })
   })
 
   test('no-ask fields still open confirm modal from quick item', async ({ page }) => {

--- a/web/src/components/shell/AppSidebarNav.test.ts
+++ b/web/src/components/shell/AppSidebarNav.test.ts
@@ -41,8 +41,13 @@ const favMocks = vi.hoisted(() => {
     hydrateDisplay: vi.fn(async () => undefined),
     unfavorite: vi.fn(),
     getFavoriteWorkflow: vi.fn(),
+    reorderFavorites: vi.fn(),
   }
 })
+
+const breakpointMocks = vi.hoisted(() => ({
+  isMobile: { __v_isRef: true, value: false },
+}))
 
 const launchMocks = vi.hoisted(() => ({
   openLaunch: vi.fn(),
@@ -71,9 +76,14 @@ vi.mock('@/lib/run/useWorkflowFavorites', async () => {
       hydrateDisplay: favMocks.hydrateDisplay,
       unfavorite: favMocks.unfavorite,
       getFavoriteWorkflow: favMocks.getFavoriteWorkflow,
+      reorderFavorites: favMocks.reorderFavorites,
     }),
   }
 })
+
+vi.mock('@/lib/composables/useBreakpoint', () => ({
+  useBreakpoint: () => breakpointMocks,
+}))
 
 vi.mock('@/lib/run/useWorkflowRunLaunch', () => ({
   useWorkflowRunLaunch: () => ({
@@ -91,6 +101,7 @@ beforeEach(() => {
   notifMocks.unreadCount.value = 0
   favMocks.displayItems.value = []
   favMocks.hydrateDisplay.mockResolvedValue(undefined)
+  breakpointMocks.isMobile.value = false
   vi.useFakeTimers()
 })
 
@@ -176,6 +187,36 @@ describe('AppSidebarNav', () => {
     await flushPromises()
     expect(favMocks.getFavoriteWorkflow).toHaveBeenCalledWith('wf-1')
     expect(launchMocks.openLaunch).toHaveBeenCalled()
+    wrapper.unmount()
+    vi.useRealTimers()
+  })
+
+  it('shows desktop-only independent drag handles without changing the item click target', async () => {
+    favMocks.displayItems.value = [
+      { workflowId: 'wf-1', favoritedAt: 2, name: '夜间回归', projectId: 'p1', projectName: 'checkout', status: 'draft' },
+      { workflowId: 'wf-2', favoritedAt: 1, name: '发布预检', projectId: 'p1', projectName: 'billing', status: 'published' },
+    ]
+    const wrapper = mountNav()
+    await flushPromises()
+    const handles = wrapper.findAll('[data-testid="nav-quick-pipeline-drag-handle"]')
+    expect(handles).toHaveLength(2)
+    await wrapper.find('[data-testid="nav-quick-pipeline-item"]').trigger('click')
+    expect(favMocks.getFavoriteWorkflow).toHaveBeenCalledWith('wf-1')
+    expect(favMocks.reorderFavorites).not.toHaveBeenCalled()
+    wrapper.unmount()
+    vi.useRealTimers()
+  })
+
+  it('hides the handle on mobile while retaining quick-item actions', async () => {
+    breakpointMocks.isMobile.value = true
+    favMocks.displayItems.value = [
+      { workflowId: 'wf-1', favoritedAt: 1, name: '夜间回归', projectId: 'p1', projectName: 'checkout', status: 'published' },
+    ]
+    const wrapper = mountNav()
+    await flushPromises()
+    expect(wrapper.find('[data-testid="nav-quick-pipeline-drag-handle"]').exists()).toBe(false)
+    await wrapper.find('[data-testid="nav-quick-pipeline-item"]').trigger('click')
+    expect(favMocks.getFavoriteWorkflow).toHaveBeenCalledWith('wf-1')
     wrapper.unmount()
     vi.useRealTimers()
   })

--- a/web/src/components/shell/AppSidebarNav.vue
+++ b/web/src/components/shell/AppSidebarNav.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { RouterLink, useRoute } from 'vue-router'
-import { watch, onMounted, onBeforeUnmount } from 'vue'
+import { computed, ref, watch, onMounted, onBeforeUnmount } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Icon from '../ui/Icon.vue'
 import { sidebarNavGroups } from '@/data/sidebarNav'
@@ -9,6 +9,7 @@ import { useRunTerminalNotifications } from '@/lib/run/useRunTerminalNotificatio
 import { useWorkflowFavorites } from '@/lib/run/useWorkflowFavorites'
 import { useWorkflowRunLaunch } from '@/lib/run/useWorkflowRunLaunch'
 import { useToast } from '@/lib/composables/useToast'
+import { useBreakpoint } from '@/lib/composables/useBreakpoint'
 
 defineProps<{ drawer?: boolean }>()
 const emit = defineEmits<{ (e: 'navigate'): void }>()
@@ -21,8 +22,28 @@ const toast = useToast()
 const { count: gateCount, peek, refresh } = usePendingGates()
 // Same unreadCount singleton as topbar bell — keep sidebar /notifications badge in sync.
 const { unreadCount } = useRunTerminalNotifications()
-const { displayItems, hydrateDisplay, unfavorite, getFavoriteWorkflow } = useWorkflowFavorites()
+const { displayItems, hydrateDisplay, unfavorite, getFavoriteWorkflow, reorderFavorites } = useWorkflowFavorites()
 const { openLaunch } = useWorkflowRunLaunch()
+const { isMobile } = useBreakpoint()
+
+const DRAG_THRESHOLD_PX = 4
+const quickList = ref<HTMLElement>()
+const suppressQuickItemClick = ref(false)
+const dragState = ref<{
+  workflowId: string
+  from: number
+  placeholder: number
+  x: number
+  y: number
+  offsetX: number
+  offsetY: number
+  width: number
+}>()
+const dragItems = computed(() =>
+  dragState.value
+    ? displayItems.value.filter((item) => item.workflowId !== dragState.value?.workflowId)
+    : displayItems.value,
+)
 
 let timer: number | undefined
 function badgeFor(to: string): number {
@@ -61,10 +82,12 @@ function onNavigate() {
 function onUnfavorite(workflowId: string, name: string, ev: Event) {
   ev.stopPropagation()
   ev.preventDefault()
+  if (suppressQuickItemClick.value) return
   unfavorite(workflowId, { name })
 }
 
 async function onLaunch(workflowId: string) {
+  if (suppressQuickItemClick.value) return
   try {
     const wf = await getFavoriteWorkflow(workflowId)
     if (!wf) return
@@ -73,6 +96,102 @@ async function onLaunch(workflowId: string) {
   } catch {
     toast.error(t('common.toast.favoriteLaunchFailed'))
   }
+}
+
+function updatePlaceholder(clientY: number) {
+  if (!dragState.value || !quickList.value) return
+  const rows = Array.from(quickList.value.querySelectorAll<HTMLElement>('[data-sortable-row]'))
+  const slot = rows.findIndex((row) => clientY < row.getBoundingClientRect().top + row.offsetHeight / 2)
+  dragState.value.placeholder = slot === -1 ? rows.length : slot
+}
+
+function onHandlePointerDown(workflowId: string, event: PointerEvent) {
+  if (isMobile.value || event.button !== 0) return
+  const source = (event.currentTarget as HTMLElement).closest<HTMLElement>('[data-sortable-row]')
+  const from = displayItems.value.findIndex((item) => item.workflowId === workflowId)
+  if (!source || from < 0) return
+
+  event.preventDefault()
+  const handle = event.currentTarget as HTMLElement
+  const startX = event.clientX
+  const startY = event.clientY
+  let activated = false
+  let offsetX = 0
+  let offsetY = 0
+
+  try {
+    handle.setPointerCapture(event.pointerId)
+  } catch {
+    // Pointer capture is a progressive enhancement for the drag session.
+  }
+
+  const activate = (moveEvent: PointerEvent) => {
+    const rect = source.getBoundingClientRect()
+    offsetX = moveEvent.clientX - rect.left
+    offsetY = moveEvent.clientY - rect.top
+    activated = true
+    suppressQuickItemClick.value = true
+    dragState.value = {
+      workflowId,
+      from,
+      placeholder: from,
+      x: moveEvent.clientX,
+      y: moveEvent.clientY,
+      offsetX,
+      offsetY,
+      width: rect.width,
+    }
+    document.body.classList.add('quick-pipeline-dragging')
+    updatePlaceholder(moveEvent.clientY)
+  }
+
+  const onMove = (moveEvent: PointerEvent) => {
+    if (!activated) {
+      const dx = moveEvent.clientX - startX
+      const dy = moveEvent.clientY - startY
+      if (Math.hypot(dx, dy) < DRAG_THRESHOLD_PX) return
+      activate(moveEvent)
+    }
+    if (!dragState.value) return
+    dragState.value.x = moveEvent.clientX
+    dragState.value.y = moveEvent.clientY
+    updatePlaceholder(moveEvent.clientY)
+    moveEvent.preventDefault()
+  }
+
+  const finish = (cancelled: boolean) => {
+    handle.removeEventListener('pointermove', onMove)
+    handle.removeEventListener('pointerup', onUp)
+    handle.removeEventListener('pointercancel', onCancel)
+    window.removeEventListener('pointermove', onMove)
+    window.removeEventListener('pointerup', onUp)
+    window.removeEventListener('pointercancel', onCancel)
+    try {
+      handle.releasePointerCapture(event.pointerId)
+    } catch {
+      // Capture may already be released by the browser.
+    }
+    if (!activated || !dragState.value) return
+
+    const { from: dragFrom, placeholder } = dragState.value
+    dragState.value = undefined
+    document.body.classList.remove('quick-pipeline-dragging')
+    if (!cancelled) reorderFavorites(dragFrom, placeholder)
+    window.setTimeout(() => {
+      suppressQuickItemClick.value = false
+    }, 0)
+  }
+  const onUp = () => finish(false)
+  const onCancel = () => finish(true)
+
+  handle.addEventListener('pointermove', onMove)
+  handle.addEventListener('pointerup', onUp)
+  handle.addEventListener('pointercancel', onCancel)
+  // Once activation removes the source row from the rendered list, some browsers
+  // release element-level pointer capture. Window listeners keep the session intact.
+  window.addEventListener('pointermove', onMove)
+  window.addEventListener('pointerup', onUp)
+  window.addEventListener('pointercancel', onCancel)
 }
 
 const primaryGroup = sidebarNavGroups[0]
@@ -119,37 +238,60 @@ const configGroups = sidebarNavGroups.slice(1)
       >
         {{ t('nav.quickPipelinesEmpty') }}
       </p>
-      <div
-        v-for="item in displayItems"
-        :key="item.workflowId"
-        class="mb-0.5 grid w-full grid-cols-[1fr_28px] items-center gap-0.5 rounded-md px-2 py-1.5 text-left text-txt2 transition hover:bg-elevated hover:text-txt"
-        data-testid="nav-quick-pipeline-item"
-        role="button"
-        tabindex="0"
-        @click="onLaunch(item.workflowId)"
-        @keydown.enter.prevent="onLaunch(item.workflowId)"
-        @keydown.space.prevent="onLaunch(item.workflowId)"
-      >
-        <div class="min-w-0">
-          <div class="truncate text-[13px] text-txt" :title="item.name">{{ item.name }}</div>
-          <div class="mt-0.5 flex min-w-0 items-center gap-1.5">
-            <span class="truncate text-[11px] text-txt3" :title="item.projectName">{{ item.projectName }}</span>
-            <span
-              v-if="item.status === 'draft'"
-              class="shrink-0 border border-warn/35 bg-warn/10 px-1.5 py-px text-[10px] text-warn"
-            >{{ t('common.status.draft') }}</span>
+      <div ref="quickList" class="quick-pipelines-list">
+        <template v-for="(item, index) in dragItems" :key="item.workflowId">
+          <div
+            v-if="dragState && dragState.placeholder === index"
+            class="quick-pipeline-placeholder"
+            data-testid="nav-quick-pipeline-placeholder"
+          />
+          <div
+            class="mb-0.5 grid w-full grid-cols-[28px_1fr_28px] items-center gap-0.5 px-2 py-1.5 text-left text-txt2 transition hover:bg-elevated hover:text-txt"
+            data-sortable-row
+            data-testid="nav-quick-pipeline-item"
+            role="button"
+            tabindex="0"
+            @click="onLaunch(item.workflowId)"
+            @keydown.enter.prevent="onLaunch(item.workflowId)"
+            @keydown.space.prevent="onLaunch(item.workflowId)"
+          >
+            <button
+              v-if="!isMobile"
+              type="button"
+              class="quick-pipeline-handle flex h-7 w-7 items-center justify-center text-txt3 hover:bg-overlay hover:text-txt"
+              data-testid="nav-quick-pipeline-drag-handle"
+              aria-label="拖动调整顺序"
+              title="拖动调整顺序"
+              @pointerdown="onHandlePointerDown(item.workflowId, $event)"
+            ><span aria-hidden="true">⠿</span></button>
+            <div v-else aria-hidden="true" />
+            <div class="min-w-0">
+              <div class="truncate text-[13px] text-txt" :title="item.name">{{ item.name }}</div>
+              <div class="mt-0.5 flex min-w-0 items-center gap-1.5">
+                <span class="truncate text-[11px] text-txt3" :title="item.projectName">{{ item.projectName }}</span>
+                <span
+                  v-if="item.status === 'draft'"
+                  class="shrink-0 border border-warn/35 bg-warn/10 px-1.5 py-px text-[10px] text-warn"
+                >{{ t('common.status.draft') }}</span>
+              </div>
+            </div>
+            <button
+              type="button"
+              class="flex h-7 w-7 items-center justify-center text-warn hover:text-warn"
+              data-testid="nav-quick-pipeline-unfavorite"
+              :aria-label="t('common.buttons.unfavorite')"
+              :title="t('common.buttons.unfavorite')"
+              @click="onUnfavorite(item.workflowId, item.name, $event)"
+            >
+              <Icon name="star-filled" :size="14" />
+            </button>
           </div>
-        </div>
-        <button
-          type="button"
-          class="flex h-7 w-7 items-center justify-center text-warn hover:text-warn"
-          data-testid="nav-quick-pipeline-unfavorite"
-          :aria-label="t('common.buttons.unfavorite')"
-          :title="t('common.buttons.unfavorite')"
-          @click="onUnfavorite(item.workflowId, item.name, $event)"
-        >
-          <Icon name="star-filled" :size="14" />
-        </button>
+        </template>
+        <div
+          v-if="dragState && dragState.placeholder === dragItems.length"
+          class="quick-pipeline-placeholder"
+          data-testid="nav-quick-pipeline-placeholder"
+        />
       </div>
     </div>
 
@@ -175,4 +317,56 @@ const configGroups = sidebarNavGroups.slice(1)
       </RouterLink>
     </div>
   </nav>
+  <div
+    v-if="dragState"
+    class="quick-pipeline-drag-float grid grid-cols-[28px_1fr_28px] items-center gap-0.5 px-2 py-1.5"
+    :style="{
+      width: `${dragState.width}px`,
+      left: `${dragState.x - dragState.offsetX}px`,
+      top: `${dragState.y - dragState.offsetY}px`,
+    }"
+    aria-hidden="true"
+  >
+    <span class="flex h-7 w-7 items-center justify-center text-txt">⠿</span>
+    <div class="min-w-0">
+      <div class="truncate text-[13px] text-txt">{{ displayItems.find((item) => item.workflowId === dragState?.workflowId)?.name }}</div>
+      <div class="truncate text-[11px] text-txt3">{{ displayItems.find((item) => item.workflowId === dragState?.workflowId)?.projectName }}</div>
+    </div>
+    <span class="flex h-7 w-7 items-center justify-center text-warn"><Icon name="star-filled" :size="14" /></span>
+  </div>
 </template>
+
+<style scoped>
+.quick-pipeline-handle {
+  cursor: grab;
+  touch-action: none;
+}
+
+.quick-pipeline-handle:active {
+  cursor: grabbing;
+}
+
+.quick-pipeline-placeholder {
+  height: 46px;
+  margin-bottom: 2px;
+  border: 1px dashed rgb(var(--c-accent) / 70%);
+  background: rgb(var(--c-accent) / 12%);
+}
+
+.quick-pipeline-drag-float {
+  position: fixed;
+  z-index: 9999;
+  pointer-events: none;
+  border: 1px solid rgb(var(--c-accent));
+  background: rgb(var(--c-elevated));
+  box-shadow: 0 12px 28px rgb(0 0 0 / 55%), 0 0 0 1px rgb(var(--c-accent) / 35%);
+  opacity: 0.96;
+  transform: scale(1.02);
+}
+
+:global(body.quick-pipeline-dragging),
+:global(body.quick-pipeline-dragging *) {
+  cursor: grabbing !important;
+  user-select: none;
+}
+</style>

--- a/web/src/lib/run/useWorkflowFavorites.test.ts
+++ b/web/src/lib/run/useWorkflowFavorites.test.ts
@@ -76,7 +76,7 @@ describe('useWorkflowFavorites', () => {
     expect(fav2.isFavorite('wf-a')).toBe(false)
   })
 
-  it('sorts by favoritedAt desc and refreshes on re-favorite', async () => {
+  it('uses persisted array order, puts new favorites first, and persists reorder', async () => {
     vi.useFakeTimers()
     const fav = withSetup(() => useWorkflowFavorites())
     vi.setSystemTime(1000)
@@ -84,11 +84,38 @@ describe('useWorkflowFavorites', () => {
     vi.setSystemTime(2000)
     fav.toggleFavorite('wf-b', { silent: true })
     expect(fav.listSorted.value.map((e) => e.workflowId)).toEqual(['wf-b', 'wf-a'])
-    fav.toggleFavorite('wf-a', { silent: true }) // unfavorite
-    vi.setSystemTime(3000)
-    fav.toggleFavorite('wf-a', { silent: true }) // re-favorite → top
+    fav.reorderFavorites(0, 1)
     expect(fav.listSorted.value.map((e) => e.workflowId)).toEqual(['wf-a', 'wf-b'])
+    expect(loadFavoriteEntries('dev.li').map((e) => e.workflowId)).toEqual(['wf-a', 'wf-b'])
+    vi.setSystemTime(3000)
+    fav.toggleFavorite('wf-c', { silent: true })
+    expect(fav.listSorted.value.map((e) => e.workflowId)).toEqual(['wf-c', 'wf-a', 'wf-b'])
     vi.useRealTimers()
+  })
+
+  it('migrates legacy favorites once to the former newest-first initial order', () => {
+    localStorage.removeItem(`${favoritesKeyForUser('dev.li')}.order-v2`)
+    localStorage.setItem(
+      favoritesKeyForUser('dev.li'),
+      JSON.stringify([
+        { workflowId: 'wf-old', favoritedAt: 1000 },
+        { workflowId: 'wf-new', favoritedAt: 2000 },
+      ]),
+    )
+    hydrateFromStorage()
+    const fav = withSetup(() => useWorkflowFavorites())
+    expect(fav.listSorted.value.map((entry) => entry.workflowId)).toEqual(['wf-new', 'wf-old'])
+    expect(loadFavoriteEntries('dev.li').map((entry) => entry.workflowId)).toEqual(['wf-new', 'wf-old'])
+
+    localStorage.setItem(
+      favoritesKeyForUser('dev.li'),
+      JSON.stringify([
+        { workflowId: 'wf-old', favoritedAt: 1000 },
+        { workflowId: 'wf-new', favoritedAt: 2000 },
+      ]),
+    )
+    hydrateFromStorage()
+    expect(fav.listSorted.value.map((entry) => entry.workflowId)).toEqual(['wf-old', 'wf-new'])
   })
 
   it('rejects the 9th favorite without LRU eviction', () => {
@@ -118,8 +145,8 @@ describe('useWorkflowFavorites', () => {
     fav.toggleFavorite('gone', { silent: true })
     await fav.hydrateDisplay()
     await nextTick()
-    expect(fav.displayItems.value.map((d) => d.workflowId)).toEqual(['gone', 'wf-ok'].filter((id) => id !== 'gone'))
-    // After strip, only wf-ok remains in storage (gone was favorited later so would be first before strip)
+    expect(fav.displayItems.value.map((d) => d.workflowId)).toEqual(['wf-ok'])
+    // After strip, only wf-ok remains in storage.
     expect(fav.isFavorite('gone')).toBe(false)
     expect(fav.isFavorite('wf-ok')).toBe(true)
     expect(fav.displayItems.value[0]?.name).toBe('WF wf-ok')

--- a/web/src/lib/run/useWorkflowFavorites.ts
+++ b/web/src/lib/run/useWorkflowFavorites.ts
@@ -11,7 +11,7 @@ export const WORKFLOW_FAVORITES_MAX = 8
 
 export type WorkflowFavoriteEntry = {
   workflowId: string
-  /** Epoch ms; newer favorites sort first. */
+  /** Epoch ms; retained as favorite metadata and for the one-time legacy-order migration. */
   favoritedAt: number
 }
 
@@ -27,6 +27,10 @@ export type FavoriteWorkflowDisplay = {
 
 export function favoritesKeyForUser(username: string): string {
   return `approving.workflowFavorites.${username || 'anonymous'}`
+}
+
+function favoritesOrderMigrationKeyForUser(username: string): string {
+  return `${favoritesKeyForUser(username)}.order-v2`
 }
 
 function resolveUsername(): { name: string; settled: boolean } {
@@ -99,7 +103,24 @@ export function hydrateFromStorage() {
   const { name, settled } = resolveUsername()
   if (!settled) return
   usernameKey.value = name
-  entries.value = loadFavoriteEntries(name)
+  const loaded = loadFavoriteEntries(name)
+  const migrationKey = favoritesOrderMigrationKeyForUser(name)
+  const needsLegacyOrderMigration =
+    typeof localStorage !== 'undefined' && localStorage.getItem(migrationKey) !== '1'
+
+  // Existing entries previously displayed by newest favorite first. Persist that as
+  // the initial manual order once, then treat the stored array order as authoritative.
+  entries.value = needsLegacyOrderMigration
+    ? loaded.slice().sort((a, b) => b.favoritedAt - a.favoritedAt || a.workflowId.localeCompare(b.workflowId))
+    : loaded
+  if (needsLegacyOrderMigration && typeof localStorage !== 'undefined') {
+    persistEntries(name, entries.value)
+    try {
+      localStorage.setItem(migrationKey, '1')
+    } catch {
+      // Private mode/quota: retain the in-memory initial order.
+    }
+  }
   prefsHydrated = true
 }
 
@@ -107,9 +128,8 @@ function ensureHydrated() {
   if (!prefsHydrated) hydrateFromStorage()
 }
 
-const listSorted = computed(() =>
-  entries.value.slice().sort((a, b) => b.favoritedAt - a.favoritedAt || a.workflowId.localeCompare(b.workflowId)),
-)
+/** Stored array order is the user's manual sidebar order. */
+const listSorted = computed(() => entries.value.slice())
 
 function isFavorite(workflowId: string): boolean {
   ensureHydrated()
@@ -136,8 +156,8 @@ function removeIds(ids: string[]) {
 export async function hydrateDisplay(): Promise<void> {
   ensureHydrated()
   const gen = ++hydrateGeneration
-  const sorted = listSorted.value
-  if (!sorted.length) {
+  const orderedEntries = listSorted.value
+  if (!orderedEntries.length) {
     displayItems.value = []
     displayError.value = null
     return
@@ -160,7 +180,7 @@ export async function hydrateDisplay(): Promise<void> {
     const rows: FavoriteWorkflowDisplay[] = []
 
     await Promise.all(
-      sorted.map(async (entry) => {
+      orderedEntries.map(async (entry) => {
         try {
           const wf = await api.getWorkflow(entry.workflowId)
           if (gen !== hydrateGeneration) return
@@ -188,8 +208,10 @@ export async function hydrateDisplay(): Promise<void> {
       removeIds(missing)
     }
 
-    rows.sort((a, b) => b.favoritedAt - a.favoritedAt || a.workflowId.localeCompare(b.workflowId))
-    displayItems.value = rows
+    const rowsByWorkflowId = new Map(rows.map((row) => [row.workflowId, row]))
+    displayItems.value = orderedEntries
+      .map((entry) => rowsByWorkflowId.get(entry.workflowId))
+      .filter((row): row is FavoriteWorkflowDisplay => !!row)
   } finally {
     if (gen === hydrateGeneration) {
       hydrating.value = false
@@ -248,7 +270,7 @@ export function useWorkflowFavorites() {
       return false
     }
 
-    writeBack([...entries.value, { workflowId: id, favoritedAt: Date.now() }])
+    writeBack([{ workflowId: id, favoritedAt: Date.now() }, ...entries.value])
     if (!opts?.silent) {
       const label = opts?.name?.trim() || id
       toast.success(t('common.toast.favoriteAdded', { name: label }))
@@ -265,6 +287,31 @@ export function useWorkflowFavorites() {
     toggleFavorite(id, opts)
   }
 
+  /** Persist a manual move. Invalid/same-index moves are intentionally no-ops. */
+  function reorderFavorites(from: number, to: number): void {
+    ensureHydrated()
+    if (
+      !Number.isInteger(from) ||
+      !Number.isInteger(to) ||
+      from < 0 ||
+      to < 0 ||
+      from >= entries.value.length ||
+      to >= entries.value.length ||
+      from === to
+    ) {
+      return
+    }
+
+    const next = entries.value.slice()
+    const [moved] = next.splice(from, 1)
+    next.splice(to, 0, moved)
+    writeBack(next)
+    const displayByWorkflowId = new Map(displayItems.value.map((item) => [item.workflowId, item]))
+    displayItems.value = next
+      .map((entry) => displayByWorkflowId.get(entry.workflowId))
+      .filter((item): item is FavoriteWorkflowDisplay => !!item)
+  }
+
   return {
     entries,
     listSorted,
@@ -274,6 +321,7 @@ export function useWorkflowFavorites() {
     isFavorite,
     toggleFavorite,
     unfavorite,
+    reorderFavorites,
     hydrateDisplay,
     hydrateFromStorage,
     getFavoriteWorkflow,


### PR DESCRIPTION
Allow desktop users to rearrange shortcut pipelines with the approved pointer interaction while preserving their order across reloads.

Co-authored-by: Cursor <cursoragent@cursor.com>
