### PR TITLE
feat(home): 立刻进入 Inbox，加载中也展示首页附件

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -45,9 +45,11 @@ watch(locale, () => {
   <AppShell v-if="!bareLayout">
     <AppSkeleton v-if="showShellSkeleton" />
     <router-view v-else-if="canShowProtected" v-slot="{ Component }">
-      <transition :name="routeViewTransition || undefined">
-        <component :is="Component" :key="String(route.name || route.path)" />
-      </transition>
+      <div class="route-view-wrap">
+        <transition :name="routeViewTransition || undefined">
+          <component :is="Component" :key="String(route.name || route.path)" />
+        </transition>
+      </div>
     </router-view>
   </AppShell>
   <router-view v-else />

--- a/web/src/components/run/ClarifyChat.test.ts
+++ b/web/src/components/run/ClarifyChat.test.ts
@@ -303,6 +303,50 @@ describe('ClarifyChat', () => {
     wrapper.unmount()
   })
 
+  it('seeds file chips with the first bubble and keeps them after idle queue_state', async () => {
+    const wrapper = mountChat({
+      nodeType: 'approve',
+      turns: [],
+      seedHumanText: '把登录做清楚',
+      seedHumanImages: [
+        { data: 'abc', mimeType: 'image/png', name: 'shot.png' },
+        { data: 'QQ==', mimeType: 'application/pdf', name: 'brief.pdf' },
+      ],
+    })
+    expect(wrapper.find('[data-testid="clarify-history-image-thumb"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="clarify-history-file-chip"]').text()).toContain('brief.pdf')
+    const vm = wrapper.vm as unknown as { applyReviewFrame: (f: Record<string, unknown>) => void }
+    vm.applyReviewFrame({
+      event: 'queue_state',
+      nodeId: 'react-1',
+      waiting: 0,
+      items: [],
+      busy: false,
+    })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="clarify-history-image-thumb"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="clarify-history-file-chip"]').text()).toContain('brief.pdf')
+    await wrapper.setProps({
+      turns: [{ role: 'human', text: '把登录做清楚', at: '2026-08-21T00:00:00Z' }],
+    })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="clarify-history-image-thumb"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="clarify-history-file-chip"]').text()).toContain('brief.pdf')
+    wrapper.unmount()
+  })
+
+  it('does not duplicate an image-only seed once the persisted human turn lands', async () => {
+    const shot = { data: 'abc', mimeType: 'image/png', name: 'shot.png' }
+    const wrapper = mountChat({
+      nodeType: 'approve',
+      turns: [{ role: 'human', text: '', at: '2026-08-21T00:00:00Z', images: [shot] }],
+      seedHumanText: '',
+      seedHumanImages: [shot],
+    })
+    expect(wrapper.findAll('[data-testid="clarify-history-image-thumb"]')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
   function mockScrollHeight(el: HTMLTextAreaElement, height: number) {
     Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => height })
   }

--- a/web/src/components/run/ClarifyChat.vue
+++ b/web/src/components/run/ClarifyChat.vue
@@ -126,11 +126,43 @@ const showApproveEmptyHint = computed(
     props.nodeType === 'approve' &&
     persistedTurns.value.length === 0 &&
     liveTurns.value.length === 0 &&
-    queued.value.length === 0,
+    queued.value.length === 0 &&
+    !seedHumanTurn.value,
 )
 const useConfirmFlowAction = computed(
   () => props.reviewMode || props.nodeType === 'approve',
 )
+
+function humanMatchesSeed(t: ClarifyTurn, seed: ClarifyTurn): boolean {
+  if (t.role !== 'human') return false
+  const want = (seed.text || '').trim()
+  if (want) return (t.text || '').trim() === want
+  return (seed.images?.length || 0) > 0 && (t.images?.length || 0) > 0
+}
+
+const seedHumanTurn = computed<ClarifyTurn | null>(() => {
+  const text = String(props.seedHumanText || '').trim()
+  const images = props.seedHumanImages || []
+  if (!text && images.length === 0) return null
+  return { role: 'human', text, images, at: '' }
+})
+
+function prependSeedHuman(list: ClarifyTurn[]): ClarifyTurn[] {
+  const seed = seedHumanTurn.value
+  if (!seed) return list
+  const seedImgs = seed.images || []
+  const idx = list.findIndex((t) => humanMatchesSeed(t, seed))
+  if (idx >= 0) {
+    const t = list[idx]
+    if (seedImgs.length && !(t.images && t.images.length)) {
+      const next = list.slice()
+      next[idx] = { ...t, images: seedImgs }
+      return next
+    }
+    return list
+  }
+  return [seed, ...list]
+}
 const liveAgentIdx = ref(-1)
 /** Coalesced markdown HTML for the live streaming agent bubble. */
 const liveStreamHtml = ref('')
@@ -352,7 +384,7 @@ const displayTurns = computed<ClarifyTurn[]>(() => {
   // Session UX: live in-flight bubbles until persisted transcript catches up.
   // Dedupe against persisted turns so mid-stream softRefresh/loadRun human does not double-render.
   if (liveTurns.value.length) {
-    return mergePersistedAndLiveTurns(list, liveTurns.value)
+    return prependSeedHuman(mergePersistedAndLiveTurns(list, liveTurns.value))
   }
   // Choice-card sessionStorage echo only (not used for free-text send).
   if (pending.value) {
@@ -376,7 +408,7 @@ const displayTurns = computed<ClarifyTurn[]>(() => {
       }
     }
   }
-  return list
+  return prependSeedHuman(list)
 })
 
 /** Single-image lightbox for human history attachments (no gallery / Esc). */
@@ -414,11 +446,11 @@ watch(
     pending.value = null
     const liveHumanText = liveTurns.value[0]?.role === 'human' ? liveTurns.value[0].text || '' : ''
     const persistedCaughtUp = persistedCompletedLiveHuman(turnList, liveHumanText)
-    // Clear live bubbles once persisted transcript includes them (not while streaming),
-    // or when poll/refresh already persisted the completed human+agent pair.
+    // Clear live bubbles once persisted transcript includes them (not while streaming).
+    // Empty persisted must not wipe an in-flight / seed-only human bubble.
     if (
       liveTurns.value.length &&
-      (persistedCaughtUp || !liveTurns.value.some((t) => t.streaming))
+      (persistedCaughtUp || (turnList.length > 0 && !liveTurns.value.some((t) => t.streaming)))
     ) {
       liveTurns.value = []
       liveAgentIdx.value = -1
@@ -543,17 +575,6 @@ function onPaste(e: ClipboardEvent) {
 }
 
 watch(draft, () => nextTick(autoGrow), { immediate: true })
-watch(
-  () => [props.seedHumanText, props.seedHumanImages] as const,
-  () => {
-    if (persistedTurns.value.length > 0 || liveTurns.value.length > 0) return
-    const text = String(props.seedHumanText || '').trim()
-    const images = props.seedHumanImages || []
-    if (!text && images.length === 0) return
-    liveTurns.value = [{ role: 'human', text, images, at: new Date().toISOString() }]
-  },
-  { immediate: true },
-)
 onMounted(() => {
   nextTick(autoGrow)
   // Mount with historical turns: force enter stick (parent v-if remounts on leave/re-enter).

--- a/web/src/lib/inbox/inboxActiveSelection.test.ts
+++ b/web/src/lib/inbox/inboxActiveSelection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   findInboxItemByKey,
+  findInboxItemForHandoff,
   inboxItemKey,
   inboxQueryKey,
   inboxTripleKey,
@@ -60,6 +61,13 @@ describe('inbox keys', () => {
     const list = [item('a'), item('b')]
     expect(findInboxItemByKey(list, 'run-b:node-b')?.label).toBe('b')
     expect(findInboxItemByKey(list, '')).toBeUndefined()
+  })
+
+  it('finds a handoff card by run+node, or by run when node id is empty', () => {
+    const list = [item('a'), item('b')]
+    expect(findInboxItemForHandoff(list, { runId: 'run-b', nodeId: 'node-b' })?.label).toBe('b')
+    expect(findInboxItemForHandoff(list, { runId: 'run-a', nodeId: '' })?.label).toBe('a')
+    expect(findInboxItemForHandoff(list, { runId: 'missing', nodeId: '' })).toBeUndefined()
   })
 })
 

--- a/web/src/lib/inbox/inboxActiveSelection.ts
+++ b/web/src/lib/inbox/inboxActiveSelection.ts
@@ -21,6 +21,18 @@ export function findInboxItemByKey<T extends Pick<InboxItem, 'runId' | 'nodeId'>
   return list.find((it) => inboxItemKey(it) === key)
 }
 
+/** Prefer run+node; if the parked node id is still empty, take the first card on that run. */
+export function findInboxItemForHandoff<T extends Pick<InboxItem, 'runId' | 'nodeId'>>(
+  list: T[],
+  handoff: Pick<InboxItem, 'runId' | 'nodeId'>,
+): T | undefined {
+  if (handoff.nodeId) {
+    const hit = findInboxItemByKey(list, inboxItemKey(handoff))
+    if (hit) return hit
+  }
+  return list.find((it) => it.runId === handoff.runId)
+}
+
 /** Triple used for inbox-context fetch / processed short-circuit. */
 export function inboxTripleKey(
   it: Pick<InboxItem, 'runId' | 'nodeId' | 'iteration'>,

--- a/web/src/lib/run/approveFirstPipeline.test.ts
+++ b/web/src/lib/run/approveFirstPipeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isApproveFirstPipeline, isPublishedApproveFirst } from './approveFirstPipeline'
+import { isApproveFirstPipeline, isPublishedApproveFirst, approveFirstNodeId } from './approveFirstPipeline'
 import type { WFEdge, WFNode } from '@/lib/shared/types'
 
 function graph(nodes: Partial<WFNode>[], edges: Partial<WFEdge>[]) {
@@ -122,5 +122,6 @@ describe('isApproveFirstPipeline', () => {
     )
     expect(isPublishedApproveFirst({ status: 'draft', ...g })).toBe(false)
     expect(isPublishedApproveFirst({ status: 'published', ...g })).toBe(true)
+    expect(approveFirstNodeId(g)).toBe('ap')
   })
 })

