### PR TITLE
fix(home): 隐藏筛选说明并消除品牌打字收尾抖动

### DIFF
--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -4,7 +4,6 @@
       "title": "Start a pre-dev clarification in one sentence",
       "subtitle": "Pick an Approve pipeline; the first message becomes the Run title",
       "placeholder": "Start your next iteration quickly",
-      "filterHint": "Only published pipelines whose first node after start is Approve (across projects)",
       "selectProject": "Select a project",
       "noProject": "No project selected. Pick a project to start an Approve pipeline from Home.",
       "noPipelines": "No published pipeline whose first node after start is Approve is available on this account.",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -4,7 +4,6 @@
       "title": "从一句话开始一次开发前澄清",
       "subtitle": "选择 Approve 流水线，第一句话会成为 Run 标题",
       "placeholder": "快速开启你的迭代",
-      "filterHint": "仅显示开始后是 Approve 的已发布流水线（跨项目）",
       "selectProject": "选择项目",
       "noProject": "尚未选择项目。选择一个项目后可从首页启动 Approve 流水线。",
       "noPipelines": "账号下暂无「开始后是 Approve」的已发布流水线。",

--- a/web/src/views/DashboardView.fill.test.ts
+++ b/web/src/views/DashboardView.fill.test.ts
@@ -75,9 +75,11 @@ describe('DashboardView home chat layout', () => {
     expect(src).not.toMatch(/rounded-full bg-err[\s\S]{0,80}data-testid="home-attach-remove"/)
   })
 
