### PR TITLE
fix(engine): auto-retry transient Cursor API and empty MCP failures

### DIFF
--- a/server/internal/engine/auto_retry.go
+++ b/server/internal/engine/auto_retry.go
@@ -10,11 +10,13 @@ import (
 )
 
 // isAutoRetryable reports whether a failed node's outcome may be auto-retried
-// from the failure position. It reads only oc.retryable — callers (execAgent /
-// execStructuredAgent) set that flag on RunAgent failures. Contract finalize
-// misses, structured-gate rejects, and other deterministic faults leave the
-// zero value false and are not auto-retried. Note: "计划未全部完成" returned as a
-// RunAgent error still goes through execAgent and is therefore retryable.
+// from the failure position. It reads only oc.retryable — callers set that
+// flag on RunAgent / finish-path transport faults and on CAPA A7 empty MCP
+// surfaces (tools unreachable). Contract finalize misses (agent wrote other
+// MCP traffic but skipped the reserved product), structured-gate rejects, and
+// other deterministic faults leave the zero value false and are not
+// auto-retried. Note: "计划未全部完成" returned as a RunAgent error still goes
+// through execAgent and is therefore retryable.
 func isAutoRetryable(oc nodeOutcome) bool {
 	return oc.retryable
 }

--- a/server/internal/engine/auto_retry_test.go
+++ b/server/internal/engine/auto_retry_test.go
@@ -105,6 +105,28 @@ func TestAutoRetryExhaustsBudget(t *testing.T) {
 	}
 }
 
+// TestAutoRetryEmptyMCPSurfaceRecovers: CAPA A7 empty MCP surface (no tool
+// traffic + no node_complete) is retryable. After two empty attempts the fake
+// emits a mark and the run completes without manual resume.
+func TestAutoRetryEmptyMCPSurfaceRecovers(t *testing.T) {
+	autoRetryBackoff = 0
+	eng, db, p := setupEngineGraphP(t, autoRetryGraph())
+	eng.SetAutoRetryMax(3)
+	p.skipOutcomeLeft = 2 // two empty-surface failures, then success
+
+	run, err := eng.StartRun("wf", nil, "test")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitRunStatus(t, db, run.ID, "completed")
+
+	var n int64
+	db.Model(&models.StateRun{}).Where("run_id = ? AND node_id = ?", run.ID, "risky").Count(&n)
+	if n != 3 {
+		t.Errorf("risky execution rows = %d, want 3 (2 empty-MCP + 1 recovered)", n)
+	}
+}
+
 // TestAutoRetryContractFinalizeNotRetried: finalizeStructured contract miss
 // carries the old marker text but leaves retryable=false, so it is never
 // auto-retried even with a cap set.

