### PR TITLE
fix(ci): harden PlatformStatus singleflight test against timing flake

### DIFF
--- a/server/internal/services/platform_status_test.go
+++ b/server/internal/services/platform_status_test.go
@@ -292,8 +292,11 @@ func TestPlatformStatus_singleflightMerges(t *testing.T) {
 			_, errs[i] = dash.PlatformStatus(context.Background(), q)
 		}(i)
 	}
-	// Give goroutines time to enter singleflight.
-	time.Sleep(50 * time.Millisecond)
+	// Wait until the singleflight leader enters the hook (avoid fixed-sleep flake).
+	deadline := time.Now().Add(2 * time.Second)
+	for atomic.LoadInt32(&started) == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
 	if got := atomic.LoadInt32(&started); got != 1 {
 		release.Done()
 		t.Fatalf("expected 1 in-flight compute, got %d", got)


### PR DESCRIPTION
## Summary
- `TestPlatformStatus_singleflightMerges` failed on the `v0.3.0-beta` tag `ci-server` run (`expected 1 in-flight compute, got 0`) due to a fixed 50ms sleep race.
- Wait/poll until the singleflight leader enters the hook (2s deadline) instead of sleeping a fixed duration.

## Test plan
- [x] `go test ./internal/services/ -run TestPlatformStatus_singleflightMerges -count=20`
- [ ] CI `ci-server` green on this PR


Made with [Cursor](https://cursor.com)