-  // plan g2.1 / g2.2 / g2.3
-  it('keeps filter hint, placeholder typewriter hook, and multiline textarea', () => {
-    expect(src).toMatch(/data-testid="home-filter-hint"/)
+  // plan g2 / g3 — no filter hint; caret opacity settle; placeholder typewriter
+  it('omits filter hint and keeps caret settle + placeholder typewriter', () => {
+    expect(src).not.toMatch(/data-testid="home-filter-hint"/)
+    expect(src).not.toMatch(/filterHint/)
+    expect(src).toMatch(/home-brand__cursor--gone/)
     expect(src).toMatch(/data-testid="home-composer-placeholder"/)
     expect(src).toMatch(/shiftKey/)
     expect(src).toMatch(/prefers-reduced-motion/)

--- a/web/src/views/DashboardView.test.ts
+++ b/web/src/views/DashboardView.test.ts
@@ -171,7 +171,6 @@ describe('DashboardView home composer', () => {
     await vi.advanceTimersByTimeAsync(220 + 78 * 9 + 50)
     expect(wrapper.get('[data-testid="home-brand-text"]').text()).toBe('Approving')
     const caret = wrapper.get('[data-testid="home-brand-cursor"]')
-    expect(caret.exists()).toBe(true)
     expect(caret.classes()).not.toContain('home-brand__cursor--gone')
     await vi.advanceTimersByTimeAsync(850 * 3 + 50)
     expect(wrapper.get('[data-testid="home-brand-text"]').text()).toBe('Approving')

--- a/web/src/views/DashboardView.test.ts
+++ b/web/src/views/DashboardView.test.ts
@@ -139,14 +139,15 @@ describe('DashboardView home composer', () => {
     wrapper.unmount()
   })
 
-  // plan g1.2 / g1.3 — Approving mono brand + Chinese hint（无 subtitle，对齐第 5 轮）
+  // plan g2 — Approving mono brand + Chinese hint；无筛选说明句
   it('renders monospace Approving brand and Chinese hint', async () => {
     const wrapper = mountDashboard()
     await flushPromises()
     expect(wrapper.get('[data-testid="home-brand"]').classes()).toContain('home-brand')
     expect(wrapper.get('[data-testid="home-title"]').text()).toBe('从一句话开始一次开发前澄清')
     expect(wrapper.find('[data-testid="home-subtitle"]').exists()).toBe(false)
-    expect(wrapper.get('[data-testid="home-filter-hint"]').text()).toContain('Approve')
+    expect(wrapper.find('[data-testid="home-filter-hint"]').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('仅显示开始后是 Approve 的已发布流水线')
     wrapper.unmount()
   })
 
@@ -162,30 +163,33 @@ describe('DashboardView home composer', () => {
     wrapper.unmount()
   })
 
-  // plan g1.1 — one-shot typewriter then settle
+  // plan g3 — one-shot typewriter then opacity-hide caret (keep layout box)
   it('types Approving once then settles without looping', async () => {
     const wrapper = mountDashboard()
     await flushPromises()
     expect(wrapper.get('[data-testid="home-brand-text"]').text()).toBe('')
     await vi.advanceTimersByTimeAsync(220 + 78 * 9 + 50)
     expect(wrapper.get('[data-testid="home-brand-text"]').text()).toBe('Approving')
-    expect(wrapper.find('[data-testid="home-brand-cursor"]').exists()).toBe(true)
+    const caret = wrapper.get('[data-testid="home-brand-cursor"]')
+    expect(caret.exists()).toBe(true)
+    expect(caret.classes()).not.toContain('home-brand__cursor--gone')
     await vi.advanceTimersByTimeAsync(850 * 3 + 50)
     expect(wrapper.get('[data-testid="home-brand-text"]').text()).toBe('Approving')
-    expect(wrapper.find('[data-testid="home-brand-cursor"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="home-brand-cursor"]').classes()).toContain('home-brand__cursor--gone')
+    expect(wrapper.get('[data-testid="home-brand-cursor"]').classes()).not.toContain('home-brand__cursor--blink')
     await vi.advanceTimersByTimeAsync(5000)
     expect(wrapper.get('[data-testid="home-brand-text"]').text()).toBe('Approving')
-    expect(wrapper.find('[data-testid="home-brand-cursor"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="home-brand-cursor"]').classes()).toContain('home-brand__cursor--gone')
     wrapper.unmount()
   })
 
-  // plan g3.3 — reduced-motion shows static brand
+  // plan g3 — reduced-motion shows static brand; caret stays in layout but gone
   it('shows full Approving immediately under reduced-motion', async () => {
     stubReducedMotion(true)
     const wrapper = mountDashboard()
     await flushPromises()
     expect(wrapper.get('[data-testid="home-brand-text"]').text()).toBe('Approving')
-    expect(wrapper.find('[data-testid="home-brand-cursor"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="home-brand-cursor"]').classes()).toContain('home-brand__cursor--gone')
     wrapper.unmount()
   })
 

--- a/web/src/views/DashboardView.vue
+++ b/web/src/views/DashboardView.vue
@@ -45,7 +45,8 @@ const {
 } = useHomeApproveChat()
 
 const brandVisible = ref('')
-const brandCursor = ref(false)
+/** Keep caret in layout; hide with opacity so settle does not shift the centered brand. */
+const brandCursorGone = ref(false)
 const brandCursorBlink = ref(false)
 const brandTimers: ReturnType<typeof setTimeout>[] = []
 const composerFocused = ref(false)
@@ -76,17 +77,17 @@ function scheduleBrand(fn: () => void, ms: number) {
   brandTimers.push(setTimeout(fn, ms))
 }
 
-/** g1.1 — monospace brand: type once, soft blink caret, then settle. */
+/** Monospace brand: type once, soft blink caret, then opacity-hide caret (keep box). */
 function runBrandTypewriter() {
   clearBrandTimers()
   brandCursorBlink.value = false
+  brandCursorGone.value = false
   if (prefersReducedMotion()) {
     brandVisible.value = BRAND_TEXT
-    brandCursor.value = false
+    brandCursorGone.value = true
     return
   }
   brandVisible.value = ''
-  brandCursor.value = true
   let i = 0
   const typeNext = () => {
     if (i < BRAND_TEXT.length) {
@@ -98,7 +99,7 @@ function runBrandTypewriter() {
     brandCursorBlink.value = true
     scheduleBrand(() => {
       brandCursorBlink.value = false
-      brandCursor.value = false
+      brandCursorGone.value = true
     }, 850 * 3)
   }
   scheduleBrand(typeNext, 220)
@@ -231,9 +232,11 @@ onBeforeUnmount(() => {
       <h1 class="home-brand" data-testid="home-brand" aria-label="Approving">
         <span class="home-brand__text" data-testid="home-brand-text">{{ brandVisible }}</span>
         <span
-          v-if="brandCursor"
           class="home-brand__cursor"
-          :class="{ 'home-brand__cursor--blink': brandCursorBlink }"
+          :class="{
+            'home-brand__cursor--blink': brandCursorBlink,
+            'home-brand__cursor--gone': brandCursorGone,
+          }"
           data-testid="home-brand-cursor"
           aria-hidden="true"
         />
@@ -370,9 +373,6 @@ onBeforeUnmount(() => {
           </div>
         </form>
       </div>
-      <p class="mt-3 text-center text-[11px] text-txt3" data-testid="home-filter-hint">
-        {{ t('pages.dashboard.filterHint') }}
-      </p>
 
       <div
         v-if="loadError"
@@ -408,7 +408,7 @@ onBeforeUnmount(() => {
 
       <div
         v-else
-        class="mt-[22px] flex w-full justify-center gap-3 overflow-x-auto pb-1"
+        class="mt-10 flex w-full justify-center gap-3 overflow-x-auto pb-1"
         data-testid="home-pipeline-cards"
       >
         <button
@@ -487,11 +487,18 @@ onBeforeUnmount(() => {
   height: 0.92em;
   margin-left: 0.06em;
   vertical-align: -0.06em;
+  flex-shrink: 0;
   background: rgb(var(--c-accent));
+  opacity: 1;
+  transition: opacity 0.2s ease;
 }
 
 .home-brand__cursor--blink {
   animation: home-brand-caret 0.85s steps(1) 3;
+}
+
+.home-brand__cursor--gone {
+  opacity: 0;
 }
 
 .home-hint {
@@ -642,7 +649,8 @@ onBeforeUnmount(() => {
   }
 
   .home-brand__cursor {
-    display: none !important;
+    opacity: 0 !important;
+    animation: none !important;
   }
 
   .home-composer__ph-cursor {


### PR DESCRIPTION
Composer 下方不再渲染 filterHint；品牌 caret 收尾改用 opacity 隐藏并保留占位，避免居中标题宽度收缩跳动。

Co-authored-by: Cursor <cursoragent@cursor.com>
