### PR TITLE
fix(inbox): allow consecutive Approve confirm while prior reply pending

### DIFF
--- a/web/e2e/inbox-confirm-leave.spec.ts
+++ b/web/e2e/inbox-confirm-leave.spec.ts
@@ -20,6 +20,8 @@ type State = {
   resumeFail: boolean
   replyResolved: boolean
   resumeResolved: boolean
+  /** Count of force reactReply calls (consecutive-approve coverage). */
+  forceReplyCount: number
 }
 
 function approveItem(): InboxItem {
@@ -32,6 +34,24 @@ function approveItem(): InboxItem {
     workflowId: 'wf-ap',
     workflowName: '审批工作流',
     runTitle: '确认后应离开待办',
+    label: 'Approve',
+    done: false,
+    requestedAt: NOW,
+    updatedAt: NOW,
+    tags: [],
+  }
+}
+
+function approveItemNeighbor(): InboxItem {
+  return {
+    type: 'clarify',
+    kind: 'approve',
+    runId: 'run-approve-b',
+    nodeId: 'approve_7gl7',
+    iteration: 1,
+    workflowId: 'wf-ap',
+    workflowName: '审批工作流',
+    runTitle: '第二个待确认',
     label: 'Approve',
     done: false,
     requestedAt: NOW,
@@ -97,14 +117,15 @@ async function mockApis(page: Page, state: State) {
     if (method === 'GET' && path.match(/\/api\/runs\/[^/]+\/inbox-context/)) {
       const runId = path.split('/')[3]
       const nodeId = url.searchParams.get('nodeId') || ''
-      if (runId === 'run-approve') {
+      if (runId === 'run-approve' || runId === 'run-approve-b') {
+        const nid = runId === 'run-approve-b' ? 'approve_7gl7' : 'approve_7gl6'
         await route.fulfill({
           json: {
             type: 'clarify',
             status: 'waiting_human',
             nodes: [
               {
-                id: 'approve_7gl6',
+                id: nid,
                 type: 'approve',
                 label: 'Approve',
                 position: { x: 0, y: 0 },
@@ -121,9 +142,9 @@ async function mockApis(page: Page, state: State) {
               { id: 'art-2', name: 'plan.json', sizeBytes: 32, createdAt: NOW },
             ],
             nodeExecutions: {
-              approve_7gl6: [
+              [nid]: [
                 {
-                  nodeId: 'approve_7gl6',
+                  nodeId: nid,
                   iteration: 1,
                   status: 'waiting_human',
                   outputs: {},
@@ -131,7 +152,7 @@ async function mockApis(page: Page, state: State) {
               ],
             },
             clarify: {
-              nodeId: 'approve_7gl6',
+              nodeId: nid,
               iteration: 1,
               turns: [
                 {
@@ -179,6 +200,8 @@ async function mockApis(page: Page, state: State) {
     }
 
     if (method === 'POST' && path.match(/\/api\/runs\/[^/]+\/react\/[^/]+\/reply\/?$/)) {
+      const parts = path.split('/')
+      const runId = parts[3]
       const body = (req.postDataJSON() as { force?: boolean } | null) || {}
       if (state.replyDelayMs > 0) {
         await new Promise((r) => setTimeout(r, state.replyDelayMs))
@@ -189,8 +212,9 @@ async function mockApis(page: Page, state: State) {
         return
       }
       if (body.force) {
+        state.forceReplyCount += 1
         state.inbox = {
-          items: state.inbox.items.filter((it) => it.runId !== 'run-approve'),
+          items: state.inbox.items.filter((it) => it.runId !== runId),
           total: Math.max(0, state.inbox.total - 1),
         }
       }
@@ -266,6 +290,7 @@ test.describe('Inbox 确认发起即离开待办', () => {
       resumeFail: false,
       replyResolved: false,
       resumeResolved: false,
+      forceReplyCount: 0,
     }
     await openGates(page, state)
 
@@ -291,6 +316,43 @@ test.describe('Inbox 确认发起即离开待办', () => {
     await page.screenshot({ path: `${SHOT}/03-after-reply-ok.png`, fullPage: true })
   })
 
+  test('plan g2.2: 连续两个 Approve，首条 reply 未返回即可确认邻居', async ({ page }) => {
+    const state: State = {
+      inbox: { items: [approveItem(), approveItemNeighbor()], total: 2 },
+      replyDelayMs: 2500,
+      replyFail: false,
+      resumeDelayMs: 0,
+      resumeFail: false,
+      replyResolved: false,
+      resumeResolved: false,
+      forceReplyCount: 0,
+    }
+    await openGates(page, state)
+
+    await approveRow(page).first().click()
+    const confirm = page.getByTestId('clarify-confirm-flow').or(page.getByRole('button', { name: '确认并流转' }))
+    await expect(confirm.first()).toBeVisible({ timeout: 15_000 })
+    await confirm.first().click()
+
+    // First left; second auto-selected while first reply still pending.
+    await expect(approveRow(page)).toHaveCount(0, { timeout: 1500 })
+    expect(state.forceReplyCount).toBe(0)
+    await expect(page.getByText('第二个待确认')).toBeVisible({ timeout: 5000 })
+
+    const confirmB = page.getByTestId('clarify-confirm-flow').or(page.getByRole('button', { name: '确认并流转' }))
+    await expect(confirmB.first()).toBeVisible({ timeout: 10_000 })
+    await expect(confirmB.first()).toBeEnabled()
+    await page.screenshot({ path: `${SHOT}/08-neighbor-ready-while-first-pending.png`, fullPage: true })
+    await confirmB.first().click()
+
+    // Second must also leave before either delayed reply resolves (no global lock swallow).
+    await expect(page.getByText('第二个待确认')).toHaveCount(0, { timeout: 1500 })
+    expect(state.forceReplyCount).toBeLessThan(2)
+
+    await expect.poll(() => state.forceReplyCount, { timeout: 8000 }).toBe(2)
+    await page.screenshot({ path: `${SHOT}/09-both-confirmed.png`, fullPage: true })
+  })
+
   test('Approve 确认失败：条目回显且可再点确认', async ({ page }) => {
     const state: State = {
       inbox: { items: [approveItem()], total: 1 },
@@ -300,6 +362,7 @@ test.describe('Inbox 确认发起即离开待办', () => {
       resumeFail: false,
       replyResolved: false,
       resumeResolved: false,
+      forceReplyCount: 0,
     }
     await openGates(page, state)
 
@@ -335,6 +398,7 @@ test.describe('Inbox 确认发起即离开待办', () => {
       resumeFail: false,
       replyResolved: false,
       resumeResolved: false,
+      forceReplyCount: 0,
     }
     await openGates(page, state)
 

--- a/web/src/views/GatesInboxView.inboxLifecycle.test.ts
+++ b/web/src/views/GatesInboxView.inboxLifecycle.test.ts
@@ -801,6 +801,135 @@ describe('GatesInboxView inbox-context lifecycle', () => {
     wrapper.unmount()
   })
 
+  it('plan g2.1/f1: neighbor force confirm proceeds while first reactReply pending', async () => {
+    const a = clarifyItem('a')
+    const b = clarifyItem('b')
+    let list: InboxItem[] = [a, b]
+    mocks.listGates.mockImplementation(async () => paged(list))
+
+    const replyResolvers: Array<(v: unknown) => void> = []
+    mocks.reactReply.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          replyResolvers.push(resolve)
+        }),
+    )
+
+    const wrapper = mountInbox()
+    await flushPromises()
+    await nextTick()
+
+    const finishA = wrapper.get('[data-testid="clarify-send"]').trigger('click')
+    await flushPromises()
+    await nextTick()
+
+    // A left; B selected while A's reactReply still hangs.
+    expect(wrapper.text()).not.toContain('Clarify a')
+    expect(wrapper.text()).toContain('Clarify b')
+    expect(mocks.reactReply).toHaveBeenCalledTimes(1)
+    expect(mocks.reactReply).toHaveBeenNthCalledWith(
+      1,
+      'run-a',
+      'clarify-a',
+      'hi',
+      [],
+      true,
+      [],
+    )
+
+    // Neighbor confirm must actually call reactReply — not silent-return on global lock.
+    const finishB = wrapper.get('[data-testid="clarify-send"]').trigger('click')
+    await flushPromises()
+    await nextTick()
+
+    expect(mocks.reactReply).toHaveBeenCalledTimes(2)
+    expect(mocks.reactReply).toHaveBeenNthCalledWith(
+      2,
+      'run-b',
+      'clarify-b',
+      'hi',
+      [],
+      true,
+      [],
+    )
+    expect(wrapper.text()).not.toContain('Clarify b')
+
+    list = []
+    replyResolvers[0]!({ status: 'ok' })
+    replyResolvers[1]!({ status: 'ok' })
+    await finishA
+    await finishB
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+
+    expect(mocks.toastSuccess).toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('plan g2.1/s2: first force fails after neighbor selected; page confirm stays usable', async () => {
+    const a = clarifyItem('a')
+    const b = clarifyItem('b')
+    let list: InboxItem[] = [a, b]
+    mocks.listGates.mockImplementation(async () => paged(list))
+
+    let rejectA!: (e: unknown) => void
+    mocks.reactReply.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectA = reject
+        }),
+    )
+
+    const wrapper = mountInbox()
+    await flushPromises()
+    await nextTick()
+
+    const finishA = wrapper.get('[data-testid="clarify-send"]').trigger('click')
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.text()).toContain('Clarify b')
+    expect(wrapper.text()).not.toContain('Clarify a')
+
+    // A fails while B was briefly selected — restore A for retry and unlock the page.
+    rejectA(new Error('confirm blew up'))
+    await finishA.catch(() => {})
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Clarify a')
+    expect(wrapper.text()).toContain('Clarify b')
+    expect(wrapper.find('[data-testid="clarify-send"]').exists()).toBe(true)
+
+    // Neighbor B remains confirmable after failure unlock (no whole-page lock residue).
+    const buttonsB = wrapper.findAll('button').filter((btn) => btn.text().includes('Clarify b'))
+    expect(buttonsB.length).toBeGreaterThan(0)
+    await buttonsB[0]!.trigger('click')
+    await flushPromises()
+    await nextTick()
+
+    mocks.reactReply.mockResolvedValueOnce({ status: 'ok' })
+    list = [a]
+    await wrapper.get('[data-testid="clarify-send"]').trigger('click')
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+
+    expect(mocks.reactReply).toHaveBeenCalledWith(
+      'run-b',
+      'clarify-b',
+      'hi',
+      [],
+      true,
+      [],
+    )
+    expect(wrapper.text()).not.toContain('Clarify b')
+    expect(wrapper.text()).toContain('Clarify a')
+    wrapper.unmount()
+  })
+
   it('plan g1.3: force-finish failure restores row and allows retry', async () => {
     const a = clarifyItem('a')
     const b = clarifyItem('b')

--- a/web/src/views/GatesInboxView.vue
+++ b/web/src/views/GatesInboxView.vue
@@ -203,10 +203,31 @@ const confirmedAbsentTriples = new Set<string>()
 const inboxContextAborts = new Map<string, AbortController>()
 /** Single-flight: one softRefresh/loadActiveRun at a time for the selected triple. */
 let inboxContextInFlight: string | null = null
-/** Processing intent lock — blocks list reselection until converge finishes. */
-const processingLock = ref(false)
-/** Snapshot used to reopen Active WS if resume/finish rolls back. */
-let processingIntentTriple: string | null = null
+/**
+ * In-flight confirm intents (triple keys). Non-empty ⇒ list reselection / refresh
+ * stay gated (race with lagging list). Force confirm is gated per-item only so a
+ * neighbor can confirm while an earlier reactReply/resume is still pending.
+ */
+const processingIntentKeys = ref(new Set<string>())
+const processingLock = computed(() => processingIntentKeys.value.size > 0)
+
+function addProcessingIntent(triple: string) {
+  const next = new Set(processingIntentKeys.value)
+  next.add(triple)
+  processingIntentKeys.value = next
+}
+
+function removeProcessingIntent(triple: string) {
+  if (!processingIntentKeys.value.has(triple)) return
+  const next = new Set(processingIntentKeys.value)
+  next.delete(triple)
+  processingIntentKeys.value = next
+}
+
+function isProcessingIntent(it: Pick<InboxItem, 'runId' | 'nodeId' | 'iteration'> | null | undefined) {
+  if (!it) return false
+  return processingIntentKeys.value.has(inboxTripleKey(it))
+}
 
 function markProcessed(it: Pick<InboxItem, 'runId' | 'nodeId' | 'iteration'>) {
   processedTriples.add(inboxTripleKey(it))
@@ -253,23 +274,22 @@ function releaseInboxContextSignal(triple: string, signal: AbortSignal) {
 
 /**
  * User clicked approve / force-finish clarify: short-circuit immediately so the
- * resume/finish window cannot emit more inbox-context traffic.
+ * resume/finish window cannot emit more inbox-context traffic for this triple.
+ * Multiple intents may be in flight (consecutive neighbor confirms).
  */
 function beginProcessingIntent(it: Pick<InboxItem, 'runId' | 'nodeId' | 'iteration'>) {
   const triple = inboxTripleKey(it)
-  processingIntentTriple = triple
-  processingLock.value = true
+  addProcessingIntent(triple)
   markProcessed(it)
   abortInboxContext(triple)
   closeActiveRunWs()
 }
 
-/** resumeGate / reactReply(force) failed — restore fetchability and unlock. */
+/** resumeGate / reactReply(force) failed — restore fetchability and drop this intent. */
 function rollbackProcessingIntent(it: Pick<InboxItem, 'runId' | 'nodeId' | 'iteration'>) {
   const triple = inboxTripleKey(it)
-  if (processingIntentTriple === triple) processingIntentTriple = null
   unmarkProcessed(it)
-  processingLock.value = false
+  removeProcessingIntent(triple)
   // Reopen Active WS only if this item is still the selected pending row.
   if (
     active.value &&
@@ -281,9 +301,9 @@ function rollbackProcessingIntent(it: Pick<InboxItem, 'runId' | 'nodeId' | 'iter
   }
 }
 
-function endProcessingIntent() {
-  processingIntentTriple = null
-  processingLock.value = false
+/** Converge finished for one intent — other in-flight neighbors keep the list lock. */
+function endProcessingIntent(it: Pick<InboxItem, 'runId' | 'nodeId' | 'iteration'>) {
+  removeProcessingIntent(inboxTripleKey(it))
 }
 
 function isActiveStillInList(it: InboxItem | null | undefined = active.value) {
@@ -334,11 +354,19 @@ function removeListItemLocally(removedKey: string) {
 /**
  * Confirm/resume failed after optimistic leave — put the row back so the user can retry.
  * `prevList` is the snapshot taken at confirm initiation (preserves card order).
+ * Re-inserts only this row into the current list so a concurrent neighbor leave is kept.
  */
 function restoreListItemLocally(it: InboxItem, prevList: InboxItem[]) {
   invalidateListLoads()
-  listItems.value = prevList.slice()
-  listTotal.value = Math.max(listTotal.value, prevList.length)
+  const key = itemKey(it)
+  if (!listItems.value.some((row) => itemKey(row) === key)) {
+    const idx = prevList.findIndex((row) => itemKey(row) === key)
+    const next = listItems.value.slice()
+    const insertAt = idx < 0 ? 0 : Math.min(idx, next.length)
+    next.splice(insertAt, 0, it)
+    listItems.value = next
+    listTotal.value = Math.max(listTotal.value, next.length)
+  }
   restoreItemLocally(it)
 }
 
@@ -1532,7 +1560,8 @@ async function onReactRevised() {
 async function onResolve(action: string, form: Record<string, any> = {}) {
   const g = active.value
   if (!g || g.type !== 'gate') return
-  if (processingLock.value) return
+  // Per-item only: another in-flight confirm must not block this neighbor.
+  if (isProcessedTriple(g) || isProcessingIntent(g)) return
   // Intent moment: short-circuit before await resume so WS cannot race.
   beginProcessingIntent(g)
   showProcessedBanner.value = false
@@ -1551,7 +1580,10 @@ async function onResolve(action: string, form: Record<string, any> = {}) {
   } catch {
     restoreListItemLocally(submittedItem, prevList)
     rollbackProcessingIntent(submittedItem)
-    active.value = submittedItem
+    // Reclaim for retry unless a newer neighbor confirm already owns the selection.
+    if (!isProcessingIntent(active.value)) {
+      active.value = submittedItem
+    }
     return
   }
   try {
@@ -1569,7 +1601,7 @@ async function onResolve(action: string, form: Record<string, any> = {}) {
       activeRun.value = null
       activeRunLoadError.value = false
     }
-    endProcessingIntent()
+    endProcessingIntent(submittedItem)
   }
 }
 
@@ -1622,7 +1654,9 @@ async function onClarifySend(
 ) {
   const it = active.value
   if (!it || it.type !== 'clarify' || it.done) return
-  if (force && processingLock.value) return
+  // Suppress duplicate force on the same triple only — neighbor confirm must proceed
+  // while an earlier reactReply(force) is still in flight (plan g1.2 / f1).
+  if (force && (isProcessedTriple(it) || isProcessingIntent(it))) return
   // Force-finish leaves pending — short-circuit at intent moment (symmetric with gate).
   // Ordinary turn replies stay pending and must not markProcessed.
   const submittedKey = itemKey(it)
@@ -1656,7 +1690,10 @@ async function onClarifySend(
       clarifyConfirmError.value = msg
       restoreListItemLocally(submittedItem, prevList!)
       rollbackProcessingIntent(submittedItem)
-      active.value = submittedItem
+      // Reclaim for retry unless a newer neighbor confirm already owns the selection.
+      if (!isProcessingIntent(active.value)) {
+        active.value = submittedItem
+      }
       return
     }
     // Non-force enqueue failed: roll back optimistic queue + surface error.
@@ -1684,7 +1721,7 @@ async function onClarifySend(
         activeRun.value = null
         activeRunLoadError.value = false
       }
-      endProcessingIntent()
+      endProcessingIntent(submittedItem)
       if (finished) {
         clarifyConfirmError.value = null
         toast.success(


### PR DESCRIPTION
Narrow processingLock from a page-wide force-confirm gate to per-triple
in-flight intents so a selected neighbor can confirm without waiting for
the previous reactReply/resume to finish or refreshing the page.

Co-authored-by: Cursor <cursoragent@cursor.com>
