### PR TITLE
feat(web): unify board Token stats charts on ECharts

### DIFF
--- a/web/src/components/board/token-stats/TokenCharts.test.ts
+++ b/web/src/components/board/token-stats/TokenCharts.test.ts
@@ -326,8 +326,14 @@ describe('Token charts (g2.3/g2.4)', () => {
     // Same purple bar as workflow — gradient #6d5cff → #9b8cff
     const pmBar = pmRow.find('[data-testid="token-rank-bar"]')
     expect(pmBar.exists()).toBe(true)
-    const barColorFn = (wrapper.vm as { barColor: (w: { kind?: string; other?: boolean }) => { colorStops: { color: string }[] } }).barColor
-    const pmGradient = barColorFn({ kind: 'pm' })
+    const barColorFn = (
+      wrapper.vm as unknown as {
+        barColor: (w: { kind?: string; other?: boolean; name: string; total: number }) => {
+          colorStops: { color: string }[]
+        }
+      }
+    ).barColor
+    const pmGradient = barColorFn({ kind: 'pm', name: 'PM', total: 80_000 })
     expect(pmGradient.colorStops[0]!.color).toBe('#6d5cff')
     expect(pmGradient.colorStops[1]!.color).toBe('#9b8cff')
     expect(pmGradient.colorStops.map((s) => s.color)).not.toContain('#f59e0b')

--- a/web/src/components/board/token-stats/TokenCharts.test.ts
+++ b/web/src/components/board/token-stats/TokenCharts.test.ts
@@ -304,6 +304,8 @@ describe('Token charts (g2.3/g2.4)', () => {
     expect(wrapper.find('.token-rank-pm').exists()).toBe(true)
     expect(wrapper.find('.token-rank-other').exists()).toBe(true)
     expect(wrapper.find('[data-kind="pm"]').exists()).toBe(true)
+    expect(wrapper.findAll('[data-testid="token-rank-bar"]').length).toBe(4)
+    expect(wrapper.findAll('[data-testid="mock-vchart"]').length).toBe(4)
     expect(wrapper.text()).toContain('项目管理')
     expect(wrapper.text()).toContain('其他')
 
@@ -321,11 +323,14 @@ describe('Token charts (g2.3/g2.4)', () => {
     const wfBadge = items[0]!.find('span')
     expect(wfBadge.classes()).toEqual(pmBadge.classes())
 
-    // Same purple bar as workflow — no amber (#f59e0b / #d97706 / #fbbf24)
-    const pmHtml = pmRow.html()
-    expect(pmHtml).toContain('#6d5cff')
-    expect(pmHtml).toContain('#9b8cff')
-    expect(pmHtml).not.toMatch(/#f59e0b|#d97706|#fbbf24|245,\s*158,\s*11/)
+    // Same purple bar as workflow — gradient #6d5cff → #9b8cff
+    const pmBar = pmRow.find('[data-testid="token-rank-bar"]')
+    expect(pmBar.exists()).toBe(true)
+    const barColorFn = (wrapper.vm as { barColor: (w: { kind?: string; other?: boolean }) => { colorStops: { color: string }[] } }).barColor
+    const pmGradient = barColorFn({ kind: 'pm' })
+    expect(pmGradient.colorStops[0]!.color).toBe('#6d5cff')
+    expect(pmGradient.colorStops[1]!.color).toBe('#9b8cff')
+    expect(pmGradient.colorStops.map((s) => s.color)).not.toContain('#f59e0b')
 
     // Compact K/M main values remain visible on the right
     const values = wrapper.findAll('[data-testid="token-rank-value"]').map((v) => v.text())

--- a/web/src/components/board/token-stats/TokenDonutChart.vue
+++ b/web/src/components/board/token-stats/TokenDonutChart.vue
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { registerECharts } from '@/components/charts/echartsSetup'
+import { BOARD_CHART_TOOLTIP } from '@/components/charts/chartTheme'
 import type { TokenStatsComposition } from '@/lib/shared/types'
 import { fmtCompactTokenCount, fmtTokenCount } from '@/lib/run/tokenUsage'
 import { TOKEN_PART_COLORS, TOKEN_PART_KEYS, type TokenPartKey } from './tokenStatsShared'
@@ -48,7 +49,7 @@ const chartOption = computed(() => {
   const visible = parts.value.filter((p) => p.value > 0)
   if (!visible.length) return null
   return {
-    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    tooltip: { trigger: 'item', ...BOARD_CHART_TOOLTIP, formatter: '{b}: {c} ({d}%)' },
     series: [
       {
         type: 'pie',

--- a/web/src/components/board/token-stats/TokenModelComposition.test.ts
+++ b/web/src/components/board/token-stats/TokenModelComposition.test.ts
@@ -1,13 +1,25 @@
 // @vitest-environment happy-dom
 import { createI18n } from 'vue-i18n'
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import common from '@/locales/zh-CN/common.json'
 import pages from '@/locales/zh-CN/pages.json'
 import enCommon from '@/locales/en/common.json'
 import enPages from '@/locales/en/pages.json'
 import TokenModelComposition from './TokenModelComposition.vue'
 import { colorForModel } from './tokenModelColors'
+
+vi.mock('vue-echarts', () => ({
+  default: {
+    name: 'VChart',
+    template: '<div data-testid="mock-vchart" class="h-full w-full"><canvas /></div>',
+    props: ['option'],
+  },
+}))
+
+vi.mock('@/components/charts/echartsSetup', () => ({
+  registerECharts: () => {},
+}))
 
 const i18n = () =>
   createI18n({
@@ -35,8 +47,12 @@ function expectNoFilledTagCopy(text: string) {
   expect(text).not.toContain('includes filled data')
 }
 
-describe('TokenModelComposition SVG solid pie (g1/g2)', () => {
-  it('renders svg/path solid pie without conic-gradient or rounded-full (g1.1/g1.2/g2.1)', () => {
+function chartData(vm: unknown) {
+  return (vm as { chartData: { name: string; value: number; color?: string }[] }).chartData
+}
+
+describe('TokenModelComposition ECharts pie (g1.1)', () => {
+  it('renders ECharts pie host without svg path sectors (g1.1/g2.1)', () => {
     const wrapper = mount(TokenModelComposition, {
       props: {
         models: [{ modelKey: '未知/未分桶', name: '未知/未分桶', total: 1056, unknown: true }],
@@ -45,20 +61,18 @@ describe('TokenModelComposition SVG solid pie (g1/g2)', () => {
     })
     const pie = wrapper.find('[data-testid="token-model-pie"]')
     expect(pie.exists()).toBe(true)
-    expect(pie.find('svg').exists()).toBe(true)
-    const paths = pie.findAll('path')
-    expect(paths.length).toBeGreaterThanOrEqual(1)
-    // Solid pie: path starts from center (M cx cy L …), not a donut ring
-    expect(paths[0]!.attributes('d')).toMatch(/^M\s+55\s+55\s+L/)
+    expect(pie.find('[data-testid="mock-vchart"]').exists()).toBe(true)
+    expect(pie.find('svg').exists()).toBe(false)
+    expect(pie.findAll('path').length).toBe(0)
     expect(wrapper.html()).not.toMatch(/conic-gradient/i)
     expect(wrapper.html()).not.toMatch(/rounded-full/)
-    expect(wrapper.html()).not.toMatch(/inset\s+0\s+0\s+0\s+28px/)
-    // No inner hole circle masking the center
-    expect(pie.findAll('circle').length).toBe(0)
+    const data = chartData(wrapper.vm)
+    expect(data).toHaveLength(1)
+    expect(data[0]!.color).toBe('#71717A')
     wrapper.unmount()
   })
 
-  it('unknown-only near-full circle: solid #71717A path + legend 100% (g1.2/g2.2)', () => {
+  it('unknown-only near-full circle: #71717A sector + legend 100% (g1.2/g2.2)', () => {
     const unknown = { modelKey: '未知/未分桶', name: '未知/未分桶', total: 1056240000, unknown: true }
     expect(colorForModel(unknown, 0)).toBe('#71717A')
 
@@ -67,11 +81,9 @@ describe('TokenModelComposition SVG solid pie (g1/g2)', () => {
       global: { plugins: [i18n()] },
     })
     const pie = wrapper.find('[data-testid="token-model-pie"]')
-    const path = pie.find('path')
-    expect(path.exists()).toBe(true)
-    expect(path.attributes('fill')).toBe('#71717A')
-    // Full circle uses two semicircle arcs (Demo describeSlice)
-    expect(path.attributes('d')).toMatch(/A\s+55\s+55\s+0\s+1\s+1/)
+    expect(pie.find('[data-testid="mock-vchart"]').exists()).toBe(true)
+    const data = chartData(wrapper.vm)
+    expect(data[0]!.color).toBe('#71717A')
     const legend = wrapper.find('[data-testid="token-model-legend"]')
     expect(legend.text()).toContain('未知/未分桶')
     expect(legend.text()).toContain('100%')
@@ -79,7 +91,7 @@ describe('TokenModelComposition SVG solid pie (g1/g2)', () => {
     wrapper.unmount()
   })
 
-  it('thin wedge + dominant bucket: circular solid sectors (g2.2 attach-like)', () => {
+  it('thin wedge + dominant bucket: ECharts sectors keep colors (g2.2 attach-like)', () => {
     const models = [
       { modelKey: 'cursor-grok', name: 'cursor-grok-4.5-high-fast', total: 50090000, filled: true },
       { modelKey: '未知/未分桶', name: '未知/未分桶', total: 1059710000, unknown: true },
@@ -88,12 +100,10 @@ describe('TokenModelComposition SVG solid pie (g1/g2)', () => {
       props: { models },
       global: { plugins: [i18n()] },
     })
-    const pie = wrapper.find('[data-testid="token-model-pie"]')
-    const paths = pie.findAll('[data-testid="token-model-pie-slice"]')
-    expect(paths.length).toBe(2)
-    expect(paths.every((p) => p.attributes('d')?.startsWith('M 55 55'))).toBe(true)
-    expect(paths[0]!.attributes('fill')).toBe(colorForModel(models[0]!, 0))
-    expect(paths[1]!.attributes('fill')).toBe('#71717A')
+    const data = chartData(wrapper.vm)
+    expect(data).toHaveLength(2)
+    expect(data[0]!.color).toBe(colorForModel(models[0]!, 0))
+    expect(data[1]!.color).toBe('#71717A')
     const legend = wrapper.find('[data-testid="token-model-legend"]').text()
     expect(legend).toContain('4.5%')
     expect(legend).toContain('95.5%')
@@ -106,7 +116,7 @@ describe('TokenModelComposition SVG solid pie (g1/g2)', () => {
     wrapper.unmount()
   })
 
-  it('multi-bucket: svg sectors keep unknown #71717A and other #A1A1AA (g1.3/g2.1/g2.2)', () => {
+  it('multi-bucket: ECharts sectors keep unknown #71717A and other #A1A1AA (g1.3/g2.1/g2.2)', () => {
     const models = [
       { modelKey: 'claude-sonnet-4', name: 'claude-sonnet-4', total: 600, filled: true },
       { modelKey: '未知/未分桶', name: '未知/未分桶', total: 300, unknown: true },
@@ -119,33 +129,27 @@ describe('TokenModelComposition SVG solid pie (g1/g2)', () => {
       props: { models },
       global: { plugins: [i18n()] },
     })
-    const pie = wrapper.find('[data-testid="token-model-pie"]')
-    const paths = pie.findAll('path')
-    expect(paths.length).toBe(3)
-    const fills = paths.map((p) => p.attributes('fill'))
-    expect(fills).toContain('#71717A')
-    expect(fills).toContain('#A1A1AA')
-    expect(pie.findAll('circle').length).toBe(0)
+    const colors = chartData(wrapper.vm).map((d) => d.color)
+    expect(colors).toContain('#71717A')
+    expect(colors).toContain('#A1A1AA')
     const legend = wrapper.find('[data-testid="token-model-legend"]').text()
     expect(legend).toContain('未知/未分桶')
     expect(legend).toContain('other')
     expect(legend).toContain('claude-sonnet-4')
-    // Layout: square swatches in legend, left pie + right legend grid
     expect(wrapper.find('[data-testid="token-model-composition"]').classes()).toContain('sm:grid-cols-[120px_1fr]')
     const swatch = wrapper.find('[data-testid="token-model-legend"] span.h-2\\.5')
     expect(swatch.exists()).toBe(true)
     wrapper.unmount()
   })
 
-  it('empty models: elevated circle placeholder, no square conic block (g2.2)', () => {
+  it('empty models: elevated placeholder, no ECharts host (g2.2)', () => {
     const wrapper = mount(TokenModelComposition, {
       props: { models: [] },
       global: { plugins: [i18n()] },
     })
     const pie = wrapper.find('[data-testid="token-model-pie"]')
-    expect(pie.find('svg').exists()).toBe(true)
-    expect(pie.findAll('path').length).toBe(0)
-    expect(pie.find('circle').exists()).toBe(true)
+    expect(pie.find('[data-testid="token-model-pie-empty"]').exists()).toBe(true)
+    expect(pie.find('[data-testid="mock-vchart"]').exists()).toBe(false)
     expect(wrapper.html()).not.toMatch(/conic-gradient/i)
     expect(wrapper.find('[data-testid="token-model-legend"]').text()).toMatch(/./)
     wrapper.unmount()
@@ -183,7 +187,7 @@ describe('TokenModelComposition hides filledTag (g2.1)', () => {
     expect(nameSpans[2]!.classes()).toContain('text-ok')
     expect(items[0]!.find('[data-testid="unknown-model-badge"]').exists()).toBe(true)
 
-    const fills = wrapper.findAll('[data-testid="token-model-pie-slice"]').map((p) => p.attributes('fill'))
+    const fills = chartData(wrapper.vm).map((d) => d.color)
     expect(fills).toEqual(['#71717A', '#34D399', '#34D399'])
     wrapper.unmount()
   })
@@ -205,7 +209,7 @@ describe('TokenModelComposition hides filledTag (g2.1)', () => {
     const nameSpan = legend.findAll('li')[0]!.findAll('span')[1]!
     expect(nameSpan.classes()).not.toContain('text-txt3')
     expect(nameSpan.classes()).toContain('text-txt')
-    const fills = wrapper.findAll('[data-testid="token-model-pie-slice"]').map((p) => p.attributes('fill'))
+    const fills = chartData(wrapper.vm).map((d) => d.color)
     expect(fills[0]).toBe('#7B61FF')
     expect(fills[0]).not.toBe('#71717A')
     expect(legend.findAll('li')).toHaveLength(2)
@@ -228,7 +232,7 @@ describe('TokenModelComposition hides filledTag (g2.1)', () => {
     const nameSpan = legend.findAll('li')[0]!.findAll('span')[1]!
     expect(nameSpan.classes()).toContain('text-ok')
     expect(nameSpan.classes()).not.toContain('text-txt3')
-    const fills = wrapper.findAll('[data-testid="token-model-pie-slice"]').map((p) => p.attributes('fill'))
+    const fills = chartData(wrapper.vm).map((d) => d.color)
     expect(fills).toEqual(['#34D399', '#34D399'])
     wrapper.unmount()
   })
@@ -245,7 +249,7 @@ describe('TokenModelComposition hides filledTag (g2.1)', () => {
     expect(wrapper.html()).not.toContain('includes filled data')
     expect(wrapper.html()).not.toContain('含补全')
 
-    const fills = wrapper.findAll('[data-testid="token-model-pie-slice"]').map((p) => p.attributes('fill'))
+    const fills = chartData(wrapper.vm).map((d) => d.color)
     expect(fills).toEqual(['#71717A', '#34D399', '#34D399'])
     wrapper.unmount()
   })

--- a/web/src/components/board/token-stats/TokenModelComposition.vue
+++ b/web/src/components/board/token-stats/TokenModelComposition.vue
@@ -1,21 +1,21 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import VChart from 'vue-echarts'
+import { registerECharts } from '@/components/charts/echartsSetup'
+import { BOARD_CHART_TOOLTIP } from '@/components/charts/chartTheme'
 import type { TokenStatsModel } from '@/lib/shared/types'
 import { fmtCompactTokenCount, fmtTokenCount, shouldShowUnknownVisual } from '@/lib/run/tokenUsage'
 import { MODEL_PALETTE, colorForModel } from './tokenModelColors'
 import UnknownModelBadge from '@/components/ui/UnknownModelBadge.vue'
+
+registerECharts()
 
 const props = defineProps<{
   models: TokenStatsModel[]
 }>()
 
 const { t } = useI18n()
-
-const SIZE = 110
-const CX = SIZE / 2
-const CY = SIZE / 2
-const R = SIZE / 2
 
 const total = computed(() => props.models.reduce((s, m) => s + (m.total || 0), 0))
 
@@ -28,90 +28,62 @@ const rows = computed(() => {
   }))
 })
 
-function polar(cx: number, cy: number, r: number, angleDeg: number) {
-  const rad = ((angleDeg - 90) * Math.PI) / 180
-  return { x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) }
-}
-
-/** Solid pie slice from center (Demo / StatsPieChart-aligned). Full circle = two semicircles. */
-function describeSlice(cx: number, cy: number, r: number, startDeg: number, endDeg: number): string {
-  if (endDeg - startDeg >= 359.999) {
-    const mid = polar(cx, cy, r, startDeg + 180)
-    const end = polar(cx, cy, r, startDeg + 360)
-    const start = polar(cx, cy, r, startDeg)
-    return [
-      `M ${cx} ${cy}`,
-      `L ${start.x} ${start.y}`,
-      `A ${r} ${r} 0 1 1 ${mid.x} ${mid.y}`,
-      `A ${r} ${r} 0 1 1 ${end.x} ${end.y}`,
-      'Z',
-    ].join(' ')
-  }
-  const start = polar(cx, cy, r, startDeg)
-  const end = polar(cx, cy, r, endDeg)
-  const large = endDeg - startDeg > 180 ? 1 : 0
-  return [
-    `M ${cx} ${cy}`,
-    `L ${start.x} ${start.y}`,
-    `A ${r} ${r} 0 ${large} 1 ${end.x} ${end.y}`,
-    'Z',
-  ].join(' ')
-}
-
-const slices = computed(() => {
+const chartOption = computed(() => {
   const sum = total.value
-  if (sum <= 0) return [] as { key: string; d: string; color: string }[]
-  let angle = 0
-  const out: { key: string; d: string; color: string }[] = []
-  rows.value.forEach((r, i) => {
-    const sweep = ((r.total || 0) / sum) * 360
-    if (sweep <= 0) return
-    out.push({
-      key: `${r.modelKey || r.name}-${i}`,
-      d: describeSlice(CX, CY, R, angle, angle + sweep),
-      color: r.color,
-    })
-    angle += sweep
-  })
-  return out
+  if (sum <= 0) return null
+  const visible = rows.value.filter((r) => (r.total || 0) > 0)
+  if (!visible.length) return null
+  return {
+    tooltip: {
+      trigger: 'item',
+      ...BOARD_CHART_TOOLTIP,
+      formatter: (p: { name: string; value: number; percent: number }) =>
+        `${p.name}: ${fmtTokenCount(p.value)} (${p.percent}%)`,
+    },
+    series: [
+      {
+        type: 'pie',
+        radius: '100%',
+        center: ['50%', '50%'],
+        data: visible.map((r, i) => ({
+          name: r.name,
+          value: r.total || 0,
+          itemStyle: { color: r.color },
+          key: `${r.modelKey || r.name}-${i}`,
+        })),
+        label: { show: false },
+        emphasis: { scale: true, scaleSize: 4 },
+      },
+    ],
+  }
 })
+
+/** Exposed for unit tests (ECharts option shape). */
+const chartData = computed(() =>
+  chartOption.value?.series?.[0]?.data?.map((d: { name: string; value: number; itemStyle?: { color: string } }) => ({
+    name: d.name,
+    value: d.value,
+    color: d.itemStyle?.color,
+  })) ?? [],
+)
+
+defineExpose({ chartOption, chartData })
 </script>
 
 <template>
   <div data-testid="token-model-composition" class="grid gap-3 sm:grid-cols-[120px_1fr] sm:items-center">
-    <!-- SVG solid pie: path geometry ignores global border-radius:0 (Demo「修复后」) -->
     <div
       class="mx-auto h-[110px] w-[110px]"
       data-testid="token-model-pie"
       role="img"
       :aria-label="t('pages.board.tokenStats.modelCompositionTitle')"
     >
-      <svg
-        v-if="slices.length"
-        class="block h-full w-full"
-        :viewBox="`0 0 ${SIZE} ${SIZE}`"
-        width="110"
-        height="110"
-        aria-hidden="true"
-      >
-        <path
-          v-for="s in slices"
-          :key="s.key"
-          :d="s.d"
-          :fill="s.color"
-          data-testid="token-model-pie-slice"
-        />
-      </svg>
-      <svg
+      <VChart v-if="chartOption" :option="chartOption" autoresize class="h-full w-full" />
+      <div
         v-else
-        class="block h-full w-full"
-        :viewBox="`0 0 ${SIZE} ${SIZE}`"
-        width="110"
-        height="110"
-        aria-hidden="true"
-      >
-        <circle :cx="CX" :cy="CY" :r="R" fill="rgb(var(--c-elevated))" />
-      </svg>
+        class="h-full w-full rounded-full bg-elevated"
+        data-testid="token-model-pie-empty"
+      />
     </div>
     <ul class="m-0 grid list-none gap-1.5 p-0" data-testid="token-model-legend">
       <li

--- a/web/src/components/board/token-stats/TokenModelRank.test.ts
+++ b/web/src/components/board/token-stats/TokenModelRank.test.ts
@@ -1,13 +1,25 @@
 // @vitest-environment happy-dom
 import { createI18n } from 'vue-i18n'
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import common from '@/locales/zh-CN/common.json'
 import pages from '@/locales/zh-CN/pages.json'
 import enCommon from '@/locales/en/common.json'
 import enPages from '@/locales/en/pages.json'
 import TokenModelRank from './TokenModelRank.vue'
 import { colorForModel } from './tokenModelColors'
+
+vi.mock('vue-echarts', () => ({
+  default: {
+    name: 'VChart',
+    template: '<div data-testid="mock-vchart" class="h-full w-full"><canvas /></div>',
+    props: ['option'],
+  },
+}))
+
+vi.mock('@/components/charts/echartsSetup', () => ({
+  registerECharts: () => {},
+}))
 
 const i18nZh = () =>
   createI18n({
@@ -28,12 +40,30 @@ function expectNoFilledTagCopy(text: string) {
   expect(text).not.toContain('includes filled data')
 }
 
+function barColor(vm: unknown, idx: number) {
+  const opts = (vm as { rowOptions: { series: { itemStyle: { color: string } }[] }[] }).rowOptions
+  return opts[idx]?.series[0]?.itemStyle?.color
+}
+
 const rankModels = [
   { modelKey: 'cursor-grok-4.5-high-fast', name: 'cursor-grok-4.5-high-fast', total: 800, filled: true },
   { modelKey: 'gpt-5.6-sol-medium', name: 'gpt-5.6-sol-medium', total: 600, filled: true },
   { modelKey: '未知/未分桶', name: '未知/未分桶', total: 400, unknown: true },
   { modelKey: 'other', name: 'other', total: 200, other: true },
 ]
+
+describe('TokenModelRank ECharts bars (g1.2)', () => {
+  it('renders ECharts bar hosts without HTML width bars', () => {
+    const wrapper = mount(TokenModelRank, {
+      props: { models: rankModels },
+      global: { plugins: [i18nZh()] },
+    })
+    expect(wrapper.findAll('[data-testid="token-model-rank-bar"]').length).toBe(4)
+    expect(wrapper.findAll('[data-testid="mock-vchart"]').length).toBe(4)
+    expect(wrapper.find('.h-full.transition-\\[width\\]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+})
 
 describe('TokenModelRank hides filledTag (g2.2)', () => {
   it('zh-CN: filled/unknown/other rows have no 含补全; data-filled keeps #34D399 / #71717A', () => {
@@ -55,8 +85,8 @@ describe('TokenModelRank hides filledTag (g2.2)', () => {
     for (const row of filledRows) {
       expectNoFilledTagCopy(row.text())
       expect(row.text()).not.toContain('含补全')
-      const bar = row.find('.h-full')
-      expect(bar.attributes('style')).toMatch(/background:\s*#34D399/i)
+      const idx = filledRows.indexOf(row)
+      expect(barColor(wrapper.vm, idx)).toBe('#34D399')
       expect(row.find('.text-ok').exists()).toBe(true)
     }
 
@@ -65,13 +95,13 @@ describe('TokenModelRank hides filledTag (g2.2)', () => {
     expect(unknownRow.attributes('data-filled')).toBe('0')
     expect(unknownRow.text()).toContain('未知/未分桶')
     expectNoFilledTagCopy(unknownRow.text())
-    expect(unknownRow.find('.h-full').attributes('style')).toMatch(/background:\s*#71717A/i)
+    expect(barColor(wrapper.vm, 2)).toBe('#71717A')
 
     const otherRow = wrapper.find('[data-other="1"]')
     expect(otherRow.exists()).toBe(true)
     expect(otherRow.text()).toContain('other（其余模型）')
     expectNoFilledTagCopy(otherRow.text())
-    expect(otherRow.find('.h-full').attributes('style')).toMatch(/background:\s*#A1A1AA/i)
+    expect(barColor(wrapper.vm, 3)).toBe('#A1A1AA')
 
     expect(root.text()).toContain('cursor-grok-4.5-high-fast')
     expect(root.text()).toContain('gpt-5.6-sol-medium')
@@ -90,13 +120,12 @@ describe('TokenModelRank hides filledTag (g2.2)', () => {
 
     const filledRows = wrapper.findAll('[data-filled="1"]')
     expect(filledRows).toHaveLength(2)
-    for (const row of filledRows) {
-      expectNoFilledTagCopy(row.text())
-      expect(row.find('.h-full').attributes('style')).toMatch(/background:\s*#34D399/i)
+    for (let i = 0; i < filledRows.length; i++) {
+      expectNoFilledTagCopy(filledRows[i]!.text())
+      expect(barColor(wrapper.vm, i)).toBe('#34D399')
     }
 
-    const unknownRow = wrapper.find('[data-unknown="1"]')
-    expect(unknownRow.find('.h-full').attributes('style')).toMatch(/background:\s*#71717A/i)
+    expect(barColor(wrapper.vm, 2)).toBe('#71717A')
 
     const otherRow = wrapper.find('[data-other="1"]')
     expect(otherRow.text()).toContain('other (remaining models)')
@@ -146,13 +175,13 @@ describe('TokenModelRank unknown vs other (g3.3)', () => {
     expect(unk.find('[data-testid="unknown-model-badge"]').exists()).toBe(true)
     expect(unk.text()).not.toContain('other（其余模型）')
     expect(unk.find('.text-txt3').exists()).toBe(true)
-    expect(unk.find('.h-full').attributes('style')).toMatch(/#71717A/i)
+    expect(barColor(wrapper.vm, 1)).toBe('#71717A')
 
     const other = wrapper.find('[data-other="1"]')
     expect(other.exists()).toBe(true)
     expect(other.attributes('data-unknown')).toBe('0')
     expect(other.text()).toContain('other（其余模型）')
-    expect(other.find('.h-full').attributes('style')).toMatch(/#A1A1AA/i)
+    expect(barColor(wrapper.vm, 2)).toBe('#A1A1AA')
     wrapper.unmount()
   })
 
@@ -161,7 +190,6 @@ describe('TokenModelRank unknown vs other (g3.3)', () => {
       { modelKey: 'gpt-5', name: 'gpt-5', total: 100 },
       { modelKey: '未知/未分桶', name: 'gpt-5', total: 80, unknown: true },
     ]
-    // Alias removes unknown-gray; falls through to palette (idx 1 → #60A5FA).
     expect(colorForModel(models[1]!, 1)).toBe('#60A5FA')
     expect(colorForModel(models[1]!, 1)).not.toBe('#71717A')
     expect(colorForModel({ name: 'gpt-5', unknown: false }, 0)).not.toBe('#71717A')
@@ -176,9 +204,8 @@ describe('TokenModelRank unknown vs other (g3.3)', () => {
     const nameRow = unk.find('.flex.min-w-0.items-center')
     expect(nameRow.classes()).not.toContain('text-txt3')
     expect(nameRow.classes()).toContain('text-txt')
-    expect(unk.find('.h-full').attributes('style')).not.toMatch(/#71717A/i)
-    expect(unk.find('.h-full').attributes('style')).toMatch(/#60A5FA/i)
-    // Two rows with same display text stay distinct via data-unknown.
+    expect(barColor(wrapper.vm, 1)).toBe('#60A5FA')
+    expect(barColor(wrapper.vm, 1)).not.toBe('#71717A')
     expect(wrapper.findAll('[data-testid="token-model-rank"] > li')).toHaveLength(2)
     wrapper.unmount()
   })
@@ -199,8 +226,8 @@ describe('TokenModelRank unknown vs other (g3.3)', () => {
     expect(unk.text()).not.toContain('未知/未分桶')
     expect(unk.find('[data-testid="unknown-model-badge"]').exists()).toBe(false)
     expect(unk.find('.text-ok').exists()).toBe(true)
-    expect(unk.find('.h-full').attributes('style')).toMatch(/#34D399/i)
-    expect(unk.find('.h-full').attributes('style')).not.toMatch(/#71717A/i)
+    expect(barColor(wrapper.vm, 0)).toBe('#34D399')
+    expect(barColor(wrapper.vm, 0)).not.toBe('#71717A')
     wrapper.unmount()
   })
 })

--- a/web/src/components/board/token-stats/TokenModelRank.vue
+++ b/web/src/components/board/token-stats/TokenModelRank.vue
@@ -1,10 +1,15 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import VChart from 'vue-echarts'
+import { registerECharts } from '@/components/charts/echartsSetup'
+import { BOARD_CHART_TOOLTIP } from '@/components/charts/chartTheme'
 import type { TokenStatsModel } from '@/lib/shared/types'
 import { fmtCompactTokenCount, fmtTokenCount, shouldShowUnknownVisual } from '@/lib/run/tokenUsage'
 import UnknownModelBadge from '@/components/ui/UnknownModelBadge.vue'
 import { colorForModel } from './tokenModelColors'
+
+registerECharts()
 
 const props = defineProps<{
   models: TokenStatsModel[]
@@ -18,9 +23,34 @@ function displayName(m: TokenStatsModel): string {
   return m.name || m.modelKey || '—'
 }
 
-function barWidth(total: number): string {
-  return `${Math.max(2, Math.round((total / maxTotal.value) * 100))}%`
+function rowChartOption(m: TokenStatsModel, i: number) {
+  const color = colorForModel(m, i)
+  return {
+    animation: false,
+    grid: { left: 0, right: 0, top: 0, bottom: 0 },
+    xAxis: { type: 'value', show: false, max: maxTotal.value },
+    yAxis: { type: 'category', data: [''], show: false },
+    tooltip: {
+      trigger: 'item',
+      ...BOARD_CHART_TOOLTIP,
+      formatter: () => fmtTokenCount(m.total),
+    },
+    series: [
+      {
+        type: 'bar',
+        data: [m.total || 0],
+        barWidth: 8,
+        itemStyle: { color, borderRadius: [0, 2, 2, 0] },
+        showBackground: true,
+        backgroundStyle: { color: 'rgb(var(--c-elevated))' },
+      },
+    ],
+  }
 }
+
+const rowOptions = computed(() => props.models.map((m, i) => rowChartOption(m, i)))
+
+defineExpose({ rowOptions, maxTotal })
 </script>
 
 <template>
@@ -42,11 +72,8 @@ function barWidth(total: number): string {
           <span class="min-w-0 truncate">{{ displayName(m) }}</span>
           <UnknownModelBadge v-if="shouldShowUnknownVisual(m.unknown, displayName(m))" />
         </div>
-        <div class="mt-1 h-2 overflow-hidden bg-elevated">
-          <div
-            class="h-full transition-[width] duration-300"
-            :style="{ width: barWidth(m.total), background: colorForModel(m, i) }"
-          />
+        <div class="mt-1 h-2 overflow-hidden" data-testid="token-model-rank-bar">
+          <VChart :option="rowOptions[i]" autoresize class="h-full w-full" />
         </div>
       </div>
       <span

--- a/web/src/components/board/token-stats/TokenStatsPanel.test.ts
+++ b/web/src/components/board/token-stats/TokenStatsPanel.test.ts
@@ -76,6 +76,8 @@ function mountPanel() {
       stubs: {
         TokenTrendChart: { template: '<div data-testid="stub-trend" />' },
         TokenDonutChart: { template: '<div data-testid="stub-donut" />' },
+        TokenModelComposition: { template: '<div data-testid="stub-model-comp" />' },
+        TokenModelRank: { template: '<div data-testid="stub-model-rank" />' },
         TokenWorkflowRank: { template: '<div data-testid="stub-rank" />' },
       },
     },

--- a/web/src/components/board/token-stats/TokenTrendChart.vue
+++ b/web/src/components/board/token-stats/TokenTrendChart.vue
@@ -4,7 +4,7 @@ import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import type { ECElementEvent } from 'echarts/core'
 import { registerECharts } from '@/components/charts/echartsSetup'
-import { CHART_AXIS, CHART_GRID, fmtCompactAxis } from '@/components/charts/chartTheme'
+import { BOARD_CHART_AXIS, CHART_GRID, fmtCompactAxis } from '@/components/charts/chartTheme'
 import type { TokenStatsBucket } from '@/lib/shared/types'
 import { fmtTokenCount } from '@/lib/run/tokenUsage'
 import { TOKEN_SOURCE_COLORS, formatBucketLabel, placeTrendTooltipAfter } from './tokenStatsShared'
@@ -55,14 +55,14 @@ const chartOption = computed(() => {
     xAxis: {
       type: 'category',
       data: labels,
-      ...CHART_AXIS,
+      ...BOARD_CHART_AXIS,
       splitLine: { show: false },
-      axisLabel: { ...CHART_AXIS.axisLabel, maxInterval: Math.ceil(labels.length / 8) },
+      axisLabel: { ...BOARD_CHART_AXIS.axisLabel, maxInterval: Math.ceil(labels.length / 8) },
     },
     yAxis: {
       type: 'value',
-      ...CHART_AXIS,
-      axisLabel: { ...CHART_AXIS.axisLabel, formatter: (v: number) => fmtCompactAxis(v) },
+      ...BOARD_CHART_AXIS,
+      axisLabel: { ...BOARD_CHART_AXIS.axisLabel, formatter: (v: number) => fmtCompactAxis(v) },
     },
     series: [
       {

--- a/web/src/components/board/token-stats/TokenWorkflowRank.vue
+++ b/web/src/components/board/token-stats/TokenWorkflowRank.vue
@@ -1,8 +1,37 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import VChart from 'vue-echarts'
+import { registerECharts } from '@/components/charts/echartsSetup'
+import { BOARD_CHART_TOOLTIP } from '@/components/charts/chartTheme'
 import type { TokenStatsWorkflow } from '@/lib/shared/types'
 import { fmtCompactTokenCount, fmtTokenCount } from '@/lib/run/tokenUsage'
+
+registerECharts()
+
+const WF_BAR_GRADIENT = {
+  type: 'linear' as const,
+  x: 0,
+  y: 0,
+  x2: 1,
+  y2: 0,
+  colorStops: [
+    { offset: 0, color: '#6d5cff' },
+    { offset: 1, color: '#9b8cff' },
+  ],
+}
+
+const OTHER_BAR_GRADIENT = {
+  type: 'linear' as const,
+  x: 0,
+  y: 0,
+  x2: 1,
+  y2: 0,
+  colorStops: [
+    { offset: 0, color: '#94a3b8' },
+    { offset: 1, color: '#cbd5e1' },
+  ],
+}
 
 const props = defineProps<{
   workflows: TokenStatsWorkflow[]
@@ -27,13 +56,8 @@ function displayName(w: TokenStatsWorkflow): string {
   return w.name || w.workflowId || '—'
 }
 
-function barWidth(total: number): string {
-  return `${Math.max(2, Math.round((total / maxTotal.value) * 100))}%`
-}
-
 function badgeLabel(w: TokenStatsWorkflow, i: number): string {
   if (isOther(w)) return '·'
-  // Workflow + PM share one continuous numeric sequence (no "PM" text badge / no 12PM34).
   let n = 0
   for (let j = 0; j <= i; j++) {
     const row = props.workflows[j]
@@ -44,18 +68,41 @@ function badgeLabel(w: TokenStatsWorkflow, i: number): string {
 
 function badgeClass(w: TokenStatsWorkflow, i: number): string {
   if (isOther(w)) return 'w-[22px] bg-elevated text-txt3'
-  // PM uses the same numeric badge classes as workflow rows (Demo-aligned).
   const n = Number(badgeLabel(w, i))
   return n <= 3
     ? 'w-[22px] bg-accent-dim text-accent-2'
     : 'w-[22px] bg-elevated text-txt3'
 }
 
-function barClass(w: TokenStatsWorkflow): string {
-  // PM bar matches workflow purple gradient (#6d5cff → #9b8cff); other stays neutral grey.
-  if (isOther(w)) return 'bg-gradient-to-r from-slate-400 to-slate-300'
-  return 'bg-gradient-to-r from-[#6d5cff] to-[#9b8cff]'
+function barColor(w: TokenStatsWorkflow) {
+  return isOther(w) ? OTHER_BAR_GRADIENT : WF_BAR_GRADIENT
 }
+
+function rowChartOption(w: TokenStatsWorkflow) {
+  return {
+    animation: false,
+    grid: { left: 0, right: 0, top: 0, bottom: 0 },
+    xAxis: { type: 'value', show: false, max: maxTotal.value },
+    yAxis: { type: 'category', data: [''], show: false },
+    tooltip: {
+      trigger: 'item',
+      ...BOARD_CHART_TOOLTIP,
+      formatter: () => fmtTokenCount(w.total),
+    },
+    series: [
+      {
+        type: 'bar',
+        data: [w.total || 0],
+        barWidth: 8,
+        itemStyle: { color: barColor(w), borderRadius: [0, 999, 999, 0] },
+        showBackground: true,
+        backgroundStyle: { color: '#f1f3f6' },
+      },
+    ],
+  }
+}
+
+const rowOptions = computed(() => props.workflows.map((w) => rowChartOption(w)))
 
 const tip = ref({ show: false, x: 0, y: 0, idx: -1 })
 
@@ -78,6 +125,8 @@ function hideTip() {
 }
 
 const tipRow = computed(() => (tip.value.idx >= 0 ? props.workflows[tip.value.idx] : null))
+
+defineExpose({ rowOptions, maxTotal, barColor })
 </script>
 
 <template>
@@ -105,12 +154,8 @@ const tipRow = computed(() => (tip.value.idx >= 0 ? props.workflows[tip.value.id
       </span>
       <div class="min-w-0">
         <div class="truncate text-xs font-medium text-txt">{{ displayName(w) }}</div>
-        <div class="mt-1 h-2 overflow-hidden rounded-full bg-[#f1f3f6]">
-          <div
-            class="h-full rounded-full transition-[width] duration-300"
-            :class="barClass(w)"
-            :style="{ width: barWidth(w.total) }"
-          />
+        <div class="mt-1 h-2 overflow-hidden rounded-full" data-testid="token-rank-bar">
+          <VChart :option="rowOptions[i]" autoresize class="h-full w-full" />
         </div>
       </div>
       <span

--- a/web/src/components/charts/chartTheme.ts
+++ b/web/src/components/charts/chartTheme.ts
@@ -6,6 +6,20 @@ export const CHART_AXIS = {
   splitLine: { lineStyle: { color: '#eef0f3' } },
 }
 
+/** Dark board token panel: unified axis / grid / tooltip tones. */
+export const BOARD_CHART_AXIS = {
+  ...CHART_AXIS,
+  axisLabel: { ...CHART_AXIS.axisLabel, color: '#9aa1ad' },
+  splitLine: { lineStyle: { color: '#2a2e36' } },
+}
+
+export const BOARD_CHART_TOOLTIP = {
+  borderRadius: 8,
+  backgroundColor: '#1a1d23',
+  borderColor: '#2a2e36',
+  textStyle: { color: '#e8eaed', fontSize: 11 },
+}
+
 export const CHART_GRID = {
   left: 42,
   right: 12,


### PR DESCRIPTION
Replace hand-drawn SVG pie and HTML/CSS bars in TokenModelComposition,
TokenModelRank, and TokenWorkflowRank with vue-echarts, aligned with
existing trend/donut charts via shared board chart theme.

Co-authored-by: Cursor <cursoragent@cursor.com>
