### PR TITLE
fix(web,server): improve token analytics readability and unknown model label

### DIFF
--- a/server/internal/models/token_usage_by_model.go
+++ b/server/internal/models/token_usage_by_model.go
@@ -6,6 +6,9 @@ import "strings"
 // flattened totals, or weak keys when ACP_BRIDGE_MODEL was not configured).
 const TokenUsageModelUnknown = "未知/未分桶"
 
+// TokenUsageModelUnknownDisplay is the default user-visible label when no project alias is set.
+const TokenUsageModelUnknownDisplay = "未知模型"
+
 // Source labels persisted on each model bucket.
 const (
 	TokenUsageSourceUpstream = "upstream"

--- a/server/internal/services/global_token_stats.go
+++ b/server/internal/services/global_token_stats.go
@@ -433,7 +433,7 @@ func rebucketGlobalModelKey(mk, projectID string, unknownAliases map[string]stri
 		return mk
 	}
 	alias := strings.TrimSpace(unknownAliases[projectID])
-	if alias != "" && alias != models.TokenUsageModelUnknown {
+	if IsConfiguredUnknownAlias(alias) {
 		return alias
 	}
 	return mk
@@ -737,7 +737,7 @@ func buildGlobalModelStats(cur, prev *globalAgg, unknownAliases map[string]strin
 		name := m.Name
 		if m.Unknown {
 			for _, alias := range unknownAliases {
-				if alias != "" {
+				if IsConfiguredUnknownAlias(alias) {
 					name = alias
 					break
 				}

--- a/server/internal/services/project.go
+++ b/server/internal/services/project.go
@@ -37,10 +37,10 @@ var (
 const UnknownModelDisplayNameMaxLen = 64
 
 // NormalizeUnknownModelDisplayName trims input; empty / whitespace-only / equal to
-// the default 「未知/未分桶」 label become "" (unset). Over-length rejects.
+// the legacy or new default label become "" (unset). Over-length rejects.
 func NormalizeUnknownModelDisplayName(raw string) (string, error) {
 	v := strings.TrimSpace(raw)
-	if v == "" || v == models.TokenUsageModelUnknown {
+	if v == "" || v == models.TokenUsageModelUnknown || v == models.TokenUsageModelUnknownDisplay {
 		return "", nil
 	}
 	if utf8.RuneCountInString(v) > UnknownModelDisplayNameMaxLen {
@@ -49,13 +49,19 @@ func NormalizeUnknownModelDisplayName(raw string) (string, error) {
 	return v, nil
 }
 
-// ResolveUnknownModelDisplayName returns the configured alias or the default label.
+// ResolveUnknownModelDisplayName returns the configured alias or the default display label.
 func ResolveUnknownModelDisplayName(alias string) string {
 	v := strings.TrimSpace(alias)
-	if v == "" || v == models.TokenUsageModelUnknown {
-		return models.TokenUsageModelUnknown
+	if v == "" || v == models.TokenUsageModelUnknown || v == models.TokenUsageModelUnknownDisplay {
+		return models.TokenUsageModelUnknownDisplay
 	}
 	return v
+}
+
+// IsConfiguredUnknownAlias reports whether alias is a real project override (not empty/default labels).
+func IsConfiguredUnknownAlias(alias string) bool {
+	v := strings.TrimSpace(alias)
+	return v != "" && v != models.TokenUsageModelUnknown && v != models.TokenUsageModelUnknownDisplay
 }
 
 // ProjectService manages project CRUD and secret-aware config updates.

--- a/server/internal/services/project_test.go
+++ b/server/internal/services/project_test.go
@@ -634,6 +634,7 @@ func TestNormalizeUnknownModelDisplayName(t *testing.T) {
 		{"", "", false},
 		{"  ", "", false},
 		{models.TokenUsageModelUnknown, "", false},
+		{models.TokenUsageModelUnknownDisplay, "", false},
 		{" gpt-5 ", "gpt-5", false},
 		{strings.Repeat("a", 65), "", true},
 		{strings.Repeat("中", 64), strings.Repeat("中", 64), false},
@@ -671,8 +672,16 @@ func TestProjectUpdateUnknownModelDisplayName(t *testing.T) {
 	if p.UnknownModelDisplayName != "gpt-5" {
 		t.Fatalf("alias=%q", p.UnknownModelDisplayName)
 	}
-	sameAsDefault := models.TokenUsageModelUnknown
+	sameAsDefault := models.TokenUsageModelUnknownDisplay
 	p, err = s.Update(p.ID, nil, nil, nil, nil, nil, &sameAsDefault)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.UnknownModelDisplayName != "" {
+		t.Fatalf("new default name should clear, got %q", p.UnknownModelDisplayName)
+	}
+	sameAsLegacy := models.TokenUsageModelUnknown
+	p, err = s.Update(p.ID, nil, nil, nil, nil, nil, &sameAsLegacy)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/internal/services/project_token_stats_test.go
+++ b/server/internal/services/project_token_stats_test.go
@@ -587,7 +587,7 @@ func TestBuildModelStatsDemoScenes(t *testing.T) {
 					t.Fatal("duplicate unknown row")
 				}
 				unkIdx = i
-				if r.Name != models.TokenUsageModelUnknown {
+				if r.Name != models.TokenUsageModelUnknownDisplay {
 					t.Fatalf("unknown renamed: %q", r.Name)
 				}
 				if r.Other {
@@ -685,7 +685,7 @@ func TestBuildModelStatsDemoScenes(t *testing.T) {
 			}
 			if r.Unknown {
 				hasUnk = true
-				if r.Name != models.TokenUsageModelUnknown {
+				if r.Name != models.TokenUsageModelUnknownDisplay {
 					t.Fatalf("unknown name=%q", r.Name)
 				}
 			}
@@ -733,7 +733,7 @@ func TestTokenStatsLegacyMapsToUnknown(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(res.ModelComposition) != 1 || res.ModelComposition[0].Name != models.TokenUsageModelUnknown {
+	if len(res.ModelComposition) != 1 || res.ModelComposition[0].Name != models.TokenUsageModelUnknownDisplay {
 		t.Fatalf("composition=%+v", res.ModelComposition)
 	}
 	if res.ModelComposition[0].Total != 50 || !res.ModelComposition[0].Unknown {
@@ -782,7 +782,7 @@ func TestBuildModelStatsUnknownAlias(t *testing.T) {
 	t.Run("empty_alias_keeps_default_name", func(t *testing.T) {
 		comp, _ := buildModelStats(totals, "  ")
 		for _, r := range comp {
-			if r.Unknown && r.Name != models.TokenUsageModelUnknown {
+			if r.Unknown && r.Name != models.TokenUsageModelUnknownDisplay {
 				t.Fatalf("empty alias Name=%q", r.Name)
 			}
 		}

--- a/web/e2e/unknown-model-display-name.spec.ts
+++ b/web/e2e/unknown-model-display-name.spec.ts
@@ -222,6 +222,7 @@ test.describe('未知模型显示名', () => {
     await expect(rank).toContainText('gpt-5')
     await expect(rank.getByTestId('unknown-model-badge')).toHaveCount(0)
     await expect(rank).not.toContainText('未知/未分桶')
+    await expect(rank).not.toContainText('未知模型')
     const unkRank = rank.locator('[data-unknown="1"]')
     await expect(unkRank).toHaveCount(1)
     // 条色非未知灰 #71717A
@@ -232,6 +233,7 @@ test.describe('未知模型显示名', () => {
     await expect(legend).toContainText('gpt-5')
     await expect(legend.getByTestId('unknown-model-badge')).toHaveCount(0)
     await expect(legend).not.toContainText('未知/未分桶')
+    await expect(legend).not.toContainText('未知模型')
 
     await page.screenshot({
       path: path.join(shotDir, '03-board-alias-no-badge.png'),
@@ -247,11 +249,11 @@ test.describe('未知模型显示名', () => {
       ...aliasedTokenStats(),
       modelComposition: [
         { modelKey: 'gpt-5', name: 'gpt-5', total: 100 },
-        { modelKey: '未知/未分桶', name: '未知/未分桶', total: 80, unknown: true },
+        { modelKey: '未知/未分桶', name: '未知模型', total: 80, unknown: true },
       ],
       modelRanking: [
         { modelKey: 'gpt-5', name: 'gpt-5', total: 100 },
-        { modelKey: '未知/未分桶', name: '未知/未分桶', total: 80, unknown: true },
+        { modelKey: '未知/未分桶', name: '未知模型', total: 80, unknown: true },
       ],
     }
 
@@ -286,16 +288,18 @@ test.describe('未知模型显示名', () => {
 
     const rank = page.getByTestId('token-model-rank')
     const unkRank = rank.locator('[data-unknown="1"]')
-    await expect(unkRank).toContainText('未知/未分桶')
+    await expect(unkRank).toContainText('未知模型')
+    await expect(unkRank).not.toContainText('未知/未分桶')
     await expect(unkRank.getByTestId('unknown-model-badge')).toHaveCount(1)
     await expect(unkRank.locator('.h-full')).toHaveCSS('background-color', 'rgb(113, 113, 122)')
 
     const legend = page.getByTestId('token-model-legend')
     await expect(legend.getByTestId('unknown-model-badge')).toHaveCount(1)
-    await expect(legend).toContainText('未知/未分桶')
+    await expect(legend).toContainText('未知模型')
+    await expect(legend).not.toContainText('未知/未分桶')
   })
 
-  test('Run 按模型明细：显示别名且无未知角标，来源列仍为未知/未分桶', async ({ page }) => {
+  test('Run 按模型明细：显示别名且无未知角标，来源列仍为未知模型', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 900 })
 
     const nodes = [
@@ -433,9 +437,11 @@ test.describe('未知模型显示名', () => {
     // 已设名：模型列无「未知」角标
     await expect(unkRow.getByTestId('unknown-model-badge')).toHaveCount(0)
     // 来源徽章属性标签不随显示名改变
-    await expect(unkRow).toContainText('未知/未分桶')
-    // 模型名区域不显示默认桶名（已被别名覆盖）；来源徽章可含「未知/未分桶」
+    await expect(unkRow).toContainText('未知模型')
+    await expect(unkRow).not.toContainText('未知/未分桶')
+    // 模型名区域不显示默认桶名（已被别名覆盖）；来源徽章显示新默认名
     await expect(unkRow.locator('[title="gpt-5"]')).toContainText('gpt-5')
+    await expect(unkRow.locator('[title="gpt-5"]')).not.toContainText('未知模型')
     await expect(unkRow.locator('[title="gpt-5"]')).not.toContainText('未知/未分桶')
 
     await page.screenshot({

--- a/web/src/components/board/token-stats/TokenModelComposition.test.ts
+++ b/web/src/components/board/token-stats/TokenModelComposition.test.ts
@@ -25,7 +25,7 @@ const i18nEn = () =>
 
 /** Screenshot-like sample: unknown grey + two filled (ACP_BRIDGE backfill) buckets. */
 const screenshotLikeModels = [
-  { modelKey: '未知/未分桶', name: '未知/未分桶', total: 100, unknown: true },
+  { modelKey: '未知/未分桶', name: '未知模型', total: 100, unknown: true },
   { modelKey: 'cursor-grok-4.5-high-fast', name: 'cursor-grok-4.5-high-fast', total: 80, filled: true },
   { modelKey: 'gpt-5.6-sol-medium', name: 'gpt-5.6-sol-medium', total: 60, filled: true },
 ]
@@ -39,7 +39,7 @@ describe('TokenModelComposition SVG solid pie (g1/g2)', () => {
   it('renders svg/path solid pie without conic-gradient or rounded-full (g1.1/g1.2/g2.1)', () => {
     const wrapper = mount(TokenModelComposition, {
       props: {
-        models: [{ modelKey: '未知/未分桶', name: '未知/未分桶', total: 1056, unknown: true }],
+        models: [{ modelKey: '未知/未分桶', name: '未知模型', total: 1056, unknown: true }],
       },
       global: { plugins: [i18n()] },
     })
@@ -59,7 +59,7 @@ describe('TokenModelComposition SVG solid pie (g1/g2)', () => {
   })
 
   it('unknown-only near-full circle: solid #71717A path + legend 100% (g1.2/g2.2)', () => {
-    const unknown = { modelKey: '未知/未分桶', name: '未知/未分桶', total: 1056240000, unknown: true }
+    const unknown = { modelKey: '未知/未分桶', name: '未知模型', total: 1056240000, unknown: true }
     expect(colorForModel(unknown, 0)).toBe('#71717A')
 
     const wrapper = mount(TokenModelComposition, {
@@ -73,16 +73,16 @@ describe('TokenModelComposition SVG solid pie (g1/g2)', () => {
     // Full circle uses two semicircle arcs (Demo describeSlice)
     expect(path.attributes('d')).toMatch(/A\s+55\s+55\s+0\s+1\s+1/)
     const legend = wrapper.find('[data-testid="token-model-legend"]')
-    expect(legend.text()).toContain('未知/未分桶')
+    expect(legend.text()).toContain('未知模型')
     expect(legend.text()).toContain('100%')
-    expect(legend.text()).toContain('1056.24M')
+    expect(legend.text()).toContain('1.06B')
     wrapper.unmount()
   })
 
   it('thin wedge + dominant bucket: circular solid sectors (g2.2 attach-like)', () => {
     const models = [
       { modelKey: 'cursor-grok', name: 'cursor-grok-4.5-high-fast', total: 50090000, filled: true },
-      { modelKey: '未知/未分桶', name: '未知/未分桶', total: 1059710000, unknown: true },
+      { modelKey: '未知/未分桶', name: '未知模型', total: 1059710000, unknown: true },
     ]
     const wrapper = mount(TokenModelComposition, {
       props: { models },
@@ -98,7 +98,7 @@ describe('TokenModelComposition SVG solid pie (g1/g2)', () => {
     expect(legend).toContain('4.5%')
     expect(legend).toContain('95.5%')
     expect(legend).toContain('50.09M')
-    expect(legend).toContain('1059.71M')
+    expect(legend).toContain('1.06B')
     expect(legend).toContain('cursor-grok-4.5-high-fast')
     expectNoFilledTagCopy(legend)
     expect(colorForModel(models[0]!, 0)).toBe('#34D399')
@@ -109,7 +109,7 @@ describe('TokenModelComposition SVG solid pie (g1/g2)', () => {
   it('multi-bucket: svg sectors keep unknown #71717A and other #A1A1AA (g1.3/g2.1/g2.2)', () => {
     const models = [
       { modelKey: 'claude-sonnet-4', name: 'claude-sonnet-4', total: 600, filled: true },
-      { modelKey: '未知/未分桶', name: '未知/未分桶', total: 300, unknown: true },
+      { modelKey: '未知/未分桶', name: '未知模型', total: 300, unknown: true },
       { modelKey: 'other', name: 'other', total: 100, other: true },
     ]
     expect(colorForModel(models[1]!, 1)).toBe('#71717A')
@@ -127,7 +127,7 @@ describe('TokenModelComposition SVG solid pie (g1/g2)', () => {
     expect(fills).toContain('#A1A1AA')
     expect(pie.findAll('circle').length).toBe(0)
     const legend = wrapper.find('[data-testid="token-model-legend"]').text()
-    expect(legend).toContain('未知/未分桶')
+    expect(legend).toContain('未知模型')
     expect(legend).toContain('other')
     expect(legend).toContain('claude-sonnet-4')
     // Layout: square swatches in legend, left pie + right legend grid
@@ -164,7 +164,7 @@ describe('TokenModelComposition hides filledTag (g2.1)', () => {
     })
     const legend = wrapper.find('[data-testid="token-model-legend"]')
     const text = legend.text()
-    expect(text).toContain('未知/未分桶')
+    expect(text).toContain('未知模型')
     expect(text).toContain('cursor-grok-4.5-high-fast')
     expect(text).toContain('gpt-5.6-sol-medium')
     expectNoFilledTagCopy(text)

--- a/web/src/components/board/token-stats/TokenModelRank.test.ts
+++ b/web/src/components/board/token-stats/TokenModelRank.test.ts
@@ -31,7 +31,7 @@ function expectNoFilledTagCopy(text: string) {
 const rankModels = [
   { modelKey: 'cursor-grok-4.5-high-fast', name: 'cursor-grok-4.5-high-fast', total: 800, filled: true },
   { modelKey: 'gpt-5.6-sol-medium', name: 'gpt-5.6-sol-medium', total: 600, filled: true },
-  { modelKey: '未知/未分桶', name: '未知/未分桶', total: 400, unknown: true },
+  { modelKey: '未知/未分桶', name: '未知模型', total: 400, unknown: true },
   { modelKey: 'other', name: 'other', total: 200, other: true },
 ]
 
@@ -63,7 +63,7 @@ describe('TokenModelRank hides filledTag (g2.2)', () => {
     const unknownRow = wrapper.find('[data-unknown="1"]')
     expect(unknownRow.exists()).toBe(true)
     expect(unknownRow.attributes('data-filled')).toBe('0')
-    expect(unknownRow.text()).toContain('未知/未分桶')
+    expect(unknownRow.text()).toContain('未知模型')
     expectNoFilledTagCopy(unknownRow.text())
     expect(unknownRow.find('.h-full').attributes('style')).toMatch(/background:\s*#71717A/i)
 
@@ -120,10 +120,10 @@ describe('TokenModelRank hides filledTag (g2.2)', () => {
 })
 
 describe('TokenModelRank unknown vs other (g3.3)', () => {
-  it('qualifying unknown keeps 未知/未分桶, data-unknown, gray text and #71717A bar', () => {
+  it('qualifying unknown keeps 未知模型, data-unknown, gray text and #71717A bar', () => {
     const models = [
       { modelKey: 'claude-sonnet-4', name: 'claude-sonnet-4', total: 100 },
-      { modelKey: '未知/未分桶', name: '未知/未分桶', total: 80, unknown: true },
+      { modelKey: '未知/未分桶', name: '未知模型', total: 80, unknown: true },
       { name: 'other', total: 30, other: true },
     ]
     expect(colorForModel(models[1]!, 1)).toBe('#71717A')
@@ -141,7 +141,7 @@ describe('TokenModelRank unknown vs other (g3.3)', () => {
     const unk = wrapper.find('[data-unknown="1"]')
     expect(unk.exists()).toBe(true)
     expect(unk.attributes('data-other')).toBe('0')
-    expect(unk.text()).toContain('未知/未分桶')
+    expect(unk.text()).toContain('未知模型')
     expect(unk.text()).toContain('未知')
     expect(unk.find('[data-testid="unknown-model-badge"]').exists()).toBe(true)
     expect(unk.text()).not.toContain('other（其余模型）')
@@ -196,7 +196,7 @@ describe('TokenModelRank unknown vs other (g3.3)', () => {
     })
     const unk = wrapper.find('[data-unknown="1"]')
     expect(unk.text()).toContain('Auto')
-    expect(unk.text()).not.toContain('未知/未分桶')
+    expect(unk.text()).not.toContain('未知模型')
     expect(unk.find('[data-testid="unknown-model-badge"]').exists()).toBe(false)
     expect(unk.find('.text-ok').exists()).toBe(true)
     expect(unk.find('.h-full').attributes('style')).toMatch(/#34D399/i)

--- a/web/src/components/board/token-stats/TokenStatsPanel.test.ts
+++ b/web/src/components/board/token-stats/TokenStatsPanel.test.ts
@@ -53,11 +53,11 @@ function sampleStats(partial: Partial<ProjectTokenStats> = {}): ProjectTokenStat
     ],
     modelComposition: [
       { modelKey: 'claude-sonnet-4', name: 'claude-sonnet-4', total: 100, filled: true },
-      { modelKey: '未知/未分桶', name: '未知/未分桶', total: 40, unknown: true },
+      { modelKey: '未知/未分桶', name: '未知模型', total: 40, unknown: true },
     ],
     modelRanking: [
       { modelKey: 'claude-sonnet-4', name: 'claude-sonnet-4', total: 100, filled: true },
-      { modelKey: '未知/未分桶', name: '未知/未分桶', total: 40, unknown: true },
+      { modelKey: '未知/未分桶', name: '未知模型', total: 40, unknown: true },
     ],
     ...partial,
   }

--- a/web/src/components/charts/chartTheme.ts
+++ b/web/src/components/charts/chartTheme.ts
@@ -15,6 +15,7 @@ export const CHART_GRID = {
 }
 
 export function fmtCompactAxis(n: number): string {
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
   if (n >= 1000) return `${(n / 1000).toFixed(1)}K`
   return String(n)

--- a/web/src/components/run/TokenUsageByModelTable.test.ts
+++ b/web/src/components/run/TokenUsageByModelTable.test.ts
@@ -59,7 +59,7 @@ describe('TokenUsageByModelTable narrow layout', () => {
       usageByModel: { '未知/未分桶': { ...sampleUsage, source: 'unknown' } },
     })
     const row = wrapper.get('[data-unknown="1"]')
-    expect(row.text()).toContain('未知/未分桶')
+    expect(row.text()).toContain('未知模型')
     expect(row.text()).toMatch(/27\.75M/)
     expect(row.text()).not.toMatch(/%/)
     expect(row.text()).toContain('input')

--- a/web/src/lib/run/tokenUsage.test.ts
+++ b/web/src/lib/run/tokenUsage.test.ts
@@ -11,6 +11,7 @@ import {
   summarizeTimelineUsage,
   sumTotalTokens,
   TOKEN_USAGE_UNKNOWN_MODEL,
+  TOKEN_USAGE_UNKNOWN_MODEL_DISPLAY,
   tokenUsageTotal,
   totalTokensOrNull,
   shouldShowUnknownVisual,
@@ -47,6 +48,7 @@ describe('tokenUsage', () => {
     expect(fmtCompactTokenCount(1_020_000)).toBe('1.02M')
     expect(fmtCompactTokenCount(1_000_000)).toBe('1M')
     expect(fmtCompactTokenCount(9_645_255)).toBe('9.65M')
+    expect(fmtCompactTokenCount(2_080_982_825)).toBe('2.08B')
   })
 
   it('formats compact token/s for KPI main values', () => {
@@ -182,17 +184,22 @@ describe('tokenUsage', () => {
 
   it('unknownDisplayName covers alias / empty / default-name / non-unknown keys', () => {
     expect(unknownDisplayName(TOKEN_USAGE_UNKNOWN_MODEL, 'gpt-5')).toBe('gpt-5')
-    expect(unknownDisplayName(TOKEN_USAGE_UNKNOWN_MODEL, '  ')).toBe(TOKEN_USAGE_UNKNOWN_MODEL)
+    expect(unknownDisplayName(TOKEN_USAGE_UNKNOWN_MODEL, '  ')).toBe(TOKEN_USAGE_UNKNOWN_MODEL_DISPLAY)
     expect(unknownDisplayName(TOKEN_USAGE_UNKNOWN_MODEL, TOKEN_USAGE_UNKNOWN_MODEL)).toBe(
-      TOKEN_USAGE_UNKNOWN_MODEL,
+      TOKEN_USAGE_UNKNOWN_MODEL_DISPLAY,
     )
-    expect(unknownDisplayName(TOKEN_USAGE_UNKNOWN_MODEL, null)).toBe(TOKEN_USAGE_UNKNOWN_MODEL)
+    expect(unknownDisplayName(TOKEN_USAGE_UNKNOWN_MODEL, TOKEN_USAGE_UNKNOWN_MODEL_DISPLAY)).toBe(
+      TOKEN_USAGE_UNKNOWN_MODEL_DISPLAY,
+    )
+    expect(unknownDisplayName(TOKEN_USAGE_UNKNOWN_MODEL, null)).toBe(TOKEN_USAGE_UNKNOWN_MODEL_DISPLAY)
     expect(unknownDisplayName('gpt-5', 'alias')).toBe('gpt-5')
   })
 
   it('shouldShowUnknownVisual: only unknown + default label', () => {
+    expect(shouldShowUnknownVisual(true, TOKEN_USAGE_UNKNOWN_MODEL_DISPLAY)).toBe(true)
     expect(shouldShowUnknownVisual(true, TOKEN_USAGE_UNKNOWN_MODEL)).toBe(true)
     expect(shouldShowUnknownVisual(true, ' 未知/未分桶 ')).toBe(true)
+    expect(shouldShowUnknownVisual(true, ' 未知模型 ')).toBe(true)
     expect(shouldShowUnknownVisual(true, 'Auto')).toBe(false)
     expect(shouldShowUnknownVisual(true, 'gpt-5')).toBe(false)
     expect(shouldShowUnknownVisual(false, TOKEN_USAGE_UNKNOWN_MODEL)).toBe(false)
@@ -203,6 +210,7 @@ describe('tokenUsage', () => {
     expect(normalizeUnknownModelDisplayNameInput(' gpt-5 ')).toEqual({ value: 'gpt-5' })
     expect(normalizeUnknownModelDisplayNameInput('   ')).toEqual({ value: '' })
     expect(normalizeUnknownModelDisplayNameInput(TOKEN_USAGE_UNKNOWN_MODEL)).toEqual({ value: '' })
+    expect(normalizeUnknownModelDisplayNameInput(TOKEN_USAGE_UNKNOWN_MODEL_DISPLAY)).toEqual({ value: '' })
     const tooLong = 'a'.repeat(65)
     expect(normalizeUnknownModelDisplayNameInput(tooLong).error).toMatch(/64/)
   })

--- a/web/src/lib/run/tokenUsage.ts
+++ b/web/src/lib/run/tokenUsage.ts
@@ -1,19 +1,26 @@
 import type { ModelTokenUsage, TokenUsage, TokenUsageByModel } from '../shared/types'
 
-/** Display key for legacy / unbucketed usage (matches server). */
+/** Persistence / API key for legacy / unbucketed usage (matches server). */
 export const TOKEN_USAGE_UNKNOWN_MODEL = '未知/未分桶'
+
+/** Default user-visible label when no project alias is configured. */
+export const TOKEN_USAGE_UNKNOWN_MODEL_DISPLAY = '未知模型'
 
 /** Max rune/char length for project unknown-model display name (matches server). */
 export const UNKNOWN_MODEL_DISPLAY_NAME_MAX_LEN = 64
 
+function isUnsetUnknownAlias(v: string): boolean {
+  return !v || v === TOKEN_USAGE_UNKNOWN_MODEL || v === TOKEN_USAGE_UNKNOWN_MODEL_DISPLAY
+}
+
 /**
  * Resolve display text for the unknown token bucket.
- * Empty / whitespace / equal to the default label → default 「未知/未分桶」.
+ * Empty / whitespace / equal to legacy or new default label → 「未知模型」.
  */
 export function unknownDisplayName(modelKey: string, alias?: string | null): string {
   if (modelKey !== TOKEN_USAGE_UNKNOWN_MODEL) return modelKey
   const v = (alias ?? '').trim()
-  if (!v || v === TOKEN_USAGE_UNKNOWN_MODEL) return TOKEN_USAGE_UNKNOWN_MODEL
+  if (isUnsetUnknownAlias(v)) return TOKEN_USAGE_UNKNOWN_MODEL_DISPLAY
   return v
 }
 
@@ -28,7 +35,8 @@ export function shouldShowUnknownVisual(
   displayName: string | null | undefined,
 ): boolean {
   if (!unknown) return false
-  return (displayName ?? '').trim() === TOKEN_USAGE_UNKNOWN_MODEL
+  const v = (displayName ?? '').trim()
+  return v === TOKEN_USAGE_UNKNOWN_MODEL_DISPLAY || v === TOKEN_USAGE_UNKNOWN_MODEL
 }
 
 /**
@@ -45,7 +53,7 @@ export function normalizeUnknownModelDisplayNameInput(
       error: `显示名最多 ${UNKNOWN_MODEL_DISPLAY_NAME_MAX_LEN} 个字符，请缩短后再保存。`,
     }
   }
-  if (!trimmed || trimmed === TOKEN_USAGE_UNKNOWN_MODEL) {
+  if (!trimmed || trimmed === TOKEN_USAGE_UNKNOWN_MODEL || trimmed === TOKEN_USAGE_UNKNOWN_MODEL_DISPLAY) {
     return { value: '' }
   }
   return { value: trimmed }
@@ -78,6 +86,9 @@ export function fmtTokenCount(n: number): string {
 export function fmtCompactTokenCount(n: number | null | undefined): string {
   if (n === null || n === undefined) return '—'
   const abs = Math.abs(n)
+  if (abs >= 1_000_000_000) {
+    return `${Math.round((n / 1_000_000_000) * 100) / 100}B`
+  }
   if (abs >= 1_000_000) {
     return `${Math.round((n / 1_000_000) * 100) / 100}M`
   }

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -289,7 +289,7 @@
       "close": "Close",
       "sourceUpstream": "upstream · reported",
       "sourceBridge": "via ACP_BRIDGE_MODEL",
-      "sourceUnknown": "Unknown/unbucketed",
+      "sourceUnknown": "Unknown model",
       "unknownBadge": "Unknown",
       "modelTableTitle": "Usage by model",
       "colModel": "Model",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -289,7 +289,7 @@
       "close": "关闭",
       "sourceUpstream": "upstream · 真实上报",
       "sourceBridge": "via ACP_BRIDGE_MODEL",
-      "sourceUnknown": "未知/未分桶",
+      "sourceUnknown": "未知模型",
       "unknownBadge": "未知",
       "modelTableTitle": "按模型用量",
       "colModel": "模型",

--- a/web/src/views/TokenAnalyticsView.test.ts
+++ b/web/src/views/TokenAnalyticsView.test.ts
@@ -140,12 +140,58 @@ describe('TokenAnalyticsView', () => {
     wrapper.unmount()
   })
 
-  it('uses fixed-height plot areas', async () => {
+  it('uses overflow-visible plot areas so tooltips are not clipped', async () => {
     const wrapper = mount(TokenAnalyticsView, { global: { plugins: [i18n] } })
     await flushPromises()
-    expect(wrapper.find('[data-testid="token-analytics-plot-lines"]').classes()).toContain('overflow-hidden')
-    expect(wrapper.find('[data-testid="token-analytics-plot-bars"]').classes()).toContain('overflow-hidden')
-    expect(wrapper.find('[data-testid="token-analytics-plot-area"]').classes()).toContain('overflow-hidden')
+    expect(wrapper.find('[data-testid="token-analytics-plot-lines"]').classes()).toContain('overflow-visible')
+    expect(wrapper.find('[data-testid="token-analytics-plot-bars"]').classes()).toContain('overflow-visible')
+    expect(wrapper.find('[data-testid="token-analytics-plot-area"]').classes()).toContain('overflow-visible')
+    expect(wrapper.find('[data-testid="token-analytics-plot-heat"]').classes()).toContain('overflow-visible')
+    wrapper.unmount()
+  })
+
+  it('pie charts use right-side legend, visible labels, and compact tooltip', async () => {
+    const wrapper = mount(TokenAnalyticsView, { global: { plugins: [i18n] } })
+    await flushPromises()
+    const charts = wrapper.findAllComponents({ name: 'VChart' })
+    expect(charts.length).toBeGreaterThan(0)
+    const pieChart = charts.find((c) => {
+      const opt = c.props('option') as { series?: { type?: string }[] }
+      return opt?.series?.[0]?.type === 'pie'
+    })
+    expect(pieChart).toBeTruthy()
+    const option = pieChart!.props('option') as {
+      legend?: { orient?: string; right?: number; bottom?: number }
+      tooltip?: { formatter?: unknown; appendToBody?: boolean }
+      series?: { label?: { show?: boolean }; center?: string[]; radius?: string | string[] }[]
+    }
+    expect(option.legend?.orient).toBe('vertical')
+    expect(option.legend?.right).toBe(0)
+    expect(option.legend?.bottom).toBeUndefined()
+    expect(option.series?.[0]?.label?.show).toBe(true)
+    expect(option.series?.[0]?.center?.[0]).toBe('38%')
+    expect(typeof option.tooltip?.formatter).toBe('function')
+    expect(option.tooltip?.appendToBody).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('axis charts use compact tooltip formatters and append tooltips to body', async () => {
+    const wrapper = mount(TokenAnalyticsView, { global: { plugins: [i18n] } })
+    await flushPromises()
+    const charts = wrapper.findAllComponents({ name: 'VChart' })
+    const lineChart = charts.find((c) => {
+      const opt = c.props('option') as { series?: { type?: string }[] }
+      return opt?.series?.[0]?.type === 'line' && opt?.series?.length === 2
+    })
+    expect(lineChart).toBeTruthy()
+    const option = lineChart!.props('option') as {
+      tooltip?: { valueFormatter?: (v: number) => string; appendToBody?: boolean; confine?: boolean }
+      yAxis?: { axisLabel?: { formatter?: (v: number) => string } }
+    }
+    expect(option.tooltip?.appendToBody).toBe(true)
+    expect(option.tooltip?.confine).toBe(false)
+    expect(option.tooltip?.valueFormatter?.(2_080_982_825)).toBe('2.08B')
+    expect(option.yAxis?.axisLabel?.formatter?.(2_500_000_000)).toBe('2.5B')
     wrapper.unmount()
   })
 

--- a/web/src/views/TokenAnalyticsView.vue
+++ b/web/src/views/TokenAnalyticsView.vue
@@ -87,8 +87,27 @@ function statsTooltip(extra: Record<string, unknown> = {}) {
     backgroundColor: dark ? '#27272a' : '#ffffff',
     borderColor: dark ? '#3f3f46' : '#e4e4e7',
     textStyle: { color: dark ? '#e4e4e7' : '#27272a', fontSize: 12 },
+    confine: false,
+    appendToBody: true,
+    extraCssText: 'z-index: 1000;',
     ...extra,
   }
+}
+
+function axisTooltip(extra: Record<string, unknown> = {}) {
+  return statsTooltip({
+    trigger: 'axis',
+    valueFormatter: (v: number) => fmtCompactTokenCount(v),
+    ...extra,
+  })
+}
+
+function pieTooltipFormatter(params: unknown): string {
+  const p = params as { name?: string; value?: number; percent?: number }
+  const name = p.name ?? ''
+  const value = fmtCompactTokenCount(p.value ?? 0)
+  const pct = p.percent != null ? p.percent.toFixed(1) : '0'
+  return `${name}: ${value} (${pct}%)`
 }
 
 const isEmpty = computed(() => !!data.value?.empty)
@@ -158,7 +177,7 @@ function lineChartOption() {
 
   return {
     grid: STATS_CHART_GRID,
-    tooltip: statsTooltip({ trigger: 'axis' }),
+    tooltip: axisTooltip(),
     legend: statsLegend(),
     xAxis: {
       type: 'category',
@@ -197,19 +216,23 @@ function pieOption(
   if (!slices.length) return null
   const colors = slices.map((s, i) => s.color || ['#4f46e5', '#7c6dff', '#a99cff', '#94a3b8'][i % 4])
   return {
-    tooltip: statsTooltip({ trigger: 'item', formatter: '{b}: {c} ({d}%)' }),
+    tooltip: statsTooltip({ trigger: 'item', formatter: pieTooltipFormatter }),
     legend: {
       show: true,
-      bottom: 0,
+      orient: 'vertical',
+      right: 0,
+      top: 'middle',
       type: 'scroll',
+      itemWidth: 10,
+      itemHeight: 8,
       itemStyle: { borderRadius: 0 },
       textStyle: { fontSize: 10, color: chartTone.value.legend },
     },
     series: [
       {
         type: 'pie',
-        radius: donut ? ['42%', '68%'] : '68%',
-        center: ['50%', '46%'],
+        radius: donut ? ['36%', '54%'] : '54%',
+        center: ['38%', '50%'],
         data: slices.map((s) => ({ name: s.name, value: s.value, key: s.key })),
         itemStyle: { borderWidth: 0 },
         color: colors,
@@ -284,7 +307,7 @@ function barChartOption() {
   })
   return {
     grid: STATS_CHART_GRID,
-    tooltip: statsTooltip({ trigger: 'axis', axisPointer: { type: 'shadow' } }),
+    tooltip: axisTooltip({ axisPointer: { type: 'shadow' } }),
     legend: {
       ...statsLegend(),
       data: TOKEN_PART_KEYS.map((k) => partLabel(k)),
@@ -311,7 +334,7 @@ function areaChartOption() {
   if (areaMode.value === 'source') {
     return {
       grid: STATS_CHART_GRID,
-      tooltip: statsTooltip({ trigger: 'axis' }),
+      tooltip: axisTooltip(),
       legend: statsLegend(),
       xAxis: {
         type: 'category',
@@ -347,7 +370,7 @@ function areaChartOption() {
   }
   return {
     grid: STATS_CHART_GRID,
-    tooltip: statsTooltip({ trigger: 'axis' }),
+    tooltip: axisTooltip(),
     legend: statsLegend(),
     xAxis: {
       type: 'category',
@@ -391,7 +414,9 @@ function heatmapOption() {
       position: 'top',
       formatter: (p: { data: [number, number, number] }) => {
       const [x, y, v] = p.data
-      return `${hm.rows[y]} × ${hm.cols[x]}<br/>${fmtTokenCount(v)}`
+      const compact = fmtCompactTokenCount(v)
+      const exact = fmtTokenCount(v)
+      return `${hm.rows[y]} × ${hm.cols[x]}<br/>${compact}<br/><span style="opacity:0.75;font-size:11px">${exact}</span>`
     }}),
     xAxis: {
       type: 'category',
@@ -666,7 +691,7 @@ watch([windowSel], () => void load())
               {{ t(`pages.tokenAnalytics.lineModes.${m}`) }}
             </button>
           </div>
-          <div class="token-analytics-plot mt-2 h-[200px] overflow-hidden" data-testid="token-analytics-plot-lines">
+          <div class="token-analytics-plot mt-2 h-[200px] overflow-visible" data-testid="token-analytics-plot-lines">
             <VChart v-if="lineChartOption()" :option="lineChartOption()!" autoresize class="h-full w-full" />
           </div>
         </section>
@@ -700,7 +725,7 @@ watch([windowSel], () => void load())
             {{ t('pages.tokenAnalytics.charts.bars') }}
             <em class="ml-2 text-[11px] font-normal text-txt3">{{ t('pages.tokenAnalytics.charts.barsHint') }}</em>
           </h2>
-          <div class="token-analytics-plot mt-2 h-[200px] overflow-hidden" data-testid="token-analytics-plot-bars">
+          <div class="token-analytics-plot mt-2 h-[200px] overflow-visible" data-testid="token-analytics-plot-bars">
             <VChart
               v-if="barChartOption()"
               :option="barChartOption()!"
@@ -728,14 +753,14 @@ watch([windowSel], () => void load())
               {{ t(`pages.tokenAnalytics.areaModes.${m}`) }}
             </button>
           </div>
-          <div class="token-analytics-plot mt-2 h-[200px] overflow-hidden" data-testid="token-analytics-plot-area">
+          <div class="token-analytics-plot mt-2 h-[200px] overflow-visible" data-testid="token-analytics-plot-area">
             <VChart v-if="areaChartOption()" :option="areaChartOption()!" autoresize class="h-full w-full" />
           </div>
         </section>
 
         <section id="heat" class="mb-3 border border-line bg-surface p-3.5" data-testid="token-analytics-heat">
           <h2 class="m-0 text-sm font-semibold">{{ t('pages.tokenAnalytics.charts.heat') }}</h2>
-          <div class="token-analytics-plot mt-2 h-[240px] overflow-hidden" data-testid="token-analytics-plot-heat">
+          <div class="token-analytics-plot mt-2 h-[240px] overflow-visible" data-testid="token-analytics-plot-heat">
             <VChart v-if="heatmapOption()" :option="heatmapOption()!" autoresize class="h-full w-full" />
           </div>
         </section>


### PR DESCRIPTION
Charts on /stats now use compact K/M/B units, right-side pie legends, and
tooltips that append to body without clipping. Default unknown bucket display
name is unified to 未知模型 while modelKey stays 未知/未分桶.

Co-authored-by: Cursor <cursoragent@cursor.com>
