### PR TITLE
fix(web): 锁定取点标注卡深色面并按祖先纯色填叶子截图

### DIFF
--- a/web/src/components/run/CommentPinInspectCard.test.ts
+++ b/web/src/components/run/CommentPinInspectCard.test.ts
@@ -72,4 +72,40 @@ describe('CommentPinInspectCard', () => {
     expect(rows.text()).toContain('159.3px')
     wrapper.unmount()
   })
+
+  it('locks Demo dark elevated tokens even when html.light is set (g1.1/g1.3)', () => {
+    document.documentElement.classList.add('light')
+    const lightOverride = document.createElement('style')
+    lightOverride.textContent =
+      'html.light{--c-elevated:244 244 245;--c-base:250 250 251;--c-txt:24 24 27;--c-txt2:82 82 91;--c-txt3:161 161 170;}'
+    document.head.appendChild(lightOverride)
+    const wrapper = mountCard()
+    const card = wrapper.get('[data-testid="comment-pin-inspect-card"]').element as HTMLElement
+    expect(card.classList.contains('comment-pin-inspect-card')).toBe(true)
+    expect(card.style.getPropertyValue('--c-elevated').trim()).toBe('28 28 33')
+    expect(card.style.getPropertyValue('--c-base').trim()).toBe('10 10 11')
+    expect(card.style.getPropertyValue('--c-txt').trim()).toBe('237 237 240')
+    expect(card.style.getPropertyValue('--c-txt2').trim()).toBe('161 161 170')
+    expect(card.style.getPropertyValue('--c-txt3').trim()).toBe('110 110 120')
+    expect(card.style.getPropertyValue('--c-line').trim()).toBe('38 38 43')
+    expect(card.style.getPropertyValue('--c-line-strong').trim()).toBe('54 54 62')
+    expect(wrapper.find('[data-testid="comment-pin-save"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="comment-pin-send-chat"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="comment-pin-input"]').exists()).toBe(true)
+    wrapper.unmount()
+    lightOverride.remove()
+    document.documentElement.classList.remove('light')
+  })
+
+  it('keeps dashed thumb at h-11 and allows pin without screenshot (g2.3/g3.2)', async () => {
+    const wrapper = mountCard({ screenshotMissing: true, imageDataUrl: '' })
+    const thumb = wrapper.get('[data-testid="comment-pin-thumb"]')
+    expect(thumb.classes()).toContain('h-11')
+    expect(thumb.classes()).toContain('border-dashed')
+    expect(thumb.text()).toContain('无截图')
+    await wrapper.find('[data-testid="comment-pin-input"]').setValue('仍可落钉')
+    await wrapper.find('[data-testid="comment-pin-save"]').trigger('click')
+    expect(wrapper.emitted('save')?.[0]).toEqual(['仍可落钉'])
+    wrapper.unmount()
+  })
 })

--- a/web/src/components/run/CommentPinInspectCard.vue
+++ b/web/src/components/run/CommentPinInspectCard.vue
@@ -34,6 +34,25 @@ const left = ref(8)
 
 const canSubmit = computed(() => comment.value.trim().length > 0)
 
