### PR TITLE
feat(web): 产物网格只展示契约产物并保留可重开 pin

### DIFF
--- a/web/src/components/run/ReactArtifactStage.test.ts
+++ b/web/src/components/run/ReactArtifactStage.test.ts
@@ -72,19 +72,19 @@ describe('ReactArtifactStage', () => {
   it('defaults to the pipeline grid tab and opens a new preview tab on card click', async () => {
     const wrapper = mount(ReactArtifactStage, {
       props: {
-        artifacts: [art({ id: 'a1', name: 'note.md', kind: 'markdown' })],
+        artifacts: [art({ id: 'a1', name: 'research.json', kind: 'json' })],
         runId: 'run-1',
       },
       global: { plugins: [i18n()], stubs },
     })
     expect(wrapper.get('[data-testid="react-artifact-tab-grid"]').attributes('aria-selected')).toBe('true')
-    expect(wrapper.get('[data-testid="react-artifact-grid"]').text()).toContain('note.md')
-    expect(wrapper.find('[data-testid="react-artifact-tab-note.md"]').exists()).toBe(false)
-    await wrapper.get('[data-testid="react-artifact-card-note.md"]').trigger('click')
+    expect(wrapper.get('[data-testid="react-artifact-grid"]').text()).toContain('research.json')
+    expect(wrapper.find('[data-testid="react-artifact-tab-research.json"]').exists()).toBe(false)
+    await wrapper.get('[data-testid="react-artifact-card-research.json"]').trigger('click')
     await flushPromises()
     expect(wrapper.find('[data-testid="react-artifact-tab-grid"]').exists()).toBe(true)
-    expect(wrapper.get('[data-testid="react-artifact-tab-note.md"]').attributes('aria-selected')).toBe('true')
-    expect(wrapper.get('[data-testid="artifact-preview"]').text()).toBe('note.md|off')
+    expect(wrapper.get('[data-testid="react-artifact-tab-research.json"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.get('[data-testid="artifact-preview"]').text()).toBe('research.json|off')
     wrapper.unmount()
   })
 
@@ -92,22 +92,22 @@ describe('ReactArtifactStage', () => {
     const wrapper = mount(ReactArtifactStage, {
       props: {
         artifacts: [
-          art({ id: 'a1', name: 'homepage-preview.html', kind: 'html' }),
-          art({ id: 'a2', name: 'copy-variants.md', kind: 'markdown' }),
+          art({ id: 'a1', name: 'research.json', kind: 'json' }),
+          art({ id: 'a2', name: 'plan.json', kind: 'json' }),
         ],
         runId: 'run-1',
       },
       global: { plugins: [i18n()], stubs },
     })
-    await wrapper.get('[data-testid="react-artifact-card-homepage-preview.html"]').trigger('click')
+    await wrapper.get('[data-testid="react-artifact-card-research.json"]').trigger('click')
     await wrapper.get('[data-testid="react-artifact-tab-grid"]').trigger('click')
-    await wrapper.get('[data-testid="react-artifact-card-copy-variants.md"]').trigger('click')
+    await wrapper.get('[data-testid="react-artifact-card-plan.json"]').trigger('click')
     await flushPromises()
-    expect(wrapper.find('[data-testid="react-artifact-tab-homepage-preview.html"]').exists()).toBe(true)
-    expect(wrapper.get('[data-testid="react-artifact-tab-copy-variants.md"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.find('[data-testid="react-artifact-tab-research.json"]').exists()).toBe(true)
+    expect(wrapper.get('[data-testid="react-artifact-tab-plan.json"]').attributes('aria-selected')).toBe('true')
     expect(wrapper.get('[data-testid="react-artifact-tab-grid"]').attributes('aria-selected')).toBe('false')
     const previews = wrapper.findAll('[data-testid="artifact-preview"]')
-    expect(previews.map((n) => n.text())).toEqual(['homepage-preview.html|off', 'copy-variants.md|off'])
+    expect(previews.map((n) => n.text())).toEqual(['research.json|off', 'plan.json|off'])
     wrapper.unmount()
   })
 
@@ -115,8 +115,8 @@ describe('ReactArtifactStage', () => {
     const wrapper = mount(ReactArtifactStage, {
       props: {
         artifacts: [
-          art({ id: 'a1', name: 'homepage-preview.html', kind: 'html', nodeId: 'clarify' }),
-          art({ id: 'a2', name: 'copy-variants.md', kind: 'markdown', nodeId: 'clarify' }),
+          art({ id: 'a1', name: 'research.json', kind: 'json', nodeId: 'clarify' }),
+          art({ id: 'a2', name: 'plan.json', kind: 'json', nodeId: 'clarify' }),
         ],
         runId: 'run-1',
         nodeId: 'clarify',
@@ -124,18 +124,18 @@ describe('ReactArtifactStage', () => {
       },
       global: { plugins: [i18n()], stubs },
     })
-    await wrapper.get('[data-testid="react-artifact-card-homepage-preview.html"]').trigger('click')
+    await wrapper.get('[data-testid="react-artifact-card-research.json"]').trigger('click')
     await wrapper.get('[data-testid="react-artifact-tab-grid"]').trigger('click')
-    await wrapper.get('[data-testid="react-artifact-card-copy-variants.md"]').trigger('click')
+    await wrapper.get('[data-testid="react-artifact-card-plan.json"]').trigger('click')
     await flushPromises()
     const previews = wrapper.findAll('[data-testid="artifact-preview"]')
-    expect(previews.map((n) => n.text())).toEqual(['homepage-preview.html|on', 'copy-variants.md|on'])
+    expect(previews.map((n) => n.text())).toEqual(['research.json|on', 'plan.json|on'])
     wrapper.unmount()
   })
 
   it('pins a preview tab when previewArtifact is set without dropping other open tabs', async () => {
     const first = art({ id: 'a1', name: 'page.html', kind: 'html', revision: 1, updatedAt: 't1' })
-    const note = art({ id: 'a2', name: 'note.md', kind: 'markdown' })
+    const note = art({ id: 'a2', name: 'research.json', kind: 'json' })
     const wrapper = mount(ReactArtifactStage, {
       props: {
         artifacts: [first, note],
@@ -146,17 +146,17 @@ describe('ReactArtifactStage', () => {
     })
     await flushPromises()
     expect(wrapper.get('[data-testid="react-artifact-tab-page.html"]').attributes('aria-selected')).toBe('true')
-    await wrapper.get('[data-testid="react-artifact-card-note.md"]').trigger('click')
+    await wrapper.get('[data-testid="react-artifact-card-research.json"]').trigger('click')
     await flushPromises()
-    expect(wrapper.find('[data-testid="react-artifact-tab-note.md"]').exists()).toBe(true)
-    expect(wrapper.get('[data-testid="react-artifact-tab-note.md"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.find('[data-testid="react-artifact-tab-research.json"]').exists()).toBe(true)
+    expect(wrapper.get('[data-testid="react-artifact-tab-research.json"]').attributes('aria-selected')).toBe('true')
     await wrapper.setProps({
       artifacts: [{ ...first, revision: 2, updatedAt: 't2', sizeBytes: 99 }, note],
       previewArtifact: 'page.html',
     })
     await flushPromises()
     expect(wrapper.find('[data-testid="react-artifact-tab-page.html"]').exists()).toBe(true)
-    expect(wrapper.get('[data-testid="react-artifact-tab-note.md"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.get('[data-testid="react-artifact-tab-research.json"]').attributes('aria-selected')).toBe('true')
     expect(wrapper.get('[data-testid="react-artifact-preview-page.html"]').text()).toContain('page.html')
     wrapper.unmount()
   })
@@ -180,7 +180,7 @@ describe('ReactArtifactStage', () => {
   })
 
   it('opens a pinned tab when the artifact arrives after previewArtifact while still on the grid', async () => {
-    const note = art({ id: 'a2', name: 'note.md', kind: 'markdown' })
+    const note = art({ id: 'a2', name: 'research.json', kind: 'json' })
     const page = art({ id: 'a1', name: 'page.html', kind: 'html', revision: 1 })
     const wrapper = mount(ReactArtifactStage, {
       props: {
@@ -200,7 +200,7 @@ describe('ReactArtifactStage', () => {
   })
 
   it('does not steal focus when a pinned artifact arrives after the user opened another tab', async () => {
-    const note = art({ id: 'a2', name: 'note.md', kind: 'markdown' })
+    const note = art({ id: 'a2', name: 'research.json', kind: 'json' })
     const page = art({ id: 'a1', name: 'page.html', kind: 'html', revision: 1 })
     const wrapper = mount(ReactArtifactStage, {
       props: {
@@ -210,20 +210,20 @@ describe('ReactArtifactStage', () => {
       },
       global: { plugins: [i18n()], stubs },
     })
-    await wrapper.get('[data-testid="react-artifact-card-note.md"]').trigger('click')
+    await wrapper.get('[data-testid="react-artifact-card-research.json"]').trigger('click')
     await flushPromises()
-    expect(wrapper.get('[data-testid="react-artifact-tab-note.md"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.get('[data-testid="react-artifact-tab-research.json"]').attributes('aria-selected')).toBe('true')
     await wrapper.setProps({ artifacts: [note, page], previewArtifact: 'page.html' })
     await flushPromises()
     expect(wrapper.find('[data-testid="react-artifact-tab-page.html"]').exists()).toBe(false)
-    expect(wrapper.get('[data-testid="react-artifact-tab-note.md"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.get('[data-testid="react-artifact-tab-research.json"]').attributes('aria-selected')).toBe('true')
     wrapper.unmount()
   })
 
   it('does not steal focus when an unrelated artifact is added under the same pin', async () => {
     const page = art({ id: 'a1', name: 'page.html', kind: 'html' })
-    const note = art({ id: 'a2', name: 'note.md', kind: 'markdown' })
-    const extra = art({ id: 'a3', name: 'extra.md', kind: 'markdown' })
+    const note = art({ id: 'a2', name: 'research.json', kind: 'json' })
+    const extra = art({ id: 'a3', name: 'plan.json', kind: 'json' })
     const wrapper = mount(ReactArtifactStage, {
       props: {
         artifacts: [page, note],
@@ -235,10 +235,10 @@ describe('ReactArtifactStage', () => {
     await flushPromises()
     expect(wrapper.get('[data-testid="react-artifact-tab-page.html"]').attributes('aria-selected')).toBe('true')
     await wrapper.get('[data-testid="react-artifact-tab-grid"]').trigger('click')
-    await wrapper.get('[data-testid="react-artifact-card-note.md"]').trigger('click')
+    await wrapper.get('[data-testid="react-artifact-card-research.json"]').trigger('click')
     await wrapper.setProps({ artifacts: [page, note, extra], previewArtifact: 'page.html' })
     await flushPromises()
-    expect(wrapper.get('[data-testid="react-artifact-tab-note.md"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.get('[data-testid="react-artifact-tab-research.json"]').attributes('aria-selected')).toBe('true')
     wrapper.unmount()
   })
 
@@ -246,27 +246,27 @@ describe('ReactArtifactStage', () => {
     const wrapper = mount(ReactArtifactStage, {
       props: {
         artifacts: [
-          art({ id: 'a1', name: 'a.html', kind: 'html' }),
-          art({ id: 'a2', name: 'b.md', kind: 'markdown' }),
+          art({ id: 'a1', name: 'research.json', kind: 'json' }),
+          art({ id: 'a2', name: 'plan.json', kind: 'json' }),
         ],
         runId: 'run-1',
       },
       global: { plugins: [i18n()], stubs },
     })
-    await wrapper.get('[data-testid="react-artifact-card-a.html"]').trigger('click')
+    await wrapper.get('[data-testid="react-artifact-card-research.json"]').trigger('click')
     await wrapper.get('[data-testid="react-artifact-tab-grid"]').trigger('click')
-    await wrapper.get('[data-testid="react-artifact-card-b.md"]').trigger('click')
-    await wrapper.get('[data-testid="react-artifact-tab-close-b.md"]').trigger('click')
+    await wrapper.get('[data-testid="react-artifact-card-plan.json"]').trigger('click')
+    await wrapper.get('[data-testid="react-artifact-tab-close-plan.json"]').trigger('click')
     await flushPromises()
-    expect(wrapper.find('[data-testid="react-artifact-tab-b.md"]').exists()).toBe(false)
-    expect(wrapper.get('[data-testid="react-artifact-tab-a.html"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.find('[data-testid="react-artifact-tab-plan.json"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="react-artifact-tab-research.json"]').attributes('aria-selected')).toBe('true')
     wrapper.unmount()
   })
 
   it('opens a noVNC tab from the pipeline card without replacing artifact tabs', async () => {
     const wrapper = mount(ReactArtifactStage, {
       props: {
-        artifacts: [art({ id: 'a1', name: 'note.md', kind: 'markdown' })],
+        artifacts: [art({ id: 'a1', name: 'research.json', kind: 'json' })],
         runId: 'run-1',
         nodeId: 'clarify',
         annotatable: true,
@@ -275,16 +275,16 @@ describe('ReactArtifactStage', () => {
     })
     await flushPromises()
     expect(wrapper.find('[data-testid="react-artifact-card-novnc"]').exists()).toBe(true)
-    await wrapper.get('[data-testid="react-artifact-card-note.md"]').trigger('click')
+    await wrapper.get('[data-testid="react-artifact-card-research.json"]').trigger('click')
     await wrapper.get('[data-testid="react-artifact-tab-grid"]').trigger('click')
     await wrapper.get('[data-testid="react-artifact-card-novnc"]').trigger('click')
     await flushPromises()
-    expect(wrapper.find('[data-testid="react-artifact-tab-note.md"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="react-artifact-tab-research.json"]').exists()).toBe(true)
     expect(wrapper.get('[data-testid="react-artifact-tab-novnc"]').attributes('aria-selected')).toBe('true')
     expect(wrapper.get('[data-testid="novnc-stub"]').attributes('data-inspectable')).toBe('1')
     await wrapper.get('[data-testid="react-artifact-tab-close-novnc"]').trigger('click')
     expect(wrapper.find('[data-testid="react-artifact-tab-novnc"]').exists()).toBe(false)
-    expect(wrapper.get('[data-testid="react-artifact-tab-note.md"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.get('[data-testid="react-artifact-tab-research.json"]').attributes('aria-selected')).toBe('true')
     wrapper.unmount()
   })
 
@@ -361,7 +361,8 @@ describe('ReactArtifactStage', () => {
       nodeId: 'visual_1',
       content: '<p>new</p>',
     })
-    const json = art({ id: 'json', name: 'node_complete.json', kind: 'json', nodeId: 'visual_1' })
+    const json = art({ id: 'json', name: 'research.json', kind: 'json', nodeId: 'research' })
+    const complete = art({ id: 'nc', name: 'node_complete.json', kind: 'json', nodeId: 'visual_1' })
     const other = art({
       id: 'other',
       name: 'visual_other.page.html',
@@ -371,7 +372,7 @@ describe('ReactArtifactStage', () => {
     })
     const wrapper = mount(ReactArtifactStage, {
       props: {
-        artifacts: [live, alias, json, other],
+        artifacts: [live, alias, json, complete, other],
         runId: 'run-1',
         run: {
           id: 'run-1',
@@ -396,8 +397,9 @@ describe('ReactArtifactStage', () => {
     expect(wrapper.find('[data-testid="react-artifact-card-page.html"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="react-artifact-card-visual_1.page.html"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="react-artifact-card-page.html#iter-1"]').exists()).toBe(false)
-    expect(wrapper.find('[data-testid="react-artifact-card-node_complete.json"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="react-artifact-card-visual_other.page.html"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="react-artifact-card-research.json"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="react-artifact-card-node_complete.json"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="react-artifact-card-visual_other.page.html"]').exists()).toBe(false)
     expect(wrapper.findAll('[data-testid="react-artifact-card-page.html"]').length).toBe(1)
     expect(wrapper.get('[data-testid="react-artifact-version-chip-btn-page.html"]').text()).toContain('v2 · 最新')
     expect(wrapper.find('[data-testid="react-artifact-card-iteration"]').exists()).toBe(false)
@@ -419,10 +421,11 @@ describe('ReactArtifactStage', () => {
 
   it('hides the version chip for a single snapshot and still shows json cards', async () => {
     const live = art({ id: 'live', name: 'page.html', kind: 'html', nodeId: 'visual_1', content: '<p>only</p>' })
-    const json = art({ id: 'json', name: 'node_complete.json', kind: 'json', nodeId: 'visual_1' })
+    const json = art({ id: 'json', name: 'research.json', kind: 'json', nodeId: 'research' })
+    const complete = art({ id: 'nc', name: 'node_complete.json', kind: 'json', nodeId: 'visual_1' })
     const wrapper = mount(ReactArtifactStage, {
       props: {
-        artifacts: [live, json],
+        artifacts: [live, json, complete],
         runId: 'run-1',
         run: {
           id: 'run-1',
@@ -438,7 +441,8 @@ describe('ReactArtifactStage', () => {
     })
     await flushPromises()
     expect(wrapper.find('[data-testid="react-artifact-version-chip"]').exists()).toBe(false)
-    expect(wrapper.find('[data-testid="react-artifact-card-node_complete.json"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="react-artifact-card-research.json"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="react-artifact-card-node_complete.json"]').exists()).toBe(false)
     wrapper.unmount()
   })
 
@@ -480,7 +484,7 @@ describe('ReactArtifactStage', () => {
     wrapper.unmount()
   })
 
-  it('uses a footer chip on a standalone visual_*.page.html card when page.html is absent', async () => {
+  it('hides a standalone visual_*.page.html card from the known-product grid', async () => {
     const alias = art({
       id: 'alias',
       name: 'visual_1.page.html',
@@ -509,11 +513,8 @@ describe('ReactArtifactStage', () => {
     })
     await flushPromises()
     expect(wrapper.find('[data-testid="react-artifact-card-page.html"]').exists()).toBe(false)
-    expect(wrapper.find('[data-testid="react-artifact-card-visual_1.page.html"]').exists()).toBe(true)
-    await wrapper.get('[data-testid="react-artifact-version-chip-btn-visual_1.page.html"]').trigger('click')
-    await wrapper.get('[data-testid="react-artifact-version-option-v1"]').trigger('click')
-    await flushPromises()
-    expect(wrapper.get('[data-testid="artifact-preview"]').text()).toBe('visual_1.page.html|off|<p>old</p>')
+    expect(wrapper.find('[data-testid="react-artifact-card-visual_1.page.html"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="react-artifact-grid-empty"]').exists()).toBe(true)
     wrapper.unmount()
   })
 
@@ -579,6 +580,8 @@ describe('ReactArtifactStage', () => {
       'true',
     )
     expect(wrapper.find('[data-testid="react-artifact-tab-page.html"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="react-artifact-card-brand-row-preview.html"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="react-artifact-card-a.html"]').exists()).toBe(false)
     wrapper.unmount()
   })
 
@@ -664,6 +667,91 @@ describe('ReactArtifactStage', () => {
     await flushPromises()
     expect(wrapper.get('[data-testid="react-artifact-tab-grid"]').attributes('aria-selected')).toBe('true')
     expect(wrapper.get('[data-testid="react-artifact-preview-page.html"]').text()).toContain('page.html')
+    wrapper.unmount()
+  })
+
+  it('shows only known products on the visual pipeline grid and pins page.html (s6)', async () => {
+    const research = art({ id: 'r', name: 'research.json', kind: 'json', nodeId: 'research' })
+    const requirement = art({
+      id: 'c',
+      name: 'clarified_requirement.json',
+      kind: 'json',
+      nodeId: 'react_ymx0',
+    })
+    const page = art({ id: 'p', name: 'page.html', kind: 'html', nodeId: 'visual_bqc5' })
+    const complete = art({ id: 'n', name: 'node_complete.json', kind: 'json', nodeId: 'visual_bqc5' })
+    const feedback = art({ id: 'f', name: 'feedback_index.json', kind: 'json', nodeId: 'react_ymx0' })
+    const copy = art({ id: 'v', name: 'visual_bqc5.page.html', kind: 'html', nodeId: 'visual_bqc5' })
+    const demo = art({ id: 'd', name: 'brand-row-preview.html', kind: 'html', nodeId: 'react_ymx0' })
+    const wrapper = mount(ReactArtifactStage, {
+      props: {
+        artifacts: [research, requirement, page, complete, feedback, copy, demo],
+        runId: 'run-1',
+        run: {
+          id: 'run-1',
+          nodes: [
+            { id: 'visual_bqc5', type: 'visual', label: '视觉', position: { x: 0, y: 0 }, config: {} },
+            { id: 'react_ymx0', type: 'react', label: '澄清', position: { x: 0, y: 0 }, config: {} },
+            { id: 'research', type: 'research', label: '调研', position: { x: 0, y: 0 }, config: {} },
+          ],
+        } as any,
+        nodeId: 'visual_bqc5',
+        nodeType: 'visual',
+        remoteKind: 'off',
+      },
+      global: { plugins: [i18n()], stubs },
+    })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="react-artifact-card-research.json"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="react-artifact-card-clarified_requirement.json"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="react-artifact-card-page.html"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="react-artifact-card-node_complete.json"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="react-artifact-card-feedback_index.json"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="react-artifact-card-visual_bqc5.page.html"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="react-artifact-card-brand-row-preview.html"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="react-artifact-tab-page.html"]').attributes('aria-selected')).toBe('true')
+    wrapper.unmount()
+  })
+
+  it('keeps the react auto-pin on the grid so closing the tab remains reopenable', async () => {
+    const requirement = art({
+      id: 'c',
+      name: 'clarified_requirement.json',
+      kind: 'json',
+      nodeId: 'react_ymx0',
+    })
+    const demo = art({ id: 'd', name: 'brand-row-preview.html', kind: 'html', nodeId: 'react_ymx0' })
+    const complete = art({ id: 'n', name: 'node_complete.json', kind: 'json', nodeId: 'react_ymx0' })
+    const wrapper = mount(ReactArtifactStage, {
+      props: {
+        artifacts: [requirement, demo, complete],
+        runId: 'run-1',
+        run: {
+          id: 'run-1',
+          nodes: [{ id: 'react_ymx0', type: 'react', label: '澄清', position: { x: 0, y: 0 }, config: {} }],
+        } as any,
+        nodeId: 'react_ymx0',
+        nodeType: 'react',
+        remoteKind: 'off',
+      },
+      global: { plugins: [i18n()], stubs },
+    })
+    await flushPromises()
+    expect(wrapper.get('[data-testid="react-artifact-tab-brand-row-preview.html"]').attributes('aria-selected')).toBe(
+      'true',
+    )
+    expect(wrapper.find('[data-testid="react-artifact-card-brand-row-preview.html"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="react-artifact-card-node_complete.json"]').exists()).toBe(false)
+    await wrapper.get('[data-testid="react-artifact-tab-close-brand-row-preview.html"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="react-artifact-tab-brand-row-preview.html"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="react-artifact-tab-grid"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.find('[data-testid="react-artifact-card-brand-row-preview.html"]').exists()).toBe(true)
+    await wrapper.get('[data-testid="react-artifact-card-brand-row-preview.html"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.get('[data-testid="react-artifact-tab-brand-row-preview.html"]').attributes('aria-selected')).toBe(
+      'true',
+    )
     wrapper.unmount()
   })
 })

--- a/web/src/components/run/ReactArtifactStage.vue
+++ b/web/src/components/run/ReactArtifactStage.vue
@@ -37,6 +37,7 @@ import {
   resolveStageRemoteKind,
   resolveVisualPagePreviewArtifact,
   shouldActivatePinnedPreview,
+  stageGridArtifactsWithPin,
   type ReactStageRemoteKind,
   type VisualPageVersionChoice,
 } from '@/lib/run/reactArtifactPreview'
@@ -133,9 +134,20 @@ const resolvedRemoteKind = computed(() =>
 const stageNode = computed(() => props.run?.nodes?.find((n) => n.id === props.nodeId) || null)
 const resolvedNodeType = computed(() => String(props.nodeType || stageNode.value?.type || '').trim())
 const stageArtifacts = computed(() => expandStageArtifacts(props.artifacts, props.run, stageNode.value))
+const effectivePin = computed(() =>
+  resolveEffectivePreviewPin({
+    previewArtifact: props.previewArtifact,
+    artifacts: stageArtifacts.value,
+    nodeType: resolvedNodeType.value,
+    nodeId: props.nodeId,
+  }),
+)
+const gridArtifacts = computed(() =>
+  stageGridArtifactsWithPin(stageArtifacts.value, props.run, effectivePin.value),
+)
 const canOpenNovnc = computed(() => resolvedRemoteKind.value !== 'off')
 const showingNovnc = computed(() => activeTab.value === REACT_STAGE_TAB_NOVNC)
-const showGridCards = computed(() => stageArtifacts.value.length > 0 || canOpenNovnc.value)
+const showGridCards = computed(() => gridArtifacts.value.length > 0 || canOpenNovnc.value)
 const remoteCardTitle = computed(() =>
   resolvedRemoteKind.value === 'sandbox'
     ? t('pages.reactArtifactStage.novncCardTitle')
@@ -300,13 +312,7 @@ const activePreviewName = computed(() => previewTabName(activeTab.value))
 watch(
   () => {
     const arts = stageArtifacts.value
-    const pin = resolveEffectivePreviewPin({
-      previewArtifact: props.previewArtifact,
-      artifacts: arts,
-      nodeType: resolvedNodeType.value,
-      nodeId: props.nodeId,
-    })
-    return [pin, arts.map((a) => a.name)] as const
+    return [effectivePin.value, arts.map((a) => a.name)] as const
   },
   ([pin, names], prev) => {
     const nameSet = new Set(names)
@@ -335,7 +341,7 @@ watch(
 
 watch(
   () =>
-    stageArtifacts.value
+    gridArtifacts.value
       .filter((a) => a.kind === 'html')
       .map((a) => artifactFingerprint(a))
       .join('|'),
@@ -344,7 +350,7 @@ watch(
     htmlThumbAbort?.abort()
     const ac = new AbortController()
     htmlThumbAbort = ac
-    const htmlArts = stageArtifacts.value.filter((a) => a.kind === 'html')
+    const htmlArts = gridArtifacts.value.filter((a) => a.kind === 'html')
     const next: Record<string, string> = {}
     for (const a of htmlArts) {
       const fp = artifactFingerprint(a)
@@ -552,7 +558,7 @@ onBeforeUnmount(() => {
           </div>
         </button>
         <div
-          v-for="a in stageArtifacts"
+          v-for="a in gridArtifacts"
           :key="a.id"
           role="button"
           tabindex="0"

--- a/web/src/lib/run/reactArtifactPreview.test.ts
+++ b/web/src/lib/run/reactArtifactPreview.test.ts
@@ -8,6 +8,8 @@ import {
   artifactFingerprint,
   canAnnotateStageArtifact,
   expandStageArtifacts,
+  filterStageGridArtifacts,
+  isKnownStageGridArtifact,
   historicalStageArtifactId,
   inboxStageRemoteKind,
   isSamePreviewVisualCopy,
@@ -28,6 +30,7 @@ import {
   previewTabId,
   resolveEffectivePreviewPin,
   resolveStageRemoteKind,
+  stageGridArtifactsWithPin,
 } from './reactArtifactPreview'
 
 function art(partial: Partial<Artifact> & Pick<Artifact, 'id' | 'name'>): Artifact {
@@ -315,5 +318,54 @@ describe('reactArtifactPreview helpers', () => {
       }),
     ).toBe('')
     expect(latestOwnNodeHtmlName([newer], '')).toBe('')
+  })
+
+  it('keeps known contract products on the pipeline grid and drops process artifacts', () => {
+    const run = {
+      nodes: [
+        { id: 'visual_bqc5', type: 'visual', label: '视觉', position: { x: 0, y: 0 }, config: {} },
+        { id: 'react_ymx0', type: 'react', label: '澄清', position: { x: 0, y: 0 }, config: {} },
+        { id: 'research', type: 'research', label: '调研', position: { x: 0, y: 0 }, config: {} },
+        { id: 'clarify', type: 'react', label: '需求', position: { x: 0, y: 0 }, config: {} },
+      ],
+    } as unknown as Run
+    const research = art({ id: 'r', name: 'research.json', kind: 'json', nodeId: 'research' })
+    const requirement = art({
+      id: 'c',
+      name: 'clarified_requirement.json',
+      kind: 'json',
+      nodeId: 'clarify',
+    })
+    const page = art({ id: 'p', name: 'page.html', kind: 'html', nodeId: 'visual_bqc5' })
+    const hist = art({
+      id: historicalStageArtifactId('visual_bqc5', 1),
+      name: 'page.html#iter-1',
+      kind: 'html',
+      nodeId: 'visual_bqc5',
+    })
+    const complete = art({ id: 'n', name: 'node_complete.json', kind: 'json', nodeId: 'visual_bqc5' })
+    const feedback = art({ id: 'f', name: 'feedback_index.json', kind: 'json', nodeId: 'react_ymx0' })
+    const copy = art({ id: 'v', name: visualNodePageName('visual_bqc5'), kind: 'html', nodeId: 'visual_bqc5' })
+    const demo = art({ id: 'd', name: 'brand-row-preview.html', kind: 'html', nodeId: 'react_ymx0' })
+    const reactPage = art({ id: 'rp', name: 'page.html', kind: 'html', nodeId: 'react_ymx0' })
+    const names = filterStageGridArtifacts(
+      [research, requirement, page, hist, complete, feedback, copy, demo, reactPage],
+      run,
+    ).map((a) => a.name)
+    expect(names).toEqual(['research.json', 'clarified_requirement.json', 'page.html', 'page.html#iter-1'])
+    expect(isKnownStageGridArtifact(complete, run)).toBe(false)
+    expect(isKnownStageGridArtifact(demo, run)).toBe(false)
+    expect(isKnownStageGridArtifact(page)).toBe(true)
+    expect(isKnownStageGridArtifact(reactPage, run)).toBe(false)
+    expect(
+      stageGridArtifactsWithPin(
+        [research, requirement, page, complete, feedback, copy, demo, reactPage],
+        run,
+        'brand-row-preview.html',
+      ).map((a) => a.name),
+    ).toEqual(['research.json', 'clarified_requirement.json', 'page.html', 'brand-row-preview.html'])
+    expect(
+      stageGridArtifactsWithPin([research, requirement, page, demo], run, 'page.html').map((a) => a.name),
+    ).toEqual(['research.json', 'clarified_requirement.json', 'page.html'])
   })
 })

--- a/web/src/lib/run/reactArtifactPreview.ts
+++ b/web/src/lib/run/reactArtifactPreview.ts
@@ -1,5 +1,11 @@
 import type { Artifact, NodeRun, Run, WFNode } from '@/lib/shared/types'
 import { productArtifactName } from '@/lib/run/productNodeArtifacts'
+import { OUTPUT_KEY_TO_ARTIFACT } from '@/lib/run/structuredArtifacts'
+
+const KNOWN_STAGE_GRID_NAMES = new Set(Object.values(OUTPUT_KEY_TO_ARTIFACT))
+const NODE_COMPLETE_ARTIFACT = 'node_complete.json'
+const FEEDBACK_INDEX_NAME = 'feedback_index.json'
+const FEEDBACK_PREFIX = 'feedback.'
 
 export const REACT_STAGE_TAB_GRID = 'grid'
 export const REACT_STAGE_TAB_NOVNC = 'novnc'
@@ -160,6 +166,62 @@ export function expandStageArtifacts(
   if (!owner) return list
   const alias = visualNodePageName(owner)
   return list.filter((a) => a.name !== alias)
+}
+
+function gridArtifactBaseName(name: string): string {
+  return String(name || '').replace(/#iter-\d+$/, '')
+}
+
+function isFeedbackStageArtifactName(name: string): boolean {
+  return name === FEEDBACK_INDEX_NAME || name.startsWith(FEEDBACK_PREFIX)
+}
+
+function producerNodeType(run: Run | null | undefined, nodeId: string | null | undefined): string {
+  const id = String(nodeId || '').trim()
+  if (!id || !run?.nodes?.length) return ''
+  return String(run.nodes.find((n) => n.id === id)?.type || '').trim()
+}
+
+/** Known contract products for the pipeline grid (manifest names + visual page.html). */
+export function isKnownStageGridArtifact(
+  artifact: Pick<Artifact, 'name' | 'kind' | 'nodeId'> | null | undefined,
+  run?: Run | null,
+): boolean {
+  if (!artifact) return false
+  const name = String(artifact.name || '').trim()
+  if (!name || name === NODE_COMPLETE_ARTIFACT || isFeedbackStageArtifactName(name)) return false
+  const base = gridArtifactBaseName(name)
+  if (!KNOWN_STAGE_GRID_NAMES.has(base)) return false
+  if (base !== visualProductPageName()) return true
+  const type = producerNodeType(run, artifact.nodeId)
+  if (type) return type === 'visual'
+  // run present but producer unknown → deny; no run → allow (call sites without graph).
+  if (run?.nodes?.length) return false
+  return true
+}
+
+/** Pipeline-grid subset; preview tabs / pins still use the unfiltered stage list. */
+export function filterStageGridArtifacts(artifacts: Artifact[], run?: Run | null): Artifact[] {
+  return artifacts.filter((a) => isKnownStageGridArtifact(a, run))
+}
+
+/**
+ * Grid cards: known products, plus the effective pin so a closed auto-pin
+ * (e.g. react demo HTML) remains reopenable from the pipeline grid.
+ */
+export function stageGridArtifactsWithPin(
+  artifacts: Artifact[],
+  run?: Run | null,
+  pin?: string | null,
+): Artifact[] {
+  const filtered = filterStageGridArtifacts(artifacts, run)
+  const name = String(pin || '').trim()
+  if (!name || filtered.some((a) => a.name === name)) return filtered
+  const pinned = artifacts.find((a) => a.name === name)
+  if (!pinned) return filtered
+  const keepIds = new Set(filtered.map((a) => a.id))
+  keepIds.add(pinned.id)
+  return artifacts.filter((a) => keepIds.has(a.id))
 }
 
 export function resolveStageRemoteKind(opts: {


### PR DESCRIPTION
## Summary
- 流水线网格仅展示节点契约产物（`OUTPUT_KEY_TO_ARTIFACT`），并隐藏 `node_complete` / `feedback*` 等过程产物；`page.html` 仅在 visual 节点产出时保留
- 网格额外保留当前 effective pin，关闭 react 演示 HTML 预览后仍可从卡片重新打开
- 预览 tab / pin 逻辑仍基于完整 `stageArtifacts`，职责与网格过滤分离

## Test plan
- [ ] 打开 visual 节点产物台：网格只有契约产物 + `page.html`，无 `node_complete` / `feedback` / `visual_*.page.html` / react 演示 HTML；默认 pin `page.html`
- [ ] 打开 react 节点：自动 pin 最新 own-node HTML，网格可见该 pin 卡片；关闭 tab 后点卡片可再次打开
- [ ] 确认 `npx vitest run src/lib/run/reactArtifactPreview.test.ts src/components/run/ReactArtifactStage.test.ts` 通过


Made with [Cursor](https://cursor.com)