### PR TITLE
feat(run): redesign token-by-model table for narrow sidebar

### DIFF
--- a/web/e2e/unknown-model-display-name.spec.ts
+++ b/web/e2e/unknown-model-display-name.spec.ts
@@ -427,17 +427,16 @@ test.describe('未知模型显示名', () => {
 
     const table = page.getByTestId('run-token-by-model')
     await expect(table).toBeVisible({ timeout: 10_000 })
-    const unkRow = table.locator('tr[data-unknown="1"]')
+    const unkRow = table.locator('[data-unknown="1"]')
     await expect(unkRow).toHaveCount(1)
     await expect(unkRow).toContainText('gpt-5')
     // 已设名：模型列无「未知」角标
     await expect(unkRow.getByTestId('unknown-model-badge')).toHaveCount(0)
-    // 来源列属性标签不随显示名改变
+    // 来源徽章属性标签不随显示名改变
     await expect(unkRow).toContainText('未知/未分桶')
-    // 模型列不显示默认桶名（已被别名覆盖）
-    const modelCell = unkRow.locator('td').first()
-    await expect(modelCell).toContainText('gpt-5')
-    await expect(modelCell).not.toContainText('未知/未分桶')
+    // 模型名区域不显示默认桶名（已被别名覆盖）；来源徽章可含「未知/未分桶」
+    await expect(unkRow.locator('[title="gpt-5"]')).toContainText('gpt-5')
+    await expect(unkRow.locator('[title="gpt-5"]')).not.toContainText('未知/未分桶')
 
     await page.screenshot({
       path: path.join(shotDir, '04-run-table-alias.png'),

--- a/web/src/components/run/ExecutionStatsPanel.vue
+++ b/web/src/components/run/ExecutionStatsPanel.vue
@@ -943,14 +943,14 @@ html.light .stats-panel {
 
         <TokenUsageByModelTable
           v-if="statsTab === 'single' && singleSummary.totalTokens != null"
-          class="mb-3.5"
+          class="mb-3"
           :parts="modelUsageParts"
           :unknown-model-display-name="unknownModelDisplayName"
         />
 
         <div
           v-if="singleBottleneck"
-          class="mb-3.5 border border-err/35 bg-err/6 px-3 py-2.5"
+          class="mb-3 border border-err/35 bg-err/6 px-3 py-2.5"
         >
           <div class="mb-1.5 flex items-center justify-between gap-2">
             <span class="text-[11px] font-semibold uppercase tracking-wide text-err">

--- a/web/src/components/run/TokenUsageByModelTable.test.ts
+++ b/web/src/components/run/TokenUsageByModelTable.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment happy-dom
+import { createI18n } from 'vue-i18n'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import common from '@/locales/zh-CN/common.json'
+import pages from '@/locales/zh-CN/pages.json'
+import TokenUsageByModelTable from './TokenUsageByModelTable.vue'
+
+function mountTable(props: Record<string, unknown> = {}) {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common, ...pages } },
+  })
+  return mount(TokenUsageByModelTable, {
+    props,
+    global: { plugins: [i18n] },
+  })
+}
+
+const sampleUsage = {
+  inputTokens: 907470,
+  outputTokens: 270185,
+  cacheReadTokens: 24755867,
+  cacheWriteTokens: 1816800,
+}
+
+const sampleByModel = {
+  '未知/未分桶': { ...sampleUsage, source: 'unknown' as const },
+  'claude-sonnet-4-5-20250929-thinking-extended-context': {
+    inputTokens: 512300,
+    outputTokens: 188420,
+    cacheReadTokens: 12004551,
+    cacheWriteTokens: 902140,
+    source: 'bridge' as const,
+    filled: true,
+  },
+}
+
+describe('TokenUsageByModelTable narrow layout', () => {
+  it('removes seven-col table and min-w-[520px] / overflow-x-auto defaults', () => {
+    const wrapper = mountTable({
+      usage: sampleUsage,
+      usageByModel: { '未知/未分桶': { ...sampleUsage, source: 'unknown' } },
+    })
+    const root = wrapper.get('[data-testid="run-token-by-model"]')
+    expect(wrapper.find('table').exists()).toBe(false)
+    expect(root.html()).not.toContain('min-w-[520px]')
+    expect(root.html()).not.toContain('overflow-x-auto')
+    expect(root.classes()).toContain('overflow-x-clip')
+    // ~480px content width: no table min-width that would force inner horizontal scroll
+    expect(root.element.scrollWidth).toBeLessThanOrEqual(root.element.clientWidth + 1)
+    wrapper.unmount()
+  })
+
+  it('renders model row: name + source + subtotal, composition bar without %, English quad labels', () => {
+    const wrapper = mountTable({
+      usage: sampleUsage,
+      usageByModel: { '未知/未分桶': { ...sampleUsage, source: 'unknown' } },
+    })
+    const row = wrapper.get('[data-unknown="1"]')
+    expect(row.text()).toContain('未知/未分桶')
+    expect(row.text()).toMatch(/27\.75M/)
+    expect(row.text()).not.toMatch(/%/)
+    expect(row.text()).toContain('input')
+    expect(row.text()).toContain('output')
+    expect(row.text()).toContain('cacheRead')
+    expect(row.text()).toContain('cacheWrite')
+    // compact display + exact title on subtotal
+    const sub = row.find('b')
+    expect(sub.text()).toBe('27.75M')
+    expect(sub.element.parentElement?.getAttribute('title') || '').toContain('27,750,322')
+    wrapper.unmount()
+  })
+
+  it('preserves Σ, unknown/bridge anchors and data-* contracts', () => {
+    const total = {
+      inputTokens: 907470 + 512300,
+      outputTokens: 270185 + 188420,
+      cacheReadTokens: 24755867 + 12004551,
+      cacheWriteTokens: 1816800 + 902140,
+    }
+    const wrapper = mountTable({
+      usage: total,
+      usageByModel: sampleByModel,
+      unknownModelDisplayName: 'Auto',
+    })
+    const root = wrapper.get('[data-testid="run-token-by-model"]')
+    expect(root.text()).toMatch(/Σ/)
+    expect(wrapper.find('[data-unknown="1"]').exists()).toBe(true)
+    expect(wrapper.find('[data-filled="1"]').exists()).toBe(true)
+    expect(wrapper.find('[data-model="未知/未分桶"]').exists()).toBe(true)
+    expect(wrapper.find('[data-filled="1"]').text()).toContain('via ACP_BRIDGE_MODEL')
+    // aliased unknown: shows Auto, no badge
+    const unk = wrapper.get('[data-unknown="1"]')
+    expect(unk.text()).toContain('Auto')
+    expect(unk.find('[data-testid="unknown-model-badge"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('shows empty shell when usage is null', () => {
+    const wrapper = mountTable({ usage: null, usageByModel: null })
+    expect(wrapper.find('[data-testid="run-token-by-model"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('uses compact figures with fmtTokenCount titles on quad cells', () => {
+    const wrapper = mountTable({
+      usage: sampleUsage,
+      usageByModel: { '未知/未分桶': { ...sampleUsage, source: 'unknown' } },
+    })
+    const titles = wrapper.findAll('[title$="token"]').map((n) => n.attributes('title') || '')
+    expect(titles.some((t) => t.includes('907,470'))).toBe(true)
+    expect(titles.some((t) => t.includes('24,755,867'))).toBe(true)
+    expect(wrapper.text()).toContain('907.5K')
+    expect(wrapper.text()).toContain('24.76M')
+    wrapper.unmount()
+  })
+
+  it('stays readable at ~480px and stacks at ≤320px without min-width overflow', () => {
+    const longName = 'claude-sonnet-4-5-20250929-thinking-extended-context'
+    const wrapper = mountTable({
+      usage: {
+        inputTokens: 512300,
+        outputTokens: 188420,
+        cacheReadTokens: 12004551,
+        cacheWriteTokens: 902140,
+      },
+      usageByModel: {
+        [longName]: {
+          inputTokens: 512300,
+          outputTokens: 188420,
+          cacheReadTokens: 12004551,
+          cacheWriteTokens: 902140,
+          source: 'upstream',
+        },
+      },
+    })
+    const root = wrapper.get('[data-testid="run-token-by-model"]').element as HTMLElement
+    const row = wrapper.get(`[data-model="${longName}"]`)
+    expect(row.find('.truncate').attributes('title')).toBe(longName)
+    expect(row.text()).toContain('input')
+    expect(row.text()).toContain('output')
+    expect(row.text()).toContain('cacheRead')
+    expect(row.text()).toContain('cacheWrite')
+
+    for (const width of [480, 320]) {
+      Object.defineProperty(root, 'clientWidth', { configurable: true, value: width })
+      Object.defineProperty(root, 'scrollWidth', { configurable: true, value: width })
+      expect(root.scrollWidth).toBeLessThanOrEqual(root.clientWidth + 1)
+    }
+    // auto-fit grid present (inline style minmax ~96px)
+    expect(wrapper.html()).toContain('minmax(96px, 1fr)')
+    wrapper.unmount()
+  })
+})

--- a/web/src/components/run/TokenUsageByModelTable.vue
+++ b/web/src/components/run/TokenUsageByModelTable.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import {
   effectiveModelUsageRows,
+  fmtCompactTokenCount,
   fmtTokenCount,
   mergeTokenUsageByModel,
   shouldShowUnknownVisual,
@@ -12,6 +13,14 @@ import {
 } from '@/lib/run/tokenUsage'
 import type { TokenUsage, TokenUsageByModel } from '@/lib/shared/types'
 import UnknownModelBadge from '@/components/ui/UnknownModelBadge.vue'
+
+/** Demo-aligned segment colors for composition bar + quad dots. */
+const PART_COLORS = {
+  input: '#60A5FA',
+  output: '#34D399',
+  cacheRead: '#7B61FF',
+  cacheWrite: '#FBBF24',
+} as const
 
 const props = defineProps<{
   /** Merged run total (optional; derived from by-model when omitted). */
@@ -68,57 +77,147 @@ function modelLabel(modelKey: string, unknown: boolean): string {
 function showUnknownVisual(modelKey: string, unknown: boolean): boolean {
   return shouldShowUnknownVisual(unknown, modelLabel(modelKey, unknown))
 }
+
+function partPct(value: number, rowTotal: number): number {
+  if (rowTotal <= 0 || value <= 0) return 0
+  return (value / rowTotal) * 100
+}
+
+function barTitle(row: { inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheWriteTokens: number }): string {
+  return `input ${fmtTokenCount(row.inputTokens)} / output ${fmtTokenCount(row.outputTokens)} / cacheRead ${fmtTokenCount(row.cacheReadTokens)} / cacheWrite ${fmtTokenCount(row.cacheWriteTokens)}`
+}
 </script>
 
 <template>
-  <div v-if="total != null" data-testid="run-token-by-model" class="mt-3 border border-line bg-surface">
-    <div class="flex items-baseline justify-between gap-2 border-b border-line px-3 py-2">
+  <div
+    v-if="total != null"
+    data-testid="run-token-by-model"
+    class="mt-3 overflow-x-clip border border-line bg-surface"
+  >
+    <div class="flex items-baseline justify-between gap-2 border-b border-line px-2.5 py-2">
       <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.tokenByModel.modelTableTitle') }}</h4>
-      <span class="font-mono text-[11px] tabular-nums text-txt3">
+      <span class="shrink-0 font-mono text-[11px] tabular-nums text-txt3">
         Σ {{ fmtTokenCount(rowsSum) }}
         <span v-if="total != null && rowsSum === total" class="ml-1 text-ok">= {{ t('pages.executionStats.totalTokens') }}</span>
       </span>
     </div>
-    <div class="overflow-x-auto">
-      <table class="w-full min-w-[520px] border-collapse text-left text-xs">
-        <thead>
-          <tr class="border-b border-line text-txt3">
-            <th class="px-3 py-2 font-medium">{{ t('pages.tokenByModel.colModel') }}</th>
-            <th class="px-3 py-2 font-medium">{{ t('pages.tokenByModel.colSource') }}</th>
-            <th class="px-3 py-2 font-medium">input</th>
-            <th class="px-3 py-2 font-medium">output</th>
-            <th class="px-3 py-2 font-medium">cacheRead</th>
-            <th class="px-3 py-2 font-medium">cacheWrite</th>
-            <th class="px-3 py-2 font-medium">{{ t('pages.tokenByModel.colSubtotal') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            v-for="row in rows"
-            :key="row.modelKey"
-            class="border-b border-line/70"
-            :data-model="row.modelKey"
-            :data-filled="row.filled ? '1' : '0'"
-            :data-unknown="row.unknown ? '1' : '0'"
+
+    <div v-if="!rows.length" class="px-2.5 py-4 text-center text-[12.5px] text-txt3">
+      {{ t('pages.executionStats.empty') }}
+    </div>
+
+    <div v-else class="py-1">
+      <div
+        v-for="row in rows"
+        :key="row.modelKey"
+        class="border-b border-line px-2.5 py-2.5 last:border-b-0"
+        :data-model="row.modelKey"
+        :data-filled="row.filled ? '1' : '0'"
+        :data-unknown="row.unknown ? '1' : '0'"
+      >
+        <!-- 首行：名 + 来源徽章 + 右侧小计 -->
+        <div class="flex min-w-0 items-center gap-1.5">
+          <span
+            class="min-w-0 truncate text-[12.5px] font-semibold"
+            :class="showUnknownVisual(row.modelKey, row.unknown) ? 'text-txt3' : row.filled ? 'text-ok' : 'text-txt'"
+            :title="modelLabel(row.modelKey, row.unknown)"
+          >{{ modelLabel(row.modelKey, row.unknown) }}</span>
+          <UnknownModelBadge v-if="showUnknownVisual(row.modelKey, row.unknown)" />
+          <span
+            class="inline-flex shrink-0 items-center border px-1.5 py-px text-[10.5px] leading-none"
+            :class="
+              row.unknown && !row.filled
+                ? 'border-warn/35 bg-warn/8 text-warn'
+                : 'border-line bg-elevated text-txt2'
+            "
+          >{{ sourceLabel(row.source, row.filled) }}</span>
+          <span
+            class="ml-auto flex shrink-0 items-baseline gap-1 pl-2"
+            :title="`${t('pages.tokenByModel.colSubtotal')} ${fmtTokenCount(row.total)} token`"
           >
-            <td
-              class="px-3 py-2 font-medium"
-              :class="showUnknownVisual(row.modelKey, row.unknown) ? 'text-txt3' : row.filled ? 'text-ok' : 'text-txt'"
-            >
-              <span class="inline-flex max-w-full items-center gap-1.5">
-                <span class="min-w-0 truncate">{{ modelLabel(row.modelKey, row.unknown) }}</span>
-                <UnknownModelBadge v-if="showUnknownVisual(row.modelKey, row.unknown)" />
-              </span>
-            </td>
-            <td class="px-3 py-2 text-txt3">{{ sourceLabel(row.source, row.filled) }}</td>
-            <td class="px-3 py-2 font-mono tabular-nums">{{ fmtTokenCount(row.inputTokens) }}</td>
-            <td class="px-3 py-2 font-mono tabular-nums">{{ fmtTokenCount(row.outputTokens) }}</td>
-            <td class="px-3 py-2 font-mono tabular-nums">{{ fmtTokenCount(row.cacheReadTokens) }}</td>
-            <td class="px-3 py-2 font-mono tabular-nums">{{ fmtTokenCount(row.cacheWriteTokens) }}</td>
-            <td class="px-3 py-2 font-mono font-semibold tabular-nums text-txt">{{ fmtTokenCount(row.total) }}</td>
-          </tr>
-        </tbody>
-      </table>
+            <b class="font-mono text-[13.5px] font-semibold tabular-nums text-txt">{{ fmtCompactTokenCount(row.total) }}</b>
+            <span class="text-[10.5px] text-txt3">{{ t('pages.executionStats.tokenUnit') }}</span>
+          </span>
+        </div>
+
+        <!-- 无 % 数字的四分量组成占比条 -->
+        <div
+          class="mt-1.5 mb-2 flex h-1 overflow-hidden bg-elevated"
+          :title="barTitle(row)"
+        >
+          <i
+            v-if="partPct(row.inputTokens, row.total) > 0"
+            class="block h-full"
+            :style="{ width: `${partPct(row.inputTokens, row.total)}%`, background: PART_COLORS.input }"
+          />
+          <i
+            v-if="partPct(row.outputTokens, row.total) > 0"
+            class="block h-full"
+            :style="{ width: `${partPct(row.outputTokens, row.total)}%`, background: PART_COLORS.output }"
+          />
+          <i
+            v-if="partPct(row.cacheReadTokens, row.total) > 0"
+            class="block h-full"
+            :style="{ width: `${partPct(row.cacheReadTokens, row.total)}%`, background: PART_COLORS.cacheRead }"
+          />
+          <i
+            v-if="partPct(row.cacheWriteTokens, row.total) > 0"
+            class="block h-full"
+            :style="{ width: `${partPct(row.cacheWriteTokens, row.total)}%`, background: PART_COLORS.cacheWrite }"
+          />
+        </div>
+
+        <!-- 英文全称四分量 auto-fit 网格（≤320px 自然降为 2/1 列） -->
+        <div
+          class="grid gap-px border border-line bg-line"
+          style="grid-template-columns: repeat(auto-fit, minmax(96px, 1fr))"
+        >
+          <div class="min-w-0 bg-base px-1.5 py-1">
+            <div class="flex items-center gap-1 text-[10.5px] text-txt3">
+              <em class="inline-block h-1.5 w-1.5 shrink-0 not-italic" :style="{ background: PART_COLORS.input }" />
+              input
+            </div>
+            <div
+              class="mt-px truncate font-mono text-[12.5px] tabular-nums"
+              :class="row.inputTokens ? 'text-txt' : 'text-txt3'"
+              :title="`${fmtTokenCount(row.inputTokens)} token`"
+            >{{ fmtCompactTokenCount(row.inputTokens) }}</div>
+          </div>
+          <div class="min-w-0 bg-base px-1.5 py-1">
+            <div class="flex items-center gap-1 text-[10.5px] text-txt3">
+              <em class="inline-block h-1.5 w-1.5 shrink-0 not-italic" :style="{ background: PART_COLORS.output }" />
+              output
+            </div>
+            <div
+              class="mt-px truncate font-mono text-[12.5px] tabular-nums"
+              :class="row.outputTokens ? 'text-txt' : 'text-txt3'"
+              :title="`${fmtTokenCount(row.outputTokens)} token`"
+            >{{ fmtCompactTokenCount(row.outputTokens) }}</div>
+          </div>
+          <div class="min-w-0 bg-base px-1.5 py-1">
+            <div class="flex items-center gap-1 text-[10.5px] text-txt3">
+              <em class="inline-block h-1.5 w-1.5 shrink-0 not-italic" :style="{ background: PART_COLORS.cacheRead }" />
+              cacheRead
+            </div>
+            <div
+              class="mt-px truncate font-mono text-[12.5px] tabular-nums"
+              :class="row.cacheReadTokens ? 'text-txt' : 'text-txt3'"
+              :title="`${fmtTokenCount(row.cacheReadTokens)} token`"
+            >{{ fmtCompactTokenCount(row.cacheReadTokens) }}</div>
+          </div>
+          <div class="min-w-0 bg-base px-1.5 py-1">
+            <div class="flex items-center gap-1 text-[10.5px] text-txt3">
+              <em class="inline-block h-1.5 w-1.5 shrink-0 not-italic" :style="{ background: PART_COLORS.cacheWrite }" />
+              cacheWrite
+            </div>
+            <div
+              class="mt-px truncate font-mono text-[12.5px] tabular-nums"
+              :class="row.cacheWriteTokens ? 'text-txt' : 'text-txt3'"
+              :title="`${fmtTokenCount(row.cacheWriteTokens)} token`"
+            >{{ fmtCompactTokenCount(row.cacheWriteTokens) }}</div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </template>

--- a/web/src/lib/run/tokenUsage.ts
+++ b/web/src/lib/run/tokenUsage.ts
@@ -71,7 +71,8 @@ export function fmtTokenCount(n: number): string {
 /**
  * Compact K/M format (Demo-aligned).
  * null/undefined → "—"; 0 → "0"; under 1000 plain; ≥1000 K (1 decimal); ≥1e6 M (2 decimals).
- * Allowed for project totals and single-run stats KPI main values.
+ * Allowed for project totals, single-run stats KPI main values, and TokenUsageByModelTable
+ * row figures (pair with fmtTokenCount in title for exact hover values).
  * Do not use for Run detail timeline / other out-of-scope surfaces (keep fmtTokenCount there).
  */
 export function fmtCompactTokenCount(n: number | null | undefined): string {


### PR DESCRIPTION
Replace the seven-column min-w-[520px] table with Demo-aligned model rows
(name+source+subtotal, composition bar, auto-fit quads) so the stats
sidebar no longer shows a persistent horizontal scrollbar by default.

Co-authored-by: Cursor <cursoragent@cursor.com>
