### PR TITLE
feat(web): quiet gradient wordmark on desktop sidebar brand row

### DIFF
--- a/web/src/components/shell/AppSidebar.test.ts
+++ b/web/src/components/shell/AppSidebar.test.ts
@@ -57,11 +57,12 @@ describe('AppSidebar', () => {
     wrapper.unmount()
   })
 
-  it('puts a 44px hide-nav control on the 72px brand row (g2.1 / g2.2)', () => {
+  it('puts a 44px hide-nav control on the 56px brand row (g1.2 / g2.1)', () => {
     const wrapper = mountSidebar()
     const row = wrapper.find('[data-testid="sidebar-brand-row"]')
     expect(row.exists()).toBe(true)
-    expect(row.classes()).toContain('h-[72px]')
+    expect(row.classes()).toContain('h-14')
+    expect(row.classes()).not.toContain('h-[72px]')
     expect(row.classes()).toContain('justify-between')
     const hide = wrapper.find('[data-testid="desktop-nav-hide"]')
     expect(hide.exists()).toBe(true)
@@ -74,9 +75,36 @@ describe('AppSidebar', () => {
     wrapper.unmount()
   })
 
-  it('does not render brand rail below brand row (g2.3)', () => {
+  it('does not render brand rail below brand row (g1.3)', () => {
     const wrapper = mountSidebar()
     expect(wrapper.find('[data-testid="sidebar-brand-rail"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('sidebar brand row uses compact gradient wordmark without wash (g1.1 / g2.2)', () => {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages, ...shell } },
+    })
+    const wrapper = mount(AppSidebar, {
+      global: {
+        plugins: [i18n],
+        stubs: {
+          AppSidebarNav: { template: '<nav data-testid="nav" />' },
+          ShellChromeControls: { template: '<div data-testid="shell-chrome-controls" />' },
+          Icon: true,
+        },
+      },
+    })
+    const row = wrapper.find('[data-testid="sidebar-brand-row"]')
+    expect(row.classes()).toContain('h-14')
+    expect(row.classes()).toContain('app-sidebar-brand-row')
+    const logo = wrapper.find('.brand-logo')
+    expect(logo.exists()).toBe(true)
+    expect(logo.find('.brand-logo__mark').exists()).toBe(false)
+    expect(logo.find('.brand-logo__tagline').exists()).toBe(false)
+    expect(logo.find('.brand-logo__name').exists()).toBe(true)
     wrapper.unmount()
   })
 

--- a/web/src/components/shell/AppSidebar.vue
+++ b/web/src/components/shell/AppSidebar.vue
@@ -50,10 +50,10 @@ async function onHideNav() {
   >
     <div class="flex h-full w-[232px] min-w-[232px] flex-col">
       <div
-        class="app-sidebar-brand-row flex h-[72px] items-center justify-between gap-2 pl-3.5 pr-2"
+        class="app-sidebar-brand-row flex h-14 items-center justify-between gap-2 pl-3.5 pr-2"
         data-testid="sidebar-brand-row"
       >
-        <BrandLogo size="md" align="start" show-mark />
+        <BrandLogo size="md" align="start" :show-tagline="false" />
         <button
           type="button"
           class="flex h-11 w-11 shrink-0 items-center justify-center rounded-md text-txt3 hover:text-txt2"

--- a/web/src/components/shell/BrandLogo.test.ts
+++ b/web/src/components/shell/BrandLogo.test.ts
@@ -10,7 +10,7 @@ import pages from '@/locales/zh-CN/pages.json'
 import BrandLogo from './BrandLogo.vue'
 
 describe('BrandLogo', () => {
-  it('renders app name and tagline', () => {
+  it('renders app name and tagline by default', () => {
     const i18n = createI18n({
       legacy: false,
       locale: 'zh-CN',
@@ -26,58 +26,34 @@ describe('BrandLogo', () => {
     wrapper.unmount()
   })
 
-  it('shows 32px checkmark square only when showMark is true (g1.1)', () => {
-    const i18n = createI18n({
-      legacy: false,
-      locale: 'zh-CN',
-      messages: { 'zh-CN': { ...common, ...pages } },
-    })
-    const withMark = mount(BrandLogo, {
-      props: { size: 'md', showMark: true },
-      global: { plugins: [i18n] },
-    })
-    const mark = withMark.find('.brand-logo__mark')
-    expect(mark.exists()).toBe(true)
-    expect(mark.text()).not.toMatch(/A/)
-    expect(mark.find('.brand-logo__check').exists()).toBe(true)
-    expect(mark.find('path').exists()).toBe(true)
-    expect(withMark.classes()).toContain('brand-logo--with-mark')
-    expect(withMark.find('.brand-logo__tagline').exists()).toBe(false)
-    withMark.unmount()
-
-    const without = mount(BrandLogo, {
-      props: { size: 'lg', align: 'center' },
-      global: { plugins: [i18n] },
-    })
-    expect(without.find('.brand-logo__mark').exists()).toBe(false)
-    without.unmount()
-  })
-
-  it('uses static sidebar wordmark without tagline when showMark (g1.2)', () => {
+  it('hides tagline when showTagline is false (sidebar compact wordmark)', () => {
     const i18n = createI18n({
       legacy: false,
       locale: 'zh-CN',
       messages: { 'zh-CN': { ...common, ...pages } },
     })
     const wrapper = mount(BrandLogo, {
-      props: { size: 'md', showMark: true },
+      props: { size: 'md', showTagline: false },
       global: { plugins: [i18n] },
     })
     const name = wrapper.find('.brand-logo__name')
     expect(name.text()).toBe('Approving')
-    expect(name.classes()).not.toContain('brand-logo__tagline')
+    expect(wrapper.find('.brand-logo__tagline').exists()).toBe(false)
+    expect(wrapper.find('.brand-logo__mark').exists()).toBe(false)
+    expect(wrapper.classes()).not.toContain('brand-logo--with-mark')
     wrapper.unmount()
   })
 
-  it('does not leak mark to login, boot shell, or mobile drawer (g3.1)', () => {
+  it('does not leak mark markup to login, boot shell, or mobile drawer (g3.2)', () => {
     const dir = dirname(fileURLToPath(import.meta.url))
     const sidebar = readFileSync(join(dir, 'AppSidebar.vue'), 'utf8')
     const shell = readFileSync(join(dir, 'AppShell.vue'), 'utf8')
     const login = readFileSync(join(dir, '../../views/LoginView.vue'), 'utf8')
     const boot = readFileSync(join(dir, '../../../index.html'), 'utf8')
-    expect(sidebar).toMatch(/show-mark/)
-    expect(shell).not.toMatch(/show-mark|showMark/)
-    expect(login).not.toMatch(/show-mark|showMark/)
+    expect(sidebar).not.toMatch(/show-mark|showMark/)
+    expect(sidebar).toMatch(/show-tagline="false"/)
+    expect(shell).not.toMatch(/show-mark|showMark|brand-logo__mark/)
+    expect(login).not.toMatch(/show-mark|showMark|brand-logo__mark/)
     expect(boot).not.toMatch(/brand-logo__mark/)
   })
 })

--- a/web/src/components/shell/BrandLogo.vue
+++ b/web/src/components/shell/BrandLogo.vue
@@ -7,13 +7,13 @@ const props = withDefaults(
   defineProps<{
     size?: 'sm' | 'md' | 'lg'
     align?: 'start' | 'center'
-    /** Desktop AppSidebar only: 32px purple-indigo checkmark square. */
-    showMark?: boolean
+    /** When false, hide tagline (desktop sidebar compact wordmark). */
+    showTagline?: boolean
   }>(),
   {
     size: 'sm',
     align: 'start',
-    showMark: false,
+    showTagline: true,
   },
 )
 
@@ -23,7 +23,6 @@ const rootClass = computed(() => [
   'brand-logo',
   { sm: 'brand-logo--sm', md: 'brand-logo--md', lg: 'brand-logo--lg' }[props.size],
   props.align === 'center' ? 'items-center text-center' : '',
-  props.showMark ? 'brand-logo--with-mark' : '',
 ])
 
 /** Both locales use "Approving"; keep literal fallback so brand paints before locale JSON. */
@@ -39,14 +38,9 @@ const tagline = computed(() =>
 
 <template>
   <div :class="rootClass">
-    <span v-if="showMark" class="brand-logo__mark" aria-hidden="true">
-      <svg class="brand-logo__check" width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
-        <path d="M3.2 9.2 7.1 13 14.8 4.6" stroke="#fff" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" />
-      </svg>
-    </span>
     <div class="brand-logo__text">
       <span class="brand-logo__name">{{ appName }}</span>
-      <span v-if="!showMark" class="brand-logo__tagline">{{ tagline }}</span>
+      <span v-if="showTagline" class="brand-logo__tagline">{{ tagline }}</span>
     </div>
   </div>
 </template>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -206,39 +206,6 @@ html:not(.light) *.is-scrolling::-webkit-scrollbar {
     gap: 1px;
     line-height: 1.2;
   }
-  .brand-logo--with-mark {
-    flex-direction: row;
-    align-items: center;
-    gap: 10px;
-    min-width: 0;
-    flex: 1;
-  }
-  .brand-logo__mark {
-    width: 32px;
-    height: 32px;
-    flex-shrink: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: linear-gradient(135deg, #7b61ff, #6366f1);
-  }
-  .brand-logo__check {
-    display: block;
-  }
-  .brand-logo--with-mark .brand-logo__text {
-    flex-direction: row;
-    align-items: center;
-  }
-  .brand-logo--with-mark .brand-logo__name {
-    font-size: 15px;
-    font-weight: 650;
-    color: rgb(var(--c-txt));
-    background: none;
-    -webkit-background-clip: unset;
-    background-clip: unset;
-    -webkit-text-fill-color: currentColor;
-    animation: none;
-  }
   .brand-logo__text {
     display: flex;
     flex-direction: column;
@@ -391,13 +358,6 @@ html:not(.light) *.is-scrolling::-webkit-scrollbar {
   transition:
     width 0.32s cubic-bezier(0.22, 1, 0.36, 1),
     border-right-width 0.32s cubic-bezier(0.22, 1, 0.36, 1);
-}
-
-.app-sidebar-brand-row {
-  background: linear-gradient(105deg, #1a1730 0%, #16182a 55%, #12241f 100%);
-}
-html.light .app-sidebar-brand-row {
-  background: linear-gradient(105deg, #efe8ff 0%, #e8eeff 55%, #e8faf3 100%);
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Remove checkmark icon and wash background from the sidebar brand row;
restore 56px height with login-page gradient Approving and keep the
collapse control. Login, home typewriter, and mobile drawer unchanged.

Co-authored-by: Cursor <cursoragent@cursor.com>
