### PR TITLE
feat(web): enable draft image preview on home and Clarify composer

### DIFF
--- a/web/e2e/clarify-image-preview.spec.ts
+++ b/web/e2e/clarify-image-preview.spec.ts
@@ -79,9 +79,15 @@ test.describe('ClarifyChat human history image AppModal preview', () => {
 
     const draftThumb = page.getByTestId('clarify-draft-image-thumb')
     await expect(draftThumb).toBeVisible()
-    await expect(draftThumb).toContainText('不可预览')
-    await expect(draftThumb).not.toContainText('点击放大')
+    await expect(draftThumb).toContainText('点击放大')
+    await expect(draftThumb).not.toContainText('不可预览')
     await draftThumb.click()
+    await expect(page.getByTestId('clarify-image-preview-img')).toBeVisible()
+    await expect(page.getByTestId('clarify-image-preview-img')).toHaveAttribute(
+      'src',
+      `data:image/png;base64,${PNG_A}`,
+    )
+    await headerClose.click()
     await expect(page.getByTestId('clarify-image-preview-img')).toHaveCount(0)
     await shot('05-scope-guards.png')
   })

--- a/web/src/components/run/ClarifyChat.test.ts
+++ b/web/src/components/run/ClarifyChat.test.ts
@@ -1249,7 +1249,7 @@ describe('ClarifyChat', () => {
       wrapper.unmount()
     })
 
