### PR TITLE
feat(web): hide pipeline card scrollbar and add edge arrow navigation

### DIFF
--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -21,7 +21,9 @@
       "needText": "Describe the goal or attach a file first",
       "send": "Send",
       "missingRequired": "Fill required launch fields before starting",
-      "cardFallback": "Approve pre-dev clarification"
+      "cardFallback": "Approve pre-dev clarification",
+      "scrollLeft": "Scroll left",
+      "scrollRight": "Scroll right"
     },
     "board": {
       "title": "Requirement progress board",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -21,7 +21,9 @@
       "needText": "请先描述目标或附加文件",
       "send": "发送",
       "missingRequired": "启动前还需填写必填项",
-      "cardFallback": "Approve 开发前澄清"
+      "cardFallback": "Approve 开发前澄清",
+      "scrollLeft": "向左滚动",
+      "scrollRight": "向右滚动"
     },
     "board": {
       "title": "需求进度看板",

--- a/web/src/views/DashboardView.fill.test.ts
+++ b/web/src/views/DashboardView.fill.test.ts
@@ -92,6 +92,23 @@ describe('DashboardView home chat layout', () => {
     expect(src).toMatch(/prefers-reduced-motion/)
   })
 
+  // plan g1 — pipeline rail hides scrollbar and adds edge nav aligned to page.html demo
+  it('hides pipeline horizontal scrollbar and adds edge scroll arrows', () => {
+    expect(src).toMatch(/data-testid="home-pipeline-rail-wrap"/)
+    expect(src).toMatch(/data-testid="home-pipeline-scroll-prev"/)
+    expect(src).toMatch(/data-testid="home-pipeline-scroll-next"/)
+    expect(src).toMatch(/home-pipeline-rail/)
+    expect(src).toMatch(/scrollbar-width:\s*none/)
+    expect(src).toMatch(/::-webkit-scrollbar/)
+    expect(src).toMatch(/home-pipeline-nav/)
+    expect(src).toMatch(/home-pipeline-fade/)
+    expect(src).toMatch(/syncPipelineNav/)
+    expect(src).toMatch(/scrollPipelineByDir/)
+    expect(src).not.toMatch(
+      /data-testid="home-pipeline-cards"[^>]*overflow-x-auto/,
+    )
+  })
+
   // plan g2.5 / g3.2 — scoped only; no external fonts
   it('keeps styles scoped to DashboardView and does not load external fonts', () => {
     expect(src).toMatch(/<style scoped>/)

--- a/web/src/views/DashboardView.test.ts
+++ b/web/src/views/DashboardView.test.ts
@@ -470,4 +470,97 @@ describe('DashboardView home composer', () => {
     wrapper.unmount()
     vi.unstubAllGlobals()
   })
+
+  // plan g1 — pipeline rail scroll: hidden scrollbar + edge arrows
+  it('renders pipeline scroll arrows and hides horizontal scrollbar on cards rail', async () => {
+    const wrapper = mountDashboard()
+    await flushPromises()
+    expect(wrapper.find('[data-testid="home-pipeline-rail-wrap"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="home-pipeline-scroll-prev"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="home-pipeline-scroll-next"]').exists()).toBe(true)
+    const rail = wrapper.get('[data-testid="home-pipeline-cards"]')
+    expect(rail.classes()).toContain('home-pipeline-rail')
+    expect(rail.classes()).not.toContain('overflow-x-auto')
+    wrapper.unmount()
+  })
+
+  it('disables scroll arrows when pipeline list does not overflow', async () => {
+    const wrapper = mountDashboard()
+    await flushPromises()
+    const prev = wrapper.get('[data-testid="home-pipeline-scroll-prev"]').element as HTMLButtonElement
+    const next = wrapper.get('[data-testid="home-pipeline-scroll-next"]').element as HTMLButtonElement
+    expect(prev.disabled).toBe(true)
+    expect(next.disabled).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('syncs scroll arrow disabled state and edge fades when rail overflows', async () => {
+    const many = Array.from({ length: 8 }, (_, i) => ({
+      ...approveWf,
+      id: `wf-${i}`,
+      name: `流水线 ${i}`,
+    }))
+    mocks.listWorkflows.mockResolvedValue(many)
+    const wrapper = mountDashboard()
+    await flushPromises()
+
+    const rail = wrapper.get('[data-testid="home-pipeline-cards"]').element as HTMLDivElement
+    Object.defineProperty(rail, 'clientWidth', { configurable: true, value: 400 })
+    Object.defineProperty(rail, 'scrollWidth', { configurable: true, value: 1600 })
+    let scrollLeft = 0
+    Object.defineProperty(rail, 'scrollLeft', {
+      configurable: true,
+      get: () => scrollLeft,
+      set: (v: number) => {
+        scrollLeft = v
+      },
+    })
+
+    await rail.dispatchEvent(new Event('scroll'))
+    await flushPromises()
+    const prev = wrapper.get('[data-testid="home-pipeline-scroll-prev"]').element as HTMLButtonElement
+    const next = wrapper.get('[data-testid="home-pipeline-scroll-next"]').element as HTMLButtonElement
+    expect(prev.disabled).toBe(true)
+    expect(next.disabled).toBe(false)
+    expect(wrapper.find('.home-pipeline-rail-wrap--has-right').exists()).toBe(true)
+
+    scrollLeft = 1200
+    await rail.dispatchEvent(new Event('scroll'))
+    await flushPromises()
+    expect(prev.disabled).toBe(false)
+    expect(next.disabled).toBe(true)
+    expect(wrapper.find('.home-pipeline-rail-wrap--has-left').exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('arrow click does not change pipeline card selection', async () => {
+    const second: Workflow = {
+      ...approveWf,
+      id: 'wf-lite',
+      name: '快速澄清 Lite',
+      description: '轻量 Approve 入口',
+    }
+    mocks.listWorkflows.mockResolvedValue([approveWf, second])
+    const wrapper = mountDashboard()
+    await flushPromises()
+
+    const rail = wrapper.get('[data-testid="home-pipeline-cards"]').element as HTMLDivElement
+    Object.defineProperty(rail, 'clientWidth', { configurable: true, value: 200 })
+    Object.defineProperty(rail, 'scrollWidth', { configurable: true, value: 800 })
+    Object.defineProperty(rail, 'scrollLeft', {
+      configurable: true,
+      get: () => 0,
+      set: () => {},
+    })
+    await rail.dispatchEvent(new Event('scroll'))
+    await flushPromises()
+
+    await wrapper.get('[data-testid="home-pipeline-scroll-next"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.get('[data-testid="home-pipeline-card-wf-ap"]').classes()).toContain(
+      'home-shell__card--selected',
+    )
+    wrapper.unmount()
+  })
 })

--- a/web/src/views/DashboardView.vue
+++ b/web/src/views/DashboardView.vue
@@ -58,6 +58,12 @@ const composerFocused = ref(false)
 const composing = ref(false)
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
 const overflowScroll = ref(false)
+const pipelineCardsEl = ref<HTMLDivElement | null>(null)
+const pipelineCanScrollPrev = ref(false)
+const pipelineCanScrollNext = ref(false)
+const pipelineFadeLeft = ref(false)
+const pipelineFadeRight = ref(false)
+let pipelineStripObserver: ResizeObserver | null = null
 const phVisible = ref('')
 const phCursor = ref(false)
 let phTimer: ReturnType<typeof setTimeout> | null = null
@@ -222,6 +228,70 @@ function onComposerSubmit(e: Event) {
   void send()
 }
 
+const PIPELINE_SCROLL_EPS = 2
+
+function pipelineCardStep(): number {
+  const rail = pipelineCardsEl.value
+  if (!rail) return 204
+  const card = rail.querySelector('.home-shell__card')
+  if (!card) return 204
+  const styles = getComputedStyle(rail)
+  const gap = parseFloat(styles.columnGap || styles.gap || '12') || 12
+  return card.getBoundingClientRect().width + gap
+}
+
+function syncPipelineNav() {
+  const rail = pipelineCardsEl.value
+  if (!rail) {
+    pipelineCanScrollPrev.value = false
+    pipelineCanScrollNext.value = false
+    pipelineFadeLeft.value = false
+    pipelineFadeRight.value = false
+    return
+  }
+  const max = Math.max(0, rail.scrollWidth - rail.clientWidth)
+  const left = rail.scrollLeft
+  const atStart = left <= PIPELINE_SCROLL_EPS
+  const atEnd = left >= max - PIPELINE_SCROLL_EPS
+  const overflow = max > PIPELINE_SCROLL_EPS
+  pipelineCanScrollPrev.value = overflow && !atStart
+  pipelineCanScrollNext.value = overflow && !atEnd
+  pipelineFadeLeft.value = overflow && !atStart
+  pipelineFadeRight.value = overflow && !atEnd
+}
+
+function scrollPipelineByDir(dir: number) {
+  const rail = pipelineCardsEl.value
+  if (!rail) return
+  const delta = pipelineCardStep() * dir
+  if (prefersReducedMotion()) {
+    rail.classList.add('home-pipeline-rail--instant')
+    rail.scrollLeft += delta
+    requestAnimationFrame(() => rail.classList.remove('home-pipeline-rail--instant'))
+  } else {
+    rail.scrollBy({ left: delta, behavior: 'smooth' })
+  }
+}
+
+function onPipelineWheel(e: WheelEvent) {
+  const rail = pipelineCardsEl.value
+  if (!rail) return
+  if (Math.abs(e.deltaY) > Math.abs(e.deltaX) && !e.shiftKey) return
+  const dx = e.shiftKey ? e.deltaY : e.deltaX
+  if (!dx) return
+  e.preventDefault()
+  rail.scrollLeft += dx
+}
+
+function bindPipelineStripObserver() {
+  if (typeof ResizeObserver === 'undefined') return
+  pipelineStripObserver?.disconnect()
+  pipelineStripObserver = null
+  if (!pipelineCardsEl.value) return
+  pipelineStripObserver = new ResizeObserver(() => syncPipelineNav())
+  pipelineStripObserver.observe(pipelineCardsEl.value)
+}
+
 function openFilePicker() {
   fileInput.value?.click()
 }
@@ -232,14 +302,30 @@ watch(placeholderLines, () => {
   if (showPhTypewriter.value) runPlaceholderTypewriter()
 })
 
+watch(
+  () => pipelines.value.length,
+  () => nextTick(() => {
+    syncPipelineNav()
+    bindPipelineStripObserver()
+  }),
+)
+
 onMounted(() => {
   runBrandTypewriter()
-  nextTick(autoGrow)
+  nextTick(() => {
+    autoGrow()
+    syncPipelineNav()
+    bindPipelineStripObserver()
+  })
+  window.addEventListener('resize', syncPipelineNav)
 })
 
 onBeforeUnmount(() => {
   clearBrandTimers()
   clearPhTimers()
+  pipelineStripObserver?.disconnect()
+  pipelineStripObserver = null
+  window.removeEventListener('resize', syncPipelineNav)
 })
 </script>
 
@@ -429,33 +515,74 @@ onBeforeUnmount(() => {
 
       <div
         v-else
-        class="mt-10 flex w-full justify-center gap-3 overflow-x-auto pb-1"
-        data-testid="home-pipeline-cards"
+        class="home-pipeline-rail-wrap mt-10 w-full"
+        :class="{
+          'home-pipeline-rail-wrap--has-left': pipelineFadeLeft,
+          'home-pipeline-rail-wrap--has-right': pipelineFadeRight,
+        }"
+        data-testid="home-pipeline-rail-wrap"
       >
         <button
-          v-for="p in pipelines"
-          :key="p.id"
           type="button"
-          class="home-shell__card w-48 shrink-0 overflow-hidden border border-line p-0 text-left"
-          :class="p.id === selected?.id ? 'home-shell__card--selected' : 'hover:border-line-strong'"
-          :data-testid="`home-pipeline-card-${p.id}`"
-          @click="selectPipeline(p.id)"
+          class="home-pipeline-nav home-pipeline-nav--prev"
+          data-testid="home-pipeline-scroll-prev"
+          :disabled="!pipelineCanScrollPrev"
+          :aria-label="t('pages.dashboard.scrollLeft')"
+          :title="t('pages.dashboard.scrollLeft')"
+          @click="scrollPipelineByDir(-1)"
         >
-          <div class="home-shell__card-top flex h-20 items-center justify-center">
-            <span class="flex items-center gap-1.5">
-              <span class="h-2 w-2 bg-txt3" />
-              <span class="h-px w-6 bg-line-strong" />
-              <span class="h-2.5 w-2.5 bg-accent" />
-              <span class="h-px w-6 bg-line-strong" />
-              <span class="h-2 w-2 bg-txt3" />
-            </span>
-          </div>
-          <div class="px-3 py-2.5">
-            <div class="truncate text-[13px] font-medium text-txt">{{ p.name }}</div>
-            <div class="mt-0.5 line-clamp-2 text-[11px] text-txt3">
-              {{ p.description || t('pages.dashboard.cardFallback') }}
+          <Icon name="chevron-left" :size="16" />
+        </button>
+        <div class="home-pipeline-fade home-pipeline-fade--left" aria-hidden="true" />
+        <div class="home-pipeline-fade home-pipeline-fade--right" aria-hidden="true" />
+
+        <div
+          ref="pipelineCardsEl"
+          class="home-pipeline-rail flex w-full justify-center gap-3 pb-1"
+          data-testid="home-pipeline-cards"
+          tabindex="0"
+          role="list"
+          @scroll.passive="syncPipelineNav"
+          @wheel="onPipelineWheel"
+        >
+          <button
+            v-for="p in pipelines"
+            :key="p.id"
+            type="button"
+            role="listitem"
+            class="home-shell__card w-48 shrink-0 overflow-hidden border border-line p-0 text-left"
+            :class="p.id === selected?.id ? 'home-shell__card--selected' : 'hover:border-line-strong'"
+            :data-testid="`home-pipeline-card-${p.id}`"
+            @click="selectPipeline(p.id)"
+          >
+            <div class="home-shell__card-top flex h-20 items-center justify-center">
+              <span class="flex items-center gap-1.5">
+                <span class="h-2 w-2 bg-txt3" />
+                <span class="h-px w-6 bg-line-strong" />
+                <span class="h-2.5 w-2.5 bg-accent" />
+                <span class="h-px w-6 bg-line-strong" />
+                <span class="h-2 w-2 bg-txt3" />
+              </span>
             </div>
-          </div>
+            <div class="px-3 py-2.5">
+              <div class="truncate text-[13px] font-medium text-txt">{{ p.name }}</div>
+              <div class="mt-0.5 line-clamp-2 text-[11px] text-txt3">
+                {{ p.description || t('pages.dashboard.cardFallback') }}
+              </div>
+            </div>
+          </button>
+        </div>
+
+        <button
+          type="button"
+          class="home-pipeline-nav home-pipeline-nav--next"
+          data-testid="home-pipeline-scroll-next"
+          :disabled="!pipelineCanScrollNext"
+          :aria-label="t('pages.dashboard.scrollRight')"
+          :title="t('pages.dashboard.scrollRight')"
+          @click="scrollPipelineByDir(1)"
+        >
+          <Icon name="chevron-right" :size="16" />
         </button>
       </div>
     </div>
@@ -648,6 +775,100 @@ onBeforeUnmount(() => {
   background: rgb(244 244 245);
 }
 
+/* g2 — pipeline rail: hidden scrollbar + edge arrows (aligned to page.html demo) */
+.home-pipeline-rail-wrap {
+  position: relative;
+}
+
+.home-pipeline-rail {
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-behavior: smooth;
+  padding: 4px 2px 8px;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-x: contain;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.home-pipeline-rail::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+  display: none;
+  background: transparent;
+}
+
+.home-pipeline-rail--instant {
+  scroll-behavior: auto;
+}
+
+.home-pipeline-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(calc(-50% - 4px));
+  z-index: 2;
+  width: 36px;
+  height: 36px;
+  border: 1px solid rgb(var(--c-line));
+  background: color-mix(in srgb, rgb(var(--c-surface)) 92%, transparent);
+  backdrop-filter: blur(6px);
+  color: rgb(var(--c-txt2));
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  padding: 0;
+  transition:
+    opacity 0.2s ease,
+    color 0.15s ease,
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.home-pipeline-nav:hover:not(:disabled) {
+  color: rgb(var(--c-txt));
+  border-color: rgb(var(--c-line-strong));
+  background: rgb(var(--c-surface));
+}
+
+.home-pipeline-nav:disabled {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.home-pipeline-nav--prev {
+  left: -6px;
+}
+
+.home-pipeline-nav--next {
+  right: -6px;
+}
+
+.home-pipeline-fade {
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  bottom: 8px;
+  width: 28px;
+  z-index: 1;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.home-pipeline-fade--left {
+  left: 0;
+  background: linear-gradient(90deg, rgb(var(--c-base)), transparent);
+}
+
+.home-pipeline-fade--right {
+  right: 0;
+  background: linear-gradient(270deg, rgb(var(--c-base)), transparent);
+}
+
+.home-pipeline-rail-wrap--has-left .home-pipeline-fade--left,
+.home-pipeline-rail-wrap--has-right .home-pipeline-fade--right {
+  opacity: 1;
+}
+
 @keyframes home-brand-caret {
   0%,
   49% {
@@ -685,6 +906,20 @@ onBeforeUnmount(() => {
   .home-composer__ph-cursor {
     animation: none;
     opacity: 1;
+  }
+
+  .home-pipeline-rail {
+    scroll-behavior: auto;
+  }
+}
+
+@media (max-width: 640px) {
+  .home-pipeline-nav--prev {
+    left: 0;
+  }
+
+  .home-pipeline-nav--next {
+    right: 0;
   }
 }
 


### PR DESCRIPTION
Align home-pipeline-cards with confirmed page.html demo: hidden scrollbar,
overflow-aware prev/next arrows, edge fades, smooth one-card scroll step,
and prefers-reduced-motion instant scroll.

Co-authored-by: Cursor <cursoragent@cursor.com>
