### PR TITLE
fix(web): unify page/tab scroll exits for mobile

### DIFF
--- a/web/src/views/BoardView.vue
+++ b/web/src/views/BoardView.vue
@@ -147,14 +147,16 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div data-testid="board-view" class="min-w-0">
-    <div v-if="!embedded" class="mb-5 flex flex-wrap items-start justify-between gap-4">
+  <!-- plan g1.3: fill-height + single overflow-y-auto (standalone + embedded) -->
+  <div data-testid="board-view" class="flex h-full min-h-0 min-w-0 flex-col">
+    <div v-if="!embedded" class="mb-5 flex shrink-0 flex-wrap items-start justify-between gap-4">
       <div>
         <h2 class="text-lg font-semibold text-txt">{{ t('pages.board.title') }}</h2>
         <p class="text-sm text-txt3">{{ t('pages.board.subtitle') }}</p>
       </div>
     </div>
 
+    <div class="min-h-0 flex-1 overflow-y-auto">
     <div
       v-if="error && error !== 'missing_project'"
       class="mb-4 flex flex-wrap items-center justify-between gap-2 border border-err/40 bg-err/10 px-3 py-2 text-[13px] text-err"
@@ -249,6 +251,7 @@ onUnmounted(() => {
         :truncated-hint="truncatedHint(col.key)"
         @select="openPreview"
       />
+    </div>
     </div>
 
     <RunBoardPreviewDrawer :open="drawerOpen" :run="selected" @close="closePreview" />

--- a/web/src/views/DashboardView.fill.test.ts
+++ b/web/src/views/DashboardView.fill.test.ts
@@ -18,10 +18,11 @@ const shellSrc = readFileSync(join(dir, '../components/shell/AppShell.vue'), 'ut
 const globalCss = readFileSync(join(dir, '../styles/global.css'), 'utf8')
 
 describe('DashboardView home chat layout', () => {
-  it('root uses md+ flex fill without overflow-hidden', () => {
-    expect(src).toMatch(/data-testid="dashboard-view"[^>]*class="[^"]*flex flex-col md:h-full md:min-h-0/)
+  it('root uses flex fill without overflow-hidden (plan g1.4 mobile + desktop)', () => {
+    expect(src).toMatch(/data-testid="dashboard-view"[^>]*class="[^"]*flex h-full min-h-0 flex-col/)
     expect(src).not.toMatch(/data-testid="dashboard-view"[^>]*overflow-hidden/)
     expect(src).not.toMatch(/calc\(100vh/)
+    expect(src).toMatch(/home-shell__content[^>]*overflow-y-auto/)
   })
 
   it('centers composer, pipeline cards, and empty states', () => {

--- a/web/src/views/DashboardView.vue
+++ b/web/src/views/DashboardView.vue
@@ -329,10 +329,10 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div data-testid="dashboard-view" class="home-shell relative flex flex-col md:h-full md:min-h-0">
+  <div data-testid="dashboard-view" class="home-shell relative flex h-full min-h-0 flex-col">
     <HomeParticleMeshBackground />
     <div
-      class="home-shell__content relative z-[1] mx-auto flex w-full max-w-3xl flex-1 flex-col items-center justify-center px-4 py-10"
+      class="home-shell__content relative z-[1] mx-auto flex w-full max-w-3xl min-h-0 flex-1 flex-col items-center justify-center overflow-y-auto px-4 py-10"
     >
       <h1 class="home-brand" data-testid="home-brand" aria-label="Approving">
         <span class="home-brand__text" data-testid="home-brand-text">{{ brandVisible }}</span>

--- a/web/src/views/IntegrationsView.vue
+++ b/web/src/views/IntegrationsView.vue
@@ -59,12 +59,14 @@ function cardIconClass(scope: McpServer['scope']): string {
 </script>
 
 <template>
-  <div>
-    <div class="mb-5">
+  <!-- plan g1.2: fill-height + single overflow-y-auto scroll exit -->
+  <div class="flex h-full min-h-0 flex-col">
+    <div class="mb-5 shrink-0">
       <h2 class="text-lg font-semibold text-txt">{{ t('mcp.integrations.title') }}</h2>
       <p class="text-sm text-txt3">{{ t('mcp.integrations.subtitle') }}</p>
     </div>
 
+    <div class="min-h-0 flex-1 overflow-y-auto">
     <div class="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-txt3">
       {{ t('mcp.integrations.sectionTitle') }}
       <span class="chip border-accent/30 text-accent-2">{{ t('mcp.integrations.noConfigNeeded') }}</span>
@@ -108,6 +110,7 @@ function cardIconClass(scope: McpServer['scope']): string {
         </span>
       </div>
     </button>
+    </div>
 
     <AppModal
       :open="!!selected"

--- a/web/src/views/ProjectDetailView.heightChain.test.ts
+++ b/web/src/views/ProjectDetailView.heightChain.test.ts
@@ -56,9 +56,11 @@ describe('ProjectDetailView pmLeader fill-height chain (g2.2 / g2.3)', () => {
 })
 
 describe('ProjectDetailView height fix scope lock (g3.2)', () => {
-  it('other short tabs keep existing min-h-[420px] shells unchanged', () => {
-    expect(detailSrc).toMatch(/tab === 'cronJobs'" class="flex min-h-\[420px\] flex-col"/)
-    expect(detailSrc).toMatch(/tab === 'notify' && project" class="min-h-\[420px\]"/)
+  it('list B tabs use fill + overflow-y-auto (plan g2.1; no 420px floor)', () => {
+    expect(detailSrc).toMatch(/tab === 'cronJobs'[\s\S]*?class="scroll-area flex min-h-0 flex-1 flex-col overflow-y-auto"/)
+    expect(detailSrc).toMatch(/tab === 'notify' && project[\s\S]*?class="scroll-area min-h-0 flex-1 overflow-y-auto"/)
+    expect(detailSrc).not.toMatch(/tab === 'cronJobs'" class="flex min-h-\[420px\] flex-col"/)
+    expect(detailSrc).not.toMatch(/tab === 'notify' && project" class="min-h-\[420px\]"/)
   })
 
   it('fill-height tabs (meta/audit/variables/sandboxEnv) remain min-h-0 flex-1', () => {

--- a/web/src/views/ProjectDetailView.metaLayout.test.ts
+++ b/web/src/views/ProjectDetailView.metaLayout.test.ts
@@ -69,11 +69,13 @@ describe('ProjectDetailView meta tab keeps existing chrome and save semantics (g
     expect(detailFullSrc).toMatch(/async function saveMeta\(/)
   })
 
-  it('does not change AppShell height chain or other short tabs (g2.2)', () => {
+  it('does not change AppShell height chain; short tabs use fill scroll (plan g2.1)', () => {
     expect(shellSrc).toMatch(/class="relative flex h-screen w-screen overflow-hidden bg-base text-txt"/)
     expect(shellSrc).toMatch(/<main[\s\S]*class="relative min-h-0 flex-1 overflow-hidden"/)
-    expect(detailSrc).toMatch(/tab === 'cronJobs'" class="flex min-h-\[420px\] flex-col"/)
-    expect(detailSrc).toMatch(/tab === 'notify' && project" class="min-h-\[420px\]"/)
+    expect(detailSrc).toMatch(/tab === 'cronJobs'[\s\S]*?class="scroll-area flex min-h-0 flex-1 flex-col overflow-y-auto"/)
+    expect(detailSrc).toMatch(/tab === 'notify' && project[\s\S]*?class="scroll-area min-h-0 flex-1 overflow-y-auto"/)
+    expect(detailSrc).not.toMatch(/tab === 'cronJobs'" class="flex min-h-\[420px\] flex-col"/)
+    expect(detailSrc).not.toMatch(/tab === 'notify' && project" class="min-h-\[420px\]"/)
     // variables / sandboxEnv 已接入铺满链（对齐 meta），不再锁定 420 硬底
     expect(detailSrc).toMatch(/tab === 'sandboxEnv'" class="flex min-h-0 flex-1 flex-col"/)
     expect(detailSrc).toMatch(/tab === 'variables'" class="flex min-h-0 flex-1 flex-col"/)

--- a/web/src/views/ProjectDetailView.vue
+++ b/web/src/views/ProjectDetailView.vue
@@ -358,13 +358,17 @@ const {
         </div>
       </div>
 
-      <div v-else-if="tab === 'board'" class="min-w-0" data-testid="project-board-panel">
-        <BoardView :project-id="projectId" embedded />
+      <div
+        v-else-if="tab === 'board'"
+        class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+        data-testid="project-board-panel"
+      >
+        <BoardView :project-id="projectId" embedded class="min-h-0 flex-1" />
       </div>
 
       <div
         v-else-if="tab === 'requirementDrafts'"
-        class="min-w-0"
+        class="scroll-area min-h-0 flex-1 overflow-y-auto"
         data-testid="project-requirement-drafts-panel"
       >
         <RequirementDraftsPanel ref="draftsPanelRef" :project-id="projectId" />
@@ -419,11 +423,18 @@ const {
         </div>
       </div>
 
-      <div v-else-if="tab === 'cronJobs'" class="flex min-h-[420px] flex-col">
+      <!-- plan g2.1: cronJobs/notify fill + scroll exit (drop 420px hard floor) -->
+      <div
+        v-else-if="tab === 'cronJobs'"
+        class="scroll-area flex min-h-0 flex-1 flex-col overflow-y-auto"
+      >
         <PmCronJobsPanel :project-id="projectId" />
       </div>
 
-      <div v-else-if="tab === 'notify' && project" class="min-h-[420px]">
+      <div
+        v-else-if="tab === 'notify' && project"
+        class="scroll-area min-h-0 flex-1 overflow-y-auto"
+      >
         <ProjectNotifyPanel
           :project-id="projectId"
           :project="project"
@@ -432,9 +443,9 @@ const {
         />
       </div>
 
-      <!-- Workflows tab -->
-      <div v-else-if="tab === 'workflows'">
-        <div class="mb-3 flex justify-end gap-2">
+      <!-- Workflows tab — plan g2.1: min-h-0 flex-1 + overflow-y-auto -->
+      <div v-else-if="tab === 'workflows'" class="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div class="mb-3 flex shrink-0 justify-end gap-2">
           <AppButton
             v-if="isOnboardingEmpty"
             variant="outline"
@@ -451,6 +462,7 @@ const {
             {{ t('common.buttons.newWorkflow') }}
           </AppButton>
         </div>
+        <div class="scroll-area min-h-0 flex-1 overflow-y-auto">
         <div
           v-if="isOnboardingEmpty"
           class="card px-5 py-10 text-center text-[13px] text-txt3"
@@ -824,6 +836,7 @@ const {
               </tbody>
             </table>
           </div>
+        </div>
         </div>
       </div>
 

--- a/web/src/views/ProjectListView.test.ts
+++ b/web/src/views/ProjectListView.test.ts
@@ -89,6 +89,26 @@ describe('ProjectListView narrow-screen overflow constraints', () => {
     expect(src).toMatch(/flex min-w-0 flex-wrap items-center gap-x-1\.5 gap-y-0\.5/)
   })
 
+  // plan g3.3 — narrow viewport: fill root + list panel is the scroll exit (末卡可达)
+  it('uses fill-height root and project-list-panel overflow-y-auto scroll exit (g3.3)', async () => {
+    expect(src).toMatch(/flex h-full min-h-0 flex-col/)
+    expect(src).toMatch(/data-testid="project-list-panel"[\s\S]*?class="min-h-0 flex-1 overflow-y-auto"/)
+    const many = Array.from({ length: 12 }, (_, i) => ({
+      ...SAMPLE,
+      id: `p${i}`,
+      name: `项目 ${i}`,
+    }))
+    apiMocks.listProjects.mockResolvedValue(many)
+    const w = mountList()
+    await flushPromises()
+    const panel = w.get('[data-testid="project-list-panel"]')
+    expect(panel.classes()).toEqual(expect.arrayContaining(['min-h-0', 'flex-1', 'overflow-y-auto']))
+    const cards = w.findAll('[data-testid="project-list-cards"] button')
+    expect(cards.length).toBe(12)
+    expect(cards[11].text()).toContain('项目 11')
+    w.unmount()
+  })
+
   it('renders long URL description inside card without layout regression', async () => {
     const longUrl =
       'https://github.com/example/very-long-repository-name-without-spaces-that-would-overflow-on-narrow-screens'

--- a/web/src/views/ProjectListView.vue
+++ b/web/src/views/ProjectListView.vue
@@ -101,8 +101,9 @@ onMounted(() => {
 </script>
 
 <template>
-  <div>
-    <div class="mb-5 flex flex-col gap-2.5 md:flex-row md:items-start md:justify-between">
+  <!-- plan g1.1: fill-height + single overflow-y-auto scroll exit (align RunList) -->
+  <div class="flex h-full min-h-0 flex-col">
+    <div class="mb-5 flex shrink-0 flex-col gap-2.5 md:flex-row md:items-start md:justify-between">
       <div class="min-w-0">
         <h2 class="text-lg font-semibold text-txt">{{ t('pages.projectList.title') }}</h2>
         <p class="text-sm text-txt3">{{ t('pages.projectList.subtitle') }}</p>
@@ -114,6 +115,7 @@ onMounted(() => {
 
     <div
       data-testid="project-list-panel"
+      class="min-h-0 flex-1 overflow-y-auto"
       :aria-busy="loading ? 'true' : 'false'"
     >
       <div

--- a/web/src/views/RunListView.fill.test.ts
+++ b/web/src/views/RunListView.fill.test.ts
@@ -121,9 +121,9 @@ describe('RunListView fill scope lock (g4.3)', () => {
     expect(routerSrc).not.toMatch(/path: '\/runs'[^}]*full:\s*true/)
   })
 
-  it('does not change other list pages, EmptyState, or empty/fail i18n strings', () => {
-    expect(sandboxSrc).toMatch(/^\s*<div>\s*$/m)
-    expect(projectSrc).toMatch(/^\s*<div>\s*$/m)
+  it('does not change EmptyState or empty/fail i18n strings (list A pages now use fill scroll — plan g1)', () => {
+    expect(sandboxSrc).toMatch(/flex h-full min-h-0 flex-col/)
+    expect(projectSrc).toMatch(/flex h-full min-h-0 flex-col/)
     expect(src).not.toMatch(/EmptyState/)
     expect(zhCommon).toMatch(/"noRuns": "暂无运行记录"/)
     expect(zhCommon).toMatch(/"noMatchingRuns": "无匹配运行记录"/)

--- a/web/src/views/SandboxListView.vue
+++ b/web/src/views/SandboxListView.vue
@@ -294,8 +294,13 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div data-testid="sandbox-list-panel" :aria-busy="loading || initialLoading ? 'true' : 'false'">
-    <div class="mb-5 flex flex-col items-start gap-2.5 md:flex-row md:items-end md:justify-between">
+  <!-- plan g1.2: fill-height + single overflow-y-auto scroll exit -->
+  <div
+    class="flex h-full min-h-0 flex-col"
+    data-testid="sandbox-list-panel"
+    :aria-busy="loading || initialLoading ? 'true' : 'false'"
+  >
+    <div class="mb-5 flex shrink-0 flex-col items-start gap-2.5 md:flex-row md:items-end md:justify-between">
       <div class="min-w-0">
         <h2 class="text-lg font-semibold text-txt">{{ t('pages.sandboxes.title') }}</h2>
       </div>
@@ -304,12 +309,12 @@ onBeforeUnmount(() => {
 
     <div
       v-if="error && !initialLoading && rows.length && !initialLoadFailed && !loadDenied"
-      class="card mb-3 border-err/40 p-3 text-[13px] text-err"
+      class="card mb-3 shrink-0 border-err/40 p-3 text-[13px] text-err"
     >{{ t('pages.sandboxes.errorPrefix') }}{{ error }}</div>
 
     <div
       v-if="showTableLoading"
-      class="mb-2 h-[2px] overflow-hidden bg-line"
+      class="mb-2 h-[2px] shrink-0 overflow-hidden bg-line"
       data-testid="sandbox-list-thin-progress"
       aria-hidden="true"
     >
@@ -317,7 +322,11 @@ onBeforeUnmount(() => {
     </div>
 
     <!-- Mobile card list -->
-    <div v-if="isMobile" :class="{ 'table-loading': showTableLoading }">
+    <div
+      v-if="isMobile"
+      class="min-h-0 flex-1 overflow-y-auto"
+      :class="{ 'table-loading': showTableLoading }"
+    >
       <template v-if="initialLoading">
         <div class="flex flex-col gap-2">
           <div
@@ -450,8 +459,12 @@ onBeforeUnmount(() => {
     </div>
 
     <!-- Desktop table -->
-    <div v-else class="card overflow-hidden" :class="{ 'table-loading': showTableLoading }">
-      <div class="scroll-area overflow-x-auto">
+    <div
+      v-else
+      class="card flex min-h-0 flex-1 flex-col overflow-hidden"
+      :class="{ 'table-loading': showTableLoading }"
+    >
+      <div class="scroll-area min-h-0 flex-1 overflow-auto">
         <table class="w-full min-w-[920px] text-left text-[13px]">
           <thead class="border-b border-line text-[11px] uppercase tracking-wider text-txt3">
             <tr>

--- a/web/src/views/SettingsView.vue
+++ b/web/src/views/SettingsView.vue
@@ -198,8 +198,13 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div data-testid="settings-panel" :aria-busy="loading || saving ? 'true' : 'false'">
-    <div class="mb-5 flex flex-col items-stretch gap-3 md:flex-row md:items-end md:justify-between">
+  <!-- plan g1.2: fill-height + single overflow-y-auto scroll exit -->
+  <div
+    class="flex h-full min-h-0 flex-col"
+    data-testid="settings-panel"
+    :aria-busy="loading || saving ? 'true' : 'false'"
+  >
+    <div class="mb-5 flex shrink-0 flex-col items-stretch gap-3 md:flex-row md:items-end md:justify-between">
       <div>
         <h2 class="text-lg font-semibold text-txt">{{ t('pages.settings.title') }}</h2>
         <p class="text-sm text-txt3">{{ t('pages.settings.subtitle') }}</p>
@@ -215,6 +220,7 @@ onBeforeUnmount(() => {
       </div>
     </div>
 
+    <div class="min-h-0 flex-1 overflow-y-auto">
     <div
       v-if="error && items.length && !loadFailed && !loadDenied"
       class="mb-4 rounded-lg border border-err/30 bg-err/10 px-3 py-2 text-sm text-err"
@@ -427,6 +433,7 @@ onBeforeUnmount(() => {
     <p class="mt-1 text-xs text-txt3">
       {{ t('pages.settings.priorityNote') }}
     </p>
+    </div>
   </div>
 </template>
 

--- a/web/src/views/TriggersView.vue
+++ b/web/src/views/TriggersView.vue
@@ -14,12 +14,13 @@ const triggers = computed(() => [
 </script>
 
 <template>
-  <div>
-    <div class="mb-5">
+  <!-- plan g1.2: fill-height + single overflow-y-auto scroll exit -->
+  <div class="flex h-full min-h-0 flex-col">
+    <div class="mb-5 shrink-0">
       <h2 class="text-lg font-semibold text-txt">{{ t('pages.triggers.title') }}</h2>
       <p class="text-sm text-txt3">{{ t('pages.triggers.subtitle') }}</p>
     </div>
-    <div class="space-y-3">
+    <div class="min-h-0 flex-1 space-y-3 overflow-y-auto">
       <div v-for="item in triggers" :key="item.type" class="card flex min-h-11 items-center gap-3 p-4" :class="item.available ? '' : 'opacity-70'">
         <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-md" :class="item.available ? 'bg-accent-dim text-accent-2' : 'bg-elevated text-txt3'">
           <Icon :name="item.icon" :size="18" />

--- a/web/src/views/mobileScrollContract.test.ts
+++ b/web/src/views/mobileScrollContract.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment node
+/**
+ * plan g3.1 — static contract: list A pages + ProjectDetail list B tabs
+ * each have exactly one primary vertical scroll exit (fill-height + overflow-y-auto).
+ */
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const dir = dirname(fileURLToPath(import.meta.url))
+
+function read(name: string) {
+  return readFileSync(join(dir, name), 'utf8')
+}
+
+const FILL_ROOT = /flex h-full min-h-0 flex-col/
+const SCROLL_EXIT = /overflow-y-auto/
+
+describe('mobile scroll contract — list A (plan g1 / g3.1)', () => {
+  it('ProjectListView: fill root, shrink-0 header, list overflow-y-auto (g1.1)', () => {
+    const src = read('ProjectListView.vue')
+    expect(src).toMatch(FILL_ROOT)
+    expect(src).toMatch(/mb-5 flex shrink-0/)
+    expect(src).toMatch(/data-testid="project-list-panel"[\s\S]*?class="min-h-0 flex-1 overflow-y-auto"/)
+    expect(src).not.toMatch(/^\s*<div>\s*$/m)
+  })
+
+  it('SettingsView: fill root + content overflow-y-auto (g1.2)', () => {
+    const src = read('SettingsView.vue')
+    expect(src).toMatch(/data-testid="settings-panel"/)
+    expect(src).toMatch(FILL_ROOT)
+    expect(src).toMatch(/mb-5 flex shrink-0/)
+    expect(src).toMatch(/min-h-0 flex-1 overflow-y-auto/)
+  })
+
+  it('SandboxListView: fill root; mobile list scrolls; desktop table scrolls (g1.2)', () => {
+    const src = read('SandboxListView.vue')
+    expect(src).toMatch(FILL_ROOT)
+    expect(src).toMatch(/mb-5 flex shrink-0/)
+    expect(src).toMatch(/v-if="isMobile"[\s\S]*?class="min-h-0 flex-1 overflow-y-auto"/)
+    expect(src).toMatch(/card flex min-h-0 flex-1 flex-col overflow-hidden/)
+    expect(src).toMatch(/scroll-area min-h-0 flex-1 overflow-auto/)
+  })
+
+  it('TriggersView: fill root + list overflow-y-auto (g1.2)', () => {
+    const src = read('TriggersView.vue')
+    expect(src).toMatch(FILL_ROOT)
+    expect(src).toMatch(/mb-5 shrink-0/)
+    expect(src).toMatch(/min-h-0 flex-1 space-y-3 overflow-y-auto/)
+  })
+
+  it('IntegrationsView: fill root + list overflow-y-auto (g1.2)', () => {
+    const src = read('IntegrationsView.vue')
+    expect(src).toMatch(FILL_ROOT)
+    expect(src).toMatch(/mb-5 shrink-0/)
+    expect(src).toMatch(/min-h-0 flex-1 overflow-y-auto/)
+  })
+
+  it('BoardView: fill root + body overflow-y-auto for standalone and embedded (g1.3)', () => {
+    const src = read('BoardView.vue')
+    expect(src).toMatch(/data-testid="board-view"[^>]*flex h-full min-h-0/)
+    expect(src).toMatch(/min-h-0 flex-1 overflow-y-auto/)
+    expect(src).toMatch(/v-if="!embedded"/)
+  })
+
+  it('DashboardView: always h-full + content overflow-y-auto (g1.4)', () => {
+    const src = read('DashboardView.vue')
+    expect(src).toMatch(/data-testid="dashboard-view"[^>]*h-full min-h-0/)
+    expect(src).toMatch(/home-shell__content[^>]*overflow-y-auto/)
+  })
+})
+
+describe('mobile scroll contract — list B ProjectDetail tabs (plan g2.1 / g3.1)', () => {
+  const detail = read('ProjectDetailView.vue')
+
+  function tabBlock(marker: string, nextMarkers: string[]): string {
+    const start = detail.indexOf(marker)
+    expect(start, `missing ${marker}`).toBeGreaterThanOrEqual(0)
+    let end = detail.length
+    for (const n of nextMarkers) {
+      const i = detail.indexOf(n, start + marker.length)
+      if (i > start && i < end) end = i
+    }
+    return detail.slice(start, end)
+  }
+
+  it('workflows tab: min-h-0 flex-1 + scroll-area overflow-y-auto', () => {
+    const block = tabBlock("<!-- Workflows tab", ["<!-- Sandbox env tab"])
+    expect(block).toMatch(/class="flex min-h-0 flex-1 flex-col overflow-hidden"/)
+    expect(block).toMatch(/scroll-area min-h-0 flex-1 overflow-y-auto/)
+    expect(block).toMatch(/mb-3 flex shrink-0 justify-end gap-2/)
+  })
+
+  it('board tab: flex-1 min-h-0 host for BoardView scroll exit', () => {
+    const block = tabBlock("tab === 'board'", ["tab === 'requirementDrafts'"])
+    expect(block).toMatch(/flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden/)
+    expect(block).toMatch(/data-testid="project-board-panel"/)
+  })
+
+  it('requirementDrafts tab: overflow-y-auto scroll exit', () => {
+    const block = tabBlock("tab === 'requirementDrafts'", ["tab === 'pmLeader'"])
+    expect(block).toMatch(SCROLL_EXIT)
+    expect(block).toMatch(/min-h-0 flex-1/)
+    expect(block).toMatch(/data-testid="project-requirement-drafts-panel"/)
+  })
+
+  it('cronJobs / notify tabs: drop 420 floor; use overflow-y-auto', () => {
+    const cron = tabBlock("tab === 'cronJobs'", ["tab === 'notify'"])
+    const notify = tabBlock("tab === 'notify' && project", ["<!-- Workflows tab"])
+    expect(cron).toMatch(/scroll-area flex min-h-0 flex-1 flex-col overflow-y-auto/)
+    expect(notify).toMatch(/scroll-area min-h-0 flex-1 overflow-y-auto/)
+    expect(cron).not.toMatch(/min-h-\[420px\]/)
+    expect(notify).not.toMatch(/min-h-\[420px\]/)
+  })
+
+  it('existing fill tabs keep scroll exits (g2.2 regression)', () => {
+    expect(detail).toMatch(/tab === 'meta'" class="flex min-h-0 flex-1 flex-col"/)
+    expect(detail).toMatch(/tab === 'audit'" class="flex min-h-0 flex-1 flex-col"/)
+    expect(detail).toMatch(/tab === 'variables'" class="flex min-h-0 flex-1 flex-col"/)
+    expect(detail).toMatch(/tab === 'sandboxEnv'" class="flex min-h-0 flex-1 flex-col"/)
+    expect(detail).toMatch(/tab === 'pmLeader'[\s\S]*?class="flex min-h-0 flex-1 flex-col"/)
+    expect(detail).toMatch(
+      /scroll-area flex min-h-0 flex-1 flex-col gap-3\.5 overflow-y-auto p-4/,
+    )
+  })
+})
+
+describe('mobile scroll contract — shell single-exit lock (plan g3.2)', () => {
+  it('keeps route-view-wrap height:100% overflow:hidden (page-local scroll)', () => {
+    const globalCss = readFileSync(join(dir, '../styles/global.css'), 'utf8')
+    const appSrc = readFileSync(join(dir, '../App.vue'), 'utf8')
+    const shellSrc = readFileSync(join(dir, '../components/shell/AppShell.vue'), 'utf8')
+    expect(appSrc).toMatch(/route-view-wrap/)
+    expect(globalCss).toMatch(/\.route-view-wrap\s*\{[^}]*height:\s*100%/s)
+    expect(globalCss).toMatch(/\.route-view-wrap\s*\{[^}]*overflow:\s*hidden/s)
+    expect(shellSrc).toMatch(/h-screen/)
+    expect(shellSrc).toMatch(/min-h-0 flex-1/)
+    // shell outer may overflow-y-auto but inner h-full means page must own the exit
+    expect(shellSrc).toMatch(/flex h-full min-h-0 flex-col/)
+  })
+
+  it('sampling fill pages still declare internal overflow-y-auto', () => {
+    expect(read('RunListView.vue')).toMatch(/overflow-y-auto/)
+    expect(read('NotificationsView.vue')).toMatch(/min-h-0 flex-1 overflow-y-auto/)
+    expect(read('ArtifactsView.vue')).toMatch(/overflow-y-auto/)
+    expect(read('PlatformRulesView.vue')).toMatch(/overflow-y-auto/)
+    expect(read('GatesInboxView.vue')).toMatch(/overflow-y-auto/)
+  })
+})


### PR DESCRIPTION
Document-flow pages and ProjectDetail tabs without a vertical
scroll outlet were clipped by route-view-wrap; align them to the
fill-height + single overflow-y-auto contract and lock with tests.

Co-authored-by: Cursor <cursoragent@cursor.com>
