### PR TITLE
fix(ui): remove desktop sidebar brand color rail

### DIFF
--- a/web/src/components/shell/AppSidebar.test.ts
+++ b/web/src/components/shell/AppSidebar.test.ts
@@ -74,12 +74,9 @@ describe('AppSidebar', () => {
     wrapper.unmount()
   })
 
-  it('renders four-color brand rail below brand row (g2.3)', () => {
+  it('does not render brand rail below brand row (g2.3)', () => {
     const wrapper = mountSidebar()
-    const rail = wrapper.find('[data-testid="sidebar-brand-rail"]')
-    expect(rail.exists()).toBe(true)
-    expect(rail.classes()).toContain('app-sidebar-brand-rail')
-    expect(rail.findAll('span')).toHaveLength(4)
+    expect(wrapper.find('[data-testid="sidebar-brand-rail"]').exists()).toBe(false)
     wrapper.unmount()
   })
 

--- a/web/src/components/shell/AppSidebar.vue
+++ b/web/src/components/shell/AppSidebar.vue
@@ -67,9 +67,6 @@ async function onHideNav() {
           <Icon name="panel-left" :size="18" />
         </button>
       </div>
-      <div class="app-sidebar-brand-rail" aria-hidden="true" data-testid="sidebar-brand-rail">
-        <span /><span /><span /><span />
-      </div>
 
       <AppSidebarNav />
 

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -400,25 +400,6 @@ html.light .app-sidebar-brand-row {
   background: linear-gradient(105deg, #efe8ff 0%, #e8eeff 55%, #e8faf3 100%);
 }
 
-.app-sidebar-brand-rail {
-  display: grid;
-  grid-template-columns: 1.4fr 1.1fr 0.9fr 0.7fr;
-  height: 3px;
-  flex-shrink: 0;
-}
-.app-sidebar-brand-rail span:nth-child(1) {
-  background: rgb(var(--c-accent));
-}
-.app-sidebar-brand-rail span:nth-child(2) {
-  background: #6366f1;
-}
-.app-sidebar-brand-rail span:nth-child(3) {
-  background: rgb(var(--c-ok));
-}
-.app-sidebar-brand-rail span:nth-child(4) {
-  background: rgb(var(--c-warn));
-}
-
 @media (prefers-reduced-motion: reduce) {
   .brand-logo__name {
     animation: none;


### PR DESCRIPTION
Users found the four-color strip below the brand row visually
discordant. Remove the rail markup, dedicated CSS, and flip the
sidebar test to assert the decorative element is absent while
keeping brand-row wash gradients intact.

Co-authored-by: Cursor <cursoragent@cursor.com>