-    it('agent history thumbs and composer drafts do not open preview (g4.2)', async () => {
+    it('agent history thumbs stay locked; composer drafts open preview (g2.2 / g2.3)', async () => {
       const wrapper = mountChat({
         turns: [
           {
@@ -1259,7 +1259,7 @@ describe('ClarifyChat', () => {
             images: [{ data: PNG_A, mimeType: 'image/png' }],
           },
         ],
-        attachments: [{ data: PNG_B, mimeType: 'image/png' }],
+        attachments: [{ data: PNG_B, mimeType: 'image/png', name: '草稿图.png' }],
       })
       expect(wrapper.find('[data-testid="clarify-history-image-thumb"]').exists()).toBe(false)
       const agentThumb = wrapper.find('[data-testid="clarify-agent-image-thumb"]')
@@ -1272,11 +1272,19 @@ describe('ClarifyChat', () => {
 
       const draftThumb = wrapper.find('[data-testid="clarify-draft-image-thumb"]')
       expect(draftThumb.exists()).toBe(true)
-      expect(draftThumb.text()).toContain('不可预览')
-      expect(draftThumb.text()).not.toContain('点击放大')
+      expect(draftThumb.text()).toContain('点击放大')
+      expect(draftThumb.text()).not.toContain('不可预览')
       await draftThumb.trigger('click')
       await flushPromises()
+      expect(wrapper.find('[data-testid="clarify-image-preview-modal"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="clarify-image-preview-title"]').text()).toBe('图片预览 · 草稿图.png')
+      expect(wrapper.find('[data-testid="clarify-image-preview-img"]').attributes('src')).toBe(
+        `data:image/png;base64,${PNG_B}`,
+      )
+      await wrapper.find('[data-testid="clarify-image-preview-close"]').trigger('click')
+      await flushPromises()
       expect(wrapper.find('[data-testid="clarify-image-preview-modal"]').exists()).toBe(false)
+      expect(wrapper.find('[data-testid="clarify-draft-image-thumb"]').exists()).toBe(true)
       wrapper.unmount()
     })
 

--- a/web/src/components/run/ClarifyChat.test.ts
+++ b/web/src/components/run/ClarifyChat.test.ts
@@ -26,7 +26,7 @@ function mountChat(opts: {
   confirmError?: string | null
   annotateEnabled?: boolean
   annotations?: ReactAnnotation[]
-  attachments?: { data: string; mimeType: string }[]
+  attachments?: { data: string; mimeType: string; name?: string }[]
   seedHumanText?: string
   seedHumanImages?: { data: string; mimeType: string; name?: string }[]
   hideFinish?: boolean

--- a/web/src/components/run/ClarifyChat.vue
+++ b/web/src/components/run/ClarifyChat.vue
@@ -637,13 +637,14 @@ const {
         <div v-for="(im, ii) in attachments" :key="ii" class="relative">
           <ChatImageThumb
             v-if="isImageAttachment(im)"
-            mode="locked"
+            mode="previewable"
             size="sm"
             thumb-class="rounded-md"
             :src="imgSrc(im)"
             :label="attachmentDisplayName(im, ii)"
             :alt="attachmentDisplayName(im, ii)"
             test-id="clarify-draft-image-thumb"
+            @preview="openImagePreview(attachments, ii)"
           />
           <div
             v-else

--- a/web/src/views/DashboardView.test.ts
+++ b/web/src/views/DashboardView.test.ts
@@ -43,6 +43,19 @@ vi.mock('@/lib/composables/useToast', () => ({
 
 import DashboardView from './DashboardView.vue'
 
+const HomePreviewAppModalStub = {
+  props: ['open', 'title', 'width'],
+  emits: ['close'],
+  template: `
+    <div v-if="open" data-testid="home-image-preview-modal">
+      <div data-testid="home-image-preview-title">{{ title }}</div>
+      <button type="button" data-testid="home-image-preview-close" @click="$emit('close')">×</button>
+      <button type="button" data-testid="home-image-preview-backdrop" @click="$emit('close')">backdrop</button>
+      <slot />
+    </div>
+  `,
+}
+
 const approveWf: Workflow = {
   id: 'wf-ap',
   name: '自我迭代PRO',
@@ -68,7 +81,7 @@ function mountDashboard() {
   return mount(DashboardView, {
     global: {
       plugins: [i18n],
-      stubs: { Icon: true, RunLaunchModal: true },
+      stubs: { Icon: true, RunLaunchModal: true, AppModal: HomePreviewAppModalStub },
     },
   })
 }
@@ -335,6 +348,49 @@ describe('DashboardView home composer', () => {
     Object.defineProperty(pasteEv, 'clipboardData', { value: pasteDt })
     wrapper.get('[data-testid="home-composer-input"]').element.dispatchEvent(pasteEv)
     await flushPromises()
+    expect(wrapper.find('[data-testid="home-draft-image-thumb"]').exists()).toBe(true)
+
+    wrapper.unmount()
+    vi.unstubAllGlobals()
+  })
+
+  it('opens draft image preview, close keeps attachment, no unavailable overlay (g1.3)', async () => {
+    class FakeReader {
+      result: string | ArrayBuffer | null = null
+      onload: null | (() => void) = null
+      readAsDataURL(file: File) {
+        this.result = `data:${file.type || 'application/octet-stream'};base64,QUJD`
+        queueMicrotask(() => this.onload?.())
+      }
+    }
+    vi.stubGlobal('FileReader', FakeReader as unknown as typeof FileReader)
+
+    const wrapper = mountDashboard()
+    await flushPromises()
+    const img = new File(['ABC'], '首页截图.png', { type: 'image/png' })
+    const pasteDt = new DataTransfer()
+    pasteDt.items.add(img)
+    const pasteEv = new Event('paste', { bubbles: true, cancelable: true })
+    Object.defineProperty(pasteEv, 'clipboardData', { value: pasteDt })
+    wrapper.get('[data-testid="home-composer-input"]').element.dispatchEvent(pasteEv)
+    await flushPromises()
+
+    const thumb = wrapper.find('[data-testid="home-draft-image-thumb"]')
+    expect(thumb.exists()).toBe(true)
+    expect(thumb.text()).toContain('点击放大')
+    expect(thumb.text()).not.toContain('不可预览')
+
+    await thumb.trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="home-image-preview-title"]').text()).toBe('图片预览 · 首页截图.png')
+    expect(wrapper.find('[data-testid="home-image-preview-img"]').attributes('src')).toContain('base64')
+
+    await wrapper.find('[data-testid="home-image-preview-img"]').trigger('error')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="home-image-preview-failed"]').text()).toContain('图片加载失败')
+    await wrapper.find('[data-testid="home-image-preview-close"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="home-image-preview-modal"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="home-draft-image-thumb"]').exists()).toBe(true)
 
     wrapper.unmount()

--- a/web/src/views/DashboardView.vue
+++ b/web/src/views/DashboardView.vue
@@ -4,10 +4,14 @@ import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import Icon from '@/components/ui/Icon.vue'
 import ChatImageThumb from '@/components/ui/ChatImageThumb.vue'
+import ChatImagePreviewModal from '@/components/ui/ChatImagePreviewModal.vue'
 import RunLaunchModal from '@/components/workflow/RunLaunchModal.vue'
+import { useChatImagePreview } from '@/lib/composables/useChatImagePreview'
 import { useHomeApproveChat } from '@/lib/run/useHomeApproveChat'
 import { attachmentDisplayName, isImageAttachment } from '@/lib/shared/attachments'
 import { imgSrc } from '@/lib/shared/compositeText'
+
+const { preview: imagePreview, openChatImagePreview, closeChatImagePreview } = useChatImagePreview()
 
 const BRAND_TEXT = 'Approving'
 
@@ -262,13 +266,14 @@ onBeforeUnmount(() => {
           <div v-for="(im, ii) in attachments" :key="ii" class="relative">
             <ChatImageThumb
               v-if="isImageAttachment(im)"
-              mode="locked"
+              mode="previewable"
               size="sm"
               thumb-class="rounded-none"
               :src="imgSrc(im)"
               :label="attachmentDisplayName(im, ii)"
               :alt="attachmentDisplayName(im, ii)"
               test-id="home-draft-image-thumb"
+              @preview="openChatImagePreview(imgSrc(im), attachmentDisplayName(im, ii))"
             />
             <div
               v-else
@@ -453,6 +458,14 @@ onBeforeUnmount(() => {
       @close="closeLaunch()"
       @stayed="closeLaunch()"
       @started="onLaunchStarted($event)"
+    />
+
+    <ChatImagePreviewModal
+      :open="!!imagePreview"
+      :src="imagePreview?.src || ''"
+      :label="imagePreview?.label || ''"
+      test-id-prefix="home-image-preview"
+      @close="closeChatImagePreview"
     />
   </div>
 </template>


### PR DESCRIPTION
Home dashboard and Clarify pre-send attachments now use previewable
ChatImageThumb with ChatImagePreviewModal, aligned with ParagraphInput.
Agent history images remain locked. Tests and e2e updated accordingly.

Co-authored-by: Cursor <cursoragent@cursor.com>
