### PR TITLE
feat(workflow): 增加首页可见开关，默认关闭以免副本挤进首页

### DIFF
--- a/server/internal/handlers/dto.go
+++ b/server/internal/handlers/dto.go
@@ -63,6 +63,7 @@ func workflowDTO(wf models.WorkflowDef) gin.H {
 	return gin.H{
 		"id": wf.ID, "projectId": wf.ProjectID, "name": wf.Name, "description": wf.Description,
 		"status": wf.Status, "version": wf.Version, "needsRepo": wf.NeedsRepo,
+		"showOnHome":   wf.ShowOnHome,
 		"notifyPolicy": policy,
 		"updatedAt":    wf.UpdatedAt, "lastRunAt": wf.LastRunAt,
 		"nodes": graphNodesDTO(wf.Graph), "edges": wf.Graph.Edges, "variables": wf.Graph.Variables,

--- a/server/internal/handlers/workflow.go
+++ b/server/internal/handlers/workflow.go
@@ -38,6 +38,7 @@ type workflowBody struct {
 	Name         string                       `json:"name"`
 	Description  string                       `json:"description"`
 	NeedsRepo    bool                         `json:"needsRepo"`
+	ShowOnHome   *bool                        `json:"showOnHome"`
 	NotifyPolicy *models.WorkflowNotifyPolicy `json:"notifyPolicy"`
 	Nodes        []models.Node                `json:"nodes"`
 	Edges        []models.Edge                `json:"edges"`
@@ -77,6 +78,15 @@ func (h *Handlers) SaveWorkflow(c *gin.Context) {
 		if existing, ok := h.WF.Get(b.ID); ok {
 			wf.NotifyPolicy = existing.NotifyPolicy
 		}
+	}
+	// Create always false (handler + service). On update, omit → keep stored
+	// value so an editor save cannot silently turn Home visibility off (plan g1.3).
+	if isCreate {
+		wf.ShowOnHome = false
+	} else if b.ShowOnHome != nil {
+		wf.ShowOnHome = *b.ShowOnHome
+	} else if existing, ok := h.WF.Get(b.ID); ok {
+		wf.ShowOnHome = existing.ShowOnHome
 	}
 	if err := h.WF.Save(&wf); err != nil {
 		switch {
@@ -153,6 +163,51 @@ func (h *Handlers) PatchWorkflowNotifyPolicy(c *gin.Context) {
 			"notifyPolicy": wf.NotifyPolicy,
 			"status":       wf.Status,
 			"version":      wf.Version,
+		},
+	})
+	c.JSON(http.StatusOK, workflowDTO(wf))
+}
+
+type workflowHomeVisibilityBody struct {
+	ShowOnHome *bool `json:"showOnHome"`
+}
+
+// PatchWorkflowHomeVisibility handles PATCH /api/workflows/:id/home-visibility.
+// Visibility-only write path: does not accept or rewrite Graph (plan g1.2).
+func (h *Handlers) PatchWorkflowHomeVisibility(c *gin.Context) {
+	var b workflowHomeVisibilityBody
+	if err := c.ShouldBindJSON(&b); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if b.ShowOnHome == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "showOnHome is required"})
+		return
+	}
+	id := c.Param("id")
+	wf, err := h.WF.UpdateShowOnHome(id, *b.ShowOnHome)
+	if err != nil {
+		switch {
+		case errors.Is(err, services.ErrWorkflowNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		default:
+			_ = c.Error(err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		}
+		return
+	}
+	h.recordAudit(services.AuditRecord{
+		ProjectID:    wf.ProjectID,
+		Actor:        h.auditActorFromContext(c),
+		Action:       models.AuditActionWorkflowUpdate,
+		ResourceType: "workflow",
+		ResourceID:   wf.ID,
+		Outcome:      models.AuditOutcomeOK,
+		Summary:      "update workflow home visibility",
+		Payload: map[string]any{
+			"showOnHome": wf.ShowOnHome,
+			"status":     wf.Status,
+			"version":    wf.Version,
 		},
 	})
 	c.JSON(http.StatusOK, workflowDTO(wf))

--- a/server/internal/handlers/workflow_home_visibility_test.go
+++ b/server/internal/handlers/workflow_home_visibility_test.go
@@ -1,0 +1,170 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cocofhu/approving/internal/models"
+)
+
+func createPublishedWorkflow(t *testing.T, h *harness, name string) (id string, dto map[string]any) {
+	t.Helper()
+	body := map[string]any{
+		"name": name, "projectId": models.DefaultProjectID, "description": "v1",
+		"nodes": []map[string]any{
+			{
+				"id": "in", "type": "input", "label": "Start",
+				"position": map[string]any{"x": 0, "y": 0},
+				"config": map[string]any{
+					"variables": []map[string]any{
+						{"name": "repo", "type": "string", "value": "a"},
+					},
+				},
+			},
+			{"id": "out", "type": "output", "label": "End", "position": map[string]any{"x": 1, "y": 0}, "config": map[string]any{}},
+		},
+		"edges": []map[string]any{{"id": "e", "source": "in", "target": "out"}},
+	}
+	w := h.do("POST", "/api/workflows", body)
+	if w.Code != 200 {
+		t.Fatalf("create: %d %s", w.Code, w.Body)
+	}
+	var created map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &created)
+	id, _ = created["id"].(string)
+	if id == "" {
+		t.Fatal("no id")
+	}
+	if created["showOnHome"] != false {
+		t.Fatalf("create showOnHome=%v want false (plan g1.1)", created["showOnHome"])
+	}
+	if w := h.do("POST", "/api/workflows/"+id+"/publish", nil); w.Code != 200 {
+		t.Fatalf("publish: %d %s", w.Code, w.Body)
+	}
+	w = h.do("GET", "/api/workflows/"+id, nil)
+	if w.Code != 200 {
+		t.Fatalf("get: %d", w.Code)
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &dto)
+	return id, dto
+}
+
+// plan g1.1 / g1.2 / g1.4 — dedicated PATCH toggles showOnHome without touching graph/status/version.
+func TestPatchWorkflowHomeVisibilityOnly(t *testing.T) {
+	h := newHarness(t)
+	id, before := createPublishedWorkflow(t, h, "HomeOnly")
+	if before["status"] != "published" {
+		t.Fatalf("precondition status=%v", before["status"])
+	}
+	beforeNodes, _ := json.Marshal(before["nodes"])
+	beforeVersion := before["version"]
+
+	w := h.do("PATCH", "/api/workflows/"+id+"/home-visibility", map[string]any{
+		"showOnHome": true,
+	})
+	if w.Code != 200 {
+		t.Fatalf("patch home: %d %s", w.Code, w.Body)
+	}
+	var after map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &after)
+	if after["showOnHome"] != true {
+		t.Fatalf("showOnHome=%v", after["showOnHome"])
+	}
+	if after["status"] != "published" {
+		t.Fatalf("home-visibility PATCH demoted status to %v", after["status"])
+	}
+	if after["version"] != beforeVersion {
+		t.Fatalf("version mutated %v → %v", beforeVersion, after["version"])
+	}
+	afterNodes, _ := json.Marshal(after["nodes"])
+	if string(beforeNodes) != string(afterNodes) {
+		t.Fatalf("home-visibility PATCH rewrote graph:\nbefore=%s\nafter=%s", beforeNodes, afterNodes)
+	}
+
+	if w := h.do("PATCH", "/api/workflows/"+id+"/home-visibility", map[string]any{}); w.Code != 400 {
+		t.Fatalf("missing showOnHome want 400 got %d %s", w.Code, w.Body)
+	}
+	if w := h.do("PATCH", "/api/workflows/wf-missing/home-visibility", map[string]any{
+		"showOnHome": true,
+	}); w.Code != 404 {
+		t.Fatalf("missing id want 404 got %d %s", w.Code, w.Body)
+	}
+}
+
+// plan g1.3 / g1.4 — editor PUT without showOnHome must keep a previously enabled flag.
+func TestSaveWorkflowOmitsShowOnHomePreservesTrue(t *testing.T) {
+	h := newHarness(t)
+	id, _ := createPublishedWorkflow(t, h, "KeepHome")
+
+	if w := h.do("PATCH", "/api/workflows/"+id+"/home-visibility", map[string]any{
+		"showOnHome": true,
+	}); w.Code != 200 {
+		t.Fatalf("enable: %d %s", w.Code, w.Body)
+	}
+
+	put := map[string]any{
+		"name": "KeepHome", "projectId": models.DefaultProjectID, "description": "renamed subtitle",
+		"nodes": []map[string]any{
+			{
+				"id": "in", "type": "input", "label": "Start",
+				"position": map[string]any{"x": 0, "y": 0},
+				"config": map[string]any{
+					"variables": []map[string]any{
+						{"name": "repo", "type": "string", "value": "a"},
+					},
+				},
+			},
+			{"id": "out", "type": "output", "label": "End", "position": map[string]any{"x": 1, "y": 0}, "config": map[string]any{}},
+		},
+		"edges": []map[string]any{{"id": "e", "source": "in", "target": "out"}},
+	}
+	w := h.do("PUT", "/api/workflows/"+id, put)
+	if w.Code != 200 {
+		t.Fatalf("put: %d %s", w.Code, w.Body)
+	}
+	var after map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &after)
+	if after["showOnHome"] != true {
+		t.Fatalf("omitted showOnHome reset flag to %v", after["showOnHome"])
+	}
+	if after["status"] != "published" {
+		t.Fatalf("status=%v", after["status"])
+	}
+	if after["description"] != "renamed subtitle" {
+		t.Fatalf("description=%v", after["description"])
+	}
+
+	// Explicit false via PUT is allowed (not the list-row path).
+	put["showOnHome"] = false
+	w = h.do("PUT", "/api/workflows/"+id, put)
+	if w.Code != 200 {
+		t.Fatalf("put false: %d %s", w.Code, w.Body)
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &after)
+	if after["showOnHome"] != false {
+		t.Fatalf("explicit false: %v", after["showOnHome"])
+	}
+}
+
+// plan g1.3 — create with showOnHome true in body is still stored as false.
+func TestCreateWorkflowIgnoresShowOnHomeTrue(t *testing.T) {
+	h := newHarness(t)
+	body := map[string]any{
+		"name": "ForceOn", "projectId": models.DefaultProjectID,
+		"showOnHome": true,
+		"nodes": []map[string]any{
+			{"id": "in", "type": "input", "label": "Start", "position": map[string]any{"x": 0, "y": 0}, "config": map[string]any{}},
+			{"id": "out", "type": "output", "label": "End", "position": map[string]any{"x": 1, "y": 0}, "config": map[string]any{}},
+		},
+		"edges": []map[string]any{{"id": "e", "source": "in", "target": "out"}},
+	}
+	w := h.do("POST", "/api/workflows", body)
+	if w.Code != 200 {
+		t.Fatalf("create: %d %s", w.Code, w.Body)
+	}
+	var created map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &created)
+	if created["showOnHome"] != false {
+		t.Fatalf("create showOnHome=%v", created["showOnHome"])
+	}
+}

