### PR TITLE
feat: remove parentAgent reporting line; PM manages by projectId

### DIFF
--- a/agents/PMAgent/workspace/rules/role.md
+++ b/agents/PMAgent/workspace/rules/role.md
@@ -27,13 +27,15 @@ alwaysApply: true
 
 | 工具 | 用途 |
 |------|------|
-| `pm_get_org` | 只读组织架构与汇报关系 |
+| `pm_get_org` | 只读虚拟组与同项目成员扁平视图 |
 | `pm_list_agent_templates` | 列出内置工程师模板 |
 | `pm_create_agent_from_template` | 按模板创建工程师（同项目；默认继承 mcp/env；禁止覆盖重名） |
-| `pm_set_org_membership` | 设置 `groupIds` + `parentAgent`（上级须为你） |
+| `pm_set_org_membership` | 设置虚拟组 `groupIds` |
 | `pm_ensure_child_group` | 幂等确保 Pipeline 等子组存在 |
 
-命名约定：`{前缀}{角色}工程师`，例如 `Demo实现工程师`。工程师应挂在 Pipeline 子组，且 `parentAgent` 指向你。
+命名约定：`{前缀}{角色}工程师`，例如 `Demo实现工程师`。工程师应挂在 Pipeline 子组。
+
+PM 默认可管理**同一项目**下全部 Agent（鉴权看 `projectId` 一致）；无需配置上下级。
 
 若建团流程已由平台预置齐 10 人，则不必重复创建；用 `pm_get_org` 确认后直接进入编排。
 

--- a/agents/PMAgent/workspace/skills/pm-orchestrate/SKILL.md
+++ b/agents/PMAgent/workspace/skills/pm-orchestrate/SKILL.md
@@ -10,7 +10,7 @@ description: PM Leader 编排检查清单：组织确认、任务分派、门禁
 ## 组织
 
 1. 已读 `rules/project-context.md`，理解目标、技术栈与仓库诉求
-2. `pm_get_org` 显示：根组存在；Pipeline 子组存在；9 名工程师均在 Pipeline 下且 `parentAgent` 为你
+2. `pm_get_org` 显示：根组存在；Pipeline 子组存在；9 名工程师均在 Pipeline 下（`directReports` 列出同项目成员）
 3. 若缺人：用模板创建 → `pm_set_org_membership` 挂组；已存在同名则跳过并报告，不覆盖
 4. 项目 PM Leader 绑定指向你；`pm-agent-fs` 等 MCP 可用
 

--- a/docs/content/en/guide/concepts.md
+++ b/docs/content/en/guide/concepts.md
@@ -53,8 +53,8 @@ Isolation is by run token, leaving an inspectable paper trail.
 
 A project-bound PM Leader can enable the dedicated MCP `pm-agent-fs` (on by default for new projects; older projects with an explicit EnabledMcps list must opt in under PM settings):
 
-- `pm_get_org`: read the org and label self / direct / indirect / other relative to the Leader
-- `pm_fs_*`: list/read/write/delete/mkdir/rename the **host-side** `workspace/` of self and reporting-closure reports (**not** Run sandbox FS)
+- `pm_get_org`: read virtual groups and flat same-project members (self / direct / other relative to the PM)
+- `pm_fs_*`: list/read/write/delete/mkdir/rename the **host-side** `workspace/` of any same-project agent (**not** Run sandbox FS)
 
 Writes land on the same disk tree as Agent Studio「Agent workspace」and are visible after **refresh or reopen** (no live hot-reload). If Studio still has an unsaved dirty draft for the same Agent, a later Save may overwrite MCP writes — refresh and avoid concurrent dirty edits during demos.
 

--- a/docs/content/help/pm-agent-fs-demo.md
+++ b/docs/content/help/pm-agent-fs-demo.md
@@ -3,11 +3,11 @@
 对齐已批准 `page.html` 主路径，可复现步骤：
 
 1. 确认项目 PM 设置已启用 `pm-agent-fs`（新项目默认启用）。
-2. 在组织架构中准备：Leader → 直接下属 → 间接下属（`parentAgent` 链）。
-3. Leader 会话调用 `pm_get_org`，确认间接下属 relation=`indirect`，并出现在 `subtree` / `indirectReports`。
-4. 调用 `pm_fs_write`：`agentName=<间接下属>`，`path=AGENTS.md`（或 `rules/...`），写入可识别内容。
-5. 打开 Agent Studio → 选中该下属 → **刷新或重新打开**「Agent 工作目录」，对照内容一致。
-6. 对非下属 Agent 再试 `pm_fs_write`，应被拒绝。
+2. 在组织架构中准备：同项目多个 Agent（绑定相同 `projectId`），可挂虚拟组。
+3. Leader 会话调用 `pm_get_org`，确认同项目成员 relation=`direct`，并出现在 `directReports` / 扁平 `subtree`。
+4. 调用 `pm_fs_write`：`agentName=<同项目另一 Agent>`，`path=AGENTS.md`（或 `rules/...`），写入可识别内容。
+5. 打开 Agent Studio → 选中该 Agent → **刷新或重新打开**「Agent 工作目录」，对照内容一致。
+6. 对跨项目 Agent 再试 `pm_fs_write`，应被拒绝。
 7. 全程不打开/不使用任何 Run sandbox FS/Exec。
 
 证据痕迹：单测 `TestPmGetOrgRelations` / `TestPmFSDirectIndirectSelfWrite` / `TestPmFSRejectNonReportAndCrossProject` / `TestPmFSPathEscapeRejected`（`server/internal/pmmcp/agent_fs_test.go`）。

