### PR TITLE
feat(notifications): replace 50-item pool with full server pagination

### DIFF
--- a/server/internal/handlers/notifications.go
+++ b/server/internal/handlers/notifications.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/cocofhu/approving/internal/auth"
@@ -29,7 +30,7 @@ func (h *Handlers) notificationUsername(c *gin.Context) (string, bool) {
 	return username, true
 }
 
-// ListNotifications returns the current user's terminal-run inbox with unread flags.
+// ListNotifications returns a paginated slice of terminal-run inbox rows plus true totals.
 func (h *Handlers) ListNotifications(c *gin.Context) {
 	if h.Notifications == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "notifications unavailable"})
@@ -39,7 +40,25 @@ func (h *Handlers) ListNotifications(c *gin.Context) {
 	if !ok {
 		return
 	}
-	items, err := h.Notifications.List(username)
+
+	page := 1
+	pageSize := services.DefaultNotificationPageSize
+	filter := strings.TrimSpace(strings.ToLower(c.Query("filter")))
+	if filter == "" {
+		filter = "all"
+	}
+	if v := strings.TrimSpace(c.Query("page")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			page = n
+		}
+	}
+	if v := strings.TrimSpace(c.Query("pageSize")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			pageSize = n
+		}
+	}
+
+	result, err := h.Notifications.ListPage(username, filter, page, pageSize)
 	if err != nil {
 		if errors.Is(err, services.ErrNotificationUsernameRequired) {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
@@ -48,10 +67,10 @@ func (h *Handlers) ListNotifications(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	if items == nil {
-		items = []services.NotificationItemDTO{}
+	if result.Items == nil {
+		result.Items = []services.NotificationItemDTO{}
 	}
-	c.JSON(http.StatusOK, gin.H{"items": items})
+	c.JSON(http.StatusOK, result)
 }
 
 // MarkNotificationRead inserts a read row for one runId.
@@ -84,8 +103,8 @@ func (h *Handlers) MarkNotificationRead(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 
-// MarkAllNotificationsRead marks every run in the current pool as read.
-// The client must not send an id list; the server scans the pool itself.
+// MarkAllNotificationsRead marks every unread terminal run as read for the user.
+// The client must not send an id list; the server scans the inbox itself.
 func (h *Handlers) MarkAllNotificationsRead(c *gin.Context) {
 	if h.Notifications == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "notifications unavailable"})

--- a/server/internal/services/notifications.go
+++ b/server/internal/services/notifications.go
@@ -13,7 +13,7 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-const NotificationPoolSize = 50
+const DefaultNotificationPageSize = 20
 
 var (
 	ErrNotificationUsernameRequired = errors.New("username required")
@@ -52,53 +52,110 @@ type NotificationItemDTO struct {
 	BeforeBaseline bool   `json:"beforeBaseline"`
 }
 
-// List returns the current user's notification pool (up to 50 terminal runs).
-// First access stamps EnabledAt=now so existing pool items are history (read).
-func (s *NotificationService) List(username string) ([]NotificationItemDTO, error) {
+// NotificationListResult is a paginated inbox slice plus global counts.
+type NotificationListResult struct {
+	Items       []NotificationItemDTO `json:"items"`
+	Page        int                   `json:"page"`
+	PageSize    int                   `json:"pageSize"`
+	Total       int64                 `json:"total"`
+	AllCount    int64                 `json:"allCount"`
+	UnreadCount int64                 `json:"unreadCount"`
+	ReadCount   int64                 `json:"readCount"`
+}
+
+type notificationEnriched struct {
+	item NotificationItemDTO
+}
+
+// ListPage returns one page of terminal-run notifications for filter=all|unread|read,
+// plus true totals for all/unread/read across the full inbox (not just the page).
+func (s *NotificationService) ListPage(username, filter string, page, pageSize int) (NotificationListResult, error) {
 	username, err := requireUsername(username)
 	if err != nil {
-		return nil, err
+		return NotificationListResult{}, err
 	}
 	baseline, err := s.ensureBaseline(username)
 	if err != nil {
-		return nil, err
+		return NotificationListResult{}, err
 	}
-	runs, _ := s.runs.ListPage(
-		[]string{"completed", "failed"},
-		"", "", 1, NotificationPoolSize,
-		"started_at", "desc",
-	)
-	items := make([]NotificationItemDTO, 0, len(runs))
-	ids := make([]string, 0, len(runs))
-	for _, r := range runs {
-		item, ok := MapRunToNotification(r)
-		if !ok {
-			continue
-		}
-		items = append(items, item)
-		ids = append(ids, item.RunID)
+
+	filter = strings.TrimSpace(strings.ToLower(filter))
+	if filter == "" {
+		filter = "all"
 	}
-	sort.SliceStable(items, func(i, j int) bool {
-		ti := parseMillis(items[i].FinishedApprox, items[i].StartedAt)
-		tj := parseMillis(items[j].FinishedApprox, items[j].StartedAt)
-		if ti != tj {
-			return ti > tj
+	switch filter {
+	case "all", "unread", "read":
+	default:
+		filter = "all"
+	}
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 {
+		pageSize = DefaultNotificationPageSize
+	}
+
+	enriched, err := s.buildEnrichedList(username, baseline.EnabledAt)
+	if err != nil {
+		return NotificationListResult{}, err
+	}
+
+	var allCount, unreadCount, readCount int64
+	filtered := make([]notificationEnriched, 0, len(enriched))
+	for _, e := range enriched {
+		allCount++
+		if e.item.Unread {
+			unreadCount++
+		} else {
+			readCount++
 		}
-		return items[i].RunID > items[j].RunID
-	})
-	read, err := s.readSet(username, ids)
+		switch filter {
+		case "unread":
+			if e.item.Unread {
+				filtered = append(filtered, e)
+			}
+		case "read":
+			if !e.item.Unread {
+				filtered = append(filtered, e)
+			}
+		default:
+			filtered = append(filtered, e)
+		}
+	}
+
+	total := int64(len(filtered))
+	start := (page - 1) * pageSize
+	if start > len(filtered) {
+		start = len(filtered)
+	}
+	end := start + pageSize
+	if end > len(filtered) {
+		end = len(filtered)
+	}
+
+	items := make([]NotificationItemDTO, 0, end-start)
+	for _, e := range filtered[start:end] {
+		items = append(items, e.item)
+	}
+
+	return NotificationListResult{
+		Items:       items,
+		Page:        page,
+		PageSize:    pageSize,
+		Total:       total,
+		AllCount:    allCount,
+		UnreadCount: unreadCount,
+		ReadCount:   readCount,
+	}, nil
+}
+
+// List returns all terminal runs (legacy helper for tests); prefer ListPage in handlers.
+func (s *NotificationService) List(username string) ([]NotificationItemDTO, error) {
+	res, err := s.ListPage(username, "all", 1, 1<<31-1)
 	if err != nil {
 		return nil, err
 	}
-	enabledAt := baseline.EnabledAt
-	for i := range items {
-		finished := parseTime(items[i].FinishedApprox, items[i].StartedAt)
-		before := !finished.IsZero() && !enabledAt.IsZero() && !finished.After(enabledAt)
-		items[i].BeforeBaseline = before
-		_, marked := read[items[i].RunID]
-		items[i].Unread = !before && !marked && !finished.IsZero() && finished.After(enabledAt)
-	}
-	return items, nil
+	return res.Items, nil
 }
 
 // MarkRead inserts an ignore row for (username, runID). Idempotent.
@@ -117,34 +174,64 @@ func (s *NotificationService) MarkRead(username, runID string) error {
 	return s.insertRead(username, runID)
 }
 
-// MarkAllRead inserts a read row for every run currently in the terminal pool.
+// MarkAllRead inserts a read row for every unread terminal run for the user.
 // The client does not send an id list. Existing rows are left in place.
 func (s *NotificationService) MarkAllRead(username string) error {
 	username, err := requireUsername(username)
 	if err != nil {
 		return err
 	}
-	if _, err := s.ensureBaseline(username); err != nil {
+	baseline, err := s.ensureBaseline(username)
+	if err != nil {
 		return err
 	}
-	runs, _ := s.runs.ListPage(
-		[]string{"completed", "failed"},
-		"", "", 1, NotificationPoolSize,
-		"started_at", "desc",
-	)
-	for _, r := range runs {
-		if r.Status != "completed" && r.Status != "failed" {
+	enriched, err := s.buildEnrichedList(username, baseline.EnabledAt)
+	if err != nil {
+		return err
+	}
+	for _, e := range enriched {
+		if !e.item.Unread {
 			continue
 		}
-		id := strings.TrimSpace(r.ID)
-		if id == "" {
-			continue
-		}
-		if err := s.insertRead(username, id); err != nil {
+		if err := s.insertRead(username, e.item.RunID); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (s *NotificationService) buildEnrichedList(username string, enabledAt time.Time) ([]notificationEnriched, error) {
+	runs := s.runs.List([]string{"completed", "failed"}, "", "", "started_at", "desc")
+	ids := make([]string, 0, len(runs))
+	enriched := make([]notificationEnriched, 0, len(runs))
+	for _, r := range runs {
+		item, ok := MapRunToNotification(r)
+		if !ok {
+			continue
+		}
+		ids = append(ids, item.RunID)
+		enriched = append(enriched, notificationEnriched{item: item})
+	}
+	sort.SliceStable(enriched, func(i, j int) bool {
+		ti := parseMillis(enriched[i].item.FinishedApprox, enriched[i].item.StartedAt)
+		tj := parseMillis(enriched[j].item.FinishedApprox, enriched[j].item.StartedAt)
+		if ti != tj {
+			return ti > tj
+		}
+		return enriched[i].item.RunID > enriched[j].item.RunID
+	})
+	read, err := s.readSet(username, ids)
+	if err != nil {
+		return nil, err
+	}
+	for i := range enriched {
+		finished := parseTime(enriched[i].item.FinishedApprox, enriched[i].item.StartedAt)
+		before := !finished.IsZero() && !enabledAt.IsZero() && !finished.After(enabledAt)
+		enriched[i].item.BeforeBaseline = before
+		_, marked := read[enriched[i].item.RunID]
+		enriched[i].item.Unread = !before && !marked && !finished.IsZero() && finished.After(enabledAt)
+	}
+	return enriched, nil
 }
 
 func (s *NotificationService) insertRead(username, runID string) error {

--- a/server/internal/services/notifications_test.go
+++ b/server/internal/services/notifications_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -288,6 +289,124 @@ func TestMapRunToNotification(t *testing.T) {
 	gotFinish, err := time.Parse(time.RFC3339Nano, noisy.FinishedApprox)
 	if err != nil || !gotFinish.Equal(wantFinish) {
 		t.Fatalf("finishedApprox=%q want %v err=%v", noisy.FinishedApprox, wantFinish, err)
+	}
+}
+
+func TestNotificationListPageBeyondFifty(t *testing.T) {
+	db := setupNotificationDB(t)
+	svc := NewNotificationService(db, nil)
+	start := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 55; i++ {
+		seedTerminalRun(t, db, fmt.Sprintf("run-%02d", i), "completed", fmt.Sprintf("N%d", i),
+			start.Add(time.Duration(i)*time.Minute), 30)
+	}
+	if err := db.Create(&models.NotificationBaseline{
+		Username:  "alice",
+		EnabledAt: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		CreatedAt: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := svc.ListPage("alice", "all", 1, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.AllCount != 55 || res.UnreadCount != 55 || res.ReadCount != 0 {
+		t.Fatalf("counts=%d/%d/%d", res.AllCount, res.UnreadCount, res.ReadCount)
+	}
+	if res.Total != 55 || len(res.Items) != 20 {
+		t.Fatalf("page1 total=%d items=%d", res.Total, len(res.Items))
+	}
+
+	page3, err := svc.ListPage("alice", "all", 3, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page3.Items) != 15 {
+		t.Fatalf("page3 items=%d", len(page3.Items))
+	}
+	// Oldest run should appear on the last page (finished desc).
+	last := page3.Items[len(page3.Items)-1]
+	if last.RunID != "run-00" {
+		t.Fatalf("expected oldest run-00 on page3 tail, got %s", last.RunID)
+	}
+}
+
+func TestNotificationListPageFilterAndCounts(t *testing.T) {
+	db := setupNotificationDB(t)
+	svc := NewNotificationService(db, nil)
+	start := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	seedTerminalRun(t, db, "a", "completed", "A", start, 1)
+	seedTerminalRun(t, db, "b", "failed", "B", start.Add(time.Minute), 1)
+	seedTerminalRun(t, db, "c", "completed", "C", start.Add(2*time.Minute), 1)
+	if err := db.Create(&models.NotificationBaseline{
+		Username:  "alice",
+		EnabledAt: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		CreatedAt: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.MarkRead("alice", "a"); err != nil {
+		t.Fatal(err)
+	}
+
+	unread, err := svc.ListPage("alice", "unread", 1, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unread.AllCount != 3 || unread.UnreadCount != 2 || unread.ReadCount != 1 {
+		t.Fatalf("global counts=%d/%d/%d", unread.AllCount, unread.UnreadCount, unread.ReadCount)
+	}
+	if unread.Total != 2 || len(unread.Items) != 2 {
+		t.Fatalf("unread filter total=%d items=%d", unread.Total, len(unread.Items))
+	}
+	for _, it := range unread.Items {
+		if !it.Unread {
+			t.Fatalf("unread filter leaked read item %+v", it)
+		}
+	}
+}
+
+func TestNotificationMarkAllReadBeyondPool(t *testing.T) {
+	db := setupNotificationDB(t)
+	svc := NewNotificationService(db, nil)
+	start := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 60; i++ {
+		seedTerminalRun(t, db, fmt.Sprintf("run-%02d", i), "completed", fmt.Sprintf("N%d", i),
+			start.Add(time.Duration(i)*time.Minute), 30)
+	}
+	if err := db.Create(&models.NotificationBaseline{
+		Username:  "alice",
+		EnabledAt: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		CreatedAt: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	if err := svc.MarkAllRead("alice"); err != nil {
+		t.Fatal(err)
+	}
+	res, err := svc.ListPage("alice", "all", 1, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.UnreadCount != 0 {
+		t.Fatalf("unread after mark-all=%d", res.UnreadCount)
+	}
+	page3, err := svc.ListPage("alice", "all", 3, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, it := range page3.Items {
+		if it.Unread {
+			t.Fatalf("page3 still unread %+v", it)
+		}
+	}
+	var n int64
+	db.Model(&models.NotificationRead{}).Where("username = ?", "alice").Count(&n)
+	if n != 60 {
+		t.Fatalf("read rows=%d want 60", n)
 	}
 }
 

--- a/web/e2e/notifications-center-main.ts
+++ b/web/e2e/notifications-center-main.ts
@@ -369,6 +369,32 @@ function notificationItemsForScene() {
   return mapped
 }
 
+function notificationListResponse(url: string) {
+  const u = new URL(url, 'http://e2e.local')
+  const page = Math.max(1, Number(u.searchParams.get('page') || '1') || 1)
+  const pageSize = Math.max(1, Number(u.searchParams.get('pageSize') || '20') || 20)
+  const filter = (u.searchParams.get('filter') || 'all').toLowerCase()
+  const all = notificationItemsForScene()
+  const allCount = all.length
+  const unreadCount = all.filter((x) => x.unread).length
+  const readCount = allCount - unreadCount
+  let filtered = all
+  if (filter === 'unread') filtered = all.filter((x) => x.unread)
+  else if (filter === 'read') filtered = all.filter((x) => !x.unread)
+  const total = filtered.length
+  const start = (page - 1) * pageSize
+  const items = filtered.slice(start, start + pageSize)
+  return {
+    items,
+    page,
+    pageSize,
+    total,
+    allCount,
+    unreadCount,
+    readCount,
+  }
+}
+
 function requestPath(url: string): string {
   try {
     return new URL(url, 'http://e2e.local').pathname
@@ -391,7 +417,7 @@ window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
     const prefs = getOrInitHarnessPrefs()
     const next = new Set(prefs.readIds)
     for (const item of notificationItemsForScene()) {
-      next.add(item.runId)
+      if (item.unread) next.add(item.runId)
     }
     prefs.readIds = [...next]
     saveHarnessPrefs(prefs)
@@ -418,7 +444,7 @@ window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
     })
   }
   if ((path === '/api/notifications' || path.endsWith('/notifications')) && method === 'GET') {
-    return new Response(JSON.stringify({ items: notificationItemsForScene() }), {
+    return new Response(JSON.stringify(notificationListResponse(url)), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
     })

--- a/web/src/components/shell/ShellChromeControls.test.ts
+++ b/web/src/components/shell/ShellChromeControls.test.ts
@@ -29,7 +29,15 @@ vi.mock('@/lib/composables/useAuth', () => ({
 vi.mock('@/lib/api/api', () => ({
   api: {
     listRuns: vi.fn(),
-    listNotifications: vi.fn(async () => ({ items: [] })),
+    listNotifications: vi.fn(async () => ({
+      items: [],
+      page: 1,
+      pageSize: 20,
+      total: 0,
+      allCount: 0,
+      unreadCount: 0,
+      readCount: 0,
+    })),
     getRun: vi.fn(),
     artifactContent: vi.fn(),
     artifactDownloadUrl: vi.fn((id: string) => `http://test/api/artifacts/${id}/download`),
@@ -77,7 +85,23 @@ function asItem(r: Run, extra: Partial<RunTerminalNotificationItem> = {}): RunTe
 }
 
 function seedList(items: RunTerminalNotificationItem[]) {
-  vi.mocked(api.listNotifications).mockResolvedValue({ items })
+  const allCount = items.length
+  const unreadCount = items.filter((x) => x.unread).length
+  const readCount = allCount - unreadCount
+  vi.mocked(api.listNotifications).mockImplementation(async (opts?: { page?: number; pageSize?: number }) => {
+    const page = opts?.page && opts.page > 0 ? opts.page : 1
+    const pageSize = opts?.pageSize && opts.pageSize > 0 ? opts.pageSize : 20
+    const start = (page - 1) * pageSize
+    return {
+      items: items.slice(start, start + pageSize),
+      page,
+      pageSize,
+      total: allCount,
+      allCount,
+      unreadCount,
+      readCount,
+    }
+  })
 }
 
 function mountChrome(layout: 'bar' | 'sidebar' = 'sidebar') {
@@ -113,7 +137,15 @@ describe('ShellChromeControls notifications (g1.2)', () => {
     vi.mocked(api.artifactContent).mockReset()
     vi.mocked(api.markNotificationRead).mockReset()
     vi.mocked(api.markAllNotificationsRead).mockReset()
-    vi.mocked(api.listNotifications).mockResolvedValue({ items: [] })
+    vi.mocked(api.listNotifications).mockResolvedValue({
+      items: [],
+      page: 1,
+      pageSize: 20,
+      total: 0,
+      allCount: 0,
+      unreadCount: 0,
+      readCount: 0,
+    })
     vi.mocked(api.markNotificationRead).mockResolvedValue({ status: 'ok' })
     vi.mocked(api.markAllNotificationsRead).mockResolvedValue({ status: 'ok' })
     vi.mocked(api.getRun).mockResolvedValue(run({ id: 'r1', status: 'completed', artifacts: [] }))

--- a/web/src/lib/api/apiTypes.ts
+++ b/web/src/lib/api/apiTypes.ts
@@ -376,4 +376,10 @@ export interface NotificationListItem {
 
 export interface NotificationListResponse {
   items: NotificationListItem[]
+  page?: number
+  pageSize?: number
+  total?: number
+  allCount?: number
+  unreadCount?: number
+  readCount?: number
 }

--- a/web/src/lib/api/clients/notificationsClient.ts
+++ b/web/src/lib/api/clients/notificationsClient.ts
@@ -1,12 +1,25 @@
 import { req } from '../httpCore'
 import type { NotificationListResponse } from '../apiTypes'
 
+export type NotificationReadFilter = 'all' | 'unread' | 'read'
+
 export const notificationsClient = {
-  listNotifications: (opts?: { signal?: AbortSignal }) =>
-    req<NotificationListResponse>(
-      '/notifications',
+  listNotifications: (opts?: {
+    signal?: AbortSignal
+    page?: number
+    pageSize?: number
+    filter?: NotificationReadFilter
+  }) => {
+    const params = new URLSearchParams()
+    if (opts?.page != null && opts.page > 0) params.set('page', String(opts.page))
+    if (opts?.pageSize != null && opts.pageSize > 0) params.set('pageSize', String(opts.pageSize))
+    if (opts?.filter) params.set('filter', opts.filter)
+    const qs = params.toString()
+    return req<NotificationListResponse>(
+      `/notifications${qs ? `?${qs}` : ''}`,
       opts?.signal ? { signal: opts.signal } : undefined,
-    ),
+    )
+  },
   markNotificationRead: (runId: string) =>
     req<{ status: string }>('/notifications/read', {
       method: 'POST',

--- a/web/src/lib/run/useRunTerminalNotifications.test.ts
+++ b/web/src/lib/run/useRunTerminalNotifications.test.ts
@@ -14,9 +14,33 @@ const serverItems = ref<NotificationListItem[]>([])
 
 vi.mock('@/lib/api/api', () => ({
   api: {
-    listNotifications: vi.fn(async () => ({
-      items: serverItems.value.map((x) => ({ ...x })),
-    })),
+    listNotifications: vi.fn(async (opts?: {
+      page?: number
+      pageSize?: number
+      filter?: 'all' | 'unread' | 'read'
+      signal?: AbortSignal
+    }) => {
+      const all = serverItems.value.map((x) => ({ ...x }))
+      const allCount = all.length
+      const unreadCount = all.filter((x) => x.unread).length
+      const readCount = allCount - unreadCount
+      const filter = opts?.filter ?? 'all'
+      let filtered = all
+      if (filter === 'unread') filtered = all.filter((x) => x.unread)
+      else if (filter === 'read') filtered = all.filter((x) => !x.unread)
+      const page = opts?.page ?? 1
+      const pageSize = opts?.pageSize ?? 20
+      const start = (page - 1) * pageSize
+      return {
+        items: filtered.slice(start, start + pageSize),
+        page,
+        pageSize,
+        total: filtered.length,
+        allCount,
+        unreadCount,
+        readCount,
+      }
+    }),
     markNotificationRead: vi.fn(async (runId: string) => {
       serverItems.value = serverItems.value.map((x) =>
         x.runId === runId ? { ...x, unread: false } : x,
@@ -45,8 +69,8 @@ import {
   isNoisyNotificationTitle,
   mapRunToNotification,
   isBeforeBaseline,
+  NOTIFICATION_PAGE_SIZE,
   RUN_TERMINAL_PANEL_LIMIT,
-  RUN_TERMINAL_POOL_SIZE,
   useRunTerminalNotifications,
 } from './useRunTerminalNotifications'
 import type { RunTerminalNotificationItem } from './useRunTerminalNotifications'
@@ -250,7 +274,20 @@ describe('useRunTerminalNotifications', () => {
     expect(RUN_TERMINAL_PANEL_LIMIT).toBe(5)
     expect(n.remainingCount.value).toBe(7)
     expect(n.poolTotal.value).toBe(12)
-    expect(RUN_TERMINAL_POOL_SIZE).toBe(50)
+    expect(NOTIFICATION_PAGE_SIZE).toBe(20)
+  })
+
+  it('refreshPage loads server-paginated list slice', async () => {
+    seedList(
+      Array.from({ length: 25 }, (_, i) =>
+        item(run({ id: `r${i}`, status: 'completed' })),
+      ),
+    )
+    const n = useRunTerminalNotifications()
+    await n.refreshPage({ page: 2, filter: 'all', source: 'page' })
+    expect(n.listItems.value).toHaveLength(5)
+    expect(n.listTotal.value).toBe(25)
+    expect(n.allCount.value).toBe(25)
   })
 
   it('marks post-baseline items without beforeBaseline and keeps them unread until read', async () => {
@@ -263,6 +300,7 @@ describe('useRunTerminalNotifications', () => {
     ])
     const n = useRunTerminalNotifications()
     await n.refresh({ source: 'mount' })
+    await n.refreshPage({ page: 1, filter: 'all', source: 'page' })
     const newer = n.listItems.value.find((x) => x.runId === 'new')
     const older = n.listItems.value.find((x) => x.runId === 'old')
     expect(newer?.beforeBaseline).toBe(false)

--- a/web/src/lib/run/useRunTerminalNotifications.ts
+++ b/web/src/lib/run/useRunTerminalNotifications.ts
@@ -1,13 +1,14 @@
 import { computed, ref, watch } from 'vue'
 import { api } from '@/lib/api/api'
 import type { NotificationListItem } from '@/lib/api/apiTypes'
+import type { NotificationReadFilter } from '@/lib/api/clients/notificationsClient'
 import type { Run } from '@/lib/shared/types'
 import { createTimeoutController, isAbortError } from '@/lib/shared/loadingRequest'
 import { DEFAULT_LOADING_TIMEOUT_MS } from '@/lib/shared/loadingTypes'
 import { useAuth } from '@/lib/composables/useAuth'
 
-/** Recent completed/failed runs that form the notification pool (plan: ~50). */
-export const RUN_TERMINAL_POOL_SIZE = 50
+/** Notifications page default page size (matches server). */
+export const NOTIFICATION_PAGE_SIZE = 20
 /** Dropdown preview hard limit (5 per clarified requirement / Demo). */
 export const RUN_TERMINAL_PANEL_LIMIT = 5
 /** Align with AppSidebarNav pending-gates peek interval. */
@@ -46,6 +47,7 @@ export type RunTerminalRefreshSource =
   | 'focus'
   | 'manual'
   | 'auth'
+  | 'page'
 
 export function formatUnreadBadge(n: number): string {
   if (n <= 0) return ''
@@ -114,16 +116,28 @@ export function isBeforeBaseline(
   return ft <= bt
 }
 
-const pool = ref<RunTerminalNotificationItem[]>([])
+const previewPool = ref<RunTerminalNotificationItem[]>([])
+const pageItems = ref<RunTerminalNotificationItem[]>([])
+const pageTotal = ref(0)
+const pageNumber = ref(1)
+const pageFilter = ref<NotificationReadFilter>('all')
+const serverAllCount = ref(0)
+const serverUnreadCount = ref(0)
+const serverReadCount = ref(0)
+
 const usernameKey = ref('anonymous')
 const error = ref<string | null>(null)
 const lastRefreshSource = ref<RunTerminalRefreshSource | null>(null)
 const lastPeekAt = ref(0)
 const loading = ref(false)
+const pageLoading = ref(false)
 
 let refreshPromise: Promise<void> | null = null
+let pagePromise: Promise<void> | null = null
 let refreshGeneration = 0
+let pageGeneration = 0
 let abortCtrl: AbortController | null = null
+let pageAbortCtrl: AbortController | null = null
 let pollTimer: number | undefined
 let listenersAttached = false
 let authWatchInstalled = false
@@ -143,20 +157,29 @@ function resolveUsername(): { name: string; settled: boolean } {
   return { name: 'anonymous', settled: true }
 }
 
-const unreadCount = computed(() => pool.value.filter((n) => n.unread).length)
+const unreadCount = computed(() => serverUnreadCount.value)
 
-const hasUnreadFailed = computed(() => pool.value.some((n) => n.unread && n.status === 'failed'))
+const hasUnreadFailed = computed(() =>
+  previewPool.value.some((n) => n.unread && n.status === 'failed'),
+)
 
 const badgeLabel = computed(() => formatUnreadBadge(unreadCount.value))
 
-const previewItems = computed(() => pool.value.slice(0, RUN_TERMINAL_PANEL_LIMIT))
+const previewItems = computed(() => previewPool.value.slice(0, RUN_TERMINAL_PANEL_LIMIT))
 
-/** Full pool with unread flags for the independent notifications page. */
-const listItems = computed(() => pool.value)
+/** Current notifications-page slice (server-paginated). */
+const listItems = computed(() => pageItems.value)
 
-const remainingCount = computed(() => Math.max(pool.value.length - RUN_TERMINAL_PANEL_LIMIT, 0))
+const listTotal = computed(() => pageTotal.value)
 
-const poolTotal = computed(() => pool.value.length)
+const remainingCount = computed(() =>
+  Math.max(serverAllCount.value - RUN_TERMINAL_PANEL_LIMIT, 0),
+)
+
+const poolTotal = computed(() => serverAllCount.value)
+
+const allCount = computed(() => serverAllCount.value)
+const readCount = computed(() => serverReadCount.value)
 
 /**
  * Ensure auth identity is settled before fetch/write.
@@ -167,7 +190,12 @@ function ensureUsername(): boolean {
   if (!settled) return false
   if (name !== usernameKey.value) {
     usernameKey.value = name
-    pool.value = []
+    previewPool.value = []
+    pageItems.value = []
+    serverAllCount.value = 0
+    serverUnreadCount.value = 0
+    serverReadCount.value = 0
+    pageTotal.value = 0
   }
   return true
 }
@@ -180,7 +208,12 @@ function onAuthIdentityChange() {
   }
   if (name !== usernameKey.value) {
     usernameKey.value = name
-    pool.value = []
+    previewPool.value = []
+    pageItems.value = []
+    serverAllCount.value = 0
+    serverUnreadCount.value = 0
+    serverReadCount.value = 0
+    pageTotal.value = 0
   }
   // Rehydrate as soon as auth paints — do not wait for focus/15s poll.
   if (lastSettledName !== name) {
@@ -224,13 +257,69 @@ function parseListItem(raw: NotificationListItem): RunTerminalNotificationItem |
   }
 }
 
+function applyCounts(data: {
+  allCount?: number
+  unreadCount?: number
+  readCount?: number
+  items?: NotificationListItem[]
+}) {
+  if (typeof data.allCount === 'number') {
+    serverAllCount.value = data.allCount
+  } else if (Array.isArray(data.items)) {
+    serverAllCount.value = data.items.length
+  }
+  if (typeof data.unreadCount === 'number') {
+    serverUnreadCount.value = data.unreadCount
+  }
+  if (typeof data.readCount === 'number') {
+    serverReadCount.value = data.readCount
+  }
+}
+
+function mapItems(raw: NotificationListItem[]): RunTerminalNotificationItem[] {
+  const mapped: RunTerminalNotificationItem[] = []
+  for (const item of raw) {
+    const n = parseListItem(item)
+    if (n) mapped.push(n)
+  }
+  return mapped
+}
+
+function markReadLocal(runId: string) {
+  if (!runId) return
+  const pageHit = pageItems.value.find((n) => n.runId === runId)
+  const wasUnread = pageHit?.unread ?? false
+  previewPool.value = previewPool.value.map((n) =>
+    n.runId === runId && n.unread ? { ...n, unread: false } : n,
+  )
+  pageItems.value = pageItems.value.map((n) =>
+    n.runId === runId && n.unread ? { ...n, unread: false } : n,
+  )
+  if (wasUnread && pageFilter.value === 'unread') {
+    pageItems.value = pageItems.value.filter((n) => n.runId !== runId)
+    pageTotal.value = Math.max(0, pageTotal.value - 1)
+  }
+  if (wasUnread && serverUnreadCount.value > 0) {
+    serverUnreadCount.value -= 1
+    serverReadCount.value += 1
+  }
+}
+
+function markAllReadLocal() {
+  previewPool.value = previewPool.value.map((n) => (n.unread ? { ...n, unread: false } : n))
+  pageItems.value = pageItems.value.map((n) => (n.unread ? { ...n, unread: false } : n))
+  serverUnreadCount.value = 0
+  serverReadCount.value = serverAllCount.value
+}
+
 function markRead(runId: string) {
   if (!runId) return
   const { settled } = resolveUsername()
   if (!settled) return
-  const current = pool.value.find((n) => n.runId === runId)
-  if (current && !current.unread) return
-  pool.value = pool.value.map((n) => (n.runId === runId && n.unread ? { ...n, unread: false } : n))
+  const inPreview = previewPool.value.find((n) => n.runId === runId)
+  const inPage = pageItems.value.find((n) => n.runId === runId)
+  if (!inPreview?.unread && !inPage?.unread) return
+  markReadLocal(runId)
   void (async () => {
     try {
       await api.markNotificationRead(runId)
@@ -243,7 +332,7 @@ function markRead(runId: string) {
 function markAllRead() {
   const { settled } = resolveUsername()
   if (!settled) return
-  pool.value = pool.value.map((n) => (n.unread ? { ...n, unread: false } : n))
+  markAllReadLocal()
   void (async () => {
     try {
       await api.markAllNotificationsRead()
@@ -254,15 +343,35 @@ function markAllRead() {
   })()
 }
 
-async function fetchPool(signal?: AbortSignal): Promise<RunTerminalNotificationItem[]> {
-  const data = await api.listNotifications(signal ? { signal } : undefined)
+async function fetchPreview(signal?: AbortSignal): Promise<void> {
+  const data = await api.listNotifications({
+    signal,
+    page: 1,
+    pageSize: RUN_TERMINAL_PANEL_LIMIT,
+    filter: 'all',
+  })
   const raw = Array.isArray(data?.items) ? data.items : []
-  const mapped: RunTerminalNotificationItem[] = []
-  for (const item of raw) {
-    const n = parseListItem(item)
-    if (n) mapped.push(n)
-  }
-  return mapped
+  previewPool.value = mapItems(raw)
+  applyCounts(data)
+}
+
+async function fetchPage(
+  page: number,
+  filter: NotificationReadFilter,
+  signal?: AbortSignal,
+): Promise<void> {
+  const data = await api.listNotifications({
+    signal,
+    page,
+    pageSize: NOTIFICATION_PAGE_SIZE,
+    filter,
+  })
+  const raw = Array.isArray(data?.items) ? data.items : []
+  pageItems.value = mapItems(raw)
+  pageTotal.value = typeof data.total === 'number' ? data.total : pageItems.value.length
+  pageNumber.value = typeof data.page === 'number' && data.page > 0 ? data.page : page
+  pageFilter.value = filter
+  applyCounts(data)
 }
 
 async function refresh(opts?: { source?: RunTerminalRefreshSource }): Promise<void> {
@@ -293,9 +402,8 @@ async function refresh(opts?: { source?: RunTerminalRefreshSource }): Promise<vo
     loading.value = true
     try {
       if (!ensureUsername() && opts?.source !== 'auth') return
-      const next = await fetchPool(tc.signal)
+      await fetchPreview(tc.signal)
       if (gen !== refreshGeneration) return
-      pool.value = next
       error.value = null
       lastRefreshSource.value = opts?.source ?? null
       lastPeekAt.value = Date.now()
@@ -310,6 +418,51 @@ async function refresh(opts?: { source?: RunTerminalRefreshSource }): Promise<vo
     }
   })()
   refreshPromise = holder.flight
+  return holder.flight
+}
+
+async function refreshPage(opts?: {
+  page?: number
+  filter?: NotificationReadFilter
+  source?: RunTerminalRefreshSource
+}): Promise<void> {
+  installAuthWatch()
+  const { settled } = resolveUsername()
+  if (!settled) return
+
+  const page = opts?.page ?? pageNumber.value
+  const filter = opts?.filter ?? pageFilter.value
+
+  if (pagePromise) {
+    return pagePromise
+  }
+
+  const gen = ++pageGeneration
+  pageAbortCtrl?.abort()
+  pageAbortCtrl = new AbortController()
+  const tc = createTimeoutController(DEFAULT_LOADING_TIMEOUT_MS, pageAbortCtrl.signal)
+
+  const holder: { flight: Promise<void> | null } = { flight: null }
+  holder.flight = (async () => {
+    pageLoading.value = true
+    try {
+      if (!ensureUsername()) return
+      await fetchPage(page, filter, tc.signal)
+      if (gen !== pageGeneration) return
+      error.value = null
+      lastRefreshSource.value = opts?.source ?? 'page'
+      lastPeekAt.value = Date.now()
+    } catch (err) {
+      if (gen !== pageGeneration) return
+      if (isAbortError(err) && !tc.timedOut) return
+      error.value = err instanceof Error && err.message ? err.message : String(err || 'load failed')
+    } finally {
+      tc.clear()
+      if (pagePromise === holder.flight) pagePromise = null
+      pageLoading.value = false
+    }
+  })()
+  pagePromise = holder.flight
   return holder.flight
 }
 
@@ -351,40 +504,59 @@ function stopPolling() {
   }
   abortCtrl?.abort()
   abortCtrl = null
+  pageAbortCtrl?.abort()
+  pageAbortCtrl = null
 }
 
 /** Test helper: reset module singleton state. */
 export function __resetRunTerminalNotificationsForTests() {
   stopPolling()
-  pool.value = []
+  previewPool.value = []
+  pageItems.value = []
+  pageTotal.value = 0
+  pageNumber.value = 1
+  pageFilter.value = 'all'
+  serverAllCount.value = 0
+  serverUnreadCount.value = 0
+  serverReadCount.value = 0
   usernameKey.value = 'anonymous'
   error.value = null
   lastRefreshSource.value = null
   lastPeekAt.value = 0
   loading.value = false
+  pageLoading.value = false
   refreshPromise = null
+  pagePromise = null
   refreshGeneration = 0
+  pageGeneration = 0
   lastSettledName = null
   // Keep authWatchInstalled: watch is idempotent and must survive test resets.
 }
 
 export function useRunTerminalNotifications() {
   return {
-    pool,
+    pool: previewPool,
     poolTotal,
     previewItems,
     listItems,
+    listTotal,
     remainingCount,
     unreadCount,
+    allCount,
+    readCount,
     hasUnreadFailed,
     badgeLabel,
     error,
     loading,
+    pageLoading,
+    pageNumber,
+    pageFilter,
     lastRefreshSource,
     lastPeekAt,
     markRead,
     markAllRead,
     refresh,
+    refreshPage,
     startPolling,
     stopPolling,
     ensureUsername,

--- a/web/src/lib/run/useRunTerminalNotifications.ts
+++ b/web/src/lib/run/useRunTerminalNotifications.ts
@@ -288,7 +288,8 @@ function mapItems(raw: NotificationListItem[]): RunTerminalNotificationItem[] {
 function markReadLocal(runId: string) {
   if (!runId) return
   const pageHit = pageItems.value.find((n) => n.runId === runId)
-  const wasUnread = pageHit?.unread ?? false
+  const previewHit = previewPool.value.find((n) => n.runId === runId)
+  const wasUnread = Boolean(pageHit?.unread || previewHit?.unread)
   previewPool.value = previewPool.value.map((n) =>
     n.runId === runId && n.unread ? { ...n, unread: false } : n,
   )

--- a/web/src/views/NotificationsView.pagination.test.ts
+++ b/web/src/views/NotificationsView.pagination.test.ts
@@ -26,12 +26,46 @@ vi.mock('@/lib/composables/useAuth', () => ({
 
 vi.mock('@/lib/api/api', () => ({
   api: {
-    listNotifications: vi.fn(async () => ({ items: [] })),
+    listNotifications: vi.fn(async (opts?: {
+      page?: number
+      pageSize?: number
+      filter?: 'all' | 'unread' | 'read'
+      signal?: AbortSignal
+    }) => {
+      const all = listStore.value.map((x) => ({ ...x }))
+      const allCount = all.length
+      const unreadCount = all.filter((x) => x.unread).length
+      const readCount = allCount - unreadCount
+      const filter = opts?.filter ?? 'all'
+      let filtered = all
+      if (filter === 'unread') filtered = all.filter((x) => x.unread)
+      else if (filter === 'read') filtered = all.filter((x) => !x.unread)
+      const page = opts?.page ?? 1
+      const pageSize = opts?.pageSize ?? 20
+      const start = (page - 1) * pageSize
+      return {
+        items: filtered.slice(start, start + pageSize),
+        page,
+        pageSize,
+        total: filtered.length,
+        allCount,
+        unreadCount,
+        readCount,
+      }
+    }),
     getRun: vi.fn(),
     artifactContent: vi.fn(),
     artifactDownloadUrl: vi.fn((id: string) => `http://test/api/artifacts/${id}/download`),
-    markNotificationRead: vi.fn(async () => ({ status: 'ok' })),
-    markAllNotificationsRead: vi.fn(async () => ({ status: 'ok' })),
+    markNotificationRead: vi.fn(async (runId: string) => {
+      listStore.value = listStore.value.map((x) =>
+        x.runId === runId ? { ...x, unread: false } : x,
+      )
+      return { status: 'ok' }
+    }),
+    markAllNotificationsRead: vi.fn(async () => {
+      listStore.value = listStore.value.map((x) => ({ ...x, unread: false }))
+      return { status: 'ok' }
+    }),
   },
 }))
 
@@ -39,11 +73,13 @@ import { api } from '@/lib/api/api'
 import {
   __resetRunTerminalNotificationsForTests,
   mapRunToNotification,
+  NOTIFICATION_PAGE_SIZE,
   RUN_TERMINAL_PANEL_LIMIT,
-  RUN_TERMINAL_POOL_SIZE,
   useRunTerminalNotifications,
 } from '@/lib/run/useRunTerminalNotifications'
 import type { RunTerminalNotificationItem } from '@/lib/run/useRunTerminalNotifications'
+
+const listStore = ref<RunTerminalNotificationItem[]>([])
 import NotificationsView from './NotificationsView.vue'
 
 const viewSrc = readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'NotificationsView.vue'), 'utf8')
@@ -84,7 +120,29 @@ function makeItems(n: number, unreadCount = n): RunTerminalNotificationItem[] {
 }
 
 async function mountView(items: RunTerminalNotificationItem[]) {
-  vi.mocked(api.listNotifications).mockResolvedValue({ items })
+  listStore.value = items.map((x) => ({ ...x }))
+  vi.mocked(api.listNotifications).mockImplementation(async (opts) => {
+    const all = listStore.value.map((x) => ({ ...x }))
+    const allCount = all.length
+    const unreadCount = all.filter((x) => x.unread).length
+    const readCount = allCount - unreadCount
+    const filter = opts?.filter ?? 'all'
+    let filtered = all
+    if (filter === 'unread') filtered = all.filter((x) => x.unread)
+    else if (filter === 'read') filtered = all.filter((x) => !x.unread)
+    const page = opts?.page ?? 1
+    const pageSize = opts?.pageSize ?? 20
+    const start = (page - 1) * pageSize
+    return {
+      items: filtered.slice(start, start + pageSize),
+      page,
+      pageSize,
+      total: filtered.length,
+      allCount,
+      unreadCount,
+      readCount,
+    }
+  })
   const i18n = createI18n({
     legacy: false,
     locale: 'zh-CN',
@@ -112,10 +170,17 @@ async function mountView(items: RunTerminalNotificationItem[]) {
 describe('NotificationsView pagination (g1/g2/g4)', () => {
   beforeEach(() => {
     localStorage.clear()
+    listStore.value = []
     __resetRunTerminalNotificationsForTests()
     __resetNotificationsPageEntryForTests()
     vi.mocked(api.listNotifications).mockReset()
-    vi.mocked(api.listNotifications).mockResolvedValue({ items: [] })
+    vi.mocked(api.listNotifications).mockResolvedValue({
+      items: [],
+      total: 0,
+      allCount: 0,
+      unreadCount: 0,
+      readCount: 0,
+    })
   })
 
   afterEach(() => {
@@ -151,9 +216,11 @@ describe('NotificationsView pagination (g1/g2/g4)', () => {
     const items = makeItems(21).map((item, i) => ({ ...item, unread: i >= 18 }))
     const { wrapper } = await mountView(items)
     await wrapper.find('[data-testid="notifications-pagination"]').findAll('button.pg-btn')[1]!.trigger('click')
+    await flushPromises()
     await nextTick()
 
     await wrapper.find('[data-testid="notifications-filter-unread"]').trigger('click')
+    await flushPromises()
     await nextTick()
     expect(wrapper.find('[data-testid="notifications-page-range"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="notifications-pagination"]').exists()).toBe(false)
@@ -165,12 +232,17 @@ describe('NotificationsView pagination (g1/g2/g4)', () => {
     const items = makeItems(21)
     const { wrapper } = await mountView(items)
     await wrapper.find('[data-testid="notifications-filter-unread"]').trigger('click')
+    await flushPromises()
+    await nextTick()
     await wrapper.find('[data-testid="notifications-pagination"]').findAll('button.pg-btn')[1]!.trigger('click')
+    await flushPromises()
     await nextTick()
     expect(wrapper.findAll('[data-testid="notifications-item"]')).toHaveLength(1)
     const lastId = wrapper.find('[data-testid="notifications-item"]').attributes('data-run-id')!
     useRunTerminalNotifications().markRead(lastId)
+    await flushPromises()
     await nextTick()
+    await flushPromises()
     await nextTick()
     expect(wrapper.find('[data-testid="notifications-pagination"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="notifications-page-range"]').exists()).toBe(false)
@@ -195,18 +267,21 @@ describe('NotificationsView pagination (g1/g2/g4)', () => {
   it('paging does not change unread badge or preview slice / fetchPool (g1.5 / g4.1)', async () => {
     const items = makeItems(25)
     const { wrapper } = await mountView(items)
+    await flushPromises()
     const callsAfterMount = vi.mocked(api.listNotifications).mock.calls.length
     const n = useRunTerminalNotifications()
+    await n.refresh({ source: 'manual' })
     expect(n.unreadCount.value).toBe(25)
     expect(n.previewItems.value).toHaveLength(RUN_TERMINAL_PANEL_LIMIT)
     const previewIds = n.previewItems.value.map((x) => x.runId)
 
     await wrapper.find('[data-testid="notifications-pagination"]').findAll('button.pg-btn')[1]!.trigger('click')
+    await flushPromises()
     await nextTick()
     expect(n.unreadCount.value).toBe(25)
     expect(wrapper.find('[data-testid="notifications-unread-count"]').text()).toContain('25')
     expect(n.previewItems.value.map((x) => x.runId)).toEqual(previewIds)
-    expect(vi.mocked(api.listNotifications).mock.calls.length).toBe(callsAfterMount)
+    expect(vi.mocked(api.listNotifications).mock.calls.length).toBeGreaterThan(callsAfterMount)
     expect(api.listNotifications).toHaveBeenCalled()
     wrapper.unmount()
   })
@@ -257,16 +332,17 @@ describe('NotificationsView pagination conventions (g4.4 / g1.5)', () => {
   })
 
   it('gates Pagination on filteredTotal > PAGE_SIZE with shrink-0 and no pageSizeOptions', () => {
-    expect(viewSrc).toMatch(/const PAGE_SIZE = 20/)
+    expect(viewSrc).toMatch(/const PAGE_SIZE = NOTIFICATION_PAGE_SIZE/)
     expect(viewSrc).toMatch(/<Pagination[\s\S]*v-if="filteredTotal > PAGE_SIZE"/)
     expect(viewSrc).toMatch(/class="shrink-0"/)
     expect(viewSrc).not.toMatch(/page-size-options/)
     expect(viewSrc).not.toMatch(/pageSizeOptions/)
   })
 
-  it('loads the full pool from GET /notifications (server caps at 50)', () => {
+  it('loads paginated slices from GET /notifications with server counts', () => {
     expect(poolSrc).toMatch(/listNotifications/)
-    expect(poolSrc).toMatch(/export const RUN_TERMINAL_POOL_SIZE = 50/)
-    expect(RUN_TERMINAL_POOL_SIZE).toBe(50)
+    expect(poolSrc).toMatch(/export const NOTIFICATION_PAGE_SIZE = 20/)
+    expect(NOTIFICATION_PAGE_SIZE).toBe(20)
+    expect(poolSrc).not.toMatch(/RUN_TERMINAL_POOL_SIZE/)
   })
 })

--- a/web/src/views/NotificationsView.vue
+++ b/web/src/views/NotificationsView.vue
@@ -7,11 +7,15 @@ import Pagination from '@/components/ui/Pagination.vue'
 import RunOutputPptModal from '@/components/shell/RunOutputPptModal.vue'
 import { useNotificationsPageEntry } from '@/lib/composables/useNotificationsPageEntry'
 import { relTime } from '@/lib/shared/format'
-import { useRunTerminalNotifications } from '@/lib/run/useRunTerminalNotifications'
+import {
+  NOTIFICATION_PAGE_SIZE,
+  useRunTerminalNotifications,
+} from '@/lib/run/useRunTerminalNotifications'
+import type { NotificationReadFilter } from '@/lib/api/clients/notificationsClient'
 
-type ReadFilter = 'all' | 'unread' | 'read'
+type ReadFilter = NotificationReadFilter
 
-const PAGE_SIZE = 20
+const PAGE_SIZE = NOTIFICATION_PAGE_SIZE
 
 const { t } = useI18n()
 const router = useRouter()
@@ -19,12 +23,16 @@ const { enterNonce } = useNotificationsPageEntry()
 
 const {
   listItems,
+  listTotal,
   unreadCount,
+  allCount,
+  readCount,
   markRead,
   markAllRead,
-  refresh,
+  refreshPage,
   ensureUsername,
   loading,
+  pageLoading,
 } = useRunTerminalNotifications()
 
 const filter = ref<ReadFilter>('all')
@@ -33,38 +41,34 @@ const outputOpen = ref(false)
 const outputRunId = ref<string | null>(null)
 const outputContext = ref('')
 
-const filteredItems = computed(() => {
-  const items = listItems.value
-  if (filter.value === 'unread') return items.filter((n) => n.unread)
-  if (filter.value === 'read') return items.filter((n) => !n.unread)
-  return items
-})
-
-const filteredTotal = computed(() => filteredItems.value.length)
-
 const filterCounts = computed<Record<ReadFilter, number>>(() => ({
-  all: listItems.value.length,
-  unread: listItems.value.filter((n) => n.unread).length,
-  read: listItems.value.filter((n) => !n.unread).length,
+  all: allCount.value,
+  unread: unreadCount.value,
+  read: readCount.value,
 }))
 
-const pagedItems = computed(() => {
-  const start = (page.value - 1) * PAGE_SIZE
-  return filteredItems.value.slice(start, start + PAGE_SIZE)
-})
+const pagedItems = computed(() => listItems.value)
+
+const filteredTotal = computed(() => listTotal.value)
 
 const pagerSummary = computed(() =>
   t('pages.notifications.pagerSummary', { total: filteredTotal.value, pageSize: PAGE_SIZE }),
 )
 
+const showLoading = computed(
+  () => (loading.value || pageLoading.value) && !listItems.value.length,
+)
+
 function setFilter(next: ReadFilter) {
   filter.value = next
   page.value = 1
+  void refreshPage({ page: 1, filter: next, source: 'page' })
 }
 
 function resetToAllFirstPage() {
   filter.value = 'all'
   page.value = 1
+  void refreshPage({ page: 1, filter: 'all', source: 'page' })
 }
 
 function clampPage() {
@@ -76,11 +80,17 @@ function clampPage() {
   const last = Math.ceil(n / PAGE_SIZE)
   if (page.value > last || pagedItems.value.length === 0) {
     page.value = last
+    void refreshPage({ page: last, filter: filter.value, source: 'page' })
   }
 }
 
 watch(enterNonce, () => {
   resetToAllFirstPage()
+})
+
+watch(page, (next, prev) => {
+  if (next === prev) return
+  void refreshPage({ page: next, filter: filter.value, source: 'page' })
 })
 
 watch(filteredTotal, () => {
@@ -142,7 +152,7 @@ function onOutputMarkRead() {
 
 onMounted(() => {
   ensureUsername()
-  void refresh({ source: 'manual' })
+  void refreshPage({ page: 1, filter: 'all', source: 'manual' })
 })
 
 defineExpose({
@@ -198,14 +208,14 @@ defineExpose({
     <div class="card flex min-h-0 flex-1 flex-col overflow-hidden">
       <div class="min-h-0 flex-1 overflow-y-auto">
         <div
-          v-if="loading && !listItems.length"
+          v-if="showLoading"
           class="flex h-full items-center justify-center px-6 py-14 text-center text-sm text-txt3"
           data-testid="notifications-loading"
         >
           {{ t('pages.notifications.loading') }}
         </div>
         <div
-          v-else-if="!filteredItems.length"
+          v-else-if="!pagedItems.length"
           class="flex h-full items-center justify-center px-6 py-14"
         >
           <EmptyState


### PR DESCRIPTION
## Summary
- Remove the hardcoded 50-item notification pool (`NotificationPoolSize` / `RUN_TERMINAL_POOL_SIZE`) so users can page through all completed/failed inbox items.
- `GET /notifications` now accepts `page`, `pageSize` (default 20), and `filter=all|unread|read`, and returns `items` plus `total`, `allCount`, `unreadCount`, and `readCount`.
- Tab counts and the unread badge bind to server totals; Mark all read covers every unread terminal run, not just the old 50-item window. Top-bar dropdown still previews at most 5 items.

## API contract change
Clients must request with `page` / `pageSize` / `filter` and consume the new count fields. Do not assume a single response contains the entire inbox.

## Test plan
- [x] Go `Notification` service/handler tests (including >50 list + mark-all-read)
- [x] vitest `useRunTerminalNotifications` + `NotificationsView.pagination`
- [x] Playwright notifications-center e2e (25 items / 2 pages, full unread badge, mark-all-read)
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)