### PR TITLE
fix(web): 澄清卡「其他」需勾选才纳入回复，修复深色主题滚动条发白

### DIFF
--- a/web/src/components/run/ClarifyChat.test.ts
+++ b/web/src/components/run/ClarifyChat.test.ts
@@ -158,6 +158,84 @@ describe('ClarifyChat', () => {
     wrapper.unmount()
   })
 
+  const OTHER_QUESTION_TURN: ClarifyTurn = {
+    role: 'agent',
+    text: '',
+    at: '2026-07-18T00:00:00Z',
+    questions: [
+      {
+        id: 'q1',
+        prompt: '选择部署方式',
+        options: [
+          { id: 'k8s', label: 'Kubernetes' },
+          { id: 'vm', label: '虚拟机' },
+        ],
+      },
+    ],
+  }
+
+  function submitChoicesBtn(wrapper: ReturnType<typeof mountChat>) {
+    return wrapper.findAll('button').find((b) => b.text().includes('确认选择'))
+  }
+
+  it('other: typed text without checkbox cannot submit alone (g1.2)', async () => {
+    const wrapper = mountChat({ turns: [OTHER_QUESTION_TURN] })
+    await wrapper.find('[data-testid="clarify-other-input"]').setValue('自由补充内容')
+    await flushPromises()
+    const submitBtn = submitChoicesBtn(wrapper)
+    expect(submitBtn).toBeTruthy()
+    expect((submitBtn!.element as HTMLButtonElement).disabled).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('other: checked + non-empty text enables submit and appears in summary (g1.2/g1.3)', async () => {
+    const wrapper = mountChat({ turns: [OTHER_QUESTION_TURN] })
+    await wrapper.find('[data-testid="clarify-other-checkbox"]').trigger('click')
+    await wrapper.find('[data-testid="clarify-other-input"]').setValue('仅其他补充')
+    await flushPromises()
+    const submitBtn = submitChoicesBtn(wrapper)!
+    expect((submitBtn.element as HTMLButtonElement).disabled).toBe(false)
+    await submitBtn.trigger('click')
+    await flushPromises()
+    expect(wrapper.emitted('send')).toBeTruthy()
+    const sent = String(wrapper.emitted('send')![0][0])
+    expect(sent).toContain('仅其他补充')
+    expect(sent).not.toContain('Kubernetes')
+    wrapper.unmount()
+  })
+
+  it('other: checked but empty text does not count as answered (g1.2)', async () => {
+    const wrapper = mountChat({ turns: [OTHER_QUESTION_TURN] })
+    await wrapper.find('[data-testid="clarify-other-checkbox"]').trigger('click')
+    await flushPromises()
+    const submitBtn = submitChoicesBtn(wrapper)!
+    expect((submitBtn.element as HTMLButtonElement).disabled).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('other: unchecked text is omitted when option + other both present (g1.2)', async () => {
+    const wrapper = mountChat({ turns: [OTHER_QUESTION_TURN] })
+    const optionBtn = wrapper.findAll('button').find((b) => b.text().includes('Kubernetes'))
+    await optionBtn!.trigger('click')
+    await wrapper.find('[data-testid="clarify-other-input"]').setValue('不应出现')
+    await flushPromises()
+    const submitBtn = submitChoicesBtn(wrapper)!
+    expect((submitBtn.element as HTMLButtonElement).disabled).toBe(false)
+    await submitBtn.trigger('click')
+    await flushPromises()
+    const sent = String(wrapper.emitted('send')![0][0])
+    expect(sent).toContain('Kubernetes')
+    expect(sent).not.toContain('不应出现')
+    wrapper.unmount()
+  })
+
+  it('other row shows checkbox control matching question mode (g1.1)', () => {
+    const wrapper = mountChat({ turns: [OTHER_QUESTION_TURN] })
+    expect(wrapper.find('[data-testid="clarify-other-checkbox"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="clarify-other-row"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
   it('emits finish on early finish click', async () => {
     const wrapper = mountChat()
     const finishBtn = wrapper.findAll('button').find((b) => b.text().includes('结束交互'))

--- a/web/src/components/run/ClarifyChat.vue
+++ b/web/src/components/run/ClarifyChat.vue
@@ -170,6 +170,9 @@ const {
   attachNotice,
   sel,
   other,
+  otherChecked,
+  isOtherSelected,
+  toggleOther,
   activeQuestions,
   someAnswered,
   hasRecommended,
@@ -434,12 +437,32 @@ const {
                           >{{ translate('pages.clarify.recommended') }}</span>
                         </button>
                       </div>
-                      <input
-                        v-model="other[curQuestion.id]"
-                        type="text"
-                        class="input mt-1.5 h-8 w-full text-[12px]"
-                        :placeholder="translate('pages.clarify.otherPlaceholder')"
-                      />
+                      <div
+                        class="mt-1.5 flex w-full items-center gap-2 rounded-lg border px-2.5 py-2 text-left text-[12px] transition-colors"
+                        :class="isOtherSelected(curQuestion.id) ? 'border-accent bg-accent-dim/60 text-txt' : 'border-line bg-surface text-txt2'"
+                        data-testid="clarify-other-row"
+                      >
+                        <button
+                          type="button"
+                          class="flex h-4 w-4 shrink-0 items-center justify-center border"
+                          :class="[
+                            curQuestion.allowMultiple ? 'rounded' : 'rounded-full',
+                            isOtherSelected(curQuestion.id) ? 'border-accent bg-accent text-white' : 'border-line-strong',
+                          ]"
+                          data-testid="clarify-other-checkbox"
+                          :aria-label="translate('pages.clarify.otherPlaceholder')"
+                          @click="toggleOther(curQuestion)"
+                        >
+                          <Icon v-if="isOtherSelected(curQuestion.id)" name="check" :size="10" />
+                        </button>
+                        <input
+                          v-model="other[curQuestion.id]"
+                          type="text"
+                          class="input min-h-0 flex-1 border-0 bg-transparent p-0 text-[12px] shadow-none focus:border-transparent focus:ring-0"
+                          :placeholder="translate('pages.clarify.otherPlaceholder')"
+                          data-testid="clarify-other-input"
+                        />
+                      </div>
 
                       <!-- Demo previews (options with demoHtml) -->
                       <div v-if="demoOptionsOf(curQuestion).length" class="mt-2.5">

--- a/web/src/lib/inbox/useClarifyChat.ts
+++ b/web/src/lib/inbox/useClarifyChat.ts
@@ -626,6 +626,8 @@ function removeAnnotation(i: number) {
 // Selected option ids per question, plus optional "其他" free text.
 const sel = ref<Record<string, string[]>>({})
 const other = ref<Record<string, string>>({})
+/** Per-question "其他" checkbox — free text only counts when checked. */
+const otherChecked = ref<Record<string, boolean>>({})
 
 // The interactive choice card is only shown for the latest unanswered agent
 // question turn while the dialogue is live (not done / not mid-send).
@@ -649,8 +651,20 @@ function toggle(q: ReactQuestion, oid: string) {
     sel.value[q.id] = cur.includes(oid) ? [] : [oid]
   }
 }
+function isOtherSelected(qid: string): boolean {
+  return !!otherChecked.value[qid]
+}
+
+function toggleOther(q: ReactQuestion) {
+  otherChecked.value[q.id] = !otherChecked.value[q.id]
+}
+
+function otherAnswered(q: ReactQuestion): boolean {
+  return !!otherChecked.value[q.id] && !!other.value[q.id]?.trim()
+}
+
 function answered(q: ReactQuestion): boolean {
-  return (sel.value[q.id]?.length ?? 0) > 0 || !!other.value[q.id]?.trim()
+  return (sel.value[q.id]?.length ?? 0) > 0 || otherAnswered(q)
 }
 const someAnswered = computed(() => activeQuestions.value.some(answered))
 
@@ -718,7 +732,7 @@ function submitChoices() {
   // Skipped questions are omitted; only answered ones are summarized.
   const lines = qs.filter(answered).map((q) => {
     const picked = q.options.filter((o) => (sel.value[q.id] || []).includes(o.id)).map((o) => o.label)
-    const extra = other.value[q.id]?.trim()
+    const extra = otherChecked.value[q.id] ? other.value[q.id]?.trim() : ''
     if (extra) picked.push(extra)
     return `- ${q.prompt} → ${picked.join('、')}`
   })
@@ -726,6 +740,7 @@ function submitChoices() {
   writeSessionChoice(qs, text)
   sel.value = {}
   other.value = {}
+  otherChecked.value = {}
   step.value = 0
   sendMessage(text)
 }
@@ -1276,6 +1291,10 @@ function showTurnCompleted(t: ClarifyTurn): boolean {
     attachNotice,
     sel,
     other,
+    otherChecked,
+    isOtherSelected,
+    toggleOther,
+    otherAnswered,
     activeQuestions,
     someAnswered,
     hasRecommended,

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -103,12 +103,24 @@ body {
 *.is-scrolling {
   scrollbar-color: rgb(var(--c-line)) transparent;
 }
+/* Dark theme: UA-native scrollbars stay dark; visible track matches base surface */
+html:not(.light) {
+  color-scheme: dark;
+}
+html:not(.light) *:hover,
+html:not(.light) *.is-scrolling {
+  scrollbar-color: rgb(var(--c-line)) rgb(var(--c-base));
+}
 ::-webkit-scrollbar {
   width: 4px;
   height: 4px;
 }
 ::-webkit-scrollbar-track {
   background: transparent;
+}
+html:not(.light) *:hover::-webkit-scrollbar-track,
+html:not(.light) *.is-scrolling::-webkit-scrollbar-track {
+  background: rgb(var(--c-base));
 }
 ::-webkit-scrollbar-thumb {
   background: transparent;
@@ -122,6 +134,10 @@ body {
 *:hover::-webkit-scrollbar-thumb:hover,
 *.is-scrolling::-webkit-scrollbar-thumb:hover {
   background: rgb(var(--c-line-strong));
+}
+html:not(.light) *:hover::-webkit-scrollbar,
+html:not(.light) *.is-scrolling::-webkit-scrollbar {
+  background: rgb(var(--c-base));
 }
 
 @layer components {
@@ -172,6 +188,10 @@ body {
   .scroll-area:hover,
   .scroll-area.is-scrolling {
     scrollbar-color: rgb(var(--c-line)) transparent;
+  }
+  html:not(.light) .scroll-area:hover,
+  html:not(.light) .scroll-area.is-scrolling {
+    scrollbar-color: rgb(var(--c-line)) rgb(var(--c-base));
   }
   .safe-area-bottom {
     padding-bottom: env(safe-area-inset-bottom, 0px);

--- a/web/src/styles/globalScrollbar.test.ts
+++ b/web/src/styles/globalScrollbar.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const globalCss = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), 'global.css'),
+  'utf8',
+)
+
+describe('global.css dark theme scrollbar (g2)', () => {
+  it('forces dark color-scheme on html:not(.light) to avoid whitish native thumbs (g2.1/g2.2)', () => {
+    expect(globalCss).toMatch(/html:not\(\.light\)\s*\{[^}]*color-scheme:\s*dark/)
+  })
+
+  it('uses dark base surface for visible scrollbar track in dark theme (g2.2)', () => {
+    expect(globalCss).toContain('html:not(.light) *:hover::-webkit-scrollbar-track')
+    expect(globalCss).toContain('html:not(.light) *.is-scrolling::-webkit-scrollbar-track')
+    expect(globalCss).toMatch(
+      /html:not\(\.light\)[\s\S]*scrollbar-color:\s*rgb\(var\(--c-line\)\)\s*rgb\(var\(--c-base\)\)/,
+    )
+  })
+
+  it('keeps idle-invisible transparent thumb contract (g2.3)', () => {
+    expect(globalCss).toContain('scrollbar-color: transparent transparent')
+    expect(globalCss).toMatch(/::-webkit-scrollbar-thumb\s*\{[^}]*background:\s*transparent/)
+  })
+})


### PR DESCRIPTION
为选择题「其他」行增加与选项一致的勾选控件，仅勾选且文本非空时才计入 answered 与提交摘要；深色主题下为滚动条强制 color-scheme:dark 并使用 base 色轨道，消除浅色原生拇指。

Co-authored-by: Cursor <cursoragent@cursor.com>
