### PR TITLE
fix: teleport sidebar footer tip and lang menu above trigger

### DIFF
--- a/web/LIB_DOMAIN_MAP.json
+++ b/web/LIB_DOMAIN_MAP.json
@@ -25,6 +25,7 @@
       "useBreakpoint.ts",
       "useChatImagePreview.ts",
       "useDelayedBusy.ts",
+      "useFixedOverlayAbove.ts",
       "useImageAttachments.ts",
       "useNotificationsPageEntry.ts",
       "usePipelineFilter.ts",
@@ -166,7 +167,7 @@
   "totals": {
     "agent": 12,
     "api": 3,
-    "composables": 15,
+    "composables": 16,
     "inbox": 20,
     "pm": 6,
     "project": 4,

--- a/web/src/components/shell/StatusMetrics.test.ts
+++ b/web/src/components/shell/StatusMetrics.test.ts
@@ -184,6 +184,56 @@ describe('StatusMetrics', () => {
     w.unmount()
   })
 
+  it('sidebar compact variant teleports tip above trigger (g1.1)', async () => {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...shell } },
+    })
+    const clip = document.createElement('div')
+    clip.style.overflow = 'hidden'
+    clip.style.height = '120px'
+    document.body.appendChild(clip)
+
+    const w = mount(StatusMetrics, {
+      props: { variant: 'compact' },
+      global: { plugins: [i18n] },
+      attachTo: clip,
+    })
+    await flushPromises()
+
+    const trigger = w.find('[data-testid="status-metrics-compact"]')
+    expect(trigger.find('.sm-tip').exists()).toBe(false)
+
+    vi.spyOn(trigger.element as HTMLElement, 'getBoundingClientRect').mockReturnValue({
+      top: 320,
+      left: 24,
+      right: 200,
+      bottom: 352,
+      width: 176,
+      height: 32,
+      x: 24,
+      y: 320,
+      toJSON: () => ({}),
+    } as DOMRect)
+
+    await trigger.trigger('click')
+    await flushPromises()
+    await nextTick()
+
+    const tip = document.body.querySelector('[data-testid="status-metrics-compact-tip"]') as HTMLElement
+    expect(tip).toBeTruthy()
+    expect(tip.getAttribute('data-placement')).toBe('above')
+    expect(tip.style.position).toBe('fixed')
+    expect(tip.textContent).toMatch(/累计 Token:\s*1,240,582/)
+    expect(tip.textContent).toMatch(/排队:\s*5/)
+    expect(Number.parseInt(tip.style.top, 10)).toBeLessThan(320)
+
+    w.unmount()
+    clip.remove()
+    document.body.innerHTML = ''
+  })
+
   it('zero counts still show label: 0 in tip', async () => {
     platformStatus.mockResolvedValue({
       cumulativeTokens: 0,

--- a/web/src/components/shell/StatusMetrics.vue
+++ b/web/src/components/shell/StatusMetrics.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useBreakpoint } from '@/lib/composables/useBreakpoint'
+import {
+  placeFixedOverlayAbove,
+  useFixedOverlayAboveListeners,
+  type FixedOverlayAboveStyle,
+} from '@/lib/composables/useFixedOverlayAbove'
 import { usePlatformStatusMetrics } from '@/lib/composables/usePlatformStatusMetrics'
 import { fmtCompactTokenCount } from '@/lib/run/tokenUsage'
 
@@ -23,8 +28,44 @@ const useCompact = computed(() => {
   return isMobile.value
 })
 
+/** Sidebar/drawer compact tips Teleport above the trigger to escape overflow-hidden. */
+const usePortaledCompactTip = computed(() => props.variant === 'compact')
+
 /** Which tip is pinned via click/touch (Demo tip-open). */
 const tipOpen = ref<string | null>(null)
+const compactTrigger = ref<HTMLElement | null>(null)
+const compactTip = ref<HTMLElement | null>(null)
+const compactTipHovered = ref(false)
+const compactTipFocused = ref(false)
+const compactTipStyle = ref<FixedOverlayAboveStyle | null>(null)
+
+const compactTipVisible = computed(
+  () =>
+  usePortaledCompactTip.value &&
+    (tipOpen.value === 'compact' || compactTipHovered.value || compactTipFocused.value),
+)
+
+async function repositionCompactTip() {
+  if (!compactTipVisible.value) return
+  await nextTick()
+  compactTipStyle.value = await placeFixedOverlayAbove(compactTrigger.value, compactTip.value, {
+    align: 'center',
+    gap: 8,
+  })
+}
+
+const { start: startCompactTipListeners, stop: stopCompactTipListeners } =
+  useFixedOverlayAboveListeners(compactTipVisible, repositionCompactTip)
+
+watch(compactTipVisible, async (visible) => {
+  if (visible) {
+    startCompactTipListeners()
+    await repositionCompactTip()
+  } else {
+    stopCompactTipListeners()
+    compactTipStyle.value = null
+  }
+})
 
 function fmtFull(n: number | null | undefined): string {
   if (n === null || n === undefined) return '—'
@@ -181,13 +222,17 @@ function onBlurTip(id: string) {
     <!-- Narrow &lt;md: Token · RUN/Q; rate/peak only in tip -->
     <button
       v-else
+      ref="compactTrigger"
       type="button"
       class="sm-item sm-compact relative inline-flex w-full items-center gap-2 border-0 bg-elevated px-2 py-1.5 text-[11px] text-inherit hover:bg-elevated hover:text-txt focus-visible:bg-elevated focus-visible:text-txt focus-visible:outline-none"
       :class="tipOpen === 'compact' ? 'text-txt tip-open' : ''"
       data-testid="status-metrics-compact"
       :aria-label="t('shell.statusMetrics.compactAria')"
       @click="toggleTip('compact', $event)"
-      @blur="onBlurTip('compact')"
+      @blur="onBlurTip('compact'); compactTipFocused = false"
+      @focus="compactTipFocused = true"
+      @mouseenter="compactTipHovered = true"
+      @mouseleave="compactTipHovered = false"
     >
       <span class="inline-flex items-center gap-1.5">
         <svg class="sm-ico block h-[13px] w-[13px] shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
@@ -210,6 +255,7 @@ function onBlurTip(id: string) {
         <span class="sm-val text-[11px] font-semibold leading-none text-txt">{{ queued }}</span>
       </span>
       <span
+        v-if="!usePortaledCompactTip"
         class="sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden min-w-[180px] -translate-x-1/2 border border-line-strong bg-overlay px-2.5 py-2 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
         role="tooltip"
       >
@@ -220,6 +266,24 @@ function onBlurTip(id: string) {
         <div>{{ t('shell.statusMetrics.queued') }}: <span class="font-mono">{{ queued }}</span></div>
       </span>
     </button>
+
+    <Teleport v-if="usePortaledCompactTip" to="body">
+      <div
+        v-show="compactTipVisible"
+        ref="compactTip"
+        class="sm-tip pointer-events-none z-[60] min-w-[180px] border border-line-strong bg-overlay px-2.5 py-2 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
+        role="tooltip"
+        data-testid="status-metrics-compact-tip"
+        data-placement="above"
+        :style="compactTipStyle ?? undefined"
+      >
+        <div>{{ t('shell.statusMetrics.tokens') }}: <span class="font-mono">{{ fmtFull(cumulative) }}</span></div>
+        <div>{{ t('shell.statusMetrics.rate') }}: <span class="font-mono">{{ fmtFull(rate) }}</span></div>
+        <div>{{ t('shell.statusMetrics.peak') }}: <span class="font-mono">{{ fmtFull(peak) }}</span></div>
+        <div>{{ t('shell.statusMetrics.running') }}: <span class="font-mono">{{ running }}</span></div>
+        <div>{{ t('shell.statusMetrics.queued') }}: <span class="font-mono">{{ queued }}</span></div>
+      </div>
+    </Teleport>
   </div>
 </template>
 

--- a/web/src/components/ui/LangSelect.test.ts
+++ b/web/src/components/ui/LangSelect.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { createI18n } from 'vue-i18n'
-import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
 import common from '@/locales/zh-CN/common.json'
 import LangSelect from './LangSelect.vue'
 
@@ -51,5 +51,51 @@ describe('LangSelect', () => {
     expect(trigger.classes()).toContain('h-8')
     expect(trigger.classes()).not.toContain('border-line')
     wrapper.unmount()
+  })
+
+  it('ghost variant teleports menu above trigger (g1.2)', async () => {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common } },
+    })
+    const clip = document.createElement('div')
+    clip.style.overflow = 'hidden'
+    clip.style.height = '80px'
+    document.body.appendChild(clip)
+
+    const wrapper = mount(LangSelect, {
+      props: { modelValue: 'zh-CN', variant: 'ghost' },
+      global: { plugins: [i18n], stubs: { Icon: true, Teleport: false } },
+      attachTo: clip,
+    })
+
+    const triggerEl = wrapper.find('[data-testid="lang-select-trigger"]').element as HTMLElement
+    vi.spyOn(triggerEl, 'getBoundingClientRect').mockReturnValue({
+      top: 300,
+      left: 16,
+      right: 120,
+      bottom: 332,
+      width: 104,
+      height: 32,
+      x: 16,
+      y: 300,
+      toJSON: () => ({}),
+    } as DOMRect)
+
+    await wrapper.find('[data-testid="lang-select-trigger"]').trigger('click')
+    await flushPromises()
+
+    const menu = document.body.querySelector('[data-testid="lang-select-menu"]') as HTMLElement
+    expect(menu).toBeTruthy()
+    expect(menu.getAttribute('data-placement')).toBe('above')
+    expect(menu.style.position).toBe('fixed')
+    expect(menu.textContent).toContain('English')
+    expect(menu.textContent).toContain('中文')
+    expect(Number.parseInt(menu.style.top, 10)).toBeLessThan(300)
+
+    wrapper.unmount()
+    clip.remove()
+    document.body.innerHTML = ''
   })
 })

--- a/web/src/components/ui/LangSelect.vue
+++ b/web/src/components/ui/LangSelect.vue
@@ -1,8 +1,13 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Icon from './Icon.vue'
 import type { AppLocale } from '@/lib/shared/locale'
+import {
+  placeFixedOverlayAbove,
+  useFixedOverlayAboveListeners,
+  type FixedOverlayAboveStyle,
+} from '@/lib/composables/useFixedOverlayAbove'
 
 const LOCALE_LABELS: Record<AppLocale, string> = {
   en: 'English',
@@ -26,8 +31,38 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const open = ref(false)
 const root = ref<HTMLElement | null>(null)
+const trigger = ref<HTMLElement | null>(null)
+const menu = ref<HTMLElement | null>(null)
+const menuStyle = ref<FixedOverlayAboveStyle | null>(null)
+
+const usePortaledMenu = computed(() => props.variant === 'ghost')
 
 const currentLabel = computed(() => LOCALE_LABELS[props.modelValue])
+
+async function repositionMenu() {
+  if (!open.value || !usePortaledMenu.value) return
+  await nextTick()
+  menuStyle.value = await placeFixedOverlayAbove(trigger.value, menu.value, {
+    align: 'left',
+    gap: 6,
+    width: 160,
+  })
+}
+
+const { start: startMenuListeners, stop: stopMenuListeners } = useFixedOverlayAboveListeners(
+  open,
+  repositionMenu,
+)
+
+watch(open, async (isOpen) => {
+  if (isOpen && usePortaledMenu.value) {
+    startMenuListeners()
+    await repositionMenu()
+  } else {
+    stopMenuListeners()
+    menuStyle.value = null
+  }
+})
 
 function toggle() {
   open.value = !open.value
@@ -39,7 +74,10 @@ function choose(loc: AppLocale) {
 }
 
 function onDocClick(e: MouseEvent) {
-  if (open.value && root.value && !root.value.contains(e.target as Node)) open.value = false
+  const target = e.target as Node
+  if (!open.value) return
+  if (root.value?.contains(target) || menu.value?.contains(target)) return
+  open.value = false
 }
 
 onMounted(() => document.addEventListener('click', onDocClick))
@@ -49,6 +87,7 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
 <template>
   <div ref="root" class="relative" :data-variant="variant">
     <button
+      ref="trigger"
       type="button"
       class="flex items-center text-txt2 transition hover:bg-elevated hover:text-txt"
       :class="
@@ -67,7 +106,11 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
       <Icon name="chevron-down" :size="variant === 'ghost' ? 12 : 14" class="text-txt3" />
     </button>
 
-    <div v-if="open" role="listbox" class="card absolute right-0 z-30 mt-1.5 w-40 overflow-hidden">
+    <div
+      v-if="open && !usePortaledMenu"
+      role="listbox"
+      class="card absolute right-0 z-30 mt-1.5 w-40 overflow-hidden"
+    >
       <div class="p-1">
         <button
           v-for="loc in LANG_OPTIONS"
@@ -84,5 +127,33 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
         </button>
       </div>
     </div>
+
+    <Teleport v-if="usePortaledMenu" to="body">
+      <div
+        v-if="open"
+        ref="menu"
+        role="listbox"
+        class="card z-[60] w-40 overflow-hidden"
+        data-testid="lang-select-menu"
+        data-placement="above"
+        :style="menuStyle ?? undefined"
+      >
+        <div class="p-1">
+          <button
+            v-for="loc in LANG_OPTIONS"
+            :key="loc"
+            type="button"
+            role="option"
+            class="flex w-full items-center gap-2 px-2.5 py-2 text-left text-sm transition hover:bg-elevated"
+            :class="modelValue === loc ? 'bg-accent-dim text-txt' : 'text-txt2'"
+            :aria-selected="modelValue === loc"
+            @click.stop="choose(loc)"
+          >
+            <span class="flex-1">{{ LOCALE_LABELS[loc] }}</span>
+            <Icon v-if="modelValue === loc" name="check" :size="14" class="text-accent-2" />
+          </button>
+        </div>
+      </div>
+    </Teleport>
   </div>
 </template>

--- a/web/src/lib/composables/useFixedOverlayAbove.test.ts
+++ b/web/src/lib/composables/useFixedOverlayAbove.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { placeFixedOverlayAbove } from './useFixedOverlayAbove'
+
+describe('placeFixedOverlayAbove', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('positions overlay above anchor (left align)', async () => {
+    const anchor = document.createElement('button')
+    anchor.getBoundingClientRect = () =>
+      ({
+        top: 300,
+        left: 40,
+        right: 120,
+        bottom: 332,
+        width: 80,
+        height: 32,
+      }) as DOMRect
+    const overlay = document.createElement('div')
+    overlay.getBoundingClientRect = () =>
+      ({
+        top: 0,
+        left: 0,
+        right: 160,
+        bottom: 78,
+        width: 160,
+        height: 78,
+      }) as DOMRect
+    document.body.append(overlay)
+
+    const style = await placeFixedOverlayAbove(anchor, overlay, { align: 'left', gap: 6, width: 160 })
+    expect(style).toEqual({
+      position: 'fixed',
+      top: '216px',
+      left: '40px',
+      width: '160px',
+    })
+  })
+
+  it('clamps top to viewport margin without flipping below', async () => {
+    const anchor = document.createElement('button')
+    anchor.getBoundingClientRect = () =>
+      ({
+        top: 20,
+        left: 40,
+        right: 120,
+        bottom: 52,
+        width: 80,
+        height: 32,
+      }) as DOMRect
+    const overlay = document.createElement('div')
+    overlay.getBoundingClientRect = () =>
+      ({
+        top: 0,
+        left: 0,
+        right: 160,
+        bottom: 100,
+        width: 160,
+        height: 100,
+      }) as DOMRect
+    document.body.append(overlay)
+
+    const style = await placeFixedOverlayAbove(anchor, overlay, { align: 'left' })
+    expect(style?.top).toBe('8px')
+  })
+})

--- a/web/src/lib/composables/useFixedOverlayAbove.ts
+++ b/web/src/lib/composables/useFixedOverlayAbove.ts
@@ -1,0 +1,67 @@
+import { nextTick, onBeforeUnmount, type Ref } from 'vue'
+
+const VIEWPORT_MARGIN = 8
+const DEFAULT_GAP = 6
+
+export type FixedOverlayAboveStyle = {
+  position: 'fixed'
+  top: string
+  left: string
+  width?: string
+}
+
+/**
+ * Place a fixed overlay directly above an anchor (sidebar footer chrome).
+ * Clamps into the viewport without flipping below the anchor.
+ */
+export async function placeFixedOverlayAbove(
+  anchor: HTMLElement | null,
+  overlay: HTMLElement | null,
+  options?: { gap?: number; align?: 'left' | 'center'; width?: number },
+): Promise<FixedOverlayAboveStyle | null> {
+  if (!anchor || !overlay) return null
+  await nextTick()
+  const gap = options?.gap ?? DEFAULT_GAP
+  const rect = anchor.getBoundingClientRect()
+  const overlayRect = overlay.getBoundingClientRect()
+  const width = options?.width ?? overlayRect.width
+
+  let left =
+    options?.align === 'left'
+      ? rect.left
+      : rect.left + rect.width / 2 - width / 2
+  left = Math.min(window.innerWidth - width - VIEWPORT_MARGIN, Math.max(VIEWPORT_MARGIN, left))
+
+  let top = rect.top - overlayRect.height - gap
+  top = Math.max(VIEWPORT_MARGIN, top)
+
+  return {
+    position: 'fixed',
+    top: `${Math.round(top)}px`,
+    left: `${Math.round(left)}px`,
+    ...(options?.width ? { width: `${options.width}px` } : {}),
+  }
+}
+
+export function useFixedOverlayAboveListeners(
+  open: Ref<boolean>,
+  reposition: () => void | Promise<void>,
+) {
+  const onViewportChange = () => {
+    if (open.value) void reposition()
+  }
+
+  const start = () => {
+    window.addEventListener('resize', onViewportChange)
+    window.addEventListener('scroll', onViewportChange, true)
+  }
+
+  const stop = () => {
+    window.removeEventListener('resize', onViewportChange)
+    window.removeEventListener('scroll', onViewportChange, true)
+  }
+
+  onBeforeUnmount(stop)
+
+  return { start, stop, onViewportChange }
+}


### PR DESCRIPTION
Sidebar overflow-hidden was clipping StatusMetrics compact tips and
LangSelect ghost menus. Teleport both overlays to body with fixed
above-anchor positioning so footer chrome stays fully visible.

Co-authored-by: Cursor <cursoragent@cursor.com>
