### PR TITLE
fix: use copyToClipboard in external MCP panel

### DIFF
--- a/web/src/components/project/ProjectExternalMcpPanel.test.ts
+++ b/web/src/components/project/ProjectExternalMcpPanel.test.ts
@@ -1,4 +1,7 @@
 // @vitest-environment happy-dom
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
@@ -14,12 +17,22 @@ const apiMocks = vi.hoisted(() => ({
   revokeProjectMcpKey: vi.fn(),
 }))
 
+const mocks = vi.hoisted(() => ({
+  copyToClipboard: vi.fn(async (_text: string) => true),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}))
+
 vi.mock('@/lib/api/api', () => ({
   api: apiMocks,
 }))
 
+vi.mock('@/lib/shared/copyToClipboard', () => ({
+  copyToClipboard: (text: string) => mocks.copyToClipboard(text),
+}))
+
 vi.mock('@/lib/composables/useToast', () => ({
-  useToast: () => ({ success: vi.fn(), error: vi.fn() }),
+  useToast: () => ({ success: mocks.toastSuccess, error: mocks.toastError }),
 }))
 
 function mountPanel() {
@@ -31,13 +44,15 @@ function mountPanel() {
   return mount(ProjectExternalMcpPanel, {
     props: { projectId: 'proj-1' },
     attachTo: document.body,
-    global: { plugins: [i18n] },
+    global: { plugins: [i18n], stubs: { Teleport: true } },
   })
 }
 
 describe('ProjectExternalMcpPanel (plan g3.1/g3.2/g3.3)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.copyToClipboard.mockReset()
+    mocks.copyToClipboard.mockResolvedValue(true)
     apiMocks.getProjectExternalMcp.mockResolvedValue({
       enabled: false,
       enabledPacks: [],
@@ -83,5 +98,91 @@ describe('ProjectExternalMcpPanel (plan g3.1/g3.2/g3.3)', () => {
     const text = wrapper.text()
     expect(text).toContain('http://api.example.com/mcp/external/proj-1/pm-progress')
     expect(text).not.toContain('{base}')
+  })
+})
+
+describe('ProjectExternalMcpPanel copy (plan g1/g2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.copyToClipboard.mockReset()
+    mocks.copyToClipboard.mockResolvedValue(true)
+    apiMocks.getProjectExternalMcp.mockResolvedValue({
+      enabled: true,
+      enabledPacks: ['pm-progress'],
+      mcpBaseUrl: 'http://api.example.com/mcp/external/proj-1',
+    })
+    apiMocks.listProjectMcpKeys.mockResolvedValue([])
+    apiMocks.createProjectMcpKey.mockResolvedValue({
+      id: 'k1',
+      name: 'cursor',
+      key: 'cf_proj_abcd',
+      key_prefix: 'cf_proj_••••abcd',
+      created_at: '2026-01-01T00:00:00Z',
+    })
+  })
+
+  it('copies MCP base URL via copyToClipboard (g1.1 / g1.2)', async () => {
+    const wrapper = mountPanel()
+    await flushPromises()
+    await wrapper.get('[data-testid="external-mcp-copy-url"]').trigger('click')
+    await flushPromises()
+    expect(mocks.copyToClipboard).toHaveBeenCalledWith('http://api.example.com/mcp/external/proj-1')
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('已复制到剪贴板')
+    expect(mocks.toastError).not.toHaveBeenCalled()
+    expect(wrapper.get('[data-testid="external-mcp-copy-url"]').text()).toContain('已复制')
+  })
+
+  it('copies MCP JSON example via copyToClipboard (g1.1 / g1.2)', async () => {
+    const wrapper = mountPanel()
+    await flushPromises()
+    await wrapper.get('[data-testid="external-mcp-copy-example"]').trigger('click')
+    await flushPromises()
+    const call = mocks.copyToClipboard.mock.calls[0]?.[0] as string
+    expect(call).toContain('http://api.example.com/mcp/external/proj-1')
+    expect(call).toContain('mcpServers')
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('已复制到剪贴板')
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  it('copies new key plain text via copyToClipboard (g1.1 / g1.2)', async () => {
+    const wrapper = mountPanel()
+    await flushPromises()
+    await wrapper.get('[data-testid="external-mcp-create-key"]').trigger('click')
+    await flushPromises()
+    const nameInput = wrapper.get('[data-testid="external-mcp-key-name"]')
+    await nameInput.setValue('cursor')
+    const createBtn = wrapper.findAll('button').find((b) => b.text().includes('创建密钥') && !b.attributes('data-testid'))
+    expect(createBtn).toBeTruthy()
+    await createBtn!.trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).toContain('cf_proj_abcd')
+    const keyCode = wrapper.findAll('code').find((c) => c.text().includes('cf_proj_abcd'))
+    expect(keyCode).toBeTruthy()
+    const row = keyCode!.element.parentElement
+    const copyBtn = row?.querySelector('button')
+    expect(copyBtn?.textContent).toContain('复制')
+    await copyBtn!.dispatchEvent(new Event('click'))
+    await flushPromises()
+    expect(mocks.copyToClipboard).toHaveBeenCalledWith('cf_proj_abcd')
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('已复制到剪贴板')
+  })
+
+  it('shows copyFailed toast when copyToClipboard returns false (g2.1 / g2.2)', async () => {
+    mocks.copyToClipboard.mockResolvedValue(false)
+    const wrapper = mountPanel()
+    await flushPromises()
+    await wrapper.get('[data-testid="external-mcp-copy-url"]').trigger('click')
+    await flushPromises()
+    expect(mocks.toastError).toHaveBeenCalledWith('复制失败')
+    expect(mocks.toastSuccess).not.toHaveBeenCalled()
+  })
+
+  it('does not call navigator.clipboard.writeText directly (g2.2)', () => {
+    const panelSrc = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), 'ProjectExternalMcpPanel.vue'),
+      'utf8',
+    )
+    expect(panelSrc).not.toMatch(/navigator\.clipboard\.writeText/)
+    expect(panelSrc).toMatch(/copyToClipboard/)
   })
 })

--- a/web/src/components/project/ProjectExternalMcpPanel.vue
+++ b/web/src/components/project/ProjectExternalMcpPanel.vue
@@ -6,6 +6,7 @@ import AppModal from '@/components/ui/AppModal.vue'
 import AppSwitch from '@/components/ui/AppSwitch.vue'
 import { api } from '@/lib/api/api'
 import { useToast } from '@/lib/composables/useToast'
+import { copyToClipboard } from '@/lib/shared/copyToClipboard'
 import { fmtTime } from '@/lib/shared/format'
 
 const props = defineProps<{ projectId: string }>()
@@ -145,12 +146,15 @@ async function revokeKey(id: string) {
   }
 }
 
-function copyText(text: string, label = '') {
-  navigator.clipboard.writeText(text).then(() => {
+async function copyText(text: string, label = '') {
+  const ok = await copyToClipboard(text)
+  if (ok) {
     copied.value = label
     toast.success(t('pages.projectDetail.externalMcp.copySuccess'))
     setTimeout(() => { copied.value = '' }, 2000)
-  }).catch(() => toast.error(t('pages.projectDetail.externalMcp.copyFailed')))
+  } else {
+    toast.error(t('pages.projectDetail.externalMcp.copyFailed'))
+  }
 }
 
 onMounted(async () => {


### PR DESCRIPTION
Replace direct navigator.clipboard.writeText calls that throw TypeError
in non-secure contexts with the shared copyToClipboard helper, and add
tests covering all three copy entry points plus failure handling.

Co-authored-by: Cursor <cursoragent@cursor.com>
