### PR TITLE
fix(web): fill ProjectDetailView height under route-view-wrap

### DIFF
--- a/web/e2e/project-detail.spec.ts
+++ b/web/e2e/project-detail.spec.ts
@@ -602,7 +602,7 @@ test.describe('ProjectDetailView 项目信息面板', () => {
 
     const panel = page
       .locator('.border.border-line.bg-surface')
-      .filter({ hasText: '修改名称或描述后点击保存' })
+      .filter({ hasText: '修改名称、描述或未知模型显示名后点击保存' })
       .first()
     await expect(panel).toBeVisible()
     await expect(panel.getByRole('heading', { name: '项目信息' })).toBeVisible()
@@ -756,7 +756,9 @@ test.describe('ProjectDetailView 项目信息面板', () => {
     await page.getByRole('button', { name: '定时任务' }).click()
     await expect(page.getByText('暂无定时任务')).toBeVisible()
     await expect(page).toHaveURL(/tab=cronJobs/)
-    await page.getByRole('button', { name: '通知' }).click()
+    const notifyTab = page.getByTestId('project-tab-notify')
+    await notifyTab.scrollIntoViewIfNeeded()
+    await notifyTab.click()
     await expect(page.getByTestId('project-notify-panel')).toBeVisible()
     await expect(page).toHaveURL(/tab=notify/)
     await page.getByRole('button', { name: '项目信息' }).click()
@@ -1134,7 +1136,7 @@ test.describe('ProjectDetailView PM Leader 滚动', () => {
     await gotoPmLeaderChat(page, { captureWs: true })
 
     const scroller = page.getByTestId('pm-message-scroller')
-    await page.getByPlaceholder('输入问题，Enter 发送；可粘贴或选择图片').fill('测试 stick')
+    await page.getByPlaceholder('输入问题，Enter 发送；可粘贴或选择附件').fill('测试 stick')
     await page.getByRole('button', { name: '发送' }).click()
     await expect(page.getByTestId('pm-stream-bubble')).toBeVisible({ timeout: 10_000 })
 

--- a/web/src/views/ProjectDetailView.heightChain.test.ts
+++ b/web/src/views/ProjectDetailView.heightChain.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const viewsDir = dirname(fileURLToPath(import.meta.url))
+const detailSrc = readFileSync(join(viewsDir, 'ProjectDetailView.vue'), 'utf8')
+const pmChatSrc = readFileSync(join(viewsDir, '../components/pm/PmLeaderChat.vue'), 'utf8')
+const appSrc = readFileSync(join(viewsDir, '../App.vue'), 'utf8')
+const globalCss = readFileSync(join(viewsDir, '../styles/global.css'), 'utf8')
+const gatesSrc = readFileSync(join(viewsDir, 'GatesInboxView.vue'), 'utf8')
+const e2eHarnessSrc = readFileSync(join(viewsDir, '../../e2e/project-detail-main.ts'), 'utf8')
+
+function pmLeaderTabBlock(): string {
+  const start = detailSrc.indexOf("tab === 'pmLeader'")
+  expect(start, 'missing pmLeader tab block').toBeGreaterThanOrEqual(0)
+  const end = detailSrc.indexOf("tab === 'cronJobs'", start)
+  expect(end, 'missing end marker after pmLeader tab').toBeGreaterThan(start)
+  return detailSrc.slice(start, end)
+}
+
+describe('ProjectDetailView route-view-wrap height chain (g2.1 / g3.1)', () => {
+  it('root panel uses h-full like GatesInboxView to fill block route-view-wrap (g2.1)', () => {
+    expect(detailSrc).toMatch(/class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"/)
+    expect(detailSrc).toMatch(/data-testid="project-detail-panel"/)
+    expect(gatesSrc).toMatch(/class="flex h-full min-h-0 flex-col"/)
+    expect(detailSrc).not.toMatch(
+      /class="flex min-h-0 flex-1 flex-col"[\s\S]*data-testid="project-detail-panel"/,
+    )
+  })
+
+  it('production App.vue wraps routed pages in route-view-wrap with height:100% (g3.1)', () => {
+    expect(appSrc).toMatch(/<div class="route-view-wrap">/)
+    expect(globalCss).toMatch(/\.route-view-wrap\s*\{[^}]*height:\s*100%/s)
+    expect(globalCss).toMatch(/\.route-view-wrap\s*\{[^}]*overflow:\s*hidden/s)
+  })
+
+  it('e2e harness mounts RouterView without route-view-wrap (documents gap)', () => {
+    expect(e2eHarnessSrc).toMatch(/h\(AppShell, null, \{ default: \(\) => h\(RouterView\) \}\)/)
+    expect(e2eHarnessSrc).not.toMatch(/route-view-wrap/)
+  })
+})
+
+describe('ProjectDetailView pmLeader fill-height chain (g2.2 / g2.3)', () => {
+  it('pmLeader tab shell flex-1 min-h-0 to consume tab content area (g2.2)', () => {
+    const pm = pmLeaderTabBlock()
+    expect(pm).toMatch(/data-testid="project-pm-leader-panel"/)
+    expect(pm).toMatch(/class="flex min-h-0 flex-1 flex-col"/)
+  })
+
+  it('PmLeaderChat uses flex-1 overflow-hidden with internal message scroller (g2.3)', () => {
+    expect(pmChatSrc).toMatch(/class="flex min-h-0 flex-1 overflow-hidden border border-line bg-base"/)
+    expect(pmChatSrc).toMatch(/class="scroll-area min-h-0 flex-1 space-y-3 overflow-y-auto p-4"/)
+  })
+})
+
+describe('ProjectDetailView height fix scope lock (g3.2)', () => {
+  it('other short tabs keep existing min-h-[420px] shells unchanged', () => {
+    expect(detailSrc).toMatch(/tab === 'cronJobs'" class="flex min-h-\[420px\] flex-col"/)
+    expect(detailSrc).toMatch(/tab === 'notify' && project" class="min-h-\[420px\]"/)
+  })
+
+  it('fill-height tabs (meta/audit/variables/sandboxEnv) remain min-h-0 flex-1', () => {
+    expect(detailSrc).toMatch(/tab === 'meta'" class="flex min-h-0 flex-1 flex-col"/)
+    expect(detailSrc).toMatch(/tab === 'audit'" class="flex min-h-0 flex-1 flex-col"/)
+    expect(detailSrc).toMatch(/tab === 'sandboxEnv'" class="flex min-h-0 flex-1 flex-col"/)
+    expect(detailSrc).toMatch(/tab === 'variables'" class="flex min-h-0 flex-1 flex-col"/)
+  })
+})

--- a/web/src/views/ProjectDetailView.vue
+++ b/web/src/views/ProjectDetailView.vue
@@ -170,7 +170,7 @@ const {
 
 <template>
   <div
-    class="flex min-h-0 flex-1 flex-col"
+    class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
     data-testid="project-detail-panel"
     :aria-busy="loading || wfRefreshing ? 'true' : 'false'"
   >


### PR DESCRIPTION
## Summary
- Fix ProjectDetailView root height chain under `.route-view-wrap` by adding `h-full overflow-hidden` (aligned with GatesInboxView).
- Sync project-detail E2E assertions with current zh-CN copy (metaHint, PM input placeholder) and notify tab scrollIntoView for horizontal tabs.

## Test plan
- [x] `npm test -- src/views/ProjectDetailView.heightChain.test.ts` (7/7)
- [x] `npm test -- src/views/ProjectDetailView` (53/53)
- [x] `npm run test:e2e -- e2e/project-detail.spec.ts` (31/31)
- [ ] CI green on this PR

## Notes
- Core change: `cc38d5f` — ProjectDetailView.vue root class
- E2E sync (independent of height fix): `853ce98`
- Follow-up: fold route-view-wrap production-shell height harness into formal e2e


Made with [Cursor](https://cursor.com)