### PR TITLE
fix(inbox): 审批已流转后不再残留启动中 ghost

### DIFF
--- a/web/src/lib/inbox/inboxStartingCards.test.ts
+++ b/web/src/lib/inbox/inboxStartingCards.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  isApproveStillStarting,
   isStartFailedRun,
   makeIncomingGhost,
   resolveIncomingApproval,
@@ -101,6 +102,97 @@ describe('isStartFailedRun', () => {
     } as unknown as Run
     expect(isStartFailedRun(run, 'ap')).toBe(false)
     expect(isStartFailedRun(run, '')).toBe(false)
+  })
+
+  it('detects approve setup failure via graph when the hinted id misses', () => {
+    const run = {
+      status: 'running',
+      nodes: [
+        { id: 'in', type: 'input' },
+        { id: 'approve_7gl6', type: 'approve' },
+      ],
+      nodeRuns: {
+        approve_7gl6: { nodeId: 'approve_7gl6', status: 'failed', error: 'sandbox setup failed' },
+      },
+    } as unknown as Run
+    expect(isStartFailedRun(run, 'ap')).toBe(true)
+    expect(isStartFailedRun(run, '')).toBe(true)
+  })
+})
+
+describe('isApproveStillStarting', () => {
+  it('is true only while the approve node (or whole run) looks like a fresh boot', () => {
+    expect(
+      isApproveStillStarting(
+        {
+          status: 'running',
+          nodeRuns: { ap: { nodeId: 'ap', status: 'running' } },
+        } as unknown as Run,
+        'ap',
+      ),
+    ).toBe(true)
+    expect(isApproveStillStarting({ status: 'queued' } as Run, 'ap')).toBe(true)
+    expect(isApproveStillStarting({ status: 'running' } as Run, '')).toBe(true)
+  })
+
+  it('is false once the approval parked, completed, or the run left the boot window', () => {
+    expect(
+      isApproveStillStarting(
+        {
+          status: 'waiting_human',
+          nodeRuns: { ap: { nodeId: 'ap', status: 'waiting_human' } },
+        } as unknown as Run,
+        'ap',
+      ),
+    ).toBe(false)
+    expect(
+      isApproveStillStarting(
+        {
+          status: 'running',
+          nodeRuns: {
+            ap: { nodeId: 'ap', status: 'completed' },
+            implement: { nodeId: 'implement', status: 'running' },
+          },
+        } as unknown as Run,
+        'ap',
+      ),
+    ).toBe(false)
+    expect(isApproveStillStarting({ status: 'completed' } as Run, 'ap')).toBe(false)
+    expect(isApproveStillStarting({ status: 'failed' } as Run, 'ap')).toBe(false)
+  })
+
+  it('uses graph approve nodes when the hinted id misses (ap vs approve_7gl6)', () => {
+    const run = {
+      status: 'running',
+      nodes: [
+        { id: 'in', type: 'input' },
+        { id: 'approve_7gl6', type: 'approve' },
+        { id: 'implement_qnlc', type: 'implement' },
+      ],
+      nodeRuns: {
+        in: { nodeId: 'in', status: 'completed' },
+        approve_7gl6: { nodeId: 'approve_7gl6', status: 'completed' },
+        implement_qnlc: { nodeId: 'implement_qnlc', status: 'running' },
+      },
+    } as unknown as Run
+    expect(isApproveStillStarting(run, 'ap')).toBe(false)
+    expect(isApproveStillStarting(run, '')).toBe(false)
+  })
+
+  it('keeps the ghost while approve is still booting after input completed', () => {
+    const run = {
+      status: 'running',
+      nodes: [
+        { id: 'in', type: 'input' },
+        { id: 'approve_7gl6', type: 'approve' },
+      ],
+      nodeRuns: {
+        in: { nodeId: 'in', status: 'completed' },
+        approve_7gl6: { nodeId: 'approve_7gl6', status: 'running' },
+      },
+    } as unknown as Run
+    expect(isApproveStillStarting(run, 'ap')).toBe(true)
+    expect(isApproveStillStarting(run, '')).toBe(true)
   })
 })
 

