### PR TITLE
fix(web): unify Agent Studio help entry as outline buttons

### DIFF
--- a/web/src/components/agent/AgentEnvPanel.vue
+++ b/web/src/components/agent/AgentEnvPanel.vue
@@ -96,14 +96,16 @@ watch(
 <template>
   <div class="flex min-h-0 flex-1 flex-col">
     <div class="flex items-center gap-2 border-b border-line px-4 py-2">
-      <button
+      <AppButton
         type="button"
-        class="bg-transparent p-0 text-[12px] text-accent-2 underline underline-offset-[3px] hover:text-[#c4b5fd] focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-accent"
+        size="sm"
+        variant="outline"
+        icon="help"
         data-test="env-help-inject"
         @click="openEnvHelp('inject')"
       >
         {{ t('pages.agentStudio.envHelp.link') }}
-      </button>
+      </AppButton>
       <span class="flex-1" />
       <button class="rounded border border-line px-2 py-1 text-[11px] text-txt2 hover:border-line-strong" @click="toggleEnvRaw">{{ envRaw ? t('pages.agentStudio.mcp.formEdit') : t('pages.agentStudio.mcp.rawJson') }}</button>
     </div>
@@ -137,14 +139,16 @@ watch(
       <div class="mb-3 rounded-lg border border-line bg-base/50 p-3 text-[11px] leading-6 text-txt3">
         <div class="mb-1 flex items-center justify-between gap-2">
           <div class="font-medium text-txt2">{{ t('pages.agentStudio.env.backendAuthTitle') }}</div>
-          <button
+          <AppButton
             type="button"
-            class="bg-transparent p-0 text-[12px] text-accent-2 underline underline-offset-[3px] hover:text-[#c4b5fd] focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-accent"
+            size="sm"
+            variant="outline"
+            icon="help"
             data-test="env-help-acp"
             @click="openEnvHelp('acp')"
           >
             {{ t('pages.agentStudio.envHelp.link') }}
-          </button>
+          </AppButton>
         </div>
         <p class="font-mono text-accent-2">{{ currentAuthHint.key }}<span v-if="currentAuthHint.alt"> / {{ currentAuthHint.alt }}</span></p>
       </div>

--- a/web/src/components/agent/AgentGitGuide.test.ts
+++ b/web/src/components/agent/AgentGitGuide.test.ts
@@ -34,7 +34,6 @@ function mountGuide(env: { k: string; v: string }[], credentialType?: 'github_ht
       plugins: [i18n],
       stubs: {
         AppModal: AppModalStub,
-        AppButton: { template: '<button><slot /></button>' },
       },
     },
   })

--- a/web/src/components/agent/AgentGitGuide.vue
+++ b/web/src/components/agent/AgentGitGuide.vue
@@ -119,14 +119,16 @@ defineExpose({ isGitEnvKey })
         <div class="mt-0.5 text-[11px] text-txt3">{{ t('pages.agentStudio.git.subtitle') }}</div>
       </div>
       <div class="flex shrink-0 items-center gap-3">
-        <button
+        <AppButton
           type="button"
-          class="bg-transparent p-0 text-[12px] text-accent-2 underline underline-offset-[3px] hover:text-[#c4b5fd] focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          size="sm"
+          variant="outline"
+          icon="help"
           data-test="git-help-link"
           @click="emit('help', 'git')"
         >
           {{ t('pages.agentStudio.envHelp.link') }}
-        </button>
+        </AppButton>
         <AppButton size="sm" variant="outline" @click="openChooser">
           {{ t('pages.agentStudio.git.adjustType') }}
         </AppButton>