--- a/server/internal/models/models.go
+++ b/server/internal/models/models.go
@@ -94,6 +94,9 @@ type WorkflowDef struct {
 	Status      string `json:"status"` // draft | published
 	Version     int    `json:"version"`
 	NeedsRepo   bool   `json:"needsRepo"`
+	// ShowOnHome gates Home cards + Home pipeline search. Missing/zero = false
+	// so existing rows stay hidden after AutoMigrate (plan g1.1).
+	ShowOnHome bool `json:"showOnHome"`
 	// NotifyPolicy is the workflow-level override (off|inherit|custom + events).
 	// Zero value (empty mode) is treated as inherit at resolve time.
 	NotifyPolicy WorkflowNotifyPolicy `gorm:"serializer:json" json:"notifyPolicy"`

--- a/server/internal/router/router.go
+++ b/server/internal/router/router.go
@@ -142,6 +142,7 @@ func New(h *handlers.Handlers) *gin.Engine {
 		api.GET("/workflows/:id", h.GetWorkflow)
 		api.PUT("/workflows/:id", h.SaveWorkflow)
 		api.PATCH("/workflows/:id/notify-policy", h.PatchWorkflowNotifyPolicy)
+		api.PATCH("/workflows/:id/home-visibility", h.PatchWorkflowHomeVisibility)
 		api.DELETE("/workflows/:id", h.DeleteWorkflow)
 		api.GET("/workflows/:id/copy-preview", h.CopyWorkflowPreview)
 		api.POST("/workflows/:id/copy", h.CopyWorkflow)

--- a/server/internal/services/workflow.go
+++ b/server/internal/services/workflow.go
@@ -161,6 +161,7 @@ func (s *WorkflowService) Copy(sourceID, name string) (models.WorkflowDef, error
 			Name:        name,
 			Description: src.Description,
 			NeedsRepo:   src.NeedsRepo,
+			ShowOnHome:  false, // copies never inherit Home visibility (plan g1.3)
 			Status:      "draft",
 			Version:     1,
 			Graph:       graph,
@@ -205,6 +206,8 @@ func (s *WorkflowService) Save(wf *models.WorkflowDef) error {
 		if wf.NotifyPolicy.Mode == "" {
 			wf.NotifyPolicy.Mode = models.NotifyModeInherit
 		}
+		// Create always starts hidden on Home (plan g1.3).
+		wf.ShowOnHome = false
 		return s.db.Create(wf).Error
 	}
 	if wf.ProjectID != "" && wf.ProjectID != existing.ProjectID {
@@ -223,6 +226,7 @@ func (s *WorkflowService) Save(wf *models.WorkflowDef) error {
 	metaChanged := wf.Name != existing.Name ||
 		wf.Description != existing.Description ||
 		wf.NeedsRepo != existing.NeedsRepo ||
+		wf.ShowOnHome != existing.ShowOnHome ||
 		!WorkflowNotifyPoliciesEqual(wf.NotifyPolicy, existing.NotifyPolicy)
 	if graphChanged {
 		wf.Status = "draft"
@@ -235,6 +239,7 @@ func (s *WorkflowService) Save(wf *models.WorkflowDef) error {
 		wf.UpdatedAt = existing.UpdatedAt
 		wf.LastRunAt = existing.LastRunAt
 		wf.NotifyPolicy = existing.NotifyPolicy
+		wf.ShowOnHome = existing.ShowOnHome
 		return nil
 	}
 	if err := s.validateAgentProfiles(wf); err != nil {
@@ -259,6 +264,26 @@ func (s *WorkflowService) UpdateNotifyPolicy(id string, policy models.WorkflowNo
 		return wf, nil
 	}
 	wf.NotifyPolicy = policy
+	wf.UpdatedAt = time.Now()
+	if err := s.db.Save(&wf).Error; err != nil {
+		return wf, err
+	}
+	return wf, nil
+}
+
+// UpdateShowOnHome persists only the Home-visibility flag.
+// It loads the current row and never touches Graph / Status / Version, so a
+// list-row inline toggle cannot roll back a newer editor graph or demote
+// published → draft (plan g1.2).
+func (s *WorkflowService) UpdateShowOnHome(id string, show bool) (models.WorkflowDef, error) {
+	var wf models.WorkflowDef
+	if err := s.db.First(&wf, "id = ?", id).Error; err != nil {
+		return wf, ErrWorkflowNotFound
+	}
+	if wf.ShowOnHome == show {
+		return wf, nil
+	}
+	wf.ShowOnHome = show
 	wf.UpdatedAt = time.Now()
 	if err := s.db.Save(&wf).Error; err != nil {
 		return wf, err

--- a/server/internal/services/workflow_import.go
+++ b/server/internal/services/workflow_import.go
@@ -128,6 +128,7 @@ func (s *WorkflowService) Import(raw []byte, projectID string) (models.WorkflowD
 			Name:        name,
 			Description: env.Description,
 			NeedsRepo:   env.NeedsRepo,
+			ShowOnHome:  false, // import never inherits Home visibility (plan g1.3)
 			Status:      "draft",
 			Version:     1,
 			Graph:       graph,

--- a/server/internal/services/workflow_import_test.go
+++ b/server/internal/services/workflow_import_test.go
@@ -112,6 +112,9 @@ func TestWorkflowImportCreatesDraft(t *testing.T) {
 	if imported.Status != "draft" || imported.Version != 1 {
 		t.Fatalf("status/version = %s/%d", imported.Status, imported.Version)
 	}
+	if imported.ShowOnHome {
+		t.Fatal("import ShowOnHome want false (plan g1.3)")
+	}
 	if imported.ID == "wf-x" {
 		t.Fatal("expected new id")
 	}
@@ -316,4 +319,3 @@ func TestWorkflowImportMigratesAgentProfileKey(t *testing.T) {
 		t.Fatalf("agent_profile=%v", implCfg["agent_profile"])
 	}
 }
-

--- a/server/internal/services/workflow_show_on_home_test.go
+++ b/server/internal/services/workflow_show_on_home_test.go
@@ -1,0 +1,180 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cocofhu/approving/internal/models"
+)
+
+// plan g1.1 / g1.4 — new rows and AutoMigrate zero-value read as false.
+func TestShowOnHomeDefaultsFalseOnCreate(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewWorkflowService(db)
+
+	wf := &models.WorkflowDef{
+		ID:         "wf-home-new",
+		ProjectID:  models.DefaultProjectID,
+		Name:       "HomeNew",
+		Graph:      validGraph(),
+		ShowOnHome: true, // client cannot force-on via create Save
+	}
+	if err := svc.Save(wf); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, ok := svc.Get("wf-home-new")
+	if !ok {
+		t.Fatal("missing")
+	}
+	if got.ShowOnHome {
+		t.Fatal("create ShowOnHome want false")
+	}
+
+	// Seed a legacy row without the field (zero value) — reads as hidden.
+	legacy := models.WorkflowDef{
+		ID:        "wf-home-legacy",
+		ProjectID: models.DefaultProjectID,
+		Name:      "Legacy",
+		Status:    "published",
+		Version:   1,
+		Graph:     validGraph(),
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	if err := db.Create(&legacy).Error; err != nil {
+		t.Fatalf("seed legacy: %v", err)
+	}
+	reloaded, ok := svc.Get("wf-home-legacy")
+	if !ok {
+		t.Fatal("missing legacy")
+	}
+	if reloaded.ShowOnHome {
+		t.Fatal("legacy row ShowOnHome want false")
+	}
+}
+
+// plan g1.2 / g1.4 — PATCH-equivalent service must not demote or rewrite graph.
+func TestUpdateShowOnHomeDoesNotDemotePublished(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewWorkflowService(db)
+
+	wf := models.WorkflowDef{
+		ID:        "wf-home-only",
+		ProjectID: models.DefaultProjectID,
+		Name:      "HomeOnly",
+		Status:    "published",
+		Version:   3,
+		Graph: models.Graph{
+			Nodes: []models.Node{
+				{ID: "in", Type: "input", Label: "Fresh Start"},
+				{ID: "g", Type: "human_gate", Label: "Gate"},
+				{ID: "out", Type: "output", Label: "End"},
+			},
+			Edges: []models.Edge{
+				{ID: "e1", Source: "in", Target: "g"},
+				{ID: "e2", Source: "g", Target: "out"},
+			},
+		},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	if err := db.Create(&wf).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	got, err := svc.UpdateShowOnHome(wf.ID, true)
+	if err != nil {
+		t.Fatalf("UpdateShowOnHome: %v", err)
+	}
+	if !got.ShowOnHome {
+		t.Fatal("ShowOnHome not persisted")
+	}
+	if got.Status != "published" {
+		t.Fatalf("status demoted to %q", got.Status)
+	}
+	if got.Version != 3 {
+		t.Fatalf("version mutated to %d", got.Version)
+	}
+	if len(got.Graph.Nodes) != 3 || got.Graph.Nodes[0].Label != "Fresh Start" {
+		t.Fatalf("graph rewritten: %+v", got.Graph.Nodes)
+	}
+
+	reloaded, ok := svc.Get(wf.ID)
+	if !ok {
+		t.Fatal("missing after update")
+	}
+	if !reloaded.ShowOnHome || reloaded.Status != "published" || reloaded.Graph.Nodes[0].Label != "Fresh Start" {
+		t.Fatalf("persisted row corrupted: show=%v status=%s label=%s", reloaded.ShowOnHome, reloaded.Status, reloaded.Graph.Nodes[0].Label)
+	}
+
+	if _, err := svc.UpdateShowOnHome("wf-missing", true); err != ErrWorkflowNotFound {
+		t.Fatalf("missing id: %v", err)
+	}
+}
+
+// plan g1.3 / g1.4 — copy and import never inherit an enabled flag.
+func TestCopyAndImportResetShowOnHome(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewWorkflowService(db)
+
+	src := &models.WorkflowDef{
+		ID: "wf-home-src", ProjectID: models.DefaultProjectID, Name: "流水线 Home",
+		Graph: validGraph(),
+	}
+	if err := svc.Save(src); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Publish("wf-home-src"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.UpdateShowOnHome("wf-home-src", true); err != nil {
+		t.Fatal(err)
+	}
+
+	copied, err := svc.Copy("wf-home-src", "流水线 Home 副本")
+	if err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if copied.ShowOnHome {
+		t.Fatal("copy inherited showOnHome")
+	}
+
+	imported, err := svc.Import(envelopeJSON(validEnvelope("Imported Home")), models.DefaultProjectID)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if imported.ShowOnHome {
+		t.Fatal("import ShowOnHome want false")
+	}
+}
+
+// plan g1.3 / g1.4 — full Save that carries the stored true keeps it (and published).
+func TestSavePreservesShowOnHomeWhenSet(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewWorkflowService(db)
+
+	wf := &models.WorkflowDef{ID: "wf-home-save", ProjectID: models.DefaultProjectID, Name: "Keep", Graph: validGraph()}
+	if err := svc.Save(wf); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Publish("wf-home-save"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.UpdateShowOnHome("wf-home-save", true); err != nil {
+		t.Fatal(err)
+	}
+
+	upd := &models.WorkflowDef{
+		ID: "wf-home-save", Name: "Keep", Graph: validGraph(), ShowOnHome: true,
+	}
+	if err := svc.Save(upd); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := svc.Get("wf-home-save")
+	if !got.ShowOnHome {
+		t.Fatal("Save dropped showOnHome")
+	}
+	if got.Status != "published" {
+		t.Fatalf("status=%s", got.Status)
+	}
+}

--- a/web/e2e/board.spec.ts
+++ b/web/e2e/board.spec.ts
@@ -97,6 +97,7 @@ async function mockBoardApis(page: import('@playwright/test').Page) {
             version: 1,
             updatedAt: '2026-07-18T00:00:00Z',
             needsRepo: false,
+            showOnHome: true,
             nodes: [
               { id: 'in', type: 'input', label: '开始', position: { x: 0, y: 0 }, config: {} },
               { id: 'ap', type: 'approve', label: '澄清', position: { x: 0, y: 0 }, config: {} },

--- a/web/e2e/dashboard-home-chat.spec.ts
+++ b/web/e2e/dashboard-home-chat.spec.ts
@@ -13,6 +13,7 @@ function approveWorkflow() {
     version: 1,
     updatedAt: '2026-08-10T12:00:00Z',
     needsRepo: false,
+    showOnHome: true,
     nodes: [
       { id: 'in', type: 'input', label: '开始', position: { x: 0, y: 0 }, config: {} },
       { id: 'ap', type: 'approve', label: '澄清', position: { x: 0, y: 0 }, config: {} },

--- a/web/src/components/dashboard/HomePipelineSelect.test.ts
+++ b/web/src/components/dashboard/HomePipelineSelect.test.ts
@@ -51,4 +51,20 @@ describe('HomePipelineSelect', () => {
     expect(panel.classes()).toContain('home-pipeline-select__panel')
     wrapper.unmount()
   })
+
+  // plan g3.3 — search only looks at the already-filtered Home list
+  it('does not surface a pipeline omitted from props even when the query matches its name', async () => {
+    const wrapper = mountSelect({
+      pipelines: [{ id: 'wf-a', name: '自我迭代PRO' }],
+      modelValue: 'wf-a',
+    })
+    await flushPromises()
+    await wrapper.get('[data-testid="home-pipeline-select-trigger"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-testid="home-pipeline-select-search"]').setValue('内部副本')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="home-pipeline-select-option-wf-hidden"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="home-pipeline-select-empty"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
 })

--- a/web/src/components/dashboard/HomePipelineSelect.test.ts
+++ b/web/src/components/dashboard/HomePipelineSelect.test.ts
@@ -64,7 +64,7 @@ describe('HomePipelineSelect', () => {
     await wrapper.get('[data-testid="home-pipeline-select-search"]').setValue('内部副本')
     await flushPromises()
     expect(wrapper.find('[data-testid="home-pipeline-select-option-wf-hidden"]').exists()).toBe(false)
-    expect(wrapper.get('[data-testid="home-pipeline-select-empty"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="home-pipeline-select-empty"]').exists()).toBe(true)
     wrapper.unmount()
   })
 })

--- a/web/src/lib/api/api.test.ts
+++ b/web/src/lib/api/api.test.ts
@@ -408,6 +408,29 @@ describe('api.patchWorkflowNotifyPolicy', () => {
     expect(body.nodes).toBeUndefined()
     expect(body.edges).toBeUndefined()
   })
+})
+
+describe('api.patchWorkflowHomeVisibility', () => {
+  it('PATCHes showOnHome-only body without nodes/edges (plan g1.2 / g2.1)', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        id: 'w1',
+        status: 'published',
+        showOnHome: true,
+      }),
+    )
+    await expect(api.patchWorkflowHomeVisibility('w1', true)).resolves.toMatchObject({
+      id: 'w1',
+      showOnHome: true,
+    })
+    const call = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]
+    expect(String(call?.[0])).toMatch(/\/workflows\/w1\/home-visibility$/)
+    expect(call?.[1]).toMatchObject({ method: 'PATCH' })
+    const body = JSON.parse(String(call?.[1]?.body))
+    expect(body).toEqual({ showOnHome: true })
+    expect(body.nodes).toBeUndefined()
+    expect(body.edges).toBeUndefined()
+  })
 
   it('startRun sends title when provided', async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({ id: 'r1', status: 'queued' }))

--- a/web/src/lib/api/clients/workflowsClient.ts
+++ b/web/src/lib/api/clients/workflowsClient.ts
@@ -22,6 +22,12 @@ export const workflowsClient = {
       method: 'PATCH',
       body: JSON.stringify({ notifyPolicy }),
     }),
+  /** Home-visibility only: never sends nodes/edges (plan g1.2). */
+  patchWorkflowHomeVisibility: (id: string, showOnHome: boolean) =>
+    req<Workflow>(`/workflows/${id}/home-visibility`, {
+      method: 'PATCH',
+      body: JSON.stringify({ showOnHome }),
+    }),
   publishWorkflow: (id: string) => req<Workflow>(`/workflows/${id}/publish`, { method: 'POST' }),
   listAPIKeys: (workflowId: string) =>
     req<{ id: string; name: string; key_prefix: string; created_at: string }[]>(`/workflows/${workflowId}/api-keys`),

--- a/web/src/lib/project/useProjectDetail.test.ts
+++ b/web/src/lib/project/useProjectDetail.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   listAgents: vi.fn(),
   getPmLeader: vi.fn(),
   writeStoredProjectId: vi.fn(),
+  patchWorkflowHomeVisibility: vi.fn(),
 }))
 
 vi.mock('@/lib/api/api', async () => {
@@ -25,6 +26,7 @@ vi.mock('@/lib/api/api', async () => {
       listWorkflows: mocks.listWorkflows,
       listAgents: mocks.listAgents,
       getPmLeader: mocks.getPmLeader,
+      patchWorkflowHomeVisibility: mocks.patchWorkflowHomeVisibility,
     },
   }
 })
@@ -119,6 +121,7 @@ describe('useProjectDetail', () => {
     mocks.listAgents.mockReset()
     mocks.getPmLeader.mockReset()
     mocks.writeStoredProjectId.mockReset()
+    mocks.patchWorkflowHomeVisibility.mockReset()
 
     mocks.getProject.mockResolvedValue(sampleProject)
     mocks.listWorkflows.mockResolvedValue(sampleWorkflows)
@@ -164,6 +167,30 @@ describe('useProjectDetail', () => {
     expect(detail.showPmMemoryMigration.value).toBe(false)
     await detail.rewriteLegacyPmMemoryQuery()
     expect(String(router.currentRoute.value.query.tab || '')).not.toBe('pmMemory')
+
+    app.unmount()
+  })
+
+  it('PATCHes home visibility without opening the editor and rolls back on failure (g2.1 / g2.3)', async () => {
+    mocks.patchWorkflowHomeVisibility.mockResolvedValueOnce({
+      ...sampleWorkflows[0],
+      showOnHome: true,
+    })
+    const { detail, app } = await withProjectDetail()
+    await flushPromises()
+    await nextTick()
+    const wf = detail.workflows.value[0]
+    expect(wf.showOnHome).toBeFalsy()
+
+    await detail.toggleWorkflowShowOnHome(wf as any, true)
+    await flushPromises()
+    expect(mocks.patchWorkflowHomeVisibility).toHaveBeenCalledWith('wf-1', true)
+    expect(detail.workflows.value[0].showOnHome).toBe(true)
+
+    mocks.patchWorkflowHomeVisibility.mockRejectedValueOnce(new Error('network down'))
+    await detail.toggleWorkflowShowOnHome(detail.workflows.value[0] as any, false)
+    await flushPromises()
+    expect(detail.workflows.value[0].showOnHome).toBe(true)
 
     app.unmount()
   })

--- a/web/src/lib/project/useProjectDetail.ts
+++ b/web/src/lib/project/useProjectDetail.ts
@@ -362,6 +362,26 @@ async function toggleWorkflowNotifyEvent(w: Workflow, ev: 'waiting_human' | 'fai
   })
 }
 
+const savingHomeWfId = ref<string | null>(null)
+
+/** Optimistic Home-visibility toggle with rollback (plan g2.1). */
+async function toggleWorkflowShowOnHome(w: Workflow, next: boolean) {
+  const prev = !!w.showOnHome
+  if (prev === next) return
+  workflows.value = workflows.value.map((x) => (x.id === w.id ? { ...x, showOnHome: next } : x))
+  savingHomeWfId.value = w.id
+  try {
+    const saved = await api.patchWorkflowHomeVisibility(w.id, next)
+    workflows.value = workflows.value.map((x) => (x.id === w.id ? { ...x, ...saved } : x))
+    toast.success(t('pages.projectDetail.homeVisibility.updated'))
+  } catch (e: any) {
+    workflows.value = workflows.value.map((x) => (x.id === w.id ? { ...x, showOnHome: prev } : x))
+    toast.error(String(e?.message || e) || t('pages.projectDetail.homeVisibility.updateFailed'))
+  } finally {
+    savingHomeWfId.value = null
+  }
+}
+
 const VAR_TYPES = computed(() => [
   { value: 'string', label: t('common.varTypes.string') },
   { value: 'paragraph', label: t('common.varTypes.paragraph') },
@@ -877,6 +897,8 @@ onBeforeRouteUpdate(async (to, from) => {
   persistWorkflowNotify,
   setWorkflowNotifyMode,
   toggleWorkflowNotifyEvent,
+  savingHomeWfId,
+  toggleWorkflowShowOnHome,
   VAR_TYPES,
   existingNames,
   askFields,

--- a/web/src/lib/run/useHomeApproveChat.test.ts
+++ b/web/src/lib/run/useHomeApproveChat.test.ts
@@ -61,6 +61,7 @@ const approveWf: Workflow = {
   updatedAt: '',
   needsRepo: false,
   projectId: 'proj-1',
+  showOnHome: true,
   nodes: [
     { id: 'in', type: 'input', label: '开始', position: { x: 0, y: 0 }, config: {} },
     { id: 'ap', type: 'approve', label: '澄清', position: { x: 0, y: 0 }, config: {} },
@@ -433,5 +434,55 @@ describe('useHomeApproveChat', () => {
     await chat.onLaunchStarted('run-99')
     expect(loadHomeComposerDraft()).toBeNull()
     expect(chat.draft.value).toBe('')
+  })
+
+  // plan g3.1 / g3.3 — showOnHome=false is hidden even when published approve-first
+  it('hides published approve-first pipelines when showOnHome is false or missing', async () => {
+    mocks.listWorkflows.mockResolvedValue([
+      { ...approveWf, id: 'wf-off', showOnHome: false },
+      { ...approveWf, id: 'wf-missing', showOnHome: undefined },
+      approveWf,
+    ])
+    const chat = withSetup(() => useHomeApproveChat())
+    await chat.load()
+    expect(chat.pipelines.value.map((w) => w.id)).toEqual(['wf-ap'])
+  })
+
+  // plan g3.3 — draft / non-approve-first stay hidden even when showOnHome is true
+  it('still hides draft and non-approve-first pipelines when showOnHome is true', async () => {
+    mocks.listWorkflows.mockResolvedValue([
+      { ...approveWf, id: 'wf-draft', status: 'draft' as const, showOnHome: true },
+      { ...reactWf, showOnHome: true },
+      approveWf,
+    ])
+    const chat = withSetup(() => useHomeApproveChat())
+    await chat.load()
+    expect(chat.pipelines.value.map((w) => w.id)).toEqual(['wf-ap'])
+  })
+
+  // plan g3.1 / g3.3 — remembered hidden id falls back to first visible
+  it('falls back when remembered pipeline is no longer showOnHome', async () => {
+    localStorage.setItem(HOME_PIPELINE_MEMORY_KEY, 'wf-lite')
+    mocks.listWorkflows.mockResolvedValue([
+      approveWf,
+      { ...approveWfB, showOnHome: false },
+    ])
+    const chat = withSetup(() => useHomeApproveChat())
+    await chat.load()
+    expect(chat.selectedId.value).toBe('wf-ap')
+    expect(chat.selected.value?.id).toBe('wf-ap')
+    expect(localStorage.getItem(HOME_PIPELINE_MEMORY_KEY)).toBe('wf-ap')
+  })
+
+  // plan g3.3 — all hidden → empty pipelines (empty state / disabled select)
+  it('yields an empty pipeline list when every candidate is hidden', async () => {
+    mocks.listWorkflows.mockResolvedValue([
+      { ...approveWf, showOnHome: false },
+      { ...approveWfB, showOnHome: false },
+    ])
+    const chat = withSetup(() => useHomeApproveChat())
+    await chat.load()
+    expect(chat.pipelines.value).toHaveLength(0)
+    expect(chat.selected.value).toBeNull()
   })
 })

--- a/web/src/lib/run/useHomeApproveChat.ts
+++ b/web/src/lib/run/useHomeApproveChat.ts
@@ -84,7 +84,9 @@ export function useHomeApproveChat() {
   /** Toast once after a non-empty restore. */
   let restoreToastShown = false
 
-  const pipelines = computed(() => workflows.value.filter(isPublishedApproveFirst))
+  const pipelines = computed(() =>
+    workflows.value.filter((w) => isPublishedApproveFirst(w) && !!w.showOnHome),
+  )
   const selected = computed(
     () => pipelines.value.find((w) => w.id === selectedId.value) || pipelines.value[0] || null,
   )

--- a/web/src/lib/shared/types.ts
+++ b/web/src/lib/shared/types.ts
@@ -64,6 +64,8 @@ export interface Workflow {
   updatedAt: string
   lastRunAt?: string
   needsRepo: boolean
+  /** Home cards + Home search; missing/false = hidden (plan g1.1). */
+  showOnHome?: boolean
   notifyPolicy?: WorkflowNotifyPolicy
   nodes: WFNode[]
   edges: WFEdge[]

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -13,7 +13,7 @@
       ],
       "selectProject": "Select a project",
       "noProject": "No project selected. Pick a project to start an Approve pipeline from Home.",
-      "noPipelines": "No published pipeline whose first node after start is Approve is available on this account.",
+      "noPipelines": "No pipelines are available on Home. In a project, turn on “Show on Home” for a published pipeline whose first node after start is Approve.",
       "goCanvas": "Open the canvas and connect Approve after start",
       "goProjects": "Browse projects for pipelines",
       "pickPipeline": "Select a pipeline first",
@@ -456,6 +456,12 @@
         "modeInherit": "Inherit",
         "modeCustom": "Custom",
         "wfUpdated": "Updated"
+      },
+      "homeVisibility": {
+        "col": "Show on Home",
+        "label": "Show on Home",
+        "updated": "Home visibility updated",
+        "updateFailed": "Failed to update home visibility"
       },
       "audit": {
         "title": "Audit",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -13,7 +13,7 @@
       ],
       "selectProject": "选择项目",
       "noProject": "尚未选择项目。选择一个项目后可从首页启动 Approve 流水线。",
-      "noPipelines": "账号下暂无「开始后是 Approve」的已发布流水线。",
+      "noPipelines": "没有可在首页使用的流水线。请到项目详情为已发布、Approve 打头的流水线打开「首页可见」。",
       "goCanvas": "去画布把 Approve 接到开始节点后",
       "goProjects": "前往项目查看流水线",
       "pickPipeline": "请先选择一条流水线",
@@ -456,6 +456,12 @@
         "modeInherit": "跟随项目",
         "modeCustom": "自定义",
         "wfUpdated": "已更新"
+      },
+      "homeVisibility": {
+        "col": "首页可见",
+        "label": "首页可见",
+        "updated": "已更新首页可见",
+        "updateFailed": "更新首页可见失败"
       },
       "audit": {
         "title": "审计",

--- a/web/src/views/DashboardView.test.ts
+++ b/web/src/views/DashboardView.test.ts
@@ -381,7 +381,7 @@ describe('DashboardView home composer', () => {
     await flushPromises()
     expect(wrapper.find('[data-testid="home-pipelines-empty"]').exists()).toBe(true)
     expect(wrapper.get('[data-testid="home-pipelines-empty"]').text()).not.toContain('选择项目')
-    expect(wrapper.get('[data-testid="home-go-projects"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="home-go-projects"]').exists()).toBe(true)
     await wrapper.get('[data-testid="home-go-projects"]').trigger('click')
     expect(mocks.push).toHaveBeenCalledWith('/projects')
     wrapper.unmount()

--- a/web/src/views/DashboardView.test.ts
+++ b/web/src/views/DashboardView.test.ts
@@ -66,6 +66,7 @@ const approveWf: Workflow = {
   updatedAt: '',
   needsRepo: false,
   projectId: 'proj-1',
+  showOnHome: true,
   nodes: [
     { id: 'in', type: 'input', label: '开始', position: { x: 0, y: 0 }, config: {} },
     { id: 'ap', type: 'approve', label: '澄清', position: { x: 0, y: 0 }, config: {} },
@@ -380,8 +381,20 @@ describe('DashboardView home composer', () => {
     await flushPromises()
     expect(wrapper.find('[data-testid="home-pipelines-empty"]').exists()).toBe(true)
     expect(wrapper.get('[data-testid="home-pipelines-empty"]').text()).not.toContain('选择项目')
+    expect(wrapper.get('[data-testid="home-go-projects"]').exists()).toBe(true)
     await wrapper.get('[data-testid="home-go-projects"]').trigger('click')
     expect(mocks.push).toHaveBeenCalledWith('/projects')
+    wrapper.unmount()
+  })
+
+  it('shows empty state prompting project Show on Home when pipelines are hidden (g3.2 / g3.3)', async () => {
+    mocks.listWorkflows.mockResolvedValue([{ ...approveWf, showOnHome: false }])
+    const wrapper = mountDashboard()
+    await flushPromises()
+    const empty = wrapper.get('[data-testid="home-pipelines-empty"]')
+    expect(empty.text()).toContain('首页可见')
+    expect(empty.text()).not.toContain('丢失')
+    expect(wrapper.get('[data-testid="home-pipeline-select-trigger"]').element).toHaveProperty('disabled', true)
     wrapper.unmount()
   })
 

--- a/web/src/views/ProjectDetailView.homeVisibility.test.ts
+++ b/web/src/views/ProjectDetailView.homeVisibility.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const viewsDir = dirname(fileURLToPath(import.meta.url))
+const localesDir = join(viewsDir, '../locales')
+const detailSrc = readFileSync(join(viewsDir, 'ProjectDetailView.vue'), 'utf8')
+const enPages = JSON.parse(readFileSync(join(localesDir, 'en/pages.json'), 'utf8')) as {
+  pages: { projectDetail: { homeVisibility: Record<string, string> }; dashboard: { noPipelines: string } }
+}
+const zhPages = JSON.parse(readFileSync(join(localesDir, 'zh-CN/pages.json'), 'utf8')) as {
+  pages: { projectDetail: { homeVisibility: Record<string, string> }; dashboard: { noPipelines: string } }
+}
+
+function mobileWorkflowsBlock(): string {
+  const start = detailSrc.indexOf('<!-- Mobile card list:')
+  const end = detailSrc.indexOf('<!-- Desktop table -->')
+  expect(start, 'missing mobile workflows card list').toBeGreaterThanOrEqual(0)
+  expect(end, 'missing desktop table marker').toBeGreaterThan(start)
+  return detailSrc.slice(start, end)
+}
+
+describe('ProjectDetailView home visibility switch (g2.1 / g2.2 / g2.3)', () => {
+  it('desktop table has a Show on Home column next to notify policy with click.stop', () => {
+    expect(detailSrc).toMatch(/pages\.projectDetail\.notify\.colPolicy[\s\S]*pages\.projectDetail\.homeVisibility\.col/)
+    const cellStart = detailSrc.indexOf('data-testid="wf-home-visibility-cell"')
+    expect(cellStart, 'missing wf-home-visibility-cell').toBeGreaterThanOrEqual(0)
+    const cell = detailSrc.slice(Math.max(0, cellStart - 80), cellStart + 700)
+    expect(cell).toMatch(/@click\.stop/)
+    expect(cell).toMatch(/data-testid="wf-home-visibility-switch"/)
+    expect(cell).toMatch(/toggleWorkflowShowOnHome/)
+  })
+
+  it('mobile card shows the switch beside notify and stops row navigation', () => {
+    const mobile = mobileWorkflowsBlock()
+    expect(mobile).toMatch(/data-testid="wf-home-visibility-inline"/)
+    expect(mobile).toMatch(/data-testid="wf-notify-inline"/)
+    const homeStart = mobile.indexOf('data-testid="wf-home-visibility-inline"')
+    const notifyStart = mobile.indexOf('data-testid="wf-notify-inline"')
+    const menuStart = mobile.indexOf('data-wf-menu')
+    expect(homeStart).toBeGreaterThan(notifyStart)
+    expect(menuStart).toBeGreaterThan(homeStart)
+    const home = mobile.slice(homeStart, menuStart)
+    expect(home).toMatch(/@click\.stop/)
+    expect(home).toMatch(/data-testid="wf-home-visibility-switch"/)
+  })
+
+  it('zh/en copy covers column, label, success and failure (g2.2)', () => {
+    const zh = zhPages.pages.projectDetail.homeVisibility
+    const en = enPages.pages.projectDetail.homeVisibility
+    expect(zh.col).toBe('首页可见')
+    expect(zh.label).toBe('首页可见')
+    expect(zh.updated).toContain('首页可见')
+    expect(zh.updateFailed).toContain('失败')
+    expect(en.col).toBe('Show on Home')
+    expect(en.label).toBe('Show on Home')
+    expect(en.updated.toLowerCase()).toContain('home')
+    expect(en.updateFailed.toLowerCase()).toMatch(/fail/)
+  })
+
+  it('empty Home copy points at enabling in a project, not at lost pipelines (g3.2)', () => {
+    expect(zhPages.pages.dashboard.noPipelines).toContain('首页可见')
+    expect(zhPages.pages.dashboard.noPipelines).not.toMatch(/丢失/)
+    expect(enPages.pages.dashboard.noPipelines).toMatch(/Show on Home/)
+    expect(enPages.pages.dashboard.noPipelines).not.toMatch(/missing|lost|deleted/i)
+  })
+})

--- a/web/src/views/ProjectDetailView.vue
+++ b/web/src/views/ProjectDetailView.vue
@@ -2,6 +2,7 @@
 import Icon from '@/components/ui/Icon.vue'
 import AppButton from '@/components/ui/AppButton.vue'
 import AppModal from '@/components/ui/AppModal.vue'
+import AppSwitch from '@/components/ui/AppSwitch.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import StatusPill from '@/components/ui/StatusPill.vue'
 import RunLaunchModal, { type InputField } from '@/components/workflow/RunLaunchModal.vue'
@@ -108,6 +109,8 @@ const {
   persistWorkflowNotify,
   setWorkflowNotifyMode,
   toggleWorkflowNotifyEvent,
+  savingHomeWfId,
+  toggleWorkflowShowOnHome,
   VAR_TYPES,
   existingNames,
   askFields,
@@ -590,6 +593,25 @@ const {
                 </label>
               </div>
             </div>
+            <div
+              class="flex min-w-0 items-center gap-2"
+              data-testid="wf-home-visibility-inline"
+              @click.stop
+            >
+              <AppSwitch
+                :model-value="!!w.showOnHome"
+                :disabled="savingHomeWfId === w.id"
+                :aria-label="t('pages.projectDetail.homeVisibility.label')"
+                data-testid="wf-home-visibility-switch"
+                @update:model-value="toggleWorkflowShowOnHome(w, $event)"
+              />
+              <span class="text-[12px] text-txt2">{{ t('pages.projectDetail.homeVisibility.label') }}</span>
+              <span
+                v-if="savingHomeWfId === w.id"
+                class="text-[11px] text-txt3"
+                data-testid="wf-home-visibility-saving"
+              >{{ t('common.buttons.saving') }}</span>
+            </div>
             <div class="relative flex items-center gap-2" data-wf-menu @click.stop>
               <button
                 type="button"
@@ -675,6 +697,7 @@ const {
                   <th class="px-3 py-2 font-medium">{{ t('pages.projectDetail.colName') }}</th>
                   <th class="px-3 py-2 font-medium">{{ t('pages.projectDetail.colStatus') }}</th>
                   <th class="px-3 py-2 font-medium">{{ t('pages.projectDetail.notify.colPolicy') }}</th>
+                  <th class="px-3 py-2 font-medium">{{ t('pages.projectDetail.homeVisibility.col') }}</th>
                   <th class="px-3 py-2 font-medium">{{ t('pages.projectDetail.colUpdated') }}</th>
                   <th class="px-3 py-2 text-right font-medium whitespace-nowrap">{{ t('common.table.actions') }}</th>
                 </tr>
@@ -772,6 +795,22 @@ const {
                         />
                         <span>{{ t('pages.projectDetail.notify.segCompleted') }}</span>
                       </label>
+                    </div>
+                  </td>
+                  <td class="px-3 py-2.5" @click.stop data-testid="wf-home-visibility-cell">
+                    <div class="flex items-center gap-2">
+                      <AppSwitch
+                        :model-value="!!w.showOnHome"
+                        :disabled="savingHomeWfId === w.id"
+                        :aria-label="t('pages.projectDetail.homeVisibility.label')"
+                        data-testid="wf-home-visibility-switch"
+                        @update:model-value="toggleWorkflowShowOnHome(w, $event)"
+                      />
+                      <span
+                        v-if="savingHomeWfId === w.id"
+                        class="text-[11px] text-txt3"
+                        data-testid="wf-home-visibility-saving"
+                      >{{ t('common.buttons.saving') }}</span>
                     </div>
                   </td>
                   <td class="px-3 py-2.5 text-txt3">{{ fmtTime(w.updatedAt) }}</td>


### PR DESCRIPTION
项目流水线列表可立即 PATCH 开关；首页卡片与下拉搜索只展示已开启且合格的流水线，编辑器保存未带字段时保留原值。

Co-authored-by: Cursor <cursoragent@cursor.com>
