### PR TITLE
feat(agent): add API Key / custom settings.json auth mode in wizards

### DIFF
--- a/server/internal/sandbox/confighome.go
+++ b/server/internal/sandbox/confighome.go
@@ -149,15 +149,66 @@ func BuildConfigHome(spec ConfigHomeSpec) (string, error) {
 		}
 	}
 	if len(spec.Settings) > 0 {
-		b, err := json.MarshalIndent(spec.Settings, "", "  ")
-		if err != nil {
-			return "", fmt.Errorf("marshal settings.json: %w", err)
-		}
-		if err := os.WriteFile(filepath.Join(dir, "settings.json"), b, 0o644); err != nil {
+		if err := writeMergedSettingsJSON(dir, spec.Settings); err != nil {
 			return "", err
 		}
 	}
 	return dir, nil
+}
+
+// writeMergedSettingsJSON writes settings.json, merging platform Settings into an
+// existing user-authored file (user keys win; nested maps merge recursively).
+func writeMergedSettingsJSON(dir string, platform map[string]any) error {
+	if len(platform) == 0 {
+		return nil
+	}
+	path := filepath.Join(dir, "settings.json")
+	merged := platform
+	if b, err := os.ReadFile(path); err == nil {
+		var user map[string]any
+		if err := json.Unmarshal(b, &user); err == nil {
+			merged = mergeSettingsMaps(platform, user)
+		}
+	}
+	b, err := json.MarshalIndent(merged, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal settings.json: %w", err)
+	}
+	return os.WriteFile(path, b, 0o644)
+}
+
+func mergeSettingsMaps(platform, user map[string]any) map[string]any {
+	out := make(map[string]any, len(platform)+len(user))
+	for k, v := range platform {
+		out[k] = v
+	}
+	for k, uv := range user {
+		if pv, ok := out[k]; ok {
+			pm := asStringAnyMap(pv)
+			um := asStringAnyMap(uv)
+			if pm != nil && um != nil {
+				out[k] = mergeSettingsMaps(pm, um)
+				continue
+			}
+		}
+		out[k] = uv
+	}
+	return out
+}
+
+func asStringAnyMap(v any) map[string]any {
+	switch m := v.(type) {
+	case map[string]any:
+		return m
+	case map[string]string:
+		out := make(map[string]any, len(m))
+		for k, val := range m {
+			out[k] = val
+		}
+		return out
+	default:
+		return nil
+	}
 }
 
 // EmbeddedRuleBasenames returns sorted basenames of all embedded platform rules

--- a/server/internal/sandbox/confighome.go
+++ b/server/internal/sandbox/confighome.go
@@ -178,7 +178,7 @@ func writeMergedSettingsJSON(dir string, platform map[string]any) error {
 }
 
 func mergeSettingsMaps(platform, user map[string]any) map[string]any {
-	out := make(map[string]any, len(platform)+len(user))
+	out := make(map[string]any)
 	for k, v := range platform {
 		out[k] = v
 	}

--- a/server/internal/sandbox/confighome_test.go
+++ b/server/internal/sandbox/confighome_test.go
@@ -168,6 +168,53 @@ func TestBuildConfigHomeSettings(t *testing.T) {
 	}
 }
 
