### PR TITLE
fix: recognize settings.json env keys in sandbox auth merge

### DIFF
--- a/server/internal/runtime/acp_backend.go
+++ b/server/internal/runtime/acp_backend.go
@@ -1,7 +1,10 @@
 package runtime
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -131,6 +134,86 @@ func MergeAuthEnv(backend AcpBackend, env map[string]string) (map[string]string,
 	return mergeAuthEnv(backend, env)
 }
 
+// PrepareAuthEnv merges auth keys from Agent workspace settings.json.env into env
+// (explicit env wins, including empty overrides), then normalizes via mergeAuthEnv.
+func PrepareAuthEnv(backend AcpBackend, env map[string]string, workDirSrc string) (map[string]string, error) {
+	settingsAuth := ReadSettingsAuthEnv(workDirSrc, backend)
+	merged := mergeSettingsAuthIntoEnv(env, settingsAuth)
+	return mergeAuthEnv(backend, merged)
+}
+
+// ReadSettingsAuthEnv reads backend-relevant auth keys from settings.json under
+// workDirSrc. Missing file, invalid JSON, or absent keys return nil (not an error).
+func ReadSettingsAuthEnv(workDirSrc string, backend AcpBackend) map[string]string {
+	if workDirSrc == "" {
+		return nil
+	}
+	path := filepath.Join(workDirSrc, "settings.json")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(b, &doc); err != nil {
+		return nil
+	}
+	settingsEnv := settingsEnvFromDoc(doc)
+	if len(settingsEnv) == 0 {
+		return nil
+	}
+	spec := authSpecFor(backend)
+	keys := append([]string{}, spec.agentKeys...)
+	keys = append(keys, spec.cliKey)
+	out := map[string]string{}
+	for _, k := range keys {
+		if v, ok := settingsEnv[k]; ok && strings.TrimSpace(v) != "" {
+			out[k] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func settingsEnvFromDoc(doc map[string]any) map[string]string {
+	raw, ok := doc["env"]
+	if !ok {
+		return nil
+	}
+	switch m := raw.(type) {
+	case map[string]any:
+		out := make(map[string]string, len(m))
+		for k, v := range m {
+			if s, ok := v.(string); ok {
+				out[k] = s
+			}
+		}
+		return out
+	case map[string]string:
+		return m
+	default:
+		return nil
+	}
+}
+
+// mergeSettingsAuthIntoEnv overlays settings auth keys only where env lacks the key.
+func mergeSettingsAuthIntoEnv(env, settingsAuth map[string]string) map[string]string {
+	if len(settingsAuth) == 0 {
+		return env
+	}
+	out := map[string]string{}
+	for k, v := range env {
+		out[k] = v
+	}
+	for k, v := range settingsAuth {
+		if _, exists := out[k]; !exists {
+			out[k] = v
+		}
+	}
+	return out
+}
+
 // by the sandbox bridge. Returns an error when no key is configured.
 func mergeAuthEnv(backend AcpBackend, env map[string]string) (map[string]string, error) {
 	spec := authSpecFor(backend)
@@ -151,7 +234,10 @@ func mergeAuthEnv(backend AcpBackend, env map[string]string) (map[string]string,
 		}
 	}
 	if val == "" {
-		return out, fmt.Errorf("鉴权未配置:请在项目沙箱 env 或 Agent 环境变量中设置 %s", strings.Join(spec.agentKeys, " 或 "))
+		return out, fmt.Errorf(
+			"鉴权未配置:请在项目沙箱 env、Agent 环境变量或 settings.json 的 env 中设置 %s",
+			strings.Join(spec.agentKeys, " 或 "),
+		)
 	}
 	out[spec.cliKey] = val
 	mergeRegionEnv(backend, out)

--- a/server/internal/runtime/acp_backend_test.go
+++ b/server/internal/runtime/acp_backend_test.go
@@ -1,6 +1,8 @@
 package runtime
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -412,5 +414,121 @@ func TestFirstNonEmpty(t *testing.T) {
 	}
 	if got := firstNonEmpty("", "  "); got != "" {
 		t.Fatalf("got %q", got)
+	}
+}
+
+func writeSettingsJSON(dir string, content string) {
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte(content), 0o644); err != nil {
+		panic(err)
+	}
+}
+
+func TestPrepareAuthEnv_SettingsOnly(t *testing.T) {
+	workDir := t.TempDir()
+	writeSettingsJSON(workDir, `{"env":{"ANTHROPIC_API_KEY":"sk-ant-from-settings"}}`)
+
+	out, err := PrepareAuthEnv(BackendClaudeCode, map[string]string{}, workDir)
+	if err != nil {
+		t.Fatalf("PrepareAuthEnv: %v", err)
+	}
+	if out["ANTHROPIC_API_KEY"] != "sk-ant-from-settings" {
+		t.Fatalf("ANTHROPIC_API_KEY=%q", out["ANTHROPIC_API_KEY"])
+	}
+}
+
+func TestPrepareAuthEnv_EnvOnly(t *testing.T) {
+	workDir := t.TempDir()
+	out, err := PrepareAuthEnv(BackendCursor, map[string]string{
+		"CURSOR_API_KEY": "crsr-env",
+	}, workDir)
+	if err != nil {
+		t.Fatalf("PrepareAuthEnv: %v", err)
+	}
+	if out["CURSOR_API_KEY"] != "crsr-env" {
+		t.Fatalf("CURSOR_API_KEY=%q", out["CURSOR_API_KEY"])
+	}
+}
+
+func TestPrepareAuthEnv_NeitherConfigured(t *testing.T) {
+	workDir := t.TempDir()
+	_, err := PrepareAuthEnv(BackendClaudeCode, map[string]string{}, workDir)
+	if err == nil {
+		t.Fatal("expected error when no auth configured")
+	}
+	if !strings.Contains(err.Error(), "settings.json") {
+		t.Fatalf("error should mention settings.json: %v", err)
+	}
+}
+
+func TestPrepareAuthEnv_InvalidSettingsJSON(t *testing.T) {
+	workDir := t.TempDir()
+	writeSettingsJSON(workDir, `{bad json`)
+
+	_, err := PrepareAuthEnv(BackendClaudeCode, map[string]string{}, workDir)
+	if err == nil {
+		t.Fatal("invalid settings.json must not falsely pass auth")
+	}
+}
+
+func TestPrepareAuthEnv_EnvOverridesSettings(t *testing.T) {
+	workDir := t.TempDir()
+	writeSettingsJSON(workDir, `{"env":{"ANTHROPIC_API_KEY":"from-settings"}}`)
+
+	out, err := PrepareAuthEnv(BackendClaudeCode, map[string]string{
+		"ANTHROPIC_API_KEY": "from-env",
+	}, workDir)
+	if err != nil {
+		t.Fatalf("PrepareAuthEnv: %v", err)
+	}
+	if out["ANTHROPIC_API_KEY"] != "from-env" {
+		t.Fatalf("env should win: got %q", out["ANTHROPIC_API_KEY"])
+	}
+}
+
+func TestPrepareAuthEnv_EmptyEnvOverridesSettings(t *testing.T) {
+	workDir := t.TempDir()
+	writeSettingsJSON(workDir, `{"env":{"CURSOR_API_KEY":"from-settings"}}`)
+
+	_, err := PrepareAuthEnv(BackendCursor, map[string]string{
+		"CURSOR_API_KEY": "",
+	}, workDir)
+	if err == nil {
+		t.Fatal("empty explicit env must block settings fallback")
+	}
+}
+
+func TestPrepareAuthEnv_AllBackendsFromSettings(t *testing.T) {
+	cases := []struct {
+		backend AcpBackend
+		content string
+		cliKey  string
+	}{
+		{BackendClaudeCode, `{"env":{"ANTHROPIC_API_KEY":"claude-key"}}`, "ANTHROPIC_API_KEY"},
+		{BackendCursor, `{"env":{"CURSOR_API_KEY":"cursor-key"}}`, "CURSOR_API_KEY"},
+		{BackendCodeBuddy, `{"env":{"CODEBUDDY_API_KEY":"cb-key"}}`, "CODEBUDDY_API_KEY"},
+		{BackendTrae, `{"env":{"TRAECLI_PERSONAL_ACCESS_TOKEN":"trae-token"}}`, EnvTraeCLIToken},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.backend), func(t *testing.T) {
+			workDir := t.TempDir()
+			writeSettingsJSON(workDir, tc.content)
+			out, err := PrepareAuthEnv(tc.backend, map[string]string{}, workDir)
+			if err != nil {
+				t.Fatalf("PrepareAuthEnv: %v", err)
+			}
+			if out[tc.cliKey] == "" {
+				t.Fatalf("%s unset", tc.cliKey)
+			}
+		})
+	}
+}
+
+func TestReadSettingsAuthEnv_EmptyKeyIgnored(t *testing.T) {
+	workDir := t.TempDir()
+	writeSettingsJSON(workDir, `{"env":{"ANTHROPIC_API_KEY":""}}`)
+
+	got := ReadSettingsAuthEnv(workDir, BackendClaudeCode)
+	if got != nil {
+		t.Fatalf("empty key should be ignored: %v", got)
 	}
 }

