### PR TITLE
fix(sandbox): 双 token 时同时配置 GitHub 与 GitLab 鉴权

### DIFF
--- a/sandbox-gateway/sandbox/README.md
+++ b/sandbox-gateway/sandbox/README.md
@@ -106,14 +106,14 @@ docker run --privileged -d \
 
 ### 4. Git 凭据与用户信息
 
-按每个仓库 URL 的 host 精确匹配注入（HTTPS 与 SSH 互斥）：
+已配置的 `GITHUB_TOKEN` / `GITLAB_TOKEN` 都会注入（`~/.git-credentials` + `gh` / `glab` 登录），不依赖当前 clone 仓库属于哪个平台。HTTPS clone 与 SSH 仍按仓库 URL 的 scheme 互斥选择。
 
 | 变量 | 默认值 | 作用 |
 | --- | --- | --- |
-| `GITHUB_TOKEN` | 空 | GitHub token（`github.com` 或由 `GITHUB_URL` 匹配的自建实例）；命中时自动 `gh auth login` |
+| `GITHUB_TOKEN` | 空 | GitHub token（`github.com` 或由 `GITHUB_URL` 匹配的自建实例）；已配置则自动 `gh auth login` |
 | `GITHUB_URL` | 空 | 自建 GitHub 的 `scheme+host`，用于匹配 repo host |
-| `GITLAB_TOKEN` | 空 | GitLab token；命中时自动 `glab auth login` |
-| `GITLAB_URL` | 空 | GitLab 实例地址（自建必填；仅设 token 无 URL 时跳过注入） |
+| `GITLAB_TOKEN` | 空 | GitLab token；已配置则自动 `glab auth login` |
+| `GITLAB_URL` | 空 | GitLab 实例地址（自建建议显式配置；空则默认 `gitlab.com`。不会把 GitHub / `GITHUB_URL` host 当成 GitLab） |
 | `GIT_SSH_PRIVATE_KEY` | 空 | SSH 私钥内容，写入 `~/.ssh/id_rsa`（SSH clone 用） |
 | `GIT_SSH_KNOWN_HOSTS` | 空 | SSH known_hosts 内容（SSH clone 时必填，禁用 accept-new 兜底） |
 | `GIT_USER_NAME` | `sandbox` | 全局 `git config user.name` |

--- a/sandbox-gateway/sandbox/scripts/startup.sh
+++ b/sandbox-gateway/sandbox/scripts/startup.sh
@@ -5,9 +5,11 @@ set -e
 #   - 运行环境（DinD + SSH + code-server）来自 ~/sandbox
 #   - 多托管商 git 凭据路由 + 多仓库 PULL（GIT_REPOS）+ 多后端 backend（ACP 桥接）来自 code-flow
 #
-# Git 凭据路由（按每个仓库 URL 的 scheme 互斥选择，须在 clone 前完成）:
-#   HTTPS — github.com→GITHUB_TOKEN; gitlab.com→GITLAB_TOKEN;
-#           自建实例通过 GITHUB_URL / GITLAB_URL (scheme+host) 与 repo host 精确匹配。
+# Git 凭据（须在 clone 前完成）:
+#   已配置的 GITHUB_TOKEN / GITLAB_TOKEN 都会注入 ~/.git-credentials 并登录 gh / glab，
+#   不依赖当前 clone 仓库属于哪个平台。
+#   HTTPS clone 仍按仓库 URL 的 host 匹配（github.com→GITHUB_TOKEN; gitlab.com→GITLAB_TOKEN;
+#           自建实例通过 GITHUB_URL / GITLAB_URL 与 repo host 精确匹配）。
 #   SSH   — GIT_SSH_PRIVATE_KEY 写入 ~/.ssh/id_rsa (600); GIT_SSH_KNOWN_HOSTS 必填。
 # 主要环境变量：WORKSPACE_DIR, ROOT_PASSWORD, CODE_SERVER_PORT, SSH_KEY, SKIP_INNER_DOCKER,
 #   GIT_REPOS(多仓 name|url|branch) / GIT_CLONE_URL(单仓兼容),
@@ -212,20 +214,26 @@ EOF
     return 0
 }
 
