### PR TITLE
feat(review): 流转确认时让 Agent 选择性提交脏文件

### DIFF
--- a/server/internal/engine/engine_test.go
+++ b/server/internal/engine/engine_test.go
@@ -104,6 +104,22 @@ func waitRunStatus(t *testing.T, db *gorm.DB, runID, status string) {
 	t.Fatalf("run %s did not reach %q (got %q)", runID, status, r.Status)
 }
 
+// waitRunErrorArtifact polls until finish() has written run_error.json.
+// Run.status can flip to failed a few statements before the artifact lands.
+func waitRunErrorArtifact(t *testing.T, db *gorm.DB, runID string) string {
+	t.Helper()
+	arts := services.NewArtifactService(db)
+	deadline := time.Now().Add(waitPollTimeout)
+	for time.Now().Before(deadline) {
+		if body, ok := arts.Get(runID, services.RunErrorArtifactName); ok && body != "" {
+			return body
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("expected run_error.json artifact")
+	return ""
+}
+
 func waitReactPause(t *testing.T, db *gorm.DB, runID, nodeID string) {
 	t.Helper()
 	deadline := time.Now().Add(waitPollTimeout)

--- a/server/internal/engine/fakeprovider_test.go
+++ b/server/internal/engine/fakeprovider_test.go
@@ -105,6 +105,11 @@ type fakeProvider struct {
 	// retired records nodes whose parked session was released.
 	reviseCalls map[string]int
 	retired     map[string]bool
+	// wrapUpCalls counts OfferCommitOnConfirm per node id; wrapUpAfterRetire
+	// is set if wrap-up ran after RetireSession (ordering bug).
+	wrapUpCalls       map[string]int
+	wrapUpAfterRetire bool
+	wrapUpMsg         string
 	// reactReplyCalls counts ReactReply invocations per node id (assert review
 	// force no longer routes through Agent wrap-up).
 	reactReplyCalls map[string]int
@@ -525,6 +530,19 @@ func (f *fakeProvider) ReviseInPlace(ctx context.Context, req runtime.NodeReq, h
 	f.mu.Unlock()
 	return runtime.ReactTurn{Msg: msg, Done: false, Err: revErr, Usage: usage,
 		Events: []models.AcpEvent{{Kind: "message", Text: "revise-in-place"}}}
+}
+
+func (f *fakeProvider) OfferCommitOnConfirm(ctx context.Context, req runtime.NodeReq) runtime.ReactTurn {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.retired[f.parkKey(req.RunID, req.NodeID)] {
+		f.wrapUpAfterRetire = true
+	}
+	if f.wrapUpCalls == nil {
+		f.wrapUpCalls = map[string]int{}
+	}
+	f.wrapUpCalls[req.NodeID]++
+	return runtime.ReactTurn{Msg: f.wrapUpMsg}
 }
 
 func (f *fakeProvider) HasLiveSession(runID, nodeID string) bool {

--- a/server/internal/engine/finish.go
+++ b/server/internal/engine/finish.go
@@ -190,6 +190,12 @@ func (e *Engine) finish(runID, status string) bool {
 		e.finalizeActiveStateRuns(runID, status)
 		e.supersedePendingGates(runID, status)
 	}
+	// Persist run_error.json before AbortRun so (1) DB pollers that see
+	// status=failed already have the product, and (2) live sandbox logs can
+	// still be archived. AbortRun tears containers down.
+	if status == "failed" {
+		e.persistRunErrorArtifact(runID)
+	}
 	if status == "completed" || status == "failed" || status == "cancelled" {
 		if e.shareRevoker != nil {
 			e.shareRevoker.RevokeUnusedForRun(runID)
@@ -197,9 +203,6 @@ func (e *Engine) finish(runID, status string) bool {
 
 		if ab, ok := e.provider.(runtime.RunAborter); ok {
 			ab.AbortRun(runID)
-		}
-		if status == "failed" {
-			e.persistRunErrorArtifact(runID)
 		}
 		e.host.UnregisterRun(runID)
 		e.mu.Lock()

--- a/server/internal/engine/resume.go
+++ b/server/internal/engine/resume.go
@@ -358,8 +358,9 @@ func (e *Engine) snapshotPreviewIssues(c *execCtx, runID, nodeID string) error {
 // dialogue. For a clarify (react) node completion is agent-driven (finishes
 // when the agent raises no further questions, force, or the round cap). For a
 // review node the two actions are explicit: force=false does one in-place edit
-// and STAYS paused ("继续改"); force=true accepts the current store snapshot
-// without Agent wrap-up, re-validates, and advances the FSM ("确认并流转").
+// and STAYS paused ("继续改"); force=true asks the agent to wrap up leftover
+// dirty git (if any), re-validates the store snapshot, and advances the FSM
+// ("确认并流转").
 // Annotations are folded into the human instruction so the agent edits the
 // exact cited spots on revise turns.
 //
@@ -448,7 +449,7 @@ func (e *Engine) ReactReply(runID, nodeID, humanText string, images []models.Pro
 		return errors.New("react already done")
 	}
 
-	// Review force: human turn is recorded, then finalize without Agent wrap-up.
+	// Review force: human turn is recorded, then git wrap-up + finalize.
 	// Review !force already returned via EnqueueReviewTurn above.
 	if isReviewNode(node.Type) {
 		if !force {

--- a/server/internal/engine/review.go
+++ b/server/internal/engine/review.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"time"
@@ -242,9 +243,10 @@ func isReviewNode(nodeType string) bool {
 	return nodeType != "react" && nodereg.ReviewCapable(nodeType)
 }
 
-// reviewReply finalizes a post-run review dialogue when force=true: accepts the
-// current store snapshot without Agent wrap-up, re-validates the product
-// contract, then Done+RetireSession+routeSuccess (or keep paused on failure).
+// reviewReply finalizes a post-run review dialogue when force=true: if the
+// parked sandbox still has uncommitted code, the agent decides what to commit
+// (skipping temp files); then the store snapshot is re-validated and the FSM
+// advances (Done+RetireSession+routeSuccess, or keep paused on failure).
 // Non-force revise turns are handled by EnqueueReviewTurn / pumpReviewSession
 // (platform FIFO + turn_begin materialization). The caller (ReactReply) already
 // appended the human turn to conv and holds the per-conversation lock.
@@ -252,19 +254,29 @@ func (e *Engine) reviewReply(c *execCtx, node *models.Node, conv *models.ReactCo
 	runID, nodeID := c.run.ID, node.ID
 	_ = human
 	_ = images
-	_ = e.nodeReq(c, node) // SetActiveNode + KeepAliveForReview (no ClearOutcome)
+	req := e.nodeReq(c, node) // SetActiveNode + KeepAliveForReview (no ClearOutcome)
 	e.host.SetActiveReview(runID, true)
 
 	if !force {
 		return errors.New("internal: review non-force must use EnqueueReviewTurn")
 	}
 
-	// Force finish (no Agent): retire parked session, finalize from the store
-	// snapshot, run afterDefaultChecks, then Done only on success.
+	// Force finish: optional git wrap-up (agent decides commits), then retire
+	// the parked session, finalize from the store snapshot, run afterDefaultChecks,
+	// then Done only on success.
 	// Must not call ReactReply / finishAgentOutcome / TakeOutcome / routeFailure.
-	// Human turn is already persisted by ReactReply; no Agent prompt is sent.
+	// Human turn is already persisted by ReactReply.
 	// Ready-gate is enforced by ReactReply before taking the lock.
 	if rp, ok := e.provider.(runtime.ReviewProvider); ok {
+		t := rp.OfferCommitOnConfirm(context.Background(), req)
+		if strings.TrimSpace(t.Msg) != "" {
+			conv.Messages = append(conv.Messages, models.ReactMessage{
+				Role: "agent", Text: t.Msg, At: time.Now().Format(time.RFC3339),
+			})
+			logDB(e.db.Save(conv), runID, "save review git wrap-up")
+		}
+		e.flushMcpCalls(runID, nodeID)
+		e.flushTokenUsage(runID, nodeID, t.Usage, t.UsageByModel)
 		rp.RetireSession(runID, nodeID)
 	}
 
@@ -381,14 +393,24 @@ func (e *Engine) GateReactInfo(runID, gateNodeID string) (producerID string, ali
 
 // retireGateUpstreamSession releases the parked review session of a gate's
 // upstream producer once the gate is resolved (approve/select/reject decided).
+// If the producer still has uncommitted code, the agent decides what to commit
+// first so gate-ReAct edits are not dropped with the sandbox.
 func (e *Engine) retireGateUpstreamSession(c *execCtx, gateNode *models.Node) {
 	rp, ok := e.provider.(runtime.ReviewProvider)
 	if !ok {
 		return
 	}
-	if producerID := e.gateProducerNodeID(c, gateNode); producerID != "" {
-		rp.RetireSession(c.run.ID, producerID)
+	producerID := e.gateProducerNodeID(c, gateNode)
+	if producerID == "" {
+		return
 	}
+	if producer := c.graph.FindNode(producerID); producer != nil {
+		req := e.nodeReq(c, producer)
+		t := rp.OfferCommitOnConfirm(context.Background(), req)
+		e.flushMcpCalls(c.run.ID, producerID)
+		e.flushTokenUsage(c.run.ID, producerID, t.Usage, t.UsageByModel)
+	}
+	rp.RetireSession(c.run.ID, producerID)
 }
 
 // refreshProducerOutputs re-derives a producer node's outputs from its (edited)

--- a/server/internal/engine/review_test.go
+++ b/server/internal/engine/review_test.go
@@ -156,6 +156,12 @@ func TestReviewEnterReviseFinish(t *testing.T) {
 	if !provider.retired[provider.parkKey(run.ID, "prop")] {
 		t.Fatal("expected RetireSession on review force success")
 	}
+	if provider.wrapUpCalls["prop"] != 1 {
+		t.Fatalf("expected OfferCommitOnConfirm once before retire, got %d", provider.wrapUpCalls["prop"])
+	}
+	if provider.wrapUpAfterRetire {
+		t.Fatal("OfferCommitOnConfirm must run before RetireSession")
+	}
 	waitRunStatus(t, db, run.ID, "completed")
 
 	db.Where("run_id = ? AND node_id = ?", run.ID, "prop").First(&conv)
@@ -166,6 +172,41 @@ func TestReviewEnterReviseFinish(t *testing.T) {
 	// The reserved product survived the review and remains in the store.
 	if _, ok := arts(db, run.ID, mcp.ProposalsArtifactName); !ok {
 		t.Fatalf("proposals.json missing after review finish")
+	}
+}
+
+// TestReviewForcePersistsGitWrapUp: confirm-time OfferCommitOnConfirm narration
+// is stored as the agent turn answering the human「确认」.
+func TestReviewForcePersistsGitWrapUp(t *testing.T) {
+	eng, db, provider := setupReviewEngine(t, true)
+	provider.wrapUpMsg = "已提交 src/a.go,跳过 tmp.log"
+
+	run, err := eng.StartRun("review-wf", map[string]any{"idea": "登录"}, "test")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitReactPause(t, db, run.ID, "prop")
+
+	if err := eng.ReactReply(run.ID, "prop", "确认", nil, nil, true); err != nil {
+		t.Fatalf("finish reply: %v", err)
+	}
+	waitRunStatus(t, db, run.ID, "completed")
+
+	var conv models.ReactConversation
+	if err := db.Where("run_id = ? AND node_id = ?", run.ID, "prop").First(&conv).Error; err != nil {
+		t.Fatalf("load conv: %v", err)
+	}
+	if !conv.Done {
+		t.Fatal("expected Done")
+	}
+	var saw bool
+	for _, m := range conv.Messages {
+		if m.Role == "agent" && m.Text == provider.wrapUpMsg {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Fatalf("git wrap-up narration not persisted: %+v", conv.Messages)
 	}
 }
 

--- a/server/internal/engine/run_failure_observability_test.go
+++ b/server/internal/engine/run_failure_observability_test.go
@@ -84,10 +84,7 @@ func TestResearchEarlyFailureThreeChannelsNonEmpty(t *testing.T) {
 
 	// (b) run_error.json product
 	arts := services.NewArtifactService(db)
-	body, ok := arts.Get(run.ID, services.RunErrorArtifactName)
-	if !ok || body == "" {
-		t.Fatal("expected run_error.json artifact")
-	}
+	body := waitRunErrorArtifact(t, db, run.ID)
 	var parsed map[string]any
 	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
 		t.Fatalf("parse run_error.json: %v\n%s", err, body)
@@ -201,10 +198,7 @@ func TestResearchEarlyFailureNoSandboxLogBoundary(t *testing.T) {
 	if !strings.Contains(info.DisplayReason(), services.NoSandboxLogMarker) {
 		t.Fatalf("display=%q", info.DisplayReason())
 	}
-	body, ok := services.NewArtifactService(db).Get(run.ID, services.RunErrorArtifactName)
-	if !ok {
-		t.Fatal("missing run_error.json")
-	}
+	body := waitRunErrorArtifact(t, db, run.ID)
 	if !strings.Contains(body, services.NoSandboxLogMarker) && !strings.Contains(body, `"noSandboxLog": true`) {
 		t.Fatalf("run_error.json missing no-log signal: %s", body)
 	}
@@ -257,7 +251,5 @@ func TestFailRunEarlyExitPersistsReason(t *testing.T) {
 	if !strings.Contains(info.DisplayReason(), "加载运行上下文失败") {
 		t.Fatalf("display=%q", info.DisplayReason())
 	}
-	if _, ok := services.NewArtifactService(db).Get(stubID, services.RunErrorArtifactName); !ok {
-		t.Fatal("expected run_error.json from failRun")
-	}
+	waitRunErrorArtifact(t, db, stubID)
 }

--- a/server/internal/models/prompts.go
+++ b/server/internal/models/prompts.go
@@ -78,6 +78,9 @@ type AgentPrompts struct {
 	OutcomeContract string `json:"outcomeContract,omitempty"`
 	// OutcomeRetry is the re-prompt when the agent finished without node_complete.
 	OutcomeRetry string `json:"outcomeRetry,omitempty"`
+	// ReviewCommitWrapUp is sent on ReAct「确认并流转」when the parked sandbox
+	// still has uncommitted working-tree changes. Supports `{files}`.
+	ReviewCommitWrapUp string `json:"reviewCommitWrapUp,omitempty"`
 }
 
 // Built-in default prompt fragments. These are the exact strings the platform
@@ -108,6 +111,7 @@ const (
 	DefaultPreviewRetry                 = "【必须完成】你尚未成功调用 `set_preview` 注册**可达**的预览端口。请在沙箱内用 `setsid`/`nohup` **真后台**原生启动应用(不要用 docker、不要前台占会话),监听 `0.0.0.0:<port>`(不能只绑 127.0.0.1;服务在根路径 `/`),确认端口可访问后再调用 `set_preview(port, label?)`。端口不可达时 set_preview 会失败,修复后可重试。"
 	DefaultOutcomeContract              = "\n\n## 完成标记契约(强制)\n结束本节点前**必须**调用 `node_complete` 标记结果:`status` 取 `success` 或 `failed`;可选 `summary` / `error` / `outputs` / `checks`。写完产物(`set_*` / `write_artifact`)后再调用。未标记将被判定为节点失败。平台先做默认校验(产物/门禁等),通过后才可能做业务 RPC 校验。若需启动长期服务(web / dsh / Harness / 被测应用等),必须用 `setsid`/`nohup` 放入独立会话并重定向日志,禁止前台或未脱钩的命令占住 Agent 回合;不要为收尾杀掉这些进程。\n"
 	DefaultOutcomeRetry                 = "【必须完成】你尚未调用 `node_complete` 标记本节点完成结果,这是强制要求。现在立即调用 `node_complete(status=\"success\"|\"failed\", summary?, error?, outputs?)`,不要再提问或输出其它内容——只需完成这次调用。\n"
+	DefaultReviewCommitWrapUp           = "【流转收尾】用户已确认本节点,即将进入下一步。工作区仍有未提交改动:\n{files}\n\n以上列表可能含已相对基线提交的文件,请以各仓 `git status` 为准,只处理未暂存/未提交的内容。\n\n请你自行决定要不要提交:\n- 有意义的源码/配置改动:按仓 `cd` 进 `/root/workspace/<name>/`,用 `git add` **点名文件**(禁止 `git add -A` / `git add .`),再 `git commit`(写清 why)并 `git push` 当前工作分支。下游节点在全新克隆里工作,不推送就拿不到这些改动。\n- 临时文件、日志、缓存、构建产物、本地密钥、调试垃圾:**不要提交**,保持未跟踪即可。\n- 若全部都是临时文件:什么都不要做,不要空提交。\n- 禁止在 main/master/develop/release-* 上提交或推送。\n- 不要提问、不要改产物、不要调用 node_complete。做完后用一两句话说明提交了什么、跳过了什么即可。\n"
 
 	// DefaultFeedbackHeader is injected only when this node actually has human
 	// feedback in scope. Storing feedback that no agent ever reads is the same
@@ -326,4 +330,17 @@ func (p *AgentPrompts) OutcomeRetryText() string {
 		return p.OutcomeRetry
 	}
 	return DefaultOutcomeRetry
+}
+
+// ReviewCommitWrapUpFor returns the confirm-time git wrap-up prompt with the
+// dirty-file list substituted for {files}. Nil-safe.
+func (p *AgentPrompts) ReviewCommitWrapUpFor(files string) string {
+	tmpl := DefaultReviewCommitWrapUp
+	if p != nil && strings.TrimSpace(p.ReviewCommitWrapUp) != "" {
+		tmpl = p.ReviewCommitWrapUp
+	}
+	if strings.TrimSpace(files) == "" {
+		files = "(工作区 git status 为 dirty,未能列出文件)"
+	}
+	return strings.ReplaceAll(tmpl, "{files}", files)
 }

--- a/server/internal/models/prompts_more_test.go
+++ b/server/internal/models/prompts_more_test.go
@@ -41,6 +41,19 @@ func TestAgentPromptsRemainingContracts(t *testing.T) {
 	if p.OutcomeContractText() != "OC" || p.OutcomeRetryText() != "OR" {
 		t.Fatal("outcome overrides")
 	}
+	if nilP.ReviewCommitWrapUpFor("a.go") == "" {
+		t.Fatal("nil review commit wrap-up")
+	}
+	p.ReviewCommitWrapUp = "FILES:{files}"
+	if got := p.ReviewCommitWrapUpFor("- untracked tmp.log"); got != "FILES:- untracked tmp.log" {
+		t.Fatalf("wrap-up=%q", got)
+	}
+	got := (&AgentPrompts{}).ReviewCommitWrapUpFor("- untracked tmp.log")
+	for _, want := range []string{"禁止 `git add -A`", "tmp.log", "临时文件", "git status"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("DefaultReviewCommitWrapUp missing %q\n%s", want, got)
+		}
+	}
 }
 
 func TestDefaultOutcomeContractDetachesLongRunningServices(t *testing.T) {

--- a/server/internal/runtime/acp_review_git.go
+++ b/server/internal/runtime/acp_review_git.go
@@ -1,0 +1,146 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/sandbox"
+	"github.com/rs/zerolog/log"
+)
+
+const reviewDirtyFileCap = 80
+
+// OfferCommitOnConfirm asks the parked agent to decide whether leftover dirty
+// files should be committed (skipping temp files), then pushes already-committed
+// working branches. No-op when the node does not touch repos, no session is
+// parked, or the tree is clean and already pushed. Never fails the confirm.
+func (c *acpProvider) OfferCommitOnConfirm(ctx context.Context, req NodeReq) ReactTurn {
+	if !nodeTouchesRepos(req.NodeType) {
+		return ReactTurn{}
+	}
+	key := reactKey(req)
+	c.mu.Lock()
+	sess := c.sessions[key]
+	c.mu.Unlock()
+	if sess == nil || sess.sb == nil {
+		return ReactTurn{}
+	}
+
+	ch := c.collectChanges(ctx, sess.sb, req)
+	dirty, unpushed := reviewGitNeedsWrapUp(ch)
+	if !dirty && !unpushed {
+		return ReactTurn{}
+	}
+
+	var usage *models.TokenUsage
+	var usageByModel models.TokenUsageByModel
+	var events []models.AcpEvent
+	var narration string
+
+	if dirty {
+		connected := sess.acp != nil && sess.acp.IsConnected()
+		if !connected {
+			log.Warn().Str("run", req.RunID).Str("node", req.NodeID).
+				Msg("review confirm git wrap-up skipped: session disconnected")
+		} else {
+			files := formatDirtyFiles(ch)
+			prompt := c.agentPrompts(str2(req.Config["skill_profile"])).ReviewCommitWrapUpFor(files)
+			chatCtx, cancel := context.WithTimeout(ctx, c.nodeChatTimeout(req))
+			res, err := c.streamChat(chatCtx, sess.acp, req, prompt, nil)
+			cancel()
+			if err != nil {
+				log.Warn().Err(err).Str("run", req.RunID).Str("node", req.NodeID).
+					Msg("review confirm git wrap-up chat failed")
+			} else {
+				absorbChat(&usage, &usageByModel, &events, res)
+				narration = res.Narration
+				c.host.TakePendingQuestions(req.RunID, req.NodeID)
+			}
+		}
+	}
+
+	log.Info().Str("run", req.RunID).Str("node", req.NodeID).
+		Str("node_type", req.NodeType).
+		Bool("dirty", dirty).Bool("unpushed", unpushed).
+		Bool("asked_agent", narration != "").
+		Msg("review confirm git wrap-up")
+
+	c.pushWorkingBranches(ctx, sess.sb, req)
+	return ReactTurn{Msg: narration, Events: events, Usage: usage, UsageByModel: usageByModel}
+}
+
+// reviewGitNeedsWrapUp reports whether the change report has an uncommitted
+// working tree (dirty) and/or local commits that have not reached origin.
+func reviewGitNeedsWrapUp(ch *sandbox.Changes) (dirty, unpushed bool) {
+	if ch == nil || ch.VCS == "" || ch.VCS == "none" {
+		return false, false
+	}
+	if ch.VCS == "multi" {
+		for _, r := range ch.Repos {
+			d, u := repoNeedsWrapUp(r.Dirty, r.Unpushed, r.Ahead, r.Pushed, len(r.Commits))
+			dirty = dirty || d
+			unpushed = unpushed || u
+		}
+		return dirty, unpushed
+	}
+	return repoNeedsWrapUp(ch.Dirty, ch.Unpushed, ch.Ahead, ch.Pushed, len(ch.Commits))
+}
+
+func repoNeedsWrapUp(dirtyFlag bool, unpushedCount, ahead int, pushed bool, commits int) (dirty, unpushed bool) {
+	dirty = dirtyFlag
+	unpushed = unpushedCount > 0 || (!pushed && (ahead > 0 || commits > 0))
+	return dirty, unpushed
+}
+
+// formatDirtyFiles lists changed paths in dirty working trees for the wrap-up
+// prompt (relative to the session baseline, including untracked files).
+func formatDirtyFiles(ch *sandbox.Changes) string {
+	if ch == nil {
+		return ""
+	}
+	var b strings.Builder
+	listed := 0
+	if ch.VCS == "multi" {
+		for _, r := range ch.Repos {
+			if !r.Dirty {
+				continue
+			}
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			fmt.Fprintf(&b, "仓 `%s` (`%s`):\n", r.Name, r.Path)
+			listed += writeDirtyFileLines(&b, r.ChangedFiles, listed)
+		}
+		return strings.TrimRight(b.String(), "\n")
+	}
+	if ch.Dirty {
+		writeDirtyFileLines(&b, ch.ChangedFiles, 0)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func writeDirtyFileLines(b *strings.Builder, files []sandbox.ChangedFile, already int) int {
+	wrote := 0
+	for _, f := range files {
+		if already+wrote >= reviewDirtyFileCap {
+			fmt.Fprintf(b, "- …另有未列出的改动\n")
+			return wrote + 1
+		}
+		if strings.TrimSpace(f.Path) == "" {
+			continue
+		}
+		status := f.Status
+		if status == "" {
+			status = "modified"
+		}
+		fmt.Fprintf(b, "- %s %s\n", status, f.Path)
+		wrote++
+	}
+	if wrote == 0 {
+		b.WriteString("- (git status dirty,未能列出具体文件)\n")
+		wrote++
+	}
+	return wrote
+}

--- a/server/internal/runtime/acp_review_git_test.go
+++ b/server/internal/runtime/acp_review_git_test.go
@@ -1,0 +1,234 @@
+package runtime
+
+import (
+	"context"
+	"io"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cocofhu/approving/internal/mcp"
+	"github.com/cocofhu/approving/internal/sandbox"
+)
+
+func TestReviewGitNeedsWrapUp(t *testing.T) {
+	dirty, unpushed := reviewGitNeedsWrapUp(nil)
+	if dirty || unpushed {
+		t.Fatalf("nil: dirty=%v unpushed=%v", dirty, unpushed)
+	}
+	dirty, unpushed = reviewGitNeedsWrapUp(&sandbox.Changes{VCS: "none"})
+	if dirty || unpushed {
+		t.Fatalf("none: dirty=%v unpushed=%v", dirty, unpushed)
+	}
+	dirty, unpushed = reviewGitNeedsWrapUp(&sandbox.Changes{VCS: "git", Dirty: true, Pushed: true})
+	if !dirty || unpushed {
+		t.Fatalf("dirty clean-remote: dirty=%v unpushed=%v", dirty, unpushed)
+	}
+	dirty, unpushed = reviewGitNeedsWrapUp(&sandbox.Changes{VCS: "git", Dirty: false, Pushed: false, Ahead: 2})
+	if dirty || !unpushed {
+		t.Fatalf("unpushed commits: dirty=%v unpushed=%v", dirty, unpushed)
+	}
+	ch := &sandbox.Changes{VCS: "multi", Repos: []sandbox.RepoChanges{
+		{Name: "app", Changes: sandbox.Changes{Dirty: false, Pushed: true}},
+		{Name: "api", Changes: sandbox.Changes{Dirty: true, Unpushed: 1}},
+	}}
+	dirty, unpushed = reviewGitNeedsWrapUp(ch)
+	if !dirty || !unpushed {
+		t.Fatalf("multi: dirty=%v unpushed=%v", dirty, unpushed)
+	}
+}
+
+func TestFormatDirtyFiles(t *testing.T) {
+	got := formatDirtyFiles(&sandbox.Changes{
+		VCS:   "git",
+		Dirty: true,
+		ChangedFiles: []sandbox.ChangedFile{
+			{Path: "src/a.go", Status: "modified"},
+			{Path: "tmp.log", Status: "untracked"},
+		},
+	})
+	if !strings.Contains(got, "modified src/a.go") || !strings.Contains(got, "untracked tmp.log") {
+		t.Fatalf("single-repo list: %q", got)
+	}
+	got = formatDirtyFiles(&sandbox.Changes{
+		VCS: "multi",
+		Repos: []sandbox.RepoChanges{
+			{Name: "app", Path: "/root/workspace/app", Changes: sandbox.Changes{
+				Dirty:        true,
+				ChangedFiles: []sandbox.ChangedFile{{Path: "x.go", Status: "untracked"}},
+			}},
+			{Name: "clean", Path: "/root/workspace/clean", Changes: sandbox.Changes{Dirty: false}},
+		},
+	})
+	if !strings.Contains(got, "仓 `app`") || !strings.Contains(got, "untracked x.go") {
+		t.Fatalf("multi list: %q", got)
+	}
+	if strings.Contains(got, "clean") {
+		t.Fatalf("clean repo should be omitted: %q", got)
+	}
+}
+
+func TestPushWorkingBranchesOmitsGitAdd(t *testing.T) {
+	var add, push atomic.Bool
+	restore := sandbox.SetExecHook(func(_ context.Context, _ string, _ int, command string, stdin io.Reader) ([]byte, error) {
+		body := execHookBody(command, stdin)
+		if strings.Contains(body, "git add -A") {
+			add.Store(true)
+		}
+		if strings.Contains(body, "git push -u origin") {
+			push.Store(true)
+		}
+		return []byte(""), nil
+	})
+	defer restore()
+
+	host := mcp.NewHost(newMemStore())
+	p := newACPProvider(host, Options{}).(*acpProvider)
+	sb := &sandbox.Sandbox{Name: "sb", Host: "127.0.0.1", Port: 1, WorkspaceDir: "/root/workspace"}
+	req := NodeReq{Vars: map[string]any{"repos": `[{"name":"app","url":"https://h/app.git"}]`}}
+	p.pushWorkingBranches(context.Background(), sb, req)
+	if add.Load() {
+		t.Fatal("pushWorkingBranches must not git add -A")
+	}
+	if !push.Load() {
+		t.Fatal("pushWorkingBranches should git push")
+	}
+}
+
+func TestOfferCommitOnConfirmNoSessionOrNonRepoNode(t *testing.T) {
+	host := mcp.NewHost(newMemStore())
+	p := newACPProvider(host, Options{}).(*acpProvider)
+	if t0 := p.OfferCommitOnConfirm(context.Background(), NodeReq{RunID: "r", NodeID: "n", NodeType: "implement"}); t0.Msg != "" {
+		t.Fatalf("no session: %+v", t0)
+	}
+	p.sessions["r|n"] = &reactSession{sb: &sandbox.Sandbox{Name: "sb"}}
+	if t1 := p.OfferCommitOnConfirm(context.Background(), NodeReq{RunID: "r", NodeID: "n", NodeType: "proposal"}); t1.Msg != "" {
+		t.Fatalf("proposal: %+v", t1)
+	}
+}
+
+func dirtyGitReport() string {
+	return strings.Join([]string{
+		"VCS\tgit",
+		"HEAD\tdeadbeef",
+		"BRANCH\tfeat",
+		"BASEBRANCH\tmain",
+		"BASE\tcafebabe",
+		"DIRTY\t1",
+		"PUSHED\t0",
+		"REMOTESHA\t",
+		"UNPUSHED\t0",
+		"AHEAD\t0",
+		"UNTRACKED\ttmp.log",
+	}, "\n")
+}
+
+func TestOfferCommitOnConfirmDirtyWithoutACPStillPushes(t *testing.T) {
+	var add, push atomic.Bool
+	restore := sandbox.SetExecHook(func(_ context.Context, _ string, _ int, command string, stdin io.Reader) ([]byte, error) {
+		body := execHookBody(command, stdin)
+		if strings.Contains(body, "printf 'DIRTY") || strings.Contains(body, "UNTRACKED") {
+			return []byte(dirtyGitReport()), nil
+		}
+		if strings.Contains(body, "git add -A") {
+			add.Store(true)
+		}
+		if strings.Contains(body, "git push -u origin") {
+			push.Store(true)
+		}
+		return []byte(""), nil
+	})
+	defer restore()
+
+	host := mcp.NewHost(newMemStore())
+	p := newACPProvider(host, Options{}).(*acpProvider)
+	sb := &sandbox.Sandbox{Name: "sb", Host: "127.0.0.1", Port: 1, WorkspaceDir: "/root/workspace"}
+	req := NodeReq{RunID: "r", NodeID: "n", NodeType: "implement",
+		Vars: map[string]any{"repos": `[{"name":"app","url":"https://h/app.git"}]`}}
+	p.sessions[reactKey(req)] = &reactSession{sb: sb}
+	turn := p.OfferCommitOnConfirm(context.Background(), req)
+	if turn.Msg != "" {
+		t.Fatalf("disconnected ACP should not chat, got %q", turn.Msg)
+	}
+	if add.Load() {
+		t.Fatal("confirm wrap-up must not auto git add -A")
+	}
+	if !push.Load() {
+		t.Fatal("confirm wrap-up should still push existing commits")
+	}
+}
+
+// TestRunAgentReviewConfirmGitWrapUp parks an implement session and, on confirm,
+// prompts the agent about leftover dirty files instead of git add -A.
+func TestRunAgentReviewConfirmGitWrapUp(t *testing.T) {
+	var addAfterPark, wrapPush atomic.Bool
+	parked := atomic.Bool{}
+	restore := sandbox.SetExecHook(func(_ context.Context, _ string, _ int, command string, stdin io.Reader) ([]byte, error) {
+		body := execHookBody(command, stdin)
+		if strings.Contains(body, "printf 'DIRTY") || strings.Contains(body, "ls-files --others") {
+			return []byte(dirtyGitReport()), nil
+		}
+		if parked.Load() && strings.Contains(body, "git add -A") {
+			addAfterPark.Store(true)
+		}
+		if parked.Load() && strings.Contains(body, "git push -u origin") {
+			wrapPush.Store(true)
+		}
+		return []byte(""), nil
+	})
+	defer restore()
+
+	store := newMemStore()
+	host := mcp.NewHost(store)
+	runID, nodeID := "wrap-run", "impl"
+	tok := host.RegisterRun(runID)
+	t.Cleanup(func() { host.UnregisterRun(runID) })
+	mgr := newFakeManager(t, host, runID, nodeID, tok, func(int) chatFunc {
+		return func(turn int) turnAction {
+			if turn == 0 {
+				return turnAction{narration: "implemented", produces: map[string]string{
+					mcp.ImplementationResultArtifactName: `{"summary":"done"}`,
+					mcp.NodeOutcomeArtifactName:          `{"status":"success"}`,
+				}}
+			}
+			return turnAction{narration: "committed src/a.go, skipped tmp.log"}
+		}
+	})
+	p, _ := newTestProvider(t, host, testOpts(), mgr)
+	req := reqWithProfile(NodeReq{
+		RunID: runID, NodeID: nodeID, NodeType: "implement", Token: tok,
+		KeepAliveForReview: true,
+		Config:             map[string]any{"prompt": "build"},
+		Vars:               map[string]any{"repos": `[{"name":"app","url":"https://h/app.git"}]`},
+	})
+	if _, err := p.RunAgent(context.Background(), req); err != nil {
+		t.Fatalf("RunAgent: %v", err)
+	}
+	if !p.HasLiveSession(runID, nodeID) {
+		t.Fatal("expected parked session")
+	}
+	parked.Store(true)
+	turn := p.OfferCommitOnConfirm(context.Background(), req)
+	if !strings.Contains(turn.Msg, "skipped tmp.log") {
+		t.Fatalf("wrap-up narration=%q", turn.Msg)
+	}
+	var sawPrompt bool
+	for i := 0; ; i++ {
+		pr := mgr.bridge(0).promptAt(i)
+		if pr == "" {
+			break
+		}
+		if strings.Contains(pr, "流转收尾") && strings.Contains(pr, "tmp.log") && strings.Contains(pr, "git add -A") {
+			sawPrompt = true
+		}
+	}
+	if !sawPrompt {
+		t.Fatal("expected confirm wrap-up prompt listing dirty files and forbidding git add -A")
+	}
+	if addAfterPark.Load() {
+		t.Fatal("wrap-up must not git add -A after parking")
+	}
+	if !wrapPush.Load() {
+		t.Fatal("wrap-up should push after the agent decides")
+	}
+}

--- a/server/internal/runtime/acp_run_agent.go
+++ b/server/internal/runtime/acp_run_agent.go
@@ -359,8 +359,19 @@ func (c *acpProvider) harvest(ctx context.Context, sb *sandbox.Sandbox, req Node
 // downstream sandboxes (fresh clones) can check it out. It commits any leftover
 // changes the agent didn't commit, then pushes the current branch. Fully
 // best-effort: no repo / no remote / no credentials → silent no-op (never fails
-// the node).
+// the node). Review confirm uses pushWorkingBranches instead so leftover temp
+// files are not auto-committed.
 func (c *acpProvider) ensurePushed(ctx context.Context, sb *sandbox.Sandbox, req NodeReq) {
+	c.pushRepos(ctx, sb, req, true)
+}
+
+// pushWorkingBranches pushes already-committed working branches without
+// git add/commit, so confirm-time leftover temp files stay untracked.
+func (c *acpProvider) pushWorkingBranches(ctx context.Context, sb *sandbox.Sandbox, req NodeReq) {
+	c.pushRepos(ctx, sb, req, false)
+}
+
+func (c *acpProvider) pushRepos(ctx context.Context, sb *sandbox.Sandbox, req NodeReq, autoCommit bool) {
 	repos := resolveRepos(req)
 	if len(repos) == 0 {
 		return
@@ -376,9 +387,13 @@ if [ -z "$branch" ] || [ "$branch" = "HEAD" ]; then exit 0; fi
 case "$branch" in
   main|master|develop|release-*) echo "on protected branch $branch; skip auto push"; exit 0;;
 esac
-git add -A 2>/dev/null || true
+`
+		if autoCommit {
+			script += `git add -A 2>/dev/null || true
 git diff --cached --quiet 2>/dev/null || git commit -m "chore(approving): implement 收尾自动提交" >/dev/null 2>&1 || true
-git push -u origin "$branch" 2>&1 || true`
+`
+		}
+		script += `git push -u origin "$branch" 2>&1 || true`
 		if out, err := sb.ExecScript(ctx, 90*time.Second, "bash", script); err != nil {
 			log.Debug().Err(err).Str("repo", r.Name).Str("out", strings.TrimSpace(out)).Msg("implement ensurePushed (best-effort)")
 		}

--- a/server/internal/runtime/provider.go
+++ b/server/internal/runtime/provider.go
@@ -193,6 +193,12 @@ type ReviewProvider interface {
 	// returned turn is never Done — finishing is a separate force step handled
 	// by ReactReply.
 	ReviseInPlace(ctx context.Context, req NodeReq, history []models.ReactMessage, human string, images []models.PromptImage) ReactTurn
+	// OfferCommitOnConfirm inspects the parked sandbox working trees before
+	// RetireSession. If any repo is dirty it prompts the agent to selectively
+	// commit meaningful changes (skip temp files) and then pushes already-
+	// committed working branches. Best-effort: never fails the confirm.
+	// Msg is non-empty only when the agent was actually asked to decide.
+	OfferCommitOnConfirm(ctx context.Context, req NodeReq) ReactTurn
 	// HasLiveSession reports whether a parked session is currently held for
 	// (runID, nodeID) — used to decide whether an approval gate can offer the
 	// ReAct reject entry (upstream session still alive).

--- a/server/internal/runtime/registry.go
+++ b/server/internal/runtime/registry.go
@@ -102,6 +102,17 @@ func (r *ProviderRegistry) ReviseInPlace(ctx context.Context, req NodeReq, histo
 	return rp.ReviseInPlace(ctx, req, history, human, images)
 }
 
+// OfferCommitOnConfirm forwards confirm-time git wrap-up to the backend that
+// owns the parked session (same skill_profile routing as ReviseInPlace).
+func (r *ProviderRegistry) OfferCommitOnConfirm(ctx context.Context, req NodeReq) ReactTurn {
+	p := r.providerFor(req)
+	rp, ok := p.(ReviewProvider)
+	if !ok {
+		return ReactTurn{}
+	}
+	return rp.OfferCommitOnConfirm(ctx, req)
+}
+
 // HasLiveSession reports whether any backend holds a parked review session for
 // (runID, nodeID). Sessions are parked on the backend that ran the producer, so
 // we fan out like LiveNodeEvents.

--- a/server/internal/runtime/registry_test.go
+++ b/server/internal/runtime/registry_test.go
@@ -176,4 +176,9 @@ func TestProviderRegistryReviewProviderForwarding(t *testing.T) {
 	if turn.Err == nil && turn.Msg == "" {
 		t.Fatal("expected a revise turn message or error when no session exists")
 	}
+
+	wrap := reg.OfferCommitOnConfirm(context.Background(), NodeReq{RunID: "r", NodeID: "n"})
+	if wrap.Done {
+		t.Fatal("OfferCommitOnConfirm must not mark Done")
+	}
 }


### PR DESCRIPTION
## Summary
- ReAct「确认并流转」以及门禁拆掉上游会话前，检查停住沙箱的工作区（多仓按仓）。
- 有未提交改动时让 Agent 点名 `git add` 并跳过临时文件，禁止 `git add -A`；已提交未推送则只 push。
- implement / 应用预览 / 调研 / 评审会走这条收尾；计划、方案、视觉网页等不碰仓库的节点跳过。implement 生产相的自动提交兜底未改。

## Test plan
- [ ] 实现节点复审改代码后点「确认并流转」：有意义改动被提交推送，临时文件未进 commit
- [ ] 应用预览 ReAct 取点修改后确认：同样按仓选择性提交，预览服务仍保活
- [ ] 工作区干净时确认应立即流转，不打断 Agent
- [ ] 多仓仅脏仓出现在 Agent 清单；干净仓不提交
- [ ] 计划/方案/视觉网页确认不触发 git wrap-up


Made with [Cursor](https://cursor.com)