### PR TITLE
fix(web): 通知已读状态刷新/重登后不再回潮

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,2 +1,4 @@
 # RFC 6455 example nonce used only to construct a WebSocket test request.
 684d5428c38607c2b4b2e637da755123a2541947:server/internal/handlers/vnc_production_router_test.go:generic-api-key:21
+# E2E localStorage prefs key (approving.notifications.prefs.e2e) — not a secret.
+e35960d3362f881f45758972b8b1f18e7b4fa181:web/e2e/notifications-center-main.ts:generic-api-key:376

--- a/web/e2e/notifications-center-main.ts
+++ b/web/e2e/notifications-center-main.ts
@@ -373,10 +373,14 @@ async function bootstrap() {
     scene === 'legacy-structured-page' ||
     scene === 'paged'
   ) {
-    localStorage.setItem(
-      'approving.notifications.prefs.e2e',
-      JSON.stringify({ enabledAt: '2020-01-01T00:00:00Z', readIds: [] }),
-    )
+    const prefsKey = 'approving.notifications.prefs.e2e'
+    // Seed only when absent so reload tests can assert read-state persistence.
+    if (!localStorage.getItem(prefsKey)) {
+      localStorage.setItem(
+        prefsKey,
+        JSON.stringify({ enabledAt: '2020-01-01T00:00:00Z', readIds: [] }),
+      )
+    }
   } else {
     localStorage.removeItem('approving.notifications.prefs.e2e')
     localStorage.removeItem('approving.runTerminalNotifications.readIds.e2e')

--- a/web/e2e/notifications-center-main.ts
+++ b/web/e2e/notifications-center-main.ts
@@ -10,6 +10,10 @@ import { installRoutePendingGuards } from '../src/lib/shared/routePending'
 import { installAuthGuard } from '../src/lib/shared/authGuard'
 import NotificationsView from '../src/views/NotificationsView.vue'
 import { sidebarNavGroups } from '../src/data/sidebarNav'
+import {
+  prefsKeyForUser,
+  storageKeyForUser,
+} from '../src/lib/run/useRunTerminalNotifications'
 
 installIdleScrollbar()
 
@@ -373,7 +377,7 @@ async function bootstrap() {
     scene === 'legacy-structured-page' ||
     scene === 'paged'
   ) {
-    const prefsKey = 'approving.notifications.prefs.e2e'
+    const prefsKey = prefsKeyForUser('e2e')
     // Seed only when absent so reload tests can assert read-state persistence.
     if (!localStorage.getItem(prefsKey)) {
       localStorage.setItem(
@@ -382,8 +386,8 @@ async function bootstrap() {
       )
     }
   } else {
-    localStorage.removeItem('approving.notifications.prefs.e2e')
-    localStorage.removeItem('approving.runTerminalNotifications.readIds.e2e')
+    localStorage.removeItem(prefsKeyForUser('e2e'))
+    localStorage.removeItem(storageKeyForUser('e2e'))
   }
 
   const DashboardPage = defineComponent({

--- a/web/e2e/notifications-center.spec.ts
+++ b/web/e2e/notifications-center.spec.ts
@@ -206,6 +206,27 @@ test.describe('shell notification center (IA separation)', () => {
     await expect(page.getByTestId('run-notifications-badge')).toHaveText('3', { timeout: 5_000 })
   })
 
+  test('mark-all-read persists across hard reload (no unread resurgence)', async ({ page }) => {
+    await page.goto('/notifications-center.html?scene=with-items&start=notifications')
+    await expect(page.getByTestId('notifications-page')).toBeVisible({ timeout: 15_000 })
+    await settleAuth(page)
+    await expect(page.getByTestId('run-notifications-badge')).toHaveText('3')
+
+    await page.getByTestId('notifications-mark-all').click()
+    await expect(page.getByTestId('run-notifications-badge')).toHaveCount(0)
+    await expect(page.getByTestId('nav-notifications-badge')).toHaveCount(0)
+    await expect(page.getByTestId('notifications-unread-count')).toContainText('0')
+
+    await page.reload()
+    await expect(page.getByTestId('notifications-page')).toBeVisible({ timeout: 15_000 })
+    await settleAuth(page)
+    await expect(page.getByTestId('run-notifications-badge')).toHaveCount(0)
+    await expect(page.getByTestId('nav-notifications-badge')).toHaveCount(0)
+    await expect(page.getByTestId('notifications-unread-count')).toContainText('0')
+    await page.getByTestId('notifications-filter-unread').click()
+    await expect(page.getByTestId('notifications-item')).toHaveCount(0)
+  })
+
   test('independent page paginates at 20; filter and topbar entry reset to page 1 (g4.3)', async ({
     page,
   }) => {

--- a/web/src/lib/run/useRunTerminalNotifications.test.ts
+++ b/web/src/lib/run/useRunTerminalNotifications.test.ts
@@ -326,4 +326,123 @@ describe('useRunTerminalNotifications', () => {
     expect(localStorage.getItem(prefsKeyForUser('anonymous'))).toBeNull()
     n.stopPolling()
   })
+
+  it('markRead survives module reset + auth rehydrate (page refresh)', async () => {
+    seedBaseline()
+    vi.mocked(api.listRuns).mockResolvedValue(
+      paged([
+        run({ id: 'a', status: 'failed' }),
+        run({ id: 'b', status: 'completed' }),
+      ]),
+    )
+    const n1 = useRunTerminalNotifications()
+    await n1.refresh({ source: 'mount' })
+    expect(n1.unreadCount.value).toBe(2)
+    n1.markRead('a')
+    expect(n1.unreadCount.value).toBe(1)
+
+    __resetRunTerminalNotificationsForTests()
+    authReady.value = false
+    authUser.value = null
+
+    const n2 = useRunTerminalNotifications()
+    n2.startPolling()
+    expect(n2.ensureUsername()).toBe(false)
+    expect(n2.unreadCount.value).toBe(0)
+
+    authUser.value = { username: 'alice', expiresAt: 't' }
+    authReady.value = true
+    await vi.waitFor(() => {
+      expect(n2.unreadCount.value).toBe(1)
+      expect(n2.badgeLabel.value).toBe('1')
+    })
+    expect(n2.previewItems.value.find((x) => x.runId === 'a')?.unread).toBe(false)
+    expect(n2.previewItems.value.find((x) => x.runId === 'b')?.unread).toBe(true)
+    const prefs = JSON.parse(localStorage.getItem(prefsKeyForUser('alice')) || '{}')
+    expect(prefs.readIds).toContain('a')
+    expect(localStorage.getItem(prefsKeyForUser('anonymous'))).toBeNull()
+    n2.stopPolling()
+  })
+
+  it('markAllRead survives logout and same-account re-login', async () => {
+    seedBaseline()
+    vi.mocked(api.listRuns).mockResolvedValue(
+      paged([
+        run({ id: 'a', status: 'failed' }),
+        run({ id: 'b', status: 'completed' }),
+      ]),
+    )
+    const n1 = useRunTerminalNotifications()
+    await n1.refresh({ source: 'mount' })
+    expect(n1.unreadCount.value).toBe(2)
+    n1.markAllRead()
+    expect(n1.unreadCount.value).toBe(0)
+
+    authUser.value = null
+    authReady.value = true
+    __resetRunTerminalNotificationsForTests()
+
+    const n2 = useRunTerminalNotifications()
+    n2.startPolling()
+    await vi.waitFor(() => {
+      expect(n2.ensureUsername()).toBe(true)
+    })
+    expect(n2.unreadCount.value).toBe(0)
+
+    authUser.value = { username: 'alice', expiresAt: 't' }
+    await vi.waitFor(() => {
+      expect(n2.unreadCount.value).toBe(0)
+      expect(n2.badgeLabel.value).toBe('')
+    })
+    const prefs = JSON.parse(localStorage.getItem(prefsKeyForUser('alice')) || '{}')
+    expect(prefs.readIds).toEqual(expect.arrayContaining(['a', 'b']))
+    n2.stopPolling()
+  })
+
+  it('markRead before auth settle does not stamp anonymous prefs', async () => {
+    authReady.value = false
+    authUser.value = null
+    localStorage.removeItem(prefsKeyForUser('anonymous'))
+    localStorage.removeItem(prefsKeyForUser('alice'))
+
+    const n = useRunTerminalNotifications()
+    n.markRead('ghost')
+    expect(localStorage.getItem(prefsKeyForUser('anonymous'))).toBeNull()
+    expect(localStorage.getItem(prefsKeyForUser('alice'))).toBeNull()
+  })
+
+  it('markAllRead before auth settle does not stamp anonymous prefs', async () => {
+    authReady.value = false
+    authUser.value = null
+    localStorage.removeItem(prefsKeyForUser('anonymous'))
+    localStorage.removeItem(prefsKeyForUser('alice'))
+
+    const n = useRunTerminalNotifications()
+    n.markAllRead()
+    expect(localStorage.getItem(prefsKeyForUser('anonymous'))).toBeNull()
+    expect(localStorage.getItem(prefsKeyForUser('alice'))).toBeNull()
+  })
+
+  it('new terminal events after markAllRead still count as unread', async () => {
+    seedBaseline()
+    vi.mocked(api.listRuns).mockResolvedValue(
+      paged([run({ id: 'a', status: 'completed' })]),
+    )
+    const n = useRunTerminalNotifications()
+    await n.refresh({ source: 'mount' })
+    expect(n.unreadCount.value).toBe(1)
+    n.markAllRead()
+    expect(n.unreadCount.value).toBe(0)
+
+    vi.mocked(api.listRuns).mockResolvedValue(
+      paged([
+        run({ id: 'new', status: 'failed', startedAt: '2026-08-10T14:00:00Z' }),
+        run({ id: 'a', status: 'completed' }),
+      ]),
+    )
+    await n.refresh({ source: 'manual' })
+    expect(n.unreadCount.value).toBe(1)
+    expect(n.previewItems.value.find((x) => x.runId === 'new')?.unread).toBe(true)
+    expect(n.previewItems.value.find((x) => x.runId === 'a')?.unread).toBe(false)
+  })
 })

--- a/web/src/lib/run/useRunTerminalNotifications.ts
+++ b/web/src/lib/run/useRunTerminalNotifications.ts
@@ -263,6 +263,14 @@ const remainingCount = computed(() => Math.max(pool.value.length - RUN_TERMINAL_
 
 const poolTotal = computed(() => pool.value.length)
 
+function flushPrefsForKey(key: string) {
+  if (!key || !prefsHydrated) return
+  persistPrefs(key, {
+    enabledAt: enabledAt.value || new Date().toISOString(),
+    readIds: [...readIds.value],
+  })
+}
+
 /** @returns true when prefs are hydrated for a settled auth identity */
 function ensureUsername(): boolean {
   const { name, settled } = resolveUsername()
@@ -272,6 +280,7 @@ function ensureUsername(): boolean {
     return false
   }
   if (name !== usernameKey.value) {
+    flushPrefsForKey(usernameKey.value)
     usernameKey.value = name
     const prefs = loadPrefs(name)
     enabledAt.value = prefs.enabledAt
@@ -318,7 +327,12 @@ function installAuthWatch() {
 }
 
 function persistCurrent() {
-  persistPrefs(usernameKey.value, {
+  const { name, settled } = resolveUsername()
+  // Never stamp anonymous / wrong key while auth is still in flight.
+  if (!settled) return
+  usernameKey.value = name
+  prefsHydrated = true
+  persistPrefs(name, {
     enabledAt: enabledAt.value || new Date().toISOString(),
     readIds: [...readIds.value],
   })
@@ -326,6 +340,7 @@ function persistCurrent() {
 
 function markRead(runId: string) {
   if (!runId || readIds.value.has(runId)) return
+  if (!ensureUsername()) return
   const next = new Set(readIds.value)
   next.add(runId)
   readIds.value = next
@@ -333,7 +348,7 @@ function markRead(runId: string) {
 }
 
 function markAllRead() {
-  ensureUsername()
+  if (!ensureUsername()) return
   if (!pool.value.length) {
     // Still persist baseline so empty sessions don't re-seed oddly.
     persistCurrent()


### PR DESCRIPTION
persistCurrent 改为按鉴权 settle 后的真实用户名落盘，markRead/markAllRead
在身份未就绪时不再写入 anonymous 键；切换账号前 flush 当前 prefs。
补充刷新/重登回归单测与 e2e 硬刷新断言。

Co-authored-by: Cursor <cursoragent@cursor.com>