--- a/server/internal/pmmcp/agent_fs.go
+++ b/server/internal/pmmcp/agent_fs.go
@@ -27,11 +27,8 @@ func (h *Host) callAgentFS(projectID, token, name string, args map[string]any) (
 		if err != nil {
 			return map[string]any{"error": "failed to load org: " + err.Error()}, true
 		}
-		allNames := make([]string, 0)
-		for _, a := range skill.List() {
-			allNames = append(allNames, a.Name)
-		}
-		view := services.BuildOrgLeaderView(doc, sess.AgentName, allNames)
+		allAgents := skill.List()
+		view := services.BuildOrgLeaderView(doc, sess.AgentName, allAgents)
 		return view, false
 
 	case "pm_list_agent_templates", "pm_create_agent_from_template", "pm_set_org_membership", "pm_ensure_child_group":
@@ -98,10 +95,9 @@ func (h *Host) callAgentFS(projectID, token, name string, args map[string]any) (
 	return map[string]any{"error": "unknown tool: " + name}, true
 }
 
-// authorizeAgentFSTarget enforces reporting closure (incl. self) + same home project.
-func (h *Host) authorizeAgentFSTarget(sess *Session, skill *services.SkillService, org *services.OrgService, target string) (errMsg string, deny bool) {
-	leader := strings.TrimSpace(sess.AgentName)
-	if leader == "" {
+// authorizeAgentFSTarget allows PM to manage any agent bound to the same project (incl. self).
+func (h *Host) authorizeAgentFSTarget(sess *Session, skill *services.SkillService, _ *services.OrgService, target string) (errMsg string, deny bool) {
+	if strings.TrimSpace(sess.AgentName) == "" {
 		return "leader agent missing from session", true
 	}
 	ag, ok := skill.Get(target)
@@ -110,13 +106,6 @@ func (h *Host) authorizeAgentFSTarget(sess *Session, skill *services.SkillServic
 	}
 	if !services.AgentProjectMatches(ag, sess.ProjectID) {
 		return "agent not in project / not home-project bound: " + target, true
-	}
-	doc, err := org.Get()
-	if err != nil {
-		return "failed to load org: " + err.Error(), true
-	}
-	if !services.IsInReportingClosure(doc, leader, target) {
-		return "agent is not self or a direct/indirect report of the leader: " + target, true
 	}
 	return "", false
 }

--- a/server/internal/pmmcp/agent_fs_test.go
+++ b/server/internal/pmmcp/agent_fs_test.go
@@ -44,8 +44,8 @@ func setupAgentFSHost(t *testing.T) (projectID, token string, h *Host, skill *se
 	if _, err := org.Put(services.AgentOrg{
 		Agents: map[string]services.OrgAgentMembership{
 			"leader":   {},
-			"alice":    {ParentAgent: "leader"},
-			"bob":      {ParentAgent: "alice"}, // indirect
+			"alice":    {},
+			"bob":      {},
 			"outsider": {},
 		},
 	}, 0); err != nil {
@@ -111,7 +111,7 @@ func TestPmGetOrgRelations(t *testing.T) {
 		m, _ := a.(map[string]any)
 		rel[m["name"].(string)] = m["relation"].(string)
 	}
-	if rel["leader"] != "self" || rel["alice"] != "direct" || rel["bob"] != "indirect" || rel["outsider"] != "other" {
+	if rel["leader"] != "self" || rel["alice"] != "direct" || rel["bob"] != "direct" || rel["outsider"] != "direct" {
 		t.Fatalf("relations=%v", rel)
 	}
 }
@@ -152,11 +152,8 @@ func TestPmFSRejectNonReportAndCrossProject(t *testing.T) {
 		"path":      "AGENTS.md",
 		"content":   "nope",
 	})
-	if !isErr {
-		t.Fatalf("outsider should be rejected: %v", result)
-	}
-	if !strings.Contains(result["error"].(string), "not self or a direct/indirect") {
-		t.Fatalf("error=%v", result["error"])
+	if isErr {
+		t.Fatalf("same-project outsider should be allowed: %v", result)
 	}
 	_, result, isErr, _ = callAgentFSTool(t, h, pid, tok, "pm_fs_read", map[string]any{
 		"agentName": "otherproj",

--- a/server/internal/pmmcp/host.go
+++ b/server/internal/pmmcp/host.go
@@ -865,23 +865,22 @@ func toolSchemas(mcpID string) []map[string]any {
 		}
 	case MCPAgentFS:
 		return []map[string]any{
-			platformmcp.Tool("pm_get_org", "读取组织架构：全量 groups/agents（含相对当前 Leader 的 self/direct/indirect/other 标注）以及以 Leader 为根的下属树与直接/间接列表。只读，不可改 parent/groups。", nil),
+			platformmcp.Tool("pm_get_org", "读取组织架构：全量 groups/agents（含相对当前 PM 的 self/direct/other 项目成员标注）以及同项目成员扁平列表（directReports/subtree）。只读，不可改 groups。", nil),
 			platformmcp.Tool("pm_list_agent_templates", "列出内置工程师角色模板（id、中文角色名、简介），用于组建团队。", nil),
 			platformmcp.Tool("pm_create_agent_from_template", "从模板创建工程师 Agent（同项目；默认继承 Leader 的 mcp/env；禁止覆盖重名）。", map[string]any{
 				"templateId": map[string]any{"type": "string", "description": "模板 id，如 implement / clarify"},
 				"name":       map[string]any{"type": "string", "description": "新 Agent 名称，如 Approving实现工程师"},
 			}),
-			platformmcp.Tool("pm_set_org_membership", "设置 Agent 的组成员与汇报上级（parentAgent 须为当前 PM；groupIds 须在授权范围内）。", map[string]any{
-				"agentName":   map[string]any{"type": "string"},
-				"groupIds":    map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
-				"parentAgent": map[string]any{"type": "string", "description": "汇报上级，默认当前 PM"},
+			platformmcp.Tool("pm_set_org_membership", "设置 Agent 的虚拟组成员（groupIds 须在授权范围内）。", map[string]any{
+				"agentName": map[string]any{"type": "string"},
+				"groupIds":  map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
 			}),
 			platformmcp.Tool("pm_ensure_child_group", "在授权根组下幂等确保子组存在（如 Pipeline(GitHub)）。", map[string]any{
 				"name":          map[string]any{"type": "string"},
 				"parentGroupId": map[string]any{"type": "string", "description": "父组 id；省略则用建团结会话根组"},
 			}),
 			platformmcp.Tool("pm_fs_list", "列出授权 Agent 的 host 侧 workspace 目录（非 Run 沙箱）。", map[string]any{
-				"agentName": map[string]any{"type": "string", "description": "目标 Agent 名（自身或汇报闭包内下属）"},
+				"agentName": map[string]any{"type": "string", "description": "目标 Agent 名（同项目任意成员或自身）"},
 				"path":      map[string]any{"type": "string", "description": "workspace 相对目录，空或省略表示根"},
 			}),
 			platformmcp.Tool("pm_fs_read", "读取授权 Agent workspace 内文件（单文件硬上限 1MiB）。", map[string]any{

--- a/server/internal/pmmcp/team_tools.go
+++ b/server/internal/pmmcp/team_tools.go
@@ -51,13 +51,6 @@ func (h *Host) callTeamTools(sess *Session, skill *services.SkillService, name s
 
 	case "pm_set_org_membership":
 		agentName := strings.TrimSpace(platformmcp.StrArg(args, "agentName"))
-		parent := strings.TrimSpace(platformmcp.StrArg(args, "parentAgent"))
-		if parent == "" {
-			parent = sess.AgentName
-		}
-		if parent != sess.AgentName {
-			return map[string]any{"error": "parentAgent must be the current PM leader"}, true
-		}
 		groupIDs := strSliceArg(args, "groupIds")
 		if agentName == "" || len(groupIDs) == 0 {
 			return map[string]any{"error": "agentName and groupIds are required"}, true
@@ -69,15 +62,13 @@ func (h *Host) callTeamTools(sess *Session, skill *services.SkillService, name s
 		if !services.AgentProjectMatches(ag, sess.ProjectID) {
 			return map[string]any{"error": "agent not in session project"}, true
 		}
-		// Scope: target must be self or (after create) will become a report; require same project only here.
 		if err := team.SetOrgMembership(services.SetOrgMembershipArgs{
-			AgentName:   agentName,
-			GroupIDs:    groupIDs,
-			ParentAgent: parent,
+			AgentName: agentName,
+			GroupIDs:  groupIDs,
 		}); err != nil {
 			return map[string]any{"error": err.Error()}, true
 		}
-		return map[string]any{"ok": true, "agentName": agentName, "groupIds": groupIDs, "parentAgent": parent}, false
+		return map[string]any{"ok": true, "agentName": agentName, "groupIds": groupIDs}, false
 
 	case "pm_ensure_child_group":
 		gName := strings.TrimSpace(platformmcp.StrArg(args, "name"))

--- a/server/internal/services/org.go
+++ b/server/internal/services/org.go
@@ -29,11 +29,9 @@ type OrgGroup struct {
 	ParentGroupID string `json:"parentGroupId,omitempty"`
 }
 
-// OrgAgentMembership holds an Agent's group memberships and optional reporting parent.
-// ParentAgent is the other Agent's name (skill_profile identity), not a group id.
+// OrgAgentMembership holds an Agent's virtual-group memberships.
 type OrgAgentMembership struct {
-	GroupIDs    []string `json:"groupIds,omitempty"`
-	ParentAgent string   `json:"parentAgent,omitempty"`
+	GroupIDs []string `json:"groupIds,omitempty"`
 }
 
 // AgentOrg is the central organization index stored at <profilesRoot>/_org.json.
@@ -60,17 +58,20 @@ func (o *OrgService) path() string {
 	return filepath.Join(o.root, orgFileName)
 }
 
-// Get returns the organization document, pruning memberships for deleted agents
-// and normalizing dangling parentAgent references. Repairs are written back so
-// subsequent Put validation does not fail on stale parents.
+// Get returns the organization document, pruning memberships for deleted agents.
+// Legacy parentAgent keys in _org.json are stripped on load (idempotent write-back).
 func (o *OrgService) Get() (AgentOrg, error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	org, err := o.loadLocked()
+	org, legacy, err := o.loadLocked()
 	if err != nil {
 		return AgentOrg{}, err
 	}
+	changed := legacy
 	if o.pruneAgentsLocked(&org) {
+		changed = true
+	}
+	if changed {
 		org.Revision++
 		if err := o.saveLocked(org); err != nil {
 			return AgentOrg{}, err
@@ -86,7 +87,7 @@ func (o *OrgService) Put(incoming AgentOrg, expectedRevision int) (AgentOrg, err
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
-	cur, err := o.loadLocked()
+	cur, _, err := o.loadLocked()
 	if err != nil {
 		return AgentOrg{}, err
 	}
@@ -105,7 +106,7 @@ func (o *OrgService) Put(incoming AgentOrg, expectedRevision int) (AgentOrg, err
 	return normalized, nil
 }
 
-// OnRenameAgent cascades membership map keys and parentAgent references.
+// OnRenameAgent cascades membership map keys when an agent is renamed.
 func (o *OrgService) OnRenameAgent(oldName, newName string) error {
 	oldName = strings.TrimSpace(oldName)
 	newName = strings.TrimSpace(newName)
@@ -115,32 +116,21 @@ func (o *OrgService) OnRenameAgent(oldName, newName string) error {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
-	org, err := o.loadLocked()
+	org, _, err := o.loadLocked()
 	if err != nil {
 		return err
 	}
-	changed := false
-	if m, ok := org.Agents[oldName]; ok {
-		delete(org.Agents, oldName)
-		org.Agents[newName] = m
-		changed = true
-	}
-	for name, m := range org.Agents {
-		if m.ParentAgent == oldName {
-			m.ParentAgent = newName
-			org.Agents[name] = m
-			changed = true
-		}
-	}
-	if !changed {
+	m, ok := org.Agents[oldName]
+	if !ok {
 		return nil
 	}
+	delete(org.Agents, oldName)
+	org.Agents[newName] = m
 	org.Revision++
 	return o.saveLocked(org)
 }
 
-// OnDeleteAgent reparents direct reports to the deleted agent's parent (or clears),
-// then removes the deleted agent's organization membership.
+// OnDeleteAgent removes the deleted agent's organization membership.
 func (o *OrgService) OnDeleteAgent(name string) error {
 	name = strings.TrimSpace(name)
 	if name == "" {
@@ -149,32 +139,14 @@ func (o *OrgService) OnDeleteAgent(name string) error {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
-	org, err := o.loadLocked()
+	org, _, err := o.loadLocked()
 	if err != nil {
 		return err
 	}
-	deletedParent := ""
-	if m, ok := org.Agents[name]; ok {
-		deletedParent = m.ParentAgent
-	}
-	changed := false
-	for n, m := range org.Agents {
-		if n == name {
-			continue
-		}
-		if m.ParentAgent == name {
-			m.ParentAgent = deletedParent
-			org.Agents[n] = m
-			changed = true
-		}
-	}
-	if _, ok := org.Agents[name]; ok {
-		delete(org.Agents, name)
-		changed = true
-	}
-	if !changed {
+	if _, ok := org.Agents[name]; !ok {
 		return nil
 	}
+	delete(org.Agents, name)
 	org.Revision++
 	return o.saveLocked(org)
 }
@@ -184,21 +156,22 @@ func NewGroupID() string {
 	return "g_" + strings.ReplaceAll(uuid.NewString(), "-", "")
 }
 
-func (o *OrgService) loadLocked() (AgentOrg, error) {
+func (o *OrgService) loadLocked() (AgentOrg, bool, error) {
 	p := o.path()
 	b, err := os.ReadFile(p)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return emptyOrg(), nil
+			return emptyOrg(), false, nil
 		}
-		return AgentOrg{}, err
+		return AgentOrg{}, false, err
 	}
 	if len(strings.TrimSpace(string(b))) == 0 {
-		return emptyOrg(), nil
+		return emptyOrg(), false, nil
 	}
+	hadLegacyParent := strings.Contains(string(b), "parentAgent")
 	var org AgentOrg
 	if err := json.Unmarshal(b, &org); err != nil {
-		return AgentOrg{}, fmt.Errorf("parse %s: %w", orgFileName, err)
+		return AgentOrg{}, false, fmt.Errorf("parse %s: %w", orgFileName, err)
 	}
 	if org.Agents == nil {
 		org.Agents = map[string]OrgAgentMembership{}
@@ -206,7 +179,7 @@ func (o *OrgService) loadLocked() (AgentOrg, error) {
 	if org.Groups == nil {
 		org.Groups = []OrgGroup{}
 	}
-	return org, nil
+	return org, hadLegacyParent, nil
 }
 
 func emptyOrg() AgentOrg {
@@ -243,8 +216,7 @@ func (o *OrgService) saveLocked(org AgentOrg) error {
 	return nil
 }
 
-// pruneAgentsLocked removes memberships for agents missing on disk and
-// reparents/clears dangling parentAgent refs (same rules as OnDeleteAgent).
+// pruneAgentsLocked removes memberships for agents missing on disk.
 // Returns true when org was mutated.
 func (o *OrgService) pruneAgentsLocked(org *AgentOrg) bool {
 	if org.Agents == nil {
@@ -255,42 +227,11 @@ func (o *OrgService) pruneAgentsLocked(org *AgentOrg) bool {
 		return false
 	}
 	changed := false
-	for {
-		var missing string
-		var deletedParent string
-		for name, m := range org.Agents {
-			if !o.skill.Exists(name) {
-				missing = name
-				deletedParent = m.ParentAgent
-				break
-			}
-		}
-		if missing == "" {
-			break
-		}
-		for n, m := range org.Agents {
-			if n == missing {
-				continue
-			}
-			if m.ParentAgent == missing {
-				m.ParentAgent = deletedParent
-				org.Agents[n] = m
-			}
-		}
-		delete(org.Agents, missing)
-		changed = true
-	}
-	for name, m := range org.Agents {
-		if m.ParentAgent == "" || o.skill.Exists(m.ParentAgent) {
-			continue
-		}
-		m.ParentAgent = ""
-		if len(m.GroupIDs) == 0 {
+	for name := range org.Agents {
+		if !o.skill.Exists(name) {
 			delete(org.Agents, name)
-		} else {
-			org.Agents[name] = m
+			changed = true
 		}
-		changed = true
 	}
 	return changed
 }
@@ -334,7 +275,6 @@ func (o *OrgService) validateAndNormalize(incoming AgentOrg) (AgentOrg, error) {
 		return AgentOrg{}, err
 	}
 
-	// Stable group order: roots first by name, then DFS.
 	sort.SliceStable(out.Groups, func(i, j int) bool {
 		return out.Groups[i].ID < out.Groups[j].ID
 	})
@@ -353,17 +293,7 @@ func (o *OrgService) validateAndNormalize(incoming AgentOrg) (AgentOrg, error) {
 		}
 		if o.skill != nil {
 			if _, ok := existingAgents[name]; !ok {
-				// Ignore memberships for agents that no longer exist (import/cleanup).
 				continue
-			}
-		}
-		parent := strings.TrimSpace(m.ParentAgent)
-		if parent == name {
-			return AgentOrg{}, fmt.Errorf("%w: agent %q cannot be its own parent", ErrOrgValidation, name)
-		}
-		if parent != "" && o.skill != nil {
-			if _, ok := existingAgents[parent]; !ok {
-				return AgentOrg{}, fmt.Errorf("%w: parent agent %q does not exist", ErrOrgValidation, parent)
 			}
 		}
 		gids := uniqueNonEmpty(m.GroupIDs)
@@ -372,17 +302,13 @@ func (o *OrgService) validateAndNormalize(incoming AgentOrg) (AgentOrg, error) {
 				return AgentOrg{}, fmt.Errorf("%w: agent %q references unknown group %q", ErrOrgValidation, name, gid)
 			}
 		}
-		nm := OrgAgentMembership{GroupIDs: gids, ParentAgent: parent}
-		if len(nm.GroupIDs) == 0 && nm.ParentAgent == "" {
-			// No org data — omit to keep file compact (ungrouped + no parent).
+		nm := OrgAgentMembership{GroupIDs: gids}
+		if len(nm.GroupIDs) == 0 {
 			continue
 		}
 		out.Agents[name] = nm
 	}
 
-	if err := detectReportingCycles(out.Agents); err != nil {
-		return AgentOrg{}, err
-	}
 	return out, nil
 }
 
@@ -431,38 +357,6 @@ func detectGroupCycles(byID map[string]OrgGroup) error {
 	}
 	for id := range byID {
 		if err := visit(id); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func detectReportingCycles(agents map[string]OrgAgentMembership) error {
-	const (
-		white = 0
-		gray  = 1
-		black = 2
-	)
-	color := map[string]int{}
-	var visit func(name string) error
-	visit = func(name string) error {
-		switch color[name] {
-		case gray:
-			return fmt.Errorf("%w: reporting cycle involving %q", ErrOrgValidation, name)
-		case black:
-			return nil
-		}
-		color[name] = gray
-		if m, ok := agents[name]; ok && m.ParentAgent != "" {
-			if err := visit(m.ParentAgent); err != nil {
-				return err
-			}
-		}
-		color[name] = black
-		return nil
-	}
-	for name := range agents {
-		if err := visit(name); err != nil {
 			return err
 		}
 	}

--- a/server/internal/services/org_apply_test.go
+++ b/server/internal/services/org_apply_test.go
@@ -47,7 +47,7 @@ func applyDeleteGroup(org AgentOrg, groupID string) (AgentOrg, error) {
 			gids = append(gids, parentID)
 		}
 		m.GroupIDs = uniqueNonEmpty(gids)
-		if len(m.GroupIDs) == 0 && m.ParentAgent == "" {
+		if len(m.GroupIDs) == 0 {
 			continue
 		}
 		agents[name] = m
@@ -86,7 +86,7 @@ func applyMoveAgent(org AgentOrg, agentName, sourceGroupID, targetGroupID string
 		gids = append(gids, target)
 		m.GroupIDs = uniqueNonEmpty(gids)
 	}
-	if len(m.GroupIDs) == 0 && m.ParentAgent == "" {
+	if len(m.GroupIDs) == 0 {
 		delete(org.Agents, agentName)
 	} else {
 		org.Agents[agentName] = m

--- a/server/internal/services/org_closure.go
+++ b/server/internal/services/org_closure.go
@@ -5,7 +5,8 @@ import (
 	"strings"
 )
 
-// OrgRelation labels an agent relative to a Leader in the reporting tree.
+// OrgRelation labels an agent relative to the PM leader in the flat project-member view.
+// direct = same project member (not self); indirect is unused (always empty list).
 const (
 	OrgRelationSelf     = "self"
 	OrgRelationDirect   = "direct"
@@ -15,53 +16,57 @@ const (
 
 // OrgAgentAnnotated is an agent membership plus relation to the Leader.
 type OrgAgentAnnotated struct {
-	Name        string   `json:"name"`
-	GroupIDs    []string `json:"groupIds,omitempty"`
-	ParentAgent string   `json:"parentAgent,omitempty"`
-	Relation    string   `json:"relation"` // self|direct|indirect|other
+	Name     string   `json:"name"`
+	GroupIDs []string `json:"groupIds,omitempty"`
+	Relation string   `json:"relation"` // self|direct|other
 }
 
-// OrgSubtreeNode is one node in the Leader-rooted reporting subtree.
+// OrgSubtreeNode is one flat project-member node (no nested reporting children).
 type OrgSubtreeNode struct {
 	Name     string           `json:"name"`
-	Relation string           `json:"relation"` // direct|indirect (root omitted; children only)
+	Relation string           `json:"relation"` // direct for project peers
 	Children []OrgSubtreeNode `json:"children,omitempty"`
 }
 
 // OrgLeaderView is the read-only org snapshot for pm_get_org.
+// Field names are kept for response compatibility; semantics are flat project members.
 type OrgLeaderView struct {
-	Revision       int                 `json:"revision"`
-	Groups         []OrgGroup          `json:"groups"`
-	Agents         []OrgAgentAnnotated `json:"agents"`
-	Leader         string              `json:"leader"`
-	DirectReports  []string            `json:"directReports"`
-	IndirectReports []string           `json:"indirectReports"`
-	Subtree        []OrgSubtreeNode    `json:"subtree"`
+	Revision        int                 `json:"revision"`
+	Groups          []OrgGroup          `json:"groups"`
+	Agents          []OrgAgentAnnotated `json:"agents"`
+	Leader          string              `json:"leader"`
+	DirectReports   []string            `json:"directReports"`
+	IndirectReports []string            `json:"indirectReports"`
+	Subtree         []OrgSubtreeNode    `json:"subtree"`
 }
 
-// BuildOrgLeaderView annotates agents relative to leader and builds the
-// reporting subtree. allAgentNames should be the full on-disk agent set
-// (e.g. SkillService.List); when empty, falls back to org.Agents keys + leader.
-// Cycles / dangling parents must already be pruned by Get(); this helper still
-// guards BFS with a visited set so a corrupt in-memory map cannot expand access.
-func BuildOrgLeaderView(org AgentOrg, leader string, allAgentNames ...[]string) OrgLeaderView {
+// BuildOrgLeaderView builds a flat project-member view for pm_get_org.
+// allAgents supplies projectId for scope; when empty, falls back to org.Agents keys + leader.
+func BuildOrgLeaderView(org AgentOrg, leader string, allAgents ...[]Agent) OrgLeaderView {
 	leader = strings.TrimSpace(leader)
-	children := childrenByParent(org.Agents)
-	direct, indirect := reportingClosure(leader, children)
-
-	directSet := map[string]struct{}{}
-	for _, n := range direct {
-		directSet[n] = struct{}{}
+	projectID := ""
+	if len(allAgents) > 0 {
+		for _, a := range allAgents[0] {
+			if strings.TrimSpace(a.Name) == leader {
+				projectID = strings.TrimSpace(a.ProjectID)
+				break
+			}
+		}
 	}
-	indirectSet := map[string]struct{}{}
-	for _, n := range indirect {
-		indirectSet[n] = struct{}{}
+
+	projectSet := map[string]struct{}{}
+	if projectID != "" && len(allAgents) > 0 {
+		for _, a := range allAgents[0] {
+			if AgentProjectMatches(a, projectID) {
+				projectSet[strings.TrimSpace(a.Name)] = struct{}{}
+			}
+		}
 	}
 
 	names := map[string]struct{}{}
-	if len(allAgentNames) > 0 {
-		for _, n := range allAgentNames[0] {
-			n = strings.TrimSpace(n)
+	if len(allAgents) > 0 {
+		for _, a := range allAgents[0] {
+			n := strings.TrimSpace(a.Name)
 			if n != "" {
 				names[n] = struct{}{}
 			}
@@ -73,11 +78,6 @@ func BuildOrgLeaderView(org AgentOrg, leader string, allAgentNames ...[]string) 
 	if leader != "" {
 		names[leader] = struct{}{}
 	}
-	for _, m := range org.Agents {
-		if p := strings.TrimSpace(m.ParentAgent); p != "" {
-			names[p] = struct{}{}
-		}
-	}
 
 	sortedNames := make([]string, 0, len(names))
 	for n := range names {
@@ -85,6 +85,7 @@ func BuildOrgLeaderView(org AgentOrg, leader string, allAgentNames ...[]string) 
 	}
 	sort.Strings(sortedNames)
 
+	direct := make([]string, 0)
 	annotated := make([]OrgAgentAnnotated, 0, len(sortedNames))
 	for _, name := range sortedNames {
 		m := org.Agents[name]
@@ -92,148 +93,37 @@ func BuildOrgLeaderView(org AgentOrg, leader string, allAgentNames ...[]string) 
 		switch {
 		case leader != "" && name == leader:
 			rel = OrgRelationSelf
-		default:
-			if _, ok := directSet[name]; ok {
+		case projectID != "":
+			if _, inProject := projectSet[name]; inProject {
 				rel = OrgRelationDirect
-			} else if _, ok := indirectSet[name]; ok {
-				rel = OrgRelationIndirect
+				if name != leader {
+					direct = append(direct, name)
+				}
 			}
 		}
 		annotated = append(annotated, OrgAgentAnnotated{
-			Name:        name,
-			GroupIDs:    append([]string(nil), m.GroupIDs...),
-			ParentAgent: m.ParentAgent,
-			Relation:    rel,
+			Name:     name,
+			GroupIDs: append([]string(nil), m.GroupIDs...),
+			Relation: rel,
+		})
+	}
+	sort.Strings(direct)
+
+	subtree := make([]OrgSubtreeNode, 0, len(direct))
+	for _, name := range direct {
+		subtree = append(subtree, OrgSubtreeNode{
+			Name:     name,
+			Relation: OrgRelationDirect,
 		})
 	}
 
-	subtree := buildSubtree(leader, children, directSet, indirectSet)
 	return OrgLeaderView{
 		Revision:        org.Revision,
 		Groups:          append([]OrgGroup(nil), org.Groups...),
 		Agents:          annotated,
 		Leader:          leader,
 		DirectReports:   direct,
-		IndirectReports: indirect,
+		IndirectReports: nil,
 		Subtree:         subtree,
 	}
-}
-
-// IsInReportingClosure reports whether target is leader itself or a descendant
-// under parentAgent edges (direct or indirect).
-func IsInReportingClosure(org AgentOrg, leader, target string) bool {
-	leader = strings.TrimSpace(leader)
-	target = strings.TrimSpace(target)
-	if leader == "" || target == "" {
-		return false
-	}
-	if leader == target {
-		return true
-	}
-	children := childrenByParent(org.Agents)
-	direct, indirect := reportingClosure(leader, children)
-	for _, n := range direct {
-		if n == target {
-			return true
-		}
-	}
-	for _, n := range indirect {
-		if n == target {
-			return true
-		}
-	}
-	return false
-}
-
-func childrenByParent(agents map[string]OrgAgentMembership) map[string][]string {
-	out := map[string][]string{}
-	for name, m := range agents {
-		parent := strings.TrimSpace(m.ParentAgent)
-		if parent == "" {
-			continue
-		}
-		out[parent] = append(out[parent], name)
-	}
-	for p := range out {
-		sort.Strings(out[p])
-	}
-	return out
-}
-
-// reportingClosure returns sorted direct and indirect descendants of leader.
-// Visited guards against cycles so we never traverse infinitely or grant
-// extra agents outside the reachable tree from leader.
-func reportingClosure(leader string, children map[string][]string) (direct, indirect []string) {
-	leader = strings.TrimSpace(leader)
-	if leader == "" {
-		return nil, nil
-	}
-	visited := map[string]struct{}{leader: {}}
-	var queue []string
-	for _, c := range children[leader] {
-		if _, seen := visited[c]; seen {
-			continue
-		}
-		visited[c] = struct{}{}
-		direct = append(direct, c)
-		queue = append(queue, c)
-	}
-	for len(queue) > 0 {
-		cur := queue[0]
-		queue = queue[1:]
-		for _, c := range children[cur] {
-			if _, seen := visited[c]; seen {
-				continue
-			}
-			visited[c] = struct{}{}
-			indirect = append(indirect, c)
-			queue = append(queue, c)
-		}
-	}
-	sort.Strings(direct)
-	sort.Strings(indirect)
-	return direct, indirect
-}
-
-func buildSubtree(leader string, children map[string][]string, direct, indirect map[string]struct{}) []OrgSubtreeNode {
-	leader = strings.TrimSpace(leader)
-	if leader == "" {
-		return nil
-	}
-	var walk func(parent string, depth int, path map[string]struct{}) []OrgSubtreeNode
-	walk = func(parent string, depth int, path map[string]struct{}) []OrgSubtreeNode {
-		kids := children[parent]
-		if len(kids) == 0 {
-			return nil
-		}
-		out := make([]OrgSubtreeNode, 0, len(kids))
-		for _, name := range kids {
-			if _, inPath := path[name]; inPath {
-				continue // cycle guard
-			}
-			rel := OrgRelationIndirect
-			if depth == 0 {
-				if _, ok := direct[name]; ok {
-					rel = OrgRelationDirect
-				}
-			} else if _, ok := indirect[name]; ok {
-				rel = OrgRelationIndirect
-			} else if _, ok := direct[name]; ok {
-				rel = OrgRelationDirect
-			}
-			nextPath := map[string]struct{}{}
-			for k := range path {
-				nextPath[k] = struct{}{}
-			}
-			nextPath[name] = struct{}{}
-			node := OrgSubtreeNode{
-				Name:     name,
-				Relation: rel,
-				Children: walk(name, depth+1, nextPath),
-			}
-			out = append(out, node)
-		}
-		return out
-	}
-	return walk(leader, 0, map[string]struct{}{leader: {}})
 }

--- a/server/internal/services/org_closure_test.go
+++ b/server/internal/services/org_closure_test.go
@@ -4,19 +4,25 @@ import (
 	"testing"
 )
 
-func TestBuildOrgLeaderViewRelations(t *testing.T) {
+func TestBuildOrgLeaderViewFlatProjectMembers(t *testing.T) {
+	projectID := "proj-1"
 	org := AgentOrg{
 		Revision: 3,
 		Groups:   []OrgGroup{{ID: "g1", Name: "Eng"}},
 		Agents: map[string]OrgAgentMembership{
 			"leader": {GroupIDs: []string{"g1"}},
-			"alice":  {GroupIDs: []string{"g1"}, ParentAgent: "leader"},
-			"bob":    {ParentAgent: "alice"},
-			"carol":  {ParentAgent: "bob"},
-			"zoe":    {GroupIDs: []string{"g1"}}, // peer / other
+			"alice":  {GroupIDs: []string{"g1"}},
+			"bob":    {},
+			"zoe":    {GroupIDs: []string{"g1"}},
 		},
 	}
-	view := BuildOrgLeaderView(org, "leader")
+	allAgents := []Agent{
+		{Name: "leader", ProjectID: projectID},
+		{Name: "alice", ProjectID: projectID},
+		{Name: "bob", ProjectID: projectID},
+		{Name: "zoe", ProjectID: "other"},
+	}
+	view := BuildOrgLeaderView(org, "leader", allAgents)
 	if view.Leader != "leader" || view.Revision != 3 {
 		t.Fatalf("meta: %+v", view)
 	}
@@ -27,8 +33,7 @@ func TestBuildOrgLeaderViewRelations(t *testing.T) {
 	want := map[string]string{
 		"leader": OrgRelationSelf,
 		"alice":  OrgRelationDirect,
-		"bob":    OrgRelationIndirect,
-		"carol":  OrgRelationIndirect,
+		"bob":    OrgRelationDirect,
 		"zoe":    OrgRelationOther,
 	}
 	for name, w := range want {
@@ -36,100 +41,43 @@ func TestBuildOrgLeaderViewRelations(t *testing.T) {
 			t.Fatalf("%s relation=%q want %q (all=%v)", name, rel[name], w, rel)
 		}
 	}
-	if len(view.DirectReports) != 1 || view.DirectReports[0] != "alice" {
-		t.Fatalf("direct=%v", view.DirectReports)
-	}
-	if len(view.IndirectReports) != 2 || view.IndirectReports[0] != "bob" || view.IndirectReports[1] != "carol" {
-		t.Fatalf("indirect=%v", view.IndirectReports)
-	}
-	if len(view.Subtree) != 1 || view.Subtree[0].Name != "alice" || view.Subtree[0].Relation != OrgRelationDirect {
-		t.Fatalf("subtree=%+v", view.Subtree)
-	}
-	if len(view.Subtree[0].Children) != 1 || view.Subtree[0].Children[0].Name != "bob" {
-		t.Fatalf("alice children=%+v", view.Subtree[0].Children)
-	}
-}
-
-func TestIsInReportingClosure(t *testing.T) {
-	org := AgentOrg{
-		Agents: map[string]OrgAgentMembership{
-			"pm":    {},
-			"alice": {ParentAgent: "pm"},
-			"bob":   {ParentAgent: "alice"},
-			"other": {},
-		},
-	}
-	cases := []struct {
-		target string
-		want   bool
-	}{
-		{"pm", true},
-		{"alice", true},
-		{"bob", true},
-		{"other", false},
-		{"ghost", false},
-		{"", false},
-	}
-	for _, tc := range cases {
-		if got := IsInReportingClosure(org, "pm", tc.target); got != tc.want {
-			t.Fatalf("target %q: got %v want %v", tc.target, got, tc.want)
-		}
-	}
-	if IsInReportingClosure(org, "", "alice") {
-		t.Fatal("empty leader must deny")
-	}
-}
-
-func TestReportingClosureIgnoresCycle(t *testing.T) {
-	// Corrupt in-memory cycle must not hang or grant unrelated agents.
-	org := AgentOrg{
-		Agents: map[string]OrgAgentMembership{
-			"a": {ParentAgent: "b"},
-			"b": {ParentAgent: "a"},
-			"c": {ParentAgent: "a"},
-		},
-	}
-	view := BuildOrgLeaderView(org, "a")
-	// From a: child is whoever lists parent a → c (and possibly b if parent is a — here b's parent is a? No b's parent is a in this map? Wait: a->b, b->a, c->a
-	// children of a: those with ParentAgent==a → b? No: a has parent b, b has parent a, c has parent a.
-	// children[a] = [b? no - b's parent is a, yes b; and c] → b, c
-	// From a: direct b,c; then from b: child a (cycle, visited) → no new; from c: none.
-	if !containsStr(view.DirectReports, "b") || !containsStr(view.DirectReports, "c") {
-		t.Fatalf("direct=%v", view.DirectReports)
+	if len(view.DirectReports) != 2 {
+		t.Fatalf("direct=%v want alice+bob", view.DirectReports)
 	}
 	if len(view.IndirectReports) != 0 {
-		t.Fatalf("indirect should be empty under cycle guard: %v", view.IndirectReports)
+		t.Fatalf("indirect should be empty: %v", view.IndirectReports)
 	}
-	if IsInReportingClosure(org, "a", "ghost") {
-		t.Fatal("must not grant unrelated")
+	if len(view.Subtree) != 2 {
+		t.Fatalf("subtree=%+v", view.Subtree)
+	}
+	for _, n := range view.Subtree {
+		if n.Relation != OrgRelationDirect || len(n.Children) != 0 {
+			t.Fatalf("flat subtree node: %+v", n)
+		}
 	}
 }
 
-func TestReportingClosureDanglingParentDoesNotWiden(t *testing.T) {
+func TestBuildOrgLeaderViewNoProjectBinding(t *testing.T) {
 	org := AgentOrg{
 		Agents: map[string]OrgAgentMembership{
 			"leader": {},
-			"alice":  {ParentAgent: "leader"},
-			// dave points at missing parent — not reachable from leader
-			"dave": {ParentAgent: "missing"},
+			"alice":  {},
 		},
 	}
-	if IsInReportingClosure(org, "leader", "dave") {
-		t.Fatal("dangling parent agent must not enter leader closure")
+	allAgents := []Agent{
+		{Name: "leader", ProjectID: ""},
+		{Name: "alice", ProjectID: "p1"},
 	}
-	view := BuildOrgLeaderView(org, "leader")
+	view := BuildOrgLeaderView(org, "leader", allAgents)
 	for _, a := range view.Agents {
-		if a.Name == "dave" && a.Relation != OrgRelationOther {
-			t.Fatalf("dave should be other, got %q", a.Relation)
+		if a.Name == "leader" && a.Relation != OrgRelationSelf {
+			t.Fatalf("leader rel=%q", a.Relation)
+		}
+		if a.Name == "alice" && a.Relation != OrgRelationOther {
+			t.Fatalf("unbound leader: alice should be other, got %q", a.Relation)
 		}
 	}
-}
-
-func containsStr(ss []string, want string) bool {
-	for _, s := range ss {
-		if s == want {
-			return true
-		}
+	if len(view.DirectReports) != 0 {
+		t.Fatalf("direct=%v", view.DirectReports)
 	}
-	return false
 }

--- a/server/internal/services/org_dead_code_test.go
+++ b/server/internal/services/org_dead_code_test.go
@@ -1,0 +1,50 @@
+package services
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Guards against reintroducing parentAgent reporting-line business code.
+func TestNoParentAgentReportingDeadCode(t *testing.T) {
+	root := filepath.Join("..", "..")
+	patterns := []string{
+		"IsInReportingClosure",
+		"detectReportingCycles",
+		"ParentAgent string",
+		`json:"parentAgent`,
+		"wouldCreateReportingCycle",
+		"reportingClosure(",
+	}
+	var offenders []string
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if info.Name() == "vendor" || info.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		s := string(b)
+		for _, needle := range patterns {
+			if strings.Contains(s, needle) {
+				offenders = append(offenders, path+": contains "+needle)
+			}
+		}
+		return nil
+	})
+	if len(offenders) > 0 {
+		t.Fatalf("reporting-line residue:\n%s", strings.Join(offenders, "\n"))
+	}
+}

--- a/server/internal/services/org_folder.go
+++ b/server/internal/services/org_folder.go
@@ -70,8 +70,7 @@ type ImportFolderResult struct {
 }
 
 // CollectGroupSubtree returns the target group + descendants + deduped agents.
-// Empty groups are kept. Membership is clipped to the subtree; parentAgent
-// outside the agent set is dropped.
+// Empty groups are kept. Membership is clipped to the subtree.
 func CollectGroupSubtree(org AgentOrg, rootGroupID string) (GroupSubtree, error) {
 	rootGroupID = strings.TrimSpace(rootGroupID)
 	if rootGroupID == "" {
@@ -136,16 +135,7 @@ func CollectGroupSubtree(org AgentOrg, rootGroupID string) (GroupSubtree, error)
 		}
 		agentSet[name] = struct{}{}
 		memberships[name] = OrgAgentMembership{
-			GroupIDs:    uniqueNonEmpty(gids),
-			ParentAgent: strings.TrimSpace(m.ParentAgent),
-		}
-	}
-	for name, m := range memberships {
-		if m.ParentAgent != "" {
-			if _, ok := agentSet[m.ParentAgent]; !ok {
-				m.ParentAgent = ""
-				memberships[name] = m
-			}
+			GroupIDs: uniqueNonEmpty(gids),
 		}
 	}
 	names := make([]string, 0, len(agentSet))
@@ -171,7 +161,7 @@ func (o *OrgService) ExportFolderZIP(groupID string) ([]byte, string, error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
-	org, err := o.loadLocked()
+	org, _, err := o.loadLocked()
 	if err != nil {
 		return nil, "", err
 	}
@@ -182,21 +172,11 @@ func (o *OrgService) ExportFolderZIP(groupID string) ([]byte, string, error) {
 
 	// Only export agents that still exist on disk.
 	alive := make([]string, 0, len(sub.AgentNames))
-	aliveSet := map[string]struct{}{}
 	for _, name := range sub.AgentNames {
 		if o.skill.Exists(name) {
 			alive = append(alive, name)
-			aliveSet[name] = struct{}{}
 		} else {
 			delete(sub.Memberships, name)
-		}
-	}
-	for name, m := range sub.Memberships {
-		if m.ParentAgent != "" {
-			if _, ok := aliveSet[m.ParentAgent]; !ok {
-				m.ParentAgent = ""
-				sub.Memberships[name] = m
-			}
 		}
 	}
 	sub.AgentNames = alive
@@ -315,7 +295,7 @@ func (o *OrgService) ImportFolderZIP(raw []byte, targetGroupID string, mode Impo
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
-	org, err := o.loadLocked()
+	org, _, err := o.loadLocked()
 	if err != nil {
 		return ImportFolderResult{}, err
 	}
@@ -470,16 +450,8 @@ func (o *OrgService) ImportFolderZIP(raw []byte, targetGroupID string, mode Impo
 				gids = append(gids, nid)
 			}
 		}
-		parent := strings.TrimSpace(m.ParentAgent)
-		if parent != "" {
-			if mapped, ok := nameMap[parent]; ok {
-				parent = mapped
-			} else {
-				parent = ""
-			}
-		}
-		nm := OrgAgentMembership{GroupIDs: uniqueNonEmpty(gids), ParentAgent: parent}
-		if len(nm.GroupIDs) == 0 && nm.ParentAgent == "" {
+		nm := OrgAgentMembership{GroupIDs: uniqueNonEmpty(gids)}
+		if len(nm.GroupIDs) == 0 {
 			if mode == ImportFolderOverwrite && containsString(overwritten, finalName) {
 				delete(merged.Agents, finalName)
 			}

--- a/server/internal/services/org_folder_test.go
+++ b/server/internal/services/org_folder_test.go
@@ -33,8 +33,8 @@ func setupFolderOrg(t *testing.T) (*SkillService, *OrgService) {
 	if _, err := orgSvc.Put(AgentOrg{
 		Groups: []OrgGroup{gRoot, gSub, gEmpty, gOther},
 		Agents: map[string]OrgAgentMembership{
-			"alice":   {GroupIDs: []string{"g_root", "g_other"}, ParentAgent: "outside"},
-			"bob":     {GroupIDs: []string{"g_pipe", "g_root"}, ParentAgent: "alice"},
+			"alice":   {GroupIDs: []string{"g_root", "g_other"}},
+			"bob":     {GroupIDs: []string{"g_pipe", "g_root"}},
 			"carol":   {GroupIDs: []string{"g_pipe"}},
 			"outside": {GroupIDs: []string{"g_other"}},
 		},
@@ -73,12 +73,6 @@ func TestCollectGroupSubtree_emptyGroupsDedupAndClip(t *testing.T) {
 	alice := sub.Memberships["alice"]
 	if len(alice.GroupIDs) != 1 || alice.GroupIDs[0] != "g_root" {
 		t.Fatalf("alice groupIds clipped: %+v", alice.GroupIDs)
-	}
-	if alice.ParentAgent != "" {
-		t.Fatalf("outside parentAgent must be dropped, got %q", alice.ParentAgent)
-	}
-	if sub.Memberships["bob"].ParentAgent != "alice" {
-		t.Fatalf("in-subtree parentAgent kept: %+v", sub.Memberships["bob"])
 	}
 }
 
@@ -185,9 +179,6 @@ func TestExportImportFolder_remapMountRenameOverwriteRollback(t *testing.T) {
 		t.Fatalf("new root missing: %+v", renamed.Org.Groups)
 	}
 	importedAlice := renamed.Org.Agents["alice_v2"]
-	if importedAlice.ParentAgent != "" {
-		t.Fatalf("outside parentAgent restored: %+v", importedAlice)
-	}
 	if !containsString(importedAlice.GroupIDs, newRoot.ID) {
 		t.Fatalf("alice_v2 not in new root: %+v", importedAlice.GroupIDs)
 	}

--- a/server/internal/services/org_test.go
+++ b/server/internal/services/org_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -56,8 +57,8 @@ func TestOrgPutAndGet(t *testing.T) {
 	put, err := orgSvc.Put(AgentOrg{
 		Groups: []OrgGroup{g1, g2},
 		Agents: map[string]OrgAgentMembership{
-			"alice": {GroupIDs: []string{"g_eng"}, ParentAgent: ""},
-			"bob":   {GroupIDs: []string{"g_des", "g_eng"}, ParentAgent: "alice"},
+			"alice": {GroupIDs: []string{"g_eng"}},
+			"bob":   {GroupIDs: []string{"g_des", "g_eng"}},
 		},
 	}, 0)
 	if err != nil {
@@ -75,9 +76,6 @@ func TestOrgPutAndGet(t *testing.T) {
 	}
 	if len(got.Agents["bob"].GroupIDs) != 2 {
 		t.Fatalf("bob groups: %+v", got.Agents["bob"])
-	}
-	if got.Agents["bob"].ParentAgent != "alice" {
-		t.Fatalf("bob parent: %q", got.Agents["bob"].ParentAgent)
 	}
 }
 
@@ -105,38 +103,13 @@ func TestOrgRejectGroupCycle(t *testing.T) {
 	}
 }
 
-func TestOrgRejectReportingCycle(t *testing.T) {
-	_, orgSvc := setupOrg(t)
-	_, err := orgSvc.Put(AgentOrg{
-		Agents: map[string]OrgAgentMembership{
-			"alice": {ParentAgent: "bob"},
-			"bob":   {ParentAgent: "alice"},
-		},
-	}, 0)
-	if !errors.Is(err, ErrOrgValidation) {
-		t.Fatalf("want validation, got %v", err)
-	}
-}
-
-func TestOrgRejectSelfParent(t *testing.T) {
-	_, orgSvc := setupOrg(t)
-	_, err := orgSvc.Put(AgentOrg{
-		Agents: map[string]OrgAgentMembership{
-			"alice": {ParentAgent: "alice"},
-		},
-	}, 0)
-	if !errors.Is(err, ErrOrgValidation) {
-		t.Fatalf("want validation, got %v", err)
-	}
-}
-
 func TestOrgRenameCascade(t *testing.T) {
 	skill, orgSvc := setupOrg(t)
 	if _, err := orgSvc.Put(AgentOrg{
 		Groups: []OrgGroup{{ID: "g1", Name: "G"}},
 		Agents: map[string]OrgAgentMembership{
 			"alice": {GroupIDs: []string{"g1"}},
-			"bob":   {GroupIDs: []string{"g1"}, ParentAgent: "alice"},
+			"bob":   {GroupIDs: []string{"g1"}},
 		},
 	}, 0); err != nil {
 		t.Fatal(err)
@@ -157,23 +130,20 @@ func TestOrgRenameCascade(t *testing.T) {
 	if got.Agents["alice2"].GroupIDs[0] != "g1" {
 		t.Fatalf("membership not moved: %+v", got.Agents["alice2"])
 	}
-	if got.Agents["bob"].ParentAgent != "alice2" {
-		t.Fatalf("parent not renamed: %q", got.Agents["bob"].ParentAgent)
-	}
 }
 
-func TestOrgDeleteCascade(t *testing.T) {
+func TestOrgDeleteRemovesMembership(t *testing.T) {
 	skill, orgSvc := setupOrg(t)
 	if _, err := orgSvc.Put(AgentOrg{
+		Groups: []OrgGroup{{ID: "g1", Name: "G"}},
 		Agents: map[string]OrgAgentMembership{
-			"alice": {ParentAgent: ""},
-			"bob":   {ParentAgent: "alice"},
-			"carol": {ParentAgent: "bob"},
+			"alice": {GroupIDs: []string{"g1"}},
+			"bob":   {GroupIDs: []string{"g1"}},
+			"carol": {GroupIDs: []string{"g1"}},
 		},
 	}, 0); err != nil {
 		t.Fatal(err)
 	}
-	// alice has no parent; deleting bob should reparent carol -> alice
 	if err := skill.Delete("bob"); err != nil {
 		t.Fatal(err)
 	}
@@ -187,8 +157,8 @@ func TestOrgDeleteCascade(t *testing.T) {
 	if _, ok := got.Agents["bob"]; ok {
 		t.Fatal("bob still in org")
 	}
-	if got.Agents["carol"].ParentAgent != "alice" {
-		t.Fatalf("carol parent want alice, got %q", got.Agents["carol"].ParentAgent)
+	if got.Agents["carol"].GroupIDs[0] != "g1" {
+		t.Fatalf("carol membership: %+v", got.Agents["carol"])
 	}
 }
 
@@ -200,81 +170,22 @@ func TestApplyDeleteGroup(t *testing.T) {
 			{ID: "leaf", Name: "Leaf", ParentGroupID: "child"},
 		},
 		Agents: map[string]OrgAgentMembership{
-			"alice": {GroupIDs: []string{"child"}},
-			"bob":   {GroupIDs: []string{"child", "root"}},
-			"carol": {GroupIDs: []string{"leaf"}},
+			"alice": {GroupIDs: []string{"leaf"}},
+			"bob":   {GroupIDs: []string{"child"}},
 		},
 	}
 	out, err := applyDeleteGroup(org, "child")
 	if err != nil {
 		t.Fatal(err)
 	}
-	ids := map[string]string{}
-	for _, g := range out.Groups {
-		ids[g.ID] = g.ParentGroupID
+	if len(out.Groups) != 2 {
+		t.Fatalf("groups=%d", len(out.Groups))
 	}
-	if _, ok := ids["child"]; ok {
-		t.Fatal("child still present")
+	if out.Agents["bob"].GroupIDs[0] != "root" {
+		t.Fatalf("bob promoted to root: %+v", out.Agents["bob"])
 	}
-	if ids["leaf"] != "root" {
-		t.Fatalf("leaf parent want root, got %q", ids["leaf"])
-	}
-	// alice was only in child → moves to root
-	if len(out.Agents["alice"].GroupIDs) != 1 || out.Agents["alice"].GroupIDs[0] != "root" {
-		t.Fatalf("alice: %+v", out.Agents["alice"])
-	}
-	// bob keeps root (child removed, parent added but unique)
-	if len(out.Agents["bob"].GroupIDs) != 1 || out.Agents["bob"].GroupIDs[0] != "root" {
-		t.Fatalf("bob: %+v", out.Agents["bob"])
-	}
-}
-
-func TestApplyDeleteRootGroup(t *testing.T) {
-	org := AgentOrg{
-		Groups: []OrgGroup{
-			{ID: "root", Name: "Root"},
-			{ID: "child", Name: "Child", ParentGroupID: "root"},
-		},
-		Agents: map[string]OrgAgentMembership{
-			"alice": {GroupIDs: []string{"root"}},
-		},
-	}
-	out, err := applyDeleteGroup(org, "root")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(out.Groups) != 1 || out.Groups[0].ID != "child" || out.Groups[0].ParentGroupID != "" {
-		t.Fatalf("child should become root: %+v", out.Groups)
-	}
-	if _, ok := out.Agents["alice"]; ok {
-		t.Fatalf("alice should be ungrouped: %+v", out.Agents)
-	}
-}
-
-func TestApplyMoveAgent(t *testing.T) {
-	org := AgentOrg{
-		Groups: []OrgGroup{{ID: "a", Name: "A"}, {ID: "b", Name: "B"}, {ID: "c", Name: "C"}},
-		Agents: map[string]OrgAgentMembership{
-			"alice": {GroupIDs: []string{"a", "c"}},
-		},
-	}
-	out, err := applyMoveAgent(org, "alice", "a", "b")
-	if err != nil {
-		t.Fatal(err)
-	}
-	gids := out.Agents["alice"].GroupIDs
-	if len(gids) != 2 || gids[0] != "b" || gids[1] != "c" {
-		// sorted: b, c
-		if !(len(gids) == 2 && ((gids[0] == "b" && gids[1] == "c") || (gids[0] == "c" && gids[1] == "b"))) {
-			t.Fatalf("move result: %+v", gids)
-		}
-	}
-	out, err = applyMoveAgent(out, "alice", "b", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, ok := out.Agents["alice"]; ok {
-		t.Fatalf("ungrouped should clear: %+v", out.Agents["alice"])
+	if out.Agents["alice"].GroupIDs[0] != "leaf" {
+		t.Fatalf("alice still in leaf: %+v", out.Agents["alice"])
 	}
 }
 
@@ -294,19 +205,18 @@ func TestOrgDoesNotAffectSkillList(t *testing.T) {
 	}
 }
 
-func TestOrgGetPrunesAndReparentsDanglingParent(t *testing.T) {
+func TestOrgGetPrunesMissingAgent(t *testing.T) {
 	skill, orgSvc := setupOrg(t)
 	if _, err := orgSvc.Put(AgentOrg{
 		Groups: []OrgGroup{{ID: "g1", Name: "G"}},
 		Agents: map[string]OrgAgentMembership{
 			"alice": {GroupIDs: []string{"g1"}},
-			"bob":   {GroupIDs: []string{"g1"}, ParentAgent: "alice"},
-			"carol": {GroupIDs: []string{"g1"}, ParentAgent: "bob"},
+			"bob":   {GroupIDs: []string{"g1"}},
+			"carol": {GroupIDs: []string{"g1"}},
 		},
 	}, 0); err != nil {
 		t.Fatal(err)
 	}
-	// Simulate skipped OnDeleteAgent: remove bob's directory only.
 	if err := skill.Delete("bob"); err != nil {
 		t.Fatal(err)
 	}
@@ -317,10 +227,9 @@ func TestOrgGetPrunesAndReparentsDanglingParent(t *testing.T) {
 	if _, ok := got.Agents["bob"]; ok {
 		t.Fatal("bob membership should be pruned")
 	}
-	if got.Agents["carol"].ParentAgent != "alice" {
-		t.Fatalf("carol parent want alice after prune, got %q", got.Agents["carol"].ParentAgent)
+	if got.Agents["carol"].GroupIDs[0] != "g1" {
+		t.Fatalf("carol membership: %+v", got.Agents["carol"])
 	}
-	// Repair must persist so a second Get stays clean at the new revision.
 	again, err := orgSvc.Get()
 	if err != nil {
 		t.Fatal(err)
@@ -328,7 +237,49 @@ func TestOrgGetPrunesAndReparentsDanglingParent(t *testing.T) {
 	if again.Revision != got.Revision {
 		t.Fatalf("revision should be stable after repair writeback: %d vs %d", again.Revision, got.Revision)
 	}
-	if again.Agents["carol"].ParentAgent != "alice" {
-		t.Fatalf("persisted parent want alice, got %q", again.Agents["carol"].ParentAgent)
+}
+
+func TestOrgLegacyParentAgentStrippedOnGet(t *testing.T) {
+	root := t.TempDir()
+	skill := NewSkillService(root)
+	for _, name := range []string{"pm", "eng1", "eng2", "eng3"} {
+		if err := skill.Save(Agent{Name: name, ProjectID: "proj-1"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	orgSvc := NewOrgService(root, skill)
+	legacy := `{
+  "revision": 2,
+  "groups": [{"id": "g1", "name": "Pipeline"}],
+  "agents": {
+    "pm": {"groupIds": ["g1"]},
+    "eng1": {"groupIds": ["g1"], "parentAgent": "pm"},
+    "eng2": {"groupIds": ["g1"], "parentAgent": "eng1"},
+    "eng3": {"groupIds": ["g1"], "parentAgent": "eng2"}
+  }
+}`
+	if err := os.WriteFile(filepath.Join(root, orgFileName), []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := orgSvc.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Revision != 3 {
+		t.Fatalf("revision want 3 after strip writeback, got %d", got.Revision)
+	}
+	raw, err := os.ReadFile(filepath.Join(root, orgFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "parentAgent") {
+		t.Fatalf("persisted file still has parentAgent: %s", raw)
+	}
+	again, err := orgSvc.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Revision != got.Revision {
+		t.Fatalf("second get should be idempotent: %d vs %d", again.Revision, got.Revision)
 	}
 }

--- a/server/internal/services/team.go
+++ b/server/internal/services/team.go
@@ -385,12 +385,11 @@ func (s *TeamService) runBootstrap(ctx context.Context, sessionID string, req no
 			fail(err)
 			return
 		}
-		s.appendEvent(sessionID, "mcp", "pm_set_org_membership\nagent="+created.Name+"\ngroup="+req.PipelineGroup+"\nparent="+req.PMName+"\n✓ ok")
+		s.appendEvent(sessionID, "mcp", "pm_set_org_membership\nagent="+created.Name+"\ngroup="+req.PipelineGroup+"\n✓ ok")
 		if err := s.SetOrgMembership(SetOrgMembershipArgs{
-			SessionID:   sessionID,
-			AgentName:   created.Name,
-			GroupIDs:    []string{pipeID},
-			ParentAgent: req.PMName,
+			SessionID: sessionID,
+			AgentName: created.Name,
+			GroupIDs:  []string{pipeID},
 		}); err != nil {
 			fail(err)
 			return
@@ -457,10 +456,9 @@ func (s *TeamService) runRetry(ctx context.Context, sessionID string, req normal
 			return
 		}
 		if err := s.SetOrgMembership(SetOrgMembershipArgs{
-			SessionID:   sessionID,
-			AgentName:   created.Name,
-			GroupIDs:    []string{pipeID},
-			ParentAgent: pmName,
+			SessionID: sessionID,
+			AgentName: created.Name,
+			GroupIDs:  []string{pipeID},
 		}); err != nil {
 			fail(err)
 			return
@@ -618,12 +616,11 @@ func (s *TeamService) CreateAgentFromTemplate(args CreateFromTemplateArgs) (Agen
 	return tmpl, nil
 }
 
-// SetOrgMembershipArgs updates groupIds + parentAgent under scope.
+// SetOrgMembershipArgs updates groupIds under scope.
 type SetOrgMembershipArgs struct {
-	SessionID   string
-	AgentName   string
-	GroupIDs    []string
-	ParentAgent string
+	SessionID string
+	AgentName string
+	GroupIDs  []string
 }
 
 // SetOrgMembership sets membership for an agent (scoped when SessionID set).
@@ -636,7 +633,6 @@ func (s *TeamService) SetOrgMembership(args SetOrgMembershipArgs) error {
 	if !ok {
 		return fmt.Errorf("%w: agent not found: %s", ErrTeamValidation, agentName)
 	}
-	parent := strings.TrimSpace(args.ParentAgent)
 	groupIDs := uniqueNonEmptyStrings(args.GroupIDs)
 
 	if args.SessionID != "" {
@@ -647,9 +643,6 @@ func (s *TeamService) SetOrgMembership(args SetOrgMembershipArgs) error {
 		if !AgentProjectMatches(ag, sess.ProjectID) {
 			return fmt.Errorf("%w: agent not in session project", ErrTeamScopeDenied)
 		}
-		if parent != "" && parent != sess.PMAgent {
-			return fmt.Errorf("%w: parentAgent must be session PM", ErrTeamScopeDenied)
-		}
 		allowed := map[string]bool{}
 		for _, id := range sess.AllowedGroupIDs {
 			allowed[id] = true
@@ -658,9 +651,6 @@ func (s *TeamService) SetOrgMembership(args SetOrgMembershipArgs) error {
 			if !allowed[id] {
 				return fmt.Errorf("%w: group not in session allow-list: %s", ErrTeamScopeDenied, id)
 			}
-		}
-		if parent == "" {
-			parent = sess.PMAgent
 		}
 	}
 
@@ -671,7 +661,7 @@ func (s *TeamService) SetOrgMembership(args SetOrgMembershipArgs) error {
 	if org.Agents == nil {
 		org.Agents = map[string]OrgAgentMembership{}
 	}
-	org.Agents[agentName] = OrgAgentMembership{GroupIDs: groupIDs, ParentAgent: parent}
+	org.Agents[agentName] = OrgAgentMembership{GroupIDs: groupIDs}
 	_, err = s.Org.Put(org, org.Revision)
 	return err
 }

--- a/server/internal/services/team_embed/PMAgent/workspace/rules/role.md
+++ b/server/internal/services/team_embed/PMAgent/workspace/rules/role.md
@@ -27,13 +27,15 @@ alwaysApply: true
 
 | 工具 | 用途 |
 |------|------|
-| `pm_get_org` | 只读组织架构与汇报关系 |
+| `pm_get_org` | 只读虚拟组与同项目成员扁平视图 |
 | `pm_list_agent_templates` | 列出内置工程师模板 |
 | `pm_create_agent_from_template` | 按模板创建工程师（同项目；默认继承 mcp/env；禁止覆盖重名） |
-| `pm_set_org_membership` | 设置 `groupIds` + `parentAgent`（上级须为你） |
+| `pm_set_org_membership` | 设置虚拟组 `groupIds` |
 | `pm_ensure_child_group` | 幂等确保 Pipeline 等子组存在 |
 
-命名约定：`{前缀}{角色}工程师`，例如 `Demo实现工程师`。工程师应挂在 Pipeline 子组，且 `parentAgent` 指向你。
+命名约定：`{前缀}{角色}工程师`，例如 `Demo实现工程师`。工程师应挂在 Pipeline 子组。
+
+PM 默认可管理**同一项目**下全部 Agent（鉴权看 `projectId` 一致）；无需配置上下级。
 
 若建团流程已由平台预置齐 10 人，则不必重复创建；用 `pm_get_org` 确认后直接进入编排。
 

--- a/server/internal/services/team_embed/PMAgent/workspace/skills/pm-orchestrate/SKILL.md
+++ b/server/internal/services/team_embed/PMAgent/workspace/skills/pm-orchestrate/SKILL.md
@@ -10,7 +10,7 @@ description: PM Leader 编排检查清单：组织确认、任务分派、门禁
 ## 组织
 
 1. 已读 `rules/project-context.md`，理解目标、技术栈与仓库诉求
-2. `pm_get_org` 显示：根组存在；Pipeline 子组存在；9 名工程师均在 Pipeline 下且 `parentAgent` 为你
+2. `pm_get_org` 显示：根组存在；Pipeline 子组存在；9 名工程师均在 Pipeline 下（`directReports` 列出同项目成员）
 3. 若缺人：用模板创建 → `pm_set_org_membership` 挂组；已存在同名则跳过并报告，不覆盖
 4. 项目 PM Leader 绑定指向你；`pm-agent-fs` 等 MCP 可用
 

--- a/server/internal/services/team_test.go
+++ b/server/internal/services/team_test.go
@@ -99,10 +99,7 @@ func TestTeamBootstrap_CreatesRoster(t *testing.T) {
 		t.Fatal(err)
 	}
 	mem := doc.Agents[impl]
-	if mem.ParentAgent != "Demo项目经理" {
-		t.Fatalf("parent=%s", mem.ParentAgent)
-	}
-	if len(mem.GroupIDs) != 1 || mem.GroupIDs[0] != cur.PipelineGroupID {
+	if _, ok := doc.Agents[impl]; !ok || len(mem.GroupIDs) != 1 || mem.GroupIDs[0] != cur.PipelineGroupID {
 		t.Fatalf("groups=%v want pipeline %s", mem.GroupIDs, cur.PipelineGroupID)
 	}
 }
@@ -234,23 +231,21 @@ func TestSetOrgMembership_ScopeDenied(t *testing.T) {
 	}
 
 	err = team.SetOrgMembership(SetOrgMembershipArgs{
-		SessionID:   cur.ID,
-		AgentName:   "Sc实现工程师",
-		GroupIDs:    []string{"grp_foreign"},
-		ParentAgent: cur.PMAgent,
+		SessionID: cur.ID,
+		AgentName: "Sc实现工程师",
+		GroupIDs:  []string{"grp_foreign"},
 	})
 	if !errors.Is(err, ErrTeamScopeDenied) {
 		t.Fatalf("want scope denied, got %v", err)
 	}
 
 	err = team.SetOrgMembership(SetOrgMembershipArgs{
-		SessionID:   cur.ID,
-		AgentName:   "Sc实现工程师",
-		GroupIDs:    []string{cur.PipelineGroupID},
-		ParentAgent: "someone-else",
+		SessionID: cur.ID,
+		AgentName: "Sc实现工程师",
+		GroupIDs:  []string{cur.PipelineGroupID},
 	})
-	if !errors.Is(err, ErrTeamScopeDenied) {
-		t.Fatalf("want parent denied, got %v", err)
+	if err != nil {
+		t.Fatalf("valid membership: %v", err)
 	}
 
 	_, err = team.CreateAgentFromTemplate(CreateFromTemplateArgs{

--- a/web/src/components/agent/AgentMetaPanel.vue
+++ b/web/src/components/agent/AgentMetaPanel.vue
@@ -8,9 +8,7 @@ import type { AgentOrg } from '@/lib/api/api'
 import {
   groupIdsOf,
   groupPath,
-  parentOf,
   setAgentMembership,
-  wouldCreateReportingCycle,
 } from '@/lib/agent/agentOrg'
 import {
   ACP_BACKENDS,
@@ -45,7 +43,6 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
-const parentDropdownOpen = ref(false)
 let configRootTouched = false
 
 const pendingProjectId = ref<string | null>(null)
@@ -55,7 +52,6 @@ watch(
   () => props.agentName,
   () => {
     configRootTouched = false
-    parentDropdownOpen.value = false
   },
 )
 
@@ -105,33 +101,11 @@ const metaGroupTiles = computed(() => {
   }))
 })
 
-const metaParentOptions = computed(() => props.agentNames.filter((n) => n !== props.agentName))
-
-const metaParentAgent = computed(() => (props.agentName ? parentOf(props.org, props.agentName) : ''))
-
 function toggleMetaGroup(groupId: string) {
   if (!props.agentName) return
   const cur = groupIdsOf(props.org, props.agentName)
   const next = cur.includes(groupId) ? cur.filter((id) => id !== groupId) : [...cur, groupId]
-  emit(
-    'update:org',
-    setAgentMembership(props.org, props.agentName, next, parentOf(props.org, props.agentName)),
-  )
-}
-
-function setMetaParent(parent: string) {
-  if (!props.agentName) return
-  if (parent && wouldCreateReportingCycle(props.org, props.agentName, parent)) {
-    emit('error', t('pages.agentStudio.org.reportingCycle'))
-    parentDropdownOpen.value = false
-    return
-  }
-  emit('error', '')
-  emit(
-    'update:org',
-    setAgentMembership(props.org, props.agentName, groupIdsOf(props.org, props.agentName), parent),
-  )
-  parentDropdownOpen.value = false
+  emit('update:org', setAgentMembership(props.org, props.agentName, next))
 }
 
 function selectAcpBackend(id: BackendId) {
@@ -239,51 +213,6 @@ const derivedPaths = computed(() => {
         <p v-else class="border border-dashed border-line px-3 py-3 text-[12px] text-txt3">
           {{ t('pages.agentStudio.org.noGroups') }}
         </p>
-      </div>
-
-      <div>
-        <div class="mb-1 flex items-center justify-between gap-2 text-[12px] font-medium text-txt2">
-          <span>{{ t('pages.agentStudio.org.parentLabel') }}</span>
-          <span class="text-[11px] font-normal text-txt3">{{ t('pages.agentStudio.org.parentMeta') }}</span>
-        </div>
-        <p class="mb-2.5 text-[11px] leading-5 text-txt3">{{ t('pages.agentStudio.org.parentHint') }}</p>
-        <div class="relative max-w-sm">
-          <button
-            type="button"
-            class="flex w-full items-center gap-2 border border-line bg-base px-3 py-2.5 text-left text-[12.5px] text-txt transition hover:border-line-strong"
-            :class="parentDropdownOpen ? 'border-accent shadow-[0_0_0_1px_rgba(99,102,241,0.25)]' : ''"
-            @click="parentDropdownOpen = !parentDropdownOpen"
-          >
-            <span class="min-w-0 flex-1 truncate" :class="metaParentAgent ? '' : 'text-txt3'">
-              {{ metaParentAgent || t('pages.agentStudio.org.parentNone') }}
-            </span>
-            <Icon name="chevron-right" :size="14" class="shrink-0 text-txt3 transition" :class="parentDropdownOpen ? 'rotate-90' : 'rotate-90'" />
-          </button>
-          <div
-            v-if="parentDropdownOpen"
-            class="absolute left-0 right-0 top-[calc(100%+4px)] z-20 max-h-56 overflow-auto border border-line-strong bg-elevated p-1 shadow-card"
-          >
-            <button
-              type="button"
-              class="flex w-full items-center gap-2 px-2.5 py-2 text-left text-[12.5px] transition"
-              :class="!metaParentAgent ? 'bg-accent-dim text-txt' : 'text-txt2 hover:bg-overlay hover:text-txt'"
-              @click="setMetaParent('')"
-            >
-              {{ t('pages.agentStudio.org.parentNone') }}
-            </button>
-            <button
-              v-for="opt in metaParentOptions"
-              :key="opt"
-              type="button"
-              class="flex w-full items-center gap-2 px-2.5 py-2 text-left text-[12.5px] transition"
-              :class="metaParentAgent === opt ? 'bg-accent-dim text-txt' : 'text-txt2 hover:bg-overlay hover:text-txt'"
-              @click="setMetaParent(opt)"
-            >
-              <Icon name="robot" :size="13" class="shrink-0 text-accent-2" />
-              <span class="truncate">{{ opt }}</span>
-            </button>
-          </div>
-        </div>
       </div>
     </div>
 

--- a/web/src/components/agent/AgentOrgSidebar.test.ts
+++ b/web/src/components/agent/AgentOrgSidebar.test.ts
@@ -18,7 +18,7 @@ const sampleOrg: AgentOrg = {
   ],
   agents: {
     alice: { groupIds: ['g_dev'] },
-    bob: { groupIds: ['g_sub'], parentAgent: 'alice' },
+    bob: { groupIds: ['g_sub'] },
     // 10 members on g_qa → two-digit count
     ...Object.fromEntries(
       Array.from({ length: 10 }, (_, i) => [`qa${i}`, { groupIds: ['g_qa'] }]),
@@ -463,7 +463,7 @@ describe('AgentOrgSidebar agent name text color', () => {
     expect(unselectedName).not.toContain('text-txt3')
   })
 
-  it('分组名保持 text-txt2，有 parentAgent 时树内不渲染 reportsTo', () => {
+  it('分组名保持 text-txt2，树内不渲染 reportsTo', () => {
     const wrapper = mountSidebar(sampleOrg, false, { activeName: 'bob' })
 
     const group = wrapper

--- a/web/src/lib/agent/agentOrg.test.ts
+++ b/web/src/lib/agent/agentOrg.test.ts
@@ -16,7 +16,6 @@ import {
   shouldSyncDraftAfterAssign,
   unifiedProjectId,
   wouldCreateGroupCycle,
-  wouldCreateReportingCycle,
   setAgentMembership,
   UNGROUPED_ID,
 } from './agentOrg'
@@ -31,8 +30,8 @@ const sample: AgentOrg = {
     { id: 'des2', name: '设计组', parentGroupId: 'prod' },
   ],
   agents: {
-    alice: { groupIds: ['eng', 'des'], parentAgent: '' },
-    bob: { groupIds: ['des'], parentAgent: 'alice' },
+    alice: { groupIds: ['eng', 'des'] },
+    bob: { groupIds: ['des'] },
     carol: {},
   },
 }
@@ -48,11 +47,6 @@ describe('agentOrg helpers', () => {
     expect(wouldCreateGroupCycle(sample, 'des', 'prod')).toBe(false)
   })
 
-  it('detects reporting cycles', () => {
-    const o = setAgentMembership(sample, 'alice', ['eng'], 'bob')
-    expect(wouldCreateReportingCycle(o, 'alice', 'bob')).toBe(true)
-  })
-
   it('applies move semantics and ungrouped clear', () => {
     let o = applyMoveAgent(sample, 'alice', 'eng', 'prod')
     expect(o.agents.alice.groupIds?.sort()).toEqual(['des', 'prod'])
@@ -60,15 +54,11 @@ describe('agentOrg helpers', () => {
     expect(o.agents.alice).toBeUndefined()
   })
 
-  it('removes from one group only and preserves parentAgent', () => {
-    // MULTI: peel eng only → still in des
+  it('removes from one group only', () => {
     let o = applyRemoveAgentFromGroup(sample, 'alice', 'eng')
     expect(o.agents.alice.groupIds).toEqual(['des'])
-    // last group → Ungrouped, keep parentAgent
     o = applyRemoveAgentFromGroup(sample, 'bob', 'des')
-    expect(o.agents.bob.groupIds).toBeUndefined()
-    expect(o.agents.bob.parentAgent).toBe('alice')
-    // Ungrouped / empty source is a no-op
+    expect(o.agents.bob).toBeUndefined()
     expect(applyRemoveAgentFromGroup(sample, 'carol', '__ungrouped__')).toBe(sample)
   })
 
@@ -217,7 +207,7 @@ describe('recursive members + unique project label', () => {
     const pipe = rows.find((r) => r.kind === 'group' && r.id === 'pipe')
     const des = rows.find((r) => r.kind === 'group' && r.id === 'des')
     const empty = rows.find((r) => r.kind === 'group' && r.id === 'empty')
-    expect(root?.kind === 'group' && root.count).toBe(2) // pm + alice direct
+    expect(root?.kind === 'group' && root.count).toBe(2)
     expect(pipe?.kind === 'group' && pipe.count).toBe(2)
     expect(pipe?.kind === 'group' && pipe.projectLabel).toBe('GitHub')
     expect(des?.kind === 'group' && des.projectLabel).toBe('')

--- a/web/src/lib/agent/agentOrg.ts
+++ b/web/src/lib/agent/agentOrg.ts
@@ -22,10 +22,6 @@ export function groupIdsOf(org: AgentOrg, agentName: string): string[] {
   return [...(membershipOf(org, agentName).groupIds || [])]
 }
 
-export function parentOf(org: AgentOrg, agentName: string): string {
-  return membershipOf(org, agentName).parentAgent || ''
-}
-
 function groupById(org: AgentOrg): Map<string, OrgGroup> {
   const m = new Map<string, OrgGroup>()
   for (const g of org.groups || []) m.set(g.id, g)
@@ -80,8 +76,8 @@ function groupSubtreeIds(org: AgentOrg, rootId: string): Set<string> {
 }
 
 /** Agent names that belong to any group in the subtree. */
-function agentNamesInSubtree(org: AgentOrg, rootId: string, agentNames: string[]): string[] {
-  const gids = groupSubtreeIds(org, rootId)
+function agentNamesInSubtree(org: AgentOrg, rootGroupId: string, agentNames: string[]): string[] {
+  const gids = groupSubtreeIds(org, rootGroupId)
   return agentNames.filter((n) => groupIdsOf(org, n).some((id) => gids.has(id)))
 }
 
@@ -105,24 +101,6 @@ export function wouldCreateGroupCycle(org: AgentOrg, childId: string, newParentI
   return false
 }
 
-/** Would setting parentAgent create a reporting cycle? */
-export function wouldCreateReportingCycle(
-  org: AgentOrg,
-  agentName: string,
-  parentAgent: string,
-): boolean {
-  if (!parentAgent) return false
-  if (parentAgent === agentName) return true
-  let cur = parentAgent
-  const seen = new Set<string>([agentName])
-  while (cur) {
-    if (seen.has(cur)) return true
-    seen.add(cur)
-    cur = parentOf(org, cur)
-  }
-  return false
-}
-
 export function applyDeleteGroup(org: AgentOrg, groupId: string): AgentOrg {
   const deleted = (org.groups || []).find((g) => g.id === groupId)
   if (!deleted) return org
@@ -139,8 +117,7 @@ export function applyDeleteGroup(org: AgentOrg, groupId: string): AgentOrg {
     gids = [...new Set(gids)]
     const next: OrgAgentMembership = { ...m, groupIds: gids }
     if (!next.groupIds?.length) delete next.groupIds
-    if (!next.parentAgent) delete next.parentAgent
-    if (next.groupIds?.length || next.parentAgent) agents[name] = next
+    if (next.groupIds?.length) agents[name] = next
   }
   return { ...org, groups, agents }
 }
@@ -162,8 +139,7 @@ export function applyMoveAgent(
   }
   const next: OrgAgentMembership = { ...prev, groupIds: gids }
   if (!next.groupIds?.length) delete next.groupIds
-  if (!next.parentAgent) delete next.parentAgent
-  if (next.groupIds?.length || next.parentAgent) agents[agentName] = next
+  if (next.groupIds?.length) agents[agentName] = next
   else delete agents[agentName]
   return { ...org, agents }
 }
@@ -171,7 +147,7 @@ export function applyMoveAgent(
 /**
  * Remove an agent from a single virtual group only (sidebar「移出本组」).
  * Unlike applyMoveAgent(..., target=''), this does not clear all groups.
- * parentAgent is preserved; empty groupIds → Ungrouped.
+ * Empty groupIds → Ungrouped.
  */
 export function applyRemoveAgentFromGroup(
   org: AgentOrg,
@@ -184,24 +160,17 @@ export function applyRemoveAgentFromGroup(
   const gids = [...(prev.groupIds || [])].filter((id) => id !== sourceGroupId)
   const next: OrgAgentMembership = { ...prev, groupIds: gids }
   if (!next.groupIds?.length) delete next.groupIds
-  if (!next.parentAgent) delete next.parentAgent
-  if (next.groupIds?.length || next.parentAgent) agents[agentName] = next
+  if (next.groupIds?.length) agents[agentName] = next
   else delete agents[agentName]
   return { ...org, agents }
 }
 
-export function setAgentMembership(
-  org: AgentOrg,
-  agentName: string,
-  groupIds: string[],
-  parentAgent: string,
-): AgentOrg {
+export function setAgentMembership(org: AgentOrg, agentName: string, groupIds: string[]): AgentOrg {
   const agents = { ...(org.agents || {}) }
   const next: OrgAgentMembership = {}
   const gids = [...new Set(groupIds.filter(Boolean))]
   if (gids.length) next.groupIds = gids
-  if (parentAgent) next.parentAgent = parentAgent
-  if (next.groupIds?.length || next.parentAgent) agents[agentName] = next
+  if (next.groupIds?.length) agents[agentName] = next
   else delete agents[agentName]
   return { ...org, agents }
 }
@@ -209,7 +178,7 @@ export function setAgentMembership(
 export type AgentProjectRef = { name: string; projectId?: string }
 export type ProjectNameRef = { id: string; name: string }
 
-/** This group + all descendant group ids (BFS). Not reporting-line org_closure. */
+/** This group + all descendant group ids (BFS). */
 function descendantGroupIds(org: AgentOrg, groupId: string): string[] {
   const byParent = new Map<string, string[]>()
   for (const g of org.groups || []) {
@@ -339,7 +308,6 @@ export type OrgTreeRow =
       groupId: string
       depth: number
       multi: boolean
-      parentAgent: string
     }
   | {
       kind: 'ungrouped-header'
@@ -474,13 +442,11 @@ export function buildOrgTreeRows(
         groupId: g.id,
         depth: depth + 1,
         multi: gids.length >= 2,
-        parentAgent: parentOf(org, name),
       })
     }
   }
 
   for (const root of children.get('') || []) walkGroup(root, 0)
-  // Orphan groups whose parent is missing — treat as roots.
   for (const g of org.groups || []) {
     if (g.parentGroupId && !byId.has(g.parentGroupId)) walkGroup(g, 0)
   }
@@ -503,7 +469,6 @@ export function buildOrgTreeRows(
         groupId: UNGROUPED_ID,
         depth: 1,
         multi: false,
-        parentAgent: parentOf(org, name),
       })
     }
   }

--- a/web/src/lib/api/apiTypes.ts
+++ b/web/src/lib/api/apiTypes.ts
@@ -135,7 +135,6 @@ export interface OrgGroup {
 /** Per-agent organization membership (orthogonal to skill_profile identity). */
 export interface OrgAgentMembership {
   groupIds?: string[]
-  parentAgent?: string
 }
 
 /** Central organization index (GET/PUT /agents/org). */

--- a/web/src/locales/en/mcp.json
+++ b/web/src/locales/en/mcp.json
@@ -336,12 +336,12 @@
     "pmAgentFs": {
       "name": "pm-agent-fs",
       "desc": "Project Management only · read org and edit report Agent workspaces",
-      "overview": "Read the reporting tree (self/direct/indirect/other) and list/read/write/delete/mkdir/rename host-side workspace/ for self and reporting-closure agents. Does not touch Run sandboxes or agent.json metadata.",
+      "overview": "Read virtual groups and flat same-project member view (self/direct/other); list/read/write/delete/mkdir/rename host-side workspace/ for any same-project agent. Does not touch Run sandboxes or agent.json metadata.",
       "convention": "Enable under Project → Project Management settings (on by default for new projects; older projects with an explicit EnabledMcps list must opt in). Changes appear in Agent Studio「Agent workspace」after refresh/reopen (not live hot-reload). Warning: if Studio has an unsaved dirty draft for the same Agent, a later Save may overwrite MCP writes — refresh and avoid concurrent dirty edits.",
       "tools": {
         "pm_get_org": {
           "signature": "pm_get_org()",
-          "desc": "Read org and reporting relations"
+          "desc": "Read org and same-project members"
         },
         "pm_list_agent_templates": {
           "signature": "pm_list_agent_templates()",
@@ -352,8 +352,8 @@
           "desc": "Create an engineer Agent from a template (same project; no overwrite)"
         },
         "pm_set_org_membership": {
-          "signature": "pm_set_org_membership(agentName, groupIds, parentAgent?)",
-          "desc": "Set group membership and reporting parent (parent must be current PM)"
+          "signature": "pm_set_org_membership(agentName, groupIds)",
+          "desc": "Set virtual group membership (groupIds must be in allow-list)"
         },
         "pm_ensure_child_group": {
           "signature": "pm_ensure_child_group(name, parentGroupId?)",

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -1575,7 +1575,7 @@
       "errorPrefix": "Error:",
       "empty": "No agents yet. Use \"Create Agent team\" for a full roster, or \"New Agent\" for a single one.",
       "emptyTeamTitle": "Launch a full team from one entry",
-      "emptyTeamDesc": "After you fill project background and runtime config, a sandbox creates the project, root group, PM, and 9 engineers with reporting lines.",
+      "emptyTeamDesc": "After you fill project background and runtime config, a sandbox creates the project, root group, PM, and 9 engineers with virtual groups.",
       "emptyTeamCta": "Create Agent team",
       "emptyTeamOrSingle": "or create a single Agent",
       "createTeam": "Create Agent team",
@@ -1652,7 +1652,7 @@
         "renameBlockedHint": "Open Manage → Agent management, then use Rename on the list row.",
         "noSelection": "No agent selected. Pick one from the tree, or open Agent management.",
         "metaTitle": "Organization",
-        "metaIntro": "Configure this agent's virtual group and reporting line. Studio display only; does not change skill_profile runtime. Unrelated to the project's Project Management consult channel.",
+        "metaIntro": "Configure this agent's virtual group memberships. Studio display only; does not change skill_profile runtime. Unrelated to the project's Project Management consult channel.",
         "metaRenameHint": "Rename this agent in Agent management. The identity name is not editable here.",
         "groupsLabel": "Virtual groups",
         "groupsMeta": "Multi-select",
@@ -2083,7 +2083,7 @@
           "pmName": "PM Agent name",
           "background": "Project background",
           "backgroundPlaceholder": "Goals, stack, repos, pipeline needs… Used as the sandbox team-build prompt.",
-          "backgroundHint": "Like a prompt: injected into the sandbox to generate groups, reporting lines, and engineers."
+          "backgroundHint": "Like a prompt: injected into the sandbox to generate groups and engineers."
         },
         "acp": {
           "meta": "Used as the default ACP for the PM and engineers."

--- a/web/src/locales/zh-CN/mcp.json
+++ b/web/src/locales/zh-CN/mcp.json
@@ -336,12 +336,12 @@
     "pmAgentFs": {
       "name": "pm-agent-fs",
       "desc": "项目管理专用 · 读组织架构与编辑下属 Agent 工作目录",
-      "overview": "读取 _org.json 汇报树（self/direct/indirect/other），并对自身与汇报闭包内 Agent 的 host 侧 workspace/ 做 list/read/write/delete/mkdir/rename。不触及 Run 沙箱，不改 agent.json 元配置。",
+      "overview": "读取 _org.json 虚拟组与同项目成员扁平视图（self/direct/other），并对同项目任意 Agent 的 host 侧 workspace/ 做 list/read/write/delete/mkdir/rename。不触及 Run 沙箱，不改 agent.json 元配置。",
       "convention": "项目详情 → 项目管理设置中启用 pm-agent-fs（新项目默认启用；旧项目若已显式保存 EnabledMcps 需手动勾选）。变更在 Agent Studio「Agent 工作目录」刷新或重开后可见（非热更新）。注意：若 Studio 打开同一 Agent 且存在未保存草稿，随后 Save 可能覆盖 MCP 已写入内容——Demo/使用时请刷新并避免并行脏写。",
       "tools": {
         "pm_get_org": {
           "signature": "pm_get_org()",
-          "desc": "读组织架构与下属关系"
+          "desc": "读组织架构与同项目成员"
         },
         "pm_list_agent_templates": {
           "signature": "pm_list_agent_templates()",
@@ -352,8 +352,8 @@
           "desc": "从模板创建工程师 Agent（同项目，禁止覆盖重名）"
         },
         "pm_set_org_membership": {
-          "signature": "pm_set_org_membership(agentName, groupIds, parentAgent?)",
-          "desc": "设置组成员与汇报上级（parent 须为当前 PM）"
+          "signature": "pm_set_org_membership(agentName, groupIds)",
+          "desc": "设置虚拟组成员（groupIds 须在授权范围内）"
         },
         "pm_ensure_child_group": {
           "signature": "pm_ensure_child_group(name, parentGroupId?)",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -1575,7 +1575,7 @@
       "errorPrefix": "出错:",
       "empty": "暂无 Agent。可「创建 Agent 团队」一键拉起项目与流水线角色，或「新建 Agent」创建单个。",
       "emptyTeamTitle": "用一个入口拉起整支团队",
-      "emptyTeamDesc": "填写项目背景与运行配置后自动起沙箱：创建项目、根组、项目经理与 9 名工程师，并挂好上下级。",
+      "emptyTeamDesc": "填写项目背景与运行配置后自动起沙箱：创建项目、根组、项目经理与 9 名工程师，并挂好虚拟组。",
       "emptyTeamCta": "创建 Agent 团队",
       "emptyTeamOrSingle": "或新建单个 Agent",
       "createTeam": "创建 Agent 团队",
@@ -1652,7 +1652,7 @@
         "renameBlockedHint": "请打开「管理」→ Agent 管理，在列表中使用 Rename。",
         "noSelection": "未选中 Agent。从左侧树选择，或打开 Agent 管理。",
         "metaTitle": "组织关系",
-        "metaIntro": "配置本 Agent 的虚拟组归属与汇报上级。仅用于 Studio 展示与管理，不改变 skill_profile 运行时行为。与项目的项目管理咨询通道无关。",
+        "metaIntro": "配置本 Agent 的虚拟组归属。仅用于 Studio 展示与管理，不改变 skill_profile 运行时行为。与项目的项目管理咨询通道无关。",
         "metaRenameHint": "名称请在 Agent 管理中重命名。此处不可编辑身份名称。",
         "groupsLabel": "所属虚拟组",
         "groupsMeta": "可多选",
@@ -2083,7 +2083,7 @@
           "pmName": "PM Agent 名称",
           "background": "项目背景",
           "backgroundPlaceholder": "描述项目目标、技术栈、仓库形态、流水线诉求等。将作为沙箱建团 Prompt。",
-          "backgroundHint": "类似 Prompt：确认后注入沙箱，据此生成根组、上下级与工程师团队。"
+          "backgroundHint": "类似 Prompt：确认后注入沙箱，据此生成根组与工程师团队。"
         },
         "acp": {
           "meta": "该配置用于 PM 及后续工程师的默认 ACP。"


### PR DESCRIPTION
Strip legacy parentAgent from _org.json on load; hard-delete reporting
closure auth and UI; pm_get_org returns flat same-project members; MCP
pm_set_org_membership only sets groupIds.

Co-authored-by: Cursor <cursoragent@cursor.com>
