### PR TITLE
feat(mcp): write_artifact 校验保留名 kind 并拒绝 image

### DIFF
--- a/server/internal/engine/node_agent.go
+++ b/server/internal/engine/node_agent.go
@@ -41,7 +41,8 @@ const visualPageName = "page.html"
 // self-contained HTML page (page.html) via the artifact-store MCP only (never a
 // workspace file, so the repo stays clean). It enforces the artifact's
 // existence and re-saves it with kind "html" so the run UI previews it in an
-// iframe (a page written via write_artifact would default to markdown).
+// iframe (empty kind on write_artifact now infers html for page.html; re-save
+// still normalizes kind for older / mismatched writes).
 func (e *Engine) execVisual(c *execCtx, node *models.Node) nodeOutcome {
 	req := e.nodeReq(c, node)
 	res, err := e.provider.RunAgent(context.Background(), req)

--- a/server/internal/mcp/artifact_kind.go
+++ b/server/internal/mcp/artifact_kind.go
@@ -1,0 +1,101 @@
+package mcp
+
+import (
+	"fmt"
+	"strings"
+)
+
+// reservedArtifactExpectedKind maps platform contract / reserved artifact names
+// to the only kind write_artifact may store for them.
+var reservedArtifactExpectedKind = map[string]string{
+	"page.html":                          "html",
+	PlanArtifactName:                     "json",
+	ClarifiedRequirementArtifactName:     "json",
+	ResearchArtifactName:                 "json",
+	ProposalsArtifactName:                "json",
+	ProposalArtifactName:                 "json",
+	TestResultArtifactName:               "json",
+	ReviewArtifactName:                   "json",
+	ImplementationResultArtifactName:     "json",
+	NodeOutcomeArtifactName:              "json",
+	FeedbackIndexArtifactName:            "json",
+}
+
+// ExpectedKindForReservedName returns the expected kind for a platform
+// reserved/contract artifact name, or false when name is not reserved.
+// Feedback ledger round files (feedback.*) are treated as json.
+func ExpectedKindForReservedName(name string) (string, bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", false
+	}
+	if kind, ok := reservedArtifactExpectedKind[name]; ok {
+		return kind, true
+	}
+	if IsFeedbackArtifactName(name) {
+		return "json", true
+	}
+	return "", false
+}
+
+// InferWriteArtifactKind picks a text (or image) kind from the file extension.
+// Unknown / missing extensions default to markdown to preserve the historical
+// empty-kind behavior for freeform names.
+func InferWriteArtifactKind(name string) string {
+	n := strings.ToLower(strings.TrimSpace(name))
+	switch {
+	case strings.HasSuffix(n, ".json"):
+		return "json"
+	case strings.HasSuffix(n, ".yaml"), strings.HasSuffix(n, ".yml"):
+		return "yaml"
+	case strings.HasSuffix(n, ".html"), strings.HasSuffix(n, ".htm"):
+		return "html"
+	case strings.HasSuffix(n, ".md"), strings.HasSuffix(n, ".markdown"):
+		return "markdown"
+	case strings.HasSuffix(n, ".txt"):
+		return "text"
+	case strings.HasSuffix(n, ".png"),
+		strings.HasSuffix(n, ".jpg"),
+		strings.HasSuffix(n, ".jpeg"),
+		strings.HasSuffix(n, ".webp"),
+		strings.HasSuffix(n, ".gif"):
+		return "image"
+	default:
+		return "markdown"
+	}
+}
+
+// ResolveWriteArtifactKind normalizes kind for write_artifact before Save:
+// empty kind is inferred (reserved name first, else extension); kind=image is
+// always rejected; an explicit kind that disagrees with a reserved name fails.
+func ResolveWriteArtifactKind(name, kind string) (string, error) {
+	name = strings.TrimSpace(name)
+	kind = strings.ToLower(strings.TrimSpace(kind))
+
+	if kind == "" {
+		if exp, ok := ExpectedKindForReservedName(name); ok {
+			kind = exp
+		} else {
+			kind = InferWriteArtifactKind(name)
+		}
+	}
+
+	if kind == "image" {
+		if exp, ok := ExpectedKindForReservedName(name); ok {
+			return "", fmt.Errorf(
+				"产物 %q 期望 kind=%q，不能使用 image；图片请改用沙箱 `artifact-upload` 上传，不要经 write_artifact 写入",
+				name, exp,
+			)
+		}
+		return "", fmt.Errorf(
+			"write_artifact 禁止 kind=image（name=%q）；图片请改用沙箱 `artifact-upload` 上传",
+			name,
+		)
+	}
+
+	if exp, ok := ExpectedKindForReservedName(name); ok && kind != exp {
+		return "", fmt.Errorf("产物 %q 期望 kind=%q，收到 %q", name, exp, kind)
+	}
+
+	return kind, nil
+}