--- a/web/src/components/agent/AgentMcpPanel.vue
+++ b/web/src/components/agent/AgentMcpPanel.vue
@@ -120,15 +120,17 @@ watch(
   <div class="flex min-h-0 flex-1 flex-col">
     <div class="flex items-center gap-2 border-b border-line px-4 py-2">
       <button class="rounded border border-line px-2 py-1 text-[11px] text-txt2 hover:border-line-strong" @click="toggleMcpRaw">{{ mcpRaw ? t('pages.agentStudio.mcp.formEdit') : t('pages.agentStudio.mcp.rawJson') }}</button>
-      <button
+      <AppButton
         v-if="!mcpRaw"
         type="button"
-        class="bg-transparent p-0 text-[12px] text-accent-2 underline underline-offset-[3px] hover:text-[#c4b5fd] focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-accent"
+        size="sm"
+        variant="outline"
+        icon="help"
         data-test="mcp-help-link"
         @click="mcpHelpOpen = true"
       >
         {{ t('pages.agentStudio.mcpHelp.link') }}
-      </button>
+      </AppButton>
       <span class="flex-1" />
     </div>
 

--- a/web/src/components/agent/AgentStudioHelpButtons.test.ts
+++ b/web/src/components/agent/AgentStudioHelpButtons.test.ts
@@ -7,7 +7,7 @@ import pages from '@/locales/zh-CN/pages.json'
 import AgentEnvPanel from './AgentEnvPanel.vue'
 import AgentGitGuide from './AgentGitGuide.vue'
 import AgentMcpPanel from './AgentMcpPanel.vue'
-import type { AgentStudioDraft } from '@/lib/agent/agentStudioDraft'
+import { emptyPrompts, type AgentStudioDraft } from '@/lib/agent/agentStudioDraft'
 
 function createI18nPlugin() {
   return createI18n({
@@ -28,8 +28,11 @@ function expectOutlineHelpButton(wrapper: ReturnType<typeof mount>, selector: st
 
 const baseDraft: AgentStudioDraft = {
   name: 'test-agent',
+  projectId: '',
   env: [],
   mcp: [],
+  files: [],
+  prompts: emptyPrompts(),
   gitCredentialType: undefined,
   acpBackend: 'codebuddy',
   layout: { configRoot: '/tmp/agent', workspaceDir: '/tmp/workspace' },

--- a/web/src/components/agent/AgentStudioHelpButtons.test.ts
+++ b/web/src/components/agent/AgentStudioHelpButtons.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+import { createI18n } from 'vue-i18n'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import common from '@/locales/zh-CN/common.json'
+import pages from '@/locales/zh-CN/pages.json'
+import AgentEnvPanel from './AgentEnvPanel.vue'
+import AgentGitGuide from './AgentGitGuide.vue'
+import AgentMcpPanel from './AgentMcpPanel.vue'
+import type { AgentStudioDraft } from '@/lib/agent/agentStudioDraft'
+
+function createI18nPlugin() {
+  return createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common, ...pages } },
+  })
+}
+
+function expectOutlineHelpButton(wrapper: ReturnType<typeof mount>, selector: string) {
+  const el = wrapper.get(selector)
+  const classes = el.classes().join(' ')
+  expect(classes).not.toMatch(/underline/)
+  expect(classes).toContain('border')
+  expect(el.find('svg').exists()).toBe(true)
+  expect(el.text()).toBe('帮助')
+}
+
+const baseDraft: AgentStudioDraft = {
+  name: 'test-agent',
+  env: [],
+  mcp: [],
+  gitCredentialType: undefined,
+  acpBackend: 'codebuddy',
+  layout: { configRoot: '/tmp/agent' },
+}
+
+describe('Agent Studio help buttons', () => {
+  it('环境变量顶栏与 ACP 卡使用描边帮助按钮且非帮助链未误改', () => {
+    const draft = structuredClone(baseDraft)
+    const wrapper = mount(AgentEnvPanel, {
+      props: { draft },
+      global: {
+        plugins: [createI18nPlugin()],
+        stubs: {
+          AgentGitGuide: true,
+          EnvCredentialHelpModal: true,
+          CodeEditor: true,
+        },
+      },
+    })
+
+    expectOutlineHelpButton(wrapper, '[data-test="env-help-inject"]')
+    expectOutlineHelpButton(wrapper, '[data-test="env-help-acp"]')
+
+    const settingsLink = wrapper.get('[data-test="env-open-settings-file"]')
+    expect(settingsLink.classes().join(' ')).toMatch(/underline/)
+  })
+
+  it('MCP 顶栏帮助为描边按钮', () => {
+    const draft = structuredClone(baseDraft)
+    const wrapper = mount(AgentMcpPanel, {
+      props: { draft, isProjectBound: true },
+      global: {
+        plugins: [createI18nPlugin()],
+        stubs: { McpConfigHelpModal: true, CodeEditor: true },
+      },
+    })
+
+    expectOutlineHelpButton(wrapper, '[data-test="mcp-help-link"]')
+  })
+
+  it('Git 凭据卡帮助为描边按钮', () => {
+    const wrapper = mount(AgentGitGuide, {
+      props: {
+        env: [],
+        upsertEnv: () => {},
+      },
+      global: {
+        plugins: [createI18nPlugin()],
+        stubs: { AppModal: true },
+      },
+    })
+
+    expectOutlineHelpButton(wrapper, '[data-test="git-help-link"]')
+  })
+})

--- a/web/src/components/agent/AgentStudioHelpButtons.test.ts
+++ b/web/src/components/agent/AgentStudioHelpButtons.test.ts
@@ -32,7 +32,7 @@ const baseDraft: AgentStudioDraft = {
   mcp: [],
   gitCredentialType: undefined,
   acpBackend: 'codebuddy',
-  layout: { configRoot: '/tmp/agent' },
+  layout: { configRoot: '/tmp/agent', workspaceDir: '/tmp/workspace' },
 }
 
 describe('Agent Studio help buttons', () => {

--- a/web/src/components/ui/Icon.vue
+++ b/web/src/components/ui/Icon.vue
@@ -67,6 +67,7 @@ const paths: Record<string, string> = {
   tag: '<path d="M20.6 13.4 12 22l-8.6-8.6a5 5 0 0 1 0-7.1l.7-.7a5 5 0 0 1 7.1 0L12 6l.8-.8a5 5 0 0 1 7.1 0l.7.7a5 5 0 0 1 0 7.1z"/><circle cx="7.5" cy="7.5" r="1.2"/>',
   star: '<path d="m12 3.6 2.5 5.1 5.6.8-4 3.9.9 5.6L12 16.3 7 19l.9-5.6-4-3.9 5.6-.8z"/>',
   'star-filled': '<path d="m12 3.6 2.5 5.1 5.6.8-4 3.9.9 5.6L12 16.3 7 19l.9-5.6-4-3.9 5.6-.8z"/>',
+  help: '<circle cx="12" cy="12" r="9"/><path d="M9.5 9a2.5 2.5 0 1 1 3.2 2.4c-.8.3-1.2.8-1.2 1.6V14"/><circle cx="12" cy="17" r="1"/>',
 }
 
 /** Icons that render with solid fill (favorited star). */


### PR DESCRIPTION
Replace blue underlined help text links with question-mark icon
outline buttons across env, MCP, Git, and ACP panels so help
entries match toolbar controls like Raw JSON without changing
modal behavior or draft retention.

Co-authored-by: Cursor <cursoragent@cursor.com>
