### PR TITLE
fix(web): keep Run detail right panel width stable across node tabs

### DIFF
--- a/web/src/lib/inbox/reviewLayoutBudget.test.ts
+++ b/web/src/lib/inbox/reviewLayoutBudget.test.ts
@@ -6,6 +6,7 @@ import {
   OUTER_SASH_WIDTH,
   OUTER_SASH_WIDTH_KEY_CLARIFY,
   OUTER_SASH_WIDTH_KEY_REVIEW,
+  OUTER_SASH_WIDTH_KEY_SHARED,
   OUTER_STAGE_MIN,
   REVIEW_CANVAS_MIN,
   REVIEW_GAP,
@@ -21,8 +22,10 @@ import {
   isOuterSashTab,
   outerRightMax,
   parseOuterSashMem,
+  readSharedOuterSashMem,
   reviewDefaultRightPx,
   reviewRightPanelCssWidth,
+  writeSharedOuterSashMem,
 } from './reviewLayoutBudget'
 
 describe('reviewLayoutBudget constants', () => {
@@ -45,12 +48,40 @@ describe('reviewLayoutBudget constants', () => {
   it('isolates outer sash storage from inner ReviewShell keys', () => {
     expect(OUTER_SASH_WIDTH_KEY_CLARIFY).toBe('run-detail-outer-sash:clarify')
     expect(OUTER_SASH_WIDTH_KEY_REVIEW).toBe('run-detail-outer-sash:review')
+    expect(OUTER_SASH_WIDTH_KEY_SHARED).toBe('run-detail-outer-sash:shared')
     expect(OUTER_SASH_WIDTH_KEY_CLARIFY).not.toBe(REVIEW_SHELL_WIDTH_KEY_CLARIFY)
     expect(OUTER_SASH_WIDTH_KEY_REVIEW).not.toBe(REVIEW_SHELL_WIDTH_KEY_REVIEW)
     expect(isOuterSashTab('clarify')).toBe(true)
     expect(isOuterSashTab('review')).toBe(true)
     expect(isOuterSashTab('log')).toBe(false)
     expect(isOuterSashTab('product')).toBe(false)
+  })
+
+  it('readSharedOuterSashMem prefers shared key and migrates legacy clarify|review', () => {
+    const store = new Map<string, string>()
+    const ls = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        store.set(k, v)
+      },
+    }
+    const orig = globalThis.localStorage
+    Object.defineProperty(globalThis, 'localStorage', { value: ls, configurable: true })
+    try {
+      expect(readSharedOuterSashMem()).toBeNull()
+      store.set(OUTER_SASH_WIDTH_KEY_CLARIFY, '{"width":820,"fullOpen":false}')
+      expect(readSharedOuterSashMem()).toEqual({ width: 820, fullOpen: false })
+      store.set(OUTER_SASH_WIDTH_KEY_SHARED, '{"width":900,"fullOpen":true}')
+      expect(readSharedOuterSashMem()).toEqual({ width: 900, fullOpen: true })
+      store.delete(OUTER_SASH_WIDTH_KEY_SHARED)
+      store.delete(OUTER_SASH_WIDTH_KEY_CLARIFY)
+      store.set(OUTER_SASH_WIDTH_KEY_REVIEW, '{"width":750,"fullOpen":false}')
+      expect(readSharedOuterSashMem()).toEqual({ width: 750, fullOpen: false })
+      writeSharedOuterSashMem({ width: 880, fullOpen: false })
+      expect(store.get(OUTER_SASH_WIDTH_KEY_SHARED)).toBe('{"width":880,"fullOpen":false}')
+    } finally {
+      Object.defineProperty(globalThis, 'localStorage', { value: orig, configurable: true })
+    }
   })
 })
 

--- a/web/src/lib/inbox/reviewLayoutBudget.ts
+++ b/web/src/lib/inbox/reviewLayoutBudget.ts
@@ -39,13 +39,39 @@ export const REVIEW_SHELL_WIDTH_KEY_CLARIFY = 'review-shell-sidebar-width:clarif
  */
 export const OUTER_SASH_WIDTH_KEY_CLARIFY = 'run-detail-outer-sash:clarify'
 export const OUTER_SASH_WIDTH_KEY_REVIEW = 'run-detail-outer-sash:review'
+/** Shared across all desktop node tabs so tab switches do not jump width. */
+export const OUTER_SASH_WIDTH_KEY_SHARED = 'run-detail-outer-sash:shared'
 
+/** @deprecated clarify|review-only; desktop layout no longer gates on this. */
 export function isOuterSashTab(tab: string): tab is OuterSashTab {
   return tab === 'clarify' || tab === 'review'
 }
 
 export function outerSashStorageKey(tab: OuterSashTab): string {
   return tab === 'review' ? OUTER_SASH_WIDTH_KEY_REVIEW : OUTER_SASH_WIDTH_KEY_CLARIFY
+}
+
+/** Read shared outer sash memory, migrating from legacy per-scene keys when needed. */
+export function readSharedOuterSashMem(): OuterSashMem | null {
+  try {
+    if (typeof localStorage === 'undefined') return null
+    const shared = parseOuterSashMem(localStorage.getItem(OUTER_SASH_WIDTH_KEY_SHARED))
+    if (shared) return shared
+    const clarify = parseOuterSashMem(localStorage.getItem(OUTER_SASH_WIDTH_KEY_CLARIFY))
+    if (clarify) return clarify
+    return parseOuterSashMem(localStorage.getItem(OUTER_SASH_WIDTH_KEY_REVIEW))
+  } catch {
+    return null
+  }
+}
+
+export function writeSharedOuterSashMem(mem: OuterSashMem) {
+  try {
+    if (typeof localStorage === 'undefined') return
+    localStorage.setItem(OUTER_SASH_WIDTH_KEY_SHARED, JSON.stringify(mem))
+  } catch {
+    /* quota / private mode */
+  }
 }
 
 /** CSS width for the right panel default (un-customized) on outer-sash tabs. */

--- a/web/src/lib/run/useRunDetail.ts
+++ b/web/src/lib/run/useRunDetail.ts
@@ -9,15 +9,12 @@ import { useToast } from '@/lib/composables/useToast'
 import {
   applyOuterSashMem,
   clampOuterRight,
-  isOuterSashTab,
   outerRightMax,
   outerRightMin,
-  outerSashStorageKey,
-  parseOuterSashMem,
+  readSharedOuterSashMem,
   reviewDefaultRightPx,
   reviewRightPanelCssWidth,
-  type OuterSashMem,
-  type OuterSashTab,
+  writeSharedOuterSashMem,
 } from '@/lib/inbox/reviewLayoutBudget'
 import { addClarifyAnnotation, useClarifyDraft } from '@/lib/inbox/useClarifyDraft'
 import { previewPickLabel, type AppPreviewPickPayload } from '@/lib/shared/previewPickUrl'
@@ -947,13 +944,11 @@ const activePath = computed(() => {
 })
 
 /**
- * Desktop Agent交互 + 复审: outer sash (canvas/timeline vs whole right panel).
- * Other tabs stay locked md:w-[520px] and do not render the outer sash.
+ * Desktop Run Detail: outer sash (canvas/timeline vs whole right panel).
+ * All node content tabs share the same width — no per-tab md:w-[520px] fallback.
  * REVIEW_CANVAS_MIN is default reserve only — drag canvas min is 0.
  */
-const desktopOuterSashLayout = computed(
-  () => !isMobile.value && isOuterSashTab(nodeTab.value),
-)
+const desktopOuterSashLayout = computed(() => !isMobile.value)
 const splitRootRef = ref<HTMLElement | null>(null)
 const workspacePx = ref(0)
 const outerRightPx = ref(0)
@@ -969,36 +964,19 @@ function measureWorkspace(): number {
   return w && w > 0 ? w : 0
 }
 
-function readOuterMem(tab: OuterSashTab): OuterSashMem | null {
-  try {
-    return parseOuterSashMem(localStorage.getItem(outerSashStorageKey(tab)))
-  } catch {
-    return null
-  }
-}
-
-function writeOuterMem(tab: OuterSashTab, mem: OuterSashMem) {
-  try {
-    localStorage.setItem(outerSashStorageKey(tab), JSON.stringify(mem))
-  } catch {
-    /* quota / private mode */
-  }
-}
-
 function applyOuterLayout() {
   if (!desktopOuterSashLayout.value) return
   const ws = measureWorkspace()
   if (ws <= 0) return
   workspacePx.value = ws
-  const tab = nodeTab.value as OuterSashTab
-  const next = applyOuterSashMem(readOuterMem(tab), ws)
+  const next = applyOuterSashMem(readSharedOuterSashMem(), ws)
   outerRightPx.value = next.width
   outerFullOpen.value = next.fullOpen
 }
 
 function persistOuterLayout() {
-  if (!desktopOuterSashLayout.value || !isOuterSashTab(nodeTab.value)) return
-  writeOuterMem(nodeTab.value, {
+  if (!desktopOuterSashLayout.value) return
+  writeSharedOuterSashMem({
     width: outerRightPx.value,
     fullOpen: outerFullOpen.value,
   })
@@ -1090,10 +1068,11 @@ const leftPaneStyle = computed(() => {
   return { minWidth: '0px', overflow: 'hidden' }
 })
 
+// Re-init only when entering/leaving desktop sash — tab switches keep in-memory width.
 watch(
-  () => [desktopOuterSashLayout.value, nodeTab.value] as const,
-  () => {
-    nextTick(() => applyOuterLayout())
+  () => desktopOuterSashLayout.value,
+  (on) => {
+    if (on) nextTick(() => applyOuterLayout())
   },
 )
 
@@ -1297,8 +1276,6 @@ function selectExecution(nodeId: string, idx: number) {
   outerSashDidDrag,
   OUTER_SASH_DRAG_THRESHOLD_PX,
   measureWorkspace,
-  readOuterMem,
-  writeOuterMem,
   applyOuterLayout,
   persistOuterLayout,
   setOuterSashDraggingUi,

--- a/web/src/views/RunDetailView.test.ts
+++ b/web/src/views/RunDetailView.test.ts
@@ -284,21 +284,30 @@ describe('RunDetailView ACP log rehydrate state machine', () => {
 })
 
 
-describe('RunDetailView desktop outer sash layout (clarify|review)', () => {
-  it('enables outer sash only for desktop clarify|review and restores ~520 otherwise', () => {
+describe('RunDetailView desktop outer sash layout (all node tabs)', () => {
+  it('enables outer sash on desktop for every node tab with bound width', () => {
     expect(src).toMatch(/from '@\/lib\/inbox\/reviewLayoutBudget'/)
     expect(src).toMatch(/reviewRightPanelCssWidth/)
-    expect(src).toMatch(/isOuterSashTab/)
     expect(src).toMatch(
-      /desktopOuterSashLayout = computed\(\s*\(\) => !isMobile\.value && isOuterSashTab\(nodeTab\.value\),/,
+      /desktopOuterSashLayout = computed\(\(\) => !isMobile\.value\)/,
     )
     expect(src).toMatch(/:style="reviewRightPanelStyle"/)
     expect(src).toMatch(/:style="leftPaneStyle"/)
     expect(src).toMatch(/data-testid="run-detail-outer-sash"/)
-    // Non-sash tabs keep md:w-[520px]; clarify|review use bound width instead.
-    expect(src).toMatch(/desktopOuterSashLayout \? '' : 'md:w-\[520px\]'/)
-    expect(src).toMatch(/md:w-\[520px\]/)
+    // Desktop right panel uses bound width — no fixed md:w-[520px] fallback.
+    expect(viewSrc).not.toMatch(/md:w-\[520px\]/)
     expect(viewOrchestrationSrc).toMatch(/v-if="desktopOuterSashLayout"/)
+    expect(viewOrchestrationSrc).toMatch(/readSharedOuterSashMem/)
+    expect(viewOrchestrationSrc).toMatch(/writeSharedOuterSashMem/)
+  })
+
+  it('keeps in-memory outer width across tab switches (no per-tab re-read)', () => {
+    expect(viewOrchestrationSrc).toMatch(
+      /watch\(\s*\(\) => desktopOuterSashLayout\.value,/,
+    )
+    expect(viewOrchestrationSrc).not.toMatch(
+      /watch\(\s*\(\) => \[desktopOuterSashLayout\.value, nodeTab\.value\]/,
+    )
   })
 
   it('passes sidebar-width=REVIEW_SIDEBAR only on Run Detail review ReviewShell', () => {
@@ -328,7 +337,7 @@ describe('RunDetailView desktop outer sash layout (clarify|review)', () => {
     expect(viewOrchestrationSrc).toMatch(/onOuterSashDblClick/)
     expect(viewOrchestrationSrc).toMatch(/role="separator"/)
     expect(viewOrchestrationSrc).toMatch(/aria-orientation="vertical"/)
-    expect(viewOrchestrationSrc).toMatch(/outerSashStorageKey/)
+    expect(viewOrchestrationSrc).toMatch(/readSharedOuterSashMem/)
     expect(viewOrchestrationSrc).toMatch(/fullOpen/)
   })
 
@@ -337,6 +346,11 @@ describe('RunDetailView desktop outer sash layout (clarify|review)', () => {
     expect(viewSrc).toMatch(/outerFullOpen/)
     expect(viewSrc).toMatch(/md:left-5 md:z-\[1\]/)
     expect(viewSrc).toMatch(/md:left-3 md:z-10/)
+  })
+
+  it('hides outer sash on mobile (no horizontal drag)', () => {
+    expect(viewSrc).toMatch(/v-if="desktopOuterSashLayout"/)
+    expect(viewSrc).toMatch(/hidden shrink-0 cursor-col-resize bg-line md:block/)
   })
 })
 

--- a/web/src/views/RunDetailView.vue
+++ b/web/src/views/RunDetailView.vue
@@ -151,8 +151,6 @@ const {
   outerSashDidDrag,
   OUTER_SASH_DRAG_THRESHOLD_PX,
   measureWorkspace,
-  readOuterMem,
-  writeOuterMem,
   applyOuterLayout,
   persistOuterLayout,
   setOuterSashDraggingUi,
@@ -599,7 +597,7 @@ const {
         />
       </div>
 
-      <!-- Outer sash: Agent交互 + 复审 desktop only. Hidden on narrow (no horizontal drag). -->
+      <!-- Outer sash: desktop only. Hidden on narrow (no horizontal drag). -->
       <div
         v-if="desktopOuterSashLayout"
         class="run-detail-outer-sash relative hidden shrink-0 cursor-col-resize bg-line md:block"
@@ -628,7 +626,6 @@ const {
         data-testid="run-detail-right-panel"
         class="flex min-h-0 min-w-0 w-full max-w-full flex-col bg-surface"
         :class="[
-          desktopOuterSashLayout ? '' : 'md:w-[520px]',
           isMobile && viewMode === 'timeline' ? 'flex-1' : 'shrink-0 md:shrink-0',
         ]"
         :style="reviewRightPanelStyle"


### PR DESCRIPTION
## Summary
- 桌面端所有节点 Tab 共用同一 outer sash 宽度状态，切 Tab 不再回落 `md:w-[520px]`
- 持久化统一为 `run-detail-outer-sash:shared`，并迁移旧 clarify/review 键
- 拖拽、吸附、双击复位、resize 钳制与移动端行为保持不变

## Test plan
- [x] `npm run lint`
- [x] `npx vue-tsc --noEmit`
- [x] `npm test -- --run` (2339 passed)
- [x] `npm run build`


Made with [Cursor](https://cursor.com)