### PR TITLE
feat(feedback): consolidate ReAct feedback conclusions

### DIFF
--- a/server/internal/engine/feedback.go
+++ b/server/internal/engine/feedback.go
@@ -13,9 +13,9 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// recordFeedback appends one round of human feedback and renders it into
-// products: a brand-new per-round file that is never touched again, plus a
-// full rewrite of feedback_index.json.
+// recordFeedback appends one feedback event and renders the derived products.
+// ReAct review/clarify products are rewritten as a single cumulative conclusion
+// for the node execution; the feedback index remains the append-only timeline.
 //
 // It writes nothing at all when the event carries no human input — no opinion,
 // no annotation, no attachment, no ReAct turn. A gate approval clicked through
@@ -48,12 +48,9 @@ func (e *Engine) recordFeedback(ev models.FeedbackEvent) {
 	e.renderFeedbackProducts(ev.RunID, svc)
 }
 
-// renderFeedbackProducts rewrites the index from the table and backfills any
-// per-round product the index references but the store is missing.
-//
-// Deriving the index from the table on every round makes it self-healing: a
-// write that failed once is picked up by the next round's rewrite. Per-round
-// files do not heal on their own, hence the explicit backfill pass here.
+// renderFeedbackProducts rewrites the index from the table. ReAct products are
+// current-state summaries and are deliberately saved on every render; discrete
+// gate/preview products retain their historical write-once backfill behavior.
 func (e *Engine) renderFeedbackProducts(runID string, svc *services.FeedbackService) {
 	if e.store == nil {
 		return
@@ -64,18 +61,36 @@ func (e *Engine) renderFeedbackProducts(runID string, svc *services.FeedbackServ
 	}
 
 	labels, types := e.nodeMeta(runID)
+	rendered := map[string]bool{}
 	for i, ev := range events {
 		if ev.ArtifactName == "" {
 			continue
 		}
-		if _, ok := e.store.Get(runID, ev.ArtifactName); ok {
+		if rendered[ev.ArtifactName] {
 			continue
 		}
-		body, err := services.MarshalRoundJSON(ev, priorRoundsFor(events, i), runID,
-			services.NodeRef{Label: labels[ev.NodeID], Type: types[ev.NodeID]})
+		rendered[ev.ArtifactName] = true
+
+		isReact := ev.Kind == models.FeedbackKindReview || ev.Kind == models.FeedbackKindClarify
+		if !isReact {
+			if _, ok := e.store.Get(runID, ev.ArtifactName); ok {
+				continue
+			}
+		}
+
+		var (
+			body string
+			err  error
+		)
+		node := services.NodeRef{Label: labels[ev.NodeID], Type: types[ev.NodeID]}
+		if isReact {
+			body, err = services.MarshalFeedbackSummaryJSON(eventsForExecution(events, ev), runID, node)
+		} else {
+			body, err = services.MarshalRoundJSON(ev, priorRoundsFor(events, i), runID, node)
+		}
 		if err != nil {
 			log.Warn().Str("run_id", runID).Str("artifact", ev.ArtifactName).Err(err).
-				Msg("marshal feedback round failed")
+				Msg("marshal feedback product failed")
 			continue
 		}
 		// The real node id keeps the product grouped under its node in the UI;
@@ -83,7 +98,7 @@ func (e *Engine) renderFeedbackProducts(runID string, svc *services.FeedbackServ
 		// node's own deliverable capture.
 		if _, err := e.store.Save(runID, ev.NodeID, ev.ArtifactName, "json", body); err != nil {
 			log.Warn().Str("run_id", runID).Str("artifact", ev.ArtifactName).Err(err).
-				Msg("save feedback round failed")
+				Msg("save feedback product failed")
 		}
 	}
 
@@ -97,6 +112,19 @@ func (e *Engine) renderFeedbackProducts(runID string, svc *services.FeedbackServ
 	if _, err := e.store.Save(runID, "", services.FeedbackIndexArtifactName, "json", body); err != nil {
 		log.Warn().Str("run_id", runID).Err(err).Msg("save feedback index failed")
 	}
+}
+
+// eventsForExecution returns the complete append-only audit trail that feeds a
+// ReAct summary. Index-only auto-answers are included so an interrupted or
+// dual-write-free path cannot erase earlier dialogue context.
+func eventsForExecution(events []models.FeedbackEvent, current models.FeedbackEvent) []models.FeedbackEvent {
+	out := make([]models.FeedbackEvent, 0)
+	for _, ev := range events {
+		if ev.NodeID == current.NodeID && ev.Iteration == current.Iteration {
+			out = append(out, ev)
+		}
+	}
+	return out
 }
 
 // priorRoundsFor returns the rounds of the same node+iteration that precede

--- a/server/internal/engine/feedback_test.go
+++ b/server/internal/engine/feedback_test.go
@@ -38,10 +38,9 @@ func decodeIndex(t *testing.T, db *gorm.DB, runID string) map[string]any {
 	return doc
 }
 
-// Three push-backs on one execution must leave three separate products behind.
-// Overwriting would erase the reasoning of the earlier rounds, which is the
-// whole reason the ledger exists.
-func TestReviseRoundsEachProduceTheirOwnArtifact(t *testing.T) {
+// Three push-backs on one execution must converge on one cumulative product.
+// The individual reasoning remains in FeedbackEvent and feedback_index.json.
+func TestReviseRoundsProduceOneCumulativeArtifact(t *testing.T) {
 	eng, db, _ := setupReviewEngine(t, true)
 
 	run, err := eng.StartRun("review-wf", map[string]any{"idea": "登录"}, "test")
@@ -63,25 +62,23 @@ func TestReviseRoundsEachProduceTheirOwnArtifact(t *testing.T) {
 	}
 
 	rounds := feedbackArtifacts(db, run.ID)
-	if len(rounds) != 3 {
-		t.Fatalf("want 3 per-round products, got %d: %+v", len(rounds), rounds)
+	if len(rounds) != 1 {
+		t.Fatalf("want 1 cumulative product, got %d: %+v", len(rounds), rounds)
 	}
-	seen := map[string]bool{}
-	for i, a := range rounds {
-		if seen[a.Name] {
-			t.Fatalf("duplicate product name %q", a.Name)
-		}
-		seen[a.Name] = true
-		if !strings.Contains(a.Content, opinions[i]) {
-			t.Fatalf("%s does not carry its own round's opinion:\n%s", a.Name, a.Content)
-		}
-		if a.NodeID != "prop" {
-			t.Fatalf("%s should hang off the producer node, got %q", a.Name, a.NodeID)
+	a := rounds[0]
+	if a.Name != "feedback.review.prop.i1.json" {
+		t.Fatalf("unexpected cumulative name %q", a.Name)
+	}
+	for _, opinion := range opinions {
+		if !strings.Contains(a.Content, opinion) {
+			t.Fatalf("%s does not carry all rounds' conclusions:\n%s", a.Name, a.Content)
 		}
 	}
-	// Each round only carries its own body; earlier rounds are one-line refs.
-	if strings.Contains(rounds[0].Content, opinions[2]) {
-		t.Fatalf("round 1 must not contain round 3's body:\n%s", rounds[0].Content)
+	if a.NodeID != "prop" {
+		t.Fatalf("%s should hang off the producer node, got %q", a.Name, a.NodeID)
+	}
+	if !strings.Contains(a.Content, `"roundCount": 3`) {
+		t.Fatalf("cumulative product must record all rounds:\n%s", a.Content)
 	}
 
 	idx := decodeIndex(t, db, run.ID)
@@ -93,6 +90,9 @@ func TestReviseRoundsEachProduceTheirOwnArtifact(t *testing.T) {
 		m := r.(map[string]any)
 		if m["artifact"] == "" || m["artifact"] == nil {
 			t.Fatalf("index row missing artifact pointer: %+v", m)
+		}
+		if m["artifact"] != a.Name {
+			t.Fatalf("index must point every ReAct round at the shared product: %+v", m)
 		}
 	}
 	// The producer's own deliverable survived: feedback products must not be

--- a/server/internal/mcp/feedback_history_test.go
+++ b/server/internal/mcp/feedback_history_test.go
@@ -15,14 +15,13 @@ func reviewEvent(node string, iter, round int, text, artifact string) models.Fee
 	}
 }
 
-// Every round in scope must show up, each citing its own product — that pointer
-// is what makes the overview a table of contents instead of a summary.
-func TestRunHistoryListsEveryFeedbackRoundWithArtifactCitation(t *testing.T) {
+// Every audit round stays visible while ReAct rounds cite one shared conclusion.
+func TestRunHistoryListsEveryFeedbackRoundWithSharedArtifactCitation(t *testing.T) {
 	fh := twoGateRun()
 	fh.feedback = []models.FeedbackEvent{
-		reviewEvent("design", 2, 1, "证据不足", "feedback.review.design.i2r1.json"),
-		reviewEvent("design", 2, 2, "图表改柱状图", "feedback.review.design.i2r2.json"),
-		reviewEvent("design", 2, 3, "补上原始链接", "feedback.review.design.i2r3.json"),
+		reviewEvent("design", 2, 1, "证据不足", "feedback.review.design.i2.json"),
+		reviewEvent("design", 2, 2, "图表改柱状图", "feedback.review.design.i2.json"),
+		reviewEvent("design", 2, 3, "补上原始链接", "feedback.review.design.i2.json"),
 	}
 	h := NewHost(&memStore{})
 	h.SetHistoryProvider(fh)
@@ -36,11 +35,12 @@ func TestRunHistoryListsEveryFeedbackRoundWithArtifactCitation(t *testing.T) {
 			t.Fatalf("round %q missing from overview:\n%s", want, out)
 		}
 	}
-	for i := 1; i <= 3; i++ {
-		cite := fmt.Sprintf("read_artifact feedback.review.design.i2r%d.json", i)
-		if !strings.Contains(out, cite) {
-			t.Fatalf("missing drill-down %q:\n%s", cite, out)
-		}
+	cite := "read_artifact feedback.review.design.i2.json"
+	if !strings.Contains(out, cite) {
+		t.Fatalf("missing shared conclusion citation %q:\n%s", cite, out)
+	}
+	if strings.Contains(out, "i2r") {
+		t.Fatalf("ReAct history must not require per-round artifact names:\n%s", out)
 	}
 	if !strings.Contains(out, "#2.3") {
 		t.Fatalf("rounds must be addressable as iteration.round:\n%s", out)
@@ -141,7 +141,7 @@ func TestExecutionDetailRendersFeedbackRounds(t *testing.T) {
 func TestFeedbackBriefOnlyReportsInScopeRounds(t *testing.T) {
 	fh := twoGateRun()
 	fh.feedback = []models.FeedbackEvent{
-		reviewEvent("design", 1, 1, "用直角", "feedback.review.design.i1r1.json"),
+		reviewEvent("design", 1, 1, "用直角", "feedback.review.design.i1.json"),
 		{RunID: "r", Seq: 2, Round: 1, Kind: models.FeedbackKindClarify, NodeID: "design", Iteration: 1,
 			Text: "自动采纳", IndexOnly: true},
 	}
@@ -152,7 +152,7 @@ func TestFeedbackBriefOnlyReportsInScopeRounds(t *testing.T) {
 	if n != 2 {
 		t.Fatalf("count = %d, want 2", n)
 	}
-	if len(cites) != 1 || !strings.Contains(cites[0], "feedback.review.design.i1r1.json") {
+	if len(cites) != 1 || !strings.Contains(cites[0], "feedback.review.design.i1.json") {
 		t.Fatalf("only rounds with products can be cited: %v", cites)
 	}
 	if n, _ := h.FeedbackBrief("r", "code"); n != 0 {

--- a/server/internal/mcp/history.go
+++ b/server/internal/mcp/history.go
@@ -143,9 +143,8 @@ func reviewedLabel(g models.Graph, ids []string) string {
 // human feedback. Each line is self-labeled with the node + iteration so an
 // agent can never confuse which gate/stage a piece of feedback came from.
 //
-// Depth is what stays on demand: every feedback round cites its own product, so
-// the verbatim text, annotations, attachments and product diff are one
-// read_artifact away instead of being inlined here.
+// Depth is what stays on demand. ReAct rounds cite their shared cumulative
+// conclusion; gate and preview rounds continue to cite their own product.
 func (h *Host) RunHistory(runID, currentNode string, all, onlyFeedback bool) (string, error) {
 	if h.history == nil {
 		return "", errors.New("history unavailable")
@@ -259,7 +258,7 @@ func (h *Host) feedbackLines(runID string, g models.Graph, currentNode string, a
 			line += " · (该轮修改被中断,未落地)"
 		}
 		if ev.ArtifactName != "" {
-			line += "\n      (细节: read_artifact " + ev.ArtifactName + ")"
+			line += "\n      (结论: read_artifact " + ev.ArtifactName + ")"
 		}
 		out = append(out, line)
 	}
@@ -457,7 +456,8 @@ func (h *Host) ExecutionDetail(runID, nodeID string, iteration int, includeLog b
 }
 
 // FeedbackBrief returns the number of feedback rounds in scope for a node and
-// a one-line citation per round that has a product.
+// one citation per distinct product. ReAct rounds share a cumulative product,
+// so repeating its citation once per audit event is noise.
 //
 // This is what puts the ledger in front of an agent: list_run_history existed
 // long before anything told an agent to call it, so a node re-run after a
@@ -470,6 +470,7 @@ func (h *Host) FeedbackBrief(runID, nodeID string) (int, []string) {
 	run, _ := h.history.Get(runID)
 	count := 0
 	var lines []string
+	cited := map[string]bool{}
 	for _, ev := range h.history.FeedbackEvents(runID) {
 		if !feedbackInScope(run.Graph, ev, nodeID) {
 			continue
@@ -478,15 +479,19 @@ func (h *Host) FeedbackBrief(runID, nodeID string) (int, []string) {
 		if ev.ArtifactName == "" {
 			continue
 		}
-		lines = append(lines, fmt.Sprintf("`%s` — 第%d次执行第%d轮 %s: %s",
+		if cited[ev.ArtifactName] {
+			continue
+		}
+		cited[ev.ArtifactName] = true
+		lines = append(lines, fmt.Sprintf("`%s` — 第%d次执行截至第%d轮的%s结论: %s",
 			ev.ArtifactName, ev.Iteration, ev.Round, feedbackKindLabel(ev.Kind),
 			trunc(feedbackGist(ev), 120)))
 	}
 	return count, lines
 }
 
-// renderExecutionFeedback lists the feedback rounds recorded against one node
-// execution, pointing at each round's product for the full text.
+// renderExecutionFeedback lists the feedback audit trail for one node
+// execution, pointing at the current cumulative conclusion where available.
 func renderExecutionFeedback(events []models.FeedbackEvent, nodeID string, iteration int) string {
 	var b strings.Builder
 	for _, ev := range events {
@@ -496,7 +501,7 @@ func renderExecutionFeedback(events []models.FeedbackEvent, nodeID string, itera
 		fmt.Fprintf(&b, "- 第%d轮 %s %s: %s\n", ev.Round, feedbackKindLabel(ev.Kind),
 			feedbackActionLabel(ev), trunc(feedbackGist(ev), 400))
 		if ev.ArtifactName != "" {
-			b.WriteString("  (完整内容: read_artifact " + ev.ArtifactName + ")\n")
+			b.WriteString("  (全轮结论: read_artifact " + ev.ArtifactName + ")\n")
 		}
 	}
 	if b.Len() == 0 {

--- a/server/internal/models/feedback.go
+++ b/server/internal/models/feedback.go
@@ -17,7 +17,7 @@ const (
 
 // FeedbackEvent is one round of human feedback on a run, persisted append-only.
 //
-// It is the source of truth from which the per-round feedback artifacts and
+// It is the source of truth from which feedback artifacts and
 // feedback_index.json are rendered, mirroring how run_error.json is derived
 // from StateRun. Rows are only ever INSERTed: a node visited N times with M
 // revise turns each keeps every one of them, because losing a round loses the
@@ -26,8 +26,8 @@ const (
 // Two ordinals are carried on purpose. Seq is the run-global order. Round is
 // the ordinal within (NodeID, Iteration) — one execution can hold many revise
 // turns, so Iteration alone cannot address "the 3rd push-back of the 2nd run".
-// Round is what makes the artifact name unique, and therefore what makes the
-// artifact store's (run_id, name) upsert non-destructive.
+// Round remains the audit ordinal. ReAct artifacts intentionally do not include
+// it: they are upserted cumulative conclusions keyed by node and iteration.
 type FeedbackEvent struct {
 	ID    uint   `gorm:"primaryKey" json:"-"`
 	RunID string `gorm:"index" json:"runId"`
@@ -56,7 +56,8 @@ type FeedbackEvent struct {
 	// Targets are absent because nothing landed.
 	Interrupted bool `json:"interrupted,omitempty"`
 
-	// ArtifactName is the per-round product this event rendered to. Empty when
+	// ArtifactName is the product this event rendered to. ReAct rounds in one
+	// execution share it; gate/preview rounds retain distinct names. Empty when
 	// IndexOnly is set.
 	ArtifactName string `json:"artifactName,omitempty"`
 	// IndexOnly marks a round that is listed in the index but gets no
@@ -89,7 +90,7 @@ type FeedbackTarget struct {
 	Changed bool   `json:"changed"`
 }
 
-// WantsArtifact reports whether this round gets its own product file.
+// WantsArtifact reports whether this event participates in a product file.
 func (e FeedbackEvent) WantsArtifact() bool { return !e.IndexOnly }
 
 // HasSubstance reports whether the event carries actual human input worth

--- a/server/internal/services/feedback.go
+++ b/server/internal/services/feedback.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -153,7 +154,8 @@ func FeedbackDigest(content string) string {
 	return hex.EncodeToString(sum[:])[:16]
 }
 
-// MarshalRoundJSON renders one round's standalone product.
+// MarshalRoundJSON renders one round's standalone product. It remains the
+// legacy/discrete-product representation used by gate and preview feedback.
 //
 // The body holds only this round's increment. Prior rounds appear as one-line
 // summaries plus a pointer to the previous product, so the file is
@@ -208,6 +210,58 @@ func MarshalRoundJSON(ev models.FeedbackEvent, prior []models.FeedbackEvent, run
 		payload["prev"] = prev
 	}
 
+	b, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// MarshalFeedbackSummaryJSON renders the one current-state product for a ReAct
+// node execution. Its primary content is a conclusion over every event already
+// recorded for that node+iteration; round-level transcript and raw detail stay
+// in the append-only event table and feedback_index.json.
+func MarshalFeedbackSummaryJSON(events []models.FeedbackEvent, runID string, node NodeRef) (string, error) {
+	if len(events) == 0 {
+		return "", errors.New("cannot summarize empty feedback events")
+	}
+	latest := events[len(events)-1]
+	conclusions := make([]string, 0, len(events))
+	var annotations []models.ReactAnnotation
+	var attachments []models.PromptImage
+	for _, ev := range events {
+		part := strings.TrimSpace(ev.AgentSummary)
+		if part == "" {
+			part = FeedbackSummary(ev)
+		}
+		conclusions = append(conclusions, fmt.Sprintf("第%d轮：%s", ev.Round, part))
+		annotations = append(annotations, ev.Annotations...)
+		attachments = append(attachments, ev.Attachments...)
+	}
+	payload := map[string]any{
+		"runId":       runID,
+		"kind":        latest.Kind,
+		"node":        node.toMap(latest.NodeID),
+		"iteration":   latest.Iteration,
+		"roundCount":  len(events),
+		"latestRound": latest.Round,
+		"at":          latest.OccurredAt.Format(time.RFC3339),
+		"index":       FeedbackIndexArtifactName,
+		"summary":     "截至第" + fmt.Sprint(latest.Round) + "轮的归纳结论：" + strings.Join(conclusions, "；"),
+	}
+	if latest.Interrupted {
+		payload["interrupted"] = true
+	}
+	if len(annotations) > 0 || len(attachments) > 0 {
+		feedback := map[string]any{}
+		if len(annotations) > 0 {
+			feedback["annotations"] = annotations
+		}
+		if len(attachments) > 0 {
+			feedback["attachments"] = attachments
+		}
+		payload["feedback"] = feedback
+	}
 	b, err := json.MarshalIndent(payload, "", "  ")
 	if err != nil {
 		return "", err

--- a/server/internal/services/feedback_name.go
+++ b/server/internal/services/feedback_name.go
@@ -30,13 +30,11 @@ const feedbackSlugMax = 40
 // (a per-round product or the index).
 func IsFeedbackArtifactName(name string) bool { return mcp.IsFeedbackArtifactName(name) }
 
-// FeedbackArtifactName builds the per-round product name.
-//
-// Uniqueness is the whole point: the artifact store upserts on (run_id, name),
-// so a name that varies per round is what keeps every round's feedback instead
-// of overwriting the previous one. The shape stays flat and dotted because
-// gateshare.safeArtifactName truncates at the last "/" — a path-style name
-// would collapse to its basename and start colliding.
+// FeedbackArtifactName builds a feedback product name. ReAct feedback
+// (review/clarify) is a current-state document, so every round of one
+// node+iteration intentionally shares the same name and upserts its cumulative
+// conclusion. Gate and preview feedback retain their historical per-round
+// names: they are discrete submissions rather than a dialogue.
 //
 // The result always satisfies the citation name shape
 // ^[a-z0-9][a-z0-9._-]*\.[a-z0-9]{1,16}$.
@@ -47,8 +45,13 @@ func FeedbackArtifactName(kind, nodeID string, iteration, round int) string {
 	if round < 1 {
 		round = 1
 	}
+	kind = feedbackKindSlug(kind)
+	if kind == "review" || kind == "clarify" {
+		return fmt.Sprintf("%s%s.%s.i%d.json",
+			FeedbackArtifactPrefix, kind, feedbackNodeSlug(nodeID), iteration)
+	}
 	return fmt.Sprintf("%s%s.%s.i%dr%d.json",
-		FeedbackArtifactPrefix, feedbackKindSlug(kind), feedbackNodeSlug(nodeID), iteration, round)
+		FeedbackArtifactPrefix, kind, feedbackNodeSlug(nodeID), iteration, round)
 }
 
 // feedbackKindSlug keeps the kind segment inside the known set so a malformed

--- a/server/internal/services/feedback_test.go
+++ b/server/internal/services/feedback_test.go
@@ -14,7 +14,7 @@ import (
 // platform's citation name shape or it cannot be cited or read back.
 var nameShape = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*\.[a-z0-9]{1,16}$`)
 
-func TestFeedbackArtifactNameShapeAndUniqueness(t *testing.T) {
+func TestFeedbackArtifactNameShapeAndNodeIterationUniqueness(t *testing.T) {
 	cases := []struct{ kind, node string }{
 		{"review", "research-1"},
 		{"clarify", "clarify_1"},
@@ -38,8 +38,14 @@ func TestFeedbackArtifactNameShapeAndUniqueness(t *testing.T) {
 	}
 
 	// The readable case stays readable — no digest suffix when nothing is lost.
-	if got := FeedbackArtifactName("review", "research-1", 2, 3); got != "feedback.review.research-1.i2r3.json" {
+	if got := FeedbackArtifactName("review", "research-1", 2, 3); got != "feedback.review.research-1.i2.json" {
 		t.Fatalf("clean node id should not be mangled, got %q", got)
+	}
+	if FeedbackArtifactName("review", "research-1", 2, 1) != FeedbackArtifactName("review", "research-1", 2, 3) {
+		t.Fatal("ReAct rounds in one iteration must share one product name")
+	}
+	if FeedbackArtifactName("gate", "research-1", 2, 1) == FeedbackArtifactName("gate", "research-1", 2, 3) {
+		t.Fatal("gate rounds must keep their distinct product names")
 	}
 	// Case folding and separator replacement must not merge distinct ids.
 	if FeedbackArtifactName("review", "Foo", 1, 1) == FeedbackArtifactName("review", "foo", 1, 1) {
@@ -51,11 +57,14 @@ func TestFeedbackArtifactNameShapeAndUniqueness(t *testing.T) {
 }
 
 func TestFeedbackArtifactNameNormalizesOrdinals(t *testing.T) {
-	if got := FeedbackArtifactName("review", "n", 0, 0); got != "feedback.review.n.i1r1.json" {
+	if got := FeedbackArtifactName("review", "n", 0, 0); got != "feedback.review.n.i1.json" {
 		t.Fatalf("non-positive ordinals should floor to 1, got %q", got)
 	}
 	if !IsFeedbackArtifactName(FeedbackIndexArtifactName) {
 		t.Fatal("index must be recognized as a ledger name")
+	}
+	if !IsFeedbackArtifactName("feedback.review.n.i1r1.json") {
+		t.Fatal("legacy per-round feedback must remain readable")
 	}
 	if IsFeedbackArtifactName("research.json") {
 		t.Fatal("a normal product must not be treated as ledger")
@@ -114,9 +123,9 @@ func TestAppendAssignsSeqAndRoundPerNodeIteration(t *testing.T) {
 	if events[3].Round != 1 {
 		t.Fatalf("a different node starts a fresh round counter, got %d", events[3].Round)
 	}
-	// Three consecutive rounds must produce three distinct products, all kept.
-	if len(names) != 4 {
-		t.Fatalf("want 4 distinct artifact names, got %d: %v", len(names), names)
+	// ReAct rounds share a node+iteration product; another node gets its own.
+	if len(names) != 2 {
+		t.Fatalf("want 2 distinct artifact names, got %d: %v", len(names), names)
 	}
 }
 
@@ -224,6 +233,36 @@ func TestMarshalRoundJSONOmitsEmptyAgentSummary(t *testing.T) {
 	}
 	if _, ok := doc["agentSummary"]; ok {
 		t.Fatalf("empty agentSummary must be omitted, got %v", doc["agentSummary"])
+	}
+}
+
+func TestMarshalFeedbackSummaryJSONCoversAllRoundsWithoutTranscript(t *testing.T) {
+	at := time.Date(2026, 8, 13, 15, 7, 22, 0, time.UTC)
+	events := []models.FeedbackEvent{
+		{RunID: "run-1", Kind: models.FeedbackKindReview, NodeID: "research-1", Iteration: 1, Round: 1,
+			OccurredAt: at, Text: "补充竞品对比", Turns: []models.ReactMessage{{Role: "human", Text: "补充竞品对比"}}},
+		{RunID: "run-1", Kind: models.FeedbackKindReview, NodeID: "research-1", Iteration: 1, Round: 2,
+			OccurredAt: at.Add(time.Minute), AgentSummary: "图表改为柱状图"},
+	}
+	body, err := MarshalFeedbackSummaryJSON(events, "run-1", NodeRef{Label: "调研", Type: "research"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(body), &doc); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	summary, _ := doc["summary"].(string)
+	for _, want := range []string{"补充竞品对比", "图表改为柱状图"} {
+		if !strings.Contains(summary, want) {
+			t.Fatalf("summary missing %q: %s", want, summary)
+		}
+	}
+	if doc["roundCount"] != float64(2) || doc["latestRound"] != float64(2) {
+		t.Fatalf("round coverage = %#v", doc)
+	}
+	if _, ok := doc["transcript"]; ok {
+		t.Fatalf("cumulative product must not force a full transcript: %s", body)
 	}
 }
 

--- a/web/src/components/run/StructuredArtifactView.vue
+++ b/web/src/components/run/StructuredArtifactView.vue
@@ -10,9 +10,9 @@ const STRUCTURED_ARTIFACT_NAMES = new Set([
   'review.json',
 ])
 
-// Feedback ledger products are matched by prefix, not by exact name: each round
-// gets its own file (feedback.<kind>.<node>.i<n>r<n>.json) so rounds never
-// overwrite each other, which makes the set of names unbounded.
+// Feedback ledger products are matched by prefix. New ReAct products use one
+// stable feedback.<kind>.<node>.i<n>.json name per execution while legacy and
+// gate/preview products may retain their i<n>r<n> form.
 const FEEDBACK_INDEX_NAME = 'feedback_index.json'
 const FEEDBACK_PREFIX = 'feedback.'
 

--- a/web/src/components/run/product/FeedbackLedgerView.vue
+++ b/web/src/components/run/product/FeedbackLedgerView.vue
@@ -35,9 +35,10 @@ import type { Artifact } from '@/lib/shared/types'
 
 // Renders the human-feedback ledger. The same component handles both shapes the
 // ledger produces: feedback_index.json (a timeline over every round) and a
-// single feedback.<kind>.<node>.i<n>r<n>.json round. Rows start collapsed and
-// fetch their round product on demand — the point of one file per round is that
-// depth stays optional.
+// single feedback product. New ReAct products use
+// feedback.<kind>.<node>.i<n>.json and show a cumulative conclusion; legacy
+// and gate/preview products may retain the i<n>r<n> form. The index stays the
+// expandable per-round audit timeline.
 const props = defineProps<{
   name: string
   doc: any
@@ -133,7 +134,7 @@ const countEntries = computed(() =>
       </span>
       <code v-if="doc?.node?.id" class="font-mono text-[12px] text-txt">{{ doc.node.id }}</code>
       <span class="text-[11px] text-txt3">
-        {{ t('pages.product.feedback.iterRound', { i: doc?.iteration, r: doc?.round }) }}
+        {{ t('pages.product.feedback.iterRound', { i: doc?.iteration, r: doc?.latestRound ?? doc?.round }) }}
       </span>
       <span v-if="doc?.actor?.name" class="text-[11px] text-txt3">{{ doc.actor.name }}</span>
       <span v-if="doc?.at" class="ml-auto text-[10px] text-txt3">{{ fmtTime(doc.at) }}</span>

--- a/web/src/components/run/product/FeedbackRoundCard.vue
+++ b/web/src/components/run/product/FeedbackRoundCard.vue
@@ -43,6 +43,10 @@ export type FeedbackRoundDoc = {
   actor?: { name?: string; callerKind?: string; unattributable?: boolean }
   action?: string
   interrupted?: boolean
+  /** Cumulative ReAct conclusion, covering every recorded round in this execution. */
+  summary?: string
+  roundCount?: number
+  latestRound?: number
   /** Agent-authored induction for this round; absent on legacy / no-summary rounds. */
   agentSummary?: string
   feedback?: {
@@ -73,7 +77,7 @@ const props = defineProps<{ doc: FeedbackRoundDoc }>()
 const { t } = useI18n()
 
 const agentSummary = computed(() => (props.doc.agentSummary || '').trim())
-const body = computed(() => (props.doc.feedback?.text || '').trim())
+const body = computed(() => (props.doc.summary || props.doc.feedback?.text || '').trim())
 const annotations = computed(() => props.doc.feedback?.annotations || [])
 const attachments = computed(() => props.doc.feedback?.attachments || [])
 const transcript = computed(() => props.doc.transcript || [])


### PR DESCRIPTION
Keep one upserted feedback product per ReAct node iteration while retaining
per-round audit events, so reviewers can read the complete conclusion directly.

Co-authored-by: Cursor <cursoragent@cursor.com>
