### PR TITLE
feat: ACP 时间线平台快照与进页续流

### DIFF
--- a/server/internal/runtime/acp_provider.go
+++ b/server/internal/runtime/acp_provider.go
@@ -103,6 +103,9 @@ type acpProvider struct {
 	// in sessions). AbortRun closes these so Cancel-during-agent unblocks
 	// streamChat instead of waiting out ChatTimeout.
 	inflightACP map[string]*sandbox.ACPClient
+	// timeline holds platform-side ACP event snapshots while a node sandbox is
+	// live. nodeEvents reads this first; cold FetchEventLog is fallback only.
+	timeline *acpTimelineStore
 }
 
 // streamChat runs one turn (prompt + optional image attachments), streaming
@@ -118,7 +121,11 @@ func (c *acpProvider) streamChat(ctx context.Context, acp *sandbox.ACPClient, re
 		if r.BusySet {
 			busy = r.Busy
 		}
-		c.emit(req.RunID, req.NodeID, chatResultToEvents(r), busy)
+		events := chatResultToEvents(r)
+		if c.timeline != nil {
+			c.timeline.upsert(req.RunID, req.NodeID, events)
+		}
+		c.emit(req.RunID, req.NodeID, events, busy)
 	})
 }
 
@@ -165,7 +172,7 @@ func newBaseACPProvider(host *mcp.Host, opts Options, backend AcpBackend) ExecPr
 		Str("bridge", AgentRuntimeLabel(backend)).Msg("sandbox exec provider ready")
 	return &acpProvider{host: host, opts: opts, mgr: mgr, backend: backend,
 		sessions: map[string]*reactSession{}, live: map[string]*sandbox.Sandbox{},
-		inflightACP: map[string]*sandbox.ACPClient{}}
+		inflightACP: map[string]*sandbox.ACPClient{}, timeline: newAcpTimelineStore()}
 }
 
 // resolveProviderImage picks the sandbox image for one acpBackend.

--- a/server/internal/runtime/acp_react.go
+++ b/server/internal/runtime/acp_react.go
@@ -491,7 +491,14 @@ func (c *acpProvider) parkReactSession(req NodeReq, sb *sandbox.Sandbox, acp *sa
 	c.mu.Lock()
 	c.sessions[key] = sess
 	c.live[key] = sb
+	host, port := "", 0
+	if sb != nil {
+		host, port = sb.Host, sb.Port
+	}
 	c.mu.Unlock()
+	if c.timeline != nil && sb != nil {
+		c.timeline.startIngest(req.RunID, req.NodeID, host, port)
+	}
 	return sess
 }
 

