### PR TITLE
feat(visual): 审阅每次改 page.html 都留下可选版本

### DIFF
--- a/server/internal/engine/gate_artifact.go
+++ b/server/internal/engine/gate_artifact.go
@@ -248,7 +248,7 @@ func (e *Engine) syncUpstreamOutputs(c *execCtx, gate *models.Gate, gateNode *mo
 		outKey = gatenode.ArtifactToOutputKey[norm.Name]
 	}
 	if outKey == "page" || norm.Name == "page.html" {
-		outs["page"] = norm.Content
+		recordPageRevision(outs, norm.Content)
 	} else if outKey != "" {
 		outs[outKey] = norm.Rendered
 		jsonKey := norm.JSONKey
@@ -284,6 +284,45 @@ func artifactETag(content string, size int) string {
 func artifactETagWithTime(content string, t time.Time) string {
 	sum := sha256.Sum256([]byte(content))
 	return fmt.Sprintf("W/\"%d-%s\"", t.UnixNano(), hex.EncodeToString(sum[:8]))
+}
+
+// pageHistoryOutputKey stores previous page.html snapshots on StateRun.Outputs
+// so each distinct write is a selectable preview version (not only FSM iterations).
+const pageHistoryOutputKey = "page_history"
+
+func pageHistorySlice(v any) []string {
+	switch x := v.(type) {
+	case []string:
+		out := make([]string, len(x))
+		copy(out, x)
+		return out
+	case []any:
+		out := make([]string, 0, len(x))
+		for _, item := range x {
+			s, ok := item.(string)
+			if !ok || strings.TrimSpace(s) == "" {
+				continue
+			}
+			out = append(out, s)
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// recordPageRevision appends the previous outputs.page before overwriting it.
+// Identical or empty previous content is skipped so no-op writes do not mint versions.
+func recordPageRevision(outs map[string]any, newContent string) {
+	oldPage, _ := outs["page"].(string)
+	if strings.TrimSpace(oldPage) != "" && oldPage != newContent {
+		hist := pageHistorySlice(outs[pageHistoryOutputKey])
+		if n := len(hist); n == 0 || hist[n-1] != oldPage {
+			hist = append(hist, oldPage)
+			outs[pageHistoryOutputKey] = hist
+		}
+	}
+	outs["page"] = newContent
 }
 
 // ArtifactETag returns the concurrency token for an artifact payload.
@@ -341,7 +380,7 @@ func (e *Engine) syncAfterPrimaryArtifactWrite(runID, nodeID, name, content, kin
 		outs = map[string]any{}
 	}
 	if outKey == "page" || name == "page.html" {
-		outs["page"] = content
+		recordPageRevision(outs, content)
 	} else {
 		// Structured products: keep raw JSON + rendered markdown when possible.
 		outs[outKey+"_json"] = content

--- a/server/internal/engine/gate_artifact_test.go
+++ b/server/internal/engine/gate_artifact_test.go
@@ -9,6 +9,36 @@ import (
 	"github.com/cocofhu/approving/internal/models"
 )
 
+func TestRecordPageRevision(t *testing.T) {
+	outs := map[string]any{"page": "<p>v1</p>"}
+	recordPageRevision(outs, "<p>v2</p>")
+	hist, _ := outs[pageHistoryOutputKey].([]string)
+	if len(hist) != 1 || hist[0] != "<p>v1</p>" {
+		t.Fatalf("first overwrite history=%v", outs[pageHistoryOutputKey])
+	}
+	if got, _ := outs["page"].(string); got != "<p>v2</p>" {
+		t.Fatalf("page=%q", got)
+	}
+
+	recordPageRevision(outs, "<p>v2</p>")
+	hist, _ = outs[pageHistoryOutputKey].([]string)
+	if len(hist) != 1 {
+		t.Fatalf("identical write must not mint a version: %v", hist)
+	}
+
+	recordPageRevision(outs, "<p>v3</p>")
+	hist, _ = outs[pageHistoryOutputKey].([]string)
+	if len(hist) != 2 || hist[0] != "<p>v1</p>" || hist[1] != "<p>v2</p>" {
+		t.Fatalf("second overwrite history=%v", hist)
+	}
+
+	empty := map[string]any{}
+	recordPageRevision(empty, "<p>first</p>")
+	if empty[pageHistoryOutputKey] != nil {
+		t.Fatalf("empty previous must not create history: %v", empty)
+	}
+}
+
 func TestArtifactETagWithAndWithoutUpdatedAt(t *testing.T) {
 	withTime := ArtifactETag("body", 4, time.Unix(100, 0))
 	if withTime == "" || withTime == ArtifactETag("body", 4, time.Time{}) {
@@ -106,5 +136,55 @@ func TestGateArtifactErrorsAndHalt(t *testing.T) {
 	eng.Halt()
 	if _, err := eng.SaveGateArtifact(runID, "gate", "nope.json", "{}", ""); err == nil {
 		t.Fatal("halted engine should reject save")
+	}
+}
+
+func TestSaveGateArtifactRecordsPageHistory(t *testing.T) {
+	eng, db := setupEngine(t)
+	runID := "run-gate-page-hist"
+	now := time.Now()
+	oldHTML := "<!doctype html><html><body>v1</body></html>"
+	newHTML := "<!doctype html><html><body>v2</body></html>"
+	g := models.Graph{
+		Nodes: []models.Node{
+			{ID: "page", Type: "visual"},
+			{ID: "gate", Type: "human_gate", Config: map[string]any{
+				"title":         "审阅",
+				"body_template": "{{nodes.page.outputs.page}}",
+				"actions":       []any{map[string]any{"id": "approve", "label": "批准"}},
+			}},
+		},
+	}
+	if err := db.Create(&models.Run{
+		ID: runID, WorkflowID: "w", WorkflowName: "w", Status: "waiting_human",
+		Graph: g, StartedAt: now, CreatedAt: now,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	db.Create(&models.StateRun{
+		RunID: runID, NodeID: "page", NodeType: "visual", Iteration: 1, Status: "completed",
+		Outputs: map[string]any{"page": oldHTML},
+	})
+	db.Create(&models.Gate{
+		RunID: runID, NodeID: "gate", Iteration: 1, Title: "审阅", RequestedAt: now,
+		UpstreamNodeID: "page", UpstreamIteration: 1, BodyMd: oldHTML,
+		Actions: []models.GateAction{{ID: "approve", Label: "批准"}},
+	})
+	if _, err := eng.store.Save(runID, "page", visualPageName, "html", oldHTML); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := eng.SaveGateArtifact(runID, "gate", visualPageName, newHTML, ""); err != nil {
+		t.Fatalf("save page: %v", err)
+	}
+	var sr models.StateRun
+	if err := db.Where("run_id = ? AND node_id = ?", runID, "page").First(&sr).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := sr.Outputs["page"].(string); got != newHTML {
+		t.Fatalf("outputs.page=%q", got)
+	}
+	hist := pageHistorySlice(sr.Outputs[pageHistoryOutputKey])
+	if len(hist) != 1 || hist[0] != oldHTML {
+		t.Fatalf("page_history=%v", sr.Outputs[pageHistoryOutputKey])
 	}
 }

--- a/server/internal/engine/review_live_sync_test.go
+++ b/server/internal/engine/review_live_sync_test.go
@@ -163,11 +163,30 @@ func TestWriteArtifactSyncsOutputsAndPendingBodyMd(t *testing.T) {
 	if got, _ := sr.Outputs["page"].(string); got != newHTML {
 		t.Fatalf("outputs.page not synced: %q", got)
 	}
+	hist := pageHistorySlice(sr.Outputs[pageHistoryOutputKey])
+	if len(hist) != 1 || hist[0] != oldHTML {
+		t.Fatalf("page_history after first overwrite=%v", sr.Outputs[pageHistoryOutputKey])
+	}
+
+	newerHTML := "<!doctype html><html><body>newer-live</body></html>"
+	if _, err := eng.host.WriteArtifact(runID, tok, "page", visualPageName, newerHTML, "html"); err != nil {
+		t.Fatalf("WriteArtifact second: %v", err)
+	}
+	if err := db.Where("run_id = ? AND node_id = ?", runID, "page").First(&sr).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := sr.Outputs["page"].(string); got != newerHTML {
+		t.Fatalf("outputs.page after second write: %q", got)
+	}
+	hist = pageHistorySlice(sr.Outputs[pageHistoryOutputKey])
+	if len(hist) != 2 || hist[0] != oldHTML || hist[1] != newHTML {
+		t.Fatalf("page_history after second overwrite=%v", sr.Outputs[pageHistoryOutputKey])
+	}
 	var gate models.Gate
 	if err := db.Where("run_id = ? AND node_id = ?", runID, "gate").First(&gate).Error; err != nil {
 		t.Fatal(err)
 	}
-	if gate.BodyMd != newHTML {
+	if gate.BodyMd != newerHTML {
 		t.Fatalf("BodyMd not refreshed: %q", gate.BodyMd)
 	}
 }

--- a/web/src/components/run/ReactArtifactStage.test.ts
+++ b/web/src/components/run/ReactArtifactStage.test.ts
@@ -446,6 +446,44 @@ describe('ReactArtifactStage', () => {
     wrapper.unmount()
   })
 
+  it('shows the version chip when one visual execution has page_history from review edits', async () => {
+    const live = art({ id: 'live', name: 'page.html', kind: 'html', nodeId: 'visual_1', content: '<p>v2</p>' })
+    const wrapper = mount(ReactArtifactStage, {
+      props: {
+        artifacts: [live],
+        runId: 'run-1',
+        run: {
+          id: 'run-1',
+          nodes: [{ id: 'visual_1', type: 'visual', label: '视觉', position: { x: 0, y: 0 }, config: {} }],
+          nodeExecutions: {
+            visual_1: [
+              {
+                nodeId: 'visual_1',
+                iteration: 1,
+                status: 'waiting_human',
+                outputs: { page: '<p>v2</p>', page_history: ['<p>v1</p>'] },
+              },
+            ],
+          },
+        } as any,
+        nodeId: 'visual_1',
+        annotatable: true,
+        remoteKind: 'off',
+      },
+      global: { plugins: [i18n()], stubs },
+    })
+    await flushPromises()
+    expect(wrapper.findAll('[data-testid="react-artifact-card-page.html"]').length).toBe(1)
+    expect(wrapper.get('[data-testid="react-artifact-version-chip-btn-page.html"]').text()).toContain('v2 · 最新')
+    await wrapper.get('[data-testid="react-artifact-version-chip-btn-page.html"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.get('[data-testid="react-artifact-version-option-v1"]').text()).toBe('v1')
+    await wrapper.get('[data-testid="react-artifact-version-option-v1"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.get('[data-testid="artifact-preview"]').text()).toBe('page.html|off|<p>v1</p>')
+    wrapper.unmount()
+  })
+
   it('disables a missing snapshot menu item instead of previewing latest html', async () => {
     const live = art({ id: 'live', name: 'page.html', kind: 'html', nodeId: 'visual_1', content: '<p>new</p>' })
     const wrapper = mount(ReactArtifactStage, {

--- a/web/src/lib/run/reactArtifactPreview.test.ts
+++ b/web/src/lib/run/reactArtifactPreview.test.ts
@@ -14,6 +14,7 @@ import {
   inboxStageRemoteKind,
   isSamePreviewVisualCopy,
   listVisualPageVersionChoices,
+  pageHistoryEntries,
   resolveVisualPagePreviewArtifact,
   visualNodePageName,
   isHistoricalStageArtifact,
@@ -141,6 +142,53 @@ describe('reactArtifactPreview helpers', () => {
     const latest = resolveVisualPagePreviewArtifact(live, choices[2])
     expect(latest).toBe(live)
     expect(listVisualPageVersionChoices(run, art({ id: 'j', name: 'node_complete.json', kind: 'json', nodeId: 'visual_1' }))).toEqual([])
+  })
+
+  it('expands page_history from a single visual execution into version choices', () => {
+    const live = art({ id: 'live', name: 'page.html', nodeId: 'visual_1', content: '<p>v3</p>' })
+    const run = {
+      nodeExecutions: {
+        visual_1: [
+          {
+            nodeId: 'visual_1',
+            iteration: 1,
+            status: 'waiting_human',
+            outputs: { page: '<p>v3</p>', page_history: ['<p>v1</p>', '<p>v2</p>'] },
+          },
+        ],
+      },
+    } as unknown as Run
+    expect(pageHistoryEntries({ page_history: ['<p>v1</p>', 1, ''] })).toEqual(['<p>v1</p>'])
+    const choices = listVisualPageVersionChoices(run, live)
+    expect(choices).toHaveLength(3)
+    expect(choices[0]).toMatchObject({ index: 1, latest: false, available: true, html: '<p>v1</p>' })
+    expect(choices[1]).toMatchObject({ index: 2, latest: false, available: true, html: '<p>v2</p>' })
+    expect(choices[2]).toMatchObject({ index: 3, latest: true, available: true, html: '' })
+    expect(resolveVisualPagePreviewArtifact(live, choices[0]).content).toBe('<p>v1</p>')
+    expect(resolveVisualPagePreviewArtifact(live, choices[2])).toBe(live)
+  })
+
+  it('keeps prior visual iterations and appends page_history on the latest run', () => {
+    const live = art({ id: 'live', name: 'page.html', nodeId: 'visual_1', content: '<p>new</p>' })
+    const run = {
+      nodeExecutions: {
+        visual_1: [
+          { nodeId: 'visual_1', iteration: 1, status: 'completed', outputs: { page: '<p>old</p>' } },
+          {
+            nodeId: 'visual_1',
+            iteration: 2,
+            status: 'waiting_human',
+            outputs: { page: '<p>new</p>', page_history: ['<p>mid</p>'] },
+          },
+        ],
+      },
+    } as unknown as Run
+    const choices = listVisualPageVersionChoices(run, live)
+    expect(choices.map((c) => ({ index: c.index, latest: c.latest, html: c.html }))).toEqual([
+      { index: 1, latest: false, html: '<p>old</p>' },
+      { index: 2, latest: false, html: '<p>mid</p>' },
+      { index: 3, latest: true, html: '' },
+    ])
   })
 
   it('uses sandbox remote only for ReAct inbox nodes', () => {

--- a/web/src/lib/run/reactArtifactPreview.ts
+++ b/web/src/lib/run/reactArtifactPreview.ts
@@ -111,7 +111,13 @@ export type VisualPageVersionChoice = {
   html: string
 }
 
-/** User-visible v1..vN mapped to visual nodeExecutions; latest follows live artifact bytes. */
+export function pageHistoryEntries(outputs: Record<string, unknown> | null | undefined): string[] {
+  const raw = outputs?.page_history
+  if (!Array.isArray(raw)) return []
+  return raw.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+}
+
+/** User-visible v1..vN: prior visual iterations, plus each page.html overwrite on the latest run. */
 export function listVisualPageVersionChoices(
   run: Run | null | undefined,
   artifact: Pick<Artifact, 'name' | 'nodeId' | 'kind'> | null | undefined,
@@ -122,18 +128,26 @@ export function listVisualPageVersionChoices(
   if (!nodeId) return []
   const runs = listVisualNodeRuns(run, nodeId)
   if (!runs.length) return []
-  return runs.map((nodeRun, i) => {
-    const latest = i === runs.length - 1
-    const html = String(nodeRun.outputs?.page || '')
-    const available = latest || html.trim().length > 0
-    return {
-      index: i + 1,
-      iteration: nodeRun.iteration ?? i + 1,
-      latest,
-      available,
-      html: latest ? '' : html,
+  const raw: Omit<VisualPageVersionChoice, 'index'>[] = []
+  runs.forEach((nodeRun, i) => {
+    const latestRun = i === runs.length - 1
+    const iteration = nodeRun.iteration ?? i + 1
+    for (const html of pageHistoryEntries(nodeRun.outputs)) {
+      raw.push({ iteration, latest: false, available: true, html })
     }
+    const page = String(nodeRun.outputs?.page || '')
+    if (latestRun) {
+      raw.push({ iteration, latest: true, available: true, html: '' })
+      return
+    }
+    raw.push({
+      iteration,
+      latest: false,
+      available: page.trim().length > 0,
+      html: page,
+    })
   })
+  return raw.map((choice, i) => ({ ...choice, index: i + 1 }))
 }
 
 export function resolveVisualPagePreviewArtifact(
@@ -144,7 +158,7 @@ export function resolveVisualPagePreviewArtifact(
   const nodeId = visualPageOwnerNodeId(artifact)
   return {
     ...artifact,
-    id: historicalStageArtifactId(nodeId || artifact.nodeId, choice.iteration),
+    id: historicalStageArtifactId(nodeId || artifact.nodeId, choice.index),
     content: choice.html,
     sizeBytes: choice.html.length,
   }


### PR DESCRIPTION
## Summary
- 审阅/人改每次写出不同的 `page.html` 时，把上一版写入 `outputs.page_history`，版本芯片按每次改动列出 v1…vN，而不只按视觉节点整轮重跑。
- 产物网格仍只展示一张 `page.html` 卡片；相同内容再保存不会多出一个空版本。
- 视觉节点历史迭代继续保留，并与最新一轮的 `page_history` 拼成完整版本列表。

## Test plan
- [ ] 视觉审阅对话里连续改两次 `page.html`（内容不同），卡片出现版本芯片，可切回 v1 / v2，最新一版为当前页。
- [ ] 网格里仍只有一张 `page.html`，没有额外历史卡片。
- [ ] 用相同 HTML 再保存一次，版本数量不变。
- [ ] 视觉节点整轮重跑后，旧轮最终页 + 新轮审阅改动都能在芯片里看到。
- [ ] `go test ./internal/engine -run 'TestRecordPageRevision|TestWriteArtifactSyncsOutputsAndPendingBodyMd|TestSaveGateArtifactRecordsPageHistory'`
- [ ] `npx vitest run src/lib/run/reactArtifactPreview.test.ts src/components/run/ReactArtifactStage.test.ts`


Made with [Cursor](https://cursor.com)