--- a/server/internal/runtime/acp_sandbox.go
+++ b/server/internal/runtime/acp_sandbox.go
@@ -303,7 +303,7 @@ func (c *acpProvider) spec(req NodeReq) (sandbox.Spec, error) {
 			env[k] = e.Value
 		}
 	}
-	merged, err := mergeAuthEnv(c.backend, env)
+	merged, err := PrepareAuthEnv(c.backend, env, c.workDir(profile))
 	if err != nil {
 		return sandbox.Spec{}, err
 	}

--- a/server/internal/services/sandbox_agent.go
+++ b/server/internal/services/sandbox_agent.go
@@ -216,7 +216,8 @@ func (s *SandboxService) startAgentContainer(id uint, name, profile, projectID, 
 		env[k] = v
 	}
 	backend := runtime.NormalizeBackend(agent.AcpBackend)
-	merged, err := runtime.MergeAuthEnv(backend, env)
+	workDir := s.skills.WorkDir(profile)
+	merged, err := runtime.PrepareAuthEnv(backend, env, workDir)
 	if err != nil {
 		fail(err)
 		return

--- a/server/internal/services/sandbox_test_pool.go
+++ b/server/internal/services/sandbox_test_pool.go
@@ -154,7 +154,8 @@ func (s *SandboxService) startContainer(id uint, name, profile, projectID, runID
 		env[k] = substTemplate(v, vars)
 	}
 	backend := runtime.NormalizeBackend(agent.AcpBackend)
-	merged, err := runtime.MergeAuthEnv(backend, env)
+	workDir := s.skills.WorkDir(profile)
+	merged, err := runtime.PrepareAuthEnv(backend, env, workDir)
 	if err != nil {
 		fail(err)
 		return


### PR DESCRIPTION
MergeAuthEnv only inspected project/Agent env vars, so agents configured
via custom settings.json (wizard strips keys from env) failed at sandbox
create. PrepareAuthEnv reads workspace settings.json.env before merge,
with explicit env winning over settings.

Co-authored-by: Cursor <cursoragent@cursor.com>
