### PR TITLE
fix(web): 沙箱日志 live 轮询改为 silent_poll 消除 RefreshStrip 闪烁

### DIFF
--- a/web/src/components/run/RunSandboxPanel.test.ts
+++ b/web/src/components/run/RunSandboxPanel.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment happy-dom
+import { createI18n } from 'vue-i18n'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import common from '@/locales/zh-CN/common.json'
+import pages from '@/locales/zh-CN/pages.json'
+import RunSandboxPanel from './RunSandboxPanel.vue'
+
+function mountPanel(loading: boolean) {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common, ...pages } },
+  })
+  return mount(RunSandboxPanel, {
+    props: {
+      loading,
+      sbxLog: { content: 'line1\nline2', live: true, found: true },
+      selStatus: 'running',
+    },
+    global: {
+      plugins: [i18n],
+      stubs: { Icon: true },
+    },
+  })
+}
+
+describe('RunSandboxPanel', () => {
+  it('shows refresh-strip only for visible loading with existing content', () => {
+    const visible = mountPanel(true)
+    expect(visible.find('[data-testid="refresh-strip"]').exists()).toBe(true)
+    visible.unmount()
+
+    const silent = mountPanel(false)
+    expect(silent.find('[data-testid="refresh-strip"]').exists()).toBe(false)
+    silent.unmount()
+  })
+})

--- a/web/src/lib/run/useRunDetailLiveLog.test.ts
+++ b/web/src/lib/run/useRunDetailLiveLog.test.ts
@@ -20,6 +20,7 @@ vi.mock('@/lib/api/api', async () => {
   }
 })
 
+import { api } from '@/lib/api/api'
 import { useRunDetailLiveLog } from './useRunDetailLiveLog'
 
 describe('useRunDetailLiveLog', () => {
@@ -95,6 +96,130 @@ describe('useRunDetailLiveLog', () => {
     live.resetLiveLogState('run-1')
     live.abortSandboxFetches()
     live.disposeAllRehydrateOrchs()
+
+    app.unmount()
+  })
+
+  it('silent_poll does not toggle sbxLogLoading; user_initiated does', async () => {
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0)
+      return 1
+    })
+
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: '/', component: { template: '<div />' } }],
+    })
+    await router.push('/')
+    await router.isReady()
+
+    const run = ref({
+      id: 'run-1',
+      status: 'running',
+      nodeRuns: { a1: { nodeId: 'a1', status: 'running', events: [], mcpCalls: [] } },
+      artifacts: [],
+    } as unknown as Run)
+    const selected = ref<string | null>('a1')
+    const nodeTab = ref('sandbox')
+    const selIterIdx = ref<number | null>(null)
+
+    let live!: ReturnType<typeof useRunDetailLiveLog>
+    const app = createApp({
+      setup() {
+        live = useRunDetailLiveLog({
+          runId: computed(() => 'run-1'),
+          run,
+          selected,
+          selExecIdx: computed(() => 0),
+          selIterIdx,
+          selRun: computed(() => run.value.nodeRuns.a1 || null),
+          selStatus: computed(() => 'running'),
+          viewingLatest: computed(() => true),
+          nodeTab,
+          hasLog: computed(() => true),
+        })
+        return () => null
+      },
+    })
+    app.use(i18n)
+    app.use(router)
+    app.mount(document.createElement('div'))
+
+    live.sbxLogs.a1 = { content: 'cached', live: true, found: true }
+    expect(live.sbxLogLoading.value).toBe(false)
+
+    const silentPromise = live.fetchSandboxLog('a1', { intent: 'silent_poll' })
+    expect(live.sbxLogLoading.value).toBe(false)
+    await silentPromise
+    expect(live.sbxLogLoading.value).toBe(false)
+
+    const userPromise = live.fetchSandboxLog('a1', { intent: 'user_initiated' })
+    expect(live.sbxLogLoading.value).toBe(true)
+    await userPromise
+    expect(live.sbxLogLoading.value).toBe(false)
+
+    app.unmount()
+  })
+
+  it('silent_poll skips write-back when snapshot unchanged', async () => {
+    const nodeSandboxLog = vi.mocked(api.nodeSandboxLog)
+    nodeSandboxLog.mockResolvedValueOnce({
+      content: 'same',
+      live: true,
+      found: true,
+    })
+
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: '/', component: { template: '<div />' } }],
+    })
+    await router.push('/')
+    await router.isReady()
+
+    const run = ref({
+      id: 'run-1',
+      status: 'running',
+      nodeRuns: { a1: { nodeId: 'a1', status: 'running', events: [], mcpCalls: [] } },
+      artifacts: [],
+    } as unknown as Run)
+    const selected = ref<string | null>('a1')
+
+    let live!: ReturnType<typeof useRunDetailLiveLog>
+    const app = createApp({
+      setup() {
+        live = useRunDetailLiveLog({
+          runId: computed(() => 'run-1'),
+          run,
+          selected,
+          selExecIdx: computed(() => 0),
+          selIterIdx: ref(null),
+          selRun: computed(() => run.value.nodeRuns.a1 || null),
+          selStatus: computed(() => 'running'),
+          viewingLatest: computed(() => true),
+          nodeTab: ref('sandbox'),
+          hasLog: computed(() => true),
+        })
+        return () => null
+      },
+    })
+    app.use(i18n)
+    app.use(router)
+    app.mount(document.createElement('div'))
+
+    const prev = { content: 'same', live: true, found: true }
+    live.sbxLogs.a1 = { ...prev }
+    await live.fetchSandboxLog('a1', { intent: 'silent_poll' })
+    expect(live.sbxLogs.a1).toEqual(prev)
 
     app.unmount()
   })

