### PR TITLE
fix: align output source index badges for two-digit numbers

### DIFF
--- a/web/src/components/canvas/OutputSourcesEditor.test.ts
+++ b/web/src/components/canvas/OutputSourcesEditor.test.ts
@@ -67,4 +67,20 @@ describe('OutputSourcesEditor', () => {
     expect(wrapper.text()).toContain('调研')
     wrapper.unmount()
   })
+
+  it('uses fixed-width index badges for 10+ selected sources', () => {
+    // plan_coverage: g1.1 / g2.1 — 序号徽章等宽，避免一位/两位数字挤开同行控件
+    const results = Array.from({ length: 12 }, (_, i) => `custom.source.${i + 1}`)
+    const wrapper = mountEditor({ withUpstream: false, results })
+    const badges = wrapper.findAll('.inline-flex.w-\\[22px\\].tabular-nums')
+    expect(badges).toHaveLength(12)
+    for (const badge of badges) {
+      expect(badge.classes()).toContain('w-[22px]')
+      expect(badge.classes()).toContain('shrink-0')
+      expect(badge.classes()).not.toContain('min-w-[18px]')
+    }
+    expect(badges[8]?.text()).toBe('9')
+    expect(badges[9]?.text()).toBe('10')
+    wrapper.unmount()
+  })
 })

--- a/web/src/components/canvas/OutputSourcesEditor.vue
+++ b/web/src/components/canvas/OutputSourcesEditor.vue
@@ -100,7 +100,7 @@ function onDrop(target: string) {
           @drop.prevent="onDrop(template)"
         >
           <span class="cursor-grab text-[12px] text-txt3">⠿</span>
-          <span class="min-w-[18px] bg-accent-dim px-1.5 py-0.5 text-center text-[10px] text-accent-2">{{ i + 1 }}</span>
+          <span class="inline-flex w-[22px] shrink-0 items-center justify-center bg-accent-dim py-0.5 text-[10px] tabular-nums text-accent-2">{{ i + 1 }}</span>
           <AppSwitch
             :model-value="true"
             :aria-label="labelFor(template)"


### PR DESCRIPTION
Use fixed-width centered badges so switches and labels stay aligned when the selected list exceeds 9 items.

Co-authored-by: Cursor <cursoragent@cursor.com>
