### PR TITLE
fix(sandbox): Claude Code 无头模式加载 artifact-store MCP

### DIFF
--- a/sandbox-gateway/sandbox/internal/agents/registry.go
+++ b/sandbox-gateway/sandbox/internal/agents/registry.go
@@ -67,13 +67,16 @@ var registry = map[Name]provider.Provider{
 	// claude: `-p --output-format stream-json --input-format stream-json`,
 	// prompt fed as a stream-json user envelope on stdin. Autonomous headless
 	// run => bypass permissions; the interactive question tool is disabled.
+	// --strict-mcp-config + streamjson auto --mcp-config: headless -p does not
+	// load ConfigRoot/mcp.json by default (verified claude 2.1.241); without this
+	// pair artifact-store from SANDBOX_INJECT never reaches the tool list.
 	provider.ClaudeCode: streamjson.New(streamjson.Config{
 		AgentName:  provider.ClaudeCode,
 		Bin:        "claude",
 		Runtime:    "claude-stream-json",
 		ConfigRoot: "/root/.claude",
 		PromptMode: streamjson.PromptStdinJSON,
-		BaseArgs:   []string{"--verbose", "--permission-mode", "bypassPermissions", "--disallowedTools", "AskUserQuestion"},
+		BaseArgs:   []string{"--verbose", "--strict-mcp-config", "--permission-mode", "bypassPermissions", "--disallowedTools", "AskUserQuestion"},
 		ResumeFlag: "--resume",
 		ModelFlag:  "--model",
 		AuthEnvFn:  streamjson.ClaudeAuthEnv,
@@ -112,7 +115,7 @@ var registry = map[Name]provider.Provider{
 		Runtime:    "claude-stream-json",
 		ConfigRoot: "/root/.claude",
 		PromptMode: streamjson.PromptStdinJSON,
-		BaseArgs:   []string{"--verbose", "--permission-mode", "bypassPermissions", "--disallowedTools", "AskUserQuestion"},
+		BaseArgs:   []string{"--verbose", "--strict-mcp-config", "--permission-mode", "bypassPermissions", "--disallowedTools", "AskUserQuestion"},
 		ResumeFlag: "--resume",
 		ModelFlag:  "--model",
 		AuthEnvFn:  streamjson.ClaudeAuthEnv,

--- a/sandbox-gateway/sandbox/internal/agents/registry_test.go
+++ b/sandbox-gateway/sandbox/internal/agents/registry_test.go
@@ -134,13 +134,20 @@ func indexOfArg(args []string, want string) int {
 	return -1
 }
 
-func TestClaudeFamilyDoesNotUseBareStrictMcp(t *testing.T) {
-	// Only codebuddy opts into --strict-mcp-config (with streamjson auto --mcp-config).
-	// Claude loads ~/.claude/mcp.json by default — do not add bare strict here.
+// TestClaudeCodeArgsGoldenStrictPlusMcpConfig: headless -p ignores ConfigRoot/mcp.json
+// unless --strict-mcp-config triggers streamjson to attach --mcp-config <root>/mcp.json.
+func TestClaudeCodeArgsGoldenStrictPlusMcpConfig(t *testing.T) {
 	for _, n := range []provider.Name{provider.ClaudeCode, provider.ClaudeStream} {
-		if registry[n].DefaultConfigRoot() == "" {
-			t.Fatalf("%s missing ConfigRoot", n)
-		}
+		t.Run(string(n), func(t *testing.T) {
+			args := mustArgsForTest(t, registry[n])
+			if !containsArg(args, "--strict-mcp-config") {
+				t.Fatalf("%s missing --strict-mcp-config in %v", n, args)
+			}
+			wantPath := "/root/.claude/mcp.json"
+			if i := indexOfArg(args, "--mcp-config"); i < 0 || i+1 >= len(args) || args[i+1] != wantPath {
+				t.Fatalf("%s want --mcp-config %s in %v", n, wantPath, args)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- 为 `claude_code` / `claude_stream_json` 的 stream-json 启动参数增加 `--strict-mcp-config`，由 `streamjson` 自动附带 `--mcp-config /root/.claude/mcp.json`
- 修复无头 `-p` 模式下不读取 `SANDBOX_INJECT` 写入的 `mcp.json`，导致 `artifact-store` 工具（`ask_question`、`set_clarified_requirement`、`node_complete` 等）不进 `system/init` 工具列表、Agent 误判「MCP 未挂载」的问题
- 新增 `TestClaudeCodeArgsGoldenStrictPlusMcpConfig` 锁定生产 argv 形态（与 CodeBuddy 同策略）

## 背景
本地实测（Claude Code 2.1.241）：
- 无 `--mcp-config`：即使存在 `~/.claude/mcp.json`，`mcp_servers` 仍为空
- 有 `--strict-mcp-config --mcp-config <path>`：`mcp__*` 工具正常出现在 `system/init`

## Test plan
- [x] `go test ./internal/agents/... ./internal/provider/streamjson/...`（sandbox-gateway/sandbox 目录下）
- [ ] 重新打沙箱镜像后，在 Approve/澄清节点确认 Agent 首轮即可调用 `ask_question` / `set_clarified_requirement`，无需 HTTP 回退


Made with [Cursor](https://cursor.com)