### PR TITLE
feat(web): render PlanView data_design entity fields as tables

### DIFF
--- a/web/src/components/run/PlanView.test.ts
+++ b/web/src/components/run/PlanView.test.ts
@@ -128,14 +128,20 @@ describe('PlanView', () => {
     wrapper.unmount()
   })
 
-  it('renders entity fields, badges, and relationships', async () => {
+  it('renders entity fields as table with badges and relationships (g1.1/g1.3)', async () => {
     const wrapper = mountPlan(designDoc)
     await flushPromises()
-    expect(wrapper.find('[data-testid="plan-entity-fields"]').exists()).toBe(true)
+    const fields = wrapper.find('[data-testid="plan-entity-fields"]')
+    expect(fields.exists()).toBe(true)
+    expect(fields.find('table').exists()).toBe(true)
+    expect(fields.findAll('tbody tr')).toHaveLength(2)
+    // no left-border nested list for fields
+    expect(fields.find('ul').exists()).toBe(false)
     expect(wrapper.text()).toContain('title')
     expect(wrapper.text()).toContain('string')
     expect(wrapper.text()).toContain('PK')
     expect(wrapper.text()).toContain('fk→Other.ref')
+    expect(wrapper.findAll('[data-testid="plan-field-badge"]').length).toBeGreaterThanOrEqual(2)
     expect(wrapper.find('[data-testid="plan-entity-relationships"]').exists()).toBe(true)
     expect(wrapper.text()).toContain('1..* planGoal')
     expect(wrapper.find('[data-testid="plan-data-relationships"]').exists()).toBe(true)
@@ -143,7 +149,7 @@ describe('PlanView', () => {
     wrapper.unmount()
   })
 
-  it('renders legacy attributes when fields absent', () => {
+  it('renders legacy attributes when fields absent (g2.1)', () => {
     const doc: PlanDoc = {
       data_design: {
         summary: 'legacy',
@@ -152,13 +158,29 @@ describe('PlanView', () => {
       goals: [{ id: 'g1', title: 'G', status: 'pending' }],
     }
     const wrapper = mountPlan(doc)
+    expect(wrapper.find('[data-testid="plan-entity-fields"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="plan-entity-attributes"]').exists()).toBe(true)
     expect(wrapper.text()).toContain('legacy')
     expect(wrapper.text()).toContain('id')
     wrapper.unmount()
   })
 
-  it('zh-CN shows Chinese design section titles (g1.2)', async () => {
+  it('does not render empty fields table (g1.3 edge)', () => {
+    const doc: PlanDoc = {
+      data_design: {
+        summary: 'empty fields',
+        entities: [{ name: 'Empty', fields: [], description: 'no cols' }],
+      },
+      goals: [{ id: 'g1', title: 'G', status: 'pending' }],
+    }
+    const wrapper = mountPlan(doc)
+    expect(wrapper.text()).toContain('Empty')
+    expect(wrapper.text()).toContain('no cols')
+    expect(wrapper.find('[data-testid="plan-entity-fields"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('zh-CN shows Chinese design section titles and field table headers (g1.2)', async () => {
     const wrapper = mountPlan(designDoc, undefined, 'zh-CN')
     await flushPromises()
     const text = wrapper.text()
@@ -168,16 +190,21 @@ describe('PlanView', () => {
     expect(text).toContain('组件')
     expect(text).toContain('交互')
     expect(text).toContain('测试设计')
+    expect(text).toContain('字段')
+    expect(text).toContain('类型')
+    expect(text).toContain('约束')
+    expect(text).toContain('说明')
     expect(text).not.toContain('Architecture')
     expect(text).not.toContain('Data design')
     expect(text).not.toContain('Interfaces')
     expect(text).not.toContain('Components')
     expect(text).not.toContain('Interaction')
     expect(text).not.toContain('Test design')
+    expect(text).not.toContain('Constraints')
     wrapper.unmount()
   })
 
-  it('en shows English design section titles', async () => {
+  it('en shows English design section titles and field table headers (g1.2)', async () => {
     const wrapper = mountPlan(designDoc, undefined, 'en')
     await flushPromises()
     const text = wrapper.text()
@@ -187,8 +214,13 @@ describe('PlanView', () => {
     expect(text).toContain('Components')
     expect(text).toContain('Interaction')
     expect(text).toContain('Test design')
+    expect(text).toContain('Field')
+    expect(text).toContain('Type')
+    expect(text).toContain('Constraints')
+    expect(text).toContain('Description')
     expect(text).not.toContain('数据设计')
     expect(text).not.toContain('测试设计')
+    expect(text).not.toContain('约束')
     wrapper.unmount()
   })
 

--- a/web/src/components/run/PlanView.vue
+++ b/web/src/components/run/PlanView.vue
@@ -175,19 +175,45 @@ function st(s?: string) {
               <span v-if="e.description"> — {{ e.description }}</span>
               <AnnotateBtn :json-path="`data_design.entities[${ei}]`" :label="e.name || `entity ${ei + 1}`" />
             </div>
-            <ul v-if="e.fields?.length" class="mt-1 space-y-0.5 border-l border-line pl-2" data-testid="plan-entity-fields">
-              <li v-for="(f, fi) in e.fields" :key="f.name || fi" class="flex flex-wrap items-center gap-1.5">
-                <code class="font-mono text-[11px] text-txt">{{ f.name }}</code>
-                <span class="text-[11px] text-txt3">{{ f.type }}</span>
-                <span
-                  v-for="tag in fieldBadges(f)"
-                  :key="tag"
-                  class="rounded bg-base px-1 py-0.5 text-[10px] font-medium text-txt3"
-                  data-testid="plan-field-badge"
-                >{{ tag }}</span>
-                <span v-if="f.description" class="text-[11px] text-txt3">— {{ f.description }}</span>
-              </li>
-            </ul>
+            <div
+              v-if="e.fields?.length"
+              class="mt-1.5 overflow-x-auto"
+              data-testid="plan-entity-fields"
+            >
+              <table class="w-full min-w-[28rem] border-collapse text-left">
+                <thead>
+                  <tr class="border-b border-line text-[10px] font-medium uppercase tracking-wide text-txt3">
+                    <th class="py-1 pr-3 font-medium">{{ t('pages.plan.fieldTable.name') }}</th>
+                    <th class="py-1 pr-3 font-medium">{{ t('pages.plan.fieldTable.type') }}</th>
+                    <th class="py-1 pr-3 font-medium">{{ t('pages.plan.fieldTable.constraints') }}</th>
+                    <th class="py-1 font-medium">{{ t('pages.plan.fieldTable.description') }}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr
+                    v-for="(f, fi) in e.fields"
+                    :key="f.name || fi"
+                    class="border-b border-line/50 align-top last:border-b-0"
+                  >
+                    <td class="py-1 pr-3">
+                      <code class="font-mono text-[11px] text-txt">{{ f.name }}</code>
+                    </td>
+                    <td class="py-1 pr-3 text-[11px] text-txt3 break-words">{{ f.type }}</td>
+                    <td class="py-1 pr-3">
+                      <span class="inline-flex flex-wrap gap-1">
+                        <span
+                          v-for="tag in fieldBadges(f)"
+                          :key="tag"
+                          class="rounded bg-base px-1 py-0.5 text-[10px] font-medium text-txt3"
+                          data-testid="plan-field-badge"
+                        >{{ tag }}</span>
+                      </span>
+                    </td>
+                    <td class="py-1 text-[11px] text-txt3 break-words">{{ f.description }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
             <ul v-if="e.attributes?.length" class="mt-1 space-y-0.5 border-l border-line pl-2" data-testid="plan-entity-attributes">
               <li v-for="(a, ai) in e.attributes" :key="ai" class="text-[11px] text-txt3">
                 <span class="italic">legacy</span> {{ a }}

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -3025,6 +3025,12 @@
         "interaction": "Interaction",
         "testDesign": "Test design"
       },
+      "fieldTable": {
+        "name": "Field",
+        "type": "Type",
+        "constraints": "Constraints",
+        "description": "Description"
+      },
       "diagramFallback": "Diagram render failed; showing source",
       "status": {
         "done": "Done",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -3025,6 +3025,12 @@
         "interaction": "交互",
         "testDesign": "测试设计"
       },
+      "fieldTable": {
+        "name": "字段",
+        "type": "类型",
+        "constraints": "约束",
+        "description": "说明"
+      },
       "diagramFallback": "图渲染失败,显示源码",
       "status": {
         "done": "完成",


### PR DESCRIPTION
Replace the nested list for structured fields with per-entity tables
(name/type/constraints/description) so attributes align for scanning,
while keeping legacy attributes, relationships, and ER diagrams unchanged.

Co-authored-by: Cursor <cursoragent@cursor.com>
