### PR TITLE
fix: skip env auth gate when settings.json exists

### DIFF
--- a/server/internal/runtime/acp_backend.go
+++ b/server/internal/runtime/acp_backend.go
@@ -131,15 +131,29 @@ func authSpecFor(b AcpBackend) authSpec {
 // MergeAuthEnv maps agent-configured API keys into CLI env names and applies
 // CodeBuddy / Trae region (intl vs CN) normalization.
 func MergeAuthEnv(backend AcpBackend, env map[string]string) (map[string]string, error) {
-	return mergeAuthEnv(backend, env)
+	return mergeAuthEnv(backend, env, true)
+}
+
+// SettingsFileExists reports whether settings.json is present at the root of the
+// Agent workspace. Dialog-test auth gate treats file presence as sufficient; content
+// is not validated or rewritten by the gate.
+func SettingsFileExists(workDirSrc string) bool {
+	if workDirSrc == "" {
+		return false
+	}
+	_, err := os.Stat(filepath.Join(workDirSrc, "settings.json"))
+	return err == nil
 }
 
 // PrepareAuthEnv merges auth keys from Agent workspace settings.json.env into env
 // (explicit env wins, including empty overrides), then normalizes via mergeAuthEnv.
+// When settings.json exists in the workspace, the auth gate passes without requiring
+// Env keys; content is left to the backend/CLI.
 func PrepareAuthEnv(backend AcpBackend, env map[string]string, workDirSrc string) (map[string]string, error) {
 	settingsAuth := ReadSettingsAuthEnv(workDirSrc, backend)
 	merged := mergeSettingsAuthIntoEnv(env, settingsAuth)
-	return mergeAuthEnv(backend, merged)
+	requireAuth := !SettingsFileExists(workDirSrc)
+	return mergeAuthEnv(backend, merged, requireAuth)
 }
 
 // ReadSettingsAuthEnv reads backend-relevant auth keys from settings.json under
@@ -214,8 +228,9 @@ func mergeSettingsAuthIntoEnv(env, settingsAuth map[string]string) map[string]st
 	return out
 }
 
