### PR TITLE
fix: stop unknown model alias flicker on Run detail soft refresh

### DIFF
--- a/web/src/lib/run/useRunDetail.test.ts
+++ b/web/src/lib/run/useRunDetail.test.ts
@@ -245,4 +245,112 @@ describe('useRunDetail', () => {
 
     app.unmount()
   })
+
+  it('keeps unknown model alias stable during soft refresh while getProject is pending', async () => {
+    let resolveProject: ((value: { id: string; unknownModelDisplayName: string }) => void) | null = null
+    mocks.getProject.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveProject = resolve
+        }),
+    )
+
+    const { detail, app } = await withRunDetail()
+    await flushPromises()
+    await nextTick()
+
+    // First load: alias resolves to Auto.
+    resolveProject!({ id: 'proj-1', unknownModelDisplayName: 'Auto' })
+    await flushPromises()
+    expect(detail.unknownModelDisplayName.value).toBe('Auto')
+    expect(mocks.getProject).toHaveBeenCalledTimes(1)
+
+    // Soft refresh while getProject would be slow: alias must not clear.
+    mocks.getProject.mockClear()
+    mocks.getProject.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveProject = resolve
+        }),
+    )
+    await detail.loadRun(false)
+    expect(detail.unknownModelDisplayName.value).toBe('Auto')
+    expect(mocks.getProject).not.toHaveBeenCalled()
+
+    resolveProject!({ id: 'proj-1', unknownModelDisplayName: 'Auto' })
+    await flushPromises()
+    expect(detail.unknownModelDisplayName.value).toBe('Auto')
+    expect(mocks.getProject).not.toHaveBeenCalled()
+
+    app.unmount()
+  })
+
+  it('reloads unknown model alias when projectId changes on hard refresh', async () => {
+    mocks.getProject
+      .mockResolvedValueOnce({ id: 'proj-1', unknownModelDisplayName: 'Auto' })
+      .mockResolvedValueOnce({ id: 'proj-2', unknownModelDisplayName: 'gpt-5' })
+
+    const { detail, app, router } = await withRunDetail()
+    await flushPromises()
+    expect(detail.unknownModelDisplayName.value).toBe('Auto')
+
+    mocks.getRun.mockResolvedValue({
+      ...sampleRun(),
+      id: 'run-2',
+      workflowId: 'wf-2',
+    })
+    mocks.getWorkflow.mockResolvedValue({
+      ...sampleWorkflow(),
+      id: 'wf-2',
+      projectId: 'proj-2',
+    })
+
+    await router.push('/runs/run-2')
+    await flushPromises()
+    await nextTick()
+
+    expect(detail.unknownModelDisplayName.value).toBe('gpt-5')
+    expect(mocks.getProject).toHaveBeenLastCalledWith('proj-2')
+
+    app.unmount()
+  })
+
+  it('retains last successful alias when getProject fails after project switch on hard refresh', async () => {
+    mocks.getProject.mockResolvedValueOnce({ id: 'proj-1', unknownModelDisplayName: 'Auto' })
+
+    const { detail, app, router } = await withRunDetail()
+    await flushPromises()
+    expect(detail.unknownModelDisplayName.value).toBe('Auto')
+
+    mocks.getRun.mockResolvedValue({
+      ...sampleRun(),
+      id: 'run-2',
+      workflowId: 'wf-2',
+    })
+    mocks.getWorkflow.mockResolvedValue({
+      ...sampleWorkflow(),
+      id: 'wf-2',
+      projectId: 'proj-2',
+    })
+    mocks.getProject.mockRejectedValueOnce(new Error('network down'))
+
+    await router.push('/runs/run-2')
+    await flushPromises()
+    await nextTick()
+
+    // Hard refresh to new project failed to load alias → empty until success.
+    expect(detail.unknownModelDisplayName.value).toBe('')
+
+    mocks.getProject.mockResolvedValueOnce({ id: 'proj-2', unknownModelDisplayName: 'gpt-5' })
+    await detail.loadRun(false)
+    await flushPromises()
+    expect(detail.unknownModelDisplayName.value).toBe('gpt-5')
+
+    mocks.getProject.mockRejectedValueOnce(new Error('network down'))
+    await detail.loadRun(false)
+    await flushPromises()
+    expect(detail.unknownModelDisplayName.value).toBe('gpt-5')
+
+    app.unmount()
+  })
 })

--- a/web/src/lib/run/useRunDetail.ts
+++ b/web/src/lib/run/useRunDetail.ts
@@ -56,15 +56,36 @@ const run = ref<Run>(emptyRun(runId.value))
 const wf = ref<Workflow>(emptyWorkflow())
 /** Project alias for 「未知/未分桶」display on Run token table. */
 const unknownModelDisplayName = ref('')
+/** projectId for which unknownModelDisplayName was last successfully loaded. */
+let unknownAliasLoadedForProjectId: string | null = null
 
 async function loadUnknownModelDisplayName(projectId?: string | null) {
-  unknownModelDisplayName.value = ''
-  if (!projectId) return
+  const pid = projectId ?? null
+  if (!pid) {
+    unknownModelDisplayName.value = ''
+    unknownAliasLoadedForProjectId = null
+    return
+  }
+
+  const projectChanged =
+    unknownAliasLoadedForProjectId !== null && unknownAliasLoadedForProjectId !== pid
+  if (projectChanged) {
+    unknownModelDisplayName.value = ''
+    unknownAliasLoadedForProjectId = null
+  }
+
+  // Soft refresh: keep the cached alias and skip redundant getProject polls.
+  if (unknownAliasLoadedForProjectId === pid) return
+
   try {
-    const p = await api.getProject(projectId)
+    const p = await api.getProject(pid)
     unknownModelDisplayName.value = p.unknownModelDisplayName || ''
+    unknownAliasLoadedForProjectId = pid
   } catch {
-    // Keep default label when project cannot be loaded.
+    // Keep the last successful alias when refresh fails; only clear on first load miss.
+    if (unknownAliasLoadedForProjectId !== pid) {
+      unknownModelDisplayName.value = ''
+    }
   }
 }
 const runLoading = ref(false)
@@ -370,6 +391,8 @@ function resetRunState(id: string) {
   resetLiveLogState(id)
   run.value = emptyRun(id)
   wf.value = emptyWorkflow()
+  unknownModelDisplayName.value = ''
+  unknownAliasLoadedForProjectId = null
   selected.value = null
   manual.value = false
   gateError.value = null


### PR DESCRIPTION
Soft refresh and 2s polling no longer clear unknownModelDisplayName before
getProject; cache by projectId and skip redundant fetches. Hard refresh and
project switches still reset the alias. Add regression tests.

Co-authored-by: Cursor <cursoragent@cursor.com>
