### PR TITLE
feat(web): flatten Git connection guide and hide when a token exists

### DIFF
--- a/web/LIB_DOMAIN_MAP.json
+++ b/web/LIB_DOMAIN_MAP.json
@@ -15,6 +15,7 @@
       "useAgentFilesPanel.ts",
       "useAgentImport.ts",
       "useAgentStudio.ts",
+      "useInheritedGitEnv.ts",
       "workspaceHistoryDiff.ts"
     ],
     "api": [
@@ -171,7 +172,7 @@
     ]
   },
   "totals": {
-    "agent": 14,
+    "agent": 15,
     "api": 3,
     "composables": 16,
     "inbox": 20,

--- a/web/e2e/agent-create-wizard-main.ts
+++ b/web/e2e/agent-create-wizard-main.ts
@@ -23,6 +23,7 @@ async function boot() {
           h(AgentCreateWizard, {
             open: open.value,
             existingNames: [],
+            projectId: new URLSearchParams(location.search).get('projectId') || undefined,
             onClose: () => {
               open.value = false
             },

--- a/web/e2e/agent-create-wizard.spec.ts
+++ b/web/e2e/agent-create-wizard.spec.ts
@@ -73,18 +73,15 @@ test('新建 Agent 五步向导浏览器验收', async ({ page }) => {
   await expect(page.locator('.wiz-rail')).toBeVisible()
   await expect(page.locator('.sec-head h3')).toHaveText('Git')
 
-  // Select GitLab + add recommended vars (runtime ${vars.repos}) and assert no dead-end badge.
-  await page.getByRole('button', { name: /调整类型/ }).click()
-  await page.locator('input[type="radio"]').nth(1).check()
-  await page.getByRole('button', { name: /确认|应用|保存|确定|使用/ }).last().click()
-  const addRec = page.getByRole('button', { name: /添加推荐|推荐变量|一键添加/ })
-  if (await addRec.count()) {
-    await addRec.first().click()
-  }
+  // g1.1: pick GitLab on the flat first screen — no「调整类型」modal.
+  await expect(page.getByRole('button', { name: /调整类型/ })).toHaveCount(0)
+  await page.locator('[data-test="git-choice-gitlab_https"]').click()
+  await expect(page.locator('[data-test="git-choice-gitlab_https"]')).toHaveAttribute('aria-pressed', 'true')
   const gitAfter = await page.locator('.step-pane').innerText()
   expect(gitAfter).not.toContain('未逐仓解析')
   expect(gitAfter).not.toContain('无法在此页面逐仓解析')
-  expect(gitAfter).toMatch(/GitLab|运行时解析|配置形态完整|推荐/)
+  expect(gitAfter).not.toContain('调整类型')
+  expect(gitAfter).toContain('GitLab')
   await page.screenshot({ path: path.join(OUT, '06-git-typed.png'), fullPage: true })
 
   await page.getByRole('button', { name: /^下一步|^跳过/ }).last().click()
@@ -99,4 +96,41 @@ test('新建 Agent 五步向导浏览器验收', async ({ page }) => {
   await page.getByRole('button', { name: /创建并进入 Studio/ }).click()
   await expect(page.getByTestId('created-name')).toHaveText('e2e-wizard-agent', { timeout: 10_000 })
   await expect(page.locator('.wiz-rail')).toHaveCount(0)
+})
+
+test('向导能取到项目共享 Git Token 时 Git 步不出现引导（g2.1）', async ({ page }) => {
+  await page.route('**/api/**', async (route) => {
+    if (!new URL(route.request().url()).pathname.startsWith('/api/')) {
+      await route.continue()
+      return
+    }
+    const url = new URL(route.request().url())
+    if (url.pathname.includes('/shared-agent-config') && route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          projectId: 'proj-shared',
+          env: { GITLAB_TOKEN: '${vars.gitlab_pat}' },
+          files: [],
+          mcp: [],
+          layout: {},
+        }),
+      })
+      return
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  })
+
+  await page.goto('/agent-create-wizard.html?projectId=proj-shared', { waitUntil: 'networkidle' })
+  await expect(page.getByTestId('agent-create-wizard-root')).toBeVisible()
+  await page.locator('#wiz-name-input').fill('e2e-inherited-git')
+  await page.getByRole('button', { name: /^下一步/ }).click()
+  await page.getByRole('button', { name: /Cursor/ }).click()
+  await page.getByRole('button', { name: /^下一步/ }).click()
+  await page.getByRole('button', { name: /^跳过/ }).click()
+  await expect(page.locator('.sec-head h3')).toHaveText('Git')
+  await expect(page.locator('[data-test="git-guide"]')).toHaveCount(0)
+  await expect(page.locator('[data-test="git-choice-github_https"]')).toHaveCount(0)
+  await expect(page.getByText('调整类型')).toHaveCount(0)
 })

--- a/web/src/components/agent/AgentCreateWizard.test.ts
+++ b/web/src/components/agent/AgentCreateWizard.test.ts
@@ -14,14 +14,22 @@ const createAgent = vi.fn(async (payload: unknown) => payload)
 const listProjectRunTags = vi.fn(async (_projectId: string) => {
   throw Object.assign(new Error('not found'), { status: 404 })
 })
+const getProjectSharedAgentConfig = vi.fn(async () => ({
+  projectId: '',
+  env: {},
+  files: [],
+  mcp: [],
+  layout: {},
+}))
 vi.mock('@/lib/api/api', () => ({
   api: {
     createAgent: (payload: unknown) => createAgent(payload),
     listProjectRunTags: (projectId: string) => listProjectRunTags(projectId),
+    getProjectSharedAgentConfig: (...args: unknown[]) => getProjectSharedAgentConfig(...args),
   },
 }))
 
-function mountWizard(locale: 'zh-CN' | 'en' = 'zh-CN') {
+function mountWizard(locale: 'zh-CN' | 'en' = 'zh-CN', projectId?: string) {
   const i18n = createI18n({
     legacy: false,
     locale,
@@ -32,7 +40,7 @@ function mountWizard(locale: 'zh-CN' | 'en' = 'zh-CN') {
   })
   return mount(AgentCreateWizard, {
     attachTo: document.body,
-    props: { open: true, existingNames: [] },
+    props: { open: true, existingNames: [], projectId },
     global: { plugins: [i18n] },
   })
 }
@@ -214,6 +222,34 @@ describe('AgentCreateWizard 5-step IA', () => {
     expect(unhandled.some((e) => String(e).includes('is not iterable'))).toBe(false)
 
     process.off('unhandledRejection', onUnhandled)
+    wrapper.unmount()
+  })
+
+  it('Git 步在共享 Token 存在时不渲染引导（g2.1）', async () => {
+    getProjectSharedAgentConfig.mockResolvedValue({
+      projectId: 'proj-shared',
+      env: { GITLAB_TOKEN: '${vars.gitlab_pat}' },
+      files: [],
+      mcp: [],
+      layout: {},
+    })
+    const wrapper = mountWizard('zh-CN', 'proj-shared')
+    fillName('inherit-agent')
+    await wrapper.vm.$nextTick()
+    buttonByText('下一步').click()
+    await wrapper.vm.$nextTick()
+    buttonByText('下一步').click()
+    await wrapper.vm.$nextTick()
+    buttonByText('跳过').click()
+    await wrapper.vm.$nextTick()
+    await vi.waitFor(() => {
+      expect(getProjectSharedAgentConfig).toHaveBeenCalledWith('proj-shared')
+    })
+    await vi.waitFor(() => {
+      expect(document.body.querySelector('[data-test="git-guide"]')).toBeFalsy()
+    })
+    expect(document.body.textContent).toContain('Git')
+    expect(document.body.textContent).not.toContain('调整类型')
     wrapper.unmount()
   })
 

--- a/web/src/components/agent/AgentCreateWizard.test.ts
+++ b/web/src/components/agent/AgentCreateWizard.test.ts
@@ -14,7 +14,7 @@ const createAgent = vi.fn(async (payload: unknown) => payload)
 const listProjectRunTags = vi.fn(async (_projectId: string) => {
   throw Object.assign(new Error('not found'), { status: 404 })
 })
-const getProjectSharedAgentConfig = vi.fn(async () => ({
+const getProjectSharedAgentConfig = vi.fn(async (_projectId?: string) => ({
   projectId: '',
   env: {},
   files: [],
@@ -25,7 +25,7 @@ vi.mock('@/lib/api/api', () => ({
   api: {
     createAgent: (payload: unknown) => createAgent(payload),
     listProjectRunTags: (projectId: string) => listProjectRunTags(projectId),
-    getProjectSharedAgentConfig: (...args: unknown[]) => getProjectSharedAgentConfig(...args),
+    getProjectSharedAgentConfig: (projectId: string) => getProjectSharedAgentConfig(projectId),
   },
 }))
 

--- a/web/src/components/agent/AgentCreateWizard.vue
+++ b/web/src/components/agent/AgentCreateWizard.vue
@@ -46,6 +46,7 @@ const {
   onCustomConfigInput,
   onApiKeyInput,
   onGitCredentialType,
+  inheritedEnv,
   goPrev,
   goSkip,
   goNext,
@@ -230,6 +231,8 @@ const {
                   <p class="sec-meta">{{ t('pages.agentStudio.wizard.git.meta') }}</p>
                   <AgentGitGuide
                     :env="draft.env"
+                    :inherited-env="inheritedEnv"
+                    :allow-token-recommend="false"
                     :upsert-env="
                       (k, v) => {
                         upsertEnv(k, v)

--- a/web/src/components/agent/AgentEnvPanel.inherited.test.ts
+++ b/web/src/components/agent/AgentEnvPanel.inherited.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment happy-dom
+import { createI18n } from 'vue-i18n'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import common from '@/locales/zh-CN/common.json'
+import pages from '@/locales/zh-CN/pages.json'
+import AgentEnvPanel from './AgentEnvPanel.vue'
+import { emptyPrompts, type AgentStudioDraft } from '@/lib/agent/agentStudioDraft'
+
+const getProjectSharedAgentConfig = vi.fn()
+
+vi.mock('@/lib/api/api', () => ({
+  api: {
+    getProjectSharedAgentConfig: (...args: unknown[]) => getProjectSharedAgentConfig(...args),
+  },
+}))
+
+function draft(partial: Partial<AgentStudioDraft> = {}): AgentStudioDraft {
+  return {
+    name: 'test-agent',
+    projectId: '',
+    env: [],
+    mcp: [],
+    files: [],
+    prompts: emptyPrompts(),
+    gitCredentialType: undefined,
+    acpBackend: 'cursor',
+    layout: { configRoot: '/tmp/agent', workspaceDir: '/tmp/workspace' },
+    ...partial,
+  }
+}
+
+function mountPanel(d: AgentStudioDraft, context: 'agent' | 'shared' = 'agent') {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common, ...pages } },
+  })
+  return mount(AgentEnvPanel, {
+    props: { draft: d, context },
+    global: {
+      plugins: [i18n],
+      stubs: { CodeEditor: true, EnvCredentialHelpModal: true },
+    },
+  })
+}
+
+describe('AgentEnvPanel inherited Git env', () => {
+  beforeEach(() => {
+    getProjectSharedAgentConfig.mockReset()
+  })
+
+  it('agent 上下文且已绑定项目时读取共享 env，引导因继承 Token 隐藏（g2.1）', async () => {
+    getProjectSharedAgentConfig.mockResolvedValue({
+      projectId: 'proj-1',
+      env: { GITLAB_TOKEN: '${vars.gitlab_pat}' },
+      files: [],
+      mcp: [],
+      layout: {},
+    })
+    const wrapper = mountPanel(draft({ projectId: 'proj-1' }))
+    await vi.waitFor(() => {
+      expect(getProjectSharedAgentConfig).toHaveBeenCalledWith('proj-1')
+    })
+    await vi.waitFor(() => {
+      expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(false)
+    })
+    wrapper.unmount()
+  })
+
+  it('shared 上下文不请求项目共享配置，只看本面 env（g2.1）', async () => {
+    const wrapper = mountPanel(draft({ projectId: 'proj-1' }), 'shared')
+    await new Promise((r) => setTimeout(r, 20))
+    expect(getProjectSharedAgentConfig).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('未绑定项目不请求共享配置，显示三选', async () => {
+    const wrapper = mountPanel(draft({ projectId: '' }))
+    await new Promise((r) => setTimeout(r, 20))
+    expect(getProjectSharedAgentConfig).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-test="git-choice-github_https"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+})

--- a/web/src/components/agent/AgentEnvPanel.vue
+++ b/web/src/components/agent/AgentEnvPanel.vue
@@ -9,6 +9,7 @@ import EnvCredentialHelpModal, {
   type EnvCredentialHelpSection,
 } from '@/components/agent/EnvCredentialHelpModal.vue'
 import { BACKEND_AUTH_HINTS, settingsFileAbsPath } from '@/lib/agent/backendAuthGuide'
+import { useInheritedGitEnv } from '@/lib/agent/useInheritedGitEnv'
 import {
   getRegionPolicy,
   isManagedRegionKey,
@@ -31,6 +32,11 @@ const { t } = useI18n()
 
 const envContext = computed(() => props.context ?? 'agent')
 const preferSharedAuth = computed(() => envContext.value === 'agent')
+/** Agent context inherits project shared env; shared editor only looks at this surface. */
+const inheritedProjectId = computed(() =>
+  envContext.value === 'agent' ? props.draft.projectId : '',
+)
+const { inheritedEnv } = useInheritedGitEnv(inheritedProjectId)
 
 const envRaw = ref(false)
 const envRawText = ref('')
@@ -138,6 +144,7 @@ watch(
       </div>
       <AgentGitGuide
         :env="draft.env"
+        :inherited-env="inheritedEnv"
         :upsert-env="upsertEnv"
         :credential-type="draft.gitCredentialType"
         :allow-token-recommend="!preferSharedAuth"

--- a/web/src/components/agent/AgentGitGuide.test.ts
+++ b/web/src/components/agent/AgentGitGuide.test.ts
@@ -1,27 +1,29 @@
 // @vitest-environment happy-dom
-import { defineComponent } from 'vue'
 import { createI18n } from 'vue-i18n'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import common from '@/locales/zh-CN/common.json'
 import pages from '@/locales/zh-CN/pages.json'
 import AgentGitGuide from './AgentGitGuide.vue'
+import type { GitCredentialType } from '@/lib/agent/gitCredentialAnalysis'
 
-const AppModalStub = defineComponent({
-  props: { open: Boolean },
-  template: `
-    <div v-if="open" data-test="modal">
-      <slot name="header" />
-      <slot />
-      <slot name="footer" />
-    </div>
-  `,
-})
+const DIAGNOSTIC_TERMS = [
+  '调整类型',
+  '尚未选择',
+  '待确认连接方式',
+  '运行时解析',
+  '配置形态完整',
+  '静态识别凭据类型',
+]
 
 function mountGuide(
   env: { k: string; v: string }[],
-  credentialType?: 'github_https' | 'gitlab_https' | 'ssh',
-  allowTokenRecommend = true,
+  opts: {
+    credentialType?: GitCredentialType
+    allowTokenRecommend?: boolean
+    inheritedEnv?: { k: string; v: string }[] | Record<string, string>
+    upsertEnv?: (key: string, value: string) => void
+  } = {},
 ) {
   const i18n = createI18n({
     legacy: false,
@@ -31,118 +33,118 @@ function mountGuide(
   return mount(AgentGitGuide, {
     props: {
       env,
-      credentialType,
-      upsertEnv: () => {},
-      allowTokenRecommend,
+      credentialType: opts.credentialType,
+      upsertEnv: opts.upsertEnv ?? (() => {}),
+      allowTokenRecommend: opts.allowTokenRecommend,
+      inheritedEnv: opts.inheritedEnv,
     },
-    global: {
-      plugins: [i18n],
-      stubs: {
-        AppModal: AppModalStub,
-      },
-    },
+    global: { plugins: [i18n] },
   })
 }
 
 describe('AgentGitGuide', () => {
-  it('未配置仓库时显示中性未启用状态', () => {
+  it('无 Token 时平铺 GitHub / GitLab / SSH，点击立即写入类型（g1.1）', async () => {
     const wrapper = mountGuide([])
-    expect(wrapper.text()).toContain('Git 未启用')
-    expect(wrapper.text()).not.toContain('凭据不完整')
+    expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(true)
+    expect(wrapper.get('[data-test="git-choice-github_https"]').text()).toContain('GitHub')
+    expect(wrapper.get('[data-test="git-choice-gitlab_https"]').text()).toContain('GitLab')
+    expect(wrapper.get('[data-test="git-choice-ssh"]').text()).toContain('SSH')
+    expect(wrapper.text()).not.toContain('调整类型')
+    expect(wrapper.find('input[type="radio"]').exists()).toBe(false)
+
+    await wrapper.get('[data-test="git-choice-gitlab_https"]').trigger('click')
+    expect(wrapper.emitted('update:credentialType')).toEqual([['gitlab_https']])
+
+    await wrapper.setProps({ credentialType: 'gitlab_https' })
+    expect(wrapper.get('[data-test="git-choice-gitlab_https"]').attributes('aria-pressed')).toBe(
+      'true',
+    )
   })
 
-  it('完整状态不再内嵌静态检查长文，改为帮助入口', async () => {
-    const wrapper = mountGuide([
-      { k: 'GIT_REPOS', v: 'app|https://gitlab.com/acme/app.git|main' },
-      { k: 'GITLAB_TOKEN', v: '${vars.gitlab_token}' },
-    ])
-    expect(wrapper.text()).toContain('配置形态完整')
-    expect(wrapper.text()).not.toContain('不会验证变量引用的实际值')
-    expect(wrapper.text()).not.toContain('远端 clone / push 权限')
-    expect(wrapper.text()).not.toContain('可成功 clone')
+  it('首屏不含诊断词，帮助入口仍可打开（g1.4）', async () => {
+    const wrapper = mountGuide([])
+    for (const term of DIAGNOSTIC_TERMS) {
+      expect(wrapper.text(), term).not.toContain(term)
+    }
     const help = wrapper.get('[data-test="git-help-link"]')
     expect(help.text()).toBe('帮助')
-    expect(help.attributes('type')).toBe('button')
     await help.trigger('click')
     expect(wrapper.emitted('help')).toEqual([['git']])
   })
 
-  it('运行时引用未选类型时给出可操作指引，无未逐仓解析告警', () => {
+  it('本地任一 Git Token 隐藏整块引导（g1.2）', () => {
+    const wrapper = mountGuide([{ k: 'GITLAB_TOKEN', v: '${vars.gitlab_pat}' }])
+    expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('GitHub')
+    expect(wrapper.text()).not.toContain('添加推荐变量')
+  })
+
+  it('仅继承 Token 时隐藏引导；空本地不覆盖继承（g1.2 / g2.1）', () => {
+    const wrapper = mountGuide([], {
+      inheritedEnv: { GITLAB_TOKEN: '${vars.gitlab_pat}' },
+    })
+    expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(false)
+  })
+
+  it('仅 ACP API Key、没有 Git Token 时仍显示三选（g1.2）', () => {
     const wrapper = mountGuide([
-      { k: 'GIT_REPOS', v: '${vars.repos}' },
-      { k: 'GITLAB_TOKEN', v: '${vars.gitlab_token}' },
+      { k: 'APPROVING_CURSOR_API_KEY', v: 'sk-test' },
+      { k: 'CURSOR_API_KEY', v: 'sk-alt' },
     ])
-    expect(wrapper.text()).toContain('请选择凭据类型')
-    expect(wrapper.text()).toContain('GitHub / GitLab / SSH')
-    expect(wrapper.text()).toContain('运行时解析')
-    expect(wrapper.text()).not.toContain('本页不逐仓展开')
-    expect(wrapper.text()).not.toContain('未逐仓解析')
-    expect(wrapper.text()).not.toContain('无法在此页面逐仓解析')
+    expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="git-choice-github_https"]').exists()).toBe(true)
   })
 
-  it('确认类型后显示完整态与中性运行时解析，类型文案为 GitLab', async () => {
-    const env = [
-      { k: 'GIT_REPOS', v: '${vars.repos}' },
-      { k: 'GITLAB_TOKEN', v: '${vars.gitlab_token}' },
-    ]
-    const wrapper = mountGuide(env)
-    expect(wrapper.text()).toContain('请选择凭据类型')
-
-    await wrapper.findAll('header button').find((b) => b.text() === '调整类型')!.trigger('click')
-    const radios = wrapper.findAll('input[type="radio"]')
-    await radios[1].setValue()
-    const buttons = wrapper.findAll('[data-test="modal"] button')
-    await buttons[buttons.length - 1].trigger('click')
-
+  it('隐藏时仅 GITLAB_TOKEN 且无类型则推断为 GitLab（g1.3）', () => {
+    const wrapper = mountGuide([], {
+      inheritedEnv: { GITLAB_TOKEN: '${vars.gitlab_pat}' },
+    })
+    expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(false)
     expect(wrapper.emitted('update:credentialType')).toEqual([['gitlab_https']])
-    await wrapper.setProps({ credentialType: 'gitlab_https' })
-    expect(wrapper.text()).toContain('配置形态完整')
-    expect(wrapper.text()).toContain('已应用/待保存')
-    expect(wrapper.text()).toContain('GitLab')
-    expect(wrapper.text()).not.toContain('GitLab · HTTPS')
-    expect(wrapper.text()).not.toContain('未逐仓解析')
-    expect(wrapper.text()).toContain('运行时解析')
   })
 
-  it('选择与仓库证据冲突时显示选择已失效', () => {
-    const wrapper = mountGuide(
-      [
-        { k: 'GIT_REPOS', v: 'app|https://gitlab.com/acme/app.git|main' },
-        { k: 'GITLAB_TOKEN', v: '${vars.gitlab_token}' },
-      ],
-      'github_https',
-    )
-    expect(wrapper.text()).toContain('需要确认凭据类型')
-    expect(wrapper.text()).toContain('选择已失效')
-    expect(wrapper.text()).not.toContain('已应用/待保存')
+  it('隐藏时用户已选类型不被推断覆盖（g1.3）', () => {
+    const wrapper = mountGuide([{ k: 'GITHUB_TOKEN', v: 'ghp-x' }], {
+      credentialType: 'ssh',
+    })
+    expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(false)
+    expect(wrapper.emitted('update:credentialType')).toBeUndefined()
   })
 
-  it('Agent 管理下添加推荐变量不注入 Git Token（g2.4）', async () => {
+  it('多类 Git Token 且无已选类型时仍隐藏且不改写（g1.3）', () => {
+    const wrapper = mountGuide([
+      { k: 'GITHUB_TOKEN', v: 'ghp-x' },
+      { k: 'GITLAB_TOKEN', v: 'glpat-x' },
+    ])
+    expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(false)
+    expect(wrapper.emitted('update:credentialType')).toBeUndefined()
+  })
+
+  it('Studio 点选类型不写入 Git Token，也不出现补推荐变量（g1.2 / f5）', async () => {
     const added: string[] = []
-    const i18n = createI18n({
-      legacy: false,
-      locale: 'zh-CN',
-      messages: { 'zh-CN': { ...common, ...pages } },
-    })
-    const wrapper = mount(AgentGitGuide, {
-      props: {
-        env: [],
-        credentialType: 'gitlab_https',
-        allowTokenRecommend: false,
-        upsertEnv: (key: string) => {
-          added.push(key)
-        },
-      },
-      global: {
-        plugins: [i18n],
-        stubs: { AppModal: AppModalStub },
+    const wrapper = mountGuide([], {
+      allowTokenRecommend: false,
+      upsertEnv: (key) => {
+        added.push(key)
       },
     })
-    await wrapper.findAll('header button').find((b) => b.text() === '调整类型')!.trigger('click')
-    await wrapper.findAll('[data-test="modal"] button').find((b) => b.text() === '添加推荐变量')!.trigger('click')
+    await wrapper.get('[data-test="git-choice-gitlab_https"]').trigger('click')
+    expect(wrapper.emitted('update:credentialType')).toEqual([['gitlab_https']])
+    expect(wrapper.find('[data-test="git-apply-recommended"]').exists()).toBe(false)
+    expect(added).toEqual([])
+  })
+
+  it('共享面无 Token 时可选补推荐变量，写入对应 Token 键', async () => {
+    const added: string[] = []
+    const wrapper = mountGuide([], {
+      credentialType: 'gitlab_https',
+      allowTokenRecommend: true,
+      upsertEnv: (key) => {
+        added.push(key)
+      },
+    })
+    await wrapper.get('[data-test="git-apply-recommended"]').trigger('click')
     expect(added).toContain('GIT_REPOS')
-    expect(added).not.toContain('GITLAB_TOKEN')
-    expect(added).not.toContain('GITHUB_TOKEN')
-    expect(added).not.toContain('GIT_SSH_PRIVATE_KEY')
+    expect(added).toContain('GITLAB_TOKEN')
   })
 })

--- a/web/src/components/agent/AgentGitGuide.vue
+++ b/web/src/components/agent/AgentGitGuide.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import AppButton from '@/components/ui/AppButton.vue'
-import AppModal from '@/components/ui/AppModal.vue'
 import {
-  analyzeGitCredentials,
-  type GitCredentialStatus,
+  hasConfiguredGitToken,
+  inferGitCredentialTypeFromTokens,
   type GitCredentialType,
+  type GitEnv,
 } from '@/lib/agent/gitCredentialAnalysis'
+import { isGitTokenEnvKey } from '@/lib/agent/tokenEnvKeys'
 
 type KV = { k: string; v: string }
 
@@ -17,60 +18,27 @@ const GIT_ENV_KEYS = new Set([
   'GIT_SSH_PRIVATE_KEY', 'GIT_SSH_KNOWN_HOSTS',
 ])
 
+const CHOICES: GitCredentialType[] = ['github_https', 'gitlab_https', 'ssh']
+
 const props = defineProps<{
   env: KV[]
   upsertEnv: (key: string, value: string) => void
   credentialType?: GitCredentialType
-  /** When false (Agent Studio), skip injecting Git Token keys. Default true for shared config. */
+  /** When false (Agent Studio / create wizards), skip injecting Git Token keys. Default true for shared config. */
   allowTokenRecommend?: boolean
+  /** Project shared Agent env used only for hide / infer (agent context). */
+  inheritedEnv?: GitEnv
 }>()
 const emit = defineEmits<{
   'update:credentialType': [value: GitCredentialType]
   help: [section: 'git']
 }>()
 const { t } = useI18n()
-const showChooser = ref(false)
-const pendingType = ref<GitCredentialType>('github_https')
 
-const analysis = computed(() =>
-  analyzeGitCredentials({ env: props.env, selectedType: props.credentialType }),
-)
-const statusClass: Record<GitCredentialStatus, string> = {
-  disabled: 'border-line bg-base/50',
-  complete: 'border-ok/40 bg-ok/5',
-  incomplete: 'border-err/40 bg-err/5',
-  needs_confirmation: 'border-warn/40 bg-warn/5',
-  unsupported: 'border-err/40 bg-err/5',
-}
-const dotClass: Record<GitCredentialStatus, string> = {
-  disabled: 'bg-txt3',
-  complete: 'bg-ok',
-  incomplete: 'bg-err',
-  needs_confirmation: 'bg-warn',
-  unsupported: 'bg-err',
-}
-const typeLabel = computed(() =>
-  analysis.value.effectiveType
-    ? t(`pages.agentStudio.git.types.${analysis.value.effectiveType}`)
-    : t('pages.agentStudio.git.types.unknown'),
-)
-const issues = computed(() => [...analysis.value.conflicts, ...analysis.value.missing])
-/** Runtime refs are informational, not warn badges once a credential type is chosen. */
-const showRuntimeResolveBadge = computed(
-  () => analysis.value.unresolvedReference && analysis.value.status !== 'disabled',
-)
-const showActionableTypeHint = computed(
-  () =>
-    analysis.value.unresolvedReference &&
-    !analysis.value.effectiveType &&
-    analysis.value.status === 'needs_confirmation',
-)
-const sourceLabelKey = computed(() => {
-  if (analysis.value.source === 'user' && !analysis.value.selectionValid) {
-    return 'pages.agentStudio.git.source.invalid'
-  }
-  return `pages.agentStudio.git.source.${analysis.value.source}`
-})
+const hasGitToken = computed(() => hasConfiguredGitToken(props.env, props.inheritedEnv))
+const inferredType = computed(() => inferGitCredentialTypeFromTokens(props.env, props.inheritedEnv))
+const allowTokens = computed(() => props.allowTokenRecommend !== false)
+const showRecommend = computed(() => allowTokens.value && !!props.credentialType)
 
 const recommendations: Record<GitCredentialType, { key: string; value: string }[]> = {
   github_https: [
@@ -88,22 +56,24 @@ const recommendations: Record<GitCredentialType, { key: string; value: string }[
   ],
 }
 
-function openChooser() {
-  pendingType.value = props.credentialType ?? analysis.value.effectiveType ?? 'github_https'
-  showChooser.value = true
-}
+watch(
+  [hasGitToken, () => props.credentialType, inferredType],
+  ([hide, selected, inferred]) => {
+    if (!hide || selected || !inferred) return
+    emit('update:credentialType', inferred)
+  },
+  { immediate: true },
+)
 
-function confirmType() {
-  emit('update:credentialType', pendingType.value)
-  showChooser.value = false
+function selectType(type: GitCredentialType) {
+  emit('update:credentialType', type)
 }
 
 function applyRecommended() {
-  const allowTokens = props.allowTokenRecommend !== false
-  for (const item of recommendations[pendingType.value]) {
-    if (!allowTokens && (item.key === 'GITHUB_TOKEN' || item.key === 'GITLAB_TOKEN' || item.key === 'GIT_SSH_PRIVATE_KEY')) {
-      continue
-    }
+  const type = props.credentialType
+  if (!type) return
+  for (const item of recommendations[type]) {
+    if (!allowTokens.value && isGitTokenEnvKey(item.key)) continue
     if (!props.env.some((entry) => entry.k === item.key)) {
       props.upsertEnv(item.key, item.value)
     }
@@ -118,117 +88,58 @@ defineExpose({ isGitEnvKey })
 </script>
 
 <template>
-  <section class="mb-4 overflow-hidden rounded-lg border border-line bg-surface shadow-sm">
+  <section
+    v-if="!hasGitToken"
+    class="mb-4 overflow-hidden rounded-lg border border-line bg-surface shadow-sm"
+    data-test="git-guide"
+  >
     <header class="flex items-start gap-3 border-b border-line px-4 py-3">
       <div class="min-w-0 flex-1">
         <div class="text-[13px] font-semibold text-txt">{{ t('pages.agentStudio.git.title') }}</div>
-        <div class="mt-0.5 text-[11px] text-txt3">{{ t('pages.agentStudio.git.subtitle') }}</div>
       </div>
-      <div class="flex shrink-0 items-center gap-3">
-        <AppButton
-          type="button"
-          size="sm"
-          variant="outline"
-          icon="help"
-          data-test="git-help-link"
-          @click="emit('help', 'git')"
-        >
-          {{ t('pages.agentStudio.envHelp.link') }}
-        </AppButton>
-        <AppButton size="sm" variant="outline" @click="openChooser">
-          {{ t('pages.agentStudio.git.adjustType') }}
-        </AppButton>
-      </div>
+      <AppButton
+        type="button"
+        size="sm"
+        variant="outline"
+        icon="help"
+        data-test="git-help-link"
+        @click="emit('help', 'git')"
+      >
+        {{ t('pages.agentStudio.envHelp.link') }}
+      </AppButton>
     </header>
 
     <div class="p-4">
-      <div class="rounded-lg border px-3.5 py-3" :class="statusClass[analysis.status]">
-        <div class="flex items-start gap-2.5">
-          <span class="mt-1 h-2.5 w-2.5 shrink-0 rounded-full" :class="dotClass[analysis.status]" />
-          <div class="min-w-0 flex-1">
-            <div class="text-[12px] font-semibold text-txt">
-              {{
-                showActionableTypeHint
-                  ? t('pages.agentStudio.git.status.needs_type.title')
-                  : t(`pages.agentStudio.git.status.${analysis.status}.title`)
-              }}
-            </div>
-            <div class="mt-1 text-[11px] leading-5 text-txt2">
-              {{
-                showActionableTypeHint
-                  ? t('pages.agentStudio.git.status.needs_type.description')
-                  : t(`pages.agentStudio.git.status.${analysis.status}.description`)
-              }}
-            </div>
-          </div>
-          <span class="rounded bg-surface/70 px-2 py-1 text-[10px] text-txt3">
-            {{ t(sourceLabelKey) }}
-          </span>
-        </div>
+      <p class="mb-3 text-[13px] text-txt2">{{ t('pages.agentStudio.git.choiceHint') }}</p>
+      <div class="grid grid-cols-3 gap-2.5">
+        <button
+          v-for="type in CHOICES"
+          :key="type"
+          type="button"
+          class="rounded-[10px] border px-2.5 py-3.5 text-center"
+          :class="
+            credentialType === type
+              ? 'border-accent bg-accent-dim'
+              : 'border-line bg-elevated hover:border-line-strong'
+          "
+          :data-test="`git-choice-${type}`"
+          :aria-pressed="credentialType === type"
+          @click="selectType(type)"
+        >
+          <strong class="block text-[14px] text-txt">{{ t(`pages.agentStudio.git.types.${type}`) }}</strong>
+          <small class="mt-1 block text-[11px] text-txt3">{{ t(`pages.agentStudio.git.typeHints.${type}`) }}</small>
+        </button>
       </div>
-
-      <div
-        v-if="showRuntimeResolveBadge"
-        class="mt-3 rounded-lg border border-line bg-base/40 px-3.5 py-2.5 text-[11px] leading-5 text-txt2"
-      >
-        <span class="inline-block rounded bg-elevated px-1.5 py-0.5 text-[10px] text-txt3">
-          {{ t('pages.agentStudio.git.runtimeResolve') }}
-        </span>
-      </div>
-
-      <div v-if="analysis.status !== 'disabled'" class="mt-3 rounded-lg border border-line">
-        <div class="flex items-center gap-2 border-b border-line bg-base/40 px-3 py-2.5">
-          <span class="font-medium text-txt">{{ typeLabel }}</span>
-          <span
-            v-if="analysis.effectiveType && analysis.unresolvedReference"
-            class="rounded bg-elevated px-1.5 py-0.5 text-[10px] text-txt3"
-          >
-            {{ t('pages.agentStudio.git.runtimeResolve') }}
-          </span>
-        </div>
-        <div v-if="analysis.repos.length" class="divide-y divide-line px-3">
-          <div v-for="repo in analysis.repos" :key="`${repo.name}:${repo.url}`" class="flex gap-3 py-2 text-[11px]">
-            <code class="w-28 shrink-0 truncate text-accent-2">{{ repo.name }}</code>
-            <span class="min-w-0 flex-1 truncate text-txt2">{{ repo.url }}</span>
-            <span class="text-txt3">{{ repo.protocol.toUpperCase() }}</span>
-          </div>
-        </div>
-        <div v-if="issues.length" class="space-y-1 border-t border-line px-3 py-2">
-          <div v-for="(issue, i) in issues" :key="i" class="text-[11px] text-err">
-            <code v-if="issue.repo" class="mr-1">{{ issue.repo }}</code>{{ issue.reason }}
-          </div>
-        </div>
+      <div v-if="showRecommend" class="mt-3">
+        <AppButton
+          size="sm"
+          variant="outline"
+          data-test="git-apply-recommended"
+          @click="applyRecommended"
+        >
+          {{ t('pages.agentStudio.git.applyRecommended') }}
+        </AppButton>
       </div>
     </div>
   </section>
-
-  <AppModal :open="showChooser" :width="520" @close="showChooser = false">
-    <template #header>
-      <div>
-        <div class="text-[15px] font-semibold text-txt">{{ t('pages.agentStudio.git.chooseTitle') }}</div>
-        <div class="mt-1 text-[11px] text-txt3">{{ t('pages.agentStudio.git.chooseHint') }}</div>
-      </div>
-    </template>
-    <div class="space-y-2">
-      <label
-        v-for="type in (['github_https', 'gitlab_https', 'ssh'] as GitCredentialType[])"
-        :key="type"
-        class="flex cursor-pointer items-center gap-3 rounded-lg border p-3"
-        :class="pendingType === type ? 'border-accent bg-accent-dim' : 'border-line'"
-      >
-        <input v-model="pendingType" type="radio" :value="type" />
-        <span>
-          <strong class="block text-[12px] text-txt">{{ t(`pages.agentStudio.git.types.${type}`) }}</strong>
-          <small class="text-[11px] text-txt3">{{ t(`pages.agentStudio.git.typeHints.${type}`) }}</small>
-        </span>
-      </label>
-      <AppButton size="sm" variant="outline" @click="applyRecommended">
-        {{ t('pages.agentStudio.git.applyRecommended') }}
-      </AppButton>
-    </div>
-    <template #footer>
-      <AppButton variant="ghost" @click="showChooser = false">{{ t('common.buttons.cancel') }}</AppButton>
-      <AppButton variant="primary" @click="confirmType">{{ t('pages.agentStudio.git.confirmApply') }}</AppButton>
-    </template>
-  </AppModal>
 </template>

--- a/web/src/components/agent/CreateAgentTeamWizard.vue
+++ b/web/src/components/agent/CreateAgentTeamWizard.vue
@@ -28,10 +28,13 @@ import {
   stripAuthKeysFromEnv,
   type WizardAuthMode,
 } from '@/lib/agent/agentCreateWizard'
+import { useInheritedGitEnv } from '@/lib/agent/useInheritedGitEnv'
 
 const props = defineProps<{
   open: boolean
   existingNames: string[]
+  /** When set, Git step can inherit project shared Agent env for hide/infer. */
+  projectId?: string
 }>()
 
 const emit = defineEmits<{
@@ -40,6 +43,7 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const { inheritedEnv } = useInheritedGitEnv(() => props.projectId)
 const draft = ref<TeamWizardDraft>(freshTeamDraft())
 const fieldError = ref('')
 const submitError = ref('')
@@ -495,6 +499,8 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
                   </label>
                   <AgentGitGuide
                     :env="draft.env"
+                    :inherited-env="inheritedEnv"
+                    :allow-token-recommend="false"
                     :upsert-env="(k, v) => upsertEnv(k, v)"
                     :credential-type="draft.gitCredentialType"
                     @update:credential-type="onGitCredentialType"

--- a/web/src/lib/agent/gitCredentialAnalysis.test.ts
+++ b/web/src/lib/agent/gitCredentialAnalysis.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   analyzeGitCredentials,
+  hasConfiguredGitToken,
+  inferGitCredentialTypeFromTokens,
   isGitVariableReference,
   type GitCredentialStatus,
   type GitCredentialType,
@@ -252,5 +254,44 @@ describe('isGitVariableReference', () => {
     expect(isGitVariableReference('${vars.gitlab.token}')).toBe(true)
     expect(isGitVariableReference('${vars.}')).toBe(false)
     expect(isGitVariableReference('${secrets.token}')).toBe(false)
+  })
+})
+
+describe('hasConfiguredGitToken / inferGitCredentialTypeFromTokens', () => {
+  it('空串与仅空白视为未配置；合法 ${vars.*} 视为已配置', () => {
+    expect(hasConfiguredGitToken({ GITLAB_TOKEN: '' })).toBe(false)
+    expect(hasConfiguredGitToken({ GITLAB_TOKEN: '   ' })).toBe(false)
+    expect(hasConfiguredGitToken({ GITLAB_TOKEN: '${vars.gitlab_pat}' })).toBe(true)
+    expect(hasConfiguredGitToken({ GITLAB_TOKEN: '${invalid}' })).toBe(false)
+  })
+
+  it('ACP API Key 不计入 Git Token', () => {
+    expect(hasConfiguredGitToken({ APPROVING_CURSOR_API_KEY: 'sk-x', CURSOR_API_KEY: 'sk-y' })).toBe(
+      false,
+    )
+    expect(inferGitCredentialTypeFromTokens({ APPROVING_CURSOR_API_KEY: 'sk-x' })).toBeUndefined()
+  })
+
+  it('本地或继承任一有值即视为已配置（空本地不覆盖继承）', () => {
+    expect(
+      hasConfiguredGitToken({ GITLAB_TOKEN: '' }, { GITLAB_TOKEN: '${vars.gitlab_pat}' }),
+    ).toBe(true)
+    expect(hasConfiguredGitToken([{ k: 'GITHUB_TOKEN', v: 'ghp-x' }], undefined)).toBe(true)
+  })
+
+  it('单类 Token 推断对应类型；多类且无已选时不推断', () => {
+    expect(inferGitCredentialTypeFromTokens({ GITHUB_TOKEN: 't' })).toBe('github_https')
+    expect(inferGitCredentialTypeFromTokens({ GITLAB_TOKEN: '${vars.gitlab_pat}' })).toBe(
+      'gitlab_https',
+    )
+    expect(inferGitCredentialTypeFromTokens({ GIT_SSH_PRIVATE_KEY: '${vars.git_ssh_private_key}' })).toBe(
+      'ssh',
+    )
+    expect(
+      inferGitCredentialTypeFromTokens({ GITHUB_TOKEN: 't', GITLAB_TOKEN: 't' }),
+    ).toBeUndefined()
+    expect(
+      inferGitCredentialTypeFromTokens({ GITHUB_TOKEN: 't' }, { GIT_SSH_PRIVATE_KEY: 'k' }),
+    ).toBeUndefined()
   })
 })

--- a/web/src/lib/agent/gitCredentialAnalysis.ts
+++ b/web/src/lib/agent/gitCredentialAnalysis.ts
@@ -343,3 +343,47 @@ export function analyzeGitCredentials(
 export function isGitVariableReference(value: string): boolean {
   return VAR_REFERENCE_RE.test(value.trim())
 }
+
+/** Git Token keys that hide the connection-type guide (ACP keys do not count). */
+export const GIT_VISIBILITY_TOKEN_KEYS = [
+  'GITHUB_TOKEN',
+  'GITLAB_TOKEN',
+  'GIT_SSH_PRIVATE_KEY',
+] as const
+
+const GIT_TOKEN_TO_TYPE: Record<(typeof GIT_VISIBILITY_TOKEN_KEYS)[number], GitCredentialType> = {
+  GITHUB_TOKEN: 'github_https',
+  GITLAB_TOKEN: 'gitlab_https',
+  GIT_SSH_PRIVATE_KEY: 'ssh',
+}
+
+/** True if any Git Token is configured in local and/or inherited env (union, not overwrite). */
+export function hasConfiguredGitToken(...envs: Array<GitEnv | undefined>): boolean {
+  for (const env of envs) {
+    if (!env) continue
+    const rec = envRecord(env)
+    for (const key of GIT_VISIBILITY_TOKEN_KEYS) {
+      if (configured(rec[key])) return true
+    }
+  }
+  return false
+}
+
+/**
+ * Infer a single connection type from configured Git Tokens across envs.
+ * Returns undefined when none or more than one type is present.
+ */
+export function inferGitCredentialTypeFromTokens(
+  ...envs: Array<GitEnv | undefined>
+): GitCredentialType | undefined {
+  const types = new Set<GitCredentialType>()
+  for (const env of envs) {
+    if (!env) continue
+    const rec = envRecord(env)
+    for (const key of GIT_VISIBILITY_TOKEN_KEYS) {
+      if (configured(rec[key])) types.add(GIT_TOKEN_TO_TYPE[key])
+    }
+  }
+  if (types.size === 1) return [...types][0]
+  return undefined
+}

--- a/web/src/lib/agent/useAgentCreateWizard.ts
+++ b/web/src/lib/agent/useAgentCreateWizard.ts
@@ -25,10 +25,13 @@ import {
   stripAuthKeysFromEnv,
   type WizardAuthMode,
 } from '@/lib/agent/agentCreateWizard'
+import { useInheritedGitEnv } from '@/lib/agent/useInheritedGitEnv'
 
 export interface AgentCreateWizardProps {
   open: boolean
   existingNames: string[]
+  /** When set, Git step can inherit project shared Agent env for hide/infer. */
+  projectId?: string
 }
 
 export type AgentCreateWizardEmit = {
@@ -39,6 +42,7 @@ export type AgentCreateWizardEmit = {
 
 export function useAgentCreateWizard(props: AgentCreateWizardProps, emit: AgentCreateWizardEmit) {
 const { t } = useI18n()
+const { inheritedEnv } = useInheritedGitEnv(() => props.projectId)
 
 const draft = ref<WizardDraft>(freshDraft())
 const nameError = ref('')
@@ -344,6 +348,7 @@ function chipClass(kind: string) {
   onCustomConfigInput,
   onApiKeyInput,
   onGitCredentialType,
+  inheritedEnv,
   goPrev,
   goSkip,
   goNext,

--- a/web/src/lib/agent/useInheritedGitEnv.test.ts
+++ b/web/src/lib/agent/useInheritedGitEnv.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment happy-dom
+import { defineComponent, nextTick, ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useInheritedGitEnv } from './useInheritedGitEnv'
+
+const getProjectSharedAgentConfig = vi.fn()
+
+vi.mock('@/lib/api/api', () => ({
+  api: {
+    getProjectSharedAgentConfig: (...args: unknown[]) => getProjectSharedAgentConfig(...args),
+  },
+}))
+
+function mountHook(projectId: string | undefined) {
+  const pid = ref(projectId)
+  const Comp = defineComponent({
+    setup() {
+      const { inheritedEnv } = useInheritedGitEnv(pid)
+      return { inheritedEnv, pid }
+    },
+    template: '<div />',
+  })
+  return { wrapper: mount(Comp), pid }
+}
+
+describe('useInheritedGitEnv', () => {
+  beforeEach(() => {
+    getProjectSharedAgentConfig.mockReset()
+  })
+
+  it('无 projectId 时不请求，inheritedEnv 为空', async () => {
+    const { wrapper } = mountHook('')
+    await nextTick()
+    expect(getProjectSharedAgentConfig).not.toHaveBeenCalled()
+    expect(wrapper.vm.inheritedEnv).toEqual([])
+    wrapper.unmount()
+  })
+
+  it('已绑定项目时读取共享 env（g2.1）', async () => {
+    getProjectSharedAgentConfig.mockResolvedValue({
+      projectId: 'p1',
+      env: { GITLAB_TOKEN: '${vars.gitlab_pat}', GIT_REPOS: '${vars.repos}' },
+      files: [],
+      mcp: [],
+      layout: {},
+    })
+    const { wrapper } = mountHook('p1')
+    await vi.waitFor(() => {
+      expect(wrapper.vm.inheritedEnv).toEqual([
+        { k: 'GITLAB_TOKEN', v: '${vars.gitlab_pat}' },
+        { k: 'GIT_REPOS', v: '${vars.repos}' },
+      ])
+    })
+    expect(getProjectSharedAgentConfig).toHaveBeenCalledWith('p1')
+    wrapper.unmount()
+  })
+
+  it('读取失败则只看本地，不抛错（g2.1）', async () => {
+    getProjectSharedAgentConfig.mockRejectedValue(new Error('network'))
+    const { wrapper } = mountHook('p-fail')
+    await vi.waitFor(() => {
+      expect(getProjectSharedAgentConfig).toHaveBeenCalled()
+    })
+    expect(wrapper.vm.inheritedEnv).toEqual([])
+    wrapper.unmount()
+  })
+})

--- a/web/src/lib/agent/useInheritedGitEnv.ts
+++ b/web/src/lib/agent/useInheritedGitEnv.ts
@@ -1,0 +1,39 @@
+import { ref, toValue, watch, type MaybeRefOrGetter } from 'vue'
+import { api } from '@/lib/api/api'
+import { recToKV, type KV } from '@/lib/agent/agentStudioDraft'
+
+/**
+ * Load project shared Agent env for Git-guide inheritance.
+ * Failure is non-blocking: inheritedEnv stays empty and the caller falls back to local env.
+ */
+export function useInheritedGitEnv(projectId: MaybeRefOrGetter<string | undefined>) {
+  const inheritedEnv = ref<KV[]>([])
+  let seq = 0
+
+  async function load(raw: string | undefined) {
+    const my = ++seq
+    const id = raw?.trim() ?? ''
+    if (!id) {
+      inheritedEnv.value = []
+      return
+    }
+    try {
+      const cfg = await api.getProjectSharedAgentConfig(id)
+      if (my !== seq) return
+      inheritedEnv.value = recToKV(cfg.env || {})
+    } catch {
+      if (my !== seq) return
+      inheritedEnv.value = []
+    }
+  }
+
+  watch(
+    () => toValue(projectId),
+    (id) => {
+      void load(id)
+    },
+    { immediate: true },
+  )
+
+  return { inheritedEnv }
+}

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -1952,8 +1952,9 @@
         "special": "Existing special configuration: {value}"
       },
       "git": {
-        "title": "Git repositories and credentials",
-        "subtitle": "Statically detect the credential type from all repository URLs and environment variables",
+        "title": "Git connection",
+        "subtitle": "How should this Agent pull the repo? Pick one.",
+        "choiceHint": "How should this Agent pull the repo? Pick one.",
         "openWizard": "Configuration wizard",
         "adjustType": "Adjust type",
         "chooseTitle": "Choose Git credential type",
@@ -1982,9 +1983,9 @@
           "unknown": "Connection type pending"
         },
         "typeHints": {
-          "github_https": "Uses GITHUB_TOKEN; self-hosted instances must match GITHUB_URL",
-          "gitlab_https": "Uses GITLAB_TOKEN; the service URL may be inferred from the repository URL",
-          "ssh": "Uses a private key and known_hosts"
+          "github_https": "Uses a token",
+          "gitlab_https": "Uses a token",
+          "ssh": "Uses a private key"
         },
         "source": {
           "auto": "Auto-detected",
@@ -2232,7 +2233,7 @@
           "meta": "Used as the default ACP for the PM and engineers."
         },
         "git": {
-          "meta": "Optional. Helps roster selection and team Git defaults.",
+          "meta": "Optional. Pick GitHub / GitLab / SSH; skip when a Git Token already exists (including project shared).",
           "url": "Repository URL"
         },
         "mcp": {
@@ -2384,7 +2385,7 @@
           }
         },
         "git": {
-          "meta": "Choose GitHub / GitLab / SSH and optionally add recommended vars. Skip and finish later in Studio."
+          "meta": "Pick GitHub / GitLab / SSH. Skip if a Git Token already exists locally or in project shared config."
         },
         "env": {
           "meta": "Environment variables injected into the sandbox. Region keys are managed by the Agent step; secrets stay in the Agent config."

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -1952,8 +1952,9 @@
         "special": "现有特殊配置：{value}"
       },
       "git": {
-        "title": "Git 仓库与凭据",
-        "subtitle": "根据全部仓库地址和环境变量静态识别凭据类型",
+        "title": "Git 连接方式",
+        "subtitle": "这次拉仓库用哪种方式？点一个即可。",
+        "choiceHint": "这次拉仓库用哪种方式？点一个即可。",
         "openWizard": "配置向导",
         "adjustType": "调整类型",
         "chooseTitle": "选择 Git 凭据类型",
@@ -1982,9 +1983,9 @@
           "unknown": "待确认连接方式"
         },
         "typeHints": {
-          "github_https": "使用 GITHUB_TOKEN；自建实例还需匹配 GITHUB_URL",
-          "gitlab_https": "使用 GITLAB_TOKEN；服务地址可由仓库 URL 推导",
-          "ssh": "使用私钥与 known_hosts"
+          "github_https": "用 Token",
+          "gitlab_https": "用 Token",
+          "ssh": "用私钥"
         },
         "source": {
           "auto": "自动识别",
@@ -2232,7 +2233,7 @@
           "meta": "该配置用于 PM 及后续工程师的默认 ACP。"
         },
         "git": {
-          "meta": "可选。供建团结合仓库选型，并写入团队默认 Git 相关配置。",
+          "meta": "可选。点选 GitHub / GitLab / SSH；已有 Token（含项目共享）时本步无需选择。",
           "url": "仓库 URL"
         },
         "mcp": {
@@ -2384,7 +2385,7 @@
           }
         },
         "git": {
-          "meta": "选择 GitHub / GitLab / SSH 并按需添加推荐变量；可跳过，之后在 Studio 再配。"
+          "meta": "点选 GitHub / GitLab / SSH 即可；本地或项目共享已有 Token 时无需选择。可跳过，之后在 Studio 再配。"
         },
         "env": {
           "meta": "注入沙箱的环境变量。区域保留键由 Agent 步骤统一管理，密钥仅保存在 Agent 配置中。"


### PR DESCRIPTION
Replace the adjust-type modal with one-click GitHub/GitLab/SSH choices, and hide the whole guide when any local or inherited Git Token is already configured.

Co-authored-by: Cursor <cursoragent@cursor.com>
