### PR TITLE
feat(agent-studio): default org tree collapsed with selected-path expand

### DIFF
--- a/web/src/components/agent/AgentOrgSidebar.test.ts
+++ b/web/src/components/agent/AgentOrgSidebar.test.ts
@@ -31,7 +31,11 @@ const agentNames = ['alice', 'bob', ...Array.from({ length: 10 }, (_, i) => `qa$
 function mountSidebar(
   org: AgentOrg = sampleOrg,
   teleport = false,
-  extra: { agents?: { name: string; projectId?: string }[]; projects?: { id: string; name: string }[] } = {},
+  extra: {
+    agents?: { name: string; projectId?: string }[]
+    projects?: { id: string; name: string }[]
+    activeName?: string
+  } = {},
 ) {
   const i18n = createI18n({
     legacy: false,
@@ -42,7 +46,7 @@ function mountSidebar(
     props: {
       org,
       agentNames,
-      activeName: '',
+      activeName: extra.activeName ?? '',
       collapsed: false,
       agents: extra.agents,
       projects: extra.projects,
@@ -109,8 +113,10 @@ describe('AgentOrgSidebar two-column right-edge count layout', () => {
     wrapper.unmount()
   })
 
-  it('depth 缩进只作用在左侧 main，count 列不受 paddingLeft', () => {
+  it('depth 缩进只作用在左侧 main，count 列不受 paddingLeft', async () => {
     const wrapper = mountSidebar()
+    const dev = wrapper.findAll('[data-org-kind="group"]').find((r) => r.text().includes('开发部门'))!
+    await dev.find('[data-org-toggle]').trigger('click')
     const nested = wrapper
       .findAll('[data-org-kind="group"]')
       .find((r) => r.attributes('data-org-depth') === '1')
@@ -123,7 +129,7 @@ describe('AgentOrgSidebar two-column right-edge count layout', () => {
     expect((nested!.element as HTMLElement).getAttribute('style') || '').not.toMatch(/padding-left/)
   })
 
-  it('根组、嵌套子组与未分组计数右齐且支持三位数左扩', () => {
+  it('根组、嵌套子组与未分组计数右齐且支持三位数左扩', async () => {
     const orgWithTriple: AgentOrg = {
       ...sampleOrg,
       agents: {
@@ -146,7 +152,7 @@ describe('AgentOrgSidebar two-column right-edge count layout', () => {
       props: {
         org: orgWithTriple,
         agentNames: names,
-        activeName: '',
+        activeName: 'bob',
         collapsed: false,
       },
       global: {
@@ -190,18 +196,21 @@ describe('AgentOrgSidebar two-column right-edge count layout', () => {
 
   it('折叠入口仍可用，且无 hover 操作按钮', async () => {
     const wrapper = mountSidebar()
-    const group = wrapper.findAll('[data-org-kind="group"]')[0]
+    const group = wrapper
+      .findAll('[data-org-kind="group"]')
+      .find((r) => r.text().includes('开发部门'))!
     expect(group.find('[data-org-actions]').exists()).toBe(false)
     expect(group.findAll('button').filter((b) => b.attributes('data-org-toggle') !== undefined).length).toBe(1)
 
+    expect(wrapper.findAll('[data-org-kind="group"]').some((r) => r.text().includes('前端组'))).toBe(false)
     await group.find('[data-org-toggle]').trigger('click')
-    expect(wrapper.findAll('[data-org-kind="group"]').some((r) => r.text().includes('前端组'))).toBe(
-      false,
-    )
+    expect(wrapper.findAll('[data-org-kind="group"]').some((r) => r.text().includes('前端组'))).toBe(true)
+    await group.find('[data-org-toggle]').trigger('click')
+    expect(wrapper.findAll('[data-org-kind="group"]').some((r) => r.text().includes('前端组'))).toBe(false)
   })
 
   it('叶子行无计数徽章、无 hover 操作，仍可选中/拖拽', async () => {
-    const wrapper = mountSidebar()
+    const wrapper = mountSidebar(sampleOrg, false, { activeName: 'bob' })
     const leaf = wrapper.find('[data-org-kind="agent"]')
     expect(leaf.exists()).toBe(true)
     expect(leaf.find('[data-org-count]').exists()).toBe(false)
@@ -215,7 +224,7 @@ describe('AgentOrgSidebar two-column right-edge count layout', () => {
   })
 
   it('拖拽 agent 到未分组头可发出 move-agent', async () => {
-    const wrapper = mountSidebar()
+    const wrapper = mountSidebar(sampleOrg, false, { activeName: 'bob' })
     const leaf = wrapper.find('[data-org-kind="agent"]')
     const dragBtn = leaf.find('button[draggable="true"]')
     await dragBtn.trigger('dragstart', {
@@ -278,7 +287,7 @@ describe('AgentOrgSidebar context menus', () => {
   })
 
   it('叶子行与未分组头不出现指定项目', async () => {
-    const wrapper = mountSidebar(sampleOrg, true)
+    const wrapper = mountSidebar(sampleOrg, true, { activeName: 'bob' })
     const leaf = findAgentRow(wrapper, 'bob')!
     expect(leaf).toBeTruthy()
     await leaf.trigger('contextmenu', { clientX: 20, clientY: 30 })
@@ -298,7 +307,7 @@ describe('AgentOrgSidebar context menus', () => {
   })
 
   it('已分组 Agent 菜单含重命名直达管理与移出本组', async () => {
-    const wrapper = mountSidebar(sampleOrg, true)
+    const wrapper = mountSidebar(sampleOrg, true, { activeName: 'bob' })
     const leaf = findAgentRow(wrapper, 'bob')!
     await leaf.trigger('contextmenu', { clientX: 20, clientY: 30 })
 
@@ -320,7 +329,7 @@ describe('AgentOrgSidebar context menus', () => {
   })
 
   it('未分组 Agent 菜单仅重命名（前往管理）', async () => {
-    const wrapper = mountSidebar(sampleOrg, true)
+    const wrapper = mountSidebar(sampleOrg, true, { activeName: 'orphan' })
     const leaf = findAgentRow(wrapper, 'orphan')!
     expect(leaf).toBeTruthy()
     await leaf.trigger('contextmenu', { clientX: 20, clientY: 30 })
@@ -334,7 +343,7 @@ describe('AgentOrgSidebar context menus', () => {
   })
 
   it('移出本组发出 remove-from-group', async () => {
-    const wrapper = mountSidebar(sampleOrg, true)
+    const wrapper = mountSidebar(sampleOrg, true, { activeName: 'alice' })
     const leaf = findAgentRow(wrapper, 'alice')!
     await leaf.trigger('contextmenu', { clientX: 20, clientY: 30 })
     const removeBtn = document.querySelector(
@@ -455,7 +464,7 @@ describe('AgentOrgSidebar agent name text color', () => {
   })
 
   it('分组名保持 text-txt2，有 parentAgent 时树内不渲染 reportsTo', () => {
-    const wrapper = mountSidebar()
+    const wrapper = mountSidebar(sampleOrg, false, { activeName: 'bob' })
 
     const group = wrapper
       .findAll('[data-org-kind="group"]')
@@ -483,8 +492,9 @@ describe('AgentOrgSidebar agent name text color', () => {
 })
 
 describe('AgentOrgSidebar project bracket', () => {
-  it('递归成员同项目时双 span 显示括号，徽章仍为直接成员数', () => {
+  it('递归成员同项目时双 span 显示括号，徽章仍为直接成员数', async () => {
     const wrapper = mountSidebar(sampleOrg, false, {
+      activeName: 'bob',
       agents: [
         { name: 'alice', projectId: 'github' },
         { name: 'bob', projectId: 'github' },
@@ -523,7 +533,7 @@ describe('AgentOrgSidebar project bracket', () => {
     expect(wrapper.find('[data-org-kind="agent"] [data-org-project]').exists()).toBe(false)
   })
 
-  it('空组/全未绑/混合不显示括号也不显示空括号', () => {
+  it('空组/全未绑/混合不显示括号也不显示空括号', async () => {
     const org: AgentOrg = {
       revision: 1,
       groups: [
@@ -538,6 +548,7 @@ describe('AgentOrgSidebar project bracket', () => {
       },
     }
     const wrapper = mountSidebar(org, false, {
+      activeName: 'alice',
       agents: [
         { name: 'scout', projectId: '' },
         { name: 'alice', projectId: 'github' },
@@ -553,5 +564,40 @@ describe('AgentOrgSidebar project bracket', () => {
       expect(row.find('[data-org-project]').exists()).toBe(false)
       expect(row.text()).not.toMatch(/\(\)/)
     }
+  })
+})
+
+describe('AgentOrgSidebar default collapsed', () => {
+  it('无选中时默认仅展示分组行与未分组头，不渲染 Agent 子行', () => {
+    const wrapper = mountSidebar()
+    expect(wrapper.findAll('[data-org-kind="group"]').length).toBeGreaterThan(0)
+    expect(wrapper.find('[data-org-kind="ungrouped-header"]').exists()).toBe(true)
+    expect(wrapper.findAll('[data-org-kind="agent"]').length).toBe(0)
+  })
+
+  it('选中 Agent 时展开祖先路径并高亮，其它分支仍折叠', () => {
+    const wrapper = mountSidebar(sampleOrg, false, { activeName: 'bob' })
+    expect(findAgentRow(wrapper, 'bob')).toBeTruthy()
+    expect(wrapper.findAll('[data-org-kind="group"]').some((r) => r.text().includes('测试部门'))).toBe(true)
+    expect(findAgentRow(wrapper, 'qa0')).toBeFalsy()
+    const bobRow = findAgentRow(wrapper, 'bob')!
+    expect(bobRow.classes()).toContain('bg-accent-dim')
+  })
+
+  it('组织新增分组时默认折叠且保留已展开节点', async () => {
+    const wrapper = mountSidebar()
+    const dev = wrapper.findAll('[data-org-kind="group"]').find((r) => r.text().includes('开发部门'))!
+    await dev.find('[data-org-toggle]').trigger('click')
+    expect(wrapper.findAll('[data-org-kind="group"]').some((r) => r.text().includes('前端组'))).toBe(true)
+
+    const nextOrg: AgentOrg = {
+      ...sampleOrg,
+      groups: [...sampleOrg.groups!, { id: 'g_new', name: '新项目组' }],
+    }
+    await wrapper.setProps({ org: nextOrg })
+    expect(wrapper.findAll('[data-org-kind="group"]').some((r) => r.text().includes('新项目组'))).toBe(true)
+    expect(wrapper.findAll('[data-org-kind="group"]').some((r) => r.text().includes('前端组'))).toBe(true)
+    expect(findAgentRow(wrapper, 'alice')).toBeTruthy()
+    expect(findAgentRow(wrapper, 'bob')).toBeFalsy()
   })
 })

--- a/web/src/components/agent/AgentOrgSidebar.vue
+++ b/web/src/components/agent/AgentOrgSidebar.vue
@@ -5,7 +5,11 @@ import Icon from '@/components/ui/Icon.vue'
 import type { AgentOrg } from '@/lib/api/api'
 import {
   UNGROUPED_ID,
+  allGroupCollapseIds,
+  ancestorGroupIdsForAgent,
+  buildDefaultCollapsedSet,
   buildOrgTreeRows,
+  mergeCollapsedWithOrgChange,
   type AgentProjectRef,
   type OrgTreeRow,
   type ProjectNameRef,
@@ -40,7 +44,10 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
-const collapsedNodes = ref<Set<string>>(new Set())
+const collapsedNodes = ref<Set<string>>(
+  buildDefaultCollapsedSet(props.org, props.activeName ? [props.activeName] : []),
+)
+const knownGroupIds = ref<Set<string>>(new Set([...allGroupCollapseIds(props.org)]))
 const dragOverKey = ref('')
 const dragging = ref<{ kind: 'group' | 'agent'; id: string; sourceGroupId?: string } | null>(null)
 
@@ -69,9 +76,25 @@ const rows = computed(() =>
 )
 
 watch(
-  () => props.org.groups?.map((g) => g.id).join(','),
+  () => (props.org.groups || []).map((g) => g.id).join(','),
   () => {
-    // Expand new roots by default; keep prior collapse state for known ids.
+    collapsedNodes.value = mergeCollapsedWithOrgChange(
+      props.org,
+      collapsedNodes.value,
+      knownGroupIds.value,
+      props.activeName ? [props.activeName] : [],
+    )
+    knownGroupIds.value = new Set([...allGroupCollapseIds(props.org)])
+  },
+)
+
+watch(
+  () => props.activeName,
+  (name) => {
+    if (!name) return
+    const next = new Set(collapsedNodes.value)
+    for (const id of ancestorGroupIdsForAgent(props.org, name)) next.delete(id)
+    collapsedNodes.value = next
   },
 )
 

--- a/web/src/lib/agent/agentOrg.test.ts
+++ b/web/src/lib/agent/agentOrg.test.ts
@@ -4,16 +4,21 @@ import {
   applyMoveAgent,
   applyRemoveAgentFromGroup,
   assignNeedsDraftConfirm,
+  allGroupCollapseIds,
+  ancestorGroupIdsForAgent,
+  buildDefaultCollapsedSet,
   buildOrgTreeRows,
   classifyAssignTargets,
   groupPath,
   groupProjectLabel,
+  mergeCollapsedWithOrgChange,
   recursiveMemberNames,
   shouldSyncDraftAfterAssign,
   unifiedProjectId,
   wouldCreateGroupCycle,
   wouldCreateReportingCycle,
   setAgentMembership,
+  UNGROUPED_ID,
 } from './agentOrg'
 import type { AgentOrg } from '../api/api'
 
@@ -78,6 +83,40 @@ describe('agentOrg helpers', () => {
     expect(rows.some((r) => r.kind === 'agent' && r.name === 'alice' && r.multi)).toBe(true)
     expect(rows.some((r) => r.kind === 'ungrouped-header')).toBe(true)
     expect(rows.some((r) => r.kind === 'agent' && r.name === 'carol' && r.groupId === '__ungrouped__')).toBe(true)
+  })
+
+  it('default collapsed set folds all groups; selected agent expands ancestor path', () => {
+    const all = allGroupCollapseIds(sample)
+    expect(all.has('eng')).toBe(true)
+    expect(all.has(UNGROUPED_ID)).toBe(true)
+
+    const ancestors = ancestorGroupIdsForAgent(sample, 'bob')
+    expect(ancestors.has('des')).toBe(true)
+    expect(ancestors.has('eng')).toBe(true)
+
+    const collapsed = buildDefaultCollapsedSet(sample, ['bob'])
+    expect(collapsed.has('eng')).toBe(false)
+    expect(collapsed.has('des')).toBe(false)
+    expect(collapsed.has('prod')).toBe(true)
+
+    const rows = buildOrgTreeRows(sample, ['alice', 'bob', 'carol'], collapsed)
+    expect(rows.some((r) => r.kind === 'agent' && r.name === 'bob')).toBe(true)
+    expect(rows.some((r) => r.kind === 'agent' && r.name === 'carol')).toBe(false)
+    expect(rows.some((r) => r.kind === 'group' && r.id === 'prod' && r.collapsed)).toBe(true)
+  })
+
+  it('mergeCollapsedWithOrgChange keeps expanded known ids and folds new groups', () => {
+    const known = new Set(['eng', 'des', 'prod', UNGROUPED_ID])
+    const prevCollapsed = new Set(['eng', 'prod', UNGROUPED_ID])
+    const expandedOrg: AgentOrg = {
+      ...sample,
+      groups: [...sample.groups!, { id: 'new_root', name: '新组' }],
+    }
+    const merged = mergeCollapsedWithOrgChange(expandedOrg, prevCollapsed, known)
+    expect(merged.has('eng')).toBe(true)
+    expect(merged.has('des')).toBe(false)
+    expect(merged.has('new_root')).toBe(true)
+    expect(merged.has(UNGROUPED_ID)).toBe(true)
   })
 })
 

--- a/web/src/lib/agent/agentOrg.ts
+++ b/web/src/lib/agent/agentOrg.ts
@@ -349,6 +349,76 @@ export type OrgTreeRow =
       collapsed: boolean
     }
 
+/** All virtual-group ids plus UNGROUPED_ID — default collapsed set for a fresh org tree. */
+export function allGroupCollapseIds(org: AgentOrg): Set<string> {
+  const ids = new Set<string>()
+  for (const g of org.groups || []) ids.add(g.id)
+  ids.add(UNGROUPED_ID)
+  return ids
+}
+
+/**
+ * Ancestor group ids (including direct memberships) that must be expanded
+ * for an agent row to appear in the org tree.
+ */
+export function ancestorGroupIdsForAgent(org: AgentOrg, agentName: string): Set<string> {
+  const byId = groupById(org)
+  const out = new Set<string>()
+  const gids = groupIdsOf(org, agentName)
+  if (!gids.length) {
+    out.add(UNGROUPED_ID)
+    return out
+  }
+  for (const start of gids) {
+    let cur: string | undefined = start
+    const seen = new Set<string>()
+    while (cur && byId.has(cur) && !seen.has(cur)) {
+      seen.add(cur)
+      out.add(cur)
+      cur = byId.get(cur)!.parentGroupId || undefined
+    }
+  }
+  return out
+}
+
+/** Session-default collapsed set: all groups folded; optional agents' paths expanded. */
+export function buildDefaultCollapsedSet(org: AgentOrg, expandAgentNames?: string[]): Set<string> {
+  const collapsed = allGroupCollapseIds(org)
+  if (!expandAgentNames?.length) return collapsed
+  for (const name of expandAgentNames) {
+    if (!name) continue
+    for (const id of ancestorGroupIdsForAgent(org, name)) collapsed.delete(id)
+  }
+  return collapsed
+}
+
+/**
+ * After org structure changes: new ids default collapsed; known ids keep user toggle;
+ * optional agents' ancestor paths stay expanded.
+ */
+export function mergeCollapsedWithOrgChange(
+  org: AgentOrg,
+  prevCollapsed: Set<string>,
+  prevKnownIds: Set<string>,
+  expandAgentNames?: string[],
+): Set<string> {
+  const next = new Set<string>()
+  for (const id of allGroupCollapseIds(org)) {
+    if (prevKnownIds.has(id)) {
+      if (prevCollapsed.has(id)) next.add(id)
+    } else {
+      next.add(id)
+    }
+  }
+  if (expandAgentNames?.length) {
+    for (const name of expandAgentNames) {
+      if (!name) continue
+      for (const id of ancestorGroupIdsForAgent(org, name)) next.delete(id)
+    }
+  }
+  return next
+}
+
 export function buildOrgTreeRows(
   org: AgentOrg,
   agentNames: string[],

--- a/web/src/lib/agent/useAgentStudio.ts
+++ b/web/src/lib/agent/useAgentStudio.ts
@@ -14,6 +14,8 @@ import {
   applyRemoveAgentFromGroup, wouldCreateGroupCycle, buildOrgTreeRows,
   recursiveMemberNames, classifyAssignTargets, assignNeedsDraftConfirm,
   shouldSyncDraftAfterAssign, isAgentInGroupSubtree, UNGROUPED_ID,
+  allGroupCollapseIds, ancestorGroupIdsForAgent, buildDefaultCollapsedSet,
+  mergeCollapsedWithOrgChange,
 } from '@/lib/agent/agentOrg'
 import { downloadZip, validateAgentName, normalizeAgentName } from '@/lib/agent/agentIO'
 import { AGENT_SETTINGS_PATH } from '@/lib/agent/agentCreateWizard'
@@ -105,6 +107,30 @@ function closeMobileChromeOverlays() {
 /** Narrow-screen agent org tree bottom sheet (≈70vh). */
 const showOrgSheet = ref(false)
 const orgSheetCollapsed = ref<Set<string>>(new Set())
+const orgSheetKnownIds = ref<Set<string>>(new Set())
+
+function expandAgentsForOrgSheet(names: string[]): string[] {
+  const out = names.filter(Boolean)
+  if (manageFocusAgent.value && !out.includes(manageFocusAgent.value)) {
+    out.push(manageFocusAgent.value)
+  }
+  return out
+}
+
+function syncOrgSheetCollapsedFromOrg(expandNames?: string[]) {
+  const names = expandAgentsForOrgSheet(expandNames || [activeName.value])
+  if (orgSheetKnownIds.value.size === 0) {
+    orgSheetCollapsed.value = buildDefaultCollapsedSet(org.value, names)
+  } else {
+    orgSheetCollapsed.value = mergeCollapsedWithOrgChange(
+      org.value,
+      orgSheetCollapsed.value,
+      orgSheetKnownIds.value,
+      names,
+    )
+  }
+  orgSheetKnownIds.value = new Set([...allGroupCollapseIds(org.value)])
+}
 
 type LeaveConfirmCfg = {
   title: string
@@ -562,6 +588,7 @@ async function reloadOrg() {
     if (!o.groups) o.groups = []
     org.value = o
     orgBaseline.value = orgSnapshot(o)
+    syncOrgSheetCollapsedFromOrg()
   } catch (e: any) {
     error.value = String(e?.message || e)
   }
@@ -795,6 +822,7 @@ async function load() {
     if (!org.value.agents) org.value.agents = {}
     if (!org.value.groups) org.value.groups = []
     orgBaseline.value = orgSnapshot(org.value)
+    syncOrgSheetCollapsedFromOrg()
     applyingStudioQuery = true
     try {
       const qAgent = typeof route.query.agent === 'string' ? route.query.agent.trim() : ''
@@ -1275,6 +1303,19 @@ function onChromeKeydown(e: KeyboardEvent) {
 watch(activeName, () => {
   closeFullNameTip()
   nextTick(measureAgentNameTruncation)
+})
+
+watch(
+  () => (org.value.groups || []).map((g) => g.id).join(','),
+  () => syncOrgSheetCollapsedFromOrg(),
+)
+
+watch([activeName, manageFocusAgent], () => {
+  const next = new Set(orgSheetCollapsed.value)
+  for (const name of expandAgentsForOrgSheet([activeName.value])) {
+    for (const id of ancestorGroupIdsForAgent(org.value, name)) next.delete(id)
+  }
+  orgSheetCollapsed.value = next
 })
 
 watch(tabStripEl, () => {

--- a/web/src/views/AgentStudioView.test.ts
+++ b/web/src/views/AgentStudioView.test.ts
@@ -1115,6 +1115,13 @@ describe('AgentStudio mobile core path', () => {
     expect(sheet!.textContent).toContain('工程部')
     expect(sheet!.textContent).toContain('未分组')
     expect(sheet!.textContent).toContain('alpha')
+    expect(sheet!.textContent).not.toContain('beta')
+
+    const ugBtn = sheet!.querySelector(
+      '[data-org-kind="ungrouped-header"] button',
+    ) as HTMLElement | null
+    ugBtn?.click()
+    await flushPromises()
     expect(sheet!.textContent).toContain('beta')
 
     // Agent 叶子名称主文字色契约（选中/未选中均 text-txt，非灰）


### PR DESCRIPTION
Enter /agents with all group nodes folded; expand ancestor paths for the
active agent and preserve manual toggles when org structure changes. Align
narrow-screen org sheet with the same collapse semantics.

Co-authored-by: Cursor <cursoragent@cursor.com>
