### PR TITLE
fix(engine): re-deliver Approve FirstMessage after cancel/resume

### DIFF
--- a/server/internal/engine/approve_first_message.go
+++ b/server/internal/engine/approve_first_message.go
@@ -28,6 +28,13 @@ func normalizeFirstMessage(ctx context.Context, store blob.Store, msg *models.Co
 	return &models.CompositeText{Text: text, Images: images}, nil
 }
 
+// releaseApproveFirstMessageLatch clears the delivery latch so a cancelled or
+// resumed run can claim FirstMessage again on a fresh approve visit.
+func (e *Engine) releaseApproveFirstMessageLatch(runID string) {
+	logDB(e.db.Model(&models.Run{}).Where("id = ? AND first_message_delivered_at IS NOT NULL", runID).
+		UpdateColumn("first_message_delivered_at", nil), runID, "release approve first message latch")
+}
+
 // fireApproveFirstMessage delivers Run.FirstMessage into an approve node's
 // sandbox right after that node parks, so the launcher (home chat) can navigate
 // away immediately instead of polling for the pause and sending it itself.
@@ -35,7 +42,8 @@ func normalizeFirstMessage(ctx context.Context, store blob.Store, msg *models.Co
 // Exactly-once is enforced by a conditional UPDATE on
 // runs.first_message_delivered_at: only the writer that flips it from NULL
 // delivers. A failed delivery releases the latch so a later pause of the same
-// node (loop-back / resume) can retry.
+// node (loop-back / resume) can retry. Cancel / ResumeFrom also release the
+// latch so a new visit with an empty transcript can re-claim.
 func (e *Engine) fireApproveFirstMessage(c *execCtx, node *models.Node) {
 	if c == nil || c.run == nil || node == nil || node.Type != "approve" {
 		return
@@ -61,6 +69,7 @@ func (e *Engine) fireApproveFirstMessage(c *execCtx, node *models.Node) {
 
 	text := msg.Text
 	images := append([]models.PromptImage(nil), msg.Images...)
+	claimedAt := now
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
@@ -68,11 +77,22 @@ func (e *Engine) fireApproveFirstMessage(c *execCtx, node *models.Node) {
 					Interface("panic", r).Msg("approve first message: deliver panic")
 			}
 		}()
+		// Cancel/Resume may release or re-claim the latch while this goroutine is
+		// in flight; only deliver when our claim is still authoritative.
+		var stored models.Run
+		if err := e.db.Select("first_message_delivered_at").First(&stored, "id = ?", runID).Error; err != nil {
+			log.Warn().Err(err).Str("run_id", runID).Msg("approve first message: claim check failed")
+			return
+		}
+		if stored.FirstMessageDeliveredAt == nil || !stored.FirstMessageDeliveredAt.Equal(claimedAt) {
+			log.Info().Str("run_id", runID).Str("node_id", nodeID).
+				Msg("approve first message: claim superseded; skip stale delivery")
+			return
+		}
 		if err := e.ReactReply(runID, nodeID, text, images, nil, false); err != nil {
 			log.Warn().Err(err).Str("run_id", runID).Str("node_id", nodeID).
 				Msg("approve first message: deliver failed; releasing latch")
-			logDB(e.db.Model(&models.Run{}).Where("id = ?", runID).
-				UpdateColumn("first_message_delivered_at", nil), runID, "release first message latch")
+			e.releaseApproveFirstMessageLatch(runID)
 			return
 		}
 		log.Info().Str("run_id", runID).Str("node_id", nodeID).Int("images", len(images)).

--- a/server/internal/engine/approve_first_message_test.go
+++ b/server/internal/engine/approve_first_message_test.go
@@ -118,3 +118,59 @@ func TestApproveWithoutFirstMessageParksEmpty(t *testing.T) {
 		t.Fatal("latch must stay unset when there is nothing to deliver")
 	}
 }
+
+// Cancel then ResumeFrom must re-deliver FirstMessage into the new approve visit,
+// matching a fresh run — not leave the UI at "共 0 条".
+func TestApproveFirstMessageRedeliveredAfterCancelResume(t *testing.T) {
+	eng, db, _ := setupEngineGraphP(t, approveOnlyGraph())
+	msg := &models.CompositeText{Text: "把登录做清楚"}
+	run, err := eng.StartRunWithFirstMessage("wf", nil, "test", "", nil, nil, "", msg)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	turn := waitFirstHumanTurn(t, db, run.ID, "predev")
+	if turn.Text != "把登录做清楚" {
+		t.Fatalf("first delivery text = %q", turn.Text)
+	}
+	waitRunStatus(t, db, run.ID, "waiting_human")
+
+	if err := eng.Cancel(run.ID); err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+	waitRunStatus(t, db, run.ID, "cancelled")
+
+	var stored models.Run
+	if err := db.First(&stored, "id = ?", run.ID).Error; err != nil {
+		t.Fatalf("load run: %v", err)
+	}
+	if stored.FirstMessageDeliveredAt != nil {
+		t.Fatal("cancel must release delivery latch")
+	}
+
+	if err := eng.ResumeFrom(run.ID, "predev"); err != nil {
+		t.Fatalf("ResumeFrom: %v", err)
+	}
+	waitRunStatus(t, db, run.ID, "waiting_human")
+
+	var conv models.ReactConversation
+	if err := db.Where("run_id = ? AND node_id = ?", run.ID, "predev").
+		Order("iteration desc").First(&conv).Error; err != nil {
+		t.Fatalf("conv: %v", err)
+	}
+	if conv.Iteration < 2 {
+		t.Fatalf("expected new visit iteration >= 2, got %d", conv.Iteration)
+	}
+	humans := 0
+	for _, m := range conv.Messages {
+		if m.Role == "human" {
+			humans++
+			if m.Text != "把登录做清楚" {
+				t.Fatalf("redelivered text = %q", m.Text)
+			}
+		}
+	}
+	if humans != 1 {
+		t.Fatalf("new visit human turns = %d, want 1", humans)
+	}
+}

--- a/server/internal/engine/resume.go
+++ b/server/internal/engine/resume.go
@@ -639,6 +639,12 @@ func (e *Engine) ResumeFrom(runID, nodeID string) error {
 	if snap, ok := e.nodeStartVars(runID, nodeID); ok {
 		e.restoreVars(c, snap)
 	}
+	// A cancelled/failed approve visit may have already delivered FirstMessage;
+	// release the latch so the fresh visit opened by this resume can claim again.
+	if c.run.FirstMessage != nil {
+		e.releaseApproveFirstMessageLatch(runID)
+		c.run.FirstMessageDeliveredAt = nil
+	}
 	// Record the manual resume in the trace before handing off to admission.
 	// loadCtx already re-restored the MCP token from the persisted Run.McpToken
 	// (finish() unregistered it on failure), so in-sandbox artifact writes
@@ -774,6 +780,9 @@ func (e *Engine) Cancel(runID string) error {
 	// for the remainder of a long RunAgent call. The late driver observes the
 	// terminal status and exits without routing; its endExecute is gen-guarded.
 	e.forceEndExecute(runID)
+	if run.FirstMessage != nil {
+		e.releaseApproveFirstMessageLatch(runID)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Release the first_message_delivered_at latch on Cancel and ResumeFrom so
a fresh approve visit can claim and auto-send the opening message again.
Guard async delivery against superseded claims to avoid stale double-send.

Co-authored-by: Cursor <cursoragent@cursor.com>