-# 仅设置了 GITLAB_TOKEN（无 GIT_REPOS / GIT_CLONE_URL）时，按 GITLAB_URL 注入凭据。
-# 通用镜像不预设任何具体 GitLab 域名：未提供 GITLAB_URL 则跳过。
+# 按 GITLAB_URL 注入 GitLab 凭据并 glab auth login。
+# 未提供 GITLAB_URL 时默认 gitlab.com（与 GitHub 默认 github.com 对称）。
+# 若 GITLAB_URL 误指向 GitHub / GITHUB_URL host（例如服务端从 GitHub 仓推导），回退 gitlab.com。
 setup_bare_gitlab_credentials() {
-    if [ -z "$GITLAB_URL" ]; then
-        echo "startup.sh: 仅设置了 GITLAB_TOKEN 但未提供 GITLAB_URL，跳过凭据注入" >&2
-        return 0
+    local gitlab_url="${GITLAB_URL:-https://gitlab.com}"
+    local gitlab_host; gitlab_host=$(url_host "$gitlab_url")
+    local github_host="github.com"
+    if [ -n "$GITHUB_URL" ]; then
+        github_host=$(url_host "$GITHUB_URL")
     fi
-    local gitlab_host; gitlab_host=$(url_host "$GITLAB_URL")
+    if [ "$gitlab_host" = "github.com" ] || [ "$gitlab_host" = "$github_host" ]; then
+        gitlab_url="https://gitlab.com"
+        gitlab_host="gitlab.com"
+    fi
     prepare_git_credentials_file "https://oauth2:${GITLAB_TOKEN}@${gitlab_host}"
-    echo "GitLab token configured successfully for ${GITLAB_URL}"
+    echo "GitLab token configured successfully for ${gitlab_url}"
     glab_auth_login "$gitlab_host" "$GITLAB_TOKEN"
 }
 
