### PR TITLE
fix: Approve 计划产物显示与 Done 再进入门禁

### DIFF
--- a/server/internal/engine/approve_test.go
+++ b/server/internal/engine/approve_test.go
@@ -265,6 +265,105 @@ func TestApproveRejectsUpstreamPlanArtifact(t *testing.T) {
 	waitRunStatus(t, db, run.ID, "failed")
 }
 
+func markApproveDoneAndReenter(t *testing.T, eng *Engine, db *gorm.DB, runID string) nodeOutcome {
+	t.Helper()
+	var conv models.ReactConversation
+	if err := db.Where("run_id = ? AND node_id = ?", runID, "predev").First(&conv).Error; err != nil {
+		t.Fatalf("conv: %v", err)
+	}
+	conv.Done = true
+	if err := db.Save(&conv).Error; err != nil {
+		t.Fatalf("mark done: %v", err)
+	}
+	c, err := eng.loadCtx(runID)
+	if err != nil {
+		t.Fatalf("loadCtx: %v", err)
+	}
+	node := c.graph.FindNode("predev")
+	if node == nil {
+		t.Fatal("missing predev")
+	}
+	c.iter["predev"] = conv.Iteration
+	return eng.execReactEnter(c, node)
+}
+
+const doneShortCircuitClarified = `{
+		"title":"需求","summary":"Done 再进入",
+		"background":"测试背景",
+		"goals":["完成需求"],"in_scope":["本功能"],"out_of_scope":["其它"],
+		"functional_requirements":[{"id":"f1","title":"需求","detail":"实现所述需求","priority":"must","acceptance_criteria":["可验收"]}],
+		"assumptions":["无额外假设(已与用户确认)"],"dependencies":["无额外依赖(已与用户确认)"],"constraints":["无额外约束(已与用户确认)"]
+	}`
+
+// Done=true without this node's plan must not complete (g2.1).
+func TestApproveDoneShortCircuitFailsWithoutPlan(t *testing.T) {
+	eng, db, _ := setupEngineGraphP(t, approveOnlyGraph())
+	run, err := eng.StartRun("wf", nil, "test")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitReactPause(t, db, run.ID, "predev")
+	if _, err := eng.store.Save(run.ID, "predev", mcp.ClarifiedRequirementArtifactName, "json", doneShortCircuitClarified); err != nil {
+		t.Fatalf("seed clarified: %v", err)
+	}
+	oc := markApproveDoneAndReenter(t, eng, db, run.ID)
+	if oc.status == "completed" {
+		t.Fatalf("Done without plan must not complete: %+v", oc)
+	}
+	if oc.status != "failed" {
+		t.Fatalf("status=%s want failed (%s)", oc.status, oc.err)
+	}
+}
+
+func TestApproveDoneShortCircuitCompletesWithOwnedProducts(t *testing.T) {
+	eng, db, _ := setupEngineGraphP(t, approveOnlyGraph())
+	run, err := eng.StartRun("wf", nil, "test")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitReactPause(t, db, run.ID, "predev")
+	if _, err := eng.store.Save(run.ID, "predev", mcp.ClarifiedRequirementArtifactName, "json", doneShortCircuitClarified); err != nil {
+		t.Fatalf("seed clarified: %v", err)
+	}
+	_, planBody := fakeStructured("plan")
+	if _, err := eng.store.Save(run.ID, "predev", mcp.PlanArtifactName, "json", planBody); err != nil {
+		t.Fatalf("seed plan: %v", err)
+	}
+	oc := markApproveDoneAndReenter(t, eng, db, run.ID)
+	if oc.status != "completed" {
+		t.Fatalf("owned products must complete, got %s %s", oc.status, oc.err)
+	}
+	if _, ok := oc.outputs["clarified_requirement"]; !ok {
+		t.Error("missing outputs.clarified_requirement")
+	}
+	if _, ok := oc.outputs["plan"]; !ok {
+		t.Error("missing outputs.plan")
+	}
+}
+
+func TestApproveDoneShortCircuitRejectsUpstreamPlan(t *testing.T) {
+	eng, db, _ := setupEngineGraphP(t, approveOnlyGraph())
+	run, err := eng.StartRun("wf", nil, "test")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitReactPause(t, db, run.ID, "predev")
+	if _, err := eng.store.Save(run.ID, "predev", mcp.ClarifiedRequirementArtifactName, "json", doneShortCircuitClarified); err != nil {
+		t.Fatalf("seed clarified: %v", err)
+	}
+	_, planBody := fakeStructured("plan")
+	if _, err := eng.store.Save(run.ID, "upstream_plan", mcp.PlanArtifactName, "json", planBody); err != nil {
+		t.Fatalf("seed upstream plan: %v", err)
+	}
+	oc := markApproveDoneAndReenter(t, eng, db, run.ID)
+	if oc.status == "completed" {
+		t.Fatalf("upstream plan must not satisfy Done re-entry: %+v", oc)
+	}
+	if oc.status != "failed" {
+		t.Fatalf("status=%s want failed (%s)", oc.status, oc.err)
+	}
+}
+
 // Optional research written by another node must not be lifted into Approve outputs.
 func TestApproveDoesNotLiftUpstreamOptionalResearch(t *testing.T) {
 	eng, db, _ := setupEngineGraphP(t, approveOnlyGraph())

--- a/server/internal/engine/node_react.go
+++ b/server/internal/engine/node_react.go
@@ -17,7 +17,9 @@ func (e *Engine) execReactEnter(c *execCtx, node *models.Node) nodeOutcome {
 	var conv models.ReactConversation
 	err := e.db.Where("run_id = ? AND node_id = ? AND iteration = ?", c.run.ID, node.ID, iter).First(&conv).Error
 	if err == nil && conv.Done {
-		return nodeOutcome{status: "completed", outputMd: "澄清已完成"}
+		// Same-iteration re-entry must not skip the product gate: Done only
+		// means the dialogue closed, not that required artifacts exist.
+		return e.finalizeAgentProducts(c, node, runtime.NodeResult{OutputMd: "澄清已完成"})
 	}
 	if err != nil {
 

--- a/server/internal/mcp/host.go
+++ b/server/internal/mcp/host.go
@@ -454,6 +454,20 @@ func (h *Host) WriteArtifact(runID, token, nodeID, name, content, kind string) (
 	return id, nil
 }
 
+// artifactWriterNode returns the last recorded writer for name, or "".
+func (h *Host) artifactWriterNode(runID, token, name string) string {
+	infos, err := h.ListArtifacts(runID, token)
+	if err != nil {
+		return ""
+	}
+	for _, info := range infos {
+		if info.Name == name && strings.TrimSpace(info.Node) != "" {
+			return info.Node
+		}
+	}
+	return ""
+}
+
 // ReadArtifact returns a previously-written artifact within the same run.
 func (h *Host) ReadArtifact(runID, token, name string) (string, error) {
 	if !h.authorize(runID, token) {

--- a/server/internal/mcp/mcp_more_test.go
+++ b/server/internal/mcp/mcp_more_test.go
@@ -108,6 +108,23 @@ func TestCallToolErrorBranches(t *testing.T) {
 	if _, isErr := toolText(t, call(t, h, runID, tok, tc(14, "update_plan_status", `{"id":"g1.1","status":"done"}`))); isErr {
 		t.Fatal("valid update_plan_status should succeed")
 	}
+	infos, err := h.ListArtifacts(runID, tok)
+	if err != nil {
+		t.Fatalf("list after update_plan_status: %v", err)
+	}
+	keptWriter := false
+	for _, info := range infos {
+		if info.Name != PlanArtifactName {
+			continue
+		}
+		keptWriter = true
+		if info.Node != "p" {
+			t.Fatalf("update_plan_status must keep plan.json writer %q, got %q", "p", info.Node)
+		}
+	}
+	if !keptWriter {
+		t.Fatal("plan.json missing after update_plan_status")
+	}
 	// Any node may backfill plan status once a plan exists.
 	h.SetActiveNode(runID, "n", "agent")
 	if _, isErr := toolText(t, call(t, h, runID, tok, tc(16, "update_plan_status", `{"id":"g1.1","status":"done"}`))); isErr {

--- a/server/internal/mcp/tools.go
+++ b/server/internal/mcp/tools.go
@@ -116,7 +116,14 @@ func (h *Host) runTool(runID, token, name string, args map[string]any) (string, 
 			return "update_plan_status failed: 未找到计划项 id=" + id, true
 		}
 		b, _ := json.MarshalIndent(doc, "", "  ")
-		if _, err := h.WriteArtifact(runID, token, h.ActiveNode(runID), PlanArtifactName, string(b), "json"); err != nil {
+		// Status backfill must not steal authorship: Approve/plan product
+		// panels bind plan.json by writer nodeId. implement is only marking
+		// progress on the existing run-scoped plan.
+		writer := h.artifactWriterNode(runID, token, PlanArtifactName)
+		if writer == "" {
+			writer = h.ActiveNode(runID)
+		}
+		if _, err := h.WriteArtifact(runID, token, writer, PlanArtifactName, string(b), "json"); err != nil {
 			return "update_plan_status failed: " + err.Error(), true
 		}
 		return fmt.Sprintf("ok: 已更新 %s=%s;剩余未完成 %d 项", id, status, len(planIncomplete(doc))), false

--- a/web/src/components/run/StructuredProductPanel.test.ts
+++ b/web/src/components/run/StructuredProductPanel.test.ts
@@ -772,4 +772,38 @@ describe('StructuredProductPanel', () => {
     expect(wrapper.find('[data-testid="structured-product-tab-plan.json"]').exists()).toBe(true)
     wrapper.unmount()
   })
+
+  it('approve plan tab still loads after implement rewrites plan.json nodeId', async () => {
+    const node: WFNode = {
+      id: 'approve',
+      type: 'approve',
+      label: 'Approve',
+      position: { x: 0, y: 0 },
+      config: {},
+    }
+    const nodeRun: NodeRun = {
+      nodeId: 'approve',
+      iteration: 1,
+      status: 'completed',
+      outputs: {},
+    }
+    const planDoc = { goals: [{ title: 'G1', subgoals: [{ title: 'S1' }] }] }
+    apiMocks.artifactContent.mockResolvedValue({ content: JSON.stringify(planDoc) })
+    const run = runWithArtifacts([
+      artifact({
+        id: 'a-plan',
+        name: 'plan.json',
+        kind: 'json',
+        nodeId: 'implement',
+      }),
+    ])
+    const wrapper = mountPanel(node, nodeRun, run)
+    await flushPromises()
+    await wrapper.get('[data-testid="structured-product-tab-plan.json"]').trigger('click')
+    await flushPromises()
+    expect(apiMocks.artifactContent).toHaveBeenCalledWith('a-plan')
+    expect(wrapper.find('[data-testid="structured-view"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="structured-product-name"]').text()).toBe('plan.json')
+    wrapper.unmount()
+  })
 })

--- a/web/src/components/run/StructuredProductPanel.vue
+++ b/web/src/components/run/StructuredProductPanel.vue
@@ -10,7 +10,7 @@ import HtmlPreview from '../ui/HtmlPreview.vue'
 import SelectionAddToChat from './SelectionAddToChat.vue'
 import UpstreamRequirementContext from './UpstreamRequirementContext.vue'
 import { ARTIFACT_TO_OUTPUT_JSON } from '@/lib/run/structuredArtifacts'
-import { productArtifactName, productArtifactsForType } from '@/lib/run/productNodeArtifacts'
+import { productArtifactName, productArtifactsForType, resolveStructuredProductArtifact } from '@/lib/run/productNodeArtifacts'
 import { provideReviewAnnotate } from '@/lib/inbox/reviewAnnotate'
 import { addClarifyAnnotation } from '@/lib/inbox/useClarifyDraft'
 import { useToast } from '@/lib/composables/useToast'
@@ -102,15 +102,16 @@ const def = computed(() => NODE_DEFS.value[props.node.type])
 const artifact = computed(() => {
   if (!spec.value) return null
   const name = spec.value.name
-  return (
-    props.run.artifacts.find((a) => a.name === name && a.nodeId === props.node.id) ||
-    // Single-product panels historically matched by name only; keep that
-    // fallback when this node has no owned copy yet (e.g. snapshot-only load).
-    (productArtifactsForType(props.node.type).length <= 1
-      ? props.run.artifacts.find((a) => a.name === name)
-      : undefined) ||
-    null
-  )
+  const jsonKey = ARTIFACT_TO_OUTPUT_JSON[name]
+  const snap = jsonKey ? props.nodeRun.outputs?.[jsonKey] : undefined
+  return resolveStructuredProductArtifact({
+    name,
+    nodeId: props.node.id,
+    nodeType: props.node.type,
+    nodeStatus: props.nodeRun.status,
+    hasSnapshot: typeof snap === 'string' && snap.trim().length > 0,
+    artifacts: props.run.artifacts || [],
+  })
 })
 
 const doc = ref<any>(null)

--- a/web/src/lib/run/productNodeArtifacts.test.ts
+++ b/web/src/lib/run/productNodeArtifacts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { PRODUCT_ARTIFACT_BY_TYPE, PRODUCT_NODE_TYPES, productArtifactName, productArtifactsForType, productOutputDefs } from './productNodeArtifacts'
+import { PRODUCT_ARTIFACT_BY_TYPE, PRODUCT_NODE_TYPES, productArtifactName, productArtifactsForType, productOutputDefs, resolveStructuredProductArtifact } from './productNodeArtifacts'
 
 describe('productNodeArtifacts', () => {
   it('covers StructuredProductPanel node types including proposal_select', () => {
@@ -43,5 +43,36 @@ describe('productNodeArtifacts', () => {
       { key: 'page', desc: 'nodes.visual.outputs.page.desc' },
       { key: 'artifact_id', desc: 'nodes.visual.outputs.artifact_id.desc' },
     ])
+  })
+
+  it('keeps Approve plan.json visible after implement steals the store nodeId', () => {
+    const plan = { name: 'plan.json', nodeId: 'implement' }
+    expect(
+      resolveStructuredProductArtifact({
+        name: 'plan.json',
+        nodeId: 'approve',
+        nodeType: 'approve',
+        nodeStatus: 'completed',
+        artifacts: [plan],
+      }),
+    ).toEqual(plan)
+    expect(
+      resolveStructuredProductArtifact({
+        name: 'plan.json',
+        nodeId: 'approve',
+        nodeType: 'approve',
+        nodeStatus: 'waiting_human',
+        artifacts: [plan],
+      }),
+    ).toBeNull()
+    expect(
+      resolveStructuredProductArtifact({
+        name: 'research.json',
+        nodeId: 'approve',
+        nodeType: 'approve',
+        nodeStatus: 'completed',
+        artifacts: [{ name: 'research.json', nodeId: 'research' }],
+      }),
+    ).toBeNull()
   })
 })

--- a/web/src/lib/run/productNodeArtifacts.ts
+++ b/web/src/lib/run/productNodeArtifacts.ts
@@ -70,6 +70,39 @@ export function productArtifactsForType(nodeType: string): ProductArtifactSpec[]
   return name ? [{ name, required: true }] : []
 }
 
+/** Run-scoped reserved names: one copy per run; later status writes must not hide it. */
+export const RUN_SCOPED_PRODUCT_NAMES = new Set(['plan.json'])
+
+const FINISHED_NODE_STATUSES = new Set(['completed', 'failed', 'cancelled'])
+
+/** Pick the store row a structured product panel should bind. */
+export function resolveStructuredProductArtifact<T extends { name: string; nodeId?: string }>(opts: {
+  name: string
+  nodeId: string
+  nodeType: string
+  nodeStatus?: string
+  hasSnapshot?: boolean
+  artifacts: T[]
+}): T | null {
+  const { name, nodeId, nodeType, artifacts } = opts
+  if (!name) return null
+  const owned = artifacts.find((a) => a.name === name && a.nodeId === nodeId)
+  if (owned) return owned
+  const listed = productArtifactsForType(nodeType)
+  if (listed.length <= 1) {
+    return artifacts.find((a) => a.name === name) || null
+  }
+  // plan.json is run-global. implement update_plan_status used to rewrite
+  // nodeId to the implement node; after this node has finished (or already
+  // snapshotted the plan), still bind the current run copy. In-flight
+  // Approve without a snapshot must not pick up an upstream leftover.
+  const finished = FINISHED_NODE_STATUSES.has(String(opts.nodeStatus || ''))
+  if (RUN_SCOPED_PRODUCT_NAMES.has(name) && (opts.hasSnapshot || finished)) {
+    return artifacts.find((a) => a.name === name) || null
+  }
+  return null
+}
+
 /** Inspector / editor output rows derived from the nodereg manifest contract. */
 export function productOutputDefs(
   nodeType: string,


### PR DESCRIPTION
## Summary
- `update_plan_status` 不再改写 `plan.json` 的作者节点，避免实现节点更新进度后 Approve 产物页绑不到计划。
- Approve 产物页在节点已结束后按 Run 级文件名回退读取 `plan.json`，进行中仍不误显示上游残留。
- `execReactEnter` 遇到 `Done=true` 时改为走 `finalizeAgentProducts`：缺本节点强制产物则失败，齐则回填 outputs。

## Test plan
- [x] `go test ./internal/engine/ ./internal/mcp/`
- [x] `vitest`：`productNodeArtifacts` / `StructuredProductPanel`
- [ ] CI `ci-server` / `ci-web` / `ci` gate 全绿
- [ ] 用类似 Run #3a11d45b 的已结束 Approve 打开产物页，确认 `plan.json` 有正文
- [ ] 确认流转缺 plan 仍失败；Done 再进入且无本节点 plan 不能 completed


Made with [Cursor](https://cursor.com)