--- a/server/internal/engine/fakeprovider_test.go
+++ b/server/internal/engine/fakeprovider_test.go
@@ -58,6 +58,10 @@ type fakeProvider struct {
 	// skipOutcome (test-only): when true, do not call node_complete so the
 	// engine's missing-mark path can be exercised.
 	skipOutcome bool
+	// skipOutcomeLeft (test-only): when > 0, skip node_complete for that many
+	// RunAgent calls (decrementing), then resume normal emitOutcome. Used to
+	// exercise empty-MCP-surface auto-retry recovery.
+	skipOutcomeLeft int
 	// outcomeFailed (test-only): node_complete with status=failed.
 	outcomeFailed bool
 	// outcomeBeforeFail (test-only): when a forced failLeft failure fires,
@@ -160,10 +164,15 @@ func (f *fakeProvider) emitAsk(req runtime.NodeReq) {
 		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"ask_question","arguments":{"questions":[{"prompt":"补充?","options":["A","B"]}]}}}`))
 }
 
-// emitOutcome records node_complete for the active node (unless skipOutcome).
+// emitOutcome records node_complete for the active node (unless skipOutcome /
+// skipOutcomeLeft suppress it).
 func (f *fakeProvider) emitOutcome(req runtime.NodeReq, outputs map[string]any) {
 	f.mu.Lock()
 	skip := f.skipOutcome
+	if !skip && f.skipOutcomeLeft > 0 {
+		f.skipOutcomeLeft--
+		skip = true
+	}
 	failed := f.outcomeFailed
 	f.mu.Unlock()
 	if skip {

--- a/server/internal/engine/node_agent.go
+++ b/server/internal/engine/node_agent.go
@@ -46,7 +46,8 @@ func (e *Engine) execVisual(c *execCtx, node *models.Node) nodeOutcome {
 	req := e.nodeReq(c, node)
 	res, err := e.provider.RunAgent(context.Background(), req)
 	if err != nil {
-		return nodeOutcome{status: "failed", err: err.Error(), outputMd: "视觉网页节点执行失败:" + err.Error(), events: res.Events, usage: res.Usage, usageByModel: res.UsageByModel}
+		return nodeOutcome{status: "failed", err: err.Error(), outputMd: "视觉网页节点执行失败:" + err.Error(),
+			retryable: true, events: res.Events, usage: res.Usage, usageByModel: res.UsageByModel}
 	}
 	return e.withOutcome(c, node, res, func(r runtime.NodeResult) nodeOutcome {
 		return e.finalizeVisual(c, node, r)
@@ -92,7 +93,8 @@ func (e *Engine) execPlan(c *execCtx, node *models.Node) nodeOutcome {
 	req := e.nodeReq(c, node)
 	res, err := e.provider.RunAgent(context.Background(), req)
 	if err != nil {
-		return nodeOutcome{status: "failed", err: err.Error(), outputMd: "计划节点执行失败:" + err.Error(), events: res.Events, usage: res.Usage, usageByModel: res.UsageByModel}
+		return nodeOutcome{status: "failed", err: err.Error(), outputMd: "计划节点执行失败:" + err.Error(),
+			retryable: true, events: res.Events, usage: res.Usage, usageByModel: res.UsageByModel}
 	}
 	return e.withOutcome(c, node, res, func(r runtime.NodeResult) nodeOutcome {
 		return e.finalizePlan(c, node, r)

--- a/server/internal/engine/node_react.go
+++ b/server/internal/engine/node_react.go
@@ -45,7 +45,8 @@ func (e *Engine) execReactEnter(c *execCtx, node *models.Node) nodeOutcome {
 		}
 		if t.Done {
 			if t.Err != nil {
-				return nodeOutcome{status: "failed", err: t.Err.Error(), outputMd: t.Msg, events: t.Events, usage: t.Usage, usageByModel: t.UsageByModel}
+				return nodeOutcome{status: "failed", err: t.Err.Error(), outputMd: t.Msg,
+					retryable: true, events: t.Events, usage: t.Usage, usageByModel: t.UsageByModel}
 			}
 			return e.finishAgentOutcome(c, node, t.Result, func(r runtime.NodeResult) nodeOutcome {
 				return e.completeProduces(c, node, r)

--- a/server/internal/engine/outcome.go
+++ b/server/internal/engine/outcome.go
@@ -35,13 +35,18 @@ func (e *Engine) consumeNodeOutcome(c *execCtx, node *models.Node, res *runtime.
 	}
 	if !ok {
 		errMsg := e.missingOutcomeErr(c, node)
+		// True-zero MCP + no artifact usually means the tool surface was
+		// unreachable (API/transport blip), not that the agent forgot a call —
+		// mark retryable so NodeAutoRetryMax can recover with a fresh attempt.
+		retryable := errMsg == errMCPSurfaceEmpty
 		return nodeOutcome{
-			status:   "failed",
-			err:      errMsg,
-			outputMd: "节点失败:" + errMsg,
-			outputs:  res.Outputs,
-			events:   res.Events,
-			usage:    res.Usage, usageByModel: res.UsageByModel,
+			status:    "failed",
+			err:       errMsg,
+			outputMd:  "节点失败:" + errMsg,
+			outputs:   res.Outputs,
+			events:    res.Events,
+			usage:     res.Usage, usageByModel: res.UsageByModel,
+			retryable: retryable,
 		}, false
 	}
 	res.Outputs = mcp.MergeOutcomeOutputs(res.Outputs, o)

--- a/server/internal/engine/outcome_test.go
+++ b/server/internal/engine/outcome_test.go
@@ -72,6 +72,9 @@ func TestConsumeNodeOutcomeEmptyMCPSurface(t *testing.T) {
 	if fail.err != errMCPSurfaceEmpty {
 		t.Fatalf("err=%q want %q", fail.err, errMCPSurfaceEmpty)
 	}
+	if !fail.retryable {
+		t.Fatal("empty MCP surface must be retryable for NodeAutoRetryMax")
+	}
 	if !strings.Contains(fail.outputMd, errMCPSurfaceEmpty) {
 		t.Fatalf("outputMd=%q", fail.outputMd)
 	}
@@ -104,6 +107,9 @@ func TestConsumeNodeOutcomeMissingNodeComplete(t *testing.T) {
 	}
 	if fail.err != errMissingNodeComplete {
 		t.Fatalf("err=%q want %q", fail.err, errMissingNodeComplete)
+	}
+	if fail.retryable {
+		t.Fatal("missing node_complete with MCP evidence must not be auto-retryable")
 	}
 	if strings.Contains(fail.err, "工具面为空") {
 		t.Fatalf("must not use empty-surface wording when MCP traffic exists: %q", fail.err)

--- a/server/internal/engine/resume.go
+++ b/server/internal/engine/resume.go
@@ -501,7 +501,8 @@ func (e *Engine) ReactReply(runID, nodeID, humanText string, images []models.Pro
 	logDB(e.db.Save(&conv), runID, "finish react conversation")
 
 	if t.Err != nil {
-		outcome := nodeOutcome{status: "failed", err: t.Err.Error(), outputMd: t.Msg, events: t.Events, usage: t.Usage, usageByModel: t.UsageByModel}
+		outcome := nodeOutcome{status: "failed", err: t.Err.Error(), outputMd: t.Msg,
+			retryable: true, events: t.Events, usage: t.Usage, usageByModel: t.UsageByModel}
 		e.saveState(c, node, outcome)
 		e.appendTrace(c, models.TraceEntry{NodeID: nodeID, Event: "resume", Detail: "react 失败"})
 		next := e.routeFailure(c, node, outcome)

--- a/server/internal/engine/review_session.go
+++ b/server/internal/engine/review_session.go
@@ -538,7 +538,8 @@ func (e *Engine) executeClarifyTurn(ctx context.Context, s *reviewSession, item 
 	logDB(e.db.Save(&conv), s.runID, "finish clarify conversation")
 
 	if t.Err != nil {
-		outcome := nodeOutcome{status: "failed", err: t.Err.Error(), outputMd: t.Msg, events: t.Events, usage: t.Usage, usageByModel: t.UsageByModel}
+		outcome := nodeOutcome{status: "failed", err: t.Err.Error(), outputMd: t.Msg,
+			retryable: true, events: t.Events, usage: t.Usage, usageByModel: t.UsageByModel}
 		e.saveState(c, node, outcome)
 		e.appendTrace(c, models.TraceEntry{NodeID: s.producerID, Event: "resume", Detail: "react 失败"})
 		next := e.routeFailure(c, node, outcome)

--- a/server/internal/runtime/acp_ensure.go
+++ b/server/internal/runtime/acp_ensure.go
@@ -43,12 +43,12 @@ func (c *acpProvider) ensureOutcome(ctx context.Context, req NodeReq, acp *sandb
 		res, err := c.streamChat(chatCtx, acp, req, prompt, nil)
 		cancel()
 		if err != nil {
-			if isChatTimeoutErr(err) {
-				return nil, fmt.Errorf("agent chat: %w", err)
-			}
+			// Propagate transport/API faults so the engine can auto-retry the
+			// node; only a successful but empty re-prompt round falls through
+			// to fail-closed below.
 			log.Warn().Err(err).Str("run", req.RunID).Str("node", req.NodeID).
 				Msg("node_complete re-prompt failed")
-			return nil, nil
+			return nil, fmt.Errorf("agent chat: %w", err)
 		}
 		absorbChat(usage, byModel, events, res)
 		qs := c.host.TakePendingQuestions(req.RunID, req.NodeID)
@@ -89,12 +89,9 @@ func (c *acpProvider) ensureStructured(ctx context.Context, req NodeReq, acp *sa
 		res, err := c.streamChat(chatCtx, acp, req, prompt, nil)
 		cancel()
 		if err != nil {
-			if isChatTimeoutErr(err) {
-				return nil, fmt.Errorf("agent chat: %w", err)
-			}
 			log.Warn().Err(err).Str("run", req.RunID).Str("node", req.NodeID).
 				Str("artifact", name).Msg("structured product re-prompt failed")
-			return nil, nil
+			return nil, fmt.Errorf("agent chat: %w", err)
 		}
 		absorbChat(usage, byModel, events, res)
 		qs := c.host.TakePendingQuestions(req.RunID, req.NodeID)
@@ -140,12 +137,9 @@ func (c *acpProvider) ensurePlanComplete(ctx context.Context, req NodeReq, acp *
 		res, err := c.streamChat(chatCtx, acp, req, prompt, nil)
 		cancel()
 		if err != nil {
-			if isChatTimeoutErr(err) {
-				return fmt.Errorf("agent chat: %w", err)
-			}
 			log.Warn().Err(err).Str("run", req.RunID).Str("node", req.NodeID).
 				Msg("implement plan-complete re-prompt failed")
-			break
+			return fmt.Errorf("agent chat: %w", err)
 		}
 		absorbChat(usage, byModel, events, res)
 	}
@@ -179,11 +173,8 @@ func (c *acpProvider) ensurePreviewRegistered(ctx context.Context, req NodeReq, 
 		res, err := c.streamChat(chatCtx, acp, req, prompt, nil)
 		cancel()
 		if err != nil {
-			if isChatTimeoutErr(err) {
-				return fmt.Errorf("agent chat: %w", err)
-			}
 			log.Warn().Err(err).Str("node", req.NodeID).Msg("app_preview set_preview re-prompt failed")
-			break
+			return fmt.Errorf("agent chat: %w", err)
 		}
 		absorbChat(usage, byModel, events, res)
 		c.host.TakePendingQuestions(req.RunID, req.NodeID)

--- a/server/internal/runtime/acp_more_test.go
+++ b/server/internal/runtime/acp_more_test.go
@@ -207,6 +207,39 @@ func TestEnsureOutcomeNudgeTimeout(t *testing.T) {
 	}
 }
 
+// TestEnsureStructuredRepromptTransportError propagates Cursor API / ACP
+// transport faults from the structured-product nudge instead of fail-closing
+// as a silent contract miss (so the engine can auto-retry the node).
+func TestEnsureStructuredRepromptTransportError(t *testing.T) {
+	turn := 0
+	store := newMemStore()
+	host := mcp.NewHost(store)
+	tok := host.RegisterRun("r")
+	t.Cleanup(func() { host.UnregisterRun("r") })
+	mgr := newFakeManager(t, host, "r", "n", tok, func(int) chatFunc {
+		return func(int) turnAction {
+			turn++
+			if turn == 1 {
+				return turnAction{narration: "researching"}
+			}
+			return turnAction{sendError: "Failed to reach the Cursor API. If you are behind a corporate proxy, set the HTTPS_PROXY environment variable."}
+		}
+	})
+	p, _ := newTestProvider(t, host, testOpts(), mgr)
+	req := reqWithProfile(NodeReq{RunID: "r", NodeID: "n", NodeType: "research", Token: tok,
+		Config: map[string]any{"prompt": "research"}, Vars: map[string]any{}})
+	_, err := p.RunAgent(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected transport error from structured re-prompt")
+	}
+	if !strings.Contains(err.Error(), "Failed to reach the Cursor API") {
+		t.Fatalf("want Cursor API transport error, got %v", err)
+	}
+	if isRetryableSandboxErr(err) != true {
+		t.Fatalf("Cursor API fault must classify as retryable sandbox err, got %v", err)
+	}
+}
+
 // TestRunAgentChatFailurePersistsEvents best-effort snapshots ACP events when
 // streamChat fails; the NodeResult must carry an Events slice (possibly empty
 // when the sandbox produced none) instead of a zero-value NodeResult{}.

--- a/server/internal/runtime/acp_provider.go
+++ b/server/internal/runtime/acp_provider.go
@@ -31,16 +31,33 @@ var errSandboxSetup = errors.New("sandbox setup failed")
 
 // isRetryableSandboxErr reports whether err is a transient sandbox/ACP fault
 // worth retrying in a fresh container: setup failures, a connection that
-// dropped mid-turn, or an idle (stuck) turn. Agent-reported errors, the hard
-// chat deadline (DeadlineExceeded), and contract misses are NOT retryable —
-// re-running them would just waste a sandbox and likely fail identically.
+// dropped mid-turn, an idle (stuck) turn, or Cursor CLI transport/reachability
+// faults. Agent-reported logic errors, the hard chat deadline
+// (DeadlineExceeded), and contract misses are NOT retryable — re-running them
+// would just waste a sandbox and likely fail identically.
 func isRetryableSandboxErr(err error) bool {
 	if err == nil {
 		return false
 	}
 	return errors.Is(err, errSandboxSetup) ||
 		errors.Is(err, sandbox.ErrConnClosed) ||
-		errors.Is(err, sandbox.ErrChatIdle)
+		errors.Is(err, sandbox.ErrChatIdle) ||
+		isTransientACPTransportErr(err)
+}
+
+// isTransientACPTransportErr matches Cursor CLI / TLS reachability faults that
+// surface as agent-process exit errors (not typed ErrConnClosed). A fresh
+// sandbox often recovers once the upstream blip clears.
+func isTransientACPTransportErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Failed to reach the Cursor API") ||
+		strings.Contains(msg, "Client network socket disconnected before secure TLS connection was established") ||
+		strings.Contains(msg, "ECONNRESET") ||
+		strings.Contains(msg, "ETIMEDOUT") ||
+		strings.Contains(msg, "ENETUNREACH")
 }
 
 // isChatTimeoutErr reports whether err is the per-turn chat deadline (context

--- a/server/internal/runtime/retry_test.go
+++ b/server/internal/runtime/retry_test.go
@@ -30,6 +30,9 @@ func TestIsRetryableSandboxErr(t *testing.T) {
 		{"deadline", context.DeadlineExceeded, false},
 		{"canceled", context.Canceled, false},
 		{"agent-error", errors.New("acp error: model refused"), false},
+		{"cursor-api", errors.New("acp error: exit status 1; stderr: Failed to reach the Cursor API"), true},
+		{"tls-abort", errors.New("acp error: exit status 1; stderr: Error: [aborted] Client network socket disconnected before secure TLS connection was established"), true},
+		{"econnreset", errors.New("agent chat: read: connection reset by peer: ECONNRESET"), true},
 	}
 	for _, tc := range cases {
 		if got := isRetryableSandboxErr(tc.err); got != tc.want {


### PR DESCRIPTION
## Summary
- Propagate Cursor API / TLS transport faults from `ensureOutcome` / `ensureStructured` (and related ensure*) instead of silently fail-closing as contract misses.
- Treat Cursor API reachability, TLS disconnect, and common network errno strings as sandbox-retryable; mark CAPA A7 empty MCP surfaces and plan/visual RunAgent errors as engine-auto-retryable under `NodeAutoRetryMax`.
- Keep deterministic faults (missing `node_complete` with MCP evidence, structured contract misses, gate rejects) non-retryable.

## Test plan
- [x] `go test ./internal/engine/ ./internal/runtime/`
- [ ] Trigger a workflow during a brief Cursor API blip and confirm the node auto-retries (trace: `自动从失败位置重试`) instead of immediate run-failed notify
- [ ] Confirm a real contract miss (agent wrote MCP traffic but skipped reserved product) still fails once without auto-retry


Made with [Cursor](https://cursor.com)