### PR TITLE
fix(preview): hide Chrome for Testing infobar in headed VNC sessions

### DIFF
--- a/sandbox-gateway/sandbox/scripts/vnc-preview.sh
+++ b/sandbox-gateway/sandbox/scripts/vnc-preview.sh
@@ -72,9 +72,13 @@ if ! curl -fsS "http://127.0.0.1:${CDP_LOOPBACK_PORT}/json/version" >/dev/null 2
 
   # No window manager on Xvfb: pin geometry explicitly. Approving NewTab windows
   # are re-sized via CDP (presentDesktop); this covers the bootstrap window.
+  # --disable-infobars: suppress Chrome for Testing non-interactive product info
+  # bar ("…is only for automated testing…") so it never paints into the VNC
+  # framebuffer and does not reserve top viewport height (Chromium CfT switch).
   "$CHROME_BIN" \
     --no-sandbox \
     --disable-dev-shm-usage \
+    --disable-infobars \
     --remote-debugging-port="${CDP_LOOPBACK_PORT}" \
     --window-size=1920,1080 \
     --window-position=0,0 \


### PR DESCRIPTION
Pass --disable-infobars when starting CfT from vnc-preview.sh so the
product banner never paints into the noVNC framebuffer or reserves top height.

Co-authored-by: Cursor <cursoragent@cursor.com>
