### PR TITLE
feat(web): 流水线产物卡片摘要窥视、友好名与 Tab 刷新恢复

### DIFF
--- a/web/src/components/run/ReactArtifactStage.test.ts
+++ b/web/src/components/run/ReactArtifactStage.test.ts
@@ -16,7 +16,17 @@ const { mockAddClarifyAnnotation } = vi.hoisted(() => ({
 
 vi.mock('@/lib/api/api', () => ({
   api: {
-    artifactContent: vi.fn(async () => ({ content: '<html>thumb</html>' })),
+    artifactContent: vi.fn(async () => ({
+      id: 'thumb',
+      name: 'thumb.html',
+      kind: 'html',
+      nodeId: 'react',
+      runId: 'run-1',
+      workflowName: 'wf',
+      sizeBytes: 18,
+      createdAt: '2026-08-01T00:00:00Z',
+      content: '<html>thumb</html>',
+    })),
     getRunNodeSandbox: vi.fn(async () => ({ id: 42 })),
   },
 }))
@@ -74,7 +84,9 @@ describe('ReactArtifactStage', () => {
   beforeEach(() => {
     // Stage specs use runId values starting with "run-"; keep unrelated helper keys intact for parallel files.
     resetStageOpenStateForTests(':run-')
-    vi.mocked(api.artifactContent).mockImplementation(async () => ({ content: '<html>thumb</html>' }))
+    vi.mocked(api.artifactContent).mockImplementation(async () =>
+      art({ id: 'thumb', name: 'thumb.html', kind: 'html', content: '<html>thumb</html>' }),
+    )
   })
   afterEach(() => {
     resetStageOpenStateForTests(':run-')
@@ -887,10 +899,10 @@ describe('ReactArtifactStage', () => {
         '<html><head><title>Approving · Demo</title></head><body><div class="banner"><h1>主标题</h1><p>banner 摘要</p></div></body></html>',
     })
     vi.mocked(api.artifactContent).mockImplementation(async (id: string) => {
-      if (id === 'r') return { content: research.content as string }
-      if (id === 'e') return { content: empty.content as string }
-      if (id === 'p') return { content: page.content as string }
-      return { content: '' }
+      if (id === 'r') return research
+      if (id === 'e') return empty
+      if (id === 'p') return page
+      return art({ id, name: id, content: '' })
     })
     const wrapper = mount(ReactArtifactStage, {
       props: {

--- a/web/src/components/run/ReactArtifactStage.test.ts
+++ b/web/src/components/run/ReactArtifactStage.test.ts
@@ -2,11 +2,13 @@
 import { defineComponent } from 'vue'
 import { createI18n } from 'vue-i18n'
 import { flushPromises, mount } from '@vue/test-utils'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import common from '@/locales/zh-CN/common.json'
 import pages from '@/locales/zh-CN/pages.json'
 import type { Artifact } from '@/lib/shared/types'
+import { resetStageOpenStateForTests } from '@/lib/run/reactArtifactPreview'
 import ReactArtifactStage from './ReactArtifactStage.vue'
+import { api } from '@/lib/api/api'
 
 const { mockAddClarifyAnnotation } = vi.hoisted(() => ({
   mockAddClarifyAnnotation: vi.fn(() => 'added'),
@@ -69,6 +71,15 @@ const stubs = {
 }
 
 describe('ReactArtifactStage', () => {
+  beforeEach(() => {
+    // Stage specs use runId values starting with "run-"; keep unrelated helper keys intact for parallel files.
+    resetStageOpenStateForTests(':run-')
+    vi.mocked(api.artifactContent).mockImplementation(async () => ({ content: '<html>thumb</html>' }))
+  })
+  afterEach(() => {
+    resetStageOpenStateForTests(':run-')
+  })
+
   it('defaults to the pipeline grid tab and opens a new preview tab on card click', async () => {
     const wrapper = mount(ReactArtifactStage, {
       props: {
@@ -753,5 +764,231 @@ describe('ReactArtifactStage', () => {
       'true',
     )
     wrapper.unmount()
+  })
+
+  it('shows friendly card/tab titles and meta with technical file name (g2)', async () => {
+    const research = art({
+      id: 'r',
+      name: 'research.json',
+      kind: 'json',
+      nodeId: 'research',
+      content: JSON.stringify({ title: '调研标题', summary: '调研摘要内容' }),
+    })
+    const clarified = art({
+      id: 'c',
+      name: 'clarified_requirement.json',
+      kind: 'json',
+      nodeId: 'clarify',
+      content: JSON.stringify({ title: '澄清标题', summary: '澄清摘要' }),
+    })
+    const page = art({
+      id: 'p',
+      name: 'page.html',
+      kind: 'html',
+      nodeId: 'visual_bqc5',
+      content: '<html><head><title>视觉 Demo</title></head><body><p>视觉摘要</p></body></html>',
+    })
+    const proposals = art({ id: 'pr', name: 'proposals.json', kind: 'json', nodeId: 'proposal' })
+    const wrapper = mount(ReactArtifactStage, {
+      props: {
+        artifacts: [research, clarified, page, proposals],
+        runId: 'run-friendly',
+        run: {
+          id: 'run-friendly',
+          nodes: [
+            { id: 'visual_bqc5', type: 'visual', label: '视觉', position: { x: 0, y: 0 }, config: {} },
+            { id: 'research', type: 'research', label: '调研', position: { x: 0, y: 0 }, config: {} },
+            { id: 'clarify', type: 'react', label: '澄清', position: { x: 0, y: 0 }, config: {} },
+            { id: 'proposal', type: 'proposal', label: '方案', position: { x: 0, y: 0 }, config: {} },
+          ],
+        } as any,
+        nodeId: 'visual_bqc5',
+        nodeType: 'visual',
+        remoteKind: 'off',
+        inlineContent: true,
+      },
+      global: { plugins: [i18n()], stubs },
+    })
+    await flushPromises()
+    const researchCard = wrapper.get('[data-testid="react-artifact-card-research.json"]')
+    expect(researchCard.text()).toContain('调研结论')
+    expect(researchCard.text()).toContain('research.json')
+    expect(researchCard.text()).toContain('JSON')
+    expect(wrapper.get('[data-testid="react-artifact-card-clarified_requirement.json"]').text()).toContain(
+      '需求澄清文件',
+    )
+    expect(wrapper.get('[data-testid="react-artifact-card-page.html"]').text()).toContain('视觉预览文件')
+    expect(wrapper.get('[data-testid="react-artifact-card-proposals.json"]').text()).toContain('proposals.json')
+    await wrapper.get('[data-testid="react-artifact-card-research.json"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.get('[data-testid="react-artifact-tab-research.json"]').text()).toContain('调研结论')
+    wrapper.unmount()
+  })
+
+  it('renders JSON and visual HTML title+summary thumbs and keeps icon on parse failure (g1)', async () => {
+    const research = art({
+      id: 'r',
+      name: 'research.json',
+      kind: 'json',
+      nodeId: 'research',
+      content: JSON.stringify({ title: '流水线产物卡片「简单预览」技术调研', summary: '上游诉求对照截图。' }),
+    })
+    const empty = art({
+      id: 'e',
+      name: 'plan.json',
+      kind: 'json',
+      nodeId: 'plan',
+      content: JSON.stringify({ goals: [] }),
+    })
+    const page = art({
+      id: 'p',
+      name: 'page.html',
+      kind: 'html',
+      nodeId: 'visual_bqc5',
+      content:
+        '<html><head><title>Approving · Demo</title></head><body><div class="banner"><h1>主标题</h1><p>banner 摘要</p></div></body></html>',
+    })
+    vi.mocked(api.artifactContent).mockImplementation(async (id: string) => {
+      if (id === 'r') return { content: research.content as string }
+      if (id === 'e') return { content: empty.content as string }
+      if (id === 'p') return { content: page.content as string }
+      return { content: '' }
+    })
+    const wrapper = mount(ReactArtifactStage, {
+      props: {
+        artifacts: [
+          { ...research, content: undefined },
+          { ...empty, content: undefined },
+          { ...page, content: undefined },
+        ],
+        runId: 'run-summary',
+        run: {
+          id: 'run-summary',
+          nodes: [
+            { id: 'visual_bqc5', type: 'visual', label: '视觉', position: { x: 0, y: 0 }, config: {} },
+            { id: 'research', type: 'research', label: '调研', position: { x: 0, y: 0 }, config: {} },
+            { id: 'plan', type: 'plan', label: '计划', position: { x: 0, y: 0 }, config: {} },
+          ],
+        } as any,
+        nodeId: 'visual_bqc5',
+        nodeType: 'visual',
+        remoteKind: 'off',
+      },
+      global: { plugins: [i18n()], stubs },
+    })
+    await flushPromises()
+    const researchSummary = wrapper.get(
+      '[data-testid="react-artifact-card-research.json"] [data-testid="react-artifact-card-summary"]',
+    )
+    expect(researchSummary.text()).toContain('流水线产物卡片「简单预览」技术调研')
+    expect(researchSummary.text()).toContain('上游诉求对照截图。')
+    expect(
+      wrapper.find('[data-testid="react-artifact-card-plan.json"] [data-testid="react-artifact-card-summary"]').exists(),
+    ).toBe(false)
+    const pageSummary = wrapper.get(
+      '[data-testid="react-artifact-card-page.html"] [data-testid="react-artifact-card-summary"]',
+    )
+    expect(pageSummary.text()).toContain('Approving · Demo')
+    expect(pageSummary.text()).toContain('banner 摘要')
+    wrapper.unmount()
+  })
+
+  it('restores open tabs from sessionStorage and prefers restore over pin (g3)', async () => {
+    resetStageOpenStateForTests()
+    const research = art({ id: 'r', name: 'research.json', kind: 'json', nodeId: 'research' })
+    const clarified = art({
+      id: 'c',
+      name: 'clarified_requirement.json',
+      kind: 'json',
+      nodeId: 'clarify',
+    })
+    const page = art({ id: 'p', name: 'page.html', kind: 'html', nodeId: 'visual_bqc5' })
+    const stageProps = {
+      artifacts: [research, clarified, page],
+      runId: 'run-restore',
+      run: {
+        id: 'run-restore',
+        nodes: [
+          { id: 'visual_bqc5', type: 'visual', label: '视觉', position: { x: 0, y: 0 }, config: {} },
+          { id: 'research', type: 'research', label: '调研', position: { x: 0, y: 0 }, config: {} },
+          { id: 'clarify', type: 'react', label: '澄清', position: { x: 0, y: 0 }, config: {} },
+        ],
+      } as any,
+      nodeId: 'visual_bqc5',
+      nodeType: 'visual',
+      remoteKind: 'off' as const,
+    }
+    const first = mount(ReactArtifactStage, {
+      props: stageProps,
+      global: { plugins: [i18n()], stubs },
+    })
+    await flushPromises()
+    // visual pin opens page.html; open clarified and activate it, then close page
+    await first.get('[data-testid="react-artifact-card-clarified_requirement.json"]').trigger('click')
+    await flushPromises()
+    if (first.find('[data-testid="react-artifact-tab-close-page.html"]').exists()) {
+      await first.get('[data-testid="react-artifact-tab-close-page.html"]').trigger('click')
+      await flushPromises()
+    }
+    expect(first.get('[data-testid="react-artifact-tab-clarified_requirement.json"]').attributes('aria-selected')).toBe(
+      'true',
+    )
+    expect(first.find('[data-testid="react-artifact-tab-page.html"]').exists()).toBe(false)
+    first.unmount()
+
+    const second = mount(ReactArtifactStage, {
+      props: stageProps,
+      global: { plugins: [i18n()], stubs },
+    })
+    await flushPromises()
+    expect(second.find('[data-testid="react-artifact-tab-clarified_requirement.json"]').exists()).toBe(true)
+    expect(second.get('[data-testid="react-artifact-tab-clarified_requirement.json"]').attributes('aria-selected')).toBe(
+      'true',
+    )
+    // closed page.html must not be restored even though visual pin would otherwise open it
+    expect(second.find('[data-testid="react-artifact-tab-page.html"]').exists()).toBe(false)
+    expect(second.get('[data-testid="react-artifact-tab-clarified_requirement.json"]').text()).toContain(
+      '需求澄清文件',
+    )
+    second.unmount()
+    resetStageOpenStateForTests()
+  })
+
+  it('skips vanished artifacts when restoring open state (g3.3)', async () => {
+    resetStageOpenStateForTests()
+    sessionStorage.setItem(
+      'appr.reactStageOpen:run-gone:visual_bqc5',
+      JSON.stringify({
+        openNames: ['page.html', 'gone.json', 'research.json'],
+        activeTab: 'preview:gone.json',
+        novncOpen: false,
+      }),
+    )
+    const research = art({ id: 'r', name: 'research.json', kind: 'json', nodeId: 'research' })
+    const page = art({ id: 'p', name: 'page.html', kind: 'html', nodeId: 'visual_bqc5' })
+    const wrapper = mount(ReactArtifactStage, {
+      props: {
+        artifacts: [research, page],
+        runId: 'run-gone',
+        run: {
+          id: 'run-gone',
+          nodes: [
+            { id: 'visual_bqc5', type: 'visual', label: '视觉', position: { x: 0, y: 0 }, config: {} },
+            { id: 'research', type: 'research', label: '调研', position: { x: 0, y: 0 }, config: {} },
+          ],
+        } as any,
+        nodeId: 'visual_bqc5',
+        nodeType: 'visual',
+        remoteKind: 'off',
+      },
+      global: { plugins: [i18n()], stubs },
+    })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="react-artifact-tab-gone.json"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="react-artifact-tab-research.json"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="react-artifact-tab-page.html"]').exists()).toBe(true)
+    expect(wrapper.get('[data-testid="react-artifact-tab-research.json"]').attributes('aria-selected')).toBe('true')
+    wrapper.unmount()
+    resetStageOpenStateForTests()
   })
 })

--- a/web/src/components/run/ReactArtifactStage.vue
+++ b/web/src/components/run/ReactArtifactStage.vue
@@ -19,7 +19,10 @@ import type { Artifact, ReactAnnotation, Run } from '@/lib/shared/types'
 import {
   REACT_STAGE_TAB_GRID,
   REACT_STAGE_TAB_NOVNC,
+  artifactFriendlyNameKey,
   artifactKindLabelKey,
+  artifactTechnicalDisplayName,
+  buildStageCardThumb,
   closeStagePreviewTab,
   findArtifactByName,
   nextTabAfterClose,
@@ -32,13 +35,18 @@ import {
   isHistoricalStageArtifact,
   isOwnNodeArtifact,
   listVisualPageVersionChoices,
+  loadStageOpenState,
   parseHistoricalStageArtifact,
   resolveEffectivePreviewPin,
   resolveStageRemoteKind,
   resolveVisualPagePreviewArtifact,
+  restoreStageOpenState,
+  saveStageOpenState,
   shouldActivatePinnedPreview,
   stageGridArtifactsWithPin,
+  wantsTextSummaryThumb,
   type ReactStageRemoteKind,
+  type StageCardThumb,
   type VisualPageVersionChoice,
 } from '@/lib/run/reactArtifactPreview'
 
@@ -109,17 +117,22 @@ provideReviewAnnotate({
   annotate: (ann) => stageAnnotation(ann),
 })
 
-const activeTab = ref(REACT_STAGE_TAB_GRID)
-/** True after the user picks a grid tab, card, preview tab, or noVNC — auto-open must not steal focus. */
-const userMoved = ref(false)
-const openNames = ref<string[]>([])
-const htmlThumbs = ref<Record<string, string>>({})
-const novncOpen = ref(false)
+const initialOpen = restoreStageOpenState(
+  loadStageOpenState(props.runId, props.nodeId),
+  (props.artifacts || []).map((a) => a.name),
+)
+const activeTab = ref(initialOpen?.activeTab || REACT_STAGE_TAB_GRID)
+/** True after the user picks a grid tab, card, preview tab, or noVNC — auto-open must not steal focus.
+ *  Also set when session open-state restore succeeds so pin auto-activate loses to refresh restore. */
+const userMoved = ref(!!initialOpen)
+const openNames = ref<string[]>(initialOpen?.openNames || [])
+const summaryThumbs = ref<Record<string, StageCardThumb>>({})
+const novncOpen = ref(!!initialOpen?.novncOpen)
 const sandboxId = ref<number | null>(null)
 const sandboxLoading = ref(false)
-let htmlThumbGen = 0
-let htmlThumbAbort: AbortController | null = null
-const htmlThumbFp: Record<string, string> = {}
+let summaryThumbGen = 0
+let summaryThumbAbort: AbortController | null = null
+const summaryThumbFp: Record<string, string> = {}
 const versionMenuFor = ref<string | null>(null)
 const selectedVersionIndex = ref<Record<string, number>>({})
 
@@ -174,6 +187,8 @@ function artifactReadonly(a: Artifact): boolean {
 
 function artifactTitle(a: Artifact | null | undefined): string {
   if (!a) return ''
+  const friendlyKey = artifactFriendlyNameKey(a.name)
+  if (friendlyKey) return t(friendlyKey)
   const hist = parseHistoricalStageArtifact(a)
   if (!hist) return a.name
   return a.name.replace(/#iter-\d+$/, '') || a.name
@@ -237,10 +252,39 @@ const kindIcon: Record<string, string> = {
 }
 
 function metaLine(a: Artifact): string {
-  return t('pages.reactArtifactStage.metaKindTime', {
+  return t('pages.reactArtifactStage.metaNameKindTime', {
+    name: artifactTechnicalDisplayName(a.name),
     kind: t(artifactKindLabelKey(a.kind)),
     time: relTime(a.updatedAt || a.createdAt),
   })
+}
+
+function textThumb(a: Artifact): { title: string; summary: string } | null {
+  const thumb = summaryThumbs.value[a.id]
+  return thumb?.kind === 'text' ? thumb : null
+}
+
+function htmlThumbContent(a: Artifact): string | null {
+  const thumb = summaryThumbs.value[a.id]
+  return thumb?.kind === 'html' ? thumb.html : null
+}
+
+function persistOpenState() {
+  saveStageOpenState(props.runId, props.nodeId, {
+    openNames: openNames.value,
+    activeTab: activeTab.value,
+    novncOpen: novncOpen.value,
+  })
+}
+
+function applyRestoredOpenState(runId: string, nodeId: string, names: string[]) {
+  const restored = restoreStageOpenState(loadStageOpenState(runId, nodeId), names)
+  if (!restored) return false
+  openNames.value = restored.openNames
+  activeTab.value = restored.activeTab
+  novncOpen.value = restored.novncOpen
+  userMoved.value = true
+  return true
 }
 
 function artifactByName(name: string): Artifact | null {
@@ -342,45 +386,87 @@ watch(
 watch(
   () =>
     gridArtifacts.value
-      .filter((a) => a.kind === 'html')
+      .filter((a) => a.kind === 'html' || a.kind === 'json' || wantsTextSummaryThumb(a))
       .map((a) => artifactFingerprint(a))
       .join('|'),
   async () => {
-    const gen = ++htmlThumbGen
-    htmlThumbAbort?.abort()
+    const gen = ++summaryThumbGen
+    summaryThumbAbort?.abort()
     const ac = new AbortController()
-    htmlThumbAbort = ac
-    const htmlArts = gridArtifacts.value.filter((a) => a.kind === 'html')
-    const next: Record<string, string> = {}
-    for (const a of htmlArts) {
+    summaryThumbAbort = ac
+    const thumbArts = gridArtifacts.value.filter(
+      (a) => a.kind === 'html' || a.kind === 'json' || wantsTextSummaryThumb(a),
+    )
+    const next: Record<string, StageCardThumb> = {}
+    for (const a of thumbArts) {
       const fp = artifactFingerprint(a)
+      let content: string | undefined
       if (typeof a.content === 'string') {
-        next[a.id] = a.content
-        htmlThumbFp[a.id] = fp
+        content = a.content
+        summaryThumbFp[a.id] = fp
+      } else if (props.inlineContent) {
         continue
-      }
-      if (props.inlineContent) continue
-      if (htmlThumbFp[a.id] === fp && htmlThumbs.value[a.id] !== undefined) {
-        next[a.id] = htmlThumbs.value[a.id]
+      } else if (summaryThumbFp[a.id] === fp && summaryThumbs.value[a.id] !== undefined) {
+        next[a.id] = summaryThumbs.value[a.id]
         continue
+      } else {
+        try {
+          const full = await api.artifactContent(a.id, { signal: ac.signal })
+          if (gen !== summaryThumbGen) return
+          content = full.content ?? ''
+          summaryThumbFp[a.id] = fp
+        } catch (e) {
+          if (isAbortError(e) || gen !== summaryThumbGen) return
+          if (summaryThumbs.value[a.id] !== undefined) next[a.id] = summaryThumbs.value[a.id]
+          continue
+        }
       }
-      try {
-        const full = await api.artifactContent(a.id, { signal: ac.signal })
-        if (gen !== htmlThumbGen) return
-        next[a.id] = full.content ?? ''
-        htmlThumbFp[a.id] = fp
-      } catch (e) {
-        if (isAbortError(e) || gen !== htmlThumbGen) return
-        if (htmlThumbs.value[a.id] !== undefined) next[a.id] = htmlThumbs.value[a.id]
-      }
+      const thumb = buildStageCardThumb(a, content)
+      if (thumb) next[a.id] = thumb
     }
-    if (gen !== htmlThumbGen) return
-    for (const id of Object.keys(htmlThumbFp)) {
-      if (!htmlArts.some((a) => a.id === id)) delete htmlThumbFp[id]
+    if (gen !== summaryThumbGen) return
+    for (const id of Object.keys(summaryThumbFp)) {
+      if (!thumbArts.some((a) => a.id === id)) delete summaryThumbFp[id]
     }
-    htmlThumbs.value = next
+    summaryThumbs.value = next
   },
   { immediate: true },
+)
+
+watch(
+  [openNames, activeTab, novncOpen, () => props.runId, () => props.nodeId],
+  () => {
+    persistOpenState()
+  },
+  { deep: true },
+)
+
+watch(
+  () => `${props.runId}|${props.nodeId}`,
+  (key, prev) => {
+    if (!prev || key === prev) return
+    const rid = String(props.runId || '').trim()
+    const nid = String(props.nodeId || '').trim()
+    if (!rid || !nid) {
+      openNames.value = []
+      activeTab.value = REACT_STAGE_TAB_GRID
+      novncOpen.value = false
+      userMoved.value = false
+      return
+    }
+    if (
+      !applyRestoredOpenState(
+        rid,
+        nid,
+        stageArtifacts.value.map((a) => a.name),
+      )
+    ) {
+      openNames.value = []
+      activeTab.value = REACT_STAGE_TAB_GRID
+      novncOpen.value = false
+      userMoved.value = false
+    }
+  },
 )
 
 watch(
@@ -435,8 +521,8 @@ watch(
 
 onMounted(() => document.addEventListener('click', onVersionMenuDocClick))
 onBeforeUnmount(() => {
-  htmlThumbGen++
-  htmlThumbAbort?.abort()
+  summaryThumbGen++
+  summaryThumbAbort?.abort()
   document.removeEventListener('click', onVersionMenuDocClick)
 })
 </script>
@@ -568,9 +654,23 @@ onBeforeUnmount(() => {
           @keydown.enter.prevent="openArtifact(a)"
         >
           <div class="relative h-[110px] overflow-hidden bg-elevated">
+            <div
+              v-if="textThumb(a)"
+              class="pointer-events-none h-full overflow-hidden border-b border-line px-3 py-2.5"
+              data-testid="react-artifact-card-summary"
+            >
+              <div
+                v-if="textThumb(a)?.title"
+                class="line-clamp-2 text-[12px] font-semibold leading-snug text-txt"
+              >{{ textThumb(a)?.title }}</div>
+              <div
+                v-if="textThumb(a)?.summary"
+                class="mt-1.5 line-clamp-4 text-[11px] leading-snug text-txt2"
+              >{{ textThumb(a)?.summary }}</div>
+            </div>
             <HtmlPreview
-              v-if="a.kind === 'html' && htmlThumbs[a.id]"
-              :html="htmlThumbs[a.id]"
+              v-else-if="htmlThumbContent(a)"
+              :html="htmlThumbContent(a) || ''"
               mode="demo"
               :enlargeable="false"
               class="pointer-events-none h-full w-full"

--- a/web/src/lib/run/reactArtifactPreview.test.ts
+++ b/web/src/lib/run/reactArtifactPreview.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+// @vitest-environment happy-dom
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 import type { Artifact, Run } from '@/lib/shared/types'
 import {
   REACT_STAGE_TAB_GRID,
@@ -6,15 +7,25 @@ import {
   applyPreviewArtifactFromRun,
   applyPreviewArtifactName,
   artifactFingerprint,
+  artifactFriendlyNameKey,
+  artifactTechnicalDisplayName,
+  buildStageCardThumb,
   canAnnotateStageArtifact,
   expandStageArtifacts,
+  extractVisualHtmlSummary,
   filterStageGridArtifacts,
   isKnownStageGridArtifact,
   historicalStageArtifactId,
   inboxStageRemoteKind,
   isSamePreviewVisualCopy,
+  isVisualPreviewArtifactName,
   listVisualPageVersionChoices,
+  loadStageOpenState,
+  parseStructuredArtifactSummary,
   resolveVisualPagePreviewArtifact,
+  restoreStageOpenState,
+  resetStageOpenStateForTests,
+  saveStageOpenState,
   visualNodePageName,
   isHistoricalStageArtifact,
   shouldActivatePinnedPreview,
@@ -31,6 +42,8 @@ import {
   resolveEffectivePreviewPin,
   resolveStageRemoteKind,
   stageGridArtifactsWithPin,
+  stageOpenStateStorageKey,
+  wantsTextSummaryThumb,
 } from './reactArtifactPreview'
 
 function art(partial: Partial<Artifact> & Pick<Artifact, 'id' | 'name'>): Artifact {
@@ -367,5 +380,129 @@ describe('reactArtifactPreview helpers', () => {
     expect(
       stageGridArtifactsWithPin([research, requirement, page, demo], run, 'page.html').map((a) => a.name),
     ).toEqual(['research.json', 'clarified_requirement.json', 'page.html'])
+  })
+
+  it('maps the three friendly display-name keys and keeps other names technical', () => {
+    expect(artifactFriendlyNameKey('research.json')).toBe('pages.reactArtifactStage.friendlyResearch')
+    expect(artifactFriendlyNameKey('clarified_requirement.json')).toBe(
+      'pages.reactArtifactStage.friendlyClarified',
+    )
+    expect(artifactFriendlyNameKey('page.html')).toBe('pages.reactArtifactStage.friendlyVisual')
+    expect(artifactFriendlyNameKey(visualNodePageName('visual_bqc5'))).toBe(
+      'pages.reactArtifactStage.friendlyVisual',
+    )
+    expect(artifactFriendlyNameKey('proposals.json')).toBeNull()
+    expect(artifactTechnicalDisplayName('page.html#iter-2')).toBe('page.html')
+    expect(isVisualPreviewArtifactName('page.html')).toBe(true)
+    expect(isVisualPreviewArtifactName('visual_1.page.html')).toBe(true)
+    expect(isVisualPreviewArtifactName('research.json')).toBe(false)
+  })
+
+  it('parses structured JSON root title/summary and falls back when missing', () => {
+    expect(
+      parseStructuredArtifactSummary(
+        JSON.stringify({ title: '调研标题', summary: '一段摘要', extra: 1 }),
+      ),
+    ).toEqual({ title: '调研标题', summary: '一段摘要' })
+    expect(parseStructuredArtifactSummary(JSON.stringify({ title: '仅标题' }))).toEqual({
+      title: '仅标题',
+      summary: '',
+    })
+    expect(parseStructuredArtifactSummary(JSON.stringify({ summary: '仅摘要' }))).toEqual({
+      title: '',
+      summary: '仅摘要',
+    })
+    expect(parseStructuredArtifactSummary(JSON.stringify({ name: 'nope' }))).toBeNull()
+    expect(parseStructuredArtifactSummary('not-json')).toBeNull()
+    expect(parseStructuredArtifactSummary('')).toBeNull()
+  })
+
+  it('extracts visual HTML title/summary from title/h1 and meta/banner', () => {
+    const html =
+      '<!doctype html><html><head><title>Approving · Demo</title>' +
+      '<meta name="description" content="meta 摘要"/>' +
+      '</head><body><div class="banner"><h1>主标题</h1><p>banner 段落</p></div></body></html>'
+    expect(extractVisualHtmlSummary(html)).toEqual({
+      title: 'Approving · Demo',
+      summary: 'meta 摘要',
+    })
+    const noMeta =
+      '<html><body><div class="banner"><h1>流水线产物</h1><p>友好名 + 简单预览</p></div></body></html>'
+    expect(extractVisualHtmlSummary(noMeta)).toEqual({
+      title: '流水线产物',
+      summary: '友好名 + 简单预览',
+    })
+    expect(extractVisualHtmlSummary('<html><body><div>x</div></body></html>')).toBeNull()
+  })
+
+  it('builds text thumbs for JSON/visual HTML and html thumbs for other HTML', () => {
+    expect(wantsTextSummaryThumb({ kind: 'json', name: 'research.json' })).toBe(true)
+    expect(wantsTextSummaryThumb({ kind: 'html', name: 'page.html' })).toBe(true)
+    expect(wantsTextSummaryThumb({ kind: 'html', name: 'brand-row-preview.html' })).toBe(false)
+    expect(
+      buildStageCardThumb(
+        { kind: 'json', name: 'research.json' },
+        JSON.stringify({ title: 'T', summary: 'S' }),
+      ),
+    ).toEqual({ kind: 'text', title: 'T', summary: 'S' })
+    expect(
+      buildStageCardThumb(
+        { kind: 'html', name: 'page.html' },
+        '<html><head><title>视觉</title></head><body><p>摘要行</p></body></html>',
+      ),
+    ).toEqual({ kind: 'text', title: '视觉', summary: '摘要行' })
+    expect(
+      buildStageCardThumb({ kind: 'html', name: 'demo.html' }, '<html>thumb</html>'),
+    ).toEqual({ kind: 'html', html: '<html>thumb</html>' })
+    expect(buildStageCardThumb({ kind: 'json', name: 'research.json' }, '{}')).toBeNull()
+  })
+
+  describe('stage open-state sessionStorage', () => {
+    beforeEach(() => {
+      resetStageOpenStateForTests('ss-unit-run')
+    })
+    afterEach(() => {
+      resetStageOpenStateForTests('ss-unit-run')
+    })
+
+    it('persists and restores openNames + activeTab under runId+nodeId', () => {
+      expect(stageOpenStateStorageKey('ss-unit-run', 'node-b')).toBe('appr.reactStageOpen:ss-unit-run:node-b')
+      saveStageOpenState('ss-unit-run', 'node-b', {
+        openNames: ['page.html', 'research.json'],
+        activeTab: previewTabId('research.json'),
+        novncOpen: false,
+      })
+      expect(loadStageOpenState('ss-unit-run', 'node-b')).toEqual({
+        openNames: ['page.html', 'research.json'],
+        activeTab: previewTabId('research.json'),
+        novncOpen: false,
+      })
+      expect(loadStageOpenState('ss-unit-run', 'other')).toBeNull()
+      expect(loadStageOpenState('', 'node-b')).toBeNull()
+    })
+
+    it('skips gone artifacts and recalculates the active tab', () => {
+      const saved = {
+        openNames: ['page.html', 'gone.json', 'research.json'],
+        activeTab: previewTabId('gone.json'),
+        novncOpen: false,
+      }
+      expect(restoreStageOpenState(saved, ['page.html', 'research.json'])).toEqual({
+        openNames: ['page.html', 'research.json'],
+        activeTab: previewTabId('research.json'),
+        novncOpen: false,
+      })
+      expect(restoreStageOpenState(saved, [])).toEqual({
+        openNames: ['page.html', 'gone.json', 'research.json'],
+        activeTab: previewTabId('gone.json'),
+        novncOpen: false,
+      })
+      expect(
+        restoreStageOpenState(
+          { openNames: [], activeTab: REACT_STAGE_TAB_GRID, novncOpen: false },
+          ['page.html'],
+        ),
+      ).toBeNull()
+    })
   })
 })

--- a/web/src/lib/run/reactArtifactPreview.test.ts
+++ b/web/src/lib/run/reactArtifactPreview.test.ts
@@ -481,6 +481,10 @@ describe('reactArtifactPreview helpers', () => {
       summary: '友好名 + 简单预览',
     })
     expect(extractVisualHtmlSummary('<html><body><div>x</div></body></html>')).toBeNull()
+    expect(extractVisualHtmlSummary('<title>A &amp;lt; B &amp; C</title>')).toEqual({
+      title: 'A &lt; B & C',
+      summary: '',
+    })
   })
 
   it('builds text thumbs for JSON/visual HTML and html thumbs for other HTML', () => {

--- a/web/src/lib/run/reactArtifactPreview.ts
+++ b/web/src/lib/run/reactArtifactPreview.ts
@@ -441,3 +441,276 @@ export function artifactFingerprint(a: Artifact | null | undefined): string {
   if (!a) return ''
   return `${a.id}:${a.updatedAt || ''}:${a.revision ?? ''}:${a.sizeBytes}:${a.content?.length ?? ''}`
 }
+
+/** Card thumb: text peep for known JSON / visual HTML; HtmlPreview for other grid HTML. */
+export type StageCardThumb =
+  | { kind: 'text'; title: string; summary: string }
+  | { kind: 'html'; html: string }
+
+const FRIENDLY_NAME_KEYS: Record<string, string> = {
+  'research.json': 'pages.reactArtifactStage.friendlyResearch',
+  'clarified_requirement.json': 'pages.reactArtifactStage.friendlyClarified',
+}
+
+/** page.html and same-content visual_{node}.page.html share one friendly label. */
+export function isVisualPreviewArtifactName(name: string | null | undefined): boolean {
+  const base = gridArtifactBaseName(String(name || '').trim())
+  if (!base) return false
+  if (base === visualProductPageName()) return true
+  return parseVisualNodePageName(base) != null
+}
+
+/** i18n key for the three named friendly display names; null → keep technical file name. */
+export function artifactFriendlyNameKey(name: string | null | undefined): string | null {
+  const base = gridArtifactBaseName(String(name || '').trim())
+  if (!base) return null
+  if (FRIENDLY_NAME_KEYS[base]) return FRIENDLY_NAME_KEYS[base]
+  if (isVisualPreviewArtifactName(base)) return 'pages.reactArtifactStage.friendlyVisual'
+  return null
+}
+
+/** Technical file name shown in meta (strip historical #iter-N suffix for display). */
+export function artifactTechnicalDisplayName(name: string | null | undefined): string {
+  const n = String(name || '').trim()
+  if (!n) return ''
+  return gridArtifactBaseName(n) || n
+}
+
+function nonemptyText(v: unknown): string {
+  return typeof v === 'string' ? v.trim() : ''
+}
+
+/** Root-level title/summary from known contract JSON; either field is enough. */
+export function parseStructuredArtifactSummary(content: string | null | undefined): {
+  title: string
+  summary: string
+} | null {
+  const raw = String(content || '').trim()
+  if (!raw) return null
+  try {
+    const data = JSON.parse(raw) as Record<string, unknown>
+    if (!data || typeof data !== 'object' || Array.isArray(data)) return null
+    const title = nonemptyText(data.title)
+    const summary = nonemptyText(data.summary)
+    if (!title && !summary) return null
+    return { title, summary }
+  } catch {
+    return null
+  }
+}
+
+function decodeHtmlEntities(s: string): string {
+  return s
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+}
+
+function stripTags(html: string): string {
+  return decodeHtmlEntities(html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim())
+}
+
+/**
+ * Light HTML peep for visual preview pages: title/h1 + meta description / banner p.
+ * Returns null when neither title nor summary can be extracted.
+ */
+export function extractVisualHtmlSummary(html: string | null | undefined): {
+  title: string
+  summary: string
+} | null {
+  const raw = String(html || '')
+  if (!raw.trim()) return null
+
+  let title = ''
+  const titleMatch = raw.match(/<title[^>]*>([\s\S]*?)<\/title>/i)
+  if (titleMatch) title = stripTags(titleMatch[1])
+  if (!title) {
+    const h1Match = raw.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i)
+    if (h1Match) title = stripTags(h1Match[1])
+  }
+
+  let summary = ''
+  const metaMatch = raw.match(
+    /<meta[^>]+name=["']description["'][^>]*content=["']([^"']*)["'][^>]*>/i,
+  ) || raw.match(
+    /<meta[^>]+content=["']([^"']*)["'][^>]*name=["']description["'][^>]*>/i,
+  )
+  if (metaMatch) summary = decodeHtmlEntities(metaMatch[1]).trim()
+  if (!summary) {
+    const bannerP = raw.match(/<div[^>]*class=["'][^"']*\bbanner\b[^"']*["'][^>]*>[\s\S]*?<p[^>]*>([\s\S]*?)<\/p>/i)
+    if (bannerP) summary = stripTags(bannerP[1])
+  }
+  if (!summary) {
+    const pMatch = raw.match(/<p[^>]*>([\s\S]*?)<\/p>/i)
+    if (pMatch) {
+      const t = stripTags(pMatch[1])
+      if (t && t !== title) summary = t
+    }
+  }
+
+  if (!title && !summary) return null
+  return { title, summary }
+}
+
+/** Whether this grid card should try text summary peep (vs HtmlPreview / icon). */
+export function wantsTextSummaryThumb(artifact: Pick<Artifact, 'kind' | 'name'> | null | undefined): boolean {
+  if (!artifact) return false
+  if (artifact.kind === 'json') return true
+  if (isVisualPreviewArtifactName(artifact.name)) return true
+  return false
+}
+
+/** Build StageCardThumb from fetched content; null → keep document icon. */
+export function buildStageCardThumb(
+  artifact: Pick<Artifact, 'kind' | 'name'> | null | undefined,
+  content: string | null | undefined,
+): StageCardThumb | null {
+  if (!artifact) return null
+  const body = content ?? ''
+  if (wantsTextSummaryThumb(artifact)) {
+    const peep =
+      artifact.kind === 'json'
+        ? parseStructuredArtifactSummary(body)
+        : extractVisualHtmlSummary(body)
+    if (!peep) return null
+    return { kind: 'text', title: peep.title, summary: peep.summary }
+  }
+  if (artifact.kind === 'html' || isHtmlStageArtifact(artifact)) {
+    if (!String(body).trim()) return null
+    return { kind: 'html', html: body }
+  }
+  return null
+}
+
+export type StageOpenState = {
+  openNames: string[]
+  activeTab: string
+  novncOpen: boolean
+}
+
+const STAGE_OPEN_PREFIX = 'appr.reactStageOpen:'
+const stageOpenMemory = new Map<string, StageOpenState>()
+
+export function stageOpenStateStorageKey(runId?: string | null, nodeId?: string | null): string {
+  return `${STAGE_OPEN_PREFIX}${String(runId || '').trim()}:${String(nodeId || '').trim()}`
+}
+
+export function loadStageOpenState(runId?: string | null, nodeId?: string | null): StageOpenState | null {
+  const rid = String(runId || '').trim()
+  const nid = String(nodeId || '').trim()
+  if (!rid || !nid) return null
+  const key = stageOpenStateStorageKey(rid, nid)
+  const mem = stageOpenMemory.get(key)
+  if (mem) {
+    return {
+      openNames: [...mem.openNames],
+      activeTab: mem.activeTab,
+      novncOpen: mem.novncOpen,
+    }
+  }
+  if (typeof sessionStorage === 'undefined') return null
+  try {
+    const raw = sessionStorage.getItem(key)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<StageOpenState>
+    if (!parsed || !Array.isArray(parsed.openNames)) return null
+    const openNames = parsed.openNames.map((n) => String(n || '').trim()).filter(Boolean)
+    const activeTab = String(parsed.activeTab || REACT_STAGE_TAB_GRID).trim() || REACT_STAGE_TAB_GRID
+    const state: StageOpenState = {
+      openNames,
+      activeTab,
+      novncOpen: !!parsed.novncOpen,
+    }
+    stageOpenMemory.set(key, state)
+    return {
+      openNames: [...state.openNames],
+      activeTab: state.activeTab,
+      novncOpen: state.novncOpen,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function saveStageOpenState(
+  runId: string | null | undefined,
+  nodeId: string | null | undefined,
+  state: StageOpenState,
+): void {
+  const rid = String(runId || '').trim()
+  const nid = String(nodeId || '').trim()
+  if (!rid || !nid) return
+  const key = stageOpenStateStorageKey(rid, nid)
+  const next: StageOpenState = {
+    openNames: [...state.openNames],
+    activeTab: state.activeTab,
+    novncOpen: !!state.novncOpen,
+  }
+  stageOpenMemory.set(key, next)
+  if (typeof sessionStorage === 'undefined') return
+  try {
+    sessionStorage.setItem(key, JSON.stringify(next))
+  } catch {
+    // quota / private mode — memory still holds refresh-within-SPA; hard reload needs storage
+  }
+}
+
+/** Apply persisted open state against currently available artifact names. */
+export function restoreStageOpenState(
+  saved: StageOpenState | null | undefined,
+  availableNames: string[],
+): StageOpenState | null {
+  if (!saved) return null
+  const hasAny = saved.openNames.length > 0 || !!saved.novncOpen
+  if (!hasAny && (!saved.activeTab || saved.activeTab === REACT_STAGE_TAB_GRID)) return null
+
+  // Artifacts may not be loaded on first paint — keep names; gone-filter watch prunes later.
+  if (!availableNames.length) {
+    return {
+      openNames: [...saved.openNames],
+      activeTab: String(saved.activeTab || REACT_STAGE_TAB_GRID) || REACT_STAGE_TAB_GRID,
+      novncOpen: !!saved.novncOpen,
+    }
+  }
+
+  const nameSet = new Set(availableNames)
+  const openNames = saved.openNames.filter((n) => nameSet.has(n))
+  let activeTab = String(saved.activeTab || REACT_STAGE_TAB_GRID) || REACT_STAGE_TAB_GRID
+  const activeName = previewTabName(activeTab)
+  if (activeName && !openNames.includes(activeName)) {
+    activeTab = openNames.length
+      ? previewTabId(openNames[openNames.length - 1])
+      : saved.novncOpen
+        ? REACT_STAGE_TAB_NOVNC
+        : REACT_STAGE_TAB_GRID
+  } else if (activeTab === REACT_STAGE_TAB_NOVNC && !saved.novncOpen) {
+    activeTab = openNames.length ? previewTabId(openNames[openNames.length - 1]) : REACT_STAGE_TAB_GRID
+  }
+  if (!openNames.length && !saved.novncOpen && activeTab === REACT_STAGE_TAB_GRID) return null
+  return {
+    openNames,
+    activeTab,
+    novncOpen: !!saved.novncOpen,
+  }
+}
+
+/** Test-only: clear stage open session keys. Optional needle limits which keys are removed. */
+export function resetStageOpenStateForTests(needle?: string): void {
+  const match = String(needle || '').trim()
+  for (const key of [...stageOpenMemory.keys()]) {
+    if (!match || key.includes(match)) stageOpenMemory.delete(key)
+  }
+  if (typeof sessionStorage === 'undefined') return
+  const keys: string[] = []
+  for (let i = 0; i < sessionStorage.length; i++) {
+    const k = sessionStorage.key(i)
+    if (!k?.startsWith(STAGE_OPEN_PREFIX)) continue
+    if (match && !k.includes(match)) continue
+    keys.push(k)
+  }
+  for (const k of keys) sessionStorage.removeItem(k)
+}

--- a/web/src/lib/run/reactArtifactPreview.ts
+++ b/web/src/lib/run/reactArtifactPreview.ts
@@ -516,12 +516,12 @@ export function parseStructuredArtifactSummary(content: string | null | undefine
 function decodeHtmlEntities(s: string): string {
   return s
     .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
     .replace(/&lt;/gi, '<')
     .replace(/&gt;/gi, '>')
     .replace(/&quot;/gi, '"')
     .replace(/&#39;/gi, "'")
     .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+    .replace(/&amp;/gi, '&')
 }
 
 function stripTags(html: string): string {

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -2484,6 +2484,10 @@
       "revision": "v{n}",
       "meta": "{kind} · v{n} · {time}",
       "metaKindTime": "{kind} · {time}",
+      "metaNameKindTime": "{name} · {kind} · {time}",
+      "friendlyResearch": "Research findings",
+      "friendlyClarified": "Clarified requirements",
+      "friendlyVisual": "Visual preview",
       "versionChip": "v{n}",
       "versionChipLatest": "v{n} · latest",
       "versionMenu": "Choose version"

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -2484,6 +2484,10 @@
       "revision": "v{n}",
       "meta": "{kind} · v{n} · {time}",
       "metaKindTime": "{kind} · {time}",
+      "metaNameKindTime": "{name} · {kind} · {time}",
+      "friendlyResearch": "调研结论",
+      "friendlyClarified": "需求澄清文件",
+      "friendlyVisual": "视觉预览文件",
       "versionChip": "v{n}",
       "versionChipLatest": "v{n} · 最新",
       "versionMenu": "选择版本"


### PR DESCRIPTION
在 ReactArtifactStage 将 htmlThumbs 泛化为 summaryThumbs，对已知合同 JSON 与视觉预览 HTML 展示 title/summary；三类产物用友好中文名，次行保留技术文件名；sessionStorage 按 runId+nodeId 恢复打开态并优先于 pin。

Co-authored-by: Cursor <cursoragent@cursor.com>