--- a/web/src/lib/run/useRunDetailLiveLog.ts
+++ b/web/src/lib/run/useRunDetailLiveLog.ts
@@ -22,6 +22,7 @@ import {
   putLiveLogEventPage,
   putLiveLogMcpCalls,
 } from '@/lib/run/liveLogSnapshotCache'
+import type { RefreshIntent } from '@/lib/shared/loadingTypes'
 import type { AcpEvent, McpCall, NodeRun, NodeRunStatus, Run } from '@/lib/shared/types'
 
 export type EventPageState = {
@@ -227,28 +228,49 @@ export function useRunDetailLiveLog(opts: {
     }
   }
 
-  async function fetchSandboxLog(nodeId: string | null) {
+  async function fetchSandboxLog(
+    nodeId: string | null,
+    opts?: { intent?: RefreshIntent },
+  ) {
     if (!nodeId) {
       sandboxLogAbort?.abort()
       sandboxLogAbort = null
       sbxLogLoading.value = false
       return
     }
+    const intent = opts?.intent ?? 'user_initiated'
+    const silent = intent === 'silent_poll'
+    // Do not interrupt an in-flight user refresh or flash RefreshStrip on poll.
+    if (silent && sbxLogLoading.value) return
+
     const attemptGen = ++sandboxLogGen
     sandboxLogAbort?.abort()
     sandboxLogAbort = new AbortController()
-    sbxLogLoading.value = true
+    if (!silent) sbxLogLoading.value = true
     try {
       const r = await api.nodeSandboxLog(runId.value, nodeId, { signal: sandboxLogAbort.signal })
       if (attemptGen !== sandboxLogGen) return
-      // Always write the response so empty live / found=false / error map correctly
-      // (do not treat empty content as "no update").
-      sbxLogs[nodeId] = {
+      const next: SbxLogState = {
         content: r.content ?? '',
         live: !!r.live,
         found: !!r.found,
         error: r.error || undefined,
       }
+      if (silent) {
+        const prev = sbxLogs[nodeId]
+        if (
+          prev &&
+          prev.content === next.content &&
+          prev.live === next.live &&
+          prev.found === next.found &&
+          prev.error === next.error
+        ) {
+          return
+        }
+      }
+      // Always write the response so empty live / found=false / error map correctly
+      // (do not treat empty content as "no update").
+      sbxLogs[nodeId] = next
     } catch (e) {
       if (attemptGen !== sandboxLogGen) return
       if (isAbortError(e)) return
@@ -260,7 +282,7 @@ export function useRunDetailLiveLog(opts: {
         error: t('pages.runDetail.sandboxLog.loadFailed'),
       }
     } finally {
-      if (attemptGen === sandboxLogGen) sbxLogLoading.value = false
+      if (!silent && attemptGen === sandboxLogGen) sbxLogLoading.value = false
     }
   }
 

--- a/web/src/lib/run/useRunDetailWs.test.ts
+++ b/web/src/lib/run/useRunDetailWs.test.ts
@@ -99,6 +99,58 @@ describe('useRunDetailWs', () => {
     expect(typeof api.connectWs).toBe('function')
   })
 
+  it('polls sandbox log silently on sandbox tab interval', async () => {
+    vi.useFakeTimers()
+    const fetchSandboxLog = vi.fn()
+    const run = ref({
+      id: 'run-3',
+      status: 'running',
+      reactSessions: {},
+      nodeRuns: { n1: { nodeId: 'n1', status: 'running' } },
+    } as unknown as Run)
+    const selected = ref<string | null>('n1')
+    const nodeTab = ref('sandbox')
+    const eventPages: Record<string, any> = {
+      n1: { events: [{ kind: 'message', text: 'x', t: 1 }], nextCursor: '', hasMore: false, live: true },
+    }
+
+    const api = useRunDetailWs({
+      runId: computed(() => 'run-3'),
+      run,
+      selected,
+      manual: ref(false),
+      liveBusy: {},
+      liveNode: ref('n1'),
+      eventPages,
+      nodeTab,
+      reviewChatRef: ref(null),
+      gateApprovalRef: ref(null),
+      selClarify: computed(() => null),
+      fetchNodeEvents: vi.fn(async () => true),
+      mergeLiveWsAcpPage: vi.fn(),
+      rehydrateByNode: { n1: 'ready' },
+      rehydrateNodeEvents: vi.fn(async () => undefined),
+      fetchSandboxLog,
+      maybePollSandboxForBoot: vi.fn(),
+      isClarifySessionBusy: () => false,
+      loadRun: vi.fn(),
+    })
+
+    await api.initAfterLoadSuccess({
+      applyDetailArtifactsDeepLink: () => false,
+      applyOutputDeepLinkFocus: () => false,
+      defaultNode: 'n1',
+      syncAllMcpCallsFromRun: () => undefined,
+    })
+    fetchSandboxLog.mockClear()
+
+    vi.advanceTimersByTime(2000)
+    expect(fetchSandboxLog).toHaveBeenCalledWith('n1', { intent: 'silent_poll' })
+
+    api.teardownRealtime()
+    vi.useRealTimers()
+  })
+
   it('restores idle sessions and flushes without busy seed', async () => {
     const run = ref({
       id: 'run-2',

--- a/web/src/lib/run/useRunDetailWs.ts
+++ b/web/src/lib/run/useRunDetailWs.ts
@@ -42,7 +42,10 @@ export function useRunDetailWs(opts: {
   mergeLiveWsAcpPage: (nodeId: string, wsEvents: AcpEvent[]) => void
   rehydrateByNode: Record<string, string>
   rehydrateNodeEvents: (nodeId: string | null, opts?: { force?: boolean }) => Promise<void>
-  fetchSandboxLog: (nodeId: string | null) => Promise<void> | void
+  fetchSandboxLog: (
+    nodeId: string | null,
+    opts?: { intent?: 'user_initiated' | 'silent_poll' },
+  ) => Promise<void> | void
   maybePollSandboxForBoot: () => void
   isClarifySessionBusy: () => boolean
   loadRun: (hard?: boolean) => Promise<void> | void
@@ -342,7 +345,9 @@ export function useRunDetailWs(opts: {
               void rehydrateNodeEvents(sel)
             }
           }
-          if (nodeTab.value === 'sandbox') fetchSandboxLog(selected.value)
+          if (nodeTab.value === 'sandbox') {
+            fetchSandboxLog(selected.value, { intent: 'silent_poll' })
+          }
           // Boot-stage empty state needs fresh sandbox row status/containerStatus.
           maybePollSandboxForBoot()
         }


### PR DESCRIPTION
自动 2s 轮询不再置 sbxLogLoading，与 Gates Inbox 等 silent_poll 约定一致；
手动刷新与首次加载仍显示 RefreshStrip/HardLoadLayer。内容未变时跳过写回。

Co-authored-by: Cursor <cursoragent@cursor.com>