+func TestBuildConfigHomeSettingsMergeUserWins(t *testing.T) {
+	HomeBaseDir = ""
+	src := t.TempDir()
+	userSettings := `{"env":{"ANTHROPIC_API_KEY":"user-key"},"custom":true}`
+	if err := os.WriteFile(filepath.Join(src, "settings.json"), []byte(userSettings), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir, err := BuildConfigHome(ConfigHomeSpec{
+		WorkDirSrc: src,
+		Settings: map[string]any{
+			"envRouteMode": "staging",
+			"endpoint":     "https://staging-codebuddy.tencent.com",
+			"env": map[string]string{
+				"CODEBUDDY_INTERNET_ENVIRONMENT": "public",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildConfigHome: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	b, err := os.ReadFile(filepath.Join(dir, "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	env, ok := got["env"].(map[string]any)
+	if !ok {
+		t.Fatalf("env=%v", got["env"])
+	}
+	if env["ANTHROPIC_API_KEY"] != "user-key" {
+		t.Fatalf("user env key lost: %v", env)
+	}
+	if env["CODEBUDDY_INTERNET_ENVIRONMENT"] != "public" {
+		t.Fatalf("platform env not merged: %v", env)
+	}
+	if got["envRouteMode"] != "staging" {
+		t.Fatalf("platform field missing: %v", got)
+	}
+	if got["custom"] != true {
+		t.Fatalf("user custom field lost: %v", got)
+	}
+}
+
 func TestBuildConfigHomeNoSettingsWhenEmpty(t *testing.T) {
 	HomeBaseDir = ""
 	dir, err := BuildConfigHome(ConfigHomeSpec{

--- a/server/internal/services/team.go
+++ b/server/internal/services/team.go
@@ -36,6 +36,7 @@ type TeamBootstrapRequest struct {
 	Background    string            `json:"background"`
 	AcpBackend    string            `json:"acpBackend"`
 	APIKey        string            `json:"apiKey,omitempty"`
+	CustomConfig  string            `json:"customConfig,omitempty"`
 	Region        string            `json:"region,omitempty"`
 	GitURL        string            `json:"gitUrl,omitempty"`
 	GitCredType   string            `json:"gitCredentialType,omitempty"`
@@ -194,6 +195,7 @@ type normalizedTeamReq struct {
 	Background    string
 	AcpBackend    string
 	APIKey        string
+	CustomConfig  string
 	Region        string
 	GitURL        string
 	GitCredType   string
@@ -257,6 +259,7 @@ func (s *TeamService) normalizeRequest(req TeamBootstrapRequest) (normalizedTeam
 		Background:    background,
 		AcpBackend:    NormalizeAcpBackend(req.AcpBackend),
 		APIKey:        strings.TrimSpace(req.APIKey),
+		CustomConfig:  strings.TrimSpace(req.CustomConfig),
 		Region:        strings.TrimSpace(req.Region),
 		GitURL:        strings.TrimSpace(req.GitURL),
 		GitCredType:   strings.TrimSpace(req.GitCredType),
@@ -273,7 +276,7 @@ func (s *TeamService) runBootstrap(ctx context.Context, sessionID string, req no
 
 	s.appendEvent(sessionID, "sys", "creating project "+req.ProjectName)
 	var envEntries []models.EnvEntry
-	if req.APIKey != "" {
+	if req.APIKey != "" && req.CustomConfig == "" {
 		envEntries = append(envEntries, models.EnvEntry{
 			Key: primaryAuthEnvKey(req.AcpBackend), Value: req.APIKey, Secret: true,
 		})
@@ -367,15 +370,16 @@ func (s *TeamService) runBootstrap(ctx context.Context, sessionID string, req no
 		name := EngineerDisplayName(req.Prefix, role.RoleLabelZH)
 		s.appendEvent(sessionID, "mcp", "pm_create_agent_from_template\ntemplate="+role.ID+"\nname="+name+"\nproject="+proj.ID)
 		created, err := s.CreateAgentFromTemplate(CreateFromTemplateArgs{
-			SessionID:   sessionID,
-			TemplateID:  role.ID,
-			Name:        name,
-			ProjectID:   proj.ID,
-			AcpBackend:  req.AcpBackend,
-			GitCredType: req.GitCredType,
-			MCP:         req.MCP,
-			Env:         req.Env,
-			Region:      req.Region,
+			SessionID:    sessionID,
+			TemplateID:   role.ID,
+			Name:         name,
+			ProjectID:    proj.ID,
+			AcpBackend:   req.AcpBackend,
+			GitCredType:  req.GitCredType,
+			MCP:          req.MCP,
+			Env:          req.Env,
+			Region:       req.Region,
+			CustomConfig: req.CustomConfig,
 		})
 		if err != nil {
 			fail(err)
@@ -445,6 +449,7 @@ func (s *TeamService) runRetry(ctx context.Context, sessionID string, req normal
 			MCP:          req.MCP,
 			Env:          req.Env,
 			Region:       req.Region,
+			CustomConfig: req.CustomConfig,
 			SkipIfExists: true,
 		})
 		if err != nil {
@@ -533,6 +538,7 @@ type CreateFromTemplateArgs struct {
 	MCP          []MCPServer
 	Env          map[string]string
 	Region       string
+	CustomConfig string
 	SkipIfExists bool
 	// When SessionID is set, scope checks apply.
 }
@@ -601,6 +607,9 @@ func (s *TeamService) CreateAgentFromTemplate(args CreateFromTemplateArgs) (Agen
 		tmpl.MCP = args.MCP
 	} else if len(tmpl.MCP) == 0 {
 		tmpl.MCP = DefaultPlatformMCP()
+	}
+	if strings.TrimSpace(args.CustomConfig) != "" {
+		tmpl.Files = upsertAgentFile(tmpl.Files, "settings.json", strings.TrimSpace(args.CustomConfig))
 	}
 
 	if err := s.Skills.Save(tmpl); err != nil {
@@ -708,6 +717,9 @@ func (s *TeamService) buildPMAgent(req normalizedTeamReq, projectID string) (Age
 	}
 
 	tmpl.Files = upsertAgentFile(tmpl.Files, "rules/project-context.md", teamPMProjectContextMarkdown(req))
+	if strings.TrimSpace(req.CustomConfig) != "" {
+		tmpl.Files = upsertAgentFile(tmpl.Files, "settings.json", strings.TrimSpace(req.CustomConfig))
+	}
 	return tmpl, nil
 }
 

--- a/web/src/components/agent/AgentCreateWizard.vue
+++ b/web/src/components/agent/AgentCreateWizard.vue
@@ -3,6 +3,7 @@ import Icon from '@/components/ui/Icon.vue'
 import AppButton from '@/components/ui/AppButton.vue'
 import AgentGitGuide from '@/components/agent/AgentGitGuide.vue'
 import EnvCredentialHelpModal from '@/components/agent/EnvCredentialHelpModal.vue'
+import WizardApiKeyStepPanel from '@/components/agent/WizardApiKeyStepPanel.vue'
 
 import { useAgentCreateWizard } from '@/lib/agent/useAgentCreateWizard'
 import type { AgentCreateWizardProps, AgentCreateWizardEmit } from '@/lib/agent/useAgentCreateWizard'
@@ -21,6 +22,7 @@ const {
   envHelpOpen,
   stepAnimKey,
   apiKeyInput,
+  customConfigError,
   currentStep,
   progressPct,
   reviewItems,
@@ -40,6 +42,8 @@ const {
   confirmAcpSwitch,
   cancelAcpSwitch,
   syncApiKeyInput,
+  setAuthMode,
+  onCustomConfigInput,
   onApiKeyInput,
   onGitCredentialType,
   goPrev,
@@ -206,59 +210,20 @@ const {
                 </template>
 
                 <template v-else-if="currentStep.id === 'apiKey'">
-                  <p class="sec-meta">{{ t('pages.agentStudio.wizard.apiKey.meta') }}</p>
-                  <div class="mb-3 border border-accent/30 bg-accent-dim/40 px-3 py-2.5 text-[12px] leading-5 text-txt2">
-                    {{
-                      t('pages.agentStudio.wizard.apiKey.backendBanner', {
-                        backend: draft.acpBackend,
-                      })
-                    }}
-                  </div>
-                  <div class="mb-4 border border-line bg-base p-3.5">
-                    <div class="text-[13px] font-semibold text-txt">
-                      <code class="text-accent-2">{{ primaryAuthKey }}</code>
-                    </div>
-                    <p v-if="primaryAuthAlt" class="mt-1 text-[11px] text-txt3">
-                      {{ t('pages.agentStudio.wizard.apiKey.alias') }}
-                      <code>{{ primaryAuthAlt }}</code>
-                    </p>
-                    <p v-if="authGuide.noteKey" class="mt-2 text-[11px] leading-5 text-txt2">
-                      {{ t(authGuide.noteKey) }}
-                    </p>
-                    <ol class="mt-3 list-decimal space-y-1.5 pl-5 text-[12px] leading-5 text-txt2">
-                      <li v-for="stepKey in authGuide.pathStepKeys" :key="stepKey">
-                        {{ t(stepKey) }}
-                      </li>
-                    </ol>
-                    <div class="mt-3 flex flex-wrap gap-2">
-                      <a
-                        v-for="link in authGuide.links"
-                        :key="link.url"
-                        :href="link.url"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="border border-accent/40 px-2 py-1 text-[11px] text-accent-2 hover:bg-accent-dim"
-                      >
-                        {{ t(link.labelKey) }}
-                      </a>
-                    </div>
-                  </div>
-                  <label class="block">
-                    <span class="mb-1.5 block text-[12px] font-medium text-txt2">
-                      {{ t('pages.agentStudio.wizard.apiKey.inputLabel') }}
-                    </span>
-                    <input
-                      :value="apiKeyInput"
-                      type="password"
-                      autocomplete="off"
-                      class="w-full border border-line bg-base px-3 py-2 font-mono text-[12px] text-txt outline-none focus:border-accent"
-                      :placeholder="t('pages.agentStudio.wizard.apiKey.inputPlaceholder')"
-                      @input="onApiKeyInput(($event.target as HTMLInputElement).value)"
-                    />
-                    <p class="mt-1.5 text-[11px] text-txt3">
-                      {{ t('pages.agentStudio.wizard.apiKey.skipHint') }}
-                    </p>
-                  </label>
+                  <WizardApiKeyStepPanel
+                    :acp-backend="draft.acpBackend"
+                    :config-root="draft.configRoot"
+                    :auth-mode="draft.authMode"
+                    :api-key-input="apiKeyInput"
+                    :custom-config-content="draft.customConfigContent"
+                    :custom-config-error="customConfigError"
+                    :auth-guide="authGuide"
+                    :primary-auth-key="primaryAuthKey"
+                    :primary-auth-alt="primaryAuthAlt"
+                    @update:auth-mode="setAuthMode"
+                    @update:api-key-input="onApiKeyInput"
+                    @update:custom-config-content="onCustomConfigInput"
+                  />
                 </template>
 
                 <template v-else-if="currentStep.id === 'git'">

--- a/web/src/components/agent/AgentEnvPanel.vue
+++ b/web/src/components/agent/AgentEnvPanel.vue
@@ -8,7 +8,7 @@ import AgentGitGuide from '@/components/agent/AgentGitGuide.vue'
 import EnvCredentialHelpModal, {
   type EnvCredentialHelpSection,
 } from '@/components/agent/EnvCredentialHelpModal.vue'
-import { BACKEND_AUTH_HINTS } from '@/lib/agent/backendAuthGuide'
+import { BACKEND_AUTH_HINTS, settingsFileAbsPath } from '@/lib/agent/backendAuthGuide'
 import {
   getRegionPolicy,
   isManagedRegionKey,
@@ -21,7 +21,7 @@ import {
 } from '@/lib/agent/agentStudioDraft'
 
 const props = defineProps<{ draft: AgentStudioDraft }>()
-const emit = defineEmits<{ toast: [msg: string] }>()
+const emit = defineEmits<{ toast: [msg: string]; 'open-settings-file': [] }>()
 
 const { t } = useI18n()
 
@@ -32,6 +32,7 @@ const envHelpOpen = ref(false)
 const envHelpSection = ref<EnvCredentialHelpSection>('inject')
 
 const currentAuthHint = computed(() => BACKEND_AUTH_HINTS[props.draft.acpBackend || 'cursor'])
+const settingsPath = computed(() => settingsFileAbsPath(props.draft.layout?.configRoot || ''))
 const currentRegionPolicy = computed(() => getRegionPolicy(props.draft.acpBackend))
 
 function openEnvHelp(section: EnvCredentialHelpSection) {
@@ -112,6 +113,20 @@ watch(
       <div class="min-h-0 flex-1"><CodeEditor :model-value="envRawText" language="json" @update:model-value="onEnvRaw" /></div>
     </div>
     <div v-else class="scroll-area flex-1 space-y-2 overflow-y-auto p-4">
+      <div
+        class="callout mb-3 border border-dashed border-accent/45 bg-accent-dim/40 px-3 py-2.5 text-[12px] leading-6 text-txt2"
+        data-test="env-custom-config-callout"
+      >
+        {{ t('pages.agentStudio.env.customConfigCallout', { path: settingsPath }) }}
+        <button
+          type="button"
+          class="ml-1 bg-transparent p-0 text-accent-2 underline underline-offset-[3px] hover:text-[#c4b5fd]"
+          data-test="env-open-settings-file"
+          @click="emit('open-settings-file')"
+        >
+          {{ t('pages.agentStudio.env.openSettingsFile') }}
+        </button>
+      </div>
       <AgentGitGuide
         :env="draft.env"
         :upsert-env="upsertEnv"

--- a/web/src/components/agent/AgentFilesPanel.vue
+++ b/web/src/components/agent/AgentFilesPanel.vue
@@ -57,6 +57,7 @@ const {
   rows,
   openFile,
   openPath,
+  openPathOrCreate,
   selectDefaultFile,
   resetForSelect,
   snapshot,

--- a/web/src/components/agent/AgentFilesPanel.vue
+++ b/web/src/components/agent/AgentFilesPanel.vue
@@ -92,6 +92,7 @@ const {
 
 defineExpose({
   filesStep, resetForSelect, snapshot, restoreAfterDiscard, closeExplorerMore, selectDefaultFile,
+  openPath, openPathOrCreate,
 })
 </script>
 

--- a/web/src/components/agent/CreateAgentTeamWizard.vue
+++ b/web/src/components/agent/CreateAgentTeamWizard.vue
@@ -20,11 +20,10 @@ import {
   type TeamWizardDraft,
   type WizardBackendId,
 } from '@/lib/agent/agentTeamWizard'
-import { authGuideFor } from '@/lib/agent/backendAuthGuide'
+import { authGuideFor, defaultSettingsPlaceholder } from '@/lib/agent/backendAuthGuide'
 import type { GitCredentialType } from '@/lib/agent/gitCredentialAnalysis'
 import { getRegionPolicy, setRegion } from '@/lib/shared/regionPolicy'
 import {
-  defaultSettingsPlaceholder,
   parseCustomConfigJson,
   stripAuthKeysFromEnv,
   type WizardAuthMode,
@@ -608,7 +607,7 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
                   >
                     {{ t('pages.agentStudio.teamWizard.review.noArtifactWarn') }}
                   </p>
-                  <p v-if="!hasAuthKeyConfigured(draft.env, draft.acpBackend)" class="mt-3 text-[12px] text-txt3">
+                  <p v-if="!teamHasAuth(draft)" class="mt-3 text-[12px] text-txt3">
                     {{ t('pages.agentStudio.wizard.review.authReminderDetail') }}
                   </p>
                   <p v-if="submitError" class="mt-3 text-[12px] text-err">{{ submitError }}</p>

--- a/web/src/components/agent/CreateAgentTeamWizard.vue
+++ b/web/src/components/agent/CreateAgentTeamWizard.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import Icon from '@/components/ui/Icon.vue'
 import AppButton from '@/components/ui/AppButton.vue'
 import AgentGitGuide from '@/components/agent/AgentGitGuide.vue'
+import WizardApiKeyStepPanel from '@/components/agent/WizardApiKeyStepPanel.vue'
 import { api, type TeamBootstrapSession } from '@/lib/api/api'
 import {
   ACP_BACKENDS,
@@ -19,9 +20,15 @@ import {
   type TeamWizardDraft,
   type WizardBackendId,
 } from '@/lib/agent/agentTeamWizard'
-import { authGuideFor, hasAuthKeyConfigured } from '@/lib/agent/backendAuthGuide'
+import { authGuideFor } from '@/lib/agent/backendAuthGuide'
 import type { GitCredentialType } from '@/lib/agent/gitCredentialAnalysis'
 import { getRegionPolicy, setRegion } from '@/lib/shared/regionPolicy'
+import {
+  defaultSettingsPlaceholder,
+  parseCustomConfigJson,
+  stripAuthKeysFromEnv,
+  type WizardAuthMode,
+} from '@/lib/agent/agentCreateWizard'
 
 const props = defineProps<{
   open: boolean
@@ -39,6 +46,8 @@ const fieldError = ref('')
 const submitError = ref('')
 const submitting = ref(false)
 const apiKeyInput = ref('')
+const customConfigError = ref(false)
+const customConfigDraft = ref('')
 const stepAnimKey = ref(0)
 const bgExpanded = ref(true)
 
@@ -52,6 +61,7 @@ const currentRegion = computed(() => {
 })
 const authGuide = computed(() => authGuideFor(draft.value.acpBackend, currentRegion.value))
 const primaryAuthKey = computed(() => authGuide.value.keys[0]?.key || '')
+const primaryAuthAlt = computed(() => authGuide.value.keys[0]?.alt || '')
 const previewLine = computed(() => {
   const root = draft.value.rootGroupName || '—'
   const pipe = draft.value.pipelineGroupName || 'Pipeline(GitHub)'
@@ -73,6 +83,8 @@ watch(
     submitError.value = ''
     submitting.value = false
     apiKeyInput.value = ''
+    customConfigError.value = false
+    customConfigDraft.value = ''
     stepAnimKey.value++
     nextTick(() => document.getElementById('team-wiz-project')?.focus())
   },
@@ -114,6 +126,32 @@ function syncApiKeyInput() {
   apiKeyInput.value = draft.value.env.find((e) => e.k === key)?.v ?? ''
 }
 
+function clearAuthKeys() {
+  draft.value.env = stripAuthKeysFromEnv(draft.value.env, draft.value.acpBackend)
+  apiKeyInput.value = ''
+}
+
+function setAuthMode(mode: WizardAuthMode) {
+  if (mode === draft.value.authMode) return
+  customConfigError.value = false
+  if (mode === 'apiKey') {
+    customConfigDraft.value = draft.value.customConfigContent
+    draft.value.customConfigContent = ''
+    draft.value.authMode = mode
+    syncApiKeyInput()
+    return
+  }
+  clearAuthKeys()
+  draft.value.authMode = mode
+  draft.value.customConfigContent =
+    customConfigDraft.value || defaultSettingsPlaceholder(draft.value.acpBackend)
+}
+
+function onCustomConfigInput(value: string) {
+  draft.value.customConfigContent = value
+  customConfigError.value = false
+}
+
 function onApiKeyInput(value: string) {
   apiKeyInput.value = value
   const key = primaryAuthKey.value
@@ -141,14 +179,25 @@ function goSkip() {
   if (!step.skip || submitting.value) return
   draft.value.skipped[step.id] = true
   if (step.id === 'apiKey') {
-    const key = primaryAuthKey.value
-    const idx = draft.value.env.findIndex((e) => e.k === key)
-    if (idx >= 0) draft.value.env.splice(idx, 1)
-    apiKeyInput.value = ''
+    clearAuthKeys()
+    draft.value.customConfigContent = ''
+    customConfigDraft.value = ''
+    customConfigError.value = false
   }
   draft.value.step++
   stepAnimKey.value++
   if (currentStep.value.id === 'apiKey') syncApiKeyInput()
+}
+
+function validateApiKeyStep(): boolean {
+  if (draft.value.authMode !== 'customConfig') return true
+  const parsed = parseCustomConfigJson(draft.value.customConfigContent)
+  if (!parsed.ok) {
+    customConfigError.value = true
+    return false
+  }
+  customConfigError.value = false
+  return true
 }
 
 function goNext() {
@@ -161,6 +210,7 @@ function goNext() {
     }
     fieldError.value = ''
   }
+  if (currentStep.value.id === 'apiKey' && !validateApiKeyStep()) return
   if (currentStep.value.id === 'review') {
     void submit()
     return
@@ -418,20 +468,20 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
                 </template>
 
                 <template v-else-if="currentStep.id === 'apiKey'">
-                  <p class="sec-meta">{{ t('pages.agentStudio.wizard.apiKey.meta') }}</p>
-                  <label class="block">
-                    <span class="mb-1.5 block text-[12px] font-medium text-txt2">
-                      {{ t('pages.agentStudio.wizard.apiKey.inputLabel') }}
-                    </span>
-                    <input
-                      :value="apiKeyInput"
-                      type="password"
-                      autocomplete="off"
-                      class="w-full border border-line bg-base px-3 py-2 font-mono text-[12px] text-txt outline-none focus:border-accent"
-                      @input="onApiKeyInput(($event.target as HTMLInputElement).value)"
-                    />
-                    <p class="mt-1.5 text-[11px] text-txt3">{{ t('pages.agentStudio.wizard.apiKey.skipHint') }}</p>
-                  </label>
+                  <WizardApiKeyStepPanel
+                    :acp-backend="draft.acpBackend"
+                    :config-root="draft.configRoot"
+                    :auth-mode="draft.authMode"
+                    :api-key-input="apiKeyInput"
+                    :custom-config-content="draft.customConfigContent"
+                    :custom-config-error="customConfigError"
+                    :auth-guide="authGuide"
+                    :primary-auth-key="primaryAuthKey"
+                    :primary-auth-alt="primaryAuthAlt"
+                    @update:auth-mode="setAuthMode"
+                    @update:api-key-input="onApiKeyInput"
+                    @update:custom-config-content="onCustomConfigInput"
+                  />
                 </template>
 
                 <template v-else-if="currentStep.id === 'git'">
@@ -535,7 +585,7 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
                     <div>{{ t('pages.agentStudio.teamWizard.review.pipeline') }}：<strong class="text-txt">{{ draft.pipelineGroupName }}</strong></div>
                     <div>PM：<strong class="text-txt">{{ draft.pmName }}</strong></div>
                     <div>ACP：<strong class="text-txt">{{ draft.acpBackend }}</strong></div>
-                    <div>API Key：<strong class="text-txt">{{ teamHasAuth(draft) ? t('pages.agentStudio.teamWizard.review.set') : t('pages.agentStudio.teamWizard.review.skip') }}</strong></div>
+                    <div>API Key：<strong class="text-txt">{{ teamHasAuth(draft) ? (draft.authMode === 'customConfig' ? t('pages.agentStudio.wizard.review.customConfigWritten') : t('pages.agentStudio.teamWizard.review.set')) : t('pages.agentStudio.teamWizard.review.skip') }}</strong></div>
                     <div>Git：<strong class="text-txt">{{ draft.gitUrl || t('pages.agentStudio.teamWizard.review.none') }}</strong></div>
                     <div>MCP：<strong class="text-txt">{{ mcpNames }}</strong></div>
                     <div>Env：<strong class="text-txt">{{ envSummary }}</strong></div>

--- a/web/src/components/agent/WizardApiKeyStepPanel.vue
+++ b/web/src/components/agent/WizardApiKeyStepPanel.vue
@@ -1,0 +1,180 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import CodeEditor from '@/components/ui/CodeEditor.vue'
+import {
+  customConfigNoteKey,
+  settingsFileAbsPath,
+  type BackendAuthGuide,
+} from '@/lib/agent/backendAuthGuide'
+import type { WizardAuthMode, WizardBackendId } from '@/lib/agent/agentCreateWizard'
+import { AGENT_SETTINGS_PATH } from '@/lib/agent/agentCreateWizard'
+
+const props = defineProps<{
+  acpBackend: WizardBackendId
+  configRoot: string
+  authMode: WizardAuthMode
+  apiKeyInput: string
+  customConfigContent: string
+  customConfigError: boolean
+  authGuide: BackendAuthGuide
+  primaryAuthKey: string
+  primaryAuthAlt: string
+}>()
+
+const emit = defineEmits<{
+  'update:authMode': [mode: WizardAuthMode]
+  'update:apiKeyInput': [value: string]
+  'update:customConfigContent': [value: string]
+}>()
+
+const { t } = useI18n()
+
+const settingsAbsPath = computed(() => settingsFileAbsPath(props.configRoot))
+const configNoteKey = computed(() => customConfigNoteKey(props.acpBackend))
+
+function setMode(mode: WizardAuthMode) {
+  if (mode === props.authMode) return
+  emit('update:authMode', mode)
+}
+</script>
+
+<template>
+  <div>
+    <p class="sec-meta">{{ t('pages.agentStudio.wizard.apiKey.meta') }}</p>
+    <div class="mb-3 border border-accent/30 bg-accent-dim/40 px-3 py-2.5 text-[12px] leading-5 text-txt2">
+      {{
+        t('pages.agentStudio.wizard.apiKey.backendBanner', {
+          backend: acpBackend,
+        })
+      }}
+      <span class="ml-1 font-mono text-accent-2">configRoot → {{ configRoot }}</span>
+    </div>
+
+    <div
+      class="mb-4 grid grid-cols-1 gap-2 sm:grid-cols-2"
+      role="group"
+      :aria-label="t('pages.agentStudio.wizard.apiKey.modeGroup')"
+    >
+      <button
+        type="button"
+        class="border px-3 py-3 text-left transition"
+        :class="
+          authMode === 'apiKey'
+            ? 'border-accent bg-accent-dim'
+            : 'border-line bg-base hover:border-line-strong'
+        "
+        :aria-pressed="authMode === 'apiKey'"
+        data-test="auth-mode-api-key"
+        @click="setMode('apiKey')"
+      >
+        <strong class="block text-[13px] text-txt">{{ t('pages.agentStudio.wizard.apiKey.modeApiKey') }}</strong>
+        <span class="mt-1 block text-[11px] leading-5 text-txt3">
+          {{ t('pages.agentStudio.wizard.apiKey.modeApiKeyHint') }}
+        </span>
+      </button>
+      <button
+        type="button"
+        class="border px-3 py-3 text-left transition"
+        :class="
+          authMode === 'customConfig'
+            ? 'border-accent bg-accent-dim'
+            : 'border-line bg-base hover:border-line-strong'
+        "
+        :aria-pressed="authMode === 'customConfig'"
+        data-test="auth-mode-custom-config"
+        @click="setMode('customConfig')"
+      >
+        <strong class="block text-[13px] text-txt">{{ t('pages.agentStudio.wizard.apiKey.modeCustomConfig') }}</strong>
+        <span class="mt-1 block text-[11px] leading-5 text-txt3">
+          {{ t('pages.agentStudio.wizard.apiKey.modeCustomConfigHint') }}
+        </span>
+      </button>
+    </div>
+
+    <div v-if="authMode === 'apiKey'">
+      <div class="mb-4 border border-line bg-base p-3.5">
+        <div class="text-[13px] font-semibold text-txt">
+          <code class="text-accent-2">{{ primaryAuthKey }}</code>
+        </div>
+        <p v-if="primaryAuthAlt" class="mt-1 text-[11px] text-txt3">
+          {{ t('pages.agentStudio.wizard.apiKey.alias') }}
+          <code>{{ primaryAuthAlt }}</code>
+        </p>
+        <p v-if="authGuide.noteKey" class="mt-2 text-[11px] leading-5 text-txt2">
+          {{ t(authGuide.noteKey) }}
+        </p>
+        <ol class="mt-3 list-decimal space-y-1.5 pl-5 text-[12px] leading-5 text-txt2">
+          <li v-for="stepKey in authGuide.pathStepKeys" :key="stepKey">
+            {{ t(stepKey) }}
+          </li>
+        </ol>
+        <div class="mt-3 flex flex-wrap gap-2">
+          <a
+            v-for="link in authGuide.links"
+            :key="link.url"
+            :href="link.url"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="border border-accent/40 px-2 py-1 text-[11px] text-accent-2 hover:bg-accent-dim"
+          >
+            {{ t(link.labelKey) }}
+          </a>
+        </div>
+      </div>
+      <label class="block">
+        <span class="mb-1.5 block text-[12px] font-medium text-txt2">
+          {{ t('pages.agentStudio.wizard.apiKey.inputLabel') }}
+        </span>
+        <input
+          :value="apiKeyInput"
+          type="password"
+          autocomplete="off"
+          class="w-full border border-line bg-base px-3 py-2 font-mono text-[12px] text-txt outline-none focus:border-accent"
+          :placeholder="t('pages.agentStudio.wizard.apiKey.inputPlaceholder')"
+          data-test="api-key-input"
+          @input="emit('update:apiKeyInput', ($event.target as HTMLInputElement).value)"
+        />
+        <p class="mt-1.5 text-[11px] text-txt3">
+          {{ t('pages.agentStudio.wizard.apiKey.skipHint') }}
+        </p>
+      </label>
+    </div>
+
+    <div v-else>
+      <div class="mb-4 border border-line bg-base p-3.5">
+        <div class="text-[13px] font-semibold text-txt">
+          {{ t('pages.agentStudio.wizard.apiKey.customConfig.cardTitle') }}
+        </div>
+        <p class="path-row mt-2 font-mono text-[11px] text-txt3">
+          {{ t('pages.agentStudio.wizard.apiKey.customConfig.targetPath') }}
+          <span class="text-accent-2">{{ settingsAbsPath }}</span>
+          <span class="text-txt3">
+            （{{ t('pages.agentStudio.wizard.apiKey.customConfig.agentFiles') }}
+            <span class="text-accent-2">{{ AGENT_SETTINGS_PATH }}</span>）
+          </span>
+        </p>
+        <p class="mt-2 text-[11px] leading-5 text-txt2">{{ t(configNoteKey) }}</p>
+      </div>
+      <label class="block">
+        <span class="mb-1.5 block text-[12px] font-medium text-txt2">
+          {{ AGENT_SETTINGS_PATH }}
+        </span>
+        <div class="min-h-[220px] border border-line">
+          <CodeEditor
+            :model-value="customConfigContent"
+            language="json"
+            data-test="custom-config-editor"
+            @update:model-value="emit('update:customConfigContent', $event)"
+          />
+        </div>
+        <p class="mt-1.5 text-[11px] text-txt3">
+          {{ t('pages.agentStudio.wizard.apiKey.customConfig.editorHint') }}
+        </p>
+        <p v-if="customConfigError" class="mt-2 text-[11px] text-err" data-test="custom-config-error">
+          {{ t('pages.agentStudio.wizard.apiKey.customConfig.invalidJson') }}
+        </p>
+      </label>
+    </div>
+  </div>
+</template>

--- a/web/src/lib/agent/agentCreateWizard.test.ts
+++ b/web/src/lib/agent/agentCreateWizard.test.ts
@@ -9,6 +9,8 @@ import {
   hasPathDeps,
   envConfiguredCount,
   validateBasics,
+  AGENT_SETTINGS_PATH,
+  parseCustomConfigJson,
 } from './agentCreateWizard'
 
 describe('configRootFor', () => {
@@ -191,6 +193,27 @@ describe('hasPathDeps / buildReviewSummary', () => {
     const items = buildReviewSummary(d)
     expect(items.find((i) => i.key === 'apiKey')?.kind).toBe('ok')
     expect(items.find((i) => i.key === 'authReminder')).toBeUndefined()
+  })
+
+  it('writes settings.json and omits auth env in custom config mode', () => {
+    const d = freshDraft()
+    d.name = 'cfg-agent'
+    d.acpBackend = 'claude_code'
+    d.authMode = 'customConfig'
+    d.customConfigContent = JSON.stringify({ env: { ANTHROPIC_API_KEY: 'sk-ant-x' } })
+    d.env = [{ k: 'APPROVING_CLAUDE_API_KEY', v: 'should-strip' }]
+    const payload = assembleCreatePayload(d)
+    expect(payload.files?.some((f) => f.path === AGENT_SETTINGS_PATH)).toBe(true)
+    expect(payload.env?.APPROVING_CLAUDE_API_KEY).toBeUndefined()
+    const items = buildReviewSummary(d)
+    expect(items.find((i) => i.key === 'apiKey')?.labelKey).toBe(
+      'pages.agentStudio.wizard.review.customConfigWritten',
+    )
+  })
+
+  it('rejects invalid custom config json', () => {
+    expect(parseCustomConfigJson('{bad').ok).toBe(false)
+    expect(parseCustomConfigJson('{"ok":true}').ok).toBe(true)
   })
 
   it('resets regions on backend switches and excludes the managed key from ENV count', () => {

--- a/web/src/lib/agent/agentCreateWizard.ts
+++ b/web/src/lib/agent/agentCreateWizard.ts
@@ -1,7 +1,12 @@
 import type { Agent, AgentFile, AgentPrompts, MCPServer } from '@/lib/api/api'
 import type { GitCredentialType } from '@/lib/agent/gitCredentialAnalysis'
 import { validateAgentName, normalizeAgentName } from '@/lib/agent/agentIO'
-import { hasAuthKeyConfigured } from '@/lib/agent/backendAuthGuide'
+import {
+  AGENT_SETTINGS_REL_PATH,
+  authGuideFor,
+  BACKEND_AUTH_HINTS,
+  hasAuthKeyConfigured,
+} from '@/lib/agent/backendAuthGuide'
 import {
   ACP_BACKENDS,
   isManagedRegionKey,
@@ -47,11 +52,17 @@ export type WizardPrompts = Record<WizardPromptKey, string>
 
 export type WizardSkipped = Partial<Record<WizardStepId, boolean>>
 
+export type WizardAuthMode = 'apiKey' | 'customConfig'
+
+export const AGENT_SETTINGS_PATH = AGENT_SETTINGS_REL_PATH
+
 export type WizardDraft = {
   step: number
   name: string
   description: string
   acpBackend: WizardBackendId
+  authMode: WizardAuthMode
+  customConfigContent: string
   gitCredentialType?: GitCredentialType
   configRoot: string
   env: WizardKV[]
@@ -114,6 +125,8 @@ export function freshDraft(): WizardDraft {
     name: '',
     description: '',
     acpBackend: 'cursor',
+    authMode: 'apiKey',
+    customConfigContent: '',
     gitCredentialType: undefined,
     configRoot: DEFAULT_CONFIG_ROOT,
     env: [],
@@ -214,6 +227,39 @@ function draftPromptsToApi(p: WizardPrompts, skipped: boolean): AgentPrompts | u
   return any ? out : undefined
 }
 
+export function parseCustomConfigJson(
+  raw: string,
+): { ok: true; normalized: string } | { ok: false } {
+  const trimmed = raw.trim()
+  if (!trimmed) return { ok: true, normalized: '' }
+  try {
+    JSON.parse(trimmed)
+    return { ok: true, normalized: trimmed }
+  } catch {
+    return { ok: false }
+  }
+}
+
+export function hasCustomConfigWritten(draft: WizardDraft): boolean {
+  if (draft.authMode !== 'customConfig') return false
+  const parsed = parseCustomConfigJson(draft.customConfigContent)
+  return parsed.ok && parsed.normalized !== ''
+}
+
+export function stripAuthKeysFromEnv(env: WizardKV[], backend: WizardBackendId): WizardKV[] {
+  const guide = authGuideFor(backend)
+  const keys = new Set<string>()
+  for (const spec of guide.keys) {
+    keys.add(spec.key)
+    if (spec.alt) keys.add(spec.alt)
+  }
+  const hint = BACKEND_AUTH_HINTS[backend]
+  keys.add(hint.key)
+  if (hint.alt) keys.add(hint.alt)
+  if (backend === 'trae') keys.add('TRAE_API_KEY')
+  return env.filter((e) => !keys.has(e.k.trim()))
+}
+
 function collectFiles(draft: WizardDraft): AgentFile[] {
   const files: AgentFile[] = []
   const name = draft.name.trim() || 'agent'
@@ -239,6 +285,12 @@ function collectFiles(draft: WizardDraft): AgentFile[] {
       content: c.content || defaultCommandTemplate(slug),
     })
   }
+  if (draft.authMode === 'customConfig') {
+    const parsed = parseCustomConfigJson(draft.customConfigContent)
+    if (parsed.ok && parsed.normalized) {
+      files.push({ path: AGENT_SETTINGS_PATH, content: parsed.normalized })
+    }
+  }
   return files
 }
 
@@ -246,7 +298,14 @@ function collectFiles(draft: WizardDraft): AgentFile[] {
 export function assembleCreatePayload(draft: WizardDraft): Agent {
   const name = normalizeAgentName(draft.name)
   const prompts = draftPromptsToApi(draft.prompts, !!draft.skipped.prompts)
-  const env = normalizeWizardRegions(draft)
+  const envDraft: WizardDraft = {
+    ...draft,
+    env:
+      draft.authMode === 'customConfig'
+        ? stripAuthKeysFromEnv(draft.env, draft.acpBackend)
+        : draft.env,
+  }
+  const env = normalizeWizardRegions(envDraft)
   return {
     name,
     acpBackend: draft.acpBackend || 'cursor',
@@ -298,7 +357,10 @@ export function buildReviewSummary(draft: WizardDraft): ReviewSummaryItem[] {
   const region = regionSummary(normalizedEnv, draft.acpBackend, 'strict')
   const name = draft.name.trim() || '—'
   const gitN = envConfiguredCount(draft, true)
-  const authConfigured = hasAuthKeyConfigured(draft.env, draft.acpBackend)
+  const authViaKey =
+    draft.authMode === 'apiKey' && hasAuthKeyConfigured(draft.env, draft.acpBackend)
+  const authViaConfig = hasCustomConfigWritten(draft)
+  const authConfigured = authViaKey || authViaConfig
   const apiKeySkipped = !!draft.skipped.apiKey || !authConfigured
 
   const items: ReviewSummaryItem[] = [
@@ -322,9 +384,11 @@ export function buildReviewSummary(draft: WizardDraft): ReviewSummaryItem[] {
     {
       key: 'apiKey',
       kind: authConfigured ? 'ok' : 'empty',
-      labelKey: authConfigured
-        ? 'pages.agentStudio.wizard.review.apiKeyConfigured'
-        : 'pages.agentStudio.wizard.review.apiKeySkipped',
+      labelKey: authViaConfig
+        ? 'pages.agentStudio.wizard.review.customConfigWritten'
+        : authViaKey
+          ? 'pages.agentStudio.wizard.review.apiKeyConfigured'
+          : 'pages.agentStudio.wizard.review.apiKeySkipped',
     },
     {
       key: 'git',

--- a/web/src/lib/agent/agentTeamWizard.ts
+++ b/web/src/lib/agent/agentTeamWizard.ts
@@ -10,7 +10,10 @@ import {
   type WizardDraft,
   type WizardKV,
   type WizardMCP,
+  type WizardAuthMode,
   freshDraft,
+  parseCustomConfigJson,
+  stripAuthKeysFromEnv,
 } from '@/lib/agent/agentCreateWizard'
 import { normalizeAgentName, validateAgentName } from '@/lib/agent/agentIO'
 import type { GitCredentialType } from '@/lib/agent/gitCredentialAnalysis'
@@ -50,6 +53,8 @@ export type TeamWizardDraft = {
   pipelineTouched: boolean
   pmTouched: boolean
   acpBackend: WizardBackendId
+  authMode: WizardAuthMode
+  customConfigContent: string
   gitCredentialType?: GitCredentialType
   gitUrl: string
   configRoot: string
@@ -84,6 +89,8 @@ export function freshTeamDraft(): TeamWizardDraft {
     pipelineTouched: false,
     pmTouched: false,
     acpBackend: 'cursor',
+    authMode: 'apiKey',
+    customConfigContent: '',
     gitCredentialType: undefined,
     gitUrl: '',
     configRoot: configRootFor('cursor'),
@@ -116,6 +123,8 @@ function teamDraftAsWizardDraft(d: TeamWizardDraft): WizardDraft {
   const base = freshDraft()
   base.acpBackend = d.acpBackend
   base.configRoot = d.configRoot
+  base.authMode = d.authMode
+  base.customConfigContent = d.customConfigContent
   base.env = d.env.map((e) => ({ ...e }))
   base.gitCredentialType = d.gitCredentialType
   base.mcp = d.mcp.map((m) => ({
@@ -162,6 +171,7 @@ export type TeamBootstrapPayload = {
   background: string
   acpBackend: string
   apiKey?: string
+  customConfig?: string
   region?: string
   gitUrl?: string
   gitCredentialType?: string
@@ -171,6 +181,9 @@ export type TeamBootstrapPayload = {
 
 export function assembleTeamBootstrapPayload(d: TeamWizardDraft): TeamBootstrapPayload {
   const w = teamDraftAsWizardDraft(d)
+  if (w.authMode === 'customConfig') {
+    w.env = stripAuthKeysFromEnv(w.env, w.acpBackend)
+  }
   const env = normalizeWizardRegions(w)
   d.env = w.env
   const policy = getRegionPolicy(d.acpBackend)
@@ -179,7 +192,13 @@ export function assembleTeamBootstrapPayload(d: TeamWizardDraft): TeamBootstrapP
     : undefined
   const guide = authGuideFor(d.acpBackend, region || '')
   const primaryKey = guide.keys[0]?.key || ''
-  const apiKey = primaryKey ? env[primaryKey]?.trim() || undefined : undefined
+  const customParsed = parseCustomConfigJson(d.customConfigContent)
+  const customConfig =
+    d.authMode === 'customConfig' && customParsed.ok && customParsed.normalized
+      ? customParsed.normalized
+      : undefined
+  const apiKey =
+    !customConfig && primaryKey ? env[primaryKey]?.trim() || undefined : undefined
   return {
     projectName: d.projectName.trim(),
     prefix: d.prefix.trim(),
@@ -189,6 +208,7 @@ export function assembleTeamBootstrapPayload(d: TeamWizardDraft): TeamBootstrapP
     background: d.background.trim(),
     acpBackend: d.acpBackend || 'cursor',
     ...(apiKey ? { apiKey } : {}),
+    ...(customConfig ? { customConfig } : {}),
     ...(region ? { region } : {}),
     ...(d.gitUrl.trim() ? { gitUrl: d.gitUrl.trim() } : {}),
     ...(d.gitCredentialType ? { gitCredentialType: d.gitCredentialType } : {}),
@@ -198,6 +218,10 @@ export function assembleTeamBootstrapPayload(d: TeamWizardDraft): TeamBootstrapP
 }
 
 export function teamHasAuth(d: TeamWizardDraft): boolean {
+  if (d.authMode === 'customConfig') {
+    const parsed = parseCustomConfigJson(d.customConfigContent)
+    return parsed.ok && parsed.normalized !== ''
+  }
   return hasAuthKeyConfigured(d.env, d.acpBackend)
 }
 

--- a/web/src/lib/agent/backendAuthGuide.ts
+++ b/web/src/lib/agent/backendAuthGuide.ts
@@ -148,6 +148,43 @@ export function authGuideFor(backend: BackendId, region = ''): BackendAuthGuide 
   }
 }
 
+/** Relative path for backend config file written into Agent workspace/files. */
+export const AGENT_SETTINGS_REL_PATH = 'settings.json'
+
+/** Absolute configRoot path for settings.json (UI display). */
+export function settingsFileAbsPath(configRoot: string): string {
+  const root = configRoot.trim() || '/root/.cursor'
+  return `${root}/${AGENT_SETTINGS_REL_PATH}`
+}
+
+/** Default JSON placeholder when user switches to custom config mode. */
+export function defaultSettingsPlaceholder(backend: BackendId): string {
+  switch (backend) {
+    case 'claude_code':
+      return JSON.stringify({ env: { ANTHROPIC_API_KEY: 'sk-ant-...' } }, null, 2)
+    case 'codebuddy':
+      return JSON.stringify({ env: { CODEBUDDY_API_KEY: 'your-key' } }, null, 2)
+    case 'cursor':
+      return JSON.stringify({ env: { CURSOR_API_KEY: 'your-key' } }, null, 2)
+    case 'trae':
+      return JSON.stringify({ env: { TRAECLI_PERSONAL_ACCESS_TOKEN: 'trae-lt-...' } }, null, 2)
+    default:
+      return '{\n  \n}'
+  }
+}
+
+/** i18n key for backend-specific custom-config guidance (optional). */
+export function customConfigNoteKey(backend: BackendId): string {
+  switch (backend) {
+    case 'claude_code':
+      return 'pages.agentStudio.wizard.apiKey.customConfig.notes.claude'
+    case 'codebuddy':
+      return 'pages.agentStudio.wizard.apiKey.customConfig.notes.codebuddy'
+    default:
+      return 'pages.agentStudio.wizard.apiKey.customConfig.notes.generic'
+  }
+}
+
 /** True when any primary/alias auth key for the backend has a non-empty value. */
 export function hasAuthKeyConfigured(
   env: Record<string, string> | { k: string; v: string }[],

--- a/web/src/lib/agent/useAgentCreateWizard.ts
+++ b/web/src/lib/agent/useAgentCreateWizard.ts
@@ -17,9 +17,14 @@ import {
   type WizardDraft,
   type WizardStepId,
 } from '@/lib/agent/agentCreateWizard'
-import { authGuideFor, hasAuthKeyConfigured } from '@/lib/agent/backendAuthGuide'
+import { authGuideFor, defaultSettingsPlaceholder, hasAuthKeyConfigured } from '@/lib/agent/backendAuthGuide'
 import type { GitCredentialType } from '@/lib/agent/gitCredentialAnalysis'
 import { getRegionPolicy, setRegion } from '@/lib/shared/regionPolicy'
+import {
+  parseCustomConfigJson,
+  stripAuthKeysFromEnv,
+  type WizardAuthMode,
+} from '@/lib/agent/agentCreateWizard'
 
 export interface AgentCreateWizardProps {
   open: boolean
@@ -44,6 +49,8 @@ const showAcpConfirm = ref(false)
 const envHelpOpen = ref(false)
 const stepAnimKey = ref(0)
 const apiKeyInput = ref('')
+const customConfigError = ref(false)
+const customConfigDraft = ref('')
 
 const currentStep = computed(() => WIZARD_STEPS[draft.value.step])
 const progressPct = computed(() => ((draft.value.step + 1) / WIZARD_STEPS.length) * 100)
@@ -55,9 +62,13 @@ const currentRegion = computed(() => {
   return draft.value.env.find((item) => item.k.trim() === policy.regionEnvKey)?.v || ''
 })
 const authGuide = computed(() => authGuideFor(draft.value.acpBackend, currentRegion.value))
-const authConfigured = computed(() =>
-  hasAuthKeyConfigured(draft.value.env, draft.value.acpBackend),
-)
+const authConfigured = computed(() => {
+  if (draft.value.authMode === 'customConfig') {
+    const parsed = parseCustomConfigJson(draft.value.customConfigContent)
+    return parsed.ok && parsed.normalized !== ''
+  }
+  return hasAuthKeyConfigured(draft.value.env, draft.value.acpBackend)
+})
 const showAuthReminder = computed(() => !authConfigured.value)
 
 const primaryAuthKey = computed(() => authGuide.value.keys[0]?.key || '')
@@ -82,6 +93,8 @@ watch(
       showAcpConfirm.value = false
       envHelpOpen.value = false
       apiKeyInput.value = ''
+      customConfigError.value = false
+      customConfigDraft.value = ''
       stepAnimKey.value++
       nextTick(() => {
         document.getElementById('wiz-name-input')?.focus()
@@ -157,6 +170,34 @@ function syncApiKeyInput() {
   apiKeyInput.value = row?.v ?? ''
 }
 
+function clearAuthKeys() {
+  draft.value.env = stripAuthKeysFromEnv(draft.value.env, draft.value.acpBackend)
+  apiKeyInput.value = ''
+}
+
+function setAuthMode(mode: WizardAuthMode) {
+  if (mode === draft.value.authMode) return
+  customConfigError.value = false
+  if (mode === 'apiKey') {
+    customConfigDraft.value = draft.value.customConfigContent
+    draft.value.customConfigContent = ''
+    draft.value.authMode = mode
+    syncApiKeyInput()
+    return
+  }
+  clearAuthKeys()
+  draft.value.authMode = mode
+  draft.value.customConfigContent =
+    customConfigDraft.value || defaultSettingsPlaceholder(draft.value.acpBackend)
+  markConfigured('apiKey')
+}
+
+function onCustomConfigInput(value: string) {
+  draft.value.customConfigContent = value
+  customConfigError.value = false
+  if (value.trim()) markConfigured('apiKey')
+}
+
 function onApiKeyInput(value: string) {
   apiKeyInput.value = value
   const key = primaryAuthKey.value
@@ -187,14 +228,25 @@ function goSkip() {
   if (!step.skip || creating.value) return
   draft.value.skipped[step.id] = true
   if (step.id === 'apiKey') {
-    const key = primaryAuthKey.value
-    const idx = draft.value.env.findIndex((e) => e.k === key)
-    if (idx >= 0) draft.value.env.splice(idx, 1)
-    apiKeyInput.value = ''
+    clearAuthKeys()
+    draft.value.customConfigContent = ''
+    customConfigDraft.value = ''
+    customConfigError.value = false
   }
   draft.value.step++
   stepAnimKey.value++
   if (currentStep.value.id === 'apiKey') syncApiKeyInput()
+}
+
+function validateApiKeyStep(): boolean {
+  if (draft.value.authMode !== 'customConfig') return true
+  const parsed = parseCustomConfigJson(draft.value.customConfigContent)
+  if (!parsed.ok) {
+    customConfigError.value = true
+    return false
+  }
+  customConfigError.value = false
+  return true
 }
 
 function goNext() {
@@ -213,6 +265,7 @@ function goNext() {
     }
     nameError.value = ''
   }
+  if (step.id === 'apiKey' && !validateApiKeyStep()) return
   if (step.id === 'review') {
     void submitCreate()
     return
@@ -267,6 +320,7 @@ function chipClass(kind: string) {
   envHelpOpen,
   stepAnimKey,
   apiKeyInput,
+  customConfigError,
   currentStep,
   progressPct,
   reviewItems,
@@ -286,6 +340,8 @@ function chipClass(kind: string) {
   confirmAcpSwitch,
   cancelAcpSwitch,
   syncApiKeyInput,
+  setAuthMode,
+  onCustomConfigInput,
   onApiKeyInput,
   onGitCredentialType,
   goPrev,

--- a/web/src/lib/agent/useAgentFilesPanel.ts
+++ b/web/src/lib/agent/useAgentFilesPanel.ts
@@ -3,6 +3,8 @@
  */
 import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { AGENT_SETTINGS_PATH } from '@/lib/agent/agentCreateWizard'
+import { defaultSettingsPlaceholder } from '@/lib/agent/backendAuthGuide'
 import type { AgentStudioDraft, DraftFile } from '@/lib/agent/agentStudioDraft'
 import type { CtxTarget } from '@/components/agent/ExplorerContextMenu.vue'
 
@@ -251,6 +253,23 @@ function openFile(f: DraftFile) {
 function openPath(path: string) {
   const f = props.draft.files.find((x) => x.path === path)
   if (f) openFile(f)
+}
+
+function openPathOrCreate(path: string, placeholder?: string) {
+  let f = props.draft.files.find((x) => x.path === path)
+  if (!f) {
+    f = {
+      path,
+      content:
+        placeholder ??
+        (path === AGENT_SETTINGS_PATH
+          ? defaultSettingsPlaceholder(props.draft.acpBackend || 'cursor')
+          : ''),
+    }
+    props.draft.files.push(f)
+    props.draft.files.sort((a, b) => a.path.localeCompare(b.path))
+  }
+  openFile(f)
 }
 
 function selectDefaultFile() {
@@ -662,6 +681,7 @@ onBeforeUnmount(() => {
   rows,
   openFile,
   openPath,
+  openPathOrCreate,
   selectDefaultFile,
   resetForSelect,
   snapshot,

--- a/web/src/lib/agent/useAgentStudio.ts
+++ b/web/src/lib/agent/useAgentStudio.ts
@@ -16,6 +16,7 @@ import {
   shouldSyncDraftAfterAssign, isAgentInGroupSubtree, UNGROUPED_ID,
 } from '@/lib/agent/agentOrg'
 import { downloadZip, validateAgentName, normalizeAgentName } from '@/lib/agent/agentIO'
+import { AGENT_SETTINGS_PATH } from '@/lib/agent/agentCreateWizard'
 import { useAgentImport } from '@/lib/agent/useAgentImport'
 import { isManagedRegionKey } from '@/lib/shared/regionPolicy'
 import {
@@ -690,6 +691,15 @@ function showToast(msg: string) {
   toastTimer = setTimeout(() => {
     toastMsg.value = ''
   }, 2800)
+}
+
+function openSettingsInFiles() {
+  if (!draft.value) return
+  tab.value = 'files'
+  syncStudioQuery()
+  nextTick(() => {
+    filesPanelRef.value?.openPathOrCreate?.(AGENT_SETTINGS_PATH)
+  })
 }
 
 function discardUnsavedChanges() {
@@ -1437,6 +1447,7 @@ onBeforeUnmount(() => {
   studioTabs,
   studioTabLabel,
   showToast,
+  openSettingsInFiles,
   discardUnsavedChanges,
   requestStudioTab,
   onDataSubTab,

--- a/web/src/lib/api/apiTypes.ts
+++ b/web/src/lib/api/apiTypes.ts
@@ -161,6 +161,7 @@ export interface TeamBootstrapRequest {
   background: string
   acpBackend: string
   apiKey?: string
+  customConfig?: string
   region?: string
   gitUrl?: string
   gitCredentialType?: string

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -1750,7 +1750,9 @@
         "regionCn": "China (trae.cn)",
         "regionIntl": "International (trae.ai)",
         "add": "Add env var",
-        "parseError": "Invalid env JSON:"
+        "parseError": "Invalid env JSON:",
+        "customConfigCallout": "Besides Env keys, auth / params can go in the backend config file: {path}.",
+        "openSettingsFile": "Open in Files"
       },
       "mcpHelp": {
         "link": "Help",
@@ -2155,8 +2157,13 @@
           "remapBody": "MCP / Skills / Commands / Rules may depend on the current paths. Switching remaps to the new configRoot; cancel keeps the current Backend."
         },
         "apiKey": {
-          "meta": "Configure the auth key for the current Backend. Skip and finish later in Studio Env.",
-          "backendBanner": "Current Backend: {backend}. Only keys for this backend are shown.",
+          "meta": "Configure auth for the current Backend; skip and finish later in Studio Env or config files.",
+          "modeGroup": "Auth method",
+          "modeApiKey": "Paste API Key",
+          "modeApiKeyHint": "Written to Env — same as production",
+          "modeCustomConfig": "Custom config",
+          "modeCustomConfigHint": "Edit settings.json; written to Agent files on create",
+          "backendBanner": "Current Backend: {backend}.",
           "alias": "Alias (either works)",
           "inputLabel": "Paste API Key",
           "inputPlaceholder": "sk-… / token… (optional; you can skip)",
@@ -2198,6 +2205,18 @@
             "codebuddyIoa": "Apply key (iOA)",
             "codebuddyStaging": "Apply key (Staging)",
             "traeTokenDocs": "Trae CLI login-token docs"
+          },
+          "customConfig": {
+            "cardTitle": "Backend config file",
+            "targetPath": "Target path ·",
+            "agentFiles": "relative Agent files:",
+            "editorHint": "Written to Agent files on create; copied to configRoot at runtime. Empty content can be skipped.",
+            "invalidJson": "Invalid JSON — fix before continuing.",
+            "notes": {
+              "claude": "Use settings.json env fields for auth instead of pasting a key here.",
+              "codebuddy": "CodeBuddy can use settings.json for env; platform staging fields merge with your content.",
+              "generic": "File is still written under configRoot; whether the CLI consumes it depends on the backend. Prefer Env keys; custom config is an advanced path."
+            }
           }
         },
         "git": {
@@ -2232,6 +2251,7 @@
           "acp": "Agent",
           "apiKeyConfigured": "API Key · configured",
           "apiKeySkipped": "API Key · not set",
+          "customConfigWritten": "Custom config · written",
           "authReminder": "Auth reminder",
           "authReminderDetail": "Auth is required before runs; you can complete it in Studio Env. This reminder does not block create.",
           "git": "Git",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -1750,7 +1750,9 @@
         "regionCn": "国内站 (trae.cn)",
         "regionIntl": "国际站 (trae.ai)",
         "add": "添加环境变量",
-        "parseError": "环境变量 JSON 无法解析:"
+        "parseError": "环境变量 JSON 无法解析:",
+        "customConfigCallout": "除 Env Key 外，可通过 Backend 配置文件完成鉴权 / 参数：{path}。",
+        "openSettingsFile": "在 Files 中打开"
       },
       "mcpHelp": {
         "link": "帮助",
@@ -2155,8 +2157,13 @@
           "remapBody": "已配置的 MCP / Skills / Commands / Rules 可能依赖当前路径。更换 Backend 将按新的 configRoot 重映射；取消则保持原 Backend。"
         },
         "apiKey": {
-          "meta": "按当前 Backend 配置鉴权 Key；可跳过，稍后在 Studio Env 补全。",
-          "backendBanner": "当前 Backend：{backend}。仅展示该后端所需 Key。",
+          "meta": "按当前 Backend 配置鉴权；可跳过，稍后在 Studio Env 或配置文件中补全。",
+          "modeGroup": "鉴权方式",
+          "modeApiKey": "粘贴 API Key",
+          "modeApiKeyHint": "写入 Env，与现网一致",
+          "modeCustomConfig": "自定义配置",
+          "modeCustomConfigHint": "编辑 settings.json，创建时写入 Agent 文件树",
+          "backendBanner": "当前 Backend：{backend}。",
           "alias": "别名（任选其一）",
           "inputLabel": "粘贴 API Key",
           "inputPlaceholder": "sk-… / token…（可留空并跳过）",
@@ -2198,6 +2205,18 @@
             "codebuddyIoa": "iOA 申请 Key",
             "codebuddyStaging": "Staging 申请 Key",
             "traeTokenDocs": "Trae CLI 登录令牌文档"
+          },
+          "customConfig": {
+            "cardTitle": "后端配置文件",
+            "targetPath": "目标路径 ·",
+            "agentFiles": "相对 Agent files:",
+            "editorHint": "创建时写入 Agent 文件树；运行时落入 configRoot。内容为空可跳过。",
+            "invalidJson": "JSON 无效，请修正后再继续。",
+            "notes": {
+              "claude": "可通过 settings.json 的 env 等字段完成鉴权，无需在本步骤粘贴 Key。",
+              "codebuddy": "CodeBuddy 支持通过 settings.json 配置 env 等字段；staging 等平台字段可与用户内容合并。",
+              "generic": "文件仍写入 configRoot；是否被 CLI 消费取决于后端。推荐优先使用 Env Key，自定义配置为高级/兼容路径。"
+            }
           }
         },
         "git": {
@@ -2232,6 +2251,7 @@
           "acp": "Agent",
           "apiKeyConfigured": "API Key · 已配置",
           "apiKeySkipped": "API Key · 未配置",
+          "customConfigWritten": "自定义配置 · 已写入",
           "authReminder": "鉴权提醒",
           "authReminderDetail": "运行前需配置鉴权，可在 Studio Env 补全。此提醒不阻止创建。",
           "git": "Git",

--- a/web/src/views/AgentStudioView.vue
+++ b/web/src/views/AgentStudioView.vue
@@ -161,6 +161,7 @@ const {
   studioTabs,
   studioTabLabel,
   showToast,
+  openSettingsInFiles,
   discardUnsavedChanges,
   requestStudioTab,
   onDataSubTab,
@@ -554,6 +555,7 @@ const {
           v-if="tab === 'env' && draft && !isMobile"
           :draft="draft"
           @toast="showToast"
+          @open-settings-file="openSettingsInFiles"
         />
 
         <AgentPromptsPanel


### PR DESCRIPTION
Let users choose between pasting an API key or editing settings.json when
creating agents or teams; Studio Env links to Files for follow-up edits.
Merge platform CodeBuddy staging settings with user-authored settings.json
at runtime instead of overwriting.

Co-authored-by: Cursor <cursoragent@cursor.com>
