### PR TITLE
feat: unify chat test to project context with searchable agent picker

### DIFF
--- a/server/internal/handlers/handlers_test.go
+++ b/server/internal/handlers/handlers_test.go
@@ -763,48 +763,6 @@ func TestAgentEndpoints(t *testing.T) {
 	if w := h.do("DELETE", "/api/agents/a2", nil); w.Code != 200 {
 		t.Fatalf("delete: %d", w.Code)
 	}
-	// CreateAgentTest for unknown agent -> 400.
-	if w := h.do("POST", "/api/agents/ghost/test", map[string]any{}); w.Code != 400 {
-		t.Fatalf("agent test unknown: %d", w.Code)
-	}
-	// A test sandbox's data ownership follows the Agent's home project, not the
-	// UI-selected projectId. Bind the agent first, then start the test.
-	wProj := h.do("POST", "/api/projects", map[string]any{"name": "TesterHome"})
-	if wProj.Code != 200 {
-		t.Fatalf("create project: %d %s", wProj.Code, wProj.Body)
-	}
-	var proj map[string]any
-	if err := json.Unmarshal(wProj.Body.Bytes(), &proj); err != nil {
-		t.Fatal(err)
-	}
-	pid, _ := proj["id"].(string)
-	if w := h.do("POST", "/api/agents", map[string]any{"name": "tester", "projectId": pid}); w.Code != 201 {
-		t.Fatalf("create tester agent: %d %s", w.Code, w.Body)
-	}
-	// CreateAgentTest accepts repos[]; UI-passed projectId is ignored in favor of agent home.
-	wRepos := h.do("POST", "/api/agents/tester/test", map[string]any{
-		"projectId": "ignored-client-project",
-		"repos": []map[string]string{
-			{"name": "web", "url": "https://h/web.git", "branch": "main"},
-		},
-	})
-	if wRepos.Code != 201 {
-		t.Fatalf("agent test repos: %d %s", wRepos.Code, wRepos.Body)
-	}
-	var sb map[string]any
-	if err := json.Unmarshal(wRepos.Body.Bytes(), &sb); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if got, _ := sb["repoUrl"].(string); got != "https://h/web.git" {
-		t.Fatalf("repoUrl = %q, want first clone URL", got)
-	}
-	if got, _ := sb["projectId"].(string); got != pid {
-		t.Fatalf("projectId = %q, want agent home project %q", got, pid)
-	}
-	// repoUrl backward compat still works.
-	if w := h.do("POST", "/api/agents/tester/test", map[string]any{"repoUrl": "https://h/legacy.git"}); w.Code != 201 {
-		t.Fatalf("agent test repoUrl: %d %s", w.Code, w.Body)
-	}
 }
 
 func TestSandboxEndpoints(t *testing.T) {

--- a/server/internal/handlers/sandbox.go
+++ b/server/internal/handlers/sandbox.go
@@ -65,26 +65,6 @@ func resolveTestRepos(repos []testRepoInput, repoURL string) []sandbox.RepoSpec 
 	return sandbox.ReposFromURL(repoURL)
 }
 
