### PR TITLE
feat(web): sidebar purple-indigo checkmark brand row

### DIFF
--- a/web/src/components/shell/AppSidebar.test.ts
+++ b/web/src/components/shell/AppSidebar.test.ts
@@ -57,17 +57,29 @@ describe('AppSidebar', () => {
     wrapper.unmount()
   })
 
-  it('puts a 44px hide-nav control on the brand row (g2.1)', () => {
+  it('puts a 44px hide-nav control on the 72px brand row (g2.1 / g2.2)', () => {
     const wrapper = mountSidebar()
-    const row = wrapper.find('.h-14')
+    const row = wrapper.find('[data-testid="sidebar-brand-row"]')
+    expect(row.exists()).toBe(true)
+    expect(row.classes()).toContain('h-[72px]')
     expect(row.classes()).toContain('justify-between')
     const hide = wrapper.find('[data-testid="desktop-nav-hide"]')
     expect(hide.exists()).toBe(true)
     expect(hide.classes()).toContain('h-11')
     expect(hide.classes()).toContain('w-11')
+    expect(hide.classes()).toContain('text-txt3')
     expect(hide.attributes('aria-label')).toBe('隐藏导航')
     expect(hide.attributes('aria-expanded')).toBe('true')
     expect(hide.attributes('aria-controls')).toBe('app-desktop-sidebar')
+    wrapper.unmount()
+  })
+
+  it('renders four-color brand rail below brand row (g2.3)', () => {
+    const wrapper = mountSidebar()
+    const rail = wrapper.find('[data-testid="sidebar-brand-rail"]')
+    expect(rail.exists()).toBe(true)
+    expect(rail.classes()).toContain('app-sidebar-brand-rail')
+    expect(rail.findAll('span')).toHaveLength(4)
     wrapper.unmount()
   })
 

--- a/web/src/components/shell/AppSidebar.vue
+++ b/web/src/components/shell/AppSidebar.vue
@@ -49,11 +49,14 @@ async function onHideNav() {
     :inert="sidebarHidden"
   >
     <div class="flex h-full w-[232px] min-w-[232px] flex-col">
-      <div class="flex h-14 items-center justify-between gap-2 px-3">
+      <div
+        class="app-sidebar-brand-row flex h-[72px] items-center justify-between gap-2 pl-3.5 pr-2"
+        data-testid="sidebar-brand-row"
+      >
         <BrandLogo size="md" align="start" show-mark />
         <button
           type="button"
-          class="flex h-11 w-11 shrink-0 items-center justify-center rounded-md text-txt2 hover:bg-elevated hover:text-txt"
+          class="flex h-11 w-11 shrink-0 items-center justify-center rounded-md text-txt3 hover:text-txt2"
           data-testid="desktop-nav-hide"
           :aria-label="t('shell.aria.hideNav')"
           :title="t('shell.aria.hideNav')"
@@ -63,6 +66,9 @@ async function onHideNav() {
         >
           <Icon name="panel-left" :size="18" />
         </button>
+      </div>
+      <div class="app-sidebar-brand-rail" aria-hidden="true" data-testid="sidebar-brand-rail">
+        <span /><span /><span /><span />
       </div>
 
       <AppSidebarNav />

--- a/web/src/components/shell/BrandLogo.test.ts
+++ b/web/src/components/shell/BrandLogo.test.ts
@@ -26,7 +26,7 @@ describe('BrandLogo', () => {
     wrapper.unmount()
   })
 
-  it('shows 28px square A mark only when showMark is true (g1.1 / g1.3)', () => {
+  it('shows 32px checkmark square only when showMark is true (g1.1)', () => {
     const i18n = createI18n({
       legacy: false,
       locale: 'zh-CN',
@@ -38,9 +38,11 @@ describe('BrandLogo', () => {
     })
     const mark = withMark.find('.brand-logo__mark')
     expect(mark.exists()).toBe(true)
-    expect(mark.text()).toBe('A')
-    expect(mark.classes()).toContain('brand-logo__mark')
+    expect(mark.text()).not.toMatch(/A/)
+    expect(mark.find('.brand-logo__check').exists()).toBe(true)
+    expect(mark.find('path').exists()).toBe(true)
     expect(withMark.classes()).toContain('brand-logo--with-mark')
+    expect(withMark.find('.brand-logo__tagline').exists()).toBe(false)
     withMark.unmount()
 
     const without = mount(BrandLogo, {
@@ -51,7 +53,23 @@ describe('BrandLogo', () => {
     without.unmount()
   })
 
-  it('does not leak mark to login, boot shell, or mobile drawer (g1.3)', () => {
+  it('uses static sidebar wordmark without tagline when showMark (g1.2)', () => {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const wrapper = mount(BrandLogo, {
+      props: { size: 'md', showMark: true },
+      global: { plugins: [i18n] },
+    })
+    const name = wrapper.find('.brand-logo__name')
+    expect(name.text()).toBe('Approving')
+    expect(name.classes()).not.toContain('brand-logo__tagline')
+    wrapper.unmount()
+  })
+
+  it('does not leak mark to login, boot shell, or mobile drawer (g3.1)', () => {
     const dir = dirname(fileURLToPath(import.meta.url))
     const sidebar = readFileSync(join(dir, 'AppSidebar.vue'), 'utf8')
     const shell = readFileSync(join(dir, 'AppShell.vue'), 'utf8')

--- a/web/src/components/shell/BrandLogo.vue
+++ b/web/src/components/shell/BrandLogo.vue
@@ -7,7 +7,7 @@ const props = withDefaults(
   defineProps<{
     size?: 'sm' | 'md' | 'lg'
     align?: 'start' | 'center'
-    /** Desktop AppSidebar only: 28px square purple A mark. */
+    /** Desktop AppSidebar only: 32px purple-indigo checkmark square. */
     showMark?: boolean
   }>(),
   {
@@ -39,10 +39,14 @@ const tagline = computed(() =>
 
 <template>
   <div :class="rootClass">
-    <span v-if="showMark" class="brand-logo__mark" aria-hidden="true">A</span>
+    <span v-if="showMark" class="brand-logo__mark" aria-hidden="true">
+      <svg class="brand-logo__check" width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+        <path d="M3.2 9.2 7.1 13 14.8 4.6" stroke="#fff" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </span>
     <div class="brand-logo__text">
       <span class="brand-logo__name">{{ appName }}</span>
-      <span class="brand-logo__tagline">{{ tagline }}</span>
+      <span v-if="!showMark" class="brand-logo__tagline">{{ tagline }}</span>
     </div>
   </div>
 </template>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -209,23 +209,35 @@ html:not(.light) *.is-scrolling::-webkit-scrollbar {
   .brand-logo--with-mark {
     flex-direction: row;
     align-items: center;
-    gap: 8px;
+    gap: 10px;
     min-width: 0;
     flex: 1;
   }
   .brand-logo__mark {
-    width: 28px;
-    height: 28px;
+    width: 32px;
+    height: 32px;
     flex-shrink: 0;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: #7b61ff;
-    color: #fff;
-    -webkit-text-fill-color: #fff;
-    font-size: 13px;
-    font-weight: 700;
-    letter-spacing: -0.02em;
+    background: linear-gradient(135deg, #7b61ff, #6366f1);
+  }
+  .brand-logo__check {
+    display: block;
+  }
+  .brand-logo--with-mark .brand-logo__text {
+    flex-direction: row;
+    align-items: center;
+  }
+  .brand-logo--with-mark .brand-logo__name {
+    font-size: 15px;
+    font-weight: 650;
+    color: rgb(var(--c-txt));
+    background: none;
+    -webkit-background-clip: unset;
+    background-clip: unset;
+    -webkit-text-fill-color: currentColor;
+    animation: none;
   }
   .brand-logo__text {
     display: flex;
@@ -379,6 +391,32 @@ html:not(.light) *.is-scrolling::-webkit-scrollbar {
   transition:
     width 0.32s cubic-bezier(0.22, 1, 0.36, 1),
     border-right-width 0.32s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.app-sidebar-brand-row {
+  background: linear-gradient(105deg, #1a1730 0%, #16182a 55%, #12241f 100%);
+}
+html.light .app-sidebar-brand-row {
+  background: linear-gradient(105deg, #efe8ff 0%, #e8eeff 55%, #e8faf3 100%);
+}
+
+.app-sidebar-brand-rail {
+  display: grid;
+  grid-template-columns: 1.4fr 1.1fr 0.9fr 0.7fr;
+  height: 3px;
+  flex-shrink: 0;
+}
+.app-sidebar-brand-rail span:nth-child(1) {
+  background: rgb(var(--c-accent));
+}
+.app-sidebar-brand-rail span:nth-child(2) {
+  background: #6366f1;
+}
+.app-sidebar-brand-rail span:nth-child(3) {
+  background: rgb(var(--c-ok));
+}
+.app-sidebar-brand-rail span:nth-child(4) {
+  background: rgb(var(--c-warn));
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Replace the desktop sidebar letter-A mark with a 32px gradient checkmark
square, static Approving wordmark, 72px wash row, demoted hide control,
and four-color accent rail per approved preview.

Co-authored-by: Cursor <cursoragent@cursor.com>