-// by the sandbox bridge. Returns an error when no key is configured.
-func mergeAuthEnv(backend AcpBackend, env map[string]string) (map[string]string, error) {
+// by the sandbox bridge. When requireAuth is false (workspace settings.json
+// exists), missing keys do not error; region normalization still applies.
+func mergeAuthEnv(backend AcpBackend, env map[string]string, requireAuth bool) (map[string]string, error) {
 	spec := authSpecFor(backend)
 	out := map[string]string{}
 	for k, v := range env {
@@ -234,10 +249,14 @@ func mergeAuthEnv(backend AcpBackend, env map[string]string) (map[string]string,
 		}
 	}
 	if val == "" {
-		return out, fmt.Errorf(
-			"鉴权未配置:请在项目沙箱 env、Agent 环境变量或 settings.json 的 env 中设置 %s",
-			strings.Join(spec.agentKeys, " 或 "),
-		)
+		if requireAuth {
+			return out, fmt.Errorf(
+				"鉴权未配置:请在 Agent 工作目录添加 settings.json，或在项目沙箱 env、Agent 环境变量中设置 %s",
+				strings.Join(spec.agentKeys, " 或 "),
+			)
+		}
+		mergeRegionEnv(backend, out)
+		return out, nil
 	}
 	out[spec.cliKey] = val
 	mergeRegionEnv(backend, out)

--- a/server/internal/runtime/acp_backend_test.go
+++ b/server/internal/runtime/acp_backend_test.go
@@ -458,15 +458,21 @@ func TestPrepareAuthEnv_NeitherConfigured(t *testing.T) {
 	if !strings.Contains(err.Error(), "settings.json") {
 		t.Fatalf("error should mention settings.json: %v", err)
 	}
+	if !strings.Contains(err.Error(), "APPROVING_CLAUDE_API_KEY") {
+		t.Fatalf("error should mention env keys: %v", err)
+	}
 }
 
 func TestPrepareAuthEnv_InvalidSettingsJSON(t *testing.T) {
 	workDir := t.TempDir()
 	writeSettingsJSON(workDir, `{bad json`)
 
-	_, err := PrepareAuthEnv(BackendClaudeCode, map[string]string{}, workDir)
-	if err == nil {
-		t.Fatal("invalid settings.json must not falsely pass auth")
+	out, err := PrepareAuthEnv(BackendClaudeCode, map[string]string{}, workDir)
+	if err != nil {
+		t.Fatalf("invalid settings.json must pass gate when file exists: %v", err)
+	}
+	if out == nil {
+		t.Fatal("expected env map")
 	}
 }
 
@@ -489,11 +495,14 @@ func TestPrepareAuthEnv_EmptyEnvOverridesSettings(t *testing.T) {
 	workDir := t.TempDir()
 	writeSettingsJSON(workDir, `{"env":{"CURSOR_API_KEY":"from-settings"}}`)
 
-	_, err := PrepareAuthEnv(BackendCursor, map[string]string{
+	out, err := PrepareAuthEnv(BackendCursor, map[string]string{
 		"CURSOR_API_KEY": "",
 	}, workDir)
-	if err == nil {
-		t.Fatal("empty explicit env must block settings fallback")
+	if err != nil {
+		t.Fatalf("settings.json present must skip env gate: %v", err)
+	}
+	if out["CURSOR_API_KEY"] != "" {
+		t.Fatalf("empty explicit env should remain: got %q", out["CURSOR_API_KEY"])
 	}
 }
 
@@ -530,5 +539,58 @@ func TestReadSettingsAuthEnv_EmptyKeyIgnored(t *testing.T) {
 	got := ReadSettingsAuthEnv(workDir, BackendClaudeCode)
 	if got != nil {
 		t.Fatalf("empty key should be ignored: %v", got)
+	}
+}
+
+func TestSettingsFileExists(t *testing.T) {
+	workDir := t.TempDir()
+	if SettingsFileExists(workDir) {
+		t.Fatal("missing file")
+	}
+	if SettingsFileExists("") {
+		t.Fatal("empty dir")
+	}
+	writeSettingsJSON(workDir, `{}`)
+	if !SettingsFileExists(workDir) {
+		t.Fatal("file should exist")
+	}
+}
+
+func TestPrepareAuthEnv_SettingsFileExistsNoEnvNoKeys(t *testing.T) {
+	workDir := t.TempDir()
+	writeSettingsJSON(workDir, `{"model":"claude-sonnet"}`)
+
+	before, err := os.ReadFile(filepath.Join(workDir, "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := PrepareAuthEnv(BackendClaudeCode, map[string]string{}, workDir)
+	if err != nil {
+		t.Fatalf("file exists gate must pass: %v", err)
+	}
+	if out == nil {
+		t.Fatal("expected env map")
+	}
+
+	after, err := os.ReadFile(filepath.Join(workDir, "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("settings.json must not be modified:\nbefore=%s\nafter=%s", before, after)
+	}
+}
+
+func TestPrepareAuthEnv_NoSettingsEnvConfigured(t *testing.T) {
+	workDir := t.TempDir()
+	out, err := PrepareAuthEnv(BackendCursor, map[string]string{
+		"CURSOR_API_KEY": "crsr-env",
+	}, workDir)
+	if err != nil {
+		t.Fatalf("PrepareAuthEnv: %v", err)
+	}
+	if out["CURSOR_API_KEY"] != "crsr-env" {
+		t.Fatalf("CURSOR_API_KEY=%q", out["CURSOR_API_KEY"])
 	}
 }


### PR DESCRIPTION
Dialog test and sandbox startup now treat workspace settings.json presence
as sufficient auth; Env keys are only required when the file is absent.

Co-authored-by: Cursor <cursoragent@cursor.com>