-// CreateAgentTest spins up an interactive sandbox bound to an Agent profile for
-// chat-testing. Body: {repos?: [{name,url,branch?}], repoUrl?}. Returns the created sandbox record.
-func (h *Handlers) CreateAgentTest(c *gin.Context) {
-	profile := c.Param("name")
-	var b struct {
-		Repos     []testRepoInput `json:"repos"`
-		RepoURL   string          `json:"repoUrl"`
-		ProjectID string          `json:"projectId"`
-	}
-	_ = c.ShouldBindJSON(&b)
-	repos := resolveTestRepos(b.Repos, b.RepoURL)
-	projectID := strings.TrimSpace(b.ProjectID)
-	row, err := h.Sbx.Open(c.Request.Context(), profile, repos, projectID)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-	c.JSON(http.StatusCreated, row)
-}
-
 // SandboxEvents returns a sandbox's full agent event log, read directly from
 // the container's acp-bridge service (no platform-side persistence).
 func (h *Handlers) SandboxEvents(c *gin.Context) {
@@ -210,7 +190,7 @@ func isSandboxLogNoSource(err error) bool {
 }
 
 // GetSandbox returns one sandbox with live-derived status. The UI polls this
-// to watch a "creating" sandbox flip to running/error after CreateAgentTest.
+// to watch a "creating" sandbox flip to running/error after test creation.
 func (h *Handlers) GetSandbox(c *gin.Context) {
 	id, ok := parseUintParam(c, "id")
 	if !ok {

--- a/server/internal/router/router.go
+++ b/server/internal/router/router.go
@@ -211,7 +211,6 @@ func New(h *handlers.Handlers) *gin.Engine {
 		api.PUT("/agents/:name", h.SaveAgent)
 		api.PATCH("/agents/:name/project", h.PatchAgentProject)
 		api.POST("/agents/:name/rename", h.RenameAgent)
-		api.POST("/agents/:name/test", h.CreateAgentTest)
 		api.DELETE("/agents/:name", h.DeleteAgent)
 		// Agent-scoped data (Studio). Project resolved from agent.projectId.
 		api.GET("/agents/:name/memories", h.ListAgentMemories)

--- a/web/src/components/agent/AgentChatTester.vue
+++ b/web/src/components/agent/AgentChatTester.vue
@@ -34,9 +34,8 @@ const props = defineProps<{
   /** Agent home project id from Studio; empty = unbound (no task-scheduler). */
   homeProjectId?: string
   /**
-   * Optional override for starting a test sandbox.
-   * Agent Studio omits this (uses POST /agents/:name/test).
-   * Project shared-config dialogue test passes createProjectSharedAgentTest.
+   * Required override for starting a test sandbox (project shared-config dialogue test).
+   * Omitted when attaching to an existing sandbox via attachId.
    */
   createTest?: (profile: string, payload: CreateAgentTestPayload) => Promise<SandboxView>
 }>()
@@ -142,6 +141,11 @@ watch(
 
 async function start() {
   if (status.value === 'starting' || !canStart.value) return
+  if (!props.createTest) {
+    status.value = 'error'
+    errorMsg.value = t('pages.agentChatTester.missingCreateTest')
+    return
+  }
   status.value = 'starting'
   errorMsg.value = ''
   turns.value = []
@@ -159,9 +163,7 @@ async function start() {
         : {
             ...(props.homeProjectId?.trim() ? { projectId: props.homeProjectId.trim() } : {}),
           }
-    sandbox.value = props.createTest
-      ? await props.createTest(props.profile, payload)
-      : await api.createAgentTest(props.profile, payload)
+    sandbox.value = await props.createTest(props.profile, payload)
     await waitReady(sandbox.value.id)
   } catch (e: any) {
     status.value = 'error'

--- a/web/src/components/project/ProjectAgentSelect.test.ts
+++ b/web/src/components/project/ProjectAgentSelect.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+import { createI18n } from 'vue-i18n'
+import { flushPromises, mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import common from '@/locales/zh-CN/common.json'
+import pages from '@/locales/zh-CN/pages.json'
+import ProjectAgentSelect from './ProjectAgentSelect.vue'
+
+function mountSelect(props: {
+  agents?: { name: string }[]
+  modelValue?: string
+  disabled?: boolean
+}) {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common, ...pages } },
+  })
+  return mount(ProjectAgentSelect, {
+    props: {
+      agents: props.agents ?? [
+        { name: 'alpha-agent' },
+        { name: 'beta-agent' },
+      ],
+      modelValue: props.modelValue ?? 'alpha-agent',
+      disabled: props.disabled ?? false,
+    },
+    global: { plugins: [i18n] },
+  })
+}
+
+describe('ProjectAgentSelect', () => {
+  it('filters options by search keyword', async () => {
+    const wrapper = mountSelect({})
+    await flushPromises()
+    await wrapper.get('[data-testid="project-agent-select-trigger"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-testid="project-agent-select-search"]').setValue('beta')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="project-agent-select-option-beta-agent"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="project-agent-select-option-alpha-agent"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('shows empty result when keyword matches nothing', async () => {
+    const wrapper = mountSelect({})
+    await flushPromises()
+    await wrapper.get('[data-testid="project-agent-select-trigger"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-testid="project-agent-select-search"]').setValue('missing')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="project-agent-select-empty"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('emits selection on option click', async () => {
+    const wrapper = mountSelect({})
+    await flushPromises()
+    await wrapper.get('[data-testid="project-agent-select-trigger"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-testid="project-agent-select-option-beta-agent"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['beta-agent'])
+    wrapper.unmount()
+  })
+})

--- a/web/src/components/project/ProjectAgentSelect.vue
+++ b/web/src/components/project/ProjectAgentSelect.vue
@@ -1,0 +1,358 @@
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+export type ProjectAgentOption = { name: string }
+
+const props = withDefaults(
+  defineProps<{
+    agents: ProjectAgentOption[]
+    modelValue: string
+    disabled?: boolean
+  }>(),
+  { disabled: false },
+)
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', v: string): void
+}>()
+
+const { t } = useI18n()
+
+const open = ref(false)
+const search = ref('')
+const activeIndex = ref(0)
+const root = ref<HTMLElement | null>(null)
+const trigger = ref<HTMLButtonElement | null>(null)
+const searchInput = ref<HTMLInputElement | null>(null)
+
+const selectedName = computed(() => {
+  if (!props.modelValue) return t('pages.projectDetail.sharedAgent.pickAgentPlaceholder')
+  return props.modelValue
+})
+
+const filtered = computed(() => {
+  const q = search.value.trim().toLowerCase()
+  if (!q) return props.agents
+  return props.agents.filter((a) => a.name.toLowerCase().includes(q))
+})
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) =>
+  ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  })[c] as string)
+}
+
+function highlightName(name: string, q: string): string {
+  if (!q) return escapeHtml(name)
+  const lower = name.toLowerCase()
+  const iq = q.toLowerCase()
+  const i = lower.indexOf(iq)
+  if (i < 0) return escapeHtml(name)
+  return (
+    escapeHtml(name.slice(0, i)) +
+    '<mark>' +
+    escapeHtml(name.slice(i, i + q.length)) +
+    '</mark>' +
+    escapeHtml(name.slice(i + q.length))
+  )
+}
+
+function openPanel() {
+  if (props.disabled || !props.agents.length) return
+  open.value = true
+  search.value = ''
+  const idx = props.agents.findIndex((a) => a.name === props.modelValue)
+  activeIndex.value = Math.max(0, idx)
+  nextTick(() => searchInput.value?.focus())
+}
+
+function closePanel() {
+  open.value = false
+}
+
+function togglePanel(e: MouseEvent) {
+  e.stopPropagation()
+  if (props.disabled || !props.agents.length) return
+  if (open.value) closePanel()
+  else openPanel()
+}
+
+function choose(name: string) {
+  emit('update:modelValue', name)
+  closePanel()
+  trigger.value?.focus()
+}
+
+function onDocClick(e: MouseEvent) {
+  if (!open.value) return
+  const target = e.target as Node
+  if (root.value?.contains(target)) return
+  closePanel()
+}
+
+function onSearchInput() {
+  activeIndex.value = 0
+}
+
+function onSearchKeydown(e: KeyboardEvent) {
+  const items = filtered.value
+  if (e.key === 'Escape') {
+    e.preventDefault()
+    closePanel()
+    trigger.value?.focus()
+    return
+  }
+  if (e.key === 'ArrowDown') {
+    e.preventDefault()
+    if (!items.length) return
+    activeIndex.value = (activeIndex.value + 1) % items.length
+    return
+  }
+  if (e.key === 'ArrowUp') {
+    e.preventDefault()
+    if (!items.length) return
+    activeIndex.value = (activeIndex.value - 1 + items.length) % items.length
+    return
+  }
+  if (e.key === 'Enter') {
+    e.preventDefault()
+    if (!items.length) return
+    choose(items[activeIndex.value].name)
+  }
+}
+
+function onTriggerKeydown(e: KeyboardEvent) {
+  if (props.disabled || !props.agents.length) return
+  if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault()
+    if (!open.value) openPanel()
+  }
+  if (e.key === 'Escape' && open.value) {
+    e.preventDefault()
+    closePanel()
+  }
+}
+
+watch(
+  () => filtered.value.length,
+  (len) => {
+    if (activeIndex.value >= len) activeIndex.value = Math.max(0, len - 1)
+  },
+)
+
+onMounted(() => document.addEventListener('click', onDocClick))
+onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
+</script>
+
+<template>
+  <div
+    ref="root"
+    class="project-agent-select"
+    data-testid="project-agent-select"
+    :class="{ 'project-agent-select--open': open }"
+  >
+    <button
+      ref="trigger"
+      type="button"
+      class="project-agent-select__trigger"
+      data-testid="project-agent-select-trigger"
+      :disabled="disabled || !agents.length"
+      aria-haspopup="listbox"
+      :aria-expanded="open"
+      aria-controls="project-agent-select-panel"
+      @click="togglePanel"
+      @keydown="onTriggerKeydown"
+    >
+      <span class="project-agent-select__label">{{ selectedName }}</span>
+      <span class="project-agent-select__chev" aria-hidden="true" />
+    </button>
+
+    <div
+      v-if="open"
+      id="project-agent-select-panel"
+      class="project-agent-select__panel"
+      role="presentation"
+      data-testid="project-agent-select-panel"
+    >
+      <div class="project-agent-select__search-wrap">
+        <input
+          ref="searchInput"
+          v-model="search"
+          type="search"
+          class="project-agent-select__search"
+          data-testid="project-agent-select-search"
+          :placeholder="t('common.search.agentPlaceholder')"
+          autocomplete="off"
+          :aria-label="t('common.search.agentPlaceholder')"
+          @input="onSearchInput"
+          @keydown="onSearchKeydown"
+          @click.stop
+        />
+      </div>
+      <div
+        class="project-agent-select__list"
+        role="listbox"
+        :aria-label="t('pages.projectDetail.sharedAgent.pickAgent')"
+      >
+        <template v-if="filtered.length">
+          <button
+            v-for="(a, i) in filtered"
+            :key="a.name"
+            type="button"
+            class="project-agent-select__opt"
+            role="option"
+            :class="{
+              'project-agent-select__opt--current': a.name === modelValue,
+              'project-agent-select__opt--active': i === activeIndex,
+            }"
+            :aria-selected="i === activeIndex"
+            :data-testid="`project-agent-select-option-${a.name}`"
+            @click.stop="choose(a.name)"
+          >
+            <span v-html="highlightName(a.name, search.trim())" />
+          </button>
+        </template>
+        <div
+          v-else
+          class="project-agent-select__empty"
+          data-testid="project-agent-select-empty"
+        >
+          {{ t('common.empty.noMatchingAgents') }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.project-agent-select {
+  position: relative;
+  max-width: 28rem;
+  min-width: 12rem;
+}
+
+.project-agent-select__trigger {
+  width: 100%;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  border: 1px solid rgb(var(--c-line));
+  background: rgb(var(--c-base));
+  color: rgb(var(--c-txt));
+  padding: 0 10px;
+  font-size: 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.15s ease;
+}
+
+.project-agent-select__trigger:hover:not(:disabled),
+.project-agent-select--open .project-agent-select__trigger {
+  border-color: rgb(var(--c-line-strong));
+}
+
+.project-agent-select__trigger:disabled {
+  cursor: default;
+  color: rgb(var(--c-txt3));
+}
+
+.project-agent-select__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.project-agent-select__chev {
+  width: 0;
+  height: 0;
+  border: 4px solid transparent;
+  border-top-color: rgb(var(--c-txt3));
+  flex-shrink: 0;
+}
+
+.project-agent-select__panel {
+  position: absolute;
+  left: 0;
+  top: calc(100% + 6px);
+  width: min(320px, 78vw);
+  border: 1px solid rgb(var(--c-line-strong));
+  background: rgb(var(--c-elevated));
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+  z-index: 20;
+}
+
+.project-agent-select__search-wrap {
+  padding: 8px;
+  border-bottom: 1px solid rgb(var(--c-line) / 0.7);
+}
+
+.project-agent-select__search {
+  width: 100%;
+  height: 32px;
+  border: 1px solid rgb(var(--c-line));
+  background: rgb(var(--c-surface));
+  color: rgb(var(--c-txt));
+  padding: 0 10px;
+  font-size: 13px;
+  outline: none;
+}
+
+.project-agent-select__search::placeholder {
+  color: rgb(var(--c-txt3));
+}
+
+.project-agent-select__search:focus {
+  border-color: rgb(var(--c-accent));
+}
+
+.project-agent-select__list {
+  max-height: 220px;
+  overflow: auto;
+  padding: 4px;
+}
+
+.project-agent-select__opt {
+  width: 100%;
+  text-align: left;
+  border: 0;
+  background: transparent;
+  color: rgb(var(--c-txt));
+  padding: 8px 10px;
+  font-size: 13px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  cursor: pointer;
+}
+
+.project-agent-select__opt:hover,
+.project-agent-select__opt--active {
+  background: rgb(var(--c-accent) / 0.16);
+  color: rgb(var(--c-txt));
+}
+
+.project-agent-select__opt--current {
+  color: rgb(var(--c-accent-2));
+}
+
+.project-agent-select__opt :deep(mark) {
+  background: rgb(var(--c-accent) / 0.35);
+  color: inherit;
+  padding: 0 1px;
+}
+
+.project-agent-select__empty {
+  padding: 16px 10px;
+  text-align: center;
+  color: rgb(var(--c-txt3));
+  font-size: 12px;
+}
+</style>

--- a/web/src/components/project/ProjectSharedAgentPanel.test.ts
+++ b/web/src/components/project/ProjectSharedAgentPanel.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment happy-dom
+import { createI18n } from 'vue-i18n'
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import common from '@/locales/zh-CN/common.json'
+import pages from '@/locales/zh-CN/pages.json'
+import ProjectSharedAgentPanel from './ProjectSharedAgentPanel.vue'
+
+const apiMocks = vi.hoisted(() => ({
+  getProjectSharedAgentConfig: vi.fn(),
+  listAgents: vi.fn(),
+  putProjectSharedAgentConfig: vi.fn(),
+  createProjectSharedAgentTest: vi.fn(),
+}))
+
+vi.mock('@/lib/api/api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/api/api')>('@/lib/api/api')
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getProjectSharedAgentConfig: apiMocks.getProjectSharedAgentConfig,
+      listAgents: apiMocks.listAgents,
+      putProjectSharedAgentConfig: apiMocks.putProjectSharedAgentConfig,
+      createProjectSharedAgentTest: apiMocks.createProjectSharedAgentTest,
+    },
+  }
+})
+
+const sharedCfg = {
+  acpBackend: 'cursor',
+  defaultProjectId: 'proj-a',
+  gitCredentialType: '',
+  files: [],
+  mcp: [],
+  env: {},
+  layout: {},
+  prompts: {},
+}
+
+function mountPanel(projectId = 'proj-a') {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common, ...pages } },
+  })
+  return mount(ProjectSharedAgentPanel, {
+    props: { projectId },
+    global: {
+      plugins: [i18n],
+      stubs: {
+        Icon: true,
+        AgentFilesPanel: true,
+        AgentMcpPanel: true,
+        AgentEnvPanel: true,
+        AgentPromptsPanel: true,
+        AgentChatTester: {
+          props: ['profile', 'homeProjectId', 'createTest'],
+          template: '<div data-testid="shared-agent-chat-tester">{{ profile }}</div>',
+        },
+      },
+    },
+  })
+}
+
+describe('ProjectSharedAgentPanel chat test picker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    apiMocks.getProjectSharedAgentConfig.mockResolvedValue(sharedCfg)
+  })
+
+  it('lists only agents bound to the current project', async () => {
+    apiMocks.listAgents.mockResolvedValue([
+      { name: 'mine', projectId: 'proj-a' },
+      { name: 'other', projectId: 'proj-b' },
+      { name: 'free' },
+    ])
+    const wrapper = mountPanel('proj-a')
+    await flushPromises()
+    await wrapper.get('[data-testid="shared-agent-subtab-test"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-testid="project-agent-select-trigger"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="project-agent-select-option-mine"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="project-agent-select-option-other"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="shared-agent-chat-tester"]').text()).toBe('mine')
+    wrapper.unmount()
+  })
+
+  it('shows empty state when no project-bound agents exist', async () => {
+    apiMocks.listAgents.mockResolvedValue([
+      { name: 'other', projectId: 'proj-b' },
+    ])
+    const wrapper = mountPanel('proj-a')
+    await flushPromises()
+    await wrapper.get('[data-testid="shared-agent-subtab-test"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="shared-agent-test-empty"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="shared-agent-chat-tester"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('filters combobox candidates and drives tester selection', async () => {
+    apiMocks.listAgents.mockResolvedValue([
+      { name: 'alpha', projectId: 'proj-a' },
+      { name: 'beta', projectId: 'proj-a' },
+    ])
+    const wrapper = mountPanel('proj-a')
+    await flushPromises()
+    await wrapper.get('[data-testid="shared-agent-subtab-test"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-testid="project-agent-select-trigger"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-testid="project-agent-select-search"]').setValue('beta')
+    await flushPromises()
+    await wrapper.get('[data-testid="project-agent-select-option-beta"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="shared-agent-chat-tester"]').text()).toBe('beta')
+    wrapper.unmount()
+  })
+})

