### PR TITLE
feat(home): 技术等宽 Approving 一次打字定格与直角 composer

### DIFF
--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -3,7 +3,7 @@
     "dashboard": {
       "title": "Start a pre-dev clarification in one sentence",
       "subtitle": "Pick an Approve pipeline; the first message becomes the Run title",
-      "placeholder": "Describe the goal, or paste/attach images and files…",
+      "placeholder": "Start your next iteration quickly",
       "filterHint": "Only published pipelines whose first node after start is Approve",
       "selectProject": "Select a project",
       "noProject": "No project selected. Pick a project to start an Approve pipeline from Home.",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -3,7 +3,7 @@
     "dashboard": {
       "title": "从一句话开始一次开发前澄清",
       "subtitle": "选择 Approve 流水线，第一句话会成为 Run 标题",
-      "placeholder": "描述目标，或粘贴/附加图片与文件…",
+      "placeholder": "快速开启你的迭代",
       "filterHint": "仅显示开始后是 Approve 的已发布流水线",
       "selectProject": "选择项目",
       "noProject": "尚未选择项目。选择一个项目后可从首页启动 Approve 流水线。",

--- a/web/src/views/DashboardView.fill.test.ts
+++ b/web/src/views/DashboardView.fill.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest'
 const dir = dirname(fileURLToPath(import.meta.url))
 const src = readFileSync(join(dir, 'DashboardView.vue'), 'utf8')
 const shellSrc = readFileSync(join(dir, '../components/shell/AppShell.vue'), 'utf8')
+const globalCss = readFileSync(join(dir, '../styles/global.css'), 'utf8')
 
 describe('DashboardView home chat layout', () => {
   it('root uses md+ flex fill without overflow-hidden', () => {
@@ -27,39 +28,56 @@ describe('DashboardView home chat layout', () => {
     expect(src).not.toMatch(/RunBoardColumn/)
   })
 
-  // plan g1.1 — edge-to-edge stage wash layers
-  it('renders full-bleed stage atmosphere layers', () => {
-    expect(src).toMatch(/data-testid="home-stage-bg"/)
-    expect(src).toMatch(/home-stage__wash/)
-    expect(src).toMatch(/home-stage__grid/)
-    expect(src).toMatch(/home-stage__glow/)
-    expect(src).toMatch(/pointer-events:\s*none/)
+  // plan g1.1 — no purple stage atmosphere
+  it('does not include full-bleed purple stage layers', () => {
+    expect(src).not.toMatch(/home-stage-bg/)
+    expect(src).not.toMatch(/home-stage__wash/)
+    expect(src).not.toMatch(/home-stage__grid/)
+    expect(src).not.toMatch(/home-stage__glow/)
+    expect(src).not.toMatch(/rgba\(91,\s*66,\s*180/)
   })
 
-  // plan g1.2 — Approving as first visual anchor
-  it('sizes brand as the dominant first-screen anchor', () => {
+  // plan g1.2 / g1.3 — monospace Approving, no gradient shimmer / staggered / serif accent
+  it('uses local monospace brand without banned brand effects', () => {
     expect(src).toMatch(/data-testid="home-brand"/)
-    expect(src).toMatch(/home-stage__brand/)
-    expect(src).toMatch(/clamp\(2\.75rem,\s*9vw,\s*5\.5rem\)/)
-    expect(src).toMatch(/font-weight:\s*700/)
-    expect(src).toMatch(/var\(--grad-logo\)/)
+    expect(src).toMatch(/JetBrains Mono/)
+    expect(src).toMatch(/ui-monospace/)
+    expect(src).toMatch(/home-brand__cursor/)
+    expect(src).not.toMatch(/var\(--grad-logo\)/)
+    expect(src).not.toMatch(/background-clip:\s*text/)
+    expect(src).not.toMatch(/shimmer/)
+    expect(src).not.toMatch(/stagger/)
+    expect(src).not.toMatch(/serif/)
+    expect(src).not.toMatch(/fonts\.googleapis|fonts\.gstatic|cdn\.jsdelivr/)
   })
 
-  // plan g1.3 — floating composer on stage plane
-  it('floats composer above the stage with glass surface', () => {
-    expect(src).toMatch(/home-stage__composer/)
-    expect(src).toMatch(/backdrop-filter:\s*blur\(12px\)/)
+  // plan g1.4 / g2.4 — right-angle Open Design composer with toolbar zone
+  it('uses right-angle Open Design composer with toolbar partition', () => {
+    expect(src).toMatch(/home-composer/)
+    expect(src).toMatch(/home-composer__toolbar/)
+    expect(src).toMatch(/home-composer__plus/)
+    expect(src).toMatch(/home-composer__send/)
     expect(src).toMatch(/data-testid="home-composer"/)
     expect(src).toMatch(/data-testid="home-composer-plus"/)
     expect(src).toMatch(/data-testid="home-pipeline-select"/)
     expect(src).toMatch(/data-testid="home-composer-send"/)
+    expect(src).toMatch(/<textarea/)
   })
 
-  // plan g2.3 — narrow-screen composer remains operable
-  it('adapts composer layout for narrow viewports', () => {
-    expect(src).toMatch(/@media \(max-width:\s*520px\)/)
-    expect(src).toMatch(/home-stage__input/)
-    expect(src).toMatch(/min-width:\s*100%/)
+  // plan g2.1 / g2.2 / g2.3
+  it('keeps filter hint, placeholder typewriter hook, and multiline textarea', () => {
+    expect(src).toMatch(/data-testid="home-filter-hint"/)
+    expect(src).toMatch(/data-testid="home-composer-placeholder"/)
+    expect(src).toMatch(/shiftKey/)
+    expect(src).toMatch(/prefers-reduced-motion/)
+  })
+
+  // plan g2.5 / g3.2 — scoped only; no external fonts
+  it('keeps styles scoped to DashboardView and does not load external fonts', () => {
+    expect(src).toMatch(/<style scoped>/)
+    expect(src).not.toMatch(/@import|googleapis|gstatic|jsdelivr.*font/)
+    expect(globalCss).toMatch(/:root|html/)
+    expect(src).not.toContain(globalCss.slice(0, 40))
   })
 
   it('does not alter AppShell height chain', () => {

--- a/web/src/views/DashboardView.fill.test.ts
+++ b/web/src/views/DashboardView.fill.test.ts
@@ -64,11 +64,14 @@ describe('DashboardView home chat layout', () => {
     expect(src).toMatch(/<textarea/)
   })
 
-  // review v1/v2 — 无 subtitle；流水线卡片直角覆盖全局 .card
+  // review v1/v2/v4 — 无 subtitle；流水线卡片脱离全局 .card；附件移除钮直角
   it('omits home-subtitle and forces square pipeline cards', () => {
     expect(src).not.toMatch(/data-testid="home-subtitle"/)
-    expect(src).toMatch(/home-shell__card[^"]*rounded-none|rounded-none[^"]*home-shell__card/)
+    expect(src).toMatch(/class="home-shell__card[^"]*border border-line/)
+    expect(src).not.toMatch(/class="[^"]*\bcard\b[^"]*home-shell__card|class="home-shell__card[^"]*\bcard\b/)
     expect(src).toMatch(/\.home-shell__card\s*\{[^}]*border-radius:\s*0/s)
+    expect(src).toMatch(/rounded-none bg-err[\s\S]{0,80}data-testid="home-attach-remove"/)
+    expect(src).not.toMatch(/rounded-full bg-err[\s\S]{0,80}data-testid="home-attach-remove"/)
   })
 
   // plan g2.1 / g2.2 / g2.3

--- a/web/src/views/DashboardView.fill.test.ts
+++ b/web/src/views/DashboardView.fill.test.ts
@@ -64,6 +64,13 @@ describe('DashboardView home chat layout', () => {
     expect(src).toMatch(/<textarea/)
   })
 
+  // review v1/v2 — 无 subtitle；流水线卡片直角覆盖全局 .card
+  it('omits home-subtitle and forces square pipeline cards', () => {
+    expect(src).not.toMatch(/data-testid="home-subtitle"/)
+    expect(src).toMatch(/home-shell__card[^"]*rounded-none|rounded-none[^"]*home-shell__card/)
+    expect(src).toMatch(/\.home-shell__card\s*\{[^}]*border-radius:\s*0/s)
+  })
+
   // plan g2.1 / g2.2 / g2.3
   it('keeps filter hint, placeholder typewriter hook, and multiline textarea', () => {
     expect(src).toMatch(/data-testid="home-filter-hint"/)

--- a/web/src/views/DashboardView.test.ts
+++ b/web/src/views/DashboardView.test.ts
@@ -133,13 +133,25 @@ describe('DashboardView home composer', () => {
     wrapper.unmount()
   })
 
-  // plan g1.2 / g1.3 — Approving mono brand + Chinese hint
+  // plan g1.2 / g1.3 — Approving mono brand + Chinese hint（无 subtitle，对齐第 5 轮）
   it('renders monospace Approving brand and Chinese hint', async () => {
     const wrapper = mountDashboard()
     await flushPromises()
     expect(wrapper.get('[data-testid="home-brand"]').classes()).toContain('home-brand')
     expect(wrapper.get('[data-testid="home-title"]').text()).toBe('从一句话开始一次开发前澄清')
+    expect(wrapper.find('[data-testid="home-subtitle"]').exists()).toBe(false)
     expect(wrapper.get('[data-testid="home-filter-hint"]').text()).toContain('Approve')
+    wrapper.unmount()
+  })
+
+  // plan g1.4 — pipeline cards are square (override global .card rounded-lg)
+  it('renders right-angle pipeline cards', async () => {
+    const wrapper = mountDashboard()
+    await flushPromises()
+    const card = wrapper.get('[data-testid="home-pipeline-card-wf-ap"]')
+    expect(card.classes()).toContain('home-shell__card')
+    expect(card.classes()).toContain('rounded-none')
+    expect(card.classes()).not.toContain('rounded-lg')
     wrapper.unmount()
   })
 

--- a/web/src/views/DashboardView.test.ts
+++ b/web/src/views/DashboardView.test.ts
@@ -144,14 +144,15 @@ describe('DashboardView home composer', () => {
     wrapper.unmount()
   })
 
-  // plan g1.4 — pipeline cards are square (override global .card rounded-lg)
+  // plan g1.4 — pipeline cards are square (no global .card / rounded-lg)
   it('renders right-angle pipeline cards', async () => {
     const wrapper = mountDashboard()
     await flushPromises()
     const card = wrapper.get('[data-testid="home-pipeline-card-wf-ap"]')
     expect(card.classes()).toContain('home-shell__card')
-    expect(card.classes()).toContain('rounded-none')
+    expect(card.classes()).not.toContain('card')
     expect(card.classes()).not.toContain('rounded-lg')
+    expect(card.classes()).toContain('border')
     wrapper.unmount()
   })
 

--- a/web/src/views/DashboardView.test.ts
+++ b/web/src/views/DashboardView.test.ts
@@ -72,6 +72,22 @@ function mountDashboard() {
   })
 }
 
+function stubReducedMotion(matches: boolean) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((query: string) => ({
+      matches: query.includes('prefers-reduced-motion') ? matches : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  )
+}
+
 describe('DashboardView home composer', () => {
   beforeEach(() => {
     mocks.push.mockReset()
@@ -89,9 +105,12 @@ describe('DashboardView home composer', () => {
       nodeRuns: { ap: { nodeId: 'ap', status: 'waiting_human' } },
     })
     mocks.reactReply.mockResolvedValue({ status: 'ok' })
+    stubReducedMotion(false)
+    vi.useFakeTimers()
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.unstubAllGlobals()
   })
 
@@ -104,14 +123,63 @@ describe('DashboardView home composer', () => {
     wrapper.unmount()
   })
 
-  // plan g1.1/g1.2 — stage atmosphere + brand anchor remain in the live tree
-  it('renders stage background and dominant Approving brand', async () => {
+  // plan g1.1 — no full-bleed purple stage layer
+  it('does not render full-screen purple stage atmosphere', async () => {
     const wrapper = mountDashboard()
     await flushPromises()
-    expect(wrapper.find('[data-testid="home-stage-bg"]').exists()).toBe(true)
-    expect(wrapper.get('[data-testid="home-brand"]').text()).toBe('Approving')
-    expect(wrapper.get('[data-testid="home-brand"]').classes()).toContain('home-stage__brand')
-    expect(wrapper.get('[data-testid="home-composer"]').classes()).toContain('home-stage__composer')
+    expect(wrapper.find('[data-testid="home-stage-bg"]').exists()).toBe(false)
+    expect(wrapper.find('.home-stage__wash').exists()).toBe(false)
+    expect(wrapper.find('.home-stage__glow').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  // plan g1.2 / g1.3 — Approving mono brand + Chinese hint
+  it('renders monospace Approving brand and Chinese hint', async () => {
+    const wrapper = mountDashboard()
+    await flushPromises()
+    expect(wrapper.get('[data-testid="home-brand"]').classes()).toContain('home-brand')
+    expect(wrapper.get('[data-testid="home-title"]').text()).toBe('从一句话开始一次开发前澄清')
+    expect(wrapper.get('[data-testid="home-filter-hint"]').text()).toContain('Approve')
+    wrapper.unmount()
+  })
+
+  // plan g1.3 — one-shot typewriter then settle
+  it('types Approving once then settles without looping', async () => {
+    const wrapper = mountDashboard()
+    await flushPromises()
+    expect(wrapper.get('[data-testid="home-brand-text"]').text()).toBe('')
+    await vi.advanceTimersByTimeAsync(120 + 72 * 9 + 50)
+    expect(wrapper.get('[data-testid="home-brand-text"]').text()).toBe('Approving')
+    expect(wrapper.find('[data-testid="home-brand-cursor"]').exists()).toBe(true)
+    await vi.advanceTimersByTimeAsync(420 + 380 * 6 + 50)
+    expect(wrapper.get('[data-testid="home-brand-text"]').text()).toBe('Approving')
+    expect(wrapper.find('[data-testid="home-brand-cursor"]').exists()).toBe(false)
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(wrapper.get('[data-testid="home-brand-text"]').text()).toBe('Approving')
+    expect(wrapper.find('[data-testid="home-brand-cursor"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  // plan g3.3 — reduced-motion shows static brand
+  it('shows full Approving immediately under reduced-motion', async () => {
+    stubReducedMotion(true)
+    const wrapper = mountDashboard()
+    await flushPromises()
+    expect(wrapper.get('[data-testid="home-brand-text"]').text()).toBe('Approving')
+    expect(wrapper.find('[data-testid="home-brand-cursor"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  // plan g2.1 — placeholder typewriter when idle/empty
+  it('shows placeholder typewriter when empty and unfocused', async () => {
+    const wrapper = mountDashboard()
+    await flushPromises()
+    expect(wrapper.find('[data-testid="home-composer-placeholder"]').exists()).toBe(true)
+    await vi.advanceTimersByTimeAsync(80 + 64 * 9 + 50)
+    expect(wrapper.get('[data-testid="home-composer-placeholder"]').text()).toContain('快速开启你的迭代')
+    await wrapper.get('[data-testid="home-composer-input"]').trigger('focus')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="home-composer-placeholder"]').exists()).toBe(false)
     wrapper.unmount()
   })
 
@@ -154,9 +222,23 @@ describe('DashboardView home composer', () => {
       title: '把登录做清楚',
       firstMessage: { text: '把登录做清楚', images: [] },
     })
-    // The engine delivers the opening message after the approve node parks.
     expect(mocks.reactReply).not.toHaveBeenCalled()
     expect(mocks.push).toHaveBeenCalledWith({ path: '/gates', query: { run: 'run-9', node: 'ap' } })
+    wrapper.unmount()
+  })
+
+  // plan g2.3 — Enter submits; Shift+Enter does not
+  it('Enter submits and Shift+Enter keeps the draft for a new line', async () => {
+    const wrapper = mountDashboard()
+    await flushPromises()
+    const input = wrapper.get('[data-testid="home-composer-input"]')
+    await input.setValue('一行需求')
+    await input.trigger('keydown', { key: 'Enter', shiftKey: true })
+    await flushPromises()
+    expect(mocks.startRun).not.toHaveBeenCalled()
+    await input.trigger('keydown', { key: 'Enter', shiftKey: false })
+    await flushPromises()
+    expect(mocks.startRun).toHaveBeenCalled()
     wrapper.unmount()
   })
 

--- a/web/src/views/DashboardView.vue
+++ b/web/src/views/DashboardView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import Icon from '@/components/ui/Icon.vue'
@@ -7,6 +8,8 @@ import RunLaunchModal from '@/components/workflow/RunLaunchModal.vue'
 import { useHomeApproveChat } from '@/lib/run/useHomeApproveChat'
 import { attachmentDisplayName, isImageAttachment } from '@/lib/shared/attachments'
 import { imgSrc } from '@/lib/shared/compositeText'
+
+const BRAND_TEXT = 'Approving'
 
 const router = useRouter()
 const { t } = useI18n()
@@ -42,6 +45,145 @@ const {
   onLaunchStarted,
 } = useHomeApproveChat()
 
+const brandVisible = ref('')
+const brandCursor = ref(false)
+const brandTimers: ReturnType<typeof setTimeout>[] = []
+const composerFocused = ref(false)
+const composing = ref(false)
+const textareaRef = ref<HTMLTextAreaElement | null>(null)
+const overflowScroll = ref(false)
+const phVisible = ref('')
+const phCursor = ref(false)
+let phTimer: ReturnType<typeof setTimeout> | null = null
+let phLoopTimer: ReturnType<typeof setTimeout> | null = null
+
+const placeholderFull = computed(() => t('pages.dashboard.placeholder'))
+const showPhTypewriter = computed(() => !draft.value.trim() && !composerFocused.value)
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || !window.matchMedia) return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+function clearBrandTimers() {
+  while (brandTimers.length) {
+    const id = brandTimers.pop()
+    if (id != null) clearTimeout(id)
+  }
+}
+
+function scheduleBrand(fn: () => void, ms: number) {
+  brandTimers.push(setTimeout(fn, ms))
+}
+
+function runBrandTypewriter() {
+  clearBrandTimers()
+  if (prefersReducedMotion()) {
+    brandVisible.value = BRAND_TEXT
+    brandCursor.value = false
+    return
+  }
+  brandVisible.value = ''
+  brandCursor.value = true
+  let i = 0
+  const typeNext = () => {
+    if (i < BRAND_TEXT.length) {
+      i += 1
+      brandVisible.value = BRAND_TEXT.slice(0, i)
+      scheduleBrand(typeNext, 72)
+      return
+    }
+    // Soft blink a few times, then hide the caret permanently.
+    let blinks = 0
+    const blink = () => {
+      brandCursor.value = !brandCursor.value
+      blinks += 1
+      if (blinks < 6) {
+        scheduleBrand(blink, 380)
+        return
+      }
+      brandCursor.value = false
+    }
+    scheduleBrand(blink, 420)
+  }
+  scheduleBrand(typeNext, 120)
+}
+
+function clearPhTimers() {
+  if (phTimer != null) {
+    clearTimeout(phTimer)
+    phTimer = null
+  }
+  if (phLoopTimer != null) {
+    clearTimeout(phLoopTimer)
+    phLoopTimer = null
+  }
+}
+
+function runPlaceholderTypewriter() {
+  clearPhTimers()
+  const full = placeholderFull.value
+  if (!showPhTypewriter.value) {
+    phVisible.value = ''
+    phCursor.value = false
+    return
+  }
+  if (prefersReducedMotion()) {
+    phVisible.value = full
+    phCursor.value = false
+    return
+  }
+  phVisible.value = ''
+  phCursor.value = true
+  let i = 0
+  const typeNext = () => {
+    if (!showPhTypewriter.value) return
+    if (i < full.length) {
+      i += 1
+      phVisible.value = full.slice(0, i)
+      phTimer = setTimeout(typeNext, 64)
+      return
+    }
+    // Hold, then briefly blink caret and restart once idle.
+    phLoopTimer = setTimeout(() => {
+      if (!showPhTypewriter.value) return
+      phCursor.value = false
+      phLoopTimer = setTimeout(() => {
+        if (showPhTypewriter.value) runPlaceholderTypewriter()
+      }, 900)
+    }, 2200)
+  }
+  phTimer = setTimeout(typeNext, 80)
+}
+
+function autoGrow() {
+  const el = textareaRef.value
+  if (!el) return
+  el.style.height = 'auto'
+  const h = Math.min(Math.max(el.scrollHeight, 56), 200)
+  el.style.height = `${h}px`
+  overflowScroll.value = el.scrollHeight > 200
+}
+
+function onTextInput() {
+  autoGrow()
+}
+
+function onComposerKeydown(e: KeyboardEvent) {
+  if (e.key !== 'Enter' || e.shiftKey) return
+  if (composing.value || e.isComposing || e.keyCode === 229) return
+  e.preventDefault()
+  void send()
+}
+
+function onComposerFocus() {
+  composerFocused.value = true
+}
+
+function onComposerBlur() {
+  composerFocused.value = false
+}
+
 function goSelectProject() {
   void router.push('/projects')
 }
@@ -68,24 +210,42 @@ function onComposerSubmit(e: Event) {
 function openFilePicker() {
   fileInput.value?.click()
 }
+
+watch(draft, () => nextTick(autoGrow))
+watch(showPhTypewriter, () => runPlaceholderTypewriter(), { immediate: true })
+watch(placeholderFull, () => {
+  if (showPhTypewriter.value) runPlaceholderTypewriter()
+})
+
+onMounted(() => {
+  runBrandTypewriter()
+  nextTick(autoGrow)
+})
+
+onBeforeUnmount(() => {
+  clearBrandTimers()
+  clearPhTimers()
+})
 </script>
 
 <template>
-  <div data-testid="dashboard-view" class="home-stage relative flex flex-col md:h-full md:min-h-0">
-    <div class="home-stage__bg" aria-hidden="true" data-testid="home-stage-bg">
-      <div class="home-stage__wash" />
-      <div class="home-stage__grid" />
-      <div class="home-stage__glow" />
-    </div>
-
+  <div data-testid="dashboard-view" class="home-shell relative flex flex-col md:h-full md:min-h-0">
     <div
-      class="home-stage__content relative z-[1] mx-auto flex w-full max-w-3xl flex-1 flex-col items-center justify-center px-4 py-10"
+      class="home-shell__content relative z-[1] mx-auto flex w-full max-w-3xl flex-1 flex-col items-center justify-center px-4 py-10"
     >
-      <p class="home-stage__brand" data-testid="home-brand">Approving</p>
-      <h2 class="home-stage__headline mt-5 text-center" data-testid="home-title">
+      <h1 class="home-brand" data-testid="home-brand" aria-label="Approving">
+        <span class="home-brand__text" data-testid="home-brand-text">{{ brandVisible }}</span>
+        <span
+          v-if="brandCursor"
+          class="home-brand__cursor"
+          data-testid="home-brand-cursor"
+          aria-hidden="true"
+        >▌</span>
+      </h1>
+      <p class="home-hint mt-4 text-center" data-testid="home-title">
         {{ t('pages.dashboard.title') }}
-      </h2>
-      <p class="mt-2.5 max-w-xl text-center text-[13px] text-txt2" data-testid="home-subtitle">
+      </p>
+      <p class="mt-2 max-w-xl text-center text-[13px] text-txt2" data-testid="home-subtitle">
         {{ t('pages.dashboard.subtitle') }}
       </p>
 
@@ -136,7 +296,7 @@ function openFilePicker() {
           </div>
         </div>
         <form
-          class="home-stage__composer flex w-full items-center gap-2 border px-3 py-2"
+          class="home-composer flex w-full flex-col border"
           data-testid="home-composer"
           @submit="onComposerSubmit"
         >
@@ -148,46 +308,72 @@ function openFilePicker() {
             data-testid="home-composer-file"
             @change="onPickFiles"
           />
-          <button
-            type="button"
-            class="flex h-8 w-8 shrink-0 items-center justify-center text-txt3 hover:text-txt disabled:opacity-40"
-            :disabled="sending"
-            :title="t('pages.clarify.addImage')"
-            data-testid="home-composer-plus"
-            @click="openFilePicker"
-          >
-            <Icon name="plus" :size="16" />
-          </button>
-          <label class="sr-only" for="home-pipeline-select">{{ t('pages.dashboard.pickPipeline') }}</label>
-          <select
-            id="home-pipeline-select"
-            class="home-stage__pipeline max-w-[10rem] shrink-0 cursor-pointer appearance-none border bg-accent/15 px-3 py-1.5 text-xs font-medium text-accent outline-none disabled:cursor-default disabled:bg-elevated disabled:text-txt3"
-            data-testid="home-pipeline-select"
-            :disabled="!pipelines.length || sending"
-            :value="selectedId"
-            @change="onPipelineChange"
-          >
-            <option v-if="!pipelines.length" value="">{{ t('pages.dashboard.noPipelineShort') }}</option>
-            <option v-for="p in pipelines" :key="p.id" :value="p.id">{{ p.name }}</option>
-          </select>
-          <input
-            v-model="draft"
-            class="home-stage__input min-w-0 flex-1 bg-transparent px-1 text-sm text-txt outline-none placeholder:text-txt3"
-            data-testid="home-composer-input"
-            :placeholder="t('pages.dashboard.placeholder')"
-            :disabled="sending"
-            autocomplete="off"
-            @paste="onPaste"
-          />
-          <button
-            type="submit"
-            class="home-stage__send flex h-8 w-8 shrink-0 items-center justify-center text-base disabled:opacity-40"
-            data-testid="home-composer-send"
-            :disabled="sending || !canSend"
-            :aria-label="t('pages.dashboard.send')"
-          >
-            <Icon name="arrow-up" :size="16" />
-          </button>
+          <div class="home-composer__field relative px-3 pt-3">
+            <label class="sr-only" for="home-composer-input">{{ t('pages.dashboard.placeholder') }}</label>
+            <textarea
+              id="home-composer-input"
+              ref="textareaRef"
+              v-model="draft"
+              class="home-composer__input w-full min-w-0 resize-none bg-transparent text-sm text-txt outline-none"
+              :class="overflowScroll ? 'scroll-area max-h-[200px] overflow-y-auto' : 'overflow-y-hidden'"
+              data-testid="home-composer-input"
+              rows="2"
+              :disabled="sending"
+              autocomplete="off"
+              @input="onTextInput"
+              @keydown="onComposerKeydown"
+              @compositionstart="composing = true"
+              @compositionend="composing = false"
+              @paste="onPaste"
+              @focus="onComposerFocus"
+              @blur="onComposerBlur"
+            />
+            <span
+              v-if="showPhTypewriter"
+              class="home-composer__ph pointer-events-none absolute left-3 top-3 text-sm text-txt3"
+              data-testid="home-composer-placeholder"
+              aria-hidden="true"
+            >
+              {{ phVisible }}<span
+                v-if="phCursor"
+                class="home-composer__ph-cursor"
+                data-testid="home-composer-ph-cursor"
+              >▌</span>
+            </span>
+          </div>
+          <div class="home-composer__toolbar flex items-center gap-2 border-t px-2 py-2">
+            <button
+              type="button"
+              class="home-composer__plus flex h-9 w-9 shrink-0 items-center justify-center border text-txt2 hover:text-txt disabled:opacity-40"
+              :disabled="sending"
+              :title="t('pages.clarify.addImage')"
+              data-testid="home-composer-plus"
+              @click="openFilePicker"
+            >
+              <Icon name="plus" :size="16" />
+            </button>
+            <label class="sr-only" for="home-pipeline-select">{{ t('pages.dashboard.pickPipeline') }}</label>
+            <select
+              id="home-pipeline-select"
+              class="home-composer__pipeline max-w-[12rem] min-w-0 flex-1 cursor-pointer appearance-none border bg-transparent px-2.5 py-1.5 text-xs font-medium text-txt outline-none disabled:cursor-default disabled:text-txt3"
+              data-testid="home-pipeline-select"
+              :disabled="!pipelines.length || sending"
+              :value="selectedId"
+              @change="onPipelineChange"
+            >
+              <option v-if="!pipelines.length" value="">{{ t('pages.dashboard.noPipelineShort') }}</option>
+              <option v-for="p in pipelines" :key="p.id" :value="p.id">{{ p.name }}</option>
+            </select>
+            <button
+              type="submit"
+              class="home-composer__send flex h-9 w-9 shrink-0 items-center justify-center text-base disabled:opacity-40"
+              data-testid="home-composer-send"
+              :disabled="sending || !canSend"
+              :aria-label="t('pages.dashboard.send')"
+            >
+              <Icon name="arrow-up" :size="16" />
+            </button>
+          </div>
         </form>
       </div>
       <p class="mt-3 text-center text-[11px] text-txt3" data-testid="home-filter-hint">
@@ -243,18 +429,18 @@ function openFilePicker() {
           v-for="p in pipelines"
           :key="p.id"
           type="button"
-          class="card home-stage__card w-48 shrink-0 overflow-hidden p-0 text-left transition"
+          class="card home-shell__card w-48 shrink-0 overflow-hidden p-0 text-left transition"
           :class="p.id === selected?.id ? 'border-accent ring-1 ring-accent/40' : 'hover:border-line-strong'"
           :data-testid="`home-pipeline-card-${p.id}`"
           @click="selectPipeline(p.id)"
         >
           <div class="flex h-20 items-center justify-center bg-elevated/80">
             <span class="flex items-center gap-1.5">
-              <span class="h-2 w-2 rounded-full bg-txt3" />
+              <span class="h-2 w-2 bg-txt3" />
               <span class="h-px w-6 bg-line-strong" />
-              <span class="h-2.5 w-2.5 rounded-full bg-accent" />
+              <span class="h-2.5 w-2.5 bg-accent" />
               <span class="h-px w-6 bg-line-strong" />
-              <span class="h-2 w-2 rounded-full bg-txt3" />
+              <span class="h-2 w-2 bg-txt3" />
             </span>
           </div>
           <div class="px-3 py-2.5">
@@ -286,189 +472,144 @@ function openFilePicker() {
 </template>
 
 <style scoped>
-/* g1.1 — edge-to-edge stage wash / grid / glow (dark + light readable) */
-.home-stage {
+/* g1 — clean shell, no full-bleed purple stage */
+.home-shell {
   isolation: isolate;
 }
 
-.home-stage__bg {
-  pointer-events: none;
-  position: absolute;
-  inset: 0;
-  z-index: 0;
-  overflow: hidden;
-}
-
-.home-stage__wash {
-  position: absolute;
-  inset: 0;
-  background:
-    radial-gradient(ellipse 90% 55% at 50% 8%, rgba(91, 66, 180, 0.48) 0%, transparent 58%),
-    radial-gradient(ellipse 60% 40% at 80% 70%, rgba(49, 46, 129, 0.28) 0%, transparent 55%),
-    linear-gradient(180deg, rgba(10, 10, 11, 0.12) 0%, rgba(10, 10, 11, 0.55) 55%, rgb(var(--c-base)) 100%),
-    linear-gradient(135deg, rgb(17 24 39) 0%, rgb(var(--c-base)) 42%, rgb(30 27 75) 100%);
-}
-
-:global(html.light) .home-stage__wash {
-  background:
-    radial-gradient(ellipse 90% 55% at 50% 8%, rgba(123, 97, 255, 0.22) 0%, transparent 58%),
-    radial-gradient(ellipse 55% 38% at 82% 72%, rgba(99, 102, 241, 0.14) 0%, transparent 55%),
-    linear-gradient(180deg, rgba(250, 250, 251, 0.35) 0%, rgba(250, 250, 251, 0.82) 55%, rgb(var(--c-base)) 100%),
-    linear-gradient(135deg, #eef0ff 0%, rgb(var(--c-base)) 45%, #e8e7f8 100%);
-}
-
-.home-stage__grid {
-  position: absolute;
-  inset: 0;
-  background-image:
-    linear-gradient(rgba(255, 255, 255, 0.045) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.045) 1px, transparent 1px);
-  background-size: 48px 48px;
-  mask-image: radial-gradient(circle at 50% 28%, #000 18%, transparent 72%);
-  -webkit-mask-image: radial-gradient(circle at 50% 28%, #000 18%, transparent 72%);
-  animation: home-stage-drift 18s linear infinite;
-}
-
-:global(html.light) .home-stage__grid {
-  background-image:
-    linear-gradient(rgba(99, 102, 241, 0.08) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(99, 102, 241, 0.08) 1px, transparent 1px);
-}
-
-.home-stage__glow {
-  position: absolute;
-  top: 10%;
-  left: 50%;
-  width: min(720px, 90vw);
-  height: 220px;
-  transform: translateX(-50%);
-  background: radial-gradient(ellipse at center, rgba(167, 139, 250, 0.28), transparent 70%);
-  filter: blur(8px);
-  animation: home-stage-pulse 5.5s ease-in-out infinite;
-}
-
-:global(html.light) .home-stage__glow {
-  background: radial-gradient(ellipse at center, rgba(123, 97, 255, 0.18), transparent 70%);
-}
-
-/* g1.2 — brand as first visual anchor */
-.home-stage__brand {
-  font-size: clamp(2.75rem, 9vw, 5.5rem);
-  font-weight: 700;
-  letter-spacing: -0.04em;
-  line-height: 0.92;
-  color: rgb(var(--c-accent-2));
-  background: var(--grad-logo);
-  background-size: var(--grad-logo-size);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  animation: home-stage-brand-in 0.9s ease-out both, shimmer 3.5s ease-in-out 0.9s infinite;
-}
-
-.home-stage__headline {
-  font-size: clamp(1.25rem, 3.2vw, 1.75rem);
+/* g1.3 — monospace brand; solid color (no gradient flash / purple haze) */
+.home-brand {
+  display: inline-flex;
+  align-items: baseline;
+  margin: 0;
+  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: clamp(2.5rem, 8vw, 4.75rem);
   font-weight: 600;
-  letter-spacing: -0.02em;
+  letter-spacing: -0.045em;
+  line-height: 0.95;
   color: rgb(var(--c-txt));
 }
 
-/* g1.3 — floating composer on stage plane */
-.home-stage__composer {
-  border-color: rgba(196, 181, 253, 0.35);
-  background: rgba(10, 10, 11, 0.58);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  box-shadow:
-    0 24px 60px rgba(0, 0, 0, 0.35),
-    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+:global(html.light) .home-brand {
+  color: rgb(var(--c-txt));
 }
 
-:global(html.light) .home-stage__composer {
-  border-color: rgba(123, 97, 255, 0.28);
-  background: rgba(255, 255, 255, 0.78);
-  box-shadow:
-    0 18px 40px rgba(16, 24, 40, 0.08),
-    inset 0 1px 0 rgba(255, 255, 255, 0.9);
+.home-brand__cursor {
+  display: inline-block;
+  margin-left: 0.06em;
+  font-weight: 400;
+  color: rgb(var(--c-accent-2));
+  animation: home-brand-caret 0.76s step-end infinite;
 }
 
-.home-stage__pipeline {
-  border-color: rgba(196, 181, 253, 0.45);
+.home-hint {
+  font-size: clamp(0.95rem, 2.4vw, 1.125rem);
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: rgb(var(--c-txt2));
 }
 
-:global(html.light) .home-stage__pipeline {
-  border-color: rgba(123, 97, 255, 0.35);
+/* g1.4 / g2.4 — right-angle Open Design composer */
+.home-composer {
+  border-color: rgb(var(--c-line-strong));
+  background: rgb(var(--c-surface));
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.22);
 }
 
-.home-stage__send {
-  background: rgb(237 233 254);
-  color: #111;
+:global(html.light) .home-composer {
+  border-color: rgb(var(--c-line));
+  background: rgb(var(--c-elevated));
+  box-shadow: 0 10px 28px rgba(16, 24, 40, 0.06);
 }
 
-:global(html.light) .home-stage__send {
+.home-composer__toolbar {
+  border-color: rgb(var(--c-line));
+  background: rgb(var(--c-elevated) / 0.55);
+}
+
+:global(html.light) .home-composer__toolbar {
+  background: rgb(var(--c-base) / 0.45);
+}
+
+.home-composer__input {
+  min-height: 56px;
+  line-height: 1.5;
+}
+
+.home-composer__ph-cursor {
+  display: inline-block;
+  margin-left: 1px;
+  color: rgb(var(--c-txt3));
+  animation: home-brand-caret 0.76s step-end infinite;
+}
+
+.home-composer__plus {
+  border-color: rgb(var(--c-line));
+  background: transparent;
+  transition: border-color 0.15s ease, color 0.15s ease, background-color 0.15s ease;
+}
+
+.home-composer__plus:hover:not(:disabled) {
+  border-color: rgb(var(--c-line-strong));
+  background: rgb(var(--c-elevated));
+}
+
+.home-composer__pipeline {
+  border-color: rgb(var(--c-line));
+  color: rgb(var(--c-txt));
+}
+
+.home-composer__pipeline:focus {
+  border-color: rgb(var(--c-accent-2));
+}
+
+.home-composer__send {
+  background: rgb(var(--c-txt));
+  color: rgb(var(--c-base));
+  transition: opacity 0.15s ease, background-color 0.15s ease;
+}
+
+.home-composer__send:hover:not(:disabled) {
+  background: rgb(var(--c-accent-2));
+  color: #fff;
+}
+
+:global(html.light) .home-composer__send:hover:not(:disabled) {
   background: rgb(var(--c-txt));
   color: rgb(var(--c-base));
 }
 
-.home-stage__card {
-  background: rgba(20, 20, 23, 0.72);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+.home-shell__card {
+  background: rgb(var(--c-surface));
 }
 
-:global(html.light) .home-stage__card {
-  background: rgba(255, 255, 255, 0.82);
+:global(html.light) .home-shell__card {
+  background: rgb(var(--c-elevated));
 }
 
-@keyframes home-stage-drift {
-  from {
-    transform: translateY(0);
-    opacity: 0.9;
-  }
-  to {
-    transform: translateY(24px);
-    opacity: 0.75;
-  }
-}
-
-@keyframes home-stage-pulse {
-  0%,
-  100% {
-    opacity: 0.55;
-  }
+@keyframes home-brand-caret {
   50% {
-    opacity: 0.9;
-  }
-}
-
-@keyframes home-stage-brand-in {
-  from {
     opacity: 0;
-    transform: translateY(12px);
-    filter: blur(4px);
-  }
-  to {
-    opacity: 1;
-    transform: none;
-    filter: none;
   }
 }
 
-/* g2.3 — narrow screens keep brand anchor + operable composer */
+@media (prefers-reduced-motion: reduce) {
+  .home-brand__cursor,
+  .home-composer__ph-cursor {
+    animation: none;
+    opacity: 1;
+  }
+}
+
 @media (max-width: 520px) {
-  .home-stage__content {
+  .home-shell__content {
     padding-top: 2rem;
     padding-bottom: 2.5rem;
     justify-content: flex-start;
   }
 
-  .home-stage__composer {
-    flex-wrap: wrap;
-  }
-
-  .home-stage__input {
-    min-width: 100%;
-    order: 3;
+  .home-composer__pipeline {
+    max-width: none;
   }
 }
 </style>

--- a/web/src/views/DashboardView.vue
+++ b/web/src/views/DashboardView.vue
@@ -245,9 +245,6 @@ onBeforeUnmount(() => {
       <p class="home-hint mt-4 text-center" data-testid="home-title">
         {{ t('pages.dashboard.title') }}
       </p>
-      <p class="mt-2 max-w-xl text-center text-[13px] text-txt2" data-testid="home-subtitle">
-        {{ t('pages.dashboard.subtitle') }}
-      </p>
 
       <div class="mt-8 w-full">
         <p
@@ -268,7 +265,7 @@ onBeforeUnmount(() => {
               v-if="isImageAttachment(im)"
               mode="locked"
               size="sm"
-              thumb-class="rounded-md"
+              thumb-class="rounded-none"
               :src="imgSrc(im)"
               :label="attachmentDisplayName(im, ii)"
               :alt="attachmentDisplayName(im, ii)"
@@ -429,7 +426,7 @@ onBeforeUnmount(() => {
           v-for="p in pipelines"
           :key="p.id"
           type="button"
-          class="card home-shell__card w-48 shrink-0 overflow-hidden p-0 text-left transition"
+          class="card home-shell__card rounded-none w-48 shrink-0 overflow-hidden p-0 text-left transition"
           :class="p.id === selected?.id ? 'border-accent ring-1 ring-accent/40' : 'hover:border-line-strong'"
           :data-testid="`home-pipeline-card-${p.id}`"
           @click="selectPipeline(p.id)"
@@ -581,6 +578,7 @@ onBeforeUnmount(() => {
 
 .home-shell__card {
   background: rgb(var(--c-surface));
+  border-radius: 0;
 }
 
 :global(html.light) .home-shell__card {

--- a/web/src/views/DashboardView.vue
+++ b/web/src/views/DashboardView.vue
@@ -284,7 +284,7 @@ onBeforeUnmount(() => {
             </div>
             <button
               type="button"
-              class="absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-err text-white"
+              class="absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-none bg-err text-white"
               data-testid="home-attach-remove"
               @click.stop="removeAttachment(ii)"
             >
@@ -426,7 +426,7 @@ onBeforeUnmount(() => {
           v-for="p in pipelines"
           :key="p.id"
           type="button"
-          class="card home-shell__card rounded-none w-48 shrink-0 overflow-hidden p-0 text-left transition"
+          class="home-shell__card w-48 shrink-0 overflow-hidden border border-line p-0 text-left transition"
           :class="p.id === selected?.id ? 'border-accent ring-1 ring-accent/40' : 'hover:border-line-strong'"
           :data-testid="`home-pipeline-card-${p.id}`"
           @click="selectPipeline(p.id)"
@@ -576,9 +576,11 @@ onBeforeUnmount(() => {
   color: rgb(var(--c-base));
 }
 
+/* 不复用全局 .card（含 rounded-lg）；局部直角卡片 */
 .home-shell__card {
   background: rgb(var(--c-surface));
   border-radius: 0;
+  box-shadow: none;
 }
 
 :global(html.light) .home-shell__card {


### PR DESCRIPTION
## Summary
- 去掉首页全屏紫雾舞台与渐变品牌闪烁，改为本地 JetBrains Mono 等宽字标 + 一次打字定格（末尾光标轻闪后消失；reduced-motion 静态完整字标）
- 直角 Open Design composer：多行自适应、Enter 发送 / Shift+Enter 换行、placeholder「快速开启你的迭代」空态打字机，下方保留 filterHint 与直角流水线卡片
- 样式仅落在 DashboardView scoped；同步单测覆盖结构/动效禁项与 reduced-motion

## Test plan
- [ ] `cd web && npm test -- src/views/DashboardView.test.ts src/views/DashboardView.fill.test.ts`
- [ ] 暗色 / 亮色各看一眼首页：无紫雾舞台，Approving 打字一次后定格
- [ ] 系统开启 reduced-motion：Approving 与 placeholder 直接完整显示
- [ ] 空态未 focus 见 placeholder 打字机；focus 或输入后消失
- [ ] 多行输入、Enter 提交、Shift+Enter 换行；卡片与 pipeline select 选中同步


Made with [Cursor](https://cursor.com)