### PR TITLE
fix(mcp): restore artifact-upload via a dedicated image channel

### DIFF
--- a/server/internal/mcp/artifact_kind.go
+++ b/server/internal/mcp/artifact_kind.go
@@ -99,3 +99,19 @@ func ResolveWriteArtifactKind(name, kind string) (string, error) {
 
 	return kind, nil
 }
+
+// ValidateImageArtifactUpload rejects names that must never be stored as
+// kind=image via the CLI-only upload channel (reserved contract names).
+func ValidateImageArtifactUpload(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("产物名不能为空")
+	}
+	if exp, ok := ExpectedKindForReservedName(name); ok {
+		return fmt.Errorf(
+			"产物 %q 为平台保留名(期望 kind=%q),不能作为截图上传;请使用自动生成的截图文件名",
+			name, exp,
+		)
+	}
+	return nil
+}

--- a/server/internal/mcp/artifact_kind_test.go
+++ b/server/internal/mcp/artifact_kind_test.go
@@ -197,3 +197,84 @@ func TestWriteArtifactKindValidation(t *testing.T) {
 		"note.md", "markdown",
 	)
 }
+
+func TestValidateImageArtifactUpload(t *testing.T) {
+	if err := ValidateImageArtifactUpload("shot.png"); err != nil {
+		t.Fatalf("shot.png: %v", err)
+	}
+	if err := ValidateImageArtifactUpload(""); err == nil {
+		t.Fatal("empty name should fail")
+	}
+	if err := ValidateImageArtifactUpload(PlanArtifactName); err == nil {
+		t.Fatal("reserved name should fail")
+	}
+	if err := ValidateImageArtifactUpload("page.html"); err == nil {
+		t.Fatal("page.html should fail")
+	}
+}
+
+// TestUploadImageArtifactChannel exercises the CLI-only image upload path (g3.1):
+// upload_image_artifact stores kind=image; set_test_result can reference it;
+// write_artifact still rejects image; upload tool is hidden from tools/list.
+func TestUploadImageArtifactChannel(t *testing.T) {
+	store := &memStore{}
+	h := NewHost(store)
+	runID := "upload-run"
+	tok := h.RegisterRun(runID)
+	h.SetActiveNode(runID, "tst", "test")
+
+	// Hidden from agent tool list (g2.2: agents should use artifact-upload CLI).
+	list := call(t, h, runID, tok, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
+	tools, _ := list["result"].(map[string]any)["tools"].([]any)
+	for _, tool := range tools {
+		m, _ := tool.(map[string]any)
+		if m["name"] == "upload_image_artifact" {
+			t.Fatal("upload_image_artifact must not appear in tools/list")
+		}
+	}
+
+	// write_artifact kind=image still rejected (g2.1).
+	failResp := call(t, h, runID, tok, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"write_artifact","arguments":{"name":"shot.png","content":"PNG","kind":"image"}}}`)
+	if failResp["result"].(map[string]any)["isError"] != true {
+		t.Fatalf("write_artifact image should fail: %v", failResp)
+	}
+
+	// upload_image_artifact succeeds (simulates artifact-upload CLI).
+	okResp := call(t, h, runID, tok, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"upload_image_artifact","arguments":{"name":"shot-e2e.png","content":"BASE64PNG"}}}`)
+	if okResp["result"].(map[string]any)["isError"] == true {
+		t.Fatalf("upload_image_artifact failed: %v", okResp)
+	}
+	if got := store.kindOf(runID, "shot-e2e.png"); got != "image" {
+		t.Fatalf("stored kind = %q, want image", got)
+	}
+
+	// set_test_result references uploaded artifact (g3.1).
+	call(t, h, runID, tok, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"set_test_result","arguments":{"summary":"s","cases":[{"name":"c1","status":"passed"}],"screenshots":[{"artifact":"shot-e2e.png","caption":"e2e","mimeType":"image/png"}]}}}`)
+	content, ok := store.Get(runID, TestResultArtifactName)
+	if !ok {
+		t.Fatal("test_result.json not written")
+	}
+	if !strings.Contains(content, "shot-e2e.png") {
+		t.Fatalf("test_result missing artifact ref: %s", content)
+	}
+	if strings.Contains(content, "BASE64PNG") {
+		t.Fatal("test_result should not inline image data")
+	}
+
+	// Reserved name rejected on upload channel.
+	reserved := call(t, h, runID, tok, `{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"upload_image_artifact","arguments":{"name":"plan.json","content":"x"}}}`)
+	if reserved["result"].(map[string]any)["isError"] != true {
+		t.Fatalf("reserved name upload should fail: %v", reserved)
+	}
+
+	// Empty content rejected.
+	empty := call(t, h, runID, tok, `{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"upload_image_artifact","arguments":{"name":"empty.png","content":""}}}`)
+	if empty["result"].(map[string]any)["isError"] != true {
+		t.Fatalf("empty content upload should fail: %v", empty)
+	}
+
+	// Wrong token rejected.
+	if _, err := h.UploadImageArtifact(runID, "wrong-token", "tst", "nope.png", "PNG"); err == nil {
+		t.Fatal("unauthorized upload should fail")
+	}
+}

--- a/server/internal/mcp/host.go
+++ b/server/internal/mcp/host.go
@@ -430,8 +430,9 @@ func (h *Host) authorize(runID, token string) bool {
 // which state produced it. Returns the artifact id.
 //
 // Before Save: empty kind is inferred (reserved name → expected kind, else
-// extension); kind=image is always rejected (use artifact-upload); an explicit
-// kind that disagrees with a reserved/contract name fails without writing.
+// extension); kind=image is always rejected (use artifact-upload →
+// upload_image_artifact); an explicit kind that disagrees with a
+// reserved/contract name fails without writing.
 func (h *Host) WriteArtifact(runID, token, nodeID, name, content, kind string) (string, error) {
 	if !h.authorize(runID, token) {
 		return "", ErrUnauthorized
@@ -450,6 +451,37 @@ func (h *Host) WriteArtifact(runID, token, nodeID, name, content, kind string) (
 	h.mu.RUnlock()
 	if hook != nil {
 		hook(runID, nodeID, name, content, kind)
+	}
+	return id, nil
+}
+
+// UploadImageArtifact persists a base64-encoded image under the run namespace.
+// It bypasses write_artifact's kind=image rejection and is intended for the
+// sandbox artifact-upload CLI (tools/call upload_image_artifact), not agents.
+func (h *Host) UploadImageArtifact(runID, token, nodeID, name, content string) (string, error) {
+	if !h.authorize(runID, token) {
+		return "", ErrUnauthorized
+	}
+	name = strings.TrimSpace(name)
+	content = strings.TrimSpace(content)
+	if err := ValidateImageArtifactUpload(name); err != nil {
+		return "", err
+	}
+	if content == "" {
+		return "", fmt.Errorf("upload_image_artifact: content 不能为空")
+	}
+	if strings.TrimSpace(nodeID) == "" {
+		nodeID = "artifact-upload"
+	}
+	id, err := h.store.Save(runID, nodeID, name, "image", content)
+	if err != nil {
+		return "", err
+	}
+	h.mu.RLock()
+	hook := h.afterWrite
+	h.mu.RUnlock()
+	if hook != nil {
+		hook(runID, nodeID, name, content, "image")
 	}
 	return id, nil
 }

--- a/server/internal/mcp/mcp_more_test.go
+++ b/server/internal/mcp/mcp_more_test.go
@@ -241,9 +241,9 @@ func TestSetTestResultValidatesScreenshotArtifacts(t *testing.T) {
 	tok := h.RegisterRun(runID)
 	h.SetActiveNode(runID, "tst", "test")
 
-	// Seed like artifact-upload → store.Save(kind=image); write_artifact must not
-	// be used for images (see TestWriteArtifactKindValidation).
-	if _, err := store.Save(runID, "tst", "shot-1.png", "image", "PNGDATA"); err != nil {
+	// Seed via upload_image_artifact (artifact-upload CLI path); write_artifact
+	// must not be used for images (see TestWriteArtifactKindValidation).
+	if _, err := h.UploadImageArtifact(runID, tok, "tst", "shot-1.png", "PNGDATA"); err != nil {
 		t.Fatalf("seed screenshot: %v", err)
 	}
 

--- a/server/internal/mcp/tools.go
+++ b/server/internal/mcp/tools.go
@@ -19,6 +19,17 @@ import (
 // in/out observable in one place.
 func (h *Host) runTool(runID, token, name string, args map[string]any) (string, bool) {
 	switch name {
+	case "upload_image_artifact":
+		aname := asString(args["name"])
+		content := asString(args["content"])
+		if aname == "" {
+			return "error: 'name' is required", true
+		}
+		id, err := h.UploadImageArtifact(runID, token, h.ActiveNode(runID), aname, content)
+		if err != nil {
+			return "upload_image_artifact failed: " + err.Error(), true
+		}
+		return fmt.Sprintf("ok: uploaded image artifact %q (id=%s)", aname, id), false
 	case "write_artifact":
 		aname := asString(args["name"])
 		content := asString(args["content"])

--- a/server/internal/sandbox/artifactcli_test.go
+++ b/server/internal/sandbox/artifactcli_test.go
@@ -28,6 +28,7 @@ func TestSeedHelperScriptsHaveNoHardcodedSPAHosts(t *testing.T) {
 			want: []string{
 				"rewrite_spa_mcp_url",
 				"_SPA_MCP_HOSTS = {}",
+				"upload_image_artifact",
 			},
 		},
 		{
@@ -62,6 +63,20 @@ func TestSeedHelperScriptsHaveNoHardcodedSPAHosts(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestArtifactUploadScriptDoesNotCallWriteArtifactImage(t *testing.T) {
+	t.Parallel()
+	if strings.Contains(artifactUploadScript, `"name": "write_artifact"`) {
+		t.Fatal("artifact-upload must not call write_artifact")
+	}
+	if strings.Contains(artifactUploadScript, "kind\": \"image\"") ||
+		strings.Contains(artifactUploadScript, "kind=image") {
+		t.Fatal("artifact-upload must not pass kind=image to write_artifact")
+	}
+	if !strings.Contains(artifactUploadScript, "upload_image_artifact") {
+		t.Fatal("artifact-upload must call upload_image_artifact")
 	}
 }
 

--- a/server/internal/sandbox/seedhelpers/artifact-upload
+++ b/server/internal/sandbox/seedhelpers/artifact-upload
@@ -2,8 +2,8 @@
 """artifact-upload: 把本地文件上传到本次运行的产物存储 (artifact-store MCP)。
 
 测试节点常用它上传浏览器/UI 截图:CLI 在本地读文件、base64 编码,经 HTTP 调用
-write_artifact 工具写入产物存储,然后把产物名打印到 stdout。Agent 只需把这个短
-产物名填进 set_test_result 的 screenshots[].artifact,无需内联 base64。
+upload_image_artifact 工具写入产物存储,然后把产物名打印到 stdout。Agent 只需把
+这个短产物名填进 set_test_result 的 screenshots[].artifact,无需内联 base64。
 
 环境变量(由平台在沙箱容器内注入):
   APPROVING_ARTIFACT_URL    运行级 artifact-store MCP 端点 (/mcp/runs/<runId>)
@@ -113,8 +113,8 @@ def main() -> int:
         "id": 1,
         "method": "tools/call",
         "params": {
-            "name": "write_artifact",
-            "arguments": {"name": name, "content": b64, "kind": "image"},
+            "name": "upload_image_artifact",
+            "arguments": {"name": name, "content": b64},
         },
     }
     body = json.dumps(payload).encode("utf-8")


### PR DESCRIPTION
## Summary
- `#375` 禁止 `write_artifact(kind=image)` 后，沙箱 `artifact-upload` 仍走该路径，截图上传会失败。
- 新增 CLI 专用、不出现在 `tools/list` 的 `upload_image_artifact`，CLI 改为调用它；`write_artifact` 继续拒图。
- 上传通道拒绝空内容、错误 token，以及 `plan.json` / `page.html` 等保留名。

## Test plan
- [x] `go test ./internal/mcp/ ./internal/sandbox/`
- [x] `go vet ./internal/mcp/ ./internal/sandbox/`
- [ ] CI `ci-server`（golangci-lint / `go test ./...` / coverage gate）通过
- [ ] 沙箱跑 `artifact-upload shot.png` 能写入 `kind=image` 产物，并把打印出的名字填进 `set_test_result.screenshots[].artifact`
- [ ] Agent 直接 `write_artifact(..., kind=image)` 仍被拒绝


Made with [Cursor](https://cursor.com)