### PR TITLE
fix: fill requirement drafts panel to available viewport height

### DIFF
--- a/web/src/components/project/RequirementDraftsPanel.vue
+++ b/web/src/components/project/RequirementDraftsPanel.vue
@@ -146,11 +146,11 @@ defineExpose({
 
 <template>
   <div
-    class="requirement-drafts flex min-h-[520px] flex-col border border-line bg-base"
+    class="requirement-drafts flex h-full min-h-0 min-w-0 flex-1 flex-col border border-line bg-base"
     data-testid="requirement-drafts-panel"
   >
     <!-- Top toolbar -->
-    <div class="flex flex-wrap items-center gap-2 border-b border-line p-3">
+    <div class="flex shrink-0 flex-wrap items-center gap-2 border-b border-line p-3">
       <div class="seg" data-testid="requirement-drafts-view-segment">
         <button
           type="button"
@@ -228,9 +228,9 @@ defineExpose({
     <!-- Edit view -->
     <div
       v-if="viewMode === 'edit'"
-      class="draft-layout grid min-h-[480px] flex-1 grid-cols-1 md:grid-cols-[280px_1fr]"
+      class="draft-layout grid min-h-0 flex-1 grid-cols-1 md:grid-cols-[280px_1fr]"
     >
-      <aside class="flex min-h-[480px] flex-col border-b border-line md:border-b-0 md:border-r">
+      <aside class="flex min-h-0 flex-col border-b border-line md:border-b-0 md:border-r">
         <div
           class="min-h-0 flex-1 space-y-1.5 overflow-auto p-2"
           data-testid="requirement-drafts-list"
@@ -287,7 +287,7 @@ defineExpose({
       </aside>
 
       <div
-        class="flex min-h-[480px] min-w-0 flex-col"
+        class="flex min-h-0 min-w-0 flex-col"
         data-testid="requirement-drafts-detail"
         @keydown="onDetailKeydown"
       >
@@ -754,7 +754,7 @@ defineExpose({
     <!-- Gantt view -->
     <div
       v-else-if="viewMode === 'gantt'"
-      class="flex min-h-[480px] flex-1 flex-col lg:flex-row"
+      class="flex min-h-0 flex-1 flex-col lg:flex-row"
     >
       <div
         class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
@@ -912,16 +912,16 @@ defineExpose({
 
       <!-- Inspector -->
       <aside
-        class="flex w-full shrink-0 flex-col border-t border-line bg-surface lg:w-[300px] lg:border-l lg:border-t-0"
+        class="flex min-h-0 w-full shrink-0 flex-col border-t border-line bg-surface lg:w-[300px] lg:border-l lg:border-t-0"
         data-testid="requirement-drafts-inspector"
       >
         <div class="border-b border-line px-3 py-2.5 text-[13px] font-medium text-txt">
           {{ t('pages.projectDetail.requirementDrafts.inspectorTitle') }}
         </div>
-        <div v-if="!hasSelection" class="flex-1 px-3 py-6 text-[13px] text-txt3">
+        <div v-if="!hasSelection" class="min-h-0 flex-1 overflow-auto px-3 py-6 text-[13px] text-txt3">
           {{ t('pages.projectDetail.requirementDrafts.inspectorEmpty') }}
         </div>
-        <div v-else class="flex flex-1 flex-col gap-3 overflow-auto p-3">
+        <div v-else class="flex min-h-0 flex-1 flex-col gap-3 overflow-auto p-3">
           <div class="text-[13px] font-medium text-txt">{{ selectedDraft?.title }}</div>
           <div class="grid gap-3">
             <label class="block text-xs text-txt2">
@@ -1010,7 +1010,7 @@ defineExpose({
     </div>
 
     <!-- Milestones view -->
-    <div v-else class="min-h-[480px] flex-1 overflow-auto p-4">
+    <div v-else class="min-h-0 flex-1 overflow-auto p-4">
       <div v-if="loading && !items.length" class="px-5 py-8 text-center text-[13px] text-txt3">
         {{ t('common.loading.label') }}
       </div>

--- a/web/src/views/ProjectDetailView.vue
+++ b/web/src/views/ProjectDetailView.vue
@@ -357,10 +357,10 @@ const {
 
       <div
         v-else-if="tab === 'requirementDrafts'"
-        class="scroll-area min-h-0 flex-1 overflow-y-auto"
+        class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
         data-testid="project-requirement-drafts-panel"
       >
-        <RequirementDraftsPanel ref="draftsPanelRef" :project-id="projectId" />
+        <RequirementDraftsPanel ref="draftsPanelRef" :project-id="projectId" class="min-h-0 flex-1" />
       </div>
 
       <div

--- a/web/src/views/mobileScrollContract.test.ts
+++ b/web/src/views/mobileScrollContract.test.ts
@@ -98,11 +98,18 @@ describe('mobile scroll contract — list B ProjectDetail tabs (plan g2.1 / g3.1
     expect(block).toMatch(/data-testid="project-board-panel"/)
   })
 
-  it('requirementDrafts tab: overflow-y-auto scroll exit', () => {
+  it('requirementDrafts tab: flex-1 min-h-0 host for panel fill-height (like board)', () => {
     const block = tabBlock("tab === 'requirementDrafts'", ["tab === 'pmLeader'"])
-    expect(block).toMatch(SCROLL_EXIT)
-    expect(block).toMatch(/min-h-0 flex-1/)
+    expect(block).toMatch(/flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden/)
     expect(block).toMatch(/data-testid="project-requirement-drafts-panel"/)
+    expect(block).toMatch(/RequirementDraftsPanel[\s\S]*?class="min-h-0 flex-1"/)
+    const panelSrc = readFileSync(
+      join(dir, '../components/project/RequirementDraftsPanel.vue'),
+      'utf8',
+    )
+    expect(panelSrc).toMatch(/data-testid="requirement-drafts-panel"/)
+    expect(panelSrc).toMatch(/flex h-full min-h-0 min-w-0 flex-1 flex-col/)
+    expect(panelSrc).toMatch(/overflow-(auto|y-auto)/)
   })
 
   it('cronJobs / notify tabs: drop 420 floor; use overflow-y-auto', () => {


### PR DESCRIPTION
Align the requirement drafts tab host with the board tab pattern
(overflow-hidden flex fill) and extend the height chain through
RequirementDraftsPanel sub-views so the gantt/inspector area no longer
stops at a fixed min-height with empty space below.

Co-authored-by: Cursor <cursoragent@cursor.com>