--- a/server/internal/mcp/artifact_kind_test.go
+++ b/server/internal/mcp/artifact_kind_test.go
@@ -1,0 +1,199 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExpectedKindForReservedName(t *testing.T) {
+	cases := []struct {
+		name string
+		kind string
+		ok   bool
+	}{
+		{"page.html", "html", true},
+		{PlanArtifactName, "json", true},
+		{ClarifiedRequirementArtifactName, "json", true},
+		{ResearchArtifactName, "json", true},
+		{ProposalsArtifactName, "json", true},
+		{ProposalArtifactName, "json", true},
+		{TestResultArtifactName, "json", true},
+		{ReviewArtifactName, "json", true},
+		{ImplementationResultArtifactName, "json", true},
+		{NodeOutcomeArtifactName, "json", true},
+		{FeedbackIndexArtifactName, "json", true},
+		{"feedback.clarify.approve_1.i1.json", "json", true},
+		{"note.md", "", false},
+		{"brand-row-preview.html", "", false},
+		{"", "", false},
+	}
+	for _, tc := range cases {
+		got, ok := ExpectedKindForReservedName(tc.name)
+		if ok != tc.ok || got != tc.kind {
+			t.Fatalf("%q: got (%q,%v) want (%q,%v)", tc.name, got, ok, tc.kind, tc.ok)
+		}
+	}
+}
+
+func TestInferWriteArtifactKind(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"a.json", "json"},
+		{"a.YAML", "yaml"},
+		{"b.yml", "yaml"},
+		{"page.html", "html"},
+		{"x.HTM", "html"},
+		{"note.md", "markdown"},
+		{"README.markdown", "markdown"},
+		{"plain.txt", "text"},
+		{"shot.png", "image"},
+		{"photo.JPG", "image"},
+		{"noext", "markdown"},
+	}
+	for _, tc := range cases {
+		if got := InferWriteArtifactKind(tc.name); got != tc.want {
+			t.Fatalf("%q: got %q want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestResolveWriteArtifactKind(t *testing.T) {
+	cases := []struct {
+		name    string
+		kind    string
+		want    string
+		wantErr string
+	}{
+		// g1.2 / g2.1: empty kind → reserved or extension
+		{"page.html", "", "html", ""},
+		{PlanArtifactName, "", "json", ""},
+		{"note.md", "", "markdown", ""},
+		{"cfg.yaml", "", "yaml", ""},
+		{"freeform", "", "markdown", ""},
+
+		// g1.4 / g2.1 / g2.3: reserved mismatch
+		{"page.html", "image", "", "期望 kind=\"html\""},
+		{"page.html", "markdown", "", "期望 kind=\"html\""},
+		{PlanArtifactName, "markdown", "", "期望 kind=\"json\""},
+		{PlanArtifactName, "html", "", "期望 kind=\"json\""},
+
+		// g1.3 / g2.2: any name + image
+		{"shot-1.png", "image", "", "artifact-upload"},
+		{"note.md", "image", "", "artifact-upload"},
+		{"shot-1.png", "", "", "artifact-upload"}, // empty infers image then reject
+
+		// success paths (f4)
+		{"page.html", "html", "html", ""},
+		{PlanArtifactName, "json", "json", ""},
+		{"note.md", "markdown", "markdown", ""},
+		{"foo.txt", "html", "html", ""}, // non-reserved: no extension/kind force match
+	}
+	for _, tc := range cases {
+		got, err := ResolveWriteArtifactKind(tc.name, tc.kind)
+		if tc.wantErr != "" {
+			if err == nil {
+				t.Fatalf("%s kind=%q: want error containing %q, got nil", tc.name, tc.kind, tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("%s kind=%q: error %q missing %q", tc.name, tc.kind, err.Error(), tc.wantErr)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("%s kind=%q: unexpected err %v", tc.name, tc.kind, err)
+		}
+		if got != tc.want {
+			t.Fatalf("%s kind=%q: got %q want %q", tc.name, tc.kind, got, tc.want)
+		}
+	}
+}
+
+// TestWriteArtifactKindValidation covers the MCP write path (g2.1–g2.4):
+// page.html image/html/empty; arbitrary name + image; reserved json mismatch;
+// error text includes expected kind / artifact-upload guidance.
+func TestWriteArtifactKindValidation(t *testing.T) {
+	store := &memStore{}
+	h := NewHost(store)
+	runID := "kind-run"
+	tok := h.RegisterRun(runID)
+
+	assertErrContains := func(t *testing.T, body, substr string) {
+		t.Helper()
+		resp := call(t, h, runID, tok, body)
+		result := resp["result"].(map[string]any)
+		if result["isError"] != true {
+			t.Fatalf("want isError, got: %v", resp)
+		}
+		text := result["content"].([]any)[0].(map[string]any)["text"].(string)
+		if !strings.Contains(text, substr) {
+			t.Fatalf("error text %q missing %q", text, substr)
+		}
+	}
+
+	assertOK := func(t *testing.T, body, name, wantKind string) {
+		t.Helper()
+		resp := call(t, h, runID, tok, body)
+		result := resp["result"].(map[string]any)
+		if result["isError"] == true {
+			t.Fatalf("want success, got: %v", resp)
+		}
+		if got := store.kindOf(runID, name); got != wantKind {
+			t.Fatalf("stored kind for %q = %q, want %q", name, got, wantKind)
+		}
+	}
+
+	// g2.1 page.html + image fails (g2.4: expected kind + artifact-upload)
+	assertErrContains(t,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"write_artifact","arguments":{"name":"page.html","content":"<html/>","kind":"image"}}}`,
+		"html",
+	)
+	assertErrContains(t,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"write_artifact","arguments":{"name":"page.html","content":"<html/>","kind":"image"}}}`,
+		"artifact-upload",
+	)
+	if _, ok := store.Get(runID, "page.html"); ok {
+		t.Fatal("page.html must not be stored after kind=image failure")
+	}
+
+	// g2.1 page.html + html succeeds
+	assertOK(t,
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"write_artifact","arguments":{"name":"page.html","content":"<html>ok</html>","kind":"html"}}}`,
+		"page.html", "html",
+	)
+
+	// g2.1 page.html empty kind → html
+	assertOK(t,
+		`{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"write_artifact","arguments":{"name":"page.html","content":"<html>inferred</html>"}}}`,
+		"page.html", "html",
+	)
+
+	// g2.2 any name + image fails
+	assertErrContains(t,
+		`{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"write_artifact","arguments":{"name":"shot-1.png","content":"PNG","kind":"image"}}}`,
+		"artifact-upload",
+	)
+	assertErrContains(t,
+		`{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"write_artifact","arguments":{"name":"note.md","content":"x","kind":"image"}}}`,
+		"artifact-upload",
+	)
+	if _, ok := store.Get(runID, "shot-1.png"); ok {
+		t.Fatal("shot-1.png must not be stored via write_artifact")
+	}
+
+	// g2.3 plan.json + markdown fails
+	assertErrContains(t,
+		`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"write_artifact","arguments":{"name":"plan.json","content":"{}","kind":"markdown"}}}`,
+		"json",
+	)
+	if _, ok := store.Get(runID, PlanArtifactName); ok {
+		t.Fatal("plan.json must not be stored with wrong kind")
+	}
+
+	// non-reserved + legal text kind still works
+	assertOK(t,
+		`{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"write_artifact","arguments":{"name":"note.md","content":"hi","kind":"markdown"}}}`,
+		"note.md", "markdown",
+	)
+}

--- a/server/internal/mcp/host.go
+++ b/server/internal/mcp/host.go
@@ -428,13 +428,19 @@ func (h *Host) authorize(runID, token string) bool {
 
 // WriteArtifact persists content under the run namespace. nodeID records
 // which state produced it. Returns the artifact id.
+//
+// Before Save: empty kind is inferred (reserved name → expected kind, else
+// extension); kind=image is always rejected (use artifact-upload); an explicit
+// kind that disagrees with a reserved/contract name fails without writing.
 func (h *Host) WriteArtifact(runID, token, nodeID, name, content, kind string) (string, error) {
 	if !h.authorize(runID, token) {
 		return "", ErrUnauthorized
 	}
-	if kind == "" {
-		kind = "markdown"
+	resolved, err := ResolveWriteArtifactKind(name, kind)
+	if err != nil {
+		return "", err
 	}
+	kind = resolved
 	id, err := h.store.Save(runID, nodeID, name, kind, content)
 	if err != nil {
 		return "", err

--- a/server/internal/mcp/httpmcp_test.go
+++ b/server/internal/mcp/httpmcp_test.go
@@ -10,6 +10,7 @@ import (
 // memStore is a minimal in-memory Store for testing the MCP dispatcher.
 type memStore struct {
 	data map[string]string // runID|name -> content
+	kind map[string]string // runID|name -> kind
 	node map[string]string // runID|name -> nodeID
 	n    int
 }
@@ -18,14 +19,25 @@ func (m *memStore) Save(runID, nodeID, name, kind, content string) (string, erro
 	if m.data == nil {
 		m.data = map[string]string{}
 	}
+	if m.kind == nil {
+		m.kind = map[string]string{}
+	}
 	if m.node == nil {
 		m.node = map[string]string{}
 	}
 	key := runID + "|" + name
 	m.data[key] = content
+	m.kind[key] = kind
 	m.node[key] = nodeID
 	m.n++
 	return "art-test", nil
+}
+
+func (m *memStore) kindOf(runID, name string) string {
+	if m.kind == nil {
+		return ""
+	}
+	return m.kind[runID+"|"+name]
 }
 func (m *memStore) Get(runID, name string) (string, bool) {
 	c, ok := m.data[runID+"|"+name]

--- a/server/internal/mcp/mcp_more_test.go
+++ b/server/internal/mcp/mcp_more_test.go
@@ -214,9 +214,9 @@ func itoa(i int) string {
 }
 
 // TestSetTestResultValidatesScreenshotArtifacts verifies the CLI-upload flow: a
-// screenshot uploaded via write_artifact is referenced by name in
-// set_test_result, and the stored test_result.json keeps the artifact ref
-// (no inline data). Missing artifact refs reject the whole write.
+// screenshot already in the store (as artifact-upload would leave it) is
+// referenced by name in set_test_result, and the stored test_result.json keeps
+// the artifact ref (no inline data). Missing artifact refs reject the whole write.
 func TestSetTestResultValidatesScreenshotArtifacts(t *testing.T) {
 	store := &memStore{}
 	h := NewHost(store)
@@ -224,7 +224,11 @@ func TestSetTestResultValidatesScreenshotArtifacts(t *testing.T) {
 	tok := h.RegisterRun(runID)
 	h.SetActiveNode(runID, "tst", "test")
 
-	call(t, h, runID, tok, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"write_artifact","arguments":{"name":"shot-1.png","content":"PNGDATA","kind":"image"}}}`)
+	// Seed like artifact-upload → store.Save(kind=image); write_artifact must not
+	// be used for images (see TestWriteArtifactKindValidation).
+	if _, err := store.Save(runID, "tst", "shot-1.png", "image", "PNGDATA"); err != nil {
+		t.Fatalf("seed screenshot: %v", err)
+	}
 
 	// Missing artifact must fail the entire write.
 	failResp := call(t, h, runID, tok, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"set_test_result","arguments":{"summary":"s","cases":[{"name":"c1","status":"passed"}],"screenshots":[{"artifact":"shot-1.png","caption":"home"},{"artifact":"missing.png"}]}}}`)


### PR DESCRIPTION
落库前对契约产物名做期望 kind 校验，空 kind 按保留名/扩展名推断；
一律拒绝 kind=image（改走 artifact-upload），避免 page.html 等被标错类型。

Co-authored-by: Cursor <cursoragent@cursor.com>
