### PR TITLE
fix(runtime): MCP 模板替换纳入共享 Agent env

### DIFF
--- a/server/internal/runtime/acp_config.go
+++ b/server/internal/runtime/acp_config.go
@@ -318,7 +318,8 @@ func (c *acpProvider) templateVars(req NodeReq) map[string]string {
 // present. Existing base keys (APPROVING_*, vars.*, …) win. Env values are
 // substituted against base only so ${vars.x} / ${APPROVING_*} still resolve.
 func MergeEnvIntoTemplateVars(base, env map[string]string) map[string]string {
-	out := make(map[string]string, len(base)+len(env))
+	// Preallocate from one side only — avoid len(base)+len(env) (CodeQL go/allocation-size-overflow).
+	out := make(map[string]string, len(base))
 	for k, v := range base {
 		out[k] = v
 	}

--- a/server/internal/runtime/acp_config.go
+++ b/server/internal/runtime/acp_config.go
@@ -307,6 +307,34 @@ func (c *acpProvider) mcpVars(req NodeReq) map[string]string {
 	return m
 }
 
+// templateVars is the substitution map for user-authored MCP fields: platform
+// mcpVars first, then effective Agent/shared env keys that are not already
+// reserved. Agent env cannot override APPROVING_* / vars.*.
+func (c *acpProvider) templateVars(req NodeReq) map[string]string {
+	return MergeEnvIntoTemplateVars(c.mcpVars(req), c.effectiveAgent(req).Env)
+}
+
+// MergeEnvIntoTemplateVars copies base, then adds env keys that are not already
+// present. Existing base keys (APPROVING_*, vars.*, …) win. Env values are
+// substituted against base only so ${vars.x} / ${APPROVING_*} still resolve.
+func MergeEnvIntoTemplateVars(base, env map[string]string) map[string]string {
+	out := make(map[string]string, len(base)+len(env))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range env {
+		k = strings.TrimSpace(k)
+		if k == "" {
+			continue
+		}
+		if _, exists := out[k]; exists {
+			continue
+		}
+		out[k] = substVars(v, base)
+	}
+	return out
+}
+
 func substVars(s string, vars map[string]string) string {
 	if s == "" {
 		return s
@@ -351,7 +379,7 @@ func (c *acpProvider) resolvedMCPSpecs(req NodeReq) []sandbox.MCPServerSpec {
 	if len(mcp) == 0 {
 		return nil
 	}
-	vars := c.mcpVars(req)
+	vars := c.templateVars(req)
 	out := make([]sandbox.MCPServerSpec, 0, len(mcp))
 	for _, m := range mcp {
 		if m.Name == "" {

--- a/server/internal/runtime/project_env_test.go
+++ b/server/internal/runtime/project_env_test.go
@@ -266,6 +266,113 @@ func TestSpecRunSandboxEnvDoesNotOverrideReservedAfterInject(t *testing.T) {
 	}
 }
 
+func TestResolvedMCPSpecsSubstitutesSharedEnv(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	agentJSON := `{"mcp":[{"name":"server-log","url":"https://logs.example/mcp","headers":{"Authorization":"Bearer ${LOG_CENTER_TOKEN}"}},{"name":"artifact-store","url":"${APPROVING_ARTIFACT_URL}","headers":{"Authorization":"Bearer ${APPROVING_ARTIFACT_TOKEN}"}}],"env":{"APPROVING_ARTIFACT_TOKEN":"evil-agent","APPROVING_CURSOR_API_KEY":"k"}}`
+	if err := os.WriteFile(filepath.Join(dir, "agent.json"), []byte(agentJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := &acpProvider{
+		opts: Options{
+			ProjectIDForWorkflow: func(string) string { return "proj-1" },
+			SharedAgentForProject: func(string) SharedAgentView {
+				return SharedAgentView{Env: map[string]string{
+					"LOG_CENTER_TOKEN": "secret-from-shared",
+				}}
+			},
+			ProfilesRoot: root,
+			MCPEndpoint:  "http://mcp.local",
+		},
+		backend: BackendCursor,
+	}
+	req := NodeReq{
+		WorkflowID: "wf-1",
+		RunID:      "run-1",
+		NodeID:     "n1",
+		Token:      "tok",
+		Config:     map[string]any{"agent_profile": "demo"},
+	}
+	specs := c.resolvedMCPSpecs(req)
+	var logHdr, artHdr string
+	for _, sp := range specs {
+		switch sp.Name {
+		case "server-log":
+			logHdr = sp.Headers["Authorization"]
+		case "artifact-store":
+			artHdr = sp.Headers["Authorization"]
+		}
+	}
+	if logHdr != "Bearer secret-from-shared" {
+		t.Fatalf("server-log Authorization = %q", logHdr)
+	}
+	if artHdr != "Bearer tok" {
+		t.Fatalf("artifact-store must keep run token, got %q", artHdr)
+	}
+	spec, err := c.spec(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec.Env["LOG_CENTER_TOKEN"] != "secret-from-shared" {
+		t.Fatalf("OS env LOG_CENTER_TOKEN = %q", spec.Env["LOG_CENTER_TOKEN"])
+	}
+}
+
+func TestResolvedMCPSpecsAgentEnvOverlaysShared(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	agentJSON := `{"mcp":[{"name":"server-log","url":"https://logs.example/mcp","headers":{"Authorization":"Bearer ${LOG_CENTER_TOKEN}"}}],"env":{"LOG_CENTER_TOKEN":"from-agent"}}`
+	if err := os.WriteFile(filepath.Join(dir, "agent.json"), []byte(agentJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := &acpProvider{
+		opts: Options{
+			ProjectIDForWorkflow: func(string) string { return "proj-1" },
+			SharedAgentForProject: func(string) SharedAgentView {
+				return SharedAgentView{Env: map[string]string{"LOG_CENTER_TOKEN": "secret-from-shared"}}
+			},
+			ProfilesRoot: root,
+		},
+		backend: BackendCursor,
+	}
+	specs := c.resolvedMCPSpecs(NodeReq{
+		WorkflowID: "wf-1",
+		Token:      "tok",
+		Config:     map[string]any{"agent_profile": "demo"},
+	})
+	if len(specs) != 1 || specs[0].Headers["Authorization"] != "Bearer from-agent" {
+		t.Fatalf("agent env should win: %+v", specs)
+	}
+}
+
+func TestMergeEnvIntoTemplateVarsReservedWinAndSubst(t *testing.T) {
+	base := map[string]string{
+		"APPROVING_ARTIFACT_TOKEN": "tok",
+		"vars.region":              "cn-east",
+	}
+	got := MergeEnvIntoTemplateVars(base, map[string]string{
+		"LOG_CENTER_TOKEN":         "secret",
+		"APPROVING_ARTIFACT_TOKEN": "evil",
+		"TEMPLATED":                "${vars.region}",
+		"":                         "skip",
+	})
+	if got["LOG_CENTER_TOKEN"] != "secret" {
+		t.Fatalf("LOG_CENTER_TOKEN=%q", got["LOG_CENTER_TOKEN"])
+	}
+	if got["APPROVING_ARTIFACT_TOKEN"] != "tok" {
+		t.Fatalf("reserved overwritten: %q", got["APPROVING_ARTIFACT_TOKEN"])
+	}
+	if got["TEMPLATED"] != "cn-east" {
+		t.Fatalf("TEMPLATED=%q", got["TEMPLATED"])
+	}
+}
+
 func TestSpecSkipsRunEnvWithoutLookup(t *testing.T) {
 	root := t.TempDir()
 	dir := filepath.Join(root, "demo")

--- a/server/internal/services/sandbox_agent.go
+++ b/server/internal/services/sandbox_agent.go
@@ -195,6 +195,7 @@ func (s *SandboxService) startAgentContainer(id uint, name, profile, projectID, 
 		}
 	}
 
+	vars = runtime.MergeEnvIntoTemplateVars(vars, agent.Env)
 	specs := filterAgentPlatformMCP(resolveAgentMCP(agent.MCP, vars))
 	specs = append(specs, platformSpecs...)
 	specs = dedupeMCPByName(specs)

--- a/server/internal/services/sandbox_service_test.go
+++ b/server/internal/services/sandbox_service_test.go
@@ -1182,6 +1182,34 @@ func TestSandboxHelpers(t *testing.T) {
 	}
 }
 
+func TestResolveAgentMCPSubstitutesMergedEnv(t *testing.T) {
+	base := map[string]string{
+		"APPROVING_ARTIFACT_URL":   "http://art",
+		"APPROVING_ARTIFACT_TOKEN": "tok",
+	}
+	vars := runtime.MergeEnvIntoTemplateVars(base, map[string]string{
+		"LOG_CENTER_TOKEN":         "secret-from-shared",
+		"APPROVING_ARTIFACT_TOKEN": "evil",
+	})
+	specs := resolveAgentMCP([]MCPServer{
+		{Name: "server-log", URL: "https://logs.example/mcp", Headers: map[string]string{"Authorization": "Bearer ${LOG_CENTER_TOKEN}"}},
+		{Name: "artifact-store", URL: "${APPROVING_ARTIFACT_URL}", Headers: map[string]string{"Authorization": "Bearer ${APPROVING_ARTIFACT_TOKEN}"}},
+	}, vars)
+	if len(specs) != 2 {
+		t.Fatalf("specs=%d", len(specs))
+	}
+	byName := map[string]sandbox.MCPServerSpec{}
+	for _, sp := range specs {
+		byName[sp.Name] = sp
+	}
+	if got := byName["server-log"].Headers["Authorization"]; got != "Bearer secret-from-shared" {
+		t.Fatalf("server-log Authorization=%q", got)
+	}
+	if got := byName["artifact-store"].Headers["Authorization"]; got != "Bearer tok" {
+		t.Fatalf("artifact-store Authorization=%q", got)
+	}
+}
+
 func TestSandboxServiceSettersAndShutdownAll(t *testing.T) {
 	db := newTestDB(t)
 	svc := newSandboxService(t, db, &dockerState{})

--- a/server/internal/services/sandbox_test_pool.go
+++ b/server/internal/services/sandbox_test_pool.go
@@ -170,7 +170,7 @@ func (s *SandboxService) startContainer(id uint, name, profile, projectID, runID
 		}
 	}()
 
-	vars := s.testMcpVars(runID, token, projectID, profile)
+	vars := runtime.MergeEnvIntoTemplateVars(s.testMcpVars(runID, token, projectID, profile), agent.Env)
 	specs := s.buildTestSandboxSpecs(projectID, profile, runID, token, agent, vars)
 
 	env := map[string]string{}


### PR DESCRIPTION
## Summary
- 工作流 / 测试 / PM 沙箱在物化 mcp.json 时，把共享+Agent env 并入模板变量，使 `${LOG_CENTER_TOKEN}` 等引用能解析为真实值。
- 平台保留键（`APPROVING_*`、`vars.*`）不可被 Agent 同名 env 覆盖。
- 补齐 runtime 与 services 单测：共享 env 注入、Agent 覆盖共享、保留键不被覆盖。

## Test plan
- [x] `go test ./internal/runtime/ ./internal/services/` 本地通过
- [ ] CI `ci-server`：golangci-lint、`go vet`、`go test ./...`、覆盖率门禁
- [ ] 项目共享 Agent 配置 `LOG_CENTER_TOKEN` 后，节点沙箱 mcp.json 中 server-log Authorization 为真实 token（不再是字面量 `${LOG_CENTER_TOKEN}`）


Made with [Cursor](https://cursor.com)