### PR TITLE
fix(preview): 取点标注取消后真正退出 Overlay 取点模式

### DIFF
--- a/server/internal/browser/inspect_cancel.go
+++ b/server/internal/browser/inspect_cancel.go
@@ -6,8 +6,10 @@ import (
 )
 
 // Overlay.setInspectMode(searchForNode) often emits inspectModeCanceled for the
-// previous mode. If that event reaches the UI, the toggle looks off while
-// Overlay is still on — the next click re-enters inspect and cancel never sticks.
+// previous mode — sometimes more than once. If any of those reach the UI, the
+// toggle looks off while Overlay is still on — the next click re-enters inspect
+// and cancel never sticks. Swallow every cancel for the skip window, not just
+// the first one.
 const inspectCancelSkip = 300 * time.Millisecond
 
 // inspectCancelFilter decides whether Overlay.inspectModeCanceled should notify
@@ -58,7 +60,6 @@ func (f *inspectCancelFilter) onCanceled() bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.skip {
-		f.skip = false
 		return false
 	}
 	if !f.wanted {

--- a/server/internal/browser/inspect_cancel_test.go
+++ b/server/internal/browser/inspect_cancel_test.go
@@ -8,8 +8,26 @@ func TestInspectCancelFilterEscAfterEnableSideEffect(t *testing.T) {
 	if f.onCanceled() {
 		t.Fatal("enable-side inspectModeCanceled must not notify UI")
 	}
+	if f.onCanceled() {
+		t.Fatal("second enable-side cancel in the skip window must not notify UI")
+	}
+	f.expireSkipNow()
 	if !f.onCanceled() {
-		t.Fatal("Esc after the skipped enable-side cancel must notify UI")
+		t.Fatal("Esc after the skip window must notify UI")
+	}
+}
+
+func TestInspectCancelFilterSwallowsAllCancelsDuringSkip(t *testing.T) {
+	var f inspectCancelFilter
+	f.set(true)
+	for i := 0; i < 3; i++ {
+		if f.onCanceled() {
+			t.Fatalf("enable-side cancel %d must not notify UI", i)
+		}
+	}
+	f.expireSkipNow()
+	if !f.onCanceled() {
+		t.Fatal("Esc after skip window must notify UI")
 	}
 }
 

--- a/server/internal/browser/rod.go
+++ b/server/internal/browser/rod.go
@@ -368,6 +368,10 @@ func (rp *rodPage) installPickListener() {
 			if !rp.inspectCancel.onCanceled() {
 				return
 			}
+			// Chromium only *notifies* on Esc; searchForNode stays armed until we
+			// set mode none. Leave inspect here so the next toolbar click can
+			// cancel instead of re-entering.
+			_ = rp.SetInspect(false)
 			if cb := rp.getInspectCanceled(); cb != nil {
 				cb()
 			}

--- a/server/internal/browser/types.go
+++ b/server/internal/browser/types.go
@@ -74,6 +74,8 @@ type Page interface {
 	// (e.g. Esc → Overlay.inspectModeCanceled). Callers sync UI button state.
 	// Enabling inspect may itself emit inspectModeCanceled for the previous
 	// mode; implementations must not invoke this callback for that side effect.
+	// Chromium does not leave searchForNode on this event — implementations
+	// must SetInspect(false) before invoking the callback so cancel sticks.
 	// Describe/recognition failures use OnDescribeFailed instead.
 	OnInspectCanceled(func())
 	// OnDescribeFailed is invoked when Overlay pick fires but describing the

--- a/web/src/components/run/DirectPreviewFrame.test.ts
+++ b/web/src/components/run/DirectPreviewFrame.test.ts
@@ -201,6 +201,30 @@ describe('DirectPreviewFrame', () => {
     wrapper.unmount()
   })
 
+  it('toggles label to 取消标注; second click posts on:false', async () => {
+    const { wrapper, posted } = mountFrame()
+    dispatchFromPreview({ type: 'direct-preview-ready', url: DIRECT })
+    await flushPromises()
+    const btn = wrapper.get('[data-testid="direct-preview-inspect"]')
+    expect(btn.text()).toContain('取点标注')
+    expect(btn.attributes('aria-pressed')).toBe('false')
+
+    await btn.trigger('click')
+    await flushPromises()
+    expect(btn.attributes('aria-pressed')).toBe('true')
+    expect(btn.text()).toContain('取消标注')
+    expect(btn.text()).not.toContain('取点标注')
+    expect(posted).toContainEqual({ type: 'direct-preview-inspect', on: true })
+
+    await btn.trigger('click')
+    await flushPromises()
+    expect(btn.attributes('aria-pressed')).toBe('false')
+    expect(btn.text()).toContain('取点标注')
+    expect(wrapper.text()).not.toContain('取消标注')
+    expect(posted).toContainEqual({ type: 'direct-preview-inspect', on: false })
+    wrapper.unmount()
+  })
+
   it('nav buttons post nav actions', async () => {
     const { wrapper, posted } = mountFrame()
     dispatchFromPreview({ type: 'direct-preview-ready', url: DIRECT })

--- a/web/src/components/run/DirectPreviewFrame.vue
+++ b/web/src/components/run/DirectPreviewFrame.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { AppPreviewPickPayload } from '@/lib/shared/previewPickUrl'
 import {
@@ -33,6 +33,9 @@ const { t } = useI18n()
 const frameSrc = ref(props.directUrl)
 const address = ref(props.directUrl)
 const inspect = ref(false)
+const inspectToggleLabel = computed(() =>
+  t(inspect.value ? 'pages.appPreview.novnc.cancelInspect' : 'pages.appPreview.novnc.inspect'),
+)
 const scriptReady = ref(false)
 const scriptTip = ref(false)
 const inlineTip = ref<string | null>(null)
@@ -243,12 +246,12 @@ onUnmounted(() => {
         type="button"
         class="rounded px-2 py-0.5 text-[11px] transition"
         :class="inspect ? 'bg-ok/20 text-ok' : 'text-txt2 hover:bg-overlay'"
-        :title="t(inspect ? 'pages.appPreview.novnc.cancelInspect' : 'pages.appPreview.novnc.inspect')"
+        :title="inspectToggleLabel"
         :aria-pressed="inspect ? 'true' : 'false'"
         data-testid="direct-preview-inspect"
         @click="toggleInspect"
       >
-        {{ t('pages.appPreview.novnc.inspect') }}
+        {{ inspectToggleLabel }}
       </button>
       <a
         :href="frameSrc"

--- a/web/src/components/run/NovncPreviewPanel.test.ts
+++ b/web/src/components/run/NovncPreviewPanel.test.ts
@@ -235,8 +235,38 @@ describe('NovncPreviewPanel', () => {
     expect(inspectButton(wrapper).attributes('aria-pressed')).toBe('false')
     expect(wrapper.text()).toContain('#keep')
     expect(wrapper.find('[data-testid="novnc-inline-tip"]').exists()).toBe(false)
-    // Remote already off — do not echo another inspect on:false
-    expect(ws.sent.slice(beforeLen)).toEqual([])
+    // Overlay.inspectModeCanceled does not leave searchForNode; echo on:false.
+    expect(lastInspectCtrl()).toEqual({ type: 'inspect', on: false })
+    expect(ws.sent.slice(beforeLen).some((s) => s.includes('"on":false'))).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('after remote cancel, toolbar click can turn inspect on then off again', async () => {
+    const wrapper = mountNovnc()
+    await flushPromises()
+    const ws = MockWebSocket.instances[0]!
+    const btn = inspectButton(wrapper)
+
+    await btn.trigger('click')
+    await flushPromises()
+    expect(btn.attributes('aria-pressed')).toBe('true')
+
+    ws.onmessage?.({ data: JSON.stringify({ type: 'inspect-canceled' }) })
+    await flushPromises()
+    expect(btn.attributes('aria-pressed')).toBe('false')
+    expect(btn.text()).toContain('取点标注')
+
+    await btn.trigger('click')
+    await flushPromises()
+    expect(btn.attributes('aria-pressed')).toBe('true')
+    expect(btn.text()).toContain('取消标注')
+    expect(lastInspectCtrl()).toEqual({ type: 'inspect', on: true })
+
+    await btn.trigger('click')
+    await flushPromises()
+    expect(btn.attributes('aria-pressed')).toBe('false')
+    expect(btn.text()).toContain('取点标注')
+    expect(lastInspectCtrl()).toEqual({ type: 'inspect', on: false })
     wrapper.unmount()
   })
 

--- a/web/src/components/run/NovncPreviewPanel.vue
+++ b/web/src/components/run/NovncPreviewPanel.vue
@@ -162,8 +162,11 @@ function handleCtrlText(data: string) {
       break
     case 'inspect-canceled':
       // Remote Esc (Overlay.inspectModeCanceled) — keep staged pick; no failure tip.
+      // Chromium does not leave searchForNode on this event; echo on:false so
+      // overlay actually turns off. Otherwise the button looks idle while
+      // inspect stays armed and the next click only re-enters.
       inlineTip.value = null
-      clearInspect('remote-esc', { syncRemote: false })
+      clearInspect('remote-esc', { syncRemote: true })
       break
     case 'closed':
       status.value = 'closed'


### PR DESCRIPTION
## Summary
- Chrome `Overlay.inspectModeCanceled` 只通知、不会退出 `searchForNode`。前端把按钮复位成「取点标注」却不发 `on:false`，叠加层一直开着，再点只会重新进入，取消不掉。
- 远程取消时后端主动 `SetInspect(false)`，前端补发 `inspect on:false`；开启后的 skip 窗口吞掉全部误报取消，不只第一条。
- 直连预览按钮开启后改为「取消标注」，再点一次即可退出。

## Test plan
- [ ] 应用预览（noVNC）：点「取点标注」应变为「取消标注」，再点一次应退出取点（十字准星/高亮消失）
- [ ] 取点过程中按 Esc，按钮回到「取点标注」，之后仍可再次开启并取消
- [ ] 点选一个元素后可再次开启取点，再取消仍有效
- [ ] 直连预览：按钮文案在「取点标注 / 取消标注」之间切换，第二次点击发送 `on:false`
- [ ] `go test ./internal/browser/` 与 `NovncPreviewPanel` / `DirectPreviewFrame` 单测通过


Made with [Cursor](https://cursor.com)