--- a/web/src/lib/inbox/inboxStartingCards.ts
+++ b/web/src/lib/inbox/inboxStartingCards.ts
@@ -48,16 +48,80 @@ export function makeIncomingGhost(
  * A clarify/approve sandbox-setup failure records the failure on the node
  * execution and stops the run *without* marking the run terminal, so run status
  * alone would miss exactly the case this has to detect. A whole-run failure or
- * cancel still counts, and an unknown node id falls back to run status so a
- * guessed id cannot invent a failure.
+ * cancel still counts. When the hinted node id misses, fall back to Approve
+ * nodes on `run.nodes` so `ap` vs `approve_7gl6` cannot hide a setup failure.
  */
 export function isStartFailedRun(
-  run: Pick<Run, 'status'> & { nodeRuns?: Run['nodeRuns'] },
+  run: Pick<Run, 'status'> & { nodeRuns?: Run['nodeRuns']; nodes?: Run['nodes'] },
   nodeId: string,
 ): boolean {
   if (run.status === 'failed' || run.status === 'cancelled') return true
   const nodeStatus = nodeId ? run.nodeRuns?.[nodeId]?.status : undefined
-  return nodeStatus === 'failed' || nodeStatus === 'cancelled'
+  if (nodeStatus === 'failed' || nodeStatus === 'cancelled') return true
+  if (nodeStatus !== undefined) return false
+
+  const approveIds = (run.nodes || []).filter((n) => n.type === 'approve').map((n) => n.id)
+  for (const id of approveIds) {
+    const st = run.nodeRuns?.[id]?.status
+    if (st === 'failed' || st === 'cancelled') return true
+  }
+  return false
+}
+
+const leftBootStatuses = new Set(['waiting_human', 'completed', 'failed', 'cancelled'])
+
+function nodeRunStatus(
+  run: { nodeRuns?: Run['nodeRuns'] },
+  nodeId: string,
+): string | undefined {
+  return nodeId ? run.nodeRuns?.[nodeId]?.status : undefined
+}
+
+/**
+ * Whether an incoming ghost may still represent a live sandbox boot.
+ *
+ * Used when `?run=&node=` (or a home handoff) would rebuild a starting card
+ * even though the run is absent from the pending list — e.g. cold refresh after
+ * the approval already parked, completed, or moved on.
+ *
+ * `nodeId` is only a hint (`ap` vs `approve_7gl6` may differ). Prefer that
+ * node's status when present; otherwise consult approve nodes from `run.nodes`
+ * so a completed input + still-booting approve is not mistaken for "already
+ * moved on", and a completed approve + running implement still drops the ghost.
+ */
+export function isApproveStillStarting(
+  run: Pick<Run, 'status'> & { nodeRuns?: Run['nodeRuns']; nodes?: Run['nodes'] },
+  nodeId: string,
+): boolean {
+  if (run.status === 'failed' || run.status === 'cancelled' || run.status === 'completed') {
+    return false
+  }
+
+  const hinted = nodeRunStatus(run, nodeId)
+  if (hinted) {
+    if (leftBootStatuses.has(hinted)) return false
+    if (hinted === 'running') return true
+  }
+
+  const approveIds = (run.nodes || []).filter((n) => n.type === 'approve').map((n) => n.id)
+  if (approveIds.length > 0) {
+    let sawApprove = false
+    for (const id of approveIds) {
+      const st = nodeRunStatus(run, id)
+      if (!st) continue
+      sawApprove = true
+      if (st === 'running') return true
+      if (leftBootStatuses.has(st)) return false
+    }
+    // Graph has Approve, but no StateRun yet — still launching.
+    if (!sawApprove) return run.status === 'queued' || run.status === 'running'
+    return false
+  }
+
+  // No graph: only keep the ghost before any node has parked or finished.
+  const runs = Object.values(run.nodeRuns || {})
+  if (runs.some((n) => n?.status && leftBootStatuses.has(n.status))) return false
+  return run.status === 'queued' || run.status === 'running'
 }
 
 /**

--- a/web/src/views/GatesInboxView.starting.test.ts
+++ b/web/src/views/GatesInboxView.starting.test.ts
@@ -218,6 +218,7 @@ beforeEach(async () => {
   if (filterState.pipelineSelected) filterState.pipelineSelected.value = ''
   if (filterState.projectSelected) filterState.projectSelected.value = ''
   mocks.listGates.mockResolvedValue(paged([]))
+  mocks.getRun.mockResolvedValue({ id: 'run-unknown', status: 'running' })
   await usePendingGates().refresh({ mode: 'force' })
 })
 
@@ -325,6 +326,12 @@ describe('GatesInboxView starting approvals', () => {
     setHomeApproveHandoff({ runId: 'run-boot', nodeId: 'ap', text: '把登录做清楚', images: [] })
     mocks.listGates.mockResolvedValue(paged([parkedItem()]))
     mocks.inboxContext.mockResolvedValue(parkedContext)
+    // Still-booting getRun must not fight the parked row; completed comes after leave.
+    mocks.getRun.mockResolvedValue({
+      id: 'run-boot',
+      status: 'waiting_human',
+      nodeRuns: { ap: { nodeId: 'ap', status: 'waiting_human' } },
+    })
     const wrapper = mountInbox()
     await flushPromises()
     await nextTick()
@@ -335,14 +342,92 @@ describe('GatesInboxView starting approvals', () => {
     // still point at it, but that must not resurrect a "starting" ghost.
     mocks.listGates.mockResolvedValue(paged([]))
     mocks.inboxContext.mockRejectedValue(new Error('no pending inbox item'))
-    mocks.getRun.mockResolvedValue({ id: 'run-boot', status: 'completed' })
+    mocks.getRun.mockResolvedValue({
+      id: 'run-boot',
+      status: 'completed',
+      nodeRuns: { ap: { nodeId: 'ap', status: 'completed' } },
+    })
     filterState.projectSelected!.value = 'proj-x'
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+    await vi.waitFor(() => {
+      expect(wrapper.find('[data-testid="inbox-item-card"]').exists()).toBe(false)
+    })
+    expect(wrapper.find('[data-testid="inbox-boot-loader"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('drops a cold-open ghost when ?run= points at an approval that already moved on', async () => {
+    // Reopen / refresh with the deep link after approve already completed and
+    // implement is running: pending list is empty, but that must not leave a
+    // permanent "…" / 启动中 ghost.
+    routeState.query = { run: 'run-f66f29e4', node: 'approve_7gl6' }
+    mocks.listGates.mockResolvedValue(paged([]))
+    mocks.getRun.mockResolvedValue({
+      id: 'run-f66f29e4',
+      status: 'running',
+      nodes: [
+        { id: 'in', type: 'input' },
+        { id: 'approve_7gl6', type: 'approve' },
+        { id: 'implement_qnlc', type: 'implement' },
+      ],
+      nodeRuns: {
+        approve_7gl6: { nodeId: 'approve_7gl6', status: 'completed' },
+        implement_qnlc: { nodeId: 'implement_qnlc', status: 'running' },
+      },
+    })
+    const wrapper = mountInbox()
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+
+    expect(mocks.getRun).toHaveBeenCalledWith('run-f66f29e4')
+    expect(wrapper.find('[data-testid="inbox-item-card"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="inbox-boot-loader"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('drops a cold-open ghost when the query node id is the published hint, not the runtime id', async () => {
+    routeState.query = { run: 'run-f66f29e4', node: 'ap' }
+    mocks.listGates.mockResolvedValue(paged([]))
+    mocks.getRun.mockResolvedValue({
+      id: 'run-f66f29e4',
+      status: 'running',
+      nodes: [
+        { id: 'in', type: 'input' },
+        { id: 'approve_7gl6', type: 'approve' },
+        { id: 'implement_qnlc', type: 'implement' },
+      ],
+      nodeRuns: {
+        approve_7gl6: { nodeId: 'approve_7gl6', status: 'completed' },
+        implement_qnlc: { nodeId: 'implement_qnlc', status: 'running' },
+      },
+    })
+    const wrapper = mountInbox()
     await flushPromises()
     await nextTick()
     await flushPromises()
 
     expect(wrapper.find('[data-testid="inbox-item-card"]').exists()).toBe(false)
-    expect(wrapper.find('[data-testid="inbox-boot-loader"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('keeps a cold-open ghost while getRun still says the approve node is booting', async () => {
+    routeState.query = { run: 'run-boot', node: 'ap' }
+    mocks.listGates.mockResolvedValue(paged([]))
+    mocks.getRun.mockResolvedValue({
+      id: 'run-boot',
+      status: 'running',
+      nodeRuns: { ap: { nodeId: 'ap', status: 'running' } },
+    })
+    const wrapper = mountInbox()
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="inbox-item-card"]').attributes('data-starting')).toBe('true')
+    expect(wrapper.find('[data-testid="inbox-boot-loader"]').exists()).toBe(true)
     wrapper.unmount()
   })
 

--- a/web/src/views/GatesInboxView.vue
+++ b/web/src/views/GatesInboxView.vue
@@ -44,6 +44,7 @@ import {
   pickNextActiveAfterRemove,
 } from '@/lib/inbox/inboxActiveSelection'
 import {
+  isApproveStillStarting,
   isStartFailedRun,
   makeIncomingGhost,
   resolveIncomingApproval,
@@ -364,10 +365,68 @@ function mergeIncomingGhost(items: InboxItem[]): InboxItem[] {
     incomingGhost.value = null
     return items
   }
+  // Cold refresh / reopen with ?run= after the approval already left pending:
+  // confirm against the run before keeping a "启动中" ghost forever.
+  void confirmIncomingGhostStillNeeded(t)
   const seed = peekHomeApproveHandoff() || homeSeed.value
   const ghost = makeIncomingGhost(t, String(seed?.text || ''))
   incomingGhost.value = ghost
   return [ghost, ...items]
+}
+
+/**
+ * Drop (or fail) a client-only starting ghost when the run is no longer booting.
+ * Without this, a stale `?run=&node=` after successful flow keeps rebuilding
+ * an empty "启动中" card on every loadList.
+ */
+let incomingGhostConfirmInFlight = ''
+async function confirmIncomingGhostStillNeeded(target: { runId: string; nodeId: string }) {
+  const nodeId = target.nodeId || 'approve'
+  const key = `${target.runId}:${nodeId}`
+  // loadList / starting-poll can call this every few seconds for the same deep
+  // link; one in-flight check is enough.
+  if (incomingGhostConfirmInFlight === key) return
+  incomingGhostConfirmInFlight = key
+  try {
+    const run = await api.getRun(target.runId)
+    // A newer navigation may have re-armed a different target while we awaited.
+    const cur = incomingTarget()
+    if (!cur || `${cur.runId}:${cur.nodeId || 'approve'}` !== key) return
+    if (isStartFailedRun(run, nodeId)) {
+      const ghost =
+        incomingGhost.value && itemKey(incomingGhost.value) === key
+          ? incomingGhost.value
+          : makeIncomingGhost(target, String((peekHomeApproveHandoff() || homeSeed.value)?.text || ''))
+      incomingArmed.value = false
+      incomingGhost.value = null
+      queryWaitGen++
+      await confirmStartingVanished(ghost)
+      return
+    }
+    if (isApproveStillStarting(run, nodeId)) return
+    incomingArmed.value = false
+    incomingGhost.value = null
+    queryWaitGen++ // stop waitForQueryItem from polling a dead deep link
+    if (listItems.value.some((it) => itemKey(it) === key)) {
+      const prevList = listItems.value.slice()
+      listItems.value = listItems.value.filter((it) => itemKey(it) !== key)
+      if (active.value && itemKey(active.value) === key) {
+        closeActiveRunWs()
+        activeRun.value = null
+        activeRunLoadError.value = false
+        selectActiveAfterRemove(prevList, key)
+      }
+    } else if (active.value && itemKey(active.value) === key) {
+      closeActiveRunWs()
+      activeRun.value = null
+      activeRunLoadError.value = false
+      active.value = listItems.value[0] || null
+    }
+  } catch {
+    // Transient getRun failure: keep the ghost; the starting poll / next load retries.
+  } finally {
+    if (incomingGhostConfirmInFlight === key) incomingGhostConfirmInFlight = ''
+  }
 }
 
 function seedIncomingIfNeeded() {


### PR DESCRIPTION
## Summary
- 修复 Inbox 深链（`?run=&node=`）冷开/刷新后，Approve 已流转仍一直显示空的「… / 启动中」客户端 ghost
- `getRun` 确认已 park/完成/失败则出列；仍在 booting 则保留
- `ap` vs `approve_7gl6` 等 nodeId 提示不对时，回退到 `run.nodes` 上的 approve 节点判定（含 sandbox 失败）

## Test plan
- [ ] 首页启动 Approve → 进入 Inbox 启动中卡 → 正常 park 出对话
- [ ] 审批确认流转后，带原 `?run=&node=` 刷新/重开 Inbox，不应再出现空的「启动中」卡
- [ ] 故意用 published 节点 id（如 `ap`）深链打开已完成的 runtime approve id，同样应出列
- [ ] Approve sandbox 启动失败时，仍应出现可关闭的失败卡
- [ ] `npm test -- --run src/lib/inbox/inboxStartingCards.test.ts src/views/GatesInboxView.starting.test.ts`


Made with [Cursor](https://cursor.com)