-# 仅设置了 GITHUB_TOKEN（无 GIT_REPOS / GIT_CLONE_URL）时注入凭据并 gh auth login。
+# 按 GITHUB_URL 注入 GitHub 凭据并 gh auth login。
 # 未提供 GITHUB_URL 时默认 github.com（与公开 GitHub 场景对齐）。
 setup_bare_github_credentials() {
     local github_host="github.com"
@@ -246,6 +254,23 @@ setup_repo_credentials() {
     esac
 }
 
+# 先按仓库 URL 配置 clone 所需凭据，再为所有已配置 token 补齐对端平台。
+configure_git_credentials() {
+    if [ -n "$GIT_REPOS" ]; then
+        IFS=',' read -ra _entries <<< "$GIT_REPOS"
+        for _entry in "${_entries[@]}"; do
+            [ -n "$_entry" ] || continue
+            IFS='|' read -r _name _url _branch <<< "$_entry"
+            [ -n "$_url" ] && setup_repo_credentials "$_url"
+        done
+        unset _entries _entry _name _url _branch
+    elif [ -n "$GIT_CLONE_URL" ]; then
+        setup_repo_credentials "$GIT_CLONE_URL"
+    fi
+    [ -n "$GITLAB_TOKEN" ] && setup_bare_gitlab_credentials
+    [ -n "$GITHUB_TOKEN" ] && setup_bare_github_credentials
+}
+
 repo_name_from_url() {
     local u="${1%/}"
     u="${u##*[:/]}"
@@ -253,20 +278,7 @@ repo_name_from_url() {
 }
 
 # --- 凭据配置（clone 前）----------------------------------------------------
-if [ -n "$GIT_REPOS" ]; then
-    IFS=',' read -ra _entries <<< "$GIT_REPOS"
-    for _entry in "${_entries[@]}"; do
-        [ -n "$_entry" ] || continue
-        IFS='|' read -r _name _url _branch <<< "$_entry"
-        [ -n "$_url" ] && setup_repo_credentials "$_url"
-    done
-    unset _entries _entry _name _url _branch
-elif [ -n "$GIT_CLONE_URL" ]; then
-    setup_repo_credentials "$GIT_CLONE_URL"
-else
-    [ -n "$GITLAB_TOKEN" ] && setup_bare_gitlab_credentials
-    [ -n "$GITHUB_TOKEN" ] && setup_bare_github_credentials
-fi
+configure_git_credentials
 
 # 配置 Git 用户信息（通用中性默认，可由环境变量覆盖）
 GIT_USER_EMAIL=${GIT_USER_EMAIL:-sandbox@localhost}

--- a/sandbox-gateway/scripts/test-git-auth.sh
+++ b/sandbox-gateway/scripts/test-git-auth.sh
@@ -6,9 +6,9 @@ STARTUP="$ROOT/sandbox/scripts/startup.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-# Extract helpers from repo_host through setup_bare_github_credentials (inclusive).
-START=$(grep -n '^repo_host()' "$STARTUP" | head -1 | cut -d: -f1)
-END=$(awk -v s="$START" 'NR>s && /^setup_repo_credentials\(\)/ {print NR-1; exit}' "$STARTUP")
+# Extract helpers from repo_scheme through configure_git_credentials (inclusive).
+START=$(grep -n '^repo_scheme()' "$STARTUP" | head -1 | cut -d: -f1)
+END=$(awk -v s="$START" 'NR>s && /^repo_name_from_url\(\)/ {print NR-1; exit}' "$STARTUP")
 sed -n "${START},${END}p" "$STARTUP" >"$TMP/git-auth.sh"
 
 # HOME-scoped mocks so we never touch the real ~/.config/gh or git creds.
@@ -104,5 +104,55 @@ grep -q 'x-access-token:still_ok@github.com' "$TMP/root/.git-credentials"
 grep -q 'argv:auth login --hostname github.com --with-token' "$HOME/gh.last"
 unset FAIL_GH
 echo "OK: gh auth failure is non-fatal for HTTPS creds"
+
+# Dual tokens: cloning GitLab still configures GitHub.
+rm -f "$HOME/gh.last" "$HOME/gh.token" "$HOME/glab.last" "$TMP/root/.git-credentials"
+GITHUB_TOKEN="gh_dual"
+GITLAB_TOKEN="gl_dual"
+GITHUB_URL=""
+GITLAB_URL="https://gitlab.com"
+GIT_REPOS="proj|https://gitlab.com/group/project.git|main"
+GIT_CLONE_URL=""
+_GIT_CRED_RESET=0
+configure_git_credentials
+grep -q 'oauth2:gl_dual@gitlab.com' "$TMP/root/.git-credentials"
+grep -q 'x-access-token:gh_dual@github.com' "$TMP/root/.git-credentials"
+grep -q 'argv:auth login --hostname gitlab.com --token gl_dual' "$HOME/glab.last"
+grep -q 'argv:auth login --hostname github.com --with-token' "$HOME/gh.last"
+echo "OK: dual tokens + GitLab clone configures both platforms"
+
+# Dual tokens: cloning GitHub still configures GitLab.
+rm -f "$HOME/gh.last" "$HOME/gh.token" "$HOME/glab.last" "$TMP/root/.git-credentials"
+GITHUB_TOKEN="gh_dual"
+GITLAB_TOKEN="gl_dual"
+GITHUB_URL=""
+GITLAB_URL=""
+GIT_REPOS="app|https://github.com/acme/app.git|main"
+GIT_CLONE_URL=""
+_GIT_CRED_RESET=0
+configure_git_credentials
+grep -q 'x-access-token:gh_dual@github.com' "$TMP/root/.git-credentials"
+grep -q 'oauth2:gl_dual@gitlab.com' "$TMP/root/.git-credentials"
+grep -q 'argv:auth login --hostname github.com --with-token' "$HOME/gh.last"
+grep -q 'argv:auth login --hostname gitlab.com --token gl_dual' "$HOME/glab.last"
+echo "OK: dual tokens + GitHub clone configures both platforms"
+
+# Mis-derived GITLAB_URL=https://github.com must not write GitLab token onto github.com.
+rm -f "$HOME/gh.last" "$HOME/gh.token" "$HOME/glab.last" "$TMP/root/.git-credentials"
+GITHUB_TOKEN="gh_dual"
+GITLAB_TOKEN="gl_dual"
+GITHUB_URL=""
+GITLAB_URL="https://github.com"
+GIT_REPOS="app|https://github.com/acme/app.git|main"
+GIT_CLONE_URL=""
+_GIT_CRED_RESET=0
+configure_git_credentials
+grep -q 'x-access-token:gh_dual@github.com' "$TMP/root/.git-credentials"
+grep -q 'oauth2:gl_dual@gitlab.com' "$TMP/root/.git-credentials"
+if grep -q 'oauth2:.*@github.com' "$TMP/root/.git-credentials"; then
+  echo "FAIL: GitLab token must not be written onto github.com" >&2
+  exit 1
+fi
+echo "OK: mis-derived GITLAB_URL=https://github.com falls back to gitlab.com"
 
 echo "OK: git auth unit smoke passed"

--- a/server/README.md
+++ b/server/README.md
@@ -338,5 +338,6 @@ Gitea/Bitbucket/Codeberg 等 **HTTPS 不支持 Token 注入**,请改用 SSH。`s
 
 例如在 `go-backend` Agent 元信息里配置 `{"GIT_REPOS":"${vars.repos}","GITLAB_TOKEN":"glpat_xxx","GITLAB_URL":"https://git.example.com"}`。
 run 执行时这些环境变量按 run 注入(kind-agnostic)沙箱用于 clone/push;`GITLAB_URL` 未显式配置
-且 `GITLAB_TOKEN` 已配时由 `repos[0].url` 自动推导(scheme+host,见 `gitBaseURL`)。平台进程本身不持有任何
+且首仓确为 GitLab(非 github.com / 非 `GITHUB_URL` host)时由 `repos[0].url` 自动推导(scheme+host,见 `gitBaseURL`)。
+沙箱启动时只要配置了 `GITHUB_TOKEN` / `GITLAB_TOKEN` 就会两边都注入凭据并登录 `gh` / `glab`。平台进程本身不持有任何
 全局 Git 凭证。`detect_push` + `create_mr` 仅对 GitLab 仓库(含 `GITLAB_URL` 匹配的自建实例)调用 glab;非 GitLab 输出 `pushed`/`branch`/`pushed_sha`,`mr_url` 为空。

--- a/server/internal/runtime/acp_repos.go
+++ b/server/internal/runtime/acp_repos.go
@@ -12,8 +12,9 @@ import (
 )
 
 // gitBaseURL returns the scheme://host origin of an http(s) repo URL, used to
-// derive GITLAB_URL (the git credential host) from repo_url. Returns "" for
-// non-http URLs (e.g. ssh git@host:…) or unparseable input.
+// derive GITLAB_URL (the git credential host) from a GitLab repo_url. Returns ""
+// for non-http URLs (e.g. ssh git@host:…) or unparseable input. GitHub hosts are
+// skipped by spec() so a GitHub first-repo cannot become GITLAB_URL.
 func gitBaseURL(repo string) string {
 	u, err := url.Parse(strings.TrimSpace(repo))
 	if err != nil || u.Host == "" {

--- a/server/internal/runtime/acp_sandbox.go
+++ b/server/internal/runtime/acp_sandbox.go
@@ -319,8 +319,15 @@ func (c *acpProvider) spec(req NodeReq) (sandbox.Spec, error) {
 	}
 
 	if len(repos) > 0 && env["GITLAB_URL"] == "" {
-		if base := gitBaseURL(repos[0].URL); base != "" {
-			env["GITLAB_URL"] = base
+		url := repos[0].URL
+		host := gitRepoHost(url)
+		ghe := gitRepoHost(env["GITHUB_URL"])
+		// Do not treat a GitHub / GHE clone URL as GITLAB_URL (would inject
+		// oauth2:GITLAB_TOKEN@github.com when both tokens are configured).
+		if host != "" && host != "github.com" && (ghe == "" || host != ghe) {
+			if base := gitBaseURL(url); base != "" {
+				env["GITLAB_URL"] = base
+			}
 		}
 	}
 	layout := c.agentLayout(profile, agentCfg)

--- a/server/internal/runtime/acp_unit_test.go
+++ b/server/internal/runtime/acp_unit_test.go
@@ -641,6 +641,23 @@ func TestAgentConfigAndMCP(t *testing.T) {
 	removeHome(sp.ConfigHome)
 }
 
+func TestSpecDoesNotDeriveGitLabURLFromGitHubRepo(t *testing.T) {
+	root := writeAgent(t, "dev", `{"env":{"GITHUB_TOKEN":"gh","GITLAB_TOKEN":"gl","APPROVING_CURSOR_API_KEY":"test-key"}}`)
+	host := mcp.NewHost(newMemStore())
+	p := newACPProvider(host, Options{ProfilesRoot: root}).(*acpProvider)
+	req := NodeReq{RunID: "run-gh", NodeID: "n", Token: "tkn", NodeType: "agent",
+		Config: map[string]any{"skill_profile": "dev"}, Vars: map[string]any{"repos": `[{"name":"app","url":"https://github.com/acme/app.git"}]`}}
+
+	sp, err := p.spec(req)
+	if err != nil {
+		t.Fatalf("spec: %v", err)
+	}
+	if got := sp.Env["GITLAB_URL"]; got != "" {
+		t.Errorf("GITLAB_URL should not be derived from a GitHub repo, got %q", got)
+	}
+	removeHome(sp.ConfigHome)
+}
+
 func TestWorkspaceWorkDirSrc(t *testing.T) {
 	root := t.TempDir()
 	profile := "dev"


### PR DESCRIPTION
## Summary
- 沙箱启动时只要配置了 `GITHUB_TOKEN` / `GITLAB_TOKEN`，就会同时写入两边凭据并登录 `gh` / `glab`，不再只按当前 clone 仓库的 host 配一边（没有仓库时同样会配置）。
- `GITLAB_URL` 为空时默认 `gitlab.com`；若被误设成 GitHub / GHE host 则回退，避免把 GitLab token 写到 GitHub。
- 服务端不再从 GitHub 首仓推导 `GITLAB_URL`；补充双 token 与 `spec()` 用例。

## Test plan
- [x] `sandbox-gateway/scripts/test-git-auth.sh`（含双 token 只拉 GitLab / 只拉 GitHub / 错误推导 `GITLAB_URL`）
- [x] `go test ./internal/runtime/ -run 'TestAgentConfigAndMCP|TestSpecDoesNotDeriveGitLabURLFromGitHubRepo|TestPureHelpers'`
- [ ] 重建沙箱镜像后，同时配置两个 token、只拉一边仓库，确认 `gh` / `glab` 都已登录
- [ ] 不配仓库、只配两个 token，确认两边凭据仍会注入


Made with [Cursor](https://cursor.com)