### PR TITLE
fix(inbox): 已离开 waiting_human 的项不得再入列待审批

### DIFF
--- a/server/internal/engine/resume.go
+++ b/server/internal/engine/resume.go
@@ -475,6 +475,12 @@ func (e *Engine) ReactReply(runID, nodeID, humanText string, images []models.Pro
 		Images: images, Annotations: annotations})
 	logDB(e.db.Save(&conv), runID, "save react human turn")
 
+	// Leave the pending inbox immediately (mirrors ResumeGate resolving before
+	// slow work): refresh/reopen must not resurface this item while wrap-up runs.
+	// Roll back Done when the agent stays open (questions / unfinished).
+	conv.Done = true
+	logDB(e.db.Save(&conv), runID, "confirm leave pending (force)")
+
 	req := e.nodeReq(c, node)
 	t := e.provider.ReactReply(context.Background(), req, conv.Messages, effective, images, force)
 	conv.Messages = append(conv.Messages, models.ReactMessage{Role: "agent", Text: t.Msg,
@@ -489,17 +495,17 @@ func (e *Engine) ReactReply(runID, nodeID, humanText string, images []models.Pro
 	}
 
 	if !t.Done {
-		logDB(e.db.Save(&conv), runID, "save react conversation")
+		conv.Done = false
+		logDB(e.db.Save(&conv), runID, "reopen react after force stay-open")
 		// Persist this turn's MCP tool calls now (the node stays paused without a
 		// saveState) so the timeline reflects every react round, not just the
 		// opening one.
 		e.flushMcpCalls(runID, nodeID)
 		e.flushTokenUsage(runID, nodeID, t.Usage, t.UsageByModel)
 		e.broker.Publish(runID, jsonMsg("react", runID, nodeID))
-		return nil
+		return errors.New("仍有待确认问题或收尾未完成，无法确认并流转")
 	}
 
-	conv.Done = true
 	logDB(e.db.Save(&conv), runID, "finish react conversation")
 
 	if t.Err != nil {

--- a/server/internal/engine/review.go
+++ b/server/internal/engine/review.go
@@ -261,12 +261,15 @@ func (e *Engine) reviewReply(c *execCtx, node *models.Node, conv *models.ReactCo
 		return errors.New("internal: review non-force must use EnqueueReviewTurn")
 	}
 
-	// Force finish: optional git wrap-up (agent decides commits), then retire
-	// the parked session, finalize from the store snapshot, run afterDefaultChecks,
-	// then Done only on success.
+	// Force finish: leave the pending inbox immediately (same as clarify force /
+	// ResumeGate), then optional git wrap-up, retire session, finalize, and
+	// roll back Done on validation failure so the item re-enters the inbox.
 	// Must not call ReactReply / finishAgentOutcome / TakeOutcome / routeFailure.
 	// Human turn is already persisted by ReactReply.
 	// Ready-gate is enforced by ReactReply before taking the lock.
+	conv.Done = true
+	logDB(e.db.Save(conv), runID, "confirm leave pending (review force)")
+
 	if rp, ok := e.provider.(runtime.ReviewProvider); ok {
 		t := rp.OfferCommitOnConfirm(context.Background(), req)
 		if strings.TrimSpace(t.Msg) != "" {
@@ -284,6 +287,8 @@ func (e *Engine) reviewReply(c *execCtx, node *models.Node, conv *models.ReactCo
 	outcome = e.afterDefaultChecks(c, node, outcome)
 	if outcome.status == "failed" {
 		// Keep paused/waiting_human so the reviewer can fix and retry.
+		conv.Done = false
+		logDB(e.db.Save(conv), runID, "reopen review after force validation failure")
 		e.host.SetActiveReview(runID, true)
 		e.broker.Publish(runID, jsonMsg("react", runID, nodeID))
 		errMsg := strings.TrimSpace(outcome.err)
@@ -308,13 +313,14 @@ func (e *Engine) reviewReply(c *execCtx, node *models.Node, conv *models.ReactCo
 		e.persistVar(runID, outVar, "pass")
 		e.forceClearPreviewIssueVars(c, runID)
 		if lifeErr := e.markPreviewIssuesResolvedByNode(runID, nodeID); lifeErr != nil {
+			conv.Done = false
+			logDB(e.db.Save(conv), runID, "reopen review after preview-issue lifecycle failure")
 			e.host.SetActiveReview(runID, true)
 			e.broker.Publish(runID, jsonMsg("react", runID, nodeID))
 			return lifeErr
 		}
 	}
 
-	conv.Done = true
 	logDB(e.db.Save(conv), runID, "finish review conversation")
 	if e.shareRevoker != nil {
 		e.shareRevoker.RevokeUnusedForGate(runID, nodeID, conv.Iteration)

--- a/server/internal/handlers/gate_share_test.go
+++ b/server/internal/handlers/gate_share_test.go
@@ -45,6 +45,9 @@ func seedHumanGate(t *testing.T, h *harness, runID, nodeID string, actions []mod
 		Actions: actions, Form: []models.GateField{{Key: "comment", Label: "意见"}},
 		RequestedAt: now,
 	})
+	h.db.Create(&models.StateRun{
+		RunID: runID, NodeID: nodeID, Iteration: 1, Status: "waiting_human",
+	})
 	h.h.Arts.Save(runID, "visual", "page.html", "html", `<html><body><a href="/api/blobs/abc">x</a><p>ok</p></body></html>`)
 	h.h.Arts.Save(runID, "visual", "clarified_requirement.json", "json", `{"title":"外部一次审批","goals":["g1"],"runId":"should-hide","projectId":"p"}`)
 }

--- a/server/internal/handlers/handlers_test.go
+++ b/server/internal/handlers/handlers_test.go
@@ -506,6 +506,7 @@ func TestGateAndArtifactEndpoints(t *testing.T) {
 		},
 	})
 	h.db.Create(&models.Gate{RunID: "r1", NodeID: "g", Resolved: false, RequestedAt: now})
+	h.db.Create(&models.StateRun{RunID: "r1", NodeID: "g", Iteration: 0, Status: "waiting_human"})
 	h.db.Create(&models.ReactConversation{
 		RunID: "r1", NodeID: "react", Iteration: 1, Done: false,
 		Messages: []models.ReactMessage{{Role: "agent", Text: "hi", At: now.Format(time.RFC3339)}},
@@ -1731,8 +1732,10 @@ func TestListGatesPagination(t *testing.T) {
 	now := time.Now()
 	h.db.Create(&models.Run{ID: "run-g1", Status: "waiting_human", WorkflowID: "wf-1", StartedAt: now})
 	h.db.Create(&models.Gate{RunID: "run-g1", NodeID: "gate1", Title: "G1", RequestedAt: now})
+	h.db.Create(&models.StateRun{RunID: "run-g1", NodeID: "gate1", Iteration: 0, Status: "waiting_human"})
 	h.db.Create(&models.Run{ID: "run-g2", Status: "waiting_human", WorkflowID: "wf-1", StartedAt: now})
 	h.db.Create(&models.Gate{RunID: "run-g2", NodeID: "gate2", Title: "G2", RequestedAt: now.Add(time.Second)})
+	h.db.Create(&models.StateRun{RunID: "run-g2", NodeID: "gate2", Iteration: 0, Status: "waiting_human"})
 
 	w := h.do("GET", "/api/gates?page=1&pageSize=1", nil)
 	if w.Code != 200 {

--- a/server/internal/handlers/inbox_context_test.go
+++ b/server/internal/handlers/inbox_context_test.go
@@ -21,6 +21,9 @@ func TestRunInboxContextGate(t *testing.T) {
 	}})
 	h.db.Create(&models.Gate{RunID: "ic-gate", NodeID: "gate", Iteration: 1, Resolved: false, RequestedAt: now})
 	h.db.Create(&models.StateRun{
+		RunID: "ic-gate", NodeID: "gate", Iteration: 1, Status: "waiting_human",
+	})
+	h.db.Create(&models.StateRun{
 		RunID: "ic-gate", NodeID: "visual", Iteration: 1, Status: "completed",
 		Outputs: map[string]any{"page": "<html>v1</html>"},
 		Events:  []models.AcpEvent{{Kind: "message", Text: "should-not-appear"}},

--- a/server/internal/services/helpers_more_test.go
+++ b/server/internal/services/helpers_more_test.go
@@ -17,6 +17,7 @@ func TestEscapeLikeAndInboxHelpers(t *testing.T) {
 	db.Create(&models.Run{ID: "run-ctx", Status: "waiting_human", Graph: g})
 	db.Create(&models.ReactConversation{RunID: "run-ctx", NodeID: "r1", Iteration: 1})
 	db.Create(&models.Gate{RunID: "run-ctx", NodeID: "r1", Iteration: 1, Title: "g", Resolved: false})
+	db.Create(&models.StateRun{RunID: "run-ctx", NodeID: "r1", Iteration: 1, Status: "waiting_human"})
 
 	if _, _, ok := s.ClarifyContext("run-ctx", "r1", 1); !ok {
 		t.Fatal("ClarifyContext")

--- a/server/internal/services/inbox.go
+++ b/server/internal/services/inbox.go
@@ -13,6 +13,16 @@ import (
 
 var terminalRunStatuses = []string{"completed", "failed", "cancelled"}
 
+// pendingGateScope restricts to unresolved gates whose node is still
+// waiting_human on a non-terminal run. Dangling unresolved rows after the node
+// left waiting must not re-enter the approvals inbox or context.
+func pendingGateScope(db *gorm.DB) *gorm.DB {
+	return db.Joins("JOIN runs ON runs.id = gates.run_id").
+		Joins("JOIN state_runs ON state_runs.run_id = gates.run_id AND state_runs.node_id = gates.node_id AND state_runs.iteration = gates.iteration").
+		Where("gates.resolved = ? AND state_runs.status = ? AND runs.status NOT IN ?",
+			false, "waiting_human", terminalRunStatuses)
+}
+
 // reactAutoEnabled reports whether a react node should self-answer without
 // waiting for a human (mirrors engine.autoReactEnabled).
 func reactAutoEnabled(node *models.Node, vars map[string]any) bool {
@@ -271,8 +281,7 @@ func (s *RunService) runMetaByIDs(runIDs []string) map[string]runInboxMeta {
 }
 
 func (s *RunService) pendingGatesFiltered(wf, projectID string, tags []string) []models.Gate {
-	q := s.db.Joins("JOIN runs ON runs.id = gates.run_id").
-		Where("gates.resolved = ? AND runs.status NOT IN ?", false, terminalRunStatuses)
+	q := pendingGateScope(s.db)
 	if wf != "" {
 		q = q.Where("runs.workflow_id = ?", wf)
 	} else if projectID != "" {

--- a/server/internal/services/inbox_context.go
+++ b/server/internal/services/inbox_context.go
@@ -30,9 +30,9 @@ const (
 // both could match. Returns ("", false) when nothing is pending.
 func (s *RunService) InboxContextKind(runID, nodeID string, iteration int) (string, bool) {
 	var gate models.Gate
-	if err := s.db.Joins("JOIN runs ON runs.id = gates.run_id").
-		Where("gates.run_id = ? AND gates.node_id = ? AND gates.iteration = ? AND gates.resolved = ? AND runs.status NOT IN ?",
-			runID, nodeID, iteration, false, terminalRunStatuses).
+	if err := pendingGateScope(s.db).
+		Where("gates.run_id = ? AND gates.node_id = ? AND gates.iteration = ?",
+			runID, nodeID, iteration).
 		First(&gate).Error; err == nil {
 		return InboxKindGate, true
 	}
@@ -260,12 +260,13 @@ func (s *RunService) ClarifyContext(runID, nodeID string, iteration int) (models
 	return conv, run, true
 }
 
-// PendingGateAt returns the unresolved gate for an exact run/node/iteration.
+// PendingGateAt returns the unresolved gate for an exact run/node/iteration
+// that is still waiting_human (same inbox eligibility as PendingInboxItems).
 func (s *RunService) PendingGateAt(runID, nodeID string, iteration int) (models.Gate, bool) {
 	var g models.Gate
-	if err := s.db.Joins("JOIN runs ON runs.id = gates.run_id").
-		Where("gates.run_id = ? AND gates.node_id = ? AND gates.iteration = ? AND gates.resolved = ? AND runs.status NOT IN ?",
-			runID, nodeID, iteration, false, terminalRunStatuses).
+	if err := pendingGateScope(s.db).
+		Where("gates.run_id = ? AND gates.node_id = ? AND gates.iteration = ?",
+			runID, nodeID, iteration).
 		First(&g).Error; err != nil {
 		return models.Gate{}, false
 	}

--- a/server/internal/services/inbox_context_test.go
+++ b/server/internal/services/inbox_context_test.go
@@ -20,6 +20,9 @@ func TestInboxContextKind(t *testing.T) {
 		RunID: "run-gate", NodeID: "gate-proposal", Iteration: 2,
 		Resolved: false, RequestedAt: now,
 	})
+	db.Create(&models.StateRun{
+		RunID: "run-gate", NodeID: "gate-proposal", Iteration: 2, Status: "waiting_human",
+	})
 
 	kind, ok := s.InboxContextKind("run-gate", "gate-proposal", 2)
 	if !ok || kind != "gate" {

--- a/server/internal/services/inbox_test.go
+++ b/server/internal/services/inbox_test.go
@@ -36,6 +36,9 @@ func TestAllPendingInboxItems(t *testing.T) {
 		RunID: "run-gate", NodeID: "gate-proposal", WorkflowID: "wf1", WorkflowName: "API 重构",
 		Title: "方案评审门禁", Resolved: false, RequestedAt: gateAt,
 	})
+	db.Create(&models.StateRun{
+		RunID: "run-gate", NodeID: "gate-proposal", Iteration: 0, Status: "waiting_human",
+	})
 
 	db.Create(&models.Run{
 		ID: "run-clarify", WorkflowID: "wf2", WorkflowName: "功能迭代工作流",
@@ -118,10 +121,12 @@ func TestPendingInboxItemsIncludesGateNodeType(t *testing.T) {
 		RunID: "run-nt", NodeID: "hg1", WorkflowID: "wf-nt", WorkflowName: "NT",
 		Title: "人审", Resolved: false, RequestedAt: now.Add(-time.Minute),
 	})
+	db.Create(&models.StateRun{RunID: "run-nt", NodeID: "hg1", Iteration: 0, Status: "waiting_human"})
 	db.Create(&models.Gate{
 		RunID: "run-nt", NodeID: "ps1", WorkflowID: "wf-nt", WorkflowName: "NT",
 		Title: "方案选择", Resolved: false, RequestedAt: now,
 	})
+	db.Create(&models.StateRun{RunID: "run-nt", NodeID: "ps1", Iteration: 0, Status: "waiting_human"})
 	items := s.AllPendingInboxItems()
 	if len(items) != 2 {
 		t.Fatalf("expected 2 gates, got %d", len(items))
@@ -151,6 +156,9 @@ func TestPendingInboxItemsOmitsEmptyRunTitle(t *testing.T) {
 	db.Create(&models.Gate{
 		RunID: "run-empty-title", NodeID: "gate-proposal", WorkflowID: "wf1", WorkflowName: "API 重构",
 		Title: "方案评审门禁", Resolved: false, RequestedAt: now,
+	})
+	db.Create(&models.StateRun{
+		RunID: "run-empty-title", NodeID: "gate-proposal", Iteration: 0, Status: "waiting_human",
 	})
 
 	items := s.AllPendingInboxItems()
@@ -271,6 +279,7 @@ func TestPendingInboxItemsFilterByTags(t *testing.T) {
 		RunID: "run-gate-both", NodeID: "gate", WorkflowID: "wf1", WorkflowName: "API 重构",
 		Title: "评审", Resolved: false, RequestedAt: now,
 	})
+	db.Create(&models.StateRun{RunID: "run-gate-both", NodeID: "gate", Iteration: 0, Status: "waiting_human"})
 	db.Create(&models.Run{
 		ID: "run-gate-one", WorkflowID: "wf1", WorkflowName: "API 重构",
 		Title: "单标签", Status: "waiting_human", StartedAt: now.Add(-time.Minute), Graph: validGraph(), Tags: []string{"bugfix"},
@@ -279,6 +288,7 @@ func TestPendingInboxItemsFilterByTags(t *testing.T) {
 		RunID: "run-gate-one", NodeID: "gate", WorkflowID: "wf1", WorkflowName: "API 重构",
 		Title: "评审", Resolved: false, RequestedAt: now.Add(-time.Minute),
 	})
+	db.Create(&models.StateRun{RunID: "run-gate-one", NodeID: "gate", Iteration: 0, Status: "waiting_human"})
 
 	items, total := s.PendingInboxItems("", "", []string{"bugfix", "spike"}, 0, 0)
 	if total != 1 || len(items) != 1 {
@@ -394,6 +404,9 @@ func TestPendingInboxIncludesAppPreview(t *testing.T) {
 		RunID: "run-gate", NodeID: "gate-proposal", WorkflowID: "wf1", WorkflowName: "门禁工作流",
 		Title: "方案评审门禁", Resolved: false, RequestedAt: gateAt,
 	})
+	db.Create(&models.StateRun{
+		RunID: "run-gate", NodeID: "gate-proposal", Iteration: 0, Status: "waiting_human",
+	})
 
 	items = s.AllPendingInboxItems()
 	if len(items) != 2 {
@@ -434,6 +447,137 @@ func TestPendingInboxIncludesAppPreview(t *testing.T) {
 		if c, ok := it.(ClarifyInboxItem); ok && c.Kind == "app_preview" {
 			t.Fatalf("done app_preview must leave inbox, got %#v", c)
 		}
+	}
+}
+
+// TestPendingInboxExcludesTransferred covers g1.2/g1.3/g2.1/g2.2: after a node
+// leaves waiting_human (or conversation is Done), refresh/reopen must not see
+// the item; total matches the filtered list; still-pending peers remain.
+func TestPendingInboxExcludesTransferred(t *testing.T) {
+	db := newTestDB(t)
+	s := NewRunService(db)
+	now := time.Now()
+
+	// Still-pending gate (must remain).
+	db.Create(&models.Run{
+		ID: "run-gate-live", WorkflowID: "wf1", WorkflowName: "W",
+		Title: "仍待门禁", Status: "waiting_human", StartedAt: now.Add(-time.Hour), Graph: validGraph(),
+	})
+	db.Create(&models.Gate{
+		RunID: "run-gate-live", NodeID: "gate-proposal", WorkflowID: "wf1", WorkflowName: "W",
+		Title: "方案评审门禁", Resolved: false, RequestedAt: now.Add(-30 * time.Minute),
+	})
+	db.Create(&models.StateRun{
+		RunID: "run-gate-live", NodeID: "gate-proposal", Iteration: 0, Status: "waiting_human",
+	})
+
+	// Dangling unresolved gate: node already left waiting_human (transferred).
+	db.Create(&models.Run{
+		ID: "run-gate-gone", WorkflowID: "wf1", WorkflowName: "W",
+		Title: "已流转门禁", Status: "running", StartedAt: now.Add(-2 * time.Hour), Graph: validGraph(),
+	})
+	db.Create(&models.Gate{
+		RunID: "run-gate-gone", NodeID: "gate-proposal", WorkflowID: "wf1", WorkflowName: "W",
+		Title: "残留门禁", Resolved: false, RequestedAt: now.Add(-90 * time.Minute),
+	})
+	db.Create(&models.StateRun{
+		RunID: "run-gate-gone", NodeID: "gate-proposal", Iteration: 0, Status: "completed",
+	})
+
+	// Still-pending clarify (must remain).
+	db.Create(&models.Run{
+		ID: "run-clarify-live", WorkflowID: "wf2", WorkflowName: "C",
+		Title: "仍待澄清", Status: "waiting_human", StartedAt: now.Add(-20 * time.Minute), Graph: reactGraph(""),
+	})
+	db.Create(&models.ReactConversation{
+		RunID: "run-clarify-live", NodeID: "react", Iteration: 1, Done: false,
+		Messages: []models.ReactMessage{{Role: "agent", Text: "q", At: now.Add(-5 * time.Minute).Format(time.RFC3339)}},
+	})
+	db.Create(&models.StateRun{
+		RunID: "run-clarify-live", NodeID: "react", Iteration: 1, Status: "waiting_human",
+	})
+
+	// Approve transferred: Done=true after confirm (refresh must not resurface).
+	db.Create(&models.Run{
+		ID: "run-approve-gone", WorkflowID: "wf3", WorkflowName: "A",
+		Title: "已流转 Approve", Status: "running", StartedAt: now.Add(-40 * time.Minute),
+		Graph: reviewCapableGraph("approve", "Approve"),
+	})
+	db.Create(&models.ReactConversation{
+		RunID: "run-approve-gone", NodeID: "approve", Iteration: 1, Done: true,
+		Messages: []models.ReactMessage{{Role: "agent", Text: "done", At: now.Add(-10 * time.Minute).Format(time.RFC3339)}},
+	})
+	db.Create(&models.StateRun{
+		RunID: "run-approve-gone", NodeID: "approve", Iteration: 1, Status: "running",
+	})
+
+	// App preview transferred via Done.
+	db.Create(&models.Run{
+		ID: "run-preview-gone", WorkflowID: "wf4", WorkflowName: "P",
+		Title: "已流转预览", Status: "running", StartedAt: now.Add(-50 * time.Minute),
+		Graph: reviewCapableGraph("app_preview", "应用预览"),
+	})
+	db.Create(&models.ReactConversation{
+		RunID: "run-preview-gone", NodeID: "app_preview", Iteration: 1, Done: true,
+		Messages: []models.ReactMessage{{Role: "agent", Text: "ok", At: now.Add(-8 * time.Minute).Format(time.RFC3339)}},
+	})
+	db.Create(&models.StateRun{
+		RunID: "run-preview-gone", NodeID: "app_preview", Iteration: 1, Status: "completed",
+	})
+
+	// Review-kind transferred: conversation Done but stale waiting_human row.
+	db.Create(&models.Run{
+		ID: "run-review-gone", WorkflowID: "wf5", WorkflowName: "R",
+		Title: "已流转评审", Status: "waiting_human", StartedAt: now.Add(-15 * time.Minute),
+		Graph: reviewCapableGraph("research", "调研"),
+	})
+	db.Create(&models.ReactConversation{
+		RunID: "run-review-gone", NodeID: "research", Iteration: 1, Done: true,
+		Messages: []models.ReactMessage{{Role: "agent", Text: "shipped", At: now.Add(-3 * time.Minute).Format(time.RFC3339)}},
+	})
+	db.Create(&models.StateRun{
+		RunID: "run-review-gone", NodeID: "research", Iteration: 1, Status: "waiting_human",
+	})
+
+	items, total := s.PendingInboxItems("", "", nil, 0, 0)
+	if total != 2 || len(items) != 2 {
+		t.Fatalf("expected 2 live items (gate+clarify), total=%d len=%d items=%#v", total, len(items), items)
+	}
+	if total != len(items) {
+		t.Fatalf("count/list mismatch: total=%d len=%d", total, len(items))
+	}
+
+	seen := map[string]bool{}
+	for _, it := range items {
+		switch v := it.(type) {
+		case GateInboxItem:
+			seen[v.RunID] = true
+			if v.RunID == "run-gate-gone" {
+				t.Fatalf("transferred gate must not appear: %#v", v)
+			}
+		case ClarifyInboxItem:
+			seen[v.RunID] = true
+			switch v.RunID {
+			case "run-approve-gone", "run-preview-gone", "run-review-gone":
+				t.Fatalf("transferred %s must not appear: %#v", v.Kind, v)
+			}
+		default:
+			t.Fatalf("unexpected item type %T", it)
+		}
+	}
+	if !seen["run-gate-live"] || !seen["run-clarify-live"] {
+		t.Fatalf("live pending peers missing: %#v", seen)
+	}
+
+	// Context helpers must agree with list eligibility (reopen path).
+	if kind, ok := s.InboxContextKind("run-gate-gone", "gate-proposal", 0); ok {
+		t.Fatalf("transferred gate context must be empty, got %q", kind)
+	}
+	if _, ok := s.PendingGateAt("run-gate-gone", "gate-proposal", 0); ok {
+		t.Fatal("PendingGateAt must exclude transferred gate")
+	}
+	if kind, ok := s.InboxContextKind("run-gate-live", "gate-proposal", 0); !ok || kind != "gate" {
+		t.Fatalf("live gate context: %q %v", kind, ok)
 	}
 }
 

--- a/server/internal/services/pm_citations_test.go
+++ b/server/internal/services/pm_citations_test.go
@@ -104,6 +104,9 @@ func TestFilterAndEnrichCitationsFailClosedAndSnippet(t *testing.T) {
 		RunID: runID, NodeID: "human_gate", WorkflowID: wfID, WorkflowName: wf.Name,
 		Title: "请审批", Resolved: false, RequestedAt: time.Now(),
 	})
+	db.Create(&models.StateRun{
+		RunID: runID, NodeID: "human_gate", Iteration: 0, Status: "waiting_human",
+	})
 
 	pm := NewPmService(db, nil)
 	thr, err := pm.CreateThread(p.ID, "u1", "t", "pm", "chat")

--- a/server/internal/services/run.go
+++ b/server/internal/services/run.go
@@ -184,26 +184,24 @@ func (s *RunService) Variables(runID string) []models.RunVariable {
 // (completed / failed / cancelled) never surface a pending gate: once a run ends
 // any dangling gate is not actionable, so a stale row must not appear as an open
 // approval on the run detail (the engine also supersedes such gates on finish).
+// Gates whose node has already left waiting_human are also excluded.
 func (s *RunService) PendingGate(runID string) (models.Gate, bool) {
 	var g models.Gate
-	if err := s.db.Joins("JOIN runs ON runs.id = gates.run_id").
-		Where("gates.run_id = ? AND gates.resolved = ? AND runs.status NOT IN ?",
-			runID, false, []string{"completed", "failed", "cancelled"}).
+	if err := pendingGateScope(s.db).
+		Where("gates.run_id = ?", runID).
 		Order("gates.iteration desc, gates.id desc").First(&g).Error; err != nil {
 		return models.Gate{}, false
 	}
 	return g, true
 }
 
-// AllPendingGates returns every unresolved gate whose run is still alive (gates
-// inbox). Gates on terminal runs (completed / failed / cancelled) are excluded:
-// once a run ends its dangling gate is no longer actionable and must not linger
-// in the approvals inbox.
+// AllPendingGates returns every unresolved gate whose run is still alive and
+// whose node is still waiting_human (gates inbox). Gates on terminal runs
+// (completed / failed / cancelled) are excluded: once a run ends its dangling
+// gate is no longer actionable and must not linger in the approvals inbox.
 func (s *RunService) AllPendingGates() []models.Gate {
 	var gates []models.Gate
-	s.db.Joins("JOIN runs ON runs.id = gates.run_id").
-		Where("gates.resolved = ? AND runs.status NOT IN ?", false, []string{"completed", "failed", "cancelled"}).
-		Order("gates.requested_at desc").Find(&gates)
+	pendingGateScope(s.db).Order("gates.requested_at desc").Find(&gates)
 	return gates
 }
 

--- a/server/internal/services/services_core_test.go
+++ b/server/internal/services/services_core_test.go
@@ -434,7 +434,10 @@ func TestRunService(t *testing.T) {
 
 	// Gates.
 	db.Create(&models.Gate{RunID: "r1", NodeID: "g1", Resolved: false, RequestedAt: now})
+	db.Create(&models.StateRun{RunID: "r1", NodeID: "g1", Iteration: 0, Status: "waiting_human"})
 	db.Create(&models.Gate{RunID: "r2", NodeID: "g2", Resolved: false, RequestedAt: now.Add(time.Second)})
+	// r2 is completed — dangling unresolved gate must not enter the inbox even
+	// if a stale waiting_human StateRun were present; terminal run excludes it.
 	if g, ok := s.PendingGate("r1"); !ok || g.NodeID != "g1" {
 		t.Fatalf("pending gate: %+v %v", g, ok)
 	}
@@ -445,6 +448,16 @@ func TestRunService(t *testing.T) {
 	// excluded from the inbox.
 	if len(s.AllPendingGates()) != 1 {
 		t.Fatal("all pending gates")
+	}
+	// Live run with unresolved gate but node already left waiting_human.
+	db.Create(&models.Run{ID: "r3", Status: "running", StartedAt: now, CreatedAt: now})
+	db.Create(&models.Gate{RunID: "r3", NodeID: "g3", Resolved: false, RequestedAt: now.Add(2 * time.Second)})
+	db.Create(&models.StateRun{RunID: "r3", NodeID: "g3", Iteration: 0, Status: "completed"})
+	if _, ok := s.PendingGate("r3"); ok {
+		t.Fatal("transferred node gate must not be pending")
+	}
+	if len(s.AllPendingGates()) != 1 {
+		t.Fatal("transferred gate must stay out of AllPendingGates")
 	}
 
 	// Conversations: active (done=false) preferred.


### PR DESCRIPTION
门禁查询统一要求 state_runs 仍为 waiting_human；澄清/评审在确认流转时立即 Done，避免收尾期间刷新残留；计数与列表共用同一过滤集。

Co-authored-by: Cursor <cursoragent@cursor.com>
