### PR TITLE
fix: avoid len+len capacity in mergePromptImages

### DIFF
--- a/server/internal/runtime/acp_react.go
+++ b/server/internal/runtime/acp_react.go
@@ -560,7 +560,8 @@ func mergePromptImages(a, b []models.PromptImage) []models.PromptImage {
 	if len(b) == 0 {
 		return a
 	}
-	out := make([]models.PromptImage, 0, len(a)+len(b))
+	// Preallocate from one side only — avoid len(a)+len(b) (CodeQL go/allocation-size-overflow).
+	out := make([]models.PromptImage, 0, len(a))
 	out = append(out, a...)
 	out = append(out, b...)
 	return out

--- a/server/internal/runtime/acp_unit_test.go
+++ b/server/internal/runtime/acp_unit_test.go
@@ -978,13 +978,58 @@ func TestReactHistoryHasDialogue(t *testing.T) {
 }
 
 func TestMergePromptImages(t *testing.T) {
-	a := []models.PromptImage{{Name: "a.png"}}
-	b := []models.PromptImage{{Name: "b.png"}}
-	got := mergePromptImages(a, b)
-	if len(got) != 2 || got[0].Name != "a.png" || got[1].Name != "b.png" {
-		t.Fatalf("merge = %+v", got)
-	}
-	if mergePromptImages(nil, b)[0].Name != "b.png" {
-		t.Fatal("nil a")
-	}
+	a := []models.PromptImage{{Name: "a.png"}, {Name: "a2.png"}}
+	b := []models.PromptImage{{Name: "b.png"}, {Name: "b2.png"}}
+
+	t.Run("both_nonempty_order_and_len", func(t *testing.T) {
+		got := mergePromptImages(a, b)
+		if len(got) != 4 {
+			t.Fatalf("len = %d, want 4", len(got))
+		}
+		want := []string{"a.png", "a2.png", "b.png", "b2.png"}
+		for i, name := range want {
+			if got[i].Name != name {
+				t.Fatalf("got[%d].Name = %q, want %q", i, got[i].Name, name)
+			}
+		}
+	})
+
+	t.Run("nil_a_returns_b", func(t *testing.T) {
+		got := mergePromptImages(nil, b)
+		if len(got) != 2 || got[0].Name != "b.png" || got[1].Name != "b2.png" {
+			t.Fatalf("nil a = %+v", got)
+		}
+	})
+
+	t.Run("empty_a_returns_b", func(t *testing.T) {
+		got := mergePromptImages([]models.PromptImage{}, b)
+		if len(got) != 2 || got[0].Name != "b.png" {
+			t.Fatalf("empty a = %+v", got)
+		}
+	})
+
+	t.Run("nil_b_returns_a", func(t *testing.T) {
+		got := mergePromptImages(a, nil)
+		if len(got) != 2 || got[0].Name != "a.png" || got[1].Name != "a2.png" {
+			t.Fatalf("nil b = %+v", got)
+		}
+	})
+
+	t.Run("empty_b_returns_a", func(t *testing.T) {
+		got := mergePromptImages(a, []models.PromptImage{})
+		if len(got) != 2 || got[0].Name != "a.png" {
+			t.Fatalf("empty b = %+v", got)
+		}
+	})
+
+	t.Run("both_empty", func(t *testing.T) {
+		got := mergePromptImages(nil, nil)
+		if len(got) != 0 {
+			t.Fatalf("both nil = %+v", got)
+		}
+		got = mergePromptImages([]models.PromptImage{}, []models.PromptImage{})
+		if len(got) != 0 {
+			t.Fatalf("both empty = %+v", got)
+		}
+	})
 }


### PR DESCRIPTION
Eliminate CodeQL go/allocation-size-overflow (alert #28) by
preallocating from one slice only; expand merge boundary tests.

Co-authored-by: Cursor <cursoragent@cursor.com>