--- a/web/src/components/project/ProjectSharedAgentPanel.vue
+++ b/web/src/components/project/ProjectSharedAgentPanel.vue
@@ -8,6 +8,7 @@ import AgentMcpPanel from '@/components/agent/AgentMcpPanel.vue'
 import AgentEnvPanel from '@/components/agent/AgentEnvPanel.vue'
 import AgentPromptsPanel from '@/components/agent/AgentPromptsPanel.vue'
 import AgentChatTester from '@/components/agent/AgentChatTester.vue'
+import ProjectAgentSelect from '@/components/project/ProjectAgentSelect.vue'
 import { api, type CreateAgentTestPayload, type ProjectSharedAgentConfig, type SandboxView } from '@/lib/api/api'
 import {
   DEFAULT_CONFIG_ROOT,
@@ -55,6 +56,20 @@ let configRootTouched = false
 
 const agents = ref<{ name: string; projectId?: string }[]>([])
 const testAgentName = ref('')
+
+const projectAgents = computed(() =>
+  agents.value.filter((a) => a.projectId === props.projectId),
+)
+
+function syncTestAgentSelection() {
+  const candidates = projectAgents.value
+  if (!candidates.length) {
+    testAgentName.value = ''
+    return
+  }
+  if (candidates.some((a) => a.name === testAgentName.value)) return
+  testAgentName.value = candidates[0]!.name
+}
 
 const dirty = computed(() => {
   if (!draft.value) return false
@@ -180,10 +195,7 @@ async function load() {
     ])
     applyLoaded(cfg)
     agents.value = agentList.map((a) => ({ name: a.name, projectId: a.projectId }))
-    if (!testAgentName.value && agents.value.length) {
-      const bound = agents.value.find((a) => a.projectId === props.projectId)
-      testAgentName.value = bound?.name || agents.value[0]!.name
-    }
+    syncTestAgentSelection()
   } catch (e: unknown) {
     loadError.value = String((e as { message?: string })?.message || e)
     draft.value = null
@@ -268,6 +280,10 @@ watch(
     void load()
   },
 )
+
+watch(projectAgents, () => {
+  syncTestAgentSelection()
+})
 
 onMounted(() => {
   void load()
@@ -505,26 +521,31 @@ onMounted(() => {
         class="flex min-h-0 flex-1 flex-col overflow-hidden"
         data-testid="shared-agent-test"
       >
-        <div class="flex shrink-0 flex-wrap items-center gap-2 border-b border-line px-3 py-2">
-          <label class="flex min-w-0 flex-1 items-center gap-2 text-[12px] text-txt2">
-            <span class="shrink-0">{{ t('pages.projectDetail.sharedAgent.pickAgent') }}</span>
-            <select
+        <div
+          class="flex shrink-0 flex-wrap items-start gap-x-3 gap-y-2 border-b border-line px-3 py-2"
+          data-testid="shared-agent-test-toolbar"
+        >
+          <div class="flex min-w-0 items-center gap-2">
+            <span class="shrink-0 text-[12px] text-txt2">
+              {{ t('pages.projectDetail.sharedAgent.pickAgent') }}
+            </span>
+            <ProjectAgentSelect
               v-model="testAgentName"
-              class="input min-w-0 flex-1 px-2 py-1.5 text-[12px]"
+              :agents="projectAgents"
               data-testid="shared-agent-test-pick"
-            >
-              <option value="" disabled>
-                {{ t('pages.projectDetail.sharedAgent.pickAgentPlaceholder') }}
-              </option>
-              <option v-for="a in agents" :key="a.name" :value="a.name">{{ a.name }}</option>
-            </select>
-          </label>
+            />
+          </div>
           <p class="w-full text-[11px] leading-5 text-txt3">
             {{ t('pages.projectDetail.sharedAgent.testHint') }}
           </p>
         </div>
-        <div v-if="!agents.length" class="flex flex-1 items-center justify-center text-[13px] text-txt3">
-          {{ t('pages.projectDetail.sharedAgent.noAgents') }}
+        <div
+          v-if="!projectAgents.length"
+          class="flex flex-1 flex-col items-center justify-center gap-2 px-4 text-center text-[13px] text-txt3"
+          data-testid="shared-agent-test-empty"
+        >
+          <Icon name="robot" :size="20" />
+          <p>{{ t('pages.projectDetail.sharedAgent.noProjectAgents') }}</p>
         </div>
         <AgentChatTester
           v-else-if="testAgentName"
@@ -533,10 +554,6 @@ onMounted(() => {
           :home-project-id="projectId"
           :create-test="createProjectContextTest"
         />
-        <div v-else class="flex flex-1 items-center justify-center gap-2 text-[13px] text-txt3">
-          <Icon name="robot" :size="16" />
-          {{ t('pages.projectDetail.sharedAgent.pickAgentPlaceholder') }}
-        </div>
       </div>
     </template>
   </div>

--- a/web/src/lib/agent/useAgentStudio.ts
+++ b/web/src/lib/agent/useAgentStudio.ts
@@ -26,8 +26,8 @@ import {
   type AgentStudioDraft as Draft,
 } from '@/lib/agent/agentStudioDraft'
 
-export type StudioTab = 'files' | 'mcp' | 'env' | 'prompts' | 'platform-rules' | 'test' | 'meta' | 'data'
-const STUDIO_TABS: StudioTab[] = ['files', 'mcp', 'env', 'prompts', 'platform-rules', 'test', 'meta', 'data']
+export type StudioTab = 'files' | 'mcp' | 'env' | 'prompts' | 'platform-rules' | 'meta' | 'data'
+const STUDIO_TABS: StudioTab[] = ['files', 'mcp', 'env', 'prompts', 'platform-rules', 'meta', 'data']
 
 function isStudioTab(q: unknown): q is StudioTab {
   return typeof q === 'string' && (STUDIO_TABS as readonly string[]).includes(q)
@@ -703,7 +703,6 @@ const studioTabs = computed(() => {
     { k: 'env' as const, l: t('pages.agentStudio.tabs.env', { n: d.env.filter((e) => !isManagedRegionKey(e.k)).length }) },
     { k: 'prompts' as const, l: pc ? t('pages.agentStudio.tabs.promptsCount', { n: pc }) : t('pages.agentStudio.tabs.prompts') },
     { k: 'platform-rules' as const, l: t('pages.agentStudio.tabs.platformRules') },
-    { k: 'test' as const, l: t('pages.agentStudio.tabs.test') },
     { k: 'data' as const, l: t('pages.agentStudio.tabs.data') },
     { k: 'meta' as const, l: t('pages.agentStudio.tabs.meta') },
   ]

--- a/web/src/lib/api/api.test.ts
+++ b/web/src/lib/api/api.test.ts
@@ -177,7 +177,6 @@ describe('api req helpers', () => {
       .mockResolvedValueOnce(jsonResponse({ status: 'ok' }))
       .mockResolvedValueOnce(new Response('zip', { status: 200 }))
       .mockResolvedValueOnce(jsonResponse(agent))
-      .mockResolvedValueOnce(jsonResponse({ id: 1, name: 's', profile: 'a1', purpose: 'test', status: 'running', createdAt: 't', updatedAt: 't', containerStatus: 'up', busy: false, connected: true, hasCodeServer: true, hasAcp: true }))
       .mockResolvedValueOnce(jsonResponse([]))
       .mockResolvedValueOnce(jsonResponse({ id: 1, name: 's', profile: 'a1', purpose: 'test', status: 'running', createdAt: 't', updatedAt: 't', containerStatus: 'up', busy: false, connected: true, hasCodeServer: true, hasAcp: true }))
       .mockResolvedValueOnce(jsonResponse({ status: 'ok' }))
@@ -234,7 +233,6 @@ describe('api req helpers', () => {
       api.importAgent(new File(['z'], 'a.zip'), { targetName: 'a1', mode: 'create' }),
     ).resolves.toEqual(agent)
 
-    await expect(api.createAgentTest('a1', { repoUrl: 'https://x' })).resolves.toMatchObject({ id: 1 })
     await expect(api.listSandboxes()).resolves.toEqual([])
     await expect(api.getSandbox(1)).resolves.toMatchObject({ id: 1 })
     await expect(api.stopSandbox(1)).resolves.toEqual({ status: 'ok' })

--- a/web/src/lib/api/clients/sandboxesClient.ts
+++ b/web/src/lib/api/clients/sandboxesClient.ts
@@ -1,13 +1,8 @@
 import { origin, req, wsUrl } from '../httpCore'
-import type { CreateAgentTestPayload, SandboxView } from '../apiTypes'
+import type { SandboxView } from '../apiTypes'
 
 export const sandboxesClient = {
   // sandboxes (interactive Agent chat-test containers)
-  createAgentTest: (profile: string, payload: CreateAgentTestPayload = {}) =>
-    req<SandboxView>(`/agents/${encodeURIComponent(profile)}/test`, {
-      method: 'POST',
-      body: JSON.stringify(payload),
-    }),
   listSandboxes: () => req<SandboxView[]>('/sandboxes'),
   getSandbox: (id: number) => req<SandboxView>(`/sandboxes/${id}`),
   stopSandbox: (id: number) => req<{ status: string }>(`/sandboxes/${id}/stop`, { method: 'POST' }),

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -117,6 +117,7 @@
     "search": {
       "placeholder": "Search workflows, runs…",
       "pipelinePlaceholder": "Search pipelines…",
+      "agentPlaceholder": "Search Agents…",
       "nodePlaceholder": "Search nodes"
     },
     "shutdown": {
@@ -166,11 +167,12 @@
       "noRuns": "No runs yet",
       "noMatchingRuns": "No matching runs",
       "noMatchingPipelines": "No matching pipelines",
+      "noMatchingAgents": "No matching Agents",
       "noArtifacts": "No artifacts",
       "noArtifactsInGroup": "No artifacts in this group",
       "selectWorkflowGroup": "Select a workflow group on the left",
       "noMatchingGroups": "No matching groups",
-      "noSandboxes": "No sandboxes yet. Node sandboxes are created when workflows run, or start a test sandbox under Agent Studio → Chat test.",
+      "noSandboxes": "No sandboxes yet. Node sandboxes are created when workflows run, or start a test sandbox under Project detail → Shared Agent config → Chat test.",
       "noAgents": "No agents yet. Click New agent, or the backend seeds a default on first start.",
       "noPendingGates": "Nothing pending",
       "noPendingGatesForPipeline": "No pending items for this pipeline",

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -768,15 +768,16 @@
       "varsEmptyTitle": "No workflow variables yet",
       "varsEmptyDesc": "Add a row to configure project-level defaults.",
       "sharedAgent": {
-        "extendHint": "Project Runs and project-context chat tests extend this shared config first, then the chosen Agent overlays same-named keys (Agent wins). Agent Studio’s own chat test does not use this merge.",
+        "extendHint": "Project Runs and project-context chat tests extend this shared config first, then the chosen Agent overlays same-named keys (Agent wins). Chat tests start only from this panel.",
         "discard": "Discard",
         "defaultProjectId": "Default project ID",
         "defaultProjectIdDesc": "Stored as defaultProjectId; may fill in when an Agent has no home project.",
         "testTab": "Chat test",
         "pickAgent": "Pick Agent",
         "pickAgentPlaceholder": "Select an Agent to overlay",
-        "testHint": "Starts a chat test with this project’s shared baseline, then overlays the selected Agent.",
-        "noAgents": "No Agents yet — create one in Agent Studio first."
+        "testHint": "Only Agents bound to this project are listed. Starts with the shared baseline, then overlays the selected Agent.",
+        "noAgents": "No Agents yet — create one in Agent Studio first.",
+        "noProjectAgents": "No Agents are bound to this project yet. Open Agent management and bind this project in the Agent’s meta tab, then try again."
       },
       "varName": "Name",
       "varValue": "Default",
@@ -1453,7 +1454,7 @@
     "sandboxes": {
       "title": "Sandboxes",
       "errorPrefix": "Error:",
-      "empty": "No sandboxes. Created on workflow runs or from Agent Studio → Chat test.",
+      "empty": "No sandboxes. Created on workflow runs or from Project detail → Shared Agent config → Chat test.",
       "copyId": "Copy ID",
       "copied": "Copied",
       "destroy": "Destroy",
@@ -2317,7 +2318,7 @@
       "data": {
         "title": "Agent data",
         "hint": "Data belongs to home project \"{project}\". Manage memories, threads, and jobs here.",
-        "unsavedBinding": "Home project binding is unsaved; data panel and chat test still use the saved binding.",
+        "unsavedBinding": "Home project binding is unsaved; the data panel still uses the saved binding.",
         "emptyTitle": "No home project",
         "emptyDesc": "Please bind a home project under Metadata on desktop before managing memories, threads, or jobs.",
         "goBind": "Bind home project",
@@ -3235,6 +3236,7 @@
       "destroy": "End & destroy",
       "acpSession": "ACP session",
       "idleHint": "Start a sandbox bound to “{profile}” (workspace / MCP / env) for multi-turn chat testing.",
+      "missingCreateTest": "Chat test launcher not configured. Open Project shared Agent config.",
       "mode": {
         "sectionLabel": "Workspace mode",
         "empty": {

--- a/web/src/locales/zh-CN/common.json
+++ b/web/src/locales/zh-CN/common.json
@@ -117,6 +117,7 @@
     "search": {
       "placeholder": "搜索工作流、运行…",
       "pipelinePlaceholder": "搜索流水线…",
+      "agentPlaceholder": "搜索 Agent…",
       "nodePlaceholder": "搜索节点"
     },
     "shutdown": {
@@ -166,11 +167,12 @@
       "noRuns": "暂无运行记录",
       "noMatchingRuns": "无匹配运行记录",
       "noMatchingPipelines": "无匹配流水线",
+      "noMatchingAgents": "无匹配 Agent",
       "noArtifacts": "暂无产物",
       "noArtifactsInGroup": "该分组暂无产物",
       "selectWorkflowGroup": "请在左侧选择工作流分组",
       "noMatchingGroups": "无匹配分组",
-      "noSandboxes": "暂无沙箱。运行工作流时会按需创建节点沙箱,或前往 \"Agent 管理 → 对话测试\" 启动一个测试沙箱。",
+      "noSandboxes": "暂无沙箱。运行工作流时会按需创建节点沙箱，或前往项目详情「共享 Agent 配置 → 对话测试」启动测试沙箱。",
       "noAgents": "暂无 Agent。点击右上角\"新建 Agent\"创建,或后端首启会落盘默认 Agent。",
       "noPendingGates": "没有待审批项",
       "noPendingGatesForPipeline": "该流水线没有待审批项",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -768,15 +768,16 @@
       "varsEmptyTitle": "暂无工作流变量",
       "varsEmptyDesc": "添加一行后，即可配置项目级默认值。",
       "sharedAgent": {
-        "extendHint": "本项目 Run / 项目上下文对话测试会先 extend 此共享配置，再由所选 Agent 同名覆盖（Agent 优先级更高）。Agent Studio 原对话测试不走此合并。",
+        "extendHint": "本项目 Run 与「共享 Agent 配置 → 对话测试」会先 extend 此共享配置，再由所选 Agent 同名覆盖（Agent 优先）。对话测试仅在此入口发起。",
         "discard": "放弃修改",
         "defaultProjectId": "默认项目 ID",
         "defaultProjectIdDesc": "写入共享配置的 defaultProjectId；Agent 未绑定项目时可作补全。",
         "testTab": "对话测试",
         "pickAgent": "选择 Agent",
         "pickAgentPlaceholder": "请选择要叠加测试的 Agent",
-        "testHint": "将以当前项目共享配置为基底，再 overlay 所选 Agent 启动对话测试。",
-        "noAgents": "暂无可用 Agent，请先到 Agent Studio 创建。"
+        "testHint": "仅列出绑定本项目的 Agent。将以共享配置为基底，再 overlay 所选 Agent 启动对话测试。",
+        "noAgents": "暂无可用 Agent，请先到 Agent Studio 创建。",
+        "noProjectAgents": "本项目尚无绑定 Agent。请前往 Agent 管理，在 Agent 元信息中绑定本项目后再试。"
       },
       "varName": "变量名",
       "varValue": "默认值",
@@ -1453,7 +1454,7 @@
     "sandboxes": {
       "title": "沙箱",
       "errorPrefix": "出错:",
-      "empty": "暂无沙箱。运行工作流时会按需创建节点沙箱,或前往 \"Agent 管理 → 对话测试\" 启动一个测试沙箱。",
+      "empty": "暂无沙箱。运行工作流时会按需创建节点沙箱，或前往项目详情「共享 Agent 配置 → 对话测试」启动测试沙箱。",
       "copyId": "复制 ID",
       "copied": "已复制",
       "destroy": "销毁",
@@ -2317,7 +2318,7 @@
       "data": {
         "title": "Agent 数据",
         "hint": "数据归属主项目「{project}」。在此管理记忆、上下文与定时任务。",
-        "unsavedBinding": "主项目绑定尚未保存；数据面板与对话测试仍使用已保存的绑定。",
+        "unsavedBinding": "主项目绑定尚未保存；数据面板仍使用已保存的绑定。",
         "emptyTitle": "尚未绑定主项目",
         "emptyDesc": "请在桌面端「元信息」绑定主项目后，再管理记忆 / 上下文 / 定时任务。",
         "goBind": "去绑定主项目",
@@ -3235,6 +3236,7 @@
       "destroy": "结束并销毁",
       "acpSession": "ACP 会话",
       "idleHint": "启动一个绑定 “{profile}” 配置(工作目录 / MCP / 环境变量)的沙箱,与该 Agent 进行多轮对话测试。",
+      "missingCreateTest": "未配置对话测试启动方式。请从项目共享 Agent 配置进入。",
       "mode": {
         "sectionLabel": "工作区模式",
         "empty": {

--- a/web/src/views/AgentStudioView.test.ts
+++ b/web/src/views/AgentStudioView.test.ts
@@ -2091,7 +2091,6 @@ describe('AgentStudioView entry assembly (g3 / Demo main path)', () => {
       'AgentPromptsPanel',
       'AgentPlatformRulesPanel',
       'AgentDataPanel',
-      'AgentChatTester',
       'AgentMetaPanel',
     ]) {
       expect(viewSrc).toContain(panel)
@@ -2104,7 +2103,7 @@ describe('AgentStudioView entry assembly (g3 / Demo main path)', () => {
     expect(src).toMatch(/v-if="tab === 'env'/)
     expect(src).toMatch(/v-if="tab === 'prompts'/)
     expect(src).toMatch(/tab === 'platform-rules'/)
-    expect(src).toMatch(/v-show="tab === 'test'/)
+    expect(src).not.toMatch(/tab === 'test'/)
     expect(src).toMatch(/tab === 'meta'/)
   })
 
@@ -2112,6 +2111,7 @@ describe('AgentStudioView entry assembly (g3 / Demo main path)', () => {
     mocks.listAgents.mockResolvedValue([agent()])
     const wrapper = await mountStudio({ agent: 'legacy' })
     await flushPromises()
+    expect(wrapper.text()).not.toContain('对话测试')
     const mcpBtn = wrapper.findAll('button').find((b) => /MCP/i.test(b.text()))
     expect(mcpBtn).toBeTruthy()
     await mcpBtn!.trigger('click')

--- a/web/src/views/AgentStudioView.vue
+++ b/web/src/views/AgentStudioView.vue
@@ -3,7 +3,6 @@ import Icon from '@/components/ui/Icon.vue'
 import AppButton from '@/components/ui/AppButton.vue'
 import AppModal from '@/components/ui/AppModal.vue'
 import AgentOrgSidebar from '@/components/agent/AgentOrgSidebar.vue'
-import AgentChatTester from '@/components/agent/AgentChatTester.vue'
 import AgentDataPanel, { type DataSubTab } from '@/components/agent/AgentDataPanel.vue'
 import AgentFilesPanel from '@/components/agent/AgentFilesPanel.vue'
 import AgentMcpPanel from '@/components/agent/AgentMcpPanel.vue'
@@ -596,11 +595,6 @@ const {
               </button>
             </div>
           </div>
-        </div>
-
-        <!-- chat test (kept mounted via v-show so the session survives tab switches) -->
-        <div v-show="tab === 'test' && !isMobile" class="flex min-h-0 flex-1 flex-col">
-          <AgentChatTester :profile="activeName" :home-project-id="savedProjectId" />
         </div>
 
         <AgentMetaPanel


### PR DESCRIPTION
Remove Agent Studio chat test tab and POST /agents/:name/test so dialogue
testing only runs via project shared config (extend→overlay). Filter project
candidates by projectId and replace the full-width select with a combobox.

Co-authored-by: Cursor <cursoragent@cursor.com>
