### PR TITLE
fix(web): prevent project list card overflow on narrow screens

### DIFF
--- a/web/src/views/ProjectListView.test.ts
+++ b/web/src/views/ProjectListView.test.ts
@@ -79,6 +79,49 @@ function mountList(locale: 'zh-CN' | 'en' = 'zh-CN') {
   })
 }
 
+describe('ProjectListView narrow-screen overflow constraints', () => {
+  it('locks grid, skeleton, and card width constraints for mobile overflow prevention', () => {
+    expect(src).toMatch(/data-testid="project-list-cards"/)
+    expect(src).toMatch(/data-testid="project-list-skeleton"/)
+    expect(src).toMatch(/grid min-w-0 gap-3 sm:grid-cols-2 xl:grid-cols-3/)
+    expect(src).toMatch(/min-w-0 w-full max-w-full flex-col gap-2 overflow-hidden/)
+    expect(src).toMatch(/line-clamp-2 break-words/)
+    expect(src).toMatch(/flex min-w-0 flex-wrap items-center gap-x-1\.5 gap-y-0\.5/)
+  })
+
+  it('renders long URL description inside card without layout regression', async () => {
+    const longUrl =
+      'https://github.com/example/very-long-repository-name-without-spaces-that-would-overflow-on-narrow-screens'
+    apiMocks.listProjects.mockResolvedValue([
+      {
+        ...SAMPLE,
+        name: 'HarnessPlugin',
+        description: longUrl,
+        totalTokens: 1234567,
+      },
+    ])
+    const w = mountList()
+    await flushPromises()
+    const card = w.get('[data-testid="project-list-cards"] button')
+    expect(card.classes()).toContain('min-w-0')
+    expect(card.classes()).toContain('max-w-full')
+    expect(card.text()).toContain('github.com')
+    expect(w.find('[data-testid="project-list-token"]').exists()).toBe(true)
+    w.unmount()
+  })
+  it('card click still navigates to project detail', async () => {
+    const { writeStoredProjectId } = await import('@/lib/composables/useProjectContext')
+    apiMocks.listProjects.mockResolvedValue([SAMPLE])
+    const w = mountList()
+    await flushPromises()
+    await w.get('[data-testid="project-list-cards"] button').trigger('click')
+    await flushPromises()
+    expect(writeStoredProjectId).toHaveBeenCalledWith('p1')
+    expect(w.vm.$router.currentRoute.value.path).toBe('/projects/p1')
+    w.unmount()
+  })
+})
+
 describe('ProjectListView source lock (Demo loading)', () => {
   it('uses isomorphic card skeleton (icon + title + meta), not equal-width bars only', () => {
     expect(src).toMatch(/data-testid="project-list-skeleton"/)

--- a/web/src/views/ProjectListView.vue
+++ b/web/src/views/ProjectListView.vue
@@ -128,14 +128,14 @@ onMounted(() => {
       <div :class="showRefreshProgress ? 'opacity-[0.55]' : ''">
         <div
           v-if="showSkeleton"
-          class="grid gap-3 sm:grid-cols-2 xl:grid-cols-3"
+          class="grid min-w-0 gap-3 sm:grid-cols-2 xl:grid-cols-3"
           data-testid="project-list-skeleton"
           aria-hidden="true"
         >
           <div
             v-for="n in SKELETON_CARDS"
             :key="'skel-' + n"
-            class="flex flex-col gap-2 rounded-lg border border-line bg-surface p-4"
+            class="flex min-w-0 w-full flex-col gap-2 rounded-lg border border-line bg-surface p-4"
           >
             <div class="flex items-start gap-3">
               <div class="h-9 w-9 shrink-0 bg-elevated animate-pulse" />
@@ -188,12 +188,12 @@ onMounted(() => {
           </EmptyState>
         </div>
 
-        <div v-else class="grid gap-3 sm:grid-cols-2 xl:grid-cols-3" data-testid="project-list-cards">
+        <div v-else class="grid min-w-0 gap-3 sm:grid-cols-2 xl:grid-cols-3" data-testid="project-list-cards">
           <button
             v-for="p in projects"
             :key="p.id"
             type="button"
-            class="flex flex-col gap-2 rounded-lg border border-line bg-surface p-4 text-left transition hover:border-line-strong hover:bg-elevated"
+            class="flex min-w-0 w-full max-w-full flex-col gap-2 overflow-hidden rounded-lg border border-line bg-surface p-4 text-left transition hover:border-line-strong hover:bg-elevated"
             @click="openProject(p)"
           >
             <div class="flex items-start gap-3">
@@ -202,20 +202,20 @@ onMounted(() => {
               </div>
               <div class="min-w-0 flex-1">
                 <div class="truncate text-sm font-semibold text-txt">{{ p.name }}</div>
-                <div v-if="p.description" class="mt-0.5 line-clamp-2 text-[12px] text-txt3">
+                <div v-if="p.description" class="mt-0.5 line-clamp-2 break-words text-[12px] text-txt3">
                   {{ p.description }}
                 </div>
               </div>
             </div>
-            <div class="flex flex-wrap items-center border-t border-line pt-2.5 text-[11px] text-txt3">
-              <span>{{ t('pages.projectList.workflowCount', { n: p.workflowCount ?? 0 }) }}</span>
+            <div class="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 border-t border-line pt-2.5 text-[11px] text-txt3">
+              <span class="shrink-0">{{ t('pages.projectList.workflowCount', { n: p.workflowCount ?? 0 }) }}</span>
               <template v-if="p.updatedAt">
-                <span class="mx-1.5 text-[#d9d9d9]" aria-hidden="true">·</span>
-                <span>{{ fmtTime(p.updatedAt) }}</span>
+                <span class="text-[#d9d9d9]" aria-hidden="true">·</span>
+                <span class="shrink-0">{{ fmtTime(p.updatedAt) }}</span>
               </template>
-              <span class="mx-1.5 text-[#d9d9d9]" aria-hidden="true">·</span>
+              <span class="text-[#d9d9d9]" aria-hidden="true">·</span>
               <span
-                class="group relative tabular-nums"
+                class="group relative min-w-0 tabular-nums"
                 :class="[
                   p.totalTokens == null ? 'text-txt3' : 'text-txt2',
                   p.totalTokens != null ? 'cursor-help' : '',


### PR DESCRIPTION
Grid items and cards lacked min-w-0/width caps, so long URLs stretched
cards past the AppShell viewport and were clipped. Add break-words and
flex-wrap meta layout plus regression tests for mobile overflow constraints.

Co-authored-by: Cursor <cursoragent@cursor.com>
