### PR TITLE
fix(sandbox): parse Claude Code nested stream-json usage

### DIFF
--- a/sandbox-gateway/sandbox/internal/provider/streamjson/streamjson.go
+++ b/sandbox-gateway/sandbox/internal/provider/streamjson/streamjson.go
@@ -5,6 +5,7 @@
 package streamjson
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"log"
@@ -231,6 +232,10 @@ type message struct {
 // (input_tokens / cache_read_input_tokens / cache_creation_input_tokens) and
 // the camelCase variant some CLIs emit (inputTokens / cacheReadTokens /
 // cacheWriteTokens), so one parser serves several stream-json dialects.
+//
+// Claude Code ≥2026 result.usage also carries nested objects (server_tool_use,
+// cache_creation) and strings (service_tier). Those must be ignored — a rigid
+// map[string]int64 would fail the whole result line and drop token totals.
 type wireUsage struct {
 	InputTokens         int64
 	OutputTokens        int64
@@ -239,35 +244,50 @@ type wireUsage struct {
 }
 
 func (u *wireUsage) UnmarshalJSON(b []byte) error {
-	var m map[string]int64
-	if err := json.Unmarshal(b, &m); err != nil {
+	b = bytes.TrimSpace(b)
+	if len(b) == 0 || string(b) == "null" {
+		return nil
+	}
+	// Legacy CLIs / older mirrors typed usage as a bare number. Ignore it
+	// rather than failing the enclosing event (we cannot split in/out).
+	if b[0] != '{' {
+		return nil
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
 	pick := func(keys ...string) int64 {
 		for _, k := range keys {
-			if v, ok := m[k]; ok {
-				return v
+			v, ok := raw[k]
+			if !ok {
+				continue
+			}
+			var n int64
+			if json.Unmarshal(v, &n) == nil {
+				return n
 			}
 		}
 		return 0
 	}
 	u.InputTokens = pick("input_tokens", "inputTokens")
 	u.OutputTokens = pick("output_tokens", "outputTokens")
-	u.CacheReadTokens = pick("cache_read_input_tokens", "cacheReadTokens", "cache_read_tokens")
-	u.CacheCreationTokens = pick("cache_creation_input_tokens", "cacheWriteTokens", "cache_creation_tokens")
+	u.CacheReadTokens = pick("cache_read_input_tokens", "cacheReadTokens", "cache_read_tokens", "cacheReadInputTokens")
+	u.CacheCreationTokens = pick("cache_creation_input_tokens", "cacheWriteTokens", "cache_creation_tokens", "cacheCreationInputTokens")
 	return nil
 }
 
 type streamEvent struct {
-	Type      string     `json:"type"`
-	Subtype   string     `json:"subtype"`
-	SessionID string     `json:"session_id"`
-	Model     string     `json:"model"`
-	Text      string     `json:"text"` // top-level text (e.g. cursor's thinking deltas)
-	Message   *message   `json:"message"`
-	Usage     *wireUsage `json:"usage"`
-	Result    string     `json:"result"`
-	IsError   bool       `json:"is_error"`
+	Type       string               `json:"type"`
+	Subtype    string               `json:"subtype"`
+	SessionID  string               `json:"session_id"`
+	Model      string               `json:"model"`
+	Text       string               `json:"text"` // top-level text (e.g. cursor's thinking deltas)
+	Message    *message             `json:"message"`
+	Usage      *wireUsage           `json:"usage"`
+	ModelUsage map[string]wireUsage `json:"modelUsage"`
+	Result     string               `json:"result"`
+	IsError    bool                 `json:"is_error"`
 }
 
 func (d *codec) ParseLine(line []byte) oneshot.ParseResult {
@@ -280,7 +300,7 @@ func (d *codec) ParseLine(line []byte) oneshot.ParseResult {
 	res.SessionID = ev.SessionID
 
 	addUsage := func(u *wireUsage, model string) {
-		if u == nil {
+		if u == nil || (u.InputTokens == 0 && u.OutputTokens == 0 && u.CacheReadTokens == 0 && u.CacheCreationTokens == 0) {
 			return
 		}
 		if model == "" {
@@ -337,7 +357,16 @@ func (d *codec) ParseLine(line []byte) oneshot.ParseResult {
 			}
 		}
 	case "result":
-		addUsage(ev.Usage, ev.Model)
+		// Prefer per-model breakdown when Claude Code emits modelUsage; fall
+		// back to the flat usage object (often the only field older CLIs send).
+		if len(ev.ModelUsage) > 0 {
+			for model, u := range ev.ModelUsage {
+				uu := u
+				addUsage(&uu, model)
+			}
+		} else {
+			addUsage(ev.Usage, ev.Model)
+		}
 		if ev.IsError {
 			res.StopReason = "failed"
 			if ev.Result != "" {

--- a/sandbox-gateway/sandbox/internal/provider/streamjson/streamjson_test.go
+++ b/sandbox-gateway/sandbox/internal/provider/streamjson/streamjson_test.go
@@ -139,6 +139,55 @@ func TestParseResult(t *testing.T) {
 	}
 }
 
+// TestParseClaudeCodeResultUsageNested is the 2026 Claude Code stream-json
+// shape: result.usage is an object with nested server_tool_use / cache_creation
+// plus a sibling modelUsage map. A rigid map[string]int64 (or Usage int64)
+// used to fail the whole line → prompt_done with empty usage.
+func TestParseClaudeCodeResultUsageNested(t *testing.T) {
+	c := &codec{}
+	line := []byte(`{"type":"result","subtype":"success","is_error":false,"duration_api_ms":156811,"num_turns":11,"stop_reason":"end_turn","session_id":"3ce37a6e-5da6-40c7-9292-abc","usage":{"input_tokens":120,"output_tokens":80,"cache_read_input_tokens":2000,"cache_creation_input_tokens":15,"server_tool_use":{"web_search_requests":1,"web_fetch_requests":0},"service_tier":"standard","cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":15}},"modelUsage":{"claude-sonnet-4-5":{"inputTokens":120,"outputTokens":80,"cacheReadInputTokens":2000,"cacheCreationInputTokens":15,"costUSD":0.01,"contextWindow":200000}}}`)
+	pr := c.ParseLine(line)
+	if pr.SessionID != "3ce37a6e-5da6-40c7-9292-abc" {
+		t.Fatalf("sid=%q", pr.SessionID)
+	}
+	if pr.StopReason != "end_turn" {
+		t.Fatalf("stop=%q", pr.StopReason)
+	}
+	u := pr.Usage["claude-sonnet-4-5"]
+	if u.InputTokens != 120 || u.OutputTokens != 80 || u.CacheReadTokens != 2000 || u.CacheWriteTokens != 15 {
+		t.Fatalf("modelUsage=%+v", u)
+	}
+	if _, ok := pr.Usage["default"]; ok {
+		t.Fatalf("should prefer modelUsage over flat usage, got %+v", pr.Usage)
+	}
+}
+
+// Nested usage without modelUsage is the live failure mode: the result line
+// still has to parse, and tokens fall back onto the flat usage object.
+func TestParseClaudeCodeResultUsageNestedNoModelUsage(t *testing.T) {
+	c := &codec{}
+	line := []byte(`{"type":"result","subtype":"success","is_error":false,"duration_api_ms":156811,"num_turns":11,"stop_reason":"end_turn","session_id":"3ce37a6e-5da6-40c7-9292-abc","usage":{"input_tokens":120,"output_tokens":80,"cache_read_input_tokens":2000,"cache_creation_input_tokens":15,"server_tool_use":{"web_search_requests":1},"service_tier":"standard","cache_creation":{"ephemeral_5m_input_tokens":15}}}`)
+	pr := c.ParseLine(line)
+	if pr.StopReason != "end_turn" {
+		t.Fatalf("stop=%q (nested usage must not drop the result line)", pr.StopReason)
+	}
+	u := pr.Usage["default"]
+	if u.InputTokens != 120 || u.OutputTokens != 80 || u.CacheReadTokens != 2000 || u.CacheWriteTokens != 15 {
+		t.Fatalf("flat usage=%+v", u)
+	}
+}
+
+func TestParseResultUsageIgnoresBareNumber(t *testing.T) {
+	c := &codec{}
+	pr := c.ParseLine([]byte(`{"type":"result","subtype":"success","session_id":"S1","usage":42}`))
+	if pr.StopReason != "end_turn" {
+		t.Fatalf("bare usage number must not drop the result line: %+v", pr)
+	}
+	if len(pr.Usage) != 0 {
+		t.Fatalf("bare number usage should be ignored: %+v", pr.Usage)
+	}
+}
+
 func TestParseToolResult(t *testing.T) {
 	c := &codec{}
 	pr := c.ParseLine([]byte(`{"type":"user","message":{"content":[{"type":"tool_result","id":"t1","content":[{"type":"text","text":"out"}]}]}}`))


### PR DESCRIPTION
## Summary
- Claude Code 更新后，`stream-json` 的 `result.usage` 从数字/扁平 int map 变成带 `server_tool_use`、`cache_creation` 的嵌套对象，并可能附带 `modelUsage`。旧解析整行失败，节点有时长但 token 恒为 0。
- `wireUsage` 改为按字段抽取数字、忽略嵌套/字符串；`result` 优先用 `modelUsage` 分桶，否则回退扁平 `usage`。
- 补上线上失败形态（只有嵌套 `usage`）和裸数字 `usage` 的回归测试。

## Test plan
- [x] `go test ./internal/provider/streamjson/ ./internal/provider/oneshot/`
- [x] `go test ./...` in `sandbox-gateway/sandbox`
- [x] `./scripts/cover-check-sandbox.sh 90`（96.6%）
- [ ] CI `ci-sandbox` / `golangci-lint` 绿
- [ ] 合并后重建并发布 `universal-sandbox-claude_code` 镜像，线上才会恢复 token


Made with [Cursor](https://cursor.com)