### PR TITLE
fix(web): prevent first pipeline card clipping on overflow

### DIFF
--- a/web/src/views/DashboardView.fill.test.ts
+++ b/web/src/views/DashboardView.fill.test.ts
@@ -98,6 +98,12 @@ describe('DashboardView home chat layout', () => {
     expect(src).toMatch(/data-testid="home-pipeline-scroll-prev"/)
     expect(src).toMatch(/data-testid="home-pipeline-scroll-next"/)
     expect(src).toMatch(/home-pipeline-rail/)
+    expect(src).toMatch(/home-pipeline-rail--overflow/)
+    expect(src).toMatch(/justify-content:\s*center/)
+    expect(src).toMatch(/home-pipeline-rail--overflow[\s\S]*justify-content:\s*flex-start/)
+    expect(src).not.toMatch(
+      /data-testid="home-pipeline-cards"[^>]*justify-center/,
+    )
     expect(src).toMatch(/scrollbar-width:\s*none/)
     expect(src).toMatch(/::-webkit-scrollbar/)
     expect(src).toMatch(/home-pipeline-nav/)

--- a/web/src/views/DashboardView.test.ts
+++ b/web/src/views/DashboardView.test.ts
@@ -518,11 +518,15 @@ describe('DashboardView home composer', () => {
 
     await rail.dispatchEvent(new Event('scroll'))
     await flushPromises()
+    expect(wrapper.get('[data-testid="home-pipeline-cards"]').classes()).toContain(
+      'home-pipeline-rail--overflow',
+    )
     const prev = wrapper.get('[data-testid="home-pipeline-scroll-prev"]').element as HTMLButtonElement
     const next = wrapper.get('[data-testid="home-pipeline-scroll-next"]').element as HTMLButtonElement
     expect(prev.disabled).toBe(true)
     expect(next.disabled).toBe(false)
     expect(wrapper.find('.home-pipeline-rail-wrap--has-right').exists()).toBe(true)
+    expect(wrapper.find('.home-pipeline-rail-wrap--has-left').exists()).toBe(false)
 
     scrollLeft = 1200
     await rail.dispatchEvent(new Event('scroll'))
@@ -530,7 +534,55 @@ describe('DashboardView home composer', () => {
     expect(prev.disabled).toBe(false)
     expect(next.disabled).toBe(true)
     expect(wrapper.find('.home-pipeline-rail-wrap--has-left').exists()).toBe(true)
+    expect(wrapper.find('.home-pipeline-rail-wrap--has-right').exists()).toBe(false)
 
+    scrollLeft = 0
+    await rail.dispatchEvent(new Event('scroll'))
+    await flushPromises()
+    expect(prev.disabled).toBe(true)
+    expect(wrapper.find('.home-pipeline-rail-wrap--has-left').exists()).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('left-aligns pipeline rail when overflowing so first card is not clipped', async () => {
+    const many = Array.from({ length: 6 }, (_, i) => ({
+      ...approveWf,
+      id: `wf-${i}`,
+      name: `流水线 ${i}`,
+    }))
+    mocks.listWorkflows.mockResolvedValue(many)
+    const wrapper = mountDashboard()
+    await flushPromises()
+
+    const rail = wrapper.get('[data-testid="home-pipeline-cards"]')
+    const railEl = rail.element as HTMLDivElement
+    Object.defineProperty(railEl, 'clientWidth', { configurable: true, value: 400 })
+    Object.defineProperty(railEl, 'scrollWidth', { configurable: true, value: 1200 })
+    Object.defineProperty(railEl, 'scrollLeft', { configurable: true, value: 0, writable: true })
+
+    await railEl.dispatchEvent(new Event('scroll'))
+    await flushPromises()
+
+    expect(rail.classes()).toContain('home-pipeline-rail--overflow')
+    expect(rail.classes()).not.toContain('justify-center')
+    wrapper.unmount()
+  })
+
+  it('keeps pipeline rail centered when cards do not overflow', async () => {
+    const wrapper = mountDashboard()
+    await flushPromises()
+
+    const rail = wrapper.get('[data-testid="home-pipeline-cards"]')
+    const railEl = rail.element as HTMLDivElement
+    Object.defineProperty(railEl, 'clientWidth', { configurable: true, value: 800 })
+    Object.defineProperty(railEl, 'scrollWidth', { configurable: true, value: 200 })
+    Object.defineProperty(railEl, 'scrollLeft', { configurable: true, value: 0, writable: true })
+
+    await railEl.dispatchEvent(new Event('scroll'))
+    await flushPromises()
+
+    expect(rail.classes()).not.toContain('home-pipeline-rail--overflow')
     wrapper.unmount()
   })
 

--- a/web/src/views/DashboardView.vue
+++ b/web/src/views/DashboardView.vue
@@ -63,6 +63,7 @@ const pipelineCanScrollPrev = ref(false)
 const pipelineCanScrollNext = ref(false)
 const pipelineFadeLeft = ref(false)
 const pipelineFadeRight = ref(false)
+const pipelineOverflows = ref(false)
 let pipelineStripObserver: ResizeObserver | null = null
 const phVisible = ref('')
 const phCursor = ref(false)
@@ -247,6 +248,7 @@ function syncPipelineNav() {
     pipelineCanScrollNext.value = false
     pipelineFadeLeft.value = false
     pipelineFadeRight.value = false
+    pipelineOverflows.value = false
     return
   }
   const max = Math.max(0, rail.scrollWidth - rail.clientWidth)
@@ -254,6 +256,7 @@ function syncPipelineNav() {
   const atStart = left <= PIPELINE_SCROLL_EPS
   const atEnd = left >= max - PIPELINE_SCROLL_EPS
   const overflow = max > PIPELINE_SCROLL_EPS
+  pipelineOverflows.value = overflow
   pipelineCanScrollPrev.value = overflow && !atStart
   pipelineCanScrollNext.value = overflow && !atEnd
   pipelineFadeLeft.value = overflow && !atStart
@@ -538,7 +541,8 @@ onBeforeUnmount(() => {
 
         <div
           ref="pipelineCardsEl"
-          class="home-pipeline-rail flex w-full justify-center gap-3 pb-1"
+          class="home-pipeline-rail flex w-full gap-3 pb-1"
+          :class="{ 'home-pipeline-rail--overflow': pipelineOverflows }"
           data-testid="home-pipeline-cards"
           tabindex="0"
           role="list"
@@ -781,6 +785,7 @@ onBeforeUnmount(() => {
 }
 
 .home-pipeline-rail {
+  justify-content: center;
   overflow-x: auto;
   overflow-y: hidden;
   scroll-behavior: smooth;
@@ -789,6 +794,10 @@ onBeforeUnmount(() => {
   overscroll-behavior-x: contain;
   scrollbar-width: none;
   -ms-overflow-style: none;
+}
+
+.home-pipeline-rail--overflow {
+  justify-content: flex-start;
 }
 
 .home-pipeline-rail::-webkit-scrollbar {


### PR DESCRIPTION
When the home pipeline rail overflows, justify-center caused unreachable
left overflow at scrollLeft=0. Switch to flex-start via an overflow
modifier while keeping center alignment when content fits.

Co-authored-by: Cursor <cursoragent@cursor.com>
