### PR TITLE
feat(web): add colorful particle mesh background to dashboard home

### DIFF
--- a/web/LIB_DOMAIN_MAP.json
+++ b/web/LIB_DOMAIN_MAP.json
@@ -140,6 +140,7 @@
       "format.ts",
       "frontmatter.ts",
       "highlightJson.ts",
+      "homeParticleMesh.ts",
       "htmlPreviewSandbox.ts",
       "i18n.ts",
       "idleScrollbar.ts",
@@ -172,6 +173,6 @@
     "pm": 6,
     "project": 4,
     "run": 50,
-    "shared": 35
+    "shared": 36
   }
 }

--- a/web/src/components/dashboard/HomeParticleMeshBackground.test.ts
+++ b/web/src/components/dashboard/HomeParticleMeshBackground.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import HomeParticleMeshBackground from './HomeParticleMeshBackground.vue'
+
+function stubReducedMotion(matches: boolean) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((query: string) => ({
+      matches: query.includes('prefers-reduced-motion') ? matches : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  )
+}
+
+describe('HomeParticleMeshBackground', () => {
+  beforeEach(() => {
+    stubReducedMotion(false)
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb(0)
+      return 1
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('renders canvas layer with pointer-events none', async () => {
+    const wrapper = mount(HomeParticleMeshBackground, {
+      attachTo: document.body,
+    })
+    await flushPromises()
+    const root = wrapper.get('[data-testid="home-particle-mesh-bg"]')
+    expect(root.classes()).toContain('home-particle-mesh')
+    const canvas = wrapper.find('canvas')
+    expect(canvas.exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('does not start animation loop under reduced-motion', async () => {
+    stubReducedMotion(true)
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame')
+    const wrapper = mount(HomeParticleMeshBackground, {
+      attachTo: document.body,
+    })
+    await flushPromises()
+    expect(rafSpy).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('stops animation loop on unmount', async () => {
+    const cancelSpy = vi.spyOn(window, 'cancelAnimationFrame')
+    const wrapper = mount(HomeParticleMeshBackground, {
+      attachTo: document.body,
+    })
+    await flushPromises()
+    wrapper.unmount()
+    expect(cancelSpy).toHaveBeenCalled()
+  })
+})

--- a/web/src/components/dashboard/HomeParticleMeshBackground.vue
+++ b/web/src/components/dashboard/HomeParticleMeshBackground.vue
@@ -1,0 +1,181 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import {
+  createParticleMeshController,
+  prefersReducedMotion,
+  type ParticleMeshController,
+} from '@/lib/shared/homeParticleMesh'
+import { theme } from '@/lib/shared/theme'
+
+const hostRef = ref<HTMLElement | null>(null)
+const canvasRef = ref<HTMLCanvasElement | null>(null)
+
+let controller: ParticleMeshController | null = null
+let raf = 0
+let reduceMotion = false
+let resizeObserver: ResizeObserver | null = null
+
+function layoutSize(): { width: number; height: number } {
+  const host = hostRef.value
+  if (!host) return { width: 0, height: 0 }
+  const rect = host.getBoundingClientRect()
+  return { width: rect.width, height: rect.height }
+}
+
+function setupCanvas() {
+  const canvas = canvasRef.value
+  const host = hostRef.value
+  if (!canvas || !host) return { width: 0, height: 0, dpr: 1 }
+
+  const rect = host.getBoundingClientRect()
+  const dpr = Math.min(window.devicePixelRatio || 1, 2)
+  const width = Math.max(1, Math.floor(rect.width))
+  const height = Math.max(1, Math.floor(rect.height))
+  canvas.width = Math.max(1, Math.floor(width * dpr))
+  canvas.height = Math.max(1, Math.floor(height * dpr))
+  canvas.style.width = `${width}px`
+  canvas.style.height = `${height}px`
+  const ctx = canvas.getContext('2d')
+  if (ctx) ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+  return { width, height, dpr }
+}
+
+function rebuild() {
+  if (!controller) return
+  const { width, height } = setupCanvas()
+  if (width <= 0 || height <= 0) return
+  controller.rebuild(width, height)
+  if (reduceMotion) paintOnce()
+}
+
+function paintOnce() {
+  const canvas = canvasRef.value
+  if (!canvas || !controller) return
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return
+  const { width, height } = layoutSize()
+  if (width <= 0 || height <= 0) return
+  controller.paint(ctx, width, height)
+}
+
+function frame() {
+  const canvas = canvasRef.value
+  if (!canvas || !controller) return
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return
+  const { width, height } = layoutSize()
+  if (width <= 0 || height <= 0) {
+    raf = requestAnimationFrame(frame)
+    return
+  }
+  controller.step(width, height)
+  controller.paint(ctx, width, height)
+  raf = requestAnimationFrame(frame)
+}
+
+function startLoop() {
+  stopLoop()
+  if (reduceMotion) {
+    paintOnce()
+    return
+  }
+  raf = requestAnimationFrame(frame)
+}
+
+function stopLoop() {
+  if (raf) {
+    cancelAnimationFrame(raf)
+    raf = 0
+  }
+}
+
+function onMouseMove(e: MouseEvent) {
+  if (!controller || !hostRef.value) return
+  const rect = hostRef.value.getBoundingClientRect()
+  controller.setMouse(e.clientX - rect.left, e.clientY - rect.top)
+}
+
+function onMouseLeave() {
+  if (!controller) return
+  const { width, height } = layoutSize()
+  controller.resetMouseToCenter(width, height)
+}
+
+function onMotionPrefChange() {
+  reduceMotion = prefersReducedMotion()
+  startLoop()
+}
+
+let motionMq: MediaQueryList | null = null
+
+onMounted(() => {
+  controller = createParticleMeshController()
+  reduceMotion = prefersReducedMotion()
+  rebuild()
+  startLoop()
+
+  const host = hostRef.value
+  if (host) {
+    host.addEventListener('mousemove', onMouseMove)
+    host.addEventListener('mouseleave', onMouseLeave)
+  }
+
+  if (typeof ResizeObserver !== 'undefined' && hostRef.value) {
+    resizeObserver = new ResizeObserver(() => rebuild())
+    resizeObserver.observe(hostRef.value)
+  } else {
+    window.addEventListener('resize', rebuild)
+  }
+
+  if (typeof window !== 'undefined' && window.matchMedia) {
+    motionMq = window.matchMedia('(prefers-reduced-motion: reduce)')
+    motionMq.addEventListener('change', onMotionPrefChange)
+  }
+})
+
+watch(theme, () => {
+  // Theme only affects shell base color; repaint keeps particles visible on both themes.
+  if (reduceMotion) paintOnce()
+})
+
+onBeforeUnmount(() => {
+  stopLoop()
+  const host = hostRef.value
+  if (host) {
+    host.removeEventListener('mousemove', onMouseMove)
+    host.removeEventListener('mouseleave', onMouseLeave)
+  }
+  resizeObserver?.disconnect()
+  resizeObserver = null
+  window.removeEventListener('resize', rebuild)
+  motionMq?.removeEventListener('change', onMotionPrefChange)
+  motionMq = null
+  controller = null
+})
+</script>
+
+<template>
+  <div ref="hostRef" class="home-particle-mesh" data-testid="home-particle-mesh-bg" aria-hidden="true">
+    <canvas ref="canvasRef" class="home-particle-mesh__canvas" />
+  </div>
+</template>
+
+<style scoped>
+.home-particle-mesh {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+  pointer-events: none;
+  background: rgb(var(--c-base));
+}
+
+.home-particle-mesh__canvas {
+  position: absolute;
+  inset: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+</style>

--- a/web/src/lib/shared/homeParticleMesh.test.ts
+++ b/web/src/lib/shared/homeParticleMesh.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import {
+  createParticleMeshController,
+  DEFAULT_PARTICLE_MESH_CONFIG,
+} from './homeParticleMesh'
+
+describe('homeParticleMesh', () => {
+  it('rebuilds particles scaled to viewport area', () => {
+    const ctrl = createParticleMeshController()
+    ctrl.rebuild(1200, 800)
+    expect(ctrl.getDotCount()).toBeGreaterThanOrEqual(80)
+    expect(ctrl.getDotCount()).toBeLessThanOrEqual(DEFAULT_PARTICLE_MESH_CONFIG.maxParticles)
+    expect(ctrl.getMouse()).toEqual({ x: 600, y: 400 })
+  })
+
+  it('resets mouse to center on leave', () => {
+    const ctrl = createParticleMeshController()
+    ctrl.rebuild(400, 300)
+    ctrl.setMouse(12, 34)
+    ctrl.resetMouseToCenter(400, 300)
+    expect(ctrl.getMouse()).toEqual({ x: 200, y: 150 })
+  })
+
+  it('paints without throwing on a mock canvas context', () => {
+    const ctrl = createParticleMeshController()
+    ctrl.rebuild(320, 240)
+    const calls: string[] = []
+    const ctx = {
+      clearRect: () => calls.push('clear'),
+      beginPath: () => calls.push('begin'),
+      fillStyle: '',
+      strokeStyle: '',
+      lineWidth: 0,
+      moveTo: () => calls.push('move'),
+      lineTo: () => calls.push('line'),
+      stroke: () => calls.push('stroke'),
+      arc: () => calls.push('arc'),
+      fill: () => calls.push('fill'),
+    } as unknown as CanvasRenderingContext2D
+    expect(() => ctrl.paint(ctx, 320, 240)).not.toThrow()
+    expect(calls).toContain('clear')
+    expect(calls).toContain('fill')
+  })
+})

--- a/web/src/lib/shared/homeParticleMesh.ts
+++ b/web/src/lib/shared/homeParticleMesh.ts
@@ -1,0 +1,172 @@
+/** Canvas particle mesh background aligned to the clarified DEMO (no jQuery). */
+
+export type ParticleMeshConfig = {
+  maxParticles: number
+  connectDistance: number
+  mouseRadius: number
+}
+
+export const DEFAULT_PARTICLE_MESH_CONFIG: ParticleMeshConfig = {
+  maxParticles: 250,
+  connectDistance: 100,
+  mouseRadius: 150,
+}
+
+type Rgb = { r: number; g: number; b: number }
+
+type Dot = {
+  x: number
+  y: number
+  vx: number
+  vy: number
+  radius: number
+  color: Rgb & { style: string }
+}
+
+export type ParticleMeshMouse = { x: number; y: number }
+
+function colorValue(min = 0): number {
+  return Math.floor(Math.random() * 255 + min)
+}
+
+function rgba(r: number, g: number, b: number, a: number): string {
+  return `rgba(${r},${g},${b},${a})`
+}
+
+function makeColor(min = 0): Dot['color'] {
+  const r = colorValue(min)
+  const g = colorValue(min)
+  const b = colorValue(min)
+  return { r, g, b, style: rgba(r, g, b, 0.85) }
+}
+
+function mix(a: number, w1: number, b: number, w2: number): number {
+  return (a * w1 + b * w2) / (w1 + w2)
+}
+
+function averageColor(a: Dot, b: Dot): string {
+  const c1 = a.color
+  const c2 = b.color
+  return rgba(
+    Math.floor(mix(c1.r, a.radius, c2.r, b.radius)),
+    Math.floor(mix(c1.g, a.radius, c2.g, b.radius)),
+    Math.floor(mix(c1.b, a.radius, c2.b, b.radius)),
+    0.75,
+  )
+}
+
+function createDot(width: number, height: number): Dot {
+  return {
+    x: Math.random() * width,
+    y: Math.random() * height,
+    vx: -0.5 + Math.random(),
+    vy: -0.5 + Math.random(),
+    radius: Math.random() * 2,
+    color: makeColor(),
+  }
+}
+
+export type ParticleMeshController = {
+  rebuild: (width: number, height: number) => void
+  setMouse: (x: number, y: number) => void
+  resetMouseToCenter: (width: number, height: number) => void
+  paint: (ctx: CanvasRenderingContext2D, width: number, height: number) => void
+  step: (width: number, height: number) => void
+  getMouse: () => ParticleMeshMouse
+  getDotCount: () => number
+}
+
+export function createParticleMeshController(
+  cfg: ParticleMeshConfig = DEFAULT_PARTICLE_MESH_CONFIG,
+): ParticleMeshController {
+  let dots: Dot[] = []
+  const mouse: ParticleMeshMouse = { x: 0, y: 0 }
+
+  function particleCount(width: number, height: number): number {
+    const area = width * height
+    return Math.max(80, Math.min(cfg.maxParticles, Math.floor(area / 7000)))
+  }
+
+  function rebuild(width: number, height: number) {
+    mouse.x = width / 2
+    mouse.y = height / 2
+    const n = particleCount(width, height)
+    dots = []
+    for (let i = 0; i < n; i++) dots.push(createDot(width, height))
+  }
+
+  function setMouse(x: number, y: number) {
+    mouse.x = x
+    mouse.y = y
+  }
+
+  function resetMouseToCenter(width: number, height: number) {
+    mouse.x = width / 2
+    mouse.y = height / 2
+  }
+
+  function move(width: number, height: number) {
+    for (let i = 0; i < dots.length; i++) {
+      const d = dots[i]
+      if (d.y < 0 || d.y > height) d.vy = -d.vy
+      else if (d.x < 0 || d.x > width) d.vx = -d.vx
+      d.x += d.vx
+      d.y += d.vy
+    }
+  }
+
+  function connect(ctx: CanvasRenderingContext2D) {
+    for (let i = 0; i < dots.length; i++) {
+      for (let j = i + 1; j < dots.length; j++) {
+        const a = dots[i]
+        const b = dots[j]
+        const dx = a.x - b.x
+        const dy = a.y - b.y
+        if (Math.abs(dx) < cfg.connectDistance && Math.abs(dy) < cfg.connectDistance) {
+          if (
+            Math.abs(a.x - mouse.x) < cfg.mouseRadius &&
+            Math.abs(a.y - mouse.y) < cfg.mouseRadius
+          ) {
+            ctx.beginPath()
+            ctx.lineWidth = 0.35
+            ctx.strokeStyle = averageColor(a, b)
+            ctx.moveTo(a.x, a.y)
+            ctx.lineTo(b.x, b.y)
+            ctx.stroke()
+          }
+        }
+      }
+    }
+  }
+
+  function paint(ctx: CanvasRenderingContext2D, width: number, height: number) {
+    ctx.clearRect(0, 0, width, height)
+    connect(ctx)
+    for (let i = 0; i < dots.length; i++) {
+      const d = dots[i]
+      ctx.beginPath()
+      ctx.fillStyle = d.color.style
+      ctx.arc(d.x, d.y, d.radius, 0, Math.PI * 2, false)
+      ctx.fill()
+    }
+  }
+
+  function step(width: number, height: number) {
+    move(width, height)
+  }
+
+  return {
+    rebuild,
+    setMouse,
+    resetMouseToCenter,
+    paint,
+    step,
+    getMouse: () => ({ ...mouse }),
+    getDotCount: () => dots.length,
+  }
+}
+
+export function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || !window.matchMedia) return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}

--- a/web/src/views/DashboardView.fill.test.ts
+++ b/web/src/views/DashboardView.fill.test.ts
@@ -6,6 +6,10 @@ import { describe, expect, it } from 'vitest'
 
 const dir = dirname(fileURLToPath(import.meta.url))
 const src = readFileSync(join(dir, 'DashboardView.vue'), 'utf8')
+const particleBgSrc = readFileSync(
+  join(dir, '../components/dashboard/HomeParticleMeshBackground.vue'),
+  'utf8',
+)
 const shellSrc = readFileSync(join(dir, '../components/shell/AppShell.vue'), 'utf8')
 const globalCss = readFileSync(join(dir, '../styles/global.css'), 'utf8')
 
@@ -29,13 +33,16 @@ describe('DashboardView home chat layout', () => {
     expect(src).not.toMatch(/RunBoardColumn/)
   })
 
-  // plan g1.1 — no purple stage atmosphere
+  // plan g1.1 — no purple stage atmosphere; particle mesh background instead
   it('does not include full-bleed purple stage layers', () => {
     expect(src).not.toMatch(/home-stage-bg/)
     expect(src).not.toMatch(/home-stage__wash/)
     expect(src).not.toMatch(/home-stage__grid/)
     expect(src).not.toMatch(/home-stage__glow/)
     expect(src).not.toMatch(/rgba\(91,\s*66,\s*180/)
+    expect(src).toMatch(/HomeParticleMeshBackground/)
+    expect(particleBgSrc).toMatch(/data-testid="home-particle-mesh-bg"/)
+    expect(particleBgSrc).toMatch(/pointer-events:\s*none/)
   })
 
   // plan g1.2 / g1.3 — monospace Approving, no gradient shimmer / staggered / serif accent

--- a/web/src/views/DashboardView.test.ts
+++ b/web/src/views/DashboardView.test.ts
@@ -129,13 +129,23 @@ describe('DashboardView home composer', () => {
     wrapper.unmount()
   })
 
-  // plan g1.1 — no full-bleed purple stage layer
+  // plan g1.1 — no full-bleed purple stage layer; particle mesh bg instead
   it('does not render full-screen purple stage atmosphere', async () => {
     const wrapper = mountDashboard()
     await flushPromises()
     expect(wrapper.find('[data-testid="home-stage-bg"]').exists()).toBe(false)
     expect(wrapper.find('.home-stage__wash').exists()).toBe(false)
     expect(wrapper.find('.home-stage__glow').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('renders particle mesh background layer behind content', async () => {
+    const wrapper = mountDashboard()
+    await flushPromises()
+    const bg = wrapper.find('[data-testid="home-particle-mesh-bg"]')
+    expect(bg.exists()).toBe(true)
+    expect(bg.classes()).toContain('home-particle-mesh')
+    expect(wrapper.find('[data-testid="home-composer"]').exists()).toBe(true)
     wrapper.unmount()
   })
 

--- a/web/src/views/DashboardView.vue
+++ b/web/src/views/DashboardView.vue
@@ -2,6 +2,7 @@
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import HomeParticleMeshBackground from '@/components/dashboard/HomeParticleMeshBackground.vue'
 import Icon from '@/components/ui/Icon.vue'
 import ChatImageThumb from '@/components/ui/ChatImageThumb.vue'
 import RunLaunchModal from '@/components/workflow/RunLaunchModal.vue'
@@ -226,6 +227,7 @@ onBeforeUnmount(() => {
 
 <template>
   <div data-testid="dashboard-view" class="home-shell relative flex flex-col md:h-full md:min-h-0">
+    <HomeParticleMeshBackground />
     <div
       class="home-shell__content relative z-[1] mx-auto flex w-full max-w-3xl flex-1 flex-col items-center justify-center px-4 py-10"
     >


### PR DESCRIPTION
Align home-shell with the approved DEMO: full-bleed canvas particles,
mouse-neighborhood connections, theme-aware base color, reduced-motion
degradation, and lifecycle cleanup without blocking composer interaction.

Co-authored-by: Cursor <cursoragent@cursor.com>