+/** Demo dark elevated surface; wins over html.light token inheritance. */
+const DEMO_DARK_SURFACE_VARS = {
+  '--c-base': '10 10 11',
+  '--c-elevated': '28 28 33',
+  '--c-line': '38 38 43',
+  '--c-line-strong': '54 54 62',
+  '--c-txt': '237 237 240',
+  '--c-txt2': '161 161 170',
+  '--c-txt3': '110 110 120',
+  '--shadow-card': '0 1px 2px 0 rgba(0, 0, 0, 0.4), 0 1px 3px 0 rgba(0, 0, 0, 0.25)',
+} as const
+
+const cardStyle = computed(() => ({
+  top: `${top.value}px`,
+  left: `${left.value}px`,
+  colorScheme: 'dark' as const,
+  ...DEMO_DARK_SURFACE_VARS,
+}))
+
 type StyleRow = { label: string; value: string; swatch?: string }
 
 function cssColorToHex(value: string | undefined): string | null {
@@ -173,8 +192,8 @@ defineExpose({ placeCardNear })
   <div
     v-show="open"
     ref="cardRef"
-    class="absolute z-20 flex max-h-[calc(100%-24px)] w-[320px] flex-col border border-line-strong bg-elevated shadow-[var(--shadow-card)]"
-    :style="{ top: top + 'px', left: left + 'px' }"
+    class="comment-pin-inspect-card absolute z-20 flex max-h-[calc(100%-24px)] w-[320px] flex-col border border-line-strong bg-elevated shadow-[var(--shadow-card)]"
+    :style="cardStyle"
     data-testid="comment-pin-inspect-card"
     role="dialog"
     :aria-label="t('pages.gateApproval.commentPins.inspectTitle')"

--- a/web/src/lib/shared/htmlPreviewSandbox.captureFill.test.ts
+++ b/web/src/lib/shared/htmlPreviewSandbox.captureFill.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest'
+import { injectInlineInspectScript } from './htmlPreviewSandbox'
+
+const TEST_ID = 'capture-fill-test'
+
+type FillHelpers = {
+  parseCssColorAlpha: (color: string) => number
+  isOpaqueFillColor: (color: string) => boolean
+  resolveOpaqueFillColor: (el: Element) => string
+}
+
+function loadFillHelpers(): FillHelpers {
+  const src = injectInlineInspectScript('<body></body>', TEST_ID)
+  const start = src.indexOf('function parseCssColorAlpha')
+  const end = src.indexOf('function captureElement')
+  expect(start).toBeGreaterThan(-1)
+  expect(end).toBeGreaterThan(start)
+  const helpers = src.slice(start, end)
+  return new Function(`${helpers}; return { parseCssColorAlpha, isOpaqueFillColor, resolveOpaqueFillColor };`)() as FillHelpers
+}
+
+describe('inspect capture opaque fill (g2.1/g3.3)', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    document.documentElement.removeAttribute('style')
+    document.body.removeAttribute('style')
+  })
+
+  it('parses transparent vs opaque CSS colors', () => {
+    const { parseCssColorAlpha, isOpaqueFillColor } = loadFillHelpers()
+    expect(parseCssColorAlpha('transparent')).toBe(0)
+    expect(parseCssColorAlpha('rgba(0, 0, 0, 0)')).toBe(0)
+    expect(isOpaqueFillColor('rgb(10, 10, 11)')).toBe(true)
+    expect(isOpaqueFillColor('#0A0A0B')).toBe(true)
+    expect(isOpaqueFillColor('rgba(237, 237, 240, 0)')).toBe(false)
+  })
+
+  it('uses dark ancestor fill for a transparent light h1 (dark page, no sash/siblings)', () => {
+    const { resolveOpaqueFillColor } = loadFillHelpers()
+    document.documentElement.style.backgroundColor = 'rgb(10, 10, 11)'
+    document.body.style.backgroundColor = 'rgb(10, 10, 11)'
+    document.body.innerHTML = `
+      <div style="background-color: rgb(10, 10, 11);">
+        <div>
+          <div>
+            <h1 id="leaf-h1" style="background-color: transparent; color: rgb(237, 237, 240);">
+              Run 详情：Agent交互产物舞台可拖加宽
+            </h1>
+            <div id="stage-sash" style="background-color: rgb(80, 80, 90);">sash</div>
+          </div>
+        </div>
+      </div>
+    `
+    const h1 = document.getElementById('leaf-h1')
+    expect(h1).toBeTruthy()
+    const fill = resolveOpaqueFillColor(h1!)
+    expect(fill).toBe('rgb(10, 10, 11)')
+    expect(fill).not.toBe('rgb(80, 80, 90)')
+  })
+
+  it('uses white page fill for a transparent dark-text leaf (white page, no regression)', () => {
+    const { resolveOpaqueFillColor } = loadFillHelpers()
+    document.documentElement.style.backgroundColor = 'rgb(255, 255, 255)'
+    document.body.style.backgroundColor = 'rgb(255, 255, 255)'
+    document.body.innerHTML = `
+      <div style="background-color: rgb(255, 255, 255);">
+        <p id="leaf-p" style="background-color: rgba(0, 0, 0, 0); color: rgb(24, 24, 27);">深色字</p>
+      </div>
+    `
+    const fill = resolveOpaqueFillColor(document.getElementById('leaf-p')!)
+    expect(fill).toBe('rgb(255, 255, 255)')
+  })
+
+  it('skips gradient/image layers and keeps walking for a solid ancestor', () => {
+    const { resolveOpaqueFillColor } = loadFillHelpers()
+    document.documentElement.style.backgroundColor = 'rgb(10, 10, 11)'
+    document.body.innerHTML = `
+      <div id="solid" style="background-color: rgb(28, 28, 33);">
+        <div id="grad" style="background-color: rgb(255, 0, 0); background-image: linear-gradient(red, blue);">
+          <span id="leaf" style="background-color: transparent;">hi</span>
+        </div>
+      </div>
+    `
+    const fill = resolveOpaqueFillColor(document.getElementById('leaf')!)
+    expect(fill).toBe('rgb(28, 28, 33)')
+  })
+})

--- a/web/src/lib/shared/htmlPreviewSandbox.test.ts
+++ b/web/src/lib/shared/htmlPreviewSandbox.test.ts
@@ -197,6 +197,21 @@ describe('injectInlineInspectScript', () => {
     expect(result).toContain('Stay in inspect after pick')
     expect(result.indexOf(TEST_ID)).toBeLessThan(result.toLowerCase().indexOf('</body>'))
   })
