### PR TITLE
feat(approve): 可配置超时，默认 30 分钟

### DIFF
--- a/server/internal/runtime/acp_provider.go
+++ b/server/internal/runtime/acp_provider.go
@@ -201,15 +201,16 @@ func (c *acpProvider) chatTimeout() time.Duration {
 // implement) get more headroom than a quick research. Two override keys are
 // accepted: the editor card field `timeout` (minutes) and the legacy
 // `chat_timeout` (seconds); `chat_timeout` wins when both are set.
-// Approve has no timeout field; leftover config is ignored.
+// Approve with neither key defaults to 30 minutes (not the global 10).
 func (c *acpProvider) nodeChatTimeout(req NodeReq) time.Duration {
-	if req.NodeType != "approve" {
-		if v, ok := toInt(req.Config["chat_timeout"]); ok && v > 0 {
-			return time.Duration(v) * time.Second
-		}
-		if v, ok := toInt(req.Config["timeout"]); ok && v > 0 {
-			return time.Duration(v) * time.Minute
-		}
+	if v, ok := toInt(req.Config["chat_timeout"]); ok && v > 0 {
+		return time.Duration(v) * time.Second
+	}
+	if v, ok := toInt(req.Config["timeout"]); ok && v > 0 {
+		return time.Duration(v) * time.Minute
+	}
+	if req.NodeType == "approve" {
+		return 30 * time.Minute
 	}
 	return c.chatTimeout()
 }

--- a/server/internal/runtime/retry_test.go
+++ b/server/internal/runtime/retry_test.go
@@ -75,9 +75,16 @@ func TestNodeChatTimeout(t *testing.T) {
 	if d := c.nodeChatTimeout(both); d != 300*time.Second {
 		t.Errorf("chat_timeout should win = %v, want 300s", d)
 	}
-	approve := NodeReq{NodeType: "approve", Config: map[string]any{"timeout": 20, "chat_timeout": 300}}
-	if d := c.nodeChatTimeout(approve); d != 90*time.Second {
-		t.Errorf("approve leftover timeout must fall back to global = %v, want 90s", d)
+	approve := NodeReq{NodeType: "approve", Config: map[string]any{"timeout": 20}}
+	if d := c.nodeChatTimeout(approve); d != 20*time.Minute {
+		t.Errorf("approve timeout(min) = %v, want 20m", d)
+	}
+	approveChat := NodeReq{NodeType: "approve", Config: map[string]any{"chat_timeout": 300}}
+	if d := c.nodeChatTimeout(approveChat); d != 300*time.Second {
+		t.Errorf("approve chat_timeout = %v, want 300s", d)
+	}
+	if d := c.nodeChatTimeout(NodeReq{NodeType: "approve"}); d != 30*time.Minute {
+		t.Errorf("approve empty config = %v, want 30m", d)
 	}
 }
 

--- a/web/src/data/nodeRegistry.approve.test.ts
+++ b/web/src/data/nodeRegistry.approve.test.ts
@@ -3,13 +3,13 @@ import { NODE_DEFS } from './nodeRegistry'
 import { productOutputDefs } from '@/lib/run/productNodeArtifacts'
 
 describe('approve node inspector', () => {
-  it('only configures skill_profile', () => {
-    expect(NODE_DEFS.approve.fields.map((f) => f.key)).toEqual(['skill_profile'])
-    expect(NODE_DEFS.approve.defaults).toEqual({})
+  it('configures skill_profile and timeout', () => {
+    expect(NODE_DEFS.approve.fields.map((f) => f.key)).toEqual(['skill_profile', 'timeout'])
+    expect(NODE_DEFS.approve.defaults).toEqual({ timeout: 30 })
   })
 
   it('has no leftover inspector knobs', () => {
-    for (const key of ['prompt', 'max_rounds', 'auto_var', 'timeout', 'conditional_prompt']) {
+    for (const key of ['prompt', 'max_rounds', 'auto_var', 'conditional_prompt']) {
       expect(NODE_DEFS.approve.fields.some((f) => f.key === key)).toBe(false)
       expect(NODE_DEFS.approve.defaults?.[key]).toBeUndefined()
     }

--- a/web/src/data/nodeRegistry.ts
+++ b/web/src/data/nodeRegistry.ts
@@ -70,11 +70,12 @@ export const NODE_DEFS: Record<NodeType, NodeTypeDef> = {
     category: 'nodes.categories.agent',
     fields: [
       { key: 'skill_profile', label: 'nodes.approve.fields.skill_profile.label', type: 'select' },
+      { key: 'timeout', label: 'nodes.approve.fields.timeout.label', type: 'duration', optional: true },
     ],
     outputs: productOutputDefs('approve', [
       { key: 'transcript', desc: 'nodes.approve.outputs.transcript.desc' },
     ]),
-    defaults: {},
+    defaults: { timeout: 30 },
     help: 'nodes.approve.help',
   },
   agent: {

--- a/web/src/locales/en/nodes.json
+++ b/web/src/locales/en/nodes.json
@@ -95,6 +95,9 @@
       "fields": {
         "skill_profile": {
           "label": "Agent (user-defined · Agent Studio)"
+        },
+        "timeout": {
+          "label": "Timeout (minutes)"
         }
       },
       "outputs": {
@@ -129,7 +132,7 @@
           "desc": "Full conversation transcript"
         }
       },
-      "help": "### Approve\n\nOne multi-turn ReAct dialogue for **pre-dev work**. This node only configures an Agent: **no prompt template**, **no round cap**, and no auto-clarify / timeout / conditional injection. The platform injects run inputs and waits for the user to state the goal first; the agent then uses tools to align requirements and only `ask_question` when there is a real decision.\n\n**Two mandatory deliverables** (both required to finish — not a single unique delivery):\n1. `set_clarified_requirement` → `clarified_requirement.json` (`open_questions` must be empty)\n2. `set_plan` → `plan.json` (at most two levels: goal → sub-goal; when writing the design zone, include all six sections or explicit 不涉及, optional Mermaid diagrams)\n\n**Optional** (shown if present, missing does not fail): `set_research`; `set_proposals` (**only when ≥2 distinct alternatives need a user pick**; no single-candidate pseudo-choice); `write_artifact` for `page.html`.\n\nIf a skill pack says “unique delivery” or forbids those tools, **platform rule `rules/approve.md` wins**. Do not write implementation code or change the repo."
+      "help": "### Approve\n\nOne multi-turn ReAct dialogue for **pre-dev work**. This node configures an Agent and a timeout (default 30 minutes): **no prompt template**, **no round cap**, and no auto-clarify / conditional injection. The platform injects run inputs and waits for the user to state the goal first; the agent then uses tools to align requirements and only `ask_question` when there is a real decision.\n\n**Two mandatory deliverables** (both required to finish — not a single unique delivery):\n1. `set_clarified_requirement` → `clarified_requirement.json` (`open_questions` must be empty)\n2. `set_plan` → `plan.json` (at most two levels: goal → sub-goal; when writing the design zone, include all six sections or explicit 不涉及, optional Mermaid diagrams)\n\n**Optional** (shown if present, missing does not fail): `set_research`; `set_proposals` (**only when ≥2 distinct alternatives need a user pick**; no single-candidate pseudo-choice); `write_artifact` for `page.html`.\n\nIf a skill pack says “unique delivery” or forbids those tools, **platform rule `rules/approve.md` wins**. Do not write implementation code or change the repo."
     },
     "agent": {
       "label": "Generic",

--- a/web/src/locales/zh-CN/nodes.json
+++ b/web/src/locales/zh-CN/nodes.json
@@ -95,6 +95,9 @@
       "fields": {
         "skill_profile": {
           "label": "Agent(用户定义 · Agent 管理)"
+        },
+        "timeout": {
+          "label": "超时(分钟)"
         }
       },
       "outputs": {
@@ -129,7 +132,7 @@
           "desc": "完整对话记录"
         }
       },
-      "help": "### Approve\n\n一次多轮 ReAct 对话完成**开发前工作**。本节点只配置 Agent:**没有 Prompt 模板**、**不限制轮次**、也没有自动澄清 / 超时 / 条件注入。开场由平台注入运行输入并等待用户先描述目标;Agent 用工具对齐需求,仅在真实分歧时 `ask_question`。\n\n**两份强制交付**(都写完才能结束,不是「唯一交付」):\n1. `set_clarified_requirement` → `clarified_requirement.json`(open_questions 必须为空)\n2. `set_plan` → `plan.json`(最多两级:大目标→小目标;写入设计区时六节齐全,无内容显式「不涉及」,可挂 Mermaid diagram)\n\n**可选**(有则展示,缺不失败):`set_research`;`set_proposals`(**仅当 ≥2 个可区分候选需用户择一时才写**;禁止单候选伪选择);`write_artifact` 写入 `page.html`。\n\n若角色包声明「唯一交付」或禁止上述工具,**以平台规则 `rules/approve.md` 为准**。不要写实现代码、不要改仓库。"
+      "help": "### Approve\n\n一次多轮 ReAct 对话完成**开发前工作**。本节点配置 Agent 与超时(默认 30 分钟):**没有 Prompt 模板**、**不限制轮次**、也没有自动澄清 / 条件注入。开场由平台注入运行输入并等待用户先描述目标;Agent 用工具对齐需求,仅在真实分歧时 `ask_question`。\n\n**两份强制交付**(都写完才能结束,不是「唯一交付」):\n1. `set_clarified_requirement` → `clarified_requirement.json`(open_questions 必须为空)\n2. `set_plan` → `plan.json`(最多两级:大目标→小目标;写入设计区时六节齐全,无内容显式「不涉及」,可挂 Mermaid diagram)\n\n**可选**(有则展示,缺不失败):`set_research`;`set_proposals`(**仅当 ≥2 个可区分候选需用户择一时才写**;禁止单候选伪选择);`write_artifact` 写入 `page.html`。\n\n若角色包声明「唯一交付」或禁止上述工具,**以平台规则 `rules/approve.md` 为准**。不要写实现代码、不要改仓库。"
     },
     "agent": {
       "label": "通用",


### PR DESCRIPTION
## Summary
- Approve 节点与其它 Agent 节点一样可配置 `timeout`（分钟）/ 遗留 `chat_timeout`（秒）；未配置时默认 30 分钟，不再套用全局 10 分钟。
- 编辑器 inspector 增加超时字段，新建节点预填 30；中英文帮助去掉「没有超时」。
- 已有、未写 timeout 的 Approve 工作流也会自动变成 30 分钟，不必重存节点。

## Test plan
- [x] `go test ./internal/runtime/ -count=1`
- [x] `TestNodeChatTimeout`：Approve `timeout:20` → 20m；`chat_timeout:300` → 300s；空配置 → 30m
- [x] `npx vitest run src/data/nodeRegistry.approve.test.ts src/locales/locales.compile.test.ts`
- [ ] CI：`ci-server` / `ci-web` / `ci` gate 通过
- [ ] 工作流编辑器打开 Approve 节点，可见「超时(分钟)」且默认 30
- [ ] 未写 timeout 的已有 Approve 工作流运行时按 30 分钟计时


Made with [Cursor](https://cursor.com)