--- a/server/internal/runtime/acp_run_agent.go
+++ b/server/internal/runtime/acp_run_agent.go
@@ -550,6 +550,13 @@ func (c *acpProvider) AbortRun(runID string) {
 	for _, k := range agentKeys {
 		delete(c.inflightACP, k)
 		delete(c.live, k)
+		if c.timeline != nil {
+			nodeID := k
+			if i := strings.IndexByte(k, '|'); i >= 0 {
+				nodeID = k[i+1:]
+			}
+			c.timeline.stop(runID, nodeID)
+		}
 	}
 	c.mu.Unlock()
 	for _, k := range sessionKeys {
@@ -579,7 +586,14 @@ func (c *acpProvider) closeSession(key string) {
 	sess := c.sessions[key]
 	delete(c.sessions, key)
 	delete(c.live, key)
+	runID, nodeID := "", ""
+	if i := strings.IndexByte(key, '|'); i >= 0 {
+		runID, nodeID = key[:i], key[i+1:]
+	}
 	c.mu.Unlock()
+	if c.timeline != nil && runID != "" && nodeID != "" {
+		c.timeline.stop(runID, nodeID)
+	}
 	if sess != nil {
 
 		c.retireRunSandbox(sess.sb, sess.acp, sess.home)

--- a/server/internal/runtime/acp_sandbox.go
+++ b/server/internal/runtime/acp_sandbox.go
@@ -23,7 +23,14 @@ func (c *acpProvider) registerLive(req NodeReq, sb *sandbox.Sandbox, acp *sandbo
 	if acp != nil {
 		c.inflightACP[key] = acp
 	}
+	host, port := "", 0
+	if sb != nil {
+		host, port = sb.Host, sb.Port
+	}
 	c.mu.Unlock()
+	if c.timeline != nil && sb != nil {
+		c.timeline.startIngest(req.RunID, req.NodeID, host, port)
+	}
 }
 
 func (c *acpProvider) deregisterLive(req NodeReq) {
@@ -32,6 +39,9 @@ func (c *acpProvider) deregisterLive(req NodeReq) {
 	delete(c.live, key)
 	delete(c.inflightACP, key)
 	c.mu.Unlock()
+	if c.timeline != nil {
+		c.timeline.stop(req.RunID, req.NodeID)
+	}
 }
 
 // LiveNodeEvents reads the in-flight sandbox's full event log directly and
@@ -41,6 +51,11 @@ func (c *acpProvider) deregisterLive(req NodeReq) {
 // registered but the bridge read fails, ok=false with a non-nil err so
 // callers can surface a distinguishable failure (never pretend live+empty).
 func (c *acpProvider) LiveNodeEvents(ctx context.Context, runID, nodeID string) ([]models.AcpEvent, bool, error) {
+	if c.timeline != nil {
+		if e, ok := c.timeline.get(runID, nodeID); ok {
+			return append([]models.AcpEvent(nil), e.events...), e.live, nil
+		}
+	}
 	c.mu.Lock()
 	sb := c.live[runID+"|"+nodeID]
 	c.mu.Unlock()
@@ -54,13 +69,22 @@ func (c *acpProvider) LiveNodeEvents(ctx context.Context, runID, nodeID string) 
 	if res == nil {
 		return nil, false, fmt.Errorf("event log unavailable")
 	}
-	return res.AcpEvents(), true, nil
+	events := res.AcpEvents()
+	if c.timeline != nil {
+		c.timeline.upsert(runID, nodeID, events)
+	}
+	return events, true, nil
 }
 
 // LiveNodeEventsPage reads a page of events from the in-flight sandbox.
 // Fetch failures return ok=false with a non-nil err (aligned with
 // LiveNodeEvents) — never live=true with an empty page that masks the error.
 func (c *acpProvider) LiveNodeEventsPage(ctx context.Context, runID, nodeID, cursor string, limit int) ([]models.AcpEvent, string, bool, bool, error) {
+	if c.timeline != nil {
+		if ev, next, more, live, ok := c.timeline.page(runID, nodeID, cursor, limit); ok {
+			return ev, next, more, live, nil
+		}
+	}
 	c.mu.Lock()
 	sb := c.live[runID+"|"+nodeID]
 	c.mu.Unlock()
@@ -74,7 +98,11 @@ func (c *acpProvider) LiveNodeEventsPage(ctx context.Context, runID, nodeID, cur
 	if page == nil {
 		return nil, "", false, false, fmt.Errorf("event log page unavailable")
 	}
-	return sandbox.AggregateFrames(page.Events), page.NextCursor, page.HasMore, true, nil
+	events := sandbox.AggregateFrames(page.Events)
+	if c.timeline != nil {
+		c.timeline.upsert(runID, nodeID, events)
+	}
+	return events, page.NextCursor, page.HasMore, true, nil
 }
 
 // snapshotEvents captures the full agent event log straight from the sandbox so

--- a/server/internal/runtime/acp_timeline.go
+++ b/server/internal/runtime/acp_timeline.go
@@ -1,0 +1,204 @@
+package runtime
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+	"github.com/cocofhu/approving/internal/sandbox"
+)
+
+// acpTimelineEntry is the platform-side in-memory ACP timeline snapshot for one
+// run+node while the sandbox session is live. It is the authoritative read path
+// for nodeEvents during execution; cold FetchEventLog is a supplement only.
+type acpTimelineEntry struct {
+	events    []models.AcpEvent
+	live      bool
+	ready     bool // at least one successful ingest or emit write
+	updatedAt time.Time
+}
+
+type acpTimelineStore struct {
+	mu      sync.Mutex
+	entries map[string]*acpTimelineEntry
+	ingest  map[string]context.CancelFunc
+}
+
+func newAcpTimelineStore() *acpTimelineStore {
+	return &acpTimelineStore{
+		entries: map[string]*acpTimelineEntry{},
+		ingest:  map[string]context.CancelFunc{},
+	}
+}
+
+func timelineKey(runID, nodeID string) string { return runID + "|" + nodeID }
+
+func (s *acpTimelineStore) begin(runID, nodeID string) {
+	key := timelineKey(runID, nodeID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.entries[key]
+	if !ok {
+		e = &acpTimelineEntry{live: true}
+		s.entries[key] = e
+	} else {
+		e.live = true
+	}
+	e.updatedAt = time.Now()
+}
+
+func (s *acpTimelineStore) upsert(runID, nodeID string, events []models.AcpEvent) {
+	if s == nil {
+		return
+	}
+	key := timelineKey(runID, nodeID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.entries[key]
+	if !ok {
+		e = &acpTimelineEntry{live: true}
+		s.entries[key] = e
+	}
+	e.ready = true
+	e.events = pickLongerEvents(e.events, events)
+	e.updatedAt = time.Now()
+}
+
+func pickLongerEvents(prev, incoming []models.AcpEvent) []models.AcpEvent {
+	if len(incoming) > len(prev) {
+		return append([]models.AcpEvent(nil), incoming...)
+	}
+	if len(incoming) == len(prev) && len(incoming) > 0 {
+		if lastT(incoming) >= lastT(prev) {
+			return append([]models.AcpEvent(nil), incoming...)
+		}
+	}
+	if len(prev) == 0 && len(incoming) == 0 {
+		return nil
+	}
+	return prev
+}
+
+func lastT(events []models.AcpEvent) int {
+	if len(events) == 0 {
+		return 0
+	}
+	return events[len(events)-1].T
+}
+
+func (s *acpTimelineStore) stop(runID, nodeID string) {
+	if s == nil {
+		return
+	}
+	key := timelineKey(runID, nodeID)
+	s.mu.Lock()
+	if cancel, ok := s.ingest[key]; ok {
+		cancel()
+		delete(s.ingest, key)
+	}
+	if e, ok := s.entries[key]; ok {
+		e.live = false
+		e.updatedAt = time.Now()
+	}
+	s.mu.Unlock()
+}
+
+func (s *acpTimelineStore) startIngest(runID, nodeID, host string, port int) {
+	if s == nil || host == "" || port <= 0 {
+		return
+	}
+	key := timelineKey(runID, nodeID)
+	s.begin(runID, nodeID)
+
+	s.mu.Lock()
+	if cancel, ok := s.ingest[key]; ok {
+		cancel()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s.ingest[key] = cancel
+	s.mu.Unlock()
+
+	go s.ingestLoop(ctx, runID, nodeID, host, port)
+}
+
+func (s *acpTimelineStore) ingestLoop(ctx context.Context, runID, nodeID, host string, port int) {
+	// Immediate first pull so cold page loads see history without waiting.
+	s.refreshFromSandbox(ctx, runID, nodeID, host, port)
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.refreshFromSandbox(ctx, runID, nodeID, host, port)
+		}
+	}
+}
+
+func (s *acpTimelineStore) refreshFromSandbox(ctx context.Context, runID, nodeID, host string, port int) {
+	res, _, err := sandbox.FetchEventLog(ctx, host, port)
+	if err != nil || res == nil {
+		return // keep existing snapshot on transient bridge failures
+	}
+	s.upsert(runID, nodeID, res.AcpEvents())
+}
+
+func (s *acpTimelineStore) get(runID, nodeID string) (acpTimelineEntry, bool) {
+	if s == nil {
+		return acpTimelineEntry{}, false
+	}
+	key := timelineKey(runID, nodeID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.entries[key]
+	if !ok || !e.ready {
+		return acpTimelineEntry{}, false
+	}
+	return *e, true
+}
+
+func (s *acpTimelineStore) page(runID, nodeID, cursor string, limit int) ([]models.AcpEvent, string, bool, bool, bool) {
+	e, ok := s.get(runID, nodeID)
+	if !ok {
+		return nil, "", false, false, false
+	}
+	ev, next, more := pageTimelineEvents(e.events, cursor, limit)
+	return ev, next, more, e.live, true
+}
+
+// pageTimelineEvents slices a chronological event array for cursor/limit
+// pagination. The first page returns the most recent limit items.
+func pageTimelineEvents(events []models.AcpEvent, cursor string, limit int) ([]models.AcpEvent, string, bool) {
+	total := len(events)
+	if total == 0 {
+		return nil, "", false
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	if cursor == "" {
+		start := total - limit
+		if start < 0 {
+			start = 0
+		}
+		page := events[start:]
+		return page, strconv.Itoa(start), start > 0
+	}
+	end, err := strconv.Atoi(cursor)
+	if err != nil || end <= 0 {
+		return nil, "", false
+	}
+	if end > total {
+		end = total
+	}
+	start := end - limit
+	if start < 0 {
+		start = 0
+	}
+	page := events[start:end]
+	return page, strconv.Itoa(start), start > 0
+}

--- a/server/internal/runtime/acp_timeline_test.go
+++ b/server/internal/runtime/acp_timeline_test.go
@@ -1,0 +1,75 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+)
+
+func TestAcpTimelineStoreUpsertAndPage(t *testing.T) {
+	s := newAcpTimelineStore()
+	s.upsert("r1", "n1", []models.AcpEvent{{T: 1, Kind: "message", Text: "a"}})
+	ev, next, more, live, ok := s.page("r1", "n1", "", 20)
+	if !ok || !live || more || len(ev) != 1 || next != "0" {
+		t.Fatalf("first page = ok=%v live=%v more=%v ev=%+v next=%q", ok, live, more, ev, next)
+	}
+
+	events := make([]models.AcpEvent, 25)
+	for i := range events {
+		events[i] = models.AcpEvent{T: i, Kind: "message", Text: "e"}
+	}
+	s.upsert("r1", "n1", events)
+	ev, next, more, _, ok = s.page("r1", "n1", "", 20)
+	if !ok || len(ev) != 20 || !more || next != "5" {
+		t.Fatalf("paged want 20 hasMore, got len=%d more=%v next=%q", len(ev), more, next)
+	}
+	ev2, _, more2, _, _ := s.page("r1", "n1", next, 20)
+	if len(ev2) != 5 || more2 {
+		t.Fatalf("older page want 5 no more, got len=%d more=%v", len(ev2), more2)
+	}
+}
+
+func TestAcpTimelineStoreStopMarksNotLive(t *testing.T) {
+	s := newAcpTimelineStore()
+	s.begin("r", "n")
+	s.upsert("r", "n", []models.AcpEvent{{T: 1, Kind: "message", Text: "x"}})
+	s.stop("r", "n")
+	e, ok := s.get("r", "n")
+	if !ok || e.live {
+		t.Fatalf("after stop want ready snapshot live=false, got ok=%v live=%v", ok, e.live)
+	}
+}
+
+func TestAcpTimelineIngestKeepsSnapshotOnRefreshFailure(t *testing.T) {
+	s := newAcpTimelineStore()
+	s.upsert("r", "n", []models.AcpEvent{{T: 1, Kind: "message", Text: "keep"}})
+	// Unreachable host — must not clear the prior snapshot.
+	s.refreshFromSandbox(context.Background(), "r", "n", "127.0.0.1", 1)
+	e, ok := s.get("r", "n")
+	if !ok || len(e.events) != 1 || e.events[0].Text != "keep" {
+		t.Fatalf("snapshot should survive refresh failure: %+v ok=%v", e.events, ok)
+	}
+}
+
+func TestPickLongerEvents(t *testing.T) {
+	prev := []models.AcpEvent{{T: 1, Kind: "message", Text: "a"}}
+	in := []models.AcpEvent{{T: 1, Kind: "message", Text: "a"}, {T: 2, Kind: "thought", Text: "b"}}
+	got := pickLongerEvents(prev, in)
+	if len(got) != 2 {
+		t.Fatalf("want longer incoming, got %d", len(got))
+	}
+	if len(pickLongerEvents(in, prev)) != 2 {
+		t.Fatal("shorter incoming must not shrink snapshot")
+	}
+}
+
+func TestAcpTimelineIngestLoopCancels(t *testing.T) {
+	s := newAcpTimelineStore()
+	s.startIngest("r", "n", "127.0.0.1", 1)
+	time.Sleep(10 * time.Millisecond)
+	s.stop("r", "n")
+	// stop is idempotent
+	s.stop("r", "n")
+}

--- a/server/internal/runtime/acp_unit_test.go
+++ b/server/internal/runtime/acp_unit_test.go
@@ -603,6 +603,22 @@ func TestLiveNodeEventsPageSuccessPath(t *testing.T) {
 	}
 }
 
+// TestLiveNodeEventsPageSnapshotFirst confirms platform timeline snapshots are
+// returned even when the live bridge is unreachable (cold dial is fallback).
+func TestLiveNodeEventsPageSnapshotFirst(t *testing.T) {
+	p := newACPProvider(mcp.NewHost(newMemStore()), Options{}).(*acpProvider)
+	p.registerLive(NodeReq{RunID: "run1", NodeID: "node1"}, &sandbox.Sandbox{Host: "127.0.0.1", Port: 1}, nil)
+	p.timeline.upsert("run1", "node1", []models.AcpEvent{{T: 1, Kind: "message", Text: "from-snapshot"}})
+
+	ev, _, more, ok, err := p.LiveNodeEventsPage(context.Background(), "run1", "node1", "", 20)
+	if err != nil || !ok {
+		t.Fatalf("snapshot page want ok err=nil, got ok=%v err=%v", ok, err)
+	}
+	if more || len(ev) != 1 || ev[0].Text != "from-snapshot" {
+		t.Fatalf("unexpected snapshot page: more=%v ev=%+v", more, ev)
+	}
+}
+
 // profilesRoot writes a minimal agent.json so agentConfig/resolvedMCPSpecs/etc.
 // have something to read.
 func writeAgent(t *testing.T, profile, agentJSON string) string {

--- a/web/src/lib/run/useRunDetailLiveLog.test.ts
+++ b/web/src/lib/run/useRunDetailLiveLog.test.ts
@@ -285,4 +285,68 @@ describe('useRunDetailLiveLog', () => {
 
     app.unmount()
   })
+
+  it('unavailable with events still rehydrates as ready (snapshot soft-degrade)', async () => {
+    vi.mocked(api.nodeEvents).mockResolvedValueOnce({
+      events: [{ kind: 'message', text: 'cached', t: 1 }],
+      live: true,
+      unavailable: true,
+      error: 'live event log read failed',
+    })
+
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0)
+      return 1
+    })
+
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: '/', component: { template: '<div />' } }],
+    })
+    await router.push('/')
+    await router.isReady()
+
+    const run = ref({
+      id: 'run-1',
+      status: 'running',
+      nodeRuns: { a1: { nodeId: 'a1', status: 'running', events: [], mcpCalls: [] } },
+      artifacts: [],
+    } as unknown as Run)
+    const selected = ref<string | null>('a1')
+
+    let live!: ReturnType<typeof useRunDetailLiveLog>
+    const app = createApp({
+      setup() {
+        live = useRunDetailLiveLog({
+          runId: computed(() => 'run-1'),
+          run,
+          selected,
+          selExecIdx: computed(() => 0),
+          selIterIdx: ref(null),
+          selRun: computed(() => run.value.nodeRuns.a1 || null),
+          selStatus: computed(() => 'running'),
+          viewingLatest: computed(() => true),
+          nodeTab: ref('log'),
+          hasLog: computed(() => true),
+        })
+        return () => null
+      },
+    })
+    app.use(i18n)
+    app.use(router)
+    app.mount(document.createElement('div'))
+
+    await live.rehydrateNodeEvents('a1')
+    expect(live.logEvents.value.map((e) => ({ kind: e.kind, text: e.text, t: e.t }))).toEqual([
+      { kind: 'message', text: 'cached', t: 1 },
+    ])
+    expect(live.selRehydrateStatus.value).toBe('ready')
+
+    app.unmount()
+  })
 })

--- a/web/src/lib/run/useRunDetailLiveLog.ts
+++ b/web/src/lib/run/useRunDetailLiveLog.ts
@@ -120,7 +120,7 @@ export function useRunDetailLiveLog(opts: {
       })
       if (opts?.signal?.aborted) return false
       if (eventFetchGen[nodeId] !== gen) return false
-      if (isNodeEventsUnavailable(r)) return false
+      if (isNodeEventsUnavailable(r) && !(r.events?.length)) return false
       const prev = eventPages[nodeId]?.events || []
       const merged = mergeAcpEvents(prev, r.events || [], { live: !!r.live })
       if ('hasMore' in r) {


### PR DESCRIPTION
节点运行期间由服务端协程持续拉取 sandbox 事件并写入内存快照，nodeEvents 优先返回该快照；前端在有快照内容时不再因冷拨失败进入整页恢复错误。

Co-authored-by: Cursor <cursoragent@cursor.com>
