### PR TITLE
fix: NodeEvents 瞬时桥读失败改为 200 软失败消噪

### DIFF
--- a/server/internal/handlers/handlers_test.go
+++ b/server/internal/handlers/handlers_test.go
@@ -1778,7 +1778,8 @@ func TestNodeEventsPaginationPersisted(t *testing.T) {
 }
 
 // liveReadFailProvider simulates a registered live sandbox whose bridge read
-// fails — NodeEvents must surface 502 {error, live:false}, not a fake empty page.
+// fails — NodeEvents must surface HTTP 200 {unavailable, error, live:false},
+// not a fake empty page and not 502 (avoids DevTools Failed to load resource).
 type liveReadFailProvider struct{ fakeProvider }
 
 func (liveReadFailProvider) LiveNodeEvents(ctx context.Context, runID, nodeID string) ([]models.AcpEvent, bool, error) {
@@ -1789,7 +1790,7 @@ func (liveReadFailProvider) LiveNodeEventsPage(ctx context.Context, runID, nodeI
 	return nil, "", false, false, errors.New("bridge unreachable")
 }
 
-func TestNodeEventsLiveReadFailureReturns502(t *testing.T) {
+func TestNodeEventsLiveReadFailureReturnsSoftFail(t *testing.T) {
 	h := newHarness(t)
 	h.db.Create(&models.Run{ID: "run-live-fail", Status: "running", StartedAt: time.Now()})
 
@@ -1801,11 +1802,11 @@ func TestNodeEventsLiveReadFailureReturns502(t *testing.T) {
 		h.h.Eng = old
 	})
 
-	assert502 := func(path string) {
+	assertSoftFail := func(path string, paginated bool) {
 		t.Helper()
 		w := h.do(http.MethodGet, path, nil)
-		if w.Code != http.StatusBadGateway {
-			t.Fatalf("%s status = %d, want 502; body=%s", path, w.Code, w.Body.String())
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s status = %d, want 200; body=%s", path, w.Code, w.Body.String())
 		}
 		var body map[string]any
 		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
@@ -1817,10 +1818,21 @@ func TestNodeEventsLiveReadFailureReturns502(t *testing.T) {
 		if body["live"] != false {
 			t.Fatalf("%s live = %v, want false", path, body["live"])
 		}
+		if body["unavailable"] != true {
+			t.Fatalf("%s unavailable = %v, want true", path, body["unavailable"])
+		}
+		if paginated {
+			if _, ok := body["nextCursor"]; !ok {
+				t.Fatalf("%s missing nextCursor: %v", path, body)
+			}
+			if _, ok := body["hasMore"]; !ok {
+				t.Fatalf("%s missing hasMore: %v", path, body)
+			}
+		}
 	}
 
-	assert502("/api/runs/run-live-fail/nodes/n1/events")
-	assert502("/api/runs/run-live-fail/nodes/n1/events?limit=20")
+	assertSoftFail("/api/runs/run-live-fail/nodes/n1/events", false)
+	assertSoftFail("/api/runs/run-live-fail/nodes/n1/events?limit=20", true)
 }
 
 func TestDoctorArtifactSessionIsLoopbackAndTokenProtected(t *testing.T) {

--- a/server/internal/handlers/run.go
+++ b/server/internal/handlers/run.go
@@ -294,12 +294,30 @@ func (h *Handlers) RunArtifacts(c *gin.Context) {
 	c.JSON(http.StatusOK, h.Arts.ByRun(c.Param("id")))
 }
 
+// writeNodeEventsLiveReadErr returns HTTP 200 with an explicit unavailable marker
+// so browsers do not log Failed to load resource for expected transient bridge
+// failures while a live sandbox is registered. Callers distinguish this from
+// a genuine empty timeline via unavailable=true (never a silent empty success).
+func writeNodeEventsLiveReadErr(c *gin.Context, paginated bool) {
+	body := gin.H{
+		"events":      []models.AcpEvent{},
+		"live":        false,
+		"unavailable": true,
+		"error":       "live event log read failed",
+	}
+	if paginated {
+		body["nextCursor"] = ""
+		body["hasMore"] = false
+	}
+	c.JSON(http.StatusOK, body)
+}
+
 // NodeEvents returns a run node's agent event log. While the node is executing
 // it is read live from its sandbox (so it survives a UI refresh / re-entry);
 // once the sandbox is gone it falls back to the node's persisted final snapshot.
 // When a live sandbox is registered but the bridge read fails, the handler
-// returns 502 with an error body so the UI can show a rehydrate failure
-// instead of a fake empty "waiting for first event" state.
+// returns HTTP 200 with unavailable=true so the UI can show a rehydrate failure
+// without polluting the browser console with 502 Failed to load resource.
 func (h *Handlers) NodeEvents(c *gin.Context) {
 	runID := c.Param("id")
 	nodeID := c.Param("nodeId")
@@ -311,7 +329,7 @@ func (h *Handlers) NodeEvents(c *gin.Context) {
 		ev, live, err := h.Eng.LiveNodeEvents(c.Request.Context(), runID, nodeID)
 		if err != nil {
 			_ = c.Error(err)
-			c.JSON(http.StatusBadGateway, gin.H{"error": "live event log read failed", "live": false})
+			writeNodeEventsLiveReadErr(c, false)
 			return
 		}
 		if live {
@@ -329,7 +347,7 @@ func (h *Handlers) NodeEvents(c *gin.Context) {
 	ev, next, hasMore, live, err := h.Eng.LiveNodeEventsPage(c.Request.Context(), runID, nodeID, cp.Cursor, cp.Limit)
 	if err != nil {
 		_ = c.Error(err)
-		c.JSON(http.StatusBadGateway, gin.H{"error": "live event log read failed", "live": false})
+		writeNodeEventsLiveReadErr(c, true)
 		return
 	}
 	if live {

--- a/web/LIB_DOMAIN_MAP.json
+++ b/web/LIB_DOMAIN_MAP.json
@@ -90,6 +90,7 @@
       "liveLogRehydrate.ts",
       "liveLogSnapshotCache.ts",
       "mergeAcpEvents.ts",
+      "nodeEventsResponse.ts",
       "outputSourceOptions.ts",
       "pendingAcpBuffer.ts",
       "productNodeArtifacts.ts",
@@ -173,7 +174,7 @@
     "inbox": 20,
     "pm": 6,
     "project": 4,
-    "run": 50,
+    "run": 51,
     "shared": 37
   }
 }

--- a/web/src/lib/api/apiTypes.ts
+++ b/web/src/lib/api/apiTypes.ts
@@ -51,6 +51,16 @@ export interface EventPaginatedResponse {
   nextCursor: string
   hasMore: boolean
   live?: boolean
+  /** Live sandbox registered but bridge read failed transiently. */
+  unavailable?: boolean
+  error?: string
+}
+
+export interface NodeEventsResponse {
+  events: AcpEvent[]
+  live: boolean
+  unavailable?: boolean
+  error?: string
 }
 
 export interface MCPServer {

--- a/web/src/lib/api/clients/runsClient.ts
+++ b/web/src/lib/api/clients/runsClient.ts
@@ -10,6 +10,7 @@ import type { InboxContextResponse } from '../../inbox/inboxContext'
 import { apiState, BASE, origin, req, wsUrl } from '../httpCore'
 import type {
   EventPaginatedResponse,
+  NodeEventsResponse,
   PaginatedResponse,
   PreviewIssue,
   PreviewPort,
@@ -301,7 +302,7 @@ export const runsClient = {
     if (params?.cursor || params?.limit != null) {
       return req<EventPaginatedResponse>(path, init)
     }
-    return req<{ events: AcpEvent[]; live: boolean }>(path, init)
+    return req<NodeEventsResponse>(path, init)
   },
   // Raw sandbox container logs (docker logs): live if running, else the archived
   // snapshot captured at teardown. Used for post-mortem troubleshooting.

--- a/web/src/lib/inbox/useGatesInbox.ts
+++ b/web/src/lib/inbox/useGatesInbox.ts
@@ -39,6 +39,7 @@ import {
   createBusySeedRetryController,
   runBusySeedRetry,
 } from '@/lib/run/busySeedRetry'
+import { isNodeEventsUnavailable } from '@/lib/run/nodeEventsResponse'
 import { createWsReconnectController } from '@/lib/run/wsReconnect'
 import { useToast } from '@/lib/composables/useToast'
 import { inboxShareKind, isHumanGateInboxItem, isShareableInboxItem } from '@/lib/inbox/gateShareLink'
@@ -1013,6 +1014,7 @@ async function seedClarifyAcpFromNodeEventsOnce(
 ): Promise<boolean> {
   try {
     const r = await api.nodeEvents(runId, nodeId, { limit: 50 })
+    if (isNodeEventsUnavailable(r)) return false
     if (!r.events?.length) return false
     const rails = pickAcpRails(r.events)
     if (!rails.thought && !rails.message) return false
@@ -1039,7 +1041,7 @@ async function seedClarifyAcpFromNodeEventsOnce(
     dialogueRailsFilled = true
     return true
   } catch {
-    /* 502 / empty — caller retries while busy */
+    /* soft-fail / empty — caller retries while busy */
     return false
   }
 }

--- a/web/src/lib/run/busySeedRetry.ts
+++ b/web/src/lib/run/busySeedRetry.ts
@@ -15,7 +15,7 @@ export type BusySeedRetryOptions = {
   liveIncrementalReceived?: () => boolean
   /**
    * Attempt one seed. Resolve true when content was obtained and applied.
-   * Empty / 502 / network errors should resolve false (not throw).
+   * Empty / soft-fail / network errors should resolve false (not throw).
    */
   seed: () => Promise<boolean>
   /** Delay between attempts (default 1500ms). */

--- a/web/src/lib/run/nodeEventsResponse.test.ts
+++ b/web/src/lib/run/nodeEventsResponse.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { isNodeEventsUnavailable } from './nodeEventsResponse'
+
+describe('nodeEventsResponse', () => {
+  it('isNodeEventsUnavailable is true only when unavailable flag is set', () => {
+    expect(isNodeEventsUnavailable({ events: [], live: false, unavailable: true })).toBe(true)
+    expect(isNodeEventsUnavailable({ events: [], live: false })).toBe(false)
+    expect(isNodeEventsUnavailable({ events: [], live: false, error: 'x' })).toBe(false)
+    expect(isNodeEventsUnavailable(null)).toBe(false)
+    expect(isNodeEventsUnavailable(undefined)).toBe(false)
+  })
+})

--- a/web/src/lib/run/nodeEventsResponse.ts
+++ b/web/src/lib/run/nodeEventsResponse.ts
@@ -1,0 +1,13 @@
+/** Shared shape for GET /runs/:id/nodes/:nodeId/events (paginated or not). */
+export type NodeEventsPayload = {
+  events?: unknown[]
+  live?: boolean
+  /** True when live sandbox is registered but bridge read failed transiently. */
+  unavailable?: boolean
+  error?: string
+}
+
+/** True when the control plane returned a soft-fail body (HTTP 200 + unavailable). */
+export function isNodeEventsUnavailable(r: NodeEventsPayload | null | undefined): boolean {
+  return !!r?.unavailable
+}

--- a/web/src/lib/run/useRunDetailLiveLog.test.ts
+++ b/web/src/lib/run/useRunDetailLiveLog.test.ts
@@ -223,4 +223,66 @@ describe('useRunDetailLiveLog', () => {
 
     app.unmount()
   })
+
+  it('fetchNodeEvents soft-fail (unavailable) returns false and leaves rehydrate as error', async () => {
+    vi.mocked(api.nodeEvents).mockResolvedValueOnce({
+      events: [],
+      live: false,
+      unavailable: true,
+      error: 'live event log read failed',
+    })
+
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0)
+      return 1
+    })
+
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: '/', component: { template: '<div />' } }],
+    })
+    await router.push('/')
+    await router.isReady()
+
+    const run = ref({
+      id: 'run-1',
+      status: 'running',
+      nodeRuns: { a1: { nodeId: 'a1', status: 'running', events: [], mcpCalls: [] } },
+      artifacts: [],
+    } as unknown as Run)
+    const selected = ref<string | null>('a1')
+
+    let live!: ReturnType<typeof useRunDetailLiveLog>
+    const app = createApp({
+      setup() {
+        live = useRunDetailLiveLog({
+          runId: computed(() => 'run-1'),
+          run,
+          selected,
+          selExecIdx: computed(() => 0),
+          selIterIdx: ref(null),
+          selRun: computed(() => run.value.nodeRuns.a1 || null),
+          selStatus: computed(() => 'running'),
+          viewingLatest: computed(() => true),
+          nodeTab: ref('log'),
+          hasLog: computed(() => true),
+        })
+        return () => null
+      },
+    })
+    app.use(i18n)
+    app.use(router)
+    app.mount(document.createElement('div'))
+
+    await live.rehydrateNodeEvents('a1')
+    expect(live.logEvents.value).toEqual([])
+    expect(live.selRehydrateStatus.value).toBe('error')
+
+    app.unmount()
+  })
 })

--- a/web/src/lib/run/useRunDetailLiveLog.ts
+++ b/web/src/lib/run/useRunDetailLiveLog.ts
@@ -14,6 +14,7 @@ import {
   RehydrateOrchestrator,
   type RehydrateStatus,
 } from '@/lib/run/liveLogRehydrate'
+import { isNodeEventsUnavailable } from '@/lib/run/nodeEventsResponse'
 import {
   clearLiveLogSnapshotsExceptRun,
   cloneEventPageSnapshot,
@@ -119,6 +120,7 @@ export function useRunDetailLiveLog(opts: {
       })
       if (opts?.signal?.aborted) return false
       if (eventFetchGen[nodeId] !== gen) return false
+      if (isNodeEventsUnavailable(r)) return false
       const prev = eventPages[nodeId]?.events || []
       const merged = mergeAcpEvents(prev, r.events || [], { live: !!r.live })
       if ('hasMore' in r) {


### PR DESCRIPTION
沙箱已登记但桥读瞬时失败时返回 HTTP 200 + unavailable 标记，
避免 DevTools Console 因 502 刷屏；前端以标记驱动 rehydrate/busy seed。

Co-authored-by: Cursor <cursoragent@cursor.com>