--- a/web/src/lib/run/approveFirstPipeline.ts
+++ b/web/src/lib/run/approveFirstPipeline.ts
@@ -22,12 +22,17 @@ function inputSuccessTargetId(graph: GraphLike): string | null {
   return picked?.target || null
 }
 
+/** Node id of the Approve that sits on the input success path, if any. */
+export function approveFirstNodeId(graph: GraphLike): string | null {
+  const targetId = inputSuccessTargetId(graph)
+  if (!targetId) return null
+  const target = (graph.nodes || []).find((n) => n.id === targetId)
+  return target?.type === 'approve' ? target.id : null
+}
+
 /** True when the node after input (success path) is an Approve node. */
 export function isApproveFirstPipeline(graph: GraphLike): boolean {
-  const targetId = inputSuccessTargetId(graph)
-  if (!targetId) return false
-  const target = (graph.nodes || []).find((n) => n.id === targetId)
-  return target?.type === 'approve'
+  return !!approveFirstNodeId(graph)
 }
 
 export function isPublishedApproveFirst(wf: Pick<Workflow, 'status'> & GraphLike): boolean {

--- a/web/src/lib/run/homeApproveHandoff.test.ts
+++ b/web/src/lib/run/homeApproveHandoff.test.ts
@@ -4,6 +4,7 @@ import {
   peekHomeApproveHandoff,
   setHomeApproveHandoff,
   takeHomeApproveHandoff,
+  updateHomeApproveHandoffNode,
 } from './homeApproveHandoff'
 
 describe('homeApproveHandoff', () => {
@@ -32,5 +33,26 @@ describe('homeApproveHandoff', () => {
     expect(peekHomeApproveHandoff()?.runId).toBe('run-1')
     expect(consumeHomeApproveHandoff('run-1', 'ap')?.text).toBe('做登录')
     expect(peekHomeApproveHandoff()).toBeNull()
+  })
+
+  it('delivers attachments on the same run when node id is still empty', () => {
+    setHomeApproveHandoff({
+      runId: 'run-1',
+      nodeId: '',
+      text: '附图',
+      images: [{ mimeType: 'application/pdf', data: 'QQ==', name: 'a.pdf' }],
+    })
+    const got = consumeHomeApproveHandoff('run-1', 'ap')
+    expect(got?.images).toEqual([{ mimeType: 'application/pdf', data: 'QQ==', name: 'a.pdf' }])
+    expect(got?.nodeId).toBe('ap')
+  })
+
+  it('updates the parked node id only while the slot is still held', () => {
+    setHomeApproveHandoff({ runId: 'run-1', nodeId: '', text: '附图', images: [] })
+    expect(updateHomeApproveHandoffNode('run-other', 'ap')).toBe(false)
+    expect(updateHomeApproveHandoffNode('run-1', 'ap')).toBe(true)
+    expect(peekHomeApproveHandoff()?.nodeId).toBe('ap')
+    takeHomeApproveHandoff()
+    expect(updateHomeApproveHandoffNode('run-1', 'ap')).toBe(false)
   })
 })

--- a/web/src/lib/run/homeApproveHandoff.ts
+++ b/web/src/lib/run/homeApproveHandoff.ts
@@ -9,12 +9,16 @@ export type HomeApproveHandoff = {
 
 let current: HomeApproveHandoff | null = null
 
+function cloneImages(images?: ClarifyImage[] | null): ClarifyImage[] {
+  return (images || []).map((im) => ({ ...im }))
+}
+
 export function setHomeApproveHandoff(next: HomeApproveHandoff) {
   current = {
     runId: next.runId,
     nodeId: next.nodeId,
     text: next.text,
-    images: next.images ? next.images.slice() : [],
+    images: cloneImages(next.images),
   }
 }
 
@@ -28,10 +32,28 @@ export function peekHomeApproveHandoff(): HomeApproveHandoff | null {
   return current
 }
 
+/** Same run; empty parked node id still belongs to this run (StartRun before graph resolve). */
+function matchesHomeApproveHandoff(
+  got: Pick<HomeApproveHandoff, 'runId' | 'nodeId'>,
+  runId: string,
+  nodeId: string,
+): boolean {
+  if (got.runId !== runId) return false
+  if (got.nodeId && nodeId && got.nodeId !== nodeId) return false
+  return true
+}
+
+/** Fill in the parked node id after waitForApprovePark, if Inbox has not consumed yet. */
+export function updateHomeApproveHandoffNode(runId: string, nodeId: string): boolean {
+  if (!current || !nodeId || current.runId !== runId) return false
+  current = { ...current, nodeId }
+  return true
+}
+
 /** Consume only when the parked card matches; otherwise leave the slot intact. */
 export function consumeHomeApproveHandoff(runId: string, nodeId: string): HomeApproveHandoff | null {
   const got = current
-  if (!got || got.runId !== runId || got.nodeId !== nodeId) return null
+  if (!got || !matchesHomeApproveHandoff(got, runId, nodeId)) return null
   current = null
-  return got
+  return { ...got, nodeId: got.nodeId || nodeId }
 }

--- a/web/src/lib/run/useHomeApproveChat.test.ts
+++ b/web/src/lib/run/useHomeApproveChat.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { createI18n } from 'vue-i18n'
 import { createApp, defineComponent, nextTick } from 'vue'
+import { flushPromises } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import common from '@/locales/zh-CN/common.json'
 import pages from '@/locales/zh-CN/pages.json'
@@ -152,6 +153,18 @@ describe('useHomeApproveChat', () => {
       { data: 'abc', mimeType: 'image/png', name: 'shot.png' },
     ])
     expect(mocks.push).toHaveBeenCalledWith({ path: '/gates', query: { run: 'run-1', node: 'ap' } })
+  })
+
+  it('opens inbox immediately with attachments, before Approve finishes parking', async () => {
+    mocks.getRun.mockImplementation(() => new Promise(() => {}))
+    const chat = withSetup(() => useHomeApproveChat())
+    await chat.load()
+    chat.attachments.value = [{ data: 'abc', mimeType: 'image/png', name: 'shot.png' }]
+    chat.draft.value = '附图说明'
+    void chat.send()
+    await flushPromises()
+    expect(mocks.push).toHaveBeenCalledWith({ path: '/gates', query: { run: 'run-1', node: 'ap' } })
+    expect(mocks.reactReply).not.toHaveBeenCalled()
   })
 
   it('still replies after the home view unmounts', async () => {

--- a/web/src/lib/run/useHomeApproveChat.ts
+++ b/web/src/lib/run/useHomeApproveChat.ts
@@ -6,9 +6,9 @@ import { api } from '@/lib/api/api'
 import { useToast } from '@/lib/composables/useToast'
 import { useImageAttachments } from '@/lib/composables/useImageAttachments'
 import { readStoredProjectId } from '@/lib/composables/useProjectContext'
-import { isPublishedApproveFirst } from '@/lib/run/approveFirstPipeline'
+import { approveFirstNodeId, isPublishedApproveFirst } from '@/lib/run/approveFirstPipeline'
 import { ApproveParkTimeout, waitForApprovePark } from '@/lib/run/homeApproveChat'
-import { setHomeApproveHandoff } from '@/lib/run/homeApproveHandoff'
+import { setHomeApproveHandoff, updateHomeApproveHandoffNode } from '@/lib/run/homeApproveHandoff'
 import { clipRunTitle } from '@/lib/run/runTitle'
 import { missingRequiredAskField, seedAskLaunchFields } from '@/lib/run/useWorkflowAskInputs'
 import { attachmentDisplayName } from '@/lib/shared/attachments'
@@ -117,31 +117,35 @@ export function useHomeApproveChat() {
   }
 
   async function afterStart(runId: string, text: string, images: ClarifyImage[]) {
+    const wf = selected.value || launchTarget.value
+    const knownNodeId = wf ? approveFirstNodeId(wf) || '' : ''
+    setHomeApproveHandoff({ runId, nodeId: knownNodeId, text, images })
+    const nav = goGates(runId, knownNodeId || undefined)
+
     parkAbort?.abort()
     const ac = new AbortController()
     parkAbort = ac
     try {
+      await nav
       const { nodeId } = await waitForApprovePark(runId, { signal: ac.signal })
       if (ac.signal.aborted) return
-      setHomeApproveHandoff({ runId, nodeId, text, images })
+      if (nodeId !== knownNodeId) updateHomeApproveHandoffNode(runId, nodeId)
       await api.reactReply(runId, nodeId, text, images)
-      await goGates(runId, nodeId)
+      if (nodeId !== knownNodeId) await goGates(runId, nodeId)
     } catch (e: any) {
       if (ac.signal.aborted || e?.name === 'AbortError') return
       if (e instanceof ApproveParkTimeout) {
         toast.warn(t('pages.dashboard.parkTimeout'))
-        await goGates(runId)
         return
       }
       toast.error(String(e?.message || e))
-      await goGates(runId)
     }
   }
 
   async function send() {
     const wf = selected.value
     const text = draft.value.trim()
-    const images = attach.attachments.value.slice()
+    const images = attach.attachments.value.map((im) => ({ ...im }))
     if (!wf) {
       toast.warn(t('pages.dashboard.pickPipeline'))
       return
@@ -184,7 +188,7 @@ export function useHomeApproveChat() {
   async function onLaunchStarted(runId: string) {
     launchOpen.value = false
     const text = pendingText.value
-    const images = pendingImages.value.slice()
+    const images = pendingImages.value.map((im) => ({ ...im }))
     sending.value = true
     try {
       draft.value = ''

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -392,8 +392,17 @@ body {
   }
 }
 
+.route-view-wrap {
+  position: relative;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
 .home-to-gates-enter-active,
 .home-to-gates-leave-active {
+  position: absolute;
+  inset: 0;
+  width: 100%;
   transition: opacity 0.22s ease, transform 0.22s ease;
 }
 .home-to-gates-enter-from {

--- a/web/src/views/GatesInboxView.inboxLifecycle.test.ts
+++ b/web/src/views/GatesInboxView.inboxLifecycle.test.ts
@@ -1376,6 +1376,43 @@ describe('GatesInboxView inbox-context lifecycle', () => {
     )
     const seedProp = wrapper.findComponent({ name: 'ReviewComposer' }).props('seedHumanText')
     expect(seedProp).toBe('把登录做清楚')
+    expect(wrapper.findComponent({ name: 'ReviewComposer' }).props('seedHumanImages')).toEqual([
+      { data: 'abc', mimeType: 'image/png', name: 'shot.png' },
+    ])
+    wrapper.unmount()
+  })
+
+  it('applies home handoff seed when the parked node id is still empty', async () => {
+    const item = {
+      ...clarifyItem('ap'),
+      runId: 'run-home',
+      nodeId: 'ap',
+      label: '开发前澄清',
+    }
+    routeState.query = { run: 'run-home' }
+    setHomeApproveHandoff({
+      runId: 'run-home',
+      nodeId: '',
+      text: '附图',
+      images: [{ data: 'QQ==', mimeType: 'application/pdf', name: 'brief.pdf' }],
+    })
+    mocks.listGates.mockResolvedValue(paged([item]))
+    mocks.inboxContext.mockResolvedValue({
+      type: 'clarify',
+      status: 'waiting_human',
+      nodes: [{ id: 'ap', type: 'approve', label: '澄清' }],
+      artifacts: [],
+      nodeExecutions: {},
+      clarify: { nodeId: 'ap', iteration: 1, turns: [], done: false, label: '澄清' },
+    })
+    const wrapper = mountInbox()
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+    expect(wrapper.findComponent({ name: 'ReviewComposer' }).props('seedHumanText')).toBe('附图')
+    expect(wrapper.findComponent({ name: 'ReviewComposer' }).props('seedHumanImages')).toEqual([
+      { data: 'QQ==', mimeType: 'application/pdf', name: 'brief.pdf' },
+    ])
     wrapper.unmount()
   })
 })

--- a/web/src/views/GatesInboxView.mobileFill.test.ts
+++ b/web/src/views/GatesInboxView.mobileFill.test.ts
@@ -56,11 +56,13 @@ describe('GatesInboxView review/clarify composer mode', () => {
     expect(src).toMatch(/inboxQueryKey/)
     expect(src).toMatch(/findInboxItemByKey/)
     expect(src).toMatch(/consumeHomeApproveHandoff/)
+    expect(src).toMatch(/findInboxItemForHandoff/)
     expect(src).toMatch(/waitForQueryItem/)
     const seedText = src.match(/:seed-human-text="activeHomeSeed\?\.text"/g) || []
-    const seedImages = src.match(/:seed-human-images="activeHomeSeed\?\.images"/g) || []
+    const seedImages = src.match(/:seed-human-images="activeHomeSeed\?\.images \?\? \[\]"/g) || []
     expect(seedText.length).toBe(2)
     expect(seedImages.length).toBe(2)
+    expect(src).toMatch(/showClarifyReviewShell/)
   })
 
   it('finish uses confirmFlowPrompt with force=true and success/error toasts', () => {
@@ -195,7 +197,7 @@ describe('GatesInboxView react artifact stage', () => {
       desktop.indexOf('<ReviewShell'),
       desktop.indexOf('</ReviewShell>') + '</ReviewShell>'.length,
     )
-    expect(shell).toMatch(/active\.type === 'clarify' && activeClarify/)
+    expect(shell).toMatch(/showClarifyReviewShell/)
     expect(shell).toMatch(/<ReactArtifactStage/)
     expect(shell).not.toMatch(/stage-kind="panel"/)
     expect(src).toMatch(/GateApproval/)

--- a/web/src/views/GatesInboxView.vue
+++ b/web/src/views/GatesInboxView.vue
@@ -36,6 +36,7 @@ import {
 } from '@/lib/inbox/inboxReviewMode'
 import {
   findInboxItemByKey,
+  findInboxItemForHandoff,
   inboxQueryKey,
   inboxTripleKey,
   isInboxLeftPendingError,
@@ -52,7 +53,7 @@ import {
 import { createWsReconnectController } from '@/lib/run/wsReconnect'
 import { useToast } from '@/lib/composables/useToast'
 import { inboxShareKind, isHumanGateInboxItem, isShareableInboxItem } from '@/lib/inbox/gateShareLink'
-import { consumeHomeApproveHandoff, type HomeApproveHandoff } from '@/lib/run/homeApproveHandoff'
+import { consumeHomeApproveHandoff, peekHomeApproveHandoff, type HomeApproveHandoff } from '@/lib/run/homeApproveHandoff'
 import type { AcpEvent, Gate, GateInboxItem, GateShareInboxStatus, InboxItem, Run } from '@/lib/shared/types'
 
 const router = useRouter()
@@ -303,16 +304,27 @@ function applyHomeHandoff() {
   if (h) homeSeed.value = h
 }
 
+function selectFromHandoff(): boolean {
+  const h = peekHomeApproveHandoff()
+  if (!h) return false
+  const hit = findInboxItemForHandoff(listItems.value, h)
+  if (!hit) return false
+  active.value = hit
+  applyHomeHandoff()
+  return true
+}
+
 let queryWaitGen = 0
 async function waitForQueryItem() {
   const gen = ++queryWaitGen
-  if (!queryInboxKey()) return
+  if (!queryInboxKey() && !peekHomeApproveHandoff()) return
   for (let i = 0; i < 8; i++) {
     if (gen !== queryWaitGen) return
     if (selectFromQuery()) {
       applyHomeHandoff()
       return
     }
+    if (selectFromHandoff()) return
     await new Promise((r) => setTimeout(r, 400))
     if (gen !== queryWaitGen) return
     await loadList()
@@ -329,6 +341,7 @@ function ensureValidActive() {
     applyHomeHandoff()
     return
   }
+  if (selectFromHandoff()) return
   const list = listItems.value
   if (!list.length) {
     if (active.value) active.value = null
@@ -1143,6 +1156,23 @@ const inboxStageNodeType = computed(() => {
   return activeRun.value?.nodes?.find((node) => node.id === id)?.type || ''
 })
 
+/** Keep the chat (and home-chat attachments) up while the product stage is still loading. */
+const showClarifyReviewShell = computed(
+  () =>
+    !!active.value &&
+    active.value.type === 'clarify' &&
+    (!!activeClarify.value || !!activeHomeSeed.value),
+)
+const clarifyComposerNodeId = computed(
+  () => activeClarify.value?.nodeId || active.value?.nodeId || '',
+)
+const clarifyComposerIteration = computed(() => activeClarify.value?.iteration ?? 1)
+const clarifyComposerTurns = computed(() => activeClarify.value?.turns ?? [])
+const clarifyComposerDone = computed(() => activeClarify.value?.done ?? false)
+const clarifyComposerNodeType = computed(
+  () => inboxStageNodeType.value || (activeHomeSeed.value ? 'approve' : ''),
+)
+
 const inboxClarifyStageKind = computed(() => (activeRunLoadError.value ? 'loadFailed' : 'pending'))
 
 // Mirror RunDetailView.reviewActive: post-run product review on a non-react
@@ -1409,7 +1439,7 @@ watch(() => [route.query.run, route.query.node], () => {
 onMounted(() => {
   hydrateProject()
   loadList({ showLoading: true }).then(() => {
-    if (queryInboxKey()) {
+    if (queryInboxKey() || peekHomeApproveHandoff()) {
       void waitForQueryItem()
       return
     }
@@ -1635,7 +1665,7 @@ function itemSecondary(it: InboxItem) {
         </button>
       </div>
       <div class="flex min-h-0 flex-1 flex-col">
-        <ArtifactLoadingPane v-if="activeRunLoading" message-key="pages.gatesInbox.loadingRun" />
+        <ArtifactLoadingPane v-if="activeRunLoading && active.type === 'gate'" message-key="pages.gatesInbox.loadingRun" />
             <GateApproval
           v-else-if="active.type === 'gate'"
           ref="gateApprovalRef"
@@ -1649,7 +1679,7 @@ function itemSecondary(it: InboxItem) {
           @open-share="openSharePanel(active)"
         />
         <ReviewShell
-          v-else-if="active.type === 'clarify' && activeClarify"
+          v-else-if="showClarifyReviewShell"
           :key="active.runId + active.nodeId"
           class="min-h-0 flex-1"
           mobile
@@ -1657,7 +1687,9 @@ function itemSecondary(it: InboxItem) {
           :storage-key="REVIEW_SHELL_WIDTH_KEY_APPROVAL"
         >
           <template #stage>
+            <ArtifactLoadingPane v-if="activeRunLoading" message-key="pages.gatesInbox.loadingRun" />
             <ReactArtifactStage
+              v-else
               :artifacts="activeRun?.artifacts || []"
               :preview-artifact="activeClarify?.previewArtifact"
               :run-id="active.runId"
@@ -1677,16 +1709,16 @@ function itemSecondary(it: InboxItem) {
               ref="reviewChatRef"
               :mode="composerMode"
               :run-id="active.runId"
-              :node-id="activeClarify.nodeId"
-              :iteration="activeClarify.iteration ?? 1"
+              :node-id="clarifyComposerNodeId"
+              :iteration="clarifyComposerIteration"
               v-model:draft="clarifyDraft"
               v-model:attachments="clarifyAttachments"
               v-model:annotations="clarifyAnnotations"
-              :turns="activeClarify.turns ?? []"
-              :node-type="inboxStageNodeType"
+              :turns="clarifyComposerTurns"
+              :node-type="clarifyComposerNodeType"
               :seed-human-text="activeHomeSeed?.text"
-              :seed-human-images="activeHomeSeed?.images"
-              :done="activeClarify.done"
+              :seed-human-images="activeHomeSeed?.images ?? []"
+              :done="clarifyComposerDone"
               :active="clarifyInputActive"
               :confirm-error="clarifyConfirmError"
               @send="onClarifySend"
@@ -1741,7 +1773,7 @@ function itemSecondary(it: InboxItem) {
             </button>
           </div>
           <div class="flex min-h-0 flex-1 flex-col overflow-hidden">
-            <ArtifactLoadingPane v-if="activeRunLoading" message-key="pages.gatesInbox.loadingRun" />
+            <ArtifactLoadingPane v-if="activeRunLoading && active.type === 'gate'" message-key="pages.gatesInbox.loadingRun" />
             <GateApproval
               v-else-if="active.type === 'gate'"
               ref="gateApprovalRef"
@@ -1757,14 +1789,16 @@ function itemSecondary(it: InboxItem) {
               @open-share="openSharePanel(active)"
             />
             <ReviewShell
-              v-else-if="active.type === 'clarify' && activeClarify"
+              v-else-if="showClarifyReviewShell"
               :key="active.runId + active.nodeId"
               class="min-h-0 flex-1"
               :sidebar-width="400"
               :storage-key="REVIEW_SHELL_WIDTH_KEY_APPROVAL"
             >
               <template #stage>
+                <ArtifactLoadingPane v-if="activeRunLoading" message-key="pages.gatesInbox.loadingRun" />
                 <ReactArtifactStage
+                  v-else
                   :artifacts="activeRun?.artifacts || []"
                   :preview-artifact="activeClarify?.previewArtifact"
                   :run-id="active.runId"
@@ -1784,16 +1818,16 @@ function itemSecondary(it: InboxItem) {
                   ref="reviewChatRef"
                   :mode="composerMode"
                   :run-id="active.runId"
-                  :node-id="activeClarify.nodeId"
-                  :iteration="activeClarify.iteration ?? 1"
+                  :node-id="clarifyComposerNodeId"
+                  :iteration="clarifyComposerIteration"
                   v-model:draft="clarifyDraft"
                   v-model:attachments="clarifyAttachments"
                   v-model:annotations="clarifyAnnotations"
-                  :turns="activeClarify.turns ?? []"
-                  :node-type="inboxStageNodeType"
+                  :turns="clarifyComposerTurns"
+                  :node-type="clarifyComposerNodeType"
                   :seed-human-text="activeHomeSeed?.text"
-                  :seed-human-images="activeHomeSeed?.images"
-                  :done="activeClarify.done"
+                  :seed-human-images="activeHomeSeed?.images ?? []"
+                  :done="clarifyComposerDone"
                   :active="clarifyInputActive"
                   :confirm-error="clarifyConfirmError"
                   @send="onClarifySend"


### PR DESCRIPTION
## Summary
- StartRun 后立刻跳 Inbox，不再等 Approve park 完才离开首页。
- 加载中也挂上对话与首页附件；handoff 空 `nodeId` 用真实卡片盖上，种子按文本/附件合并，不写进 `liveTurns`。
- 抽出 `findInboxItemForHandoff` / `updateHomeApproveHandoffNode`，Inbox 不再手写 `run:node`。

## Test plan
- [ ] 首页带图片/文件发送：立刻进入 Inbox，加载中就能看到首条人话和附件
- [ ] 流水线 Approve 节点 id 未知时（空 node）：仍选中对应 run 的卡片，附件不丢
- [ ] 服务端转写落地后附件仍在，仅附件种子不出现两条气泡
- [ ] 切到其它 Inbox 卡片不会带上首页草稿
- [ ] 首页 → Inbox 过渡不闪骨架屏
- [x] 本地单测已通过（9 files / 145）：`cd web && npm test -- --run src/lib/run/homeApproveHandoff.test.ts src/lib/inbox/inboxActiveSelection.test.ts src/lib/run/useHomeApproveChat.test.ts src/views/GatesInboxView.inboxLifecycle.test.ts src/components/run/ClarifyChat.test.ts`