+
+  it('derives opaque ancestor fill and does not hardcode wrapper/canvas #fff (g2.1/g2.2/g3.1)', () => {
+    const result = injectInlineInspectScript('<body></body>', TEST_ID)
+    expect(result).toContain('function resolveOpaqueFillColor')
+    expect(result).toContain('function isOpaqueFillColor')
+    expect(result).toContain('backgroundImage')
+    expect(result).toContain('var pad=6')
+    expect(result).toContain('innerW+2*pad')
+    expect(result).toContain('ctx.fillStyle=fill')
+    expect(result).toContain("background:'+fill")
+    expect(result).not.toContain('background:#fff')
+    expect(result).not.toContain("fillStyle='#fff'")
+    expect(result).not.toContain('fillStyle="#fff"')
+    expect(result).toContain('wrapper.appendChild(clone)')
+  })
 })
 
 describe('injectPreviewScripts', () => {

--- a/web/src/lib/shared/htmlPreviewSandbox.ts
+++ b/web/src/lib/shared/htmlPreviewSandbox.ts
@@ -230,12 +230,62 @@ function inlineClone(el){
   walk(el,clone);
   return clone;
 }
+function parseCssColorAlpha(color){
+  if(!color)return 0;
+  var c=String(color).trim().toLowerCase();
+  if(c==='transparent')return 0;
+  if(c.indexOf('rgba(')===0){
+    var parts=c.slice(5,-1).split(',');
+    if(parts.length<4)return 1;
+    var a=parseFloat(parts[3]);
+    return isNaN(a)?0:a;
+  }
+  if(c.charAt(0)==='#'){
+    if(c.length===9)return parseInt(c.slice(7,9),16)/255;
+    if(c.length===5)return parseInt(c.charAt(4)+c.charAt(4),16)/255;
+    return 1;
+  }
+  return 1;
+}
+function isOpaqueFillColor(color){
+  return parseCssColorAlpha(color)>=0.99;
+}
+function resolveOpaqueFillColor(el){
+  var node=el;
+  while(node&&node.nodeType===1){
+    try{
+      var cs=window.getComputedStyle(node);
+      var img=cs.backgroundImage;
+      if(!img||img==='none'){
+        var bg=cs.backgroundColor;
+        if(isOpaqueFillColor(bg))return bg;
+      }
+    }catch(e){}
+    if(node===document.documentElement)break;
+    node=node.parentElement;
+  }
+  try{
+    var root=document.documentElement;
+    var body=document.body;
+    var rootBg=root?window.getComputedStyle(root).backgroundColor:'';
+    if(isOpaqueFillColor(rootBg))return rootBg;
+    var bodyBg=body?window.getComputedStyle(body).backgroundColor:'';
+    if(isOpaqueFillColor(bodyBg))return bodyBg;
+    if(rootBg)return rootBg;
+    if(bodyBg)return bodyBg;
+  }catch(e){}
+  return 'rgba(0, 0, 0, 0)';
+}
 function captureElement(el){
   return new Promise(function(resolve){
     try{
+      var pad=6;
       var rect=el.getBoundingClientRect();
-      var w=Math.max(1,Math.ceil(rect.width));
-      var h=Math.max(1,Math.ceil(rect.height));
+      var innerW=Math.max(1,Math.ceil(rect.width));
+      var innerH=Math.max(1,Math.ceil(rect.height));
+      var w=innerW+2*pad;
+      var h=innerH+2*pad;
+      var fill=resolveOpaqueFillColor(el);
       var maxSide=2048;
       var scale=Math.min(2,window.devicePixelRatio||1,maxSide/Math.max(w,h,1));
       var cw=Math.max(1,Math.ceil(w*scale));
@@ -243,7 +293,7 @@ function captureElement(el){
       var clone=inlineClone(el);
       var wrapper=document.createElement('div');
       wrapper.setAttribute('xmlns','http://www.w3.org/1999/xhtml');
-      wrapper.style.cssText='width:'+w+'px;height:'+h+'px;margin:0;padding:0;box-sizing:border-box;overflow:hidden;background:#fff;';
+      wrapper.style.cssText='width:'+w+'px;height:'+h+'px;margin:0;padding:'+pad+'px;box-sizing:border-box;overflow:hidden;background:'+fill+';';
       wrapper.appendChild(clone);
       var serialized=new XMLSerializer().serializeToString(wrapper);
       var svg='<svg xmlns="http://www.w3.org/2000/svg" width="'+cw+'" height="'+ch+'">'+
@@ -256,7 +306,7 @@ function captureElement(el){
           canvas.width=cw;canvas.height=ch;
           var ctx=canvas.getContext('2d');
           if(!ctx){resolve('');return;}
-          ctx.fillStyle='#fff';
+          ctx.fillStyle=fill;
           ctx.fillRect(0,0,cw,ch);
           ctx.drawImage(img,0,0);
           resolve(canvas.toDataURL('image/png'));


### PR DESCRIPTION
避免 html.light 把 CommentPinInspectCard 洗成浅灰卡，并去掉 captureElement 对 wrapper/canvas 的死白填充，使暗底浅字 h1 在 44px 虚线框内可读。

Co-authored-by: Cursor <cursoragent@cursor.com>
