### PR TITLE
feat/align board token chart shell

### DIFF
--- a/web/e2e/board-token-stats.spec.ts
+++ b/web/e2e/board-token-stats.spec.ts
@@ -226,19 +226,15 @@ test.describe('看板 Token 统计图', () => {
     await expect(page.getByTestId('token-donut-chart').locator('canvas')).toBeVisible()
     await expect(page.getByTestId('token-stats-comp-card')).toContainText('用量构成')
     await expect(page.getByTestId('token-stats-comp-card')).not.toContainText('四分量')
-    await expect(page.getByTestId('token-donut-legend')).toContainText('输入')
-    await expect(page.getByTestId('token-donut-legend')).toContainText('输出')
-    await expect(page.getByTestId('token-donut-legend')).toContainText('缓存读')
-    await expect(page.getByTestId('token-donut-legend')).toContainText('缓存写')
-    await expect(page.getByTestId('token-donut-legend')).not.toContainText('input')
+    await expect(page.getByTestId('token-donut-legend')).toHaveCount(0)
+    await expect(page.getByTestId('token-donut-chart')).not.toContainText('总量')
     await expect(panel).toContainText('approve-main')
     await expect(panel).toContainText('项目管理')
     await expect(panel).toContainText('其他')
-    const trendLegend = page.getByTestId('token-trend-legend')
-    await expect(trendLegend.locator('[data-kind="workflow"]')).toContainText('工作流')
-    await expect(trendLegend.locator('[data-kind="pm"]')).toContainText('项目管理')
+    await expect(page.getByTestId('token-trend-legend')).toHaveCount(0)
     const canvas = page.getByTestId('token-trend-chart').locator('canvas')
     await expect(canvas).toBeVisible()
+    const trendTip = page.locator('.token-trend-tooltip')
     await expect(async () => {
       const box = await canvas.boundingBox()
       expect(box).toBeTruthy()
@@ -248,15 +244,14 @@ test.describe('看板 Token 统计图', () => {
         for (const x of xs) {
           if (x >= box!.width - 4 || y >= box!.height - 4) continue
           await canvas.hover({ position: { x, y } })
-          if (await page.getByTestId('token-trend-tooltip').isVisible().catch(() => false)) return
+          if (await trendTip.first().isVisible().catch(() => false)) return
         }
       }
       throw new Error('trend tooltip not shown')
     }).toPass({ timeout: 12_000 })
-    const trendTip = page.getByTestId('token-trend-tooltip')
-    await expect(trendTip).toBeVisible()
-    await expect(trendTip.locator('[data-tip-row="workflow"]')).toContainText('工作流')
-    await expect(trendTip.locator('[data-tip-row="pm"]')).toContainText('项目管理')
+    await expect(trendTip.first()).toBeVisible()
+    await expect(trendTip.first().locator('[data-tip-row="workflow"]')).toContainText('工作流')
+    await expect(trendTip.first().locator('[data-tip-row="pm"]')).toContainText('项目管理')
     await expect(panel).toContainText('消耗排行')
     await expect(panel).toContainText('按来源堆叠')
     await expect(page.getByTestId('token-rank-list').locator('[data-kind="pm"]')).toBeVisible()
@@ -517,9 +512,9 @@ test.describe('看板 Token 统计图', () => {
         for (const x of xs) {
           if (x >= box!.width - 4 || y >= box!.height - 4) continue
           await canvas.hover({ position: { x, y } })
-          const loc = page.getByTestId('token-trend-tooltip')
-          if (await loc.isVisible().catch(() => false)) {
-            const text = await loc.innerText()
+          const loc = page.locator('.token-trend-tooltip')
+          if (await loc.first().isVisible().catch(() => false)) {
+            const text = await loc.first().innerText()
             if (text.includes('07-11')) return
           }
         }
@@ -531,7 +526,7 @@ test.describe('看板 Token 统计图', () => {
       await hoverLeftZeroPoint()
     }).toPass({ timeout: 12_000 })
 
-    const tip = page.getByTestId('token-trend-tooltip')
+    const tip = page.locator('.token-trend-tooltip').first()
     await expect(tip).toContainText('07-11')
     await expect(tip.locator('[data-tip-row="workflow"]')).toContainText('工作流')
     await expect(tip.locator('[data-tip-row="pm"]')).toContainText('项目管理')
@@ -551,7 +546,7 @@ test.describe('看板 Token 统计图', () => {
     await testInfo.attach('token-trend-tooltip-left-zero', { path: hoverShot, contentType: 'image/png' })
 
     await page.mouse.move(4, 4)
-    await expect(page.getByTestId('token-trend-tooltip')).toHaveCount(0)
+    await expect(page.locator('.token-trend-tooltip')).toHaveCount(0)
 
     await page.setViewportSize({ width: 390, height: 844 })
     await expect(page.getByTestId('token-trend-wrap')).toBeVisible()
@@ -564,7 +559,7 @@ test.describe('看板 Token 统计图', () => {
     await expect(async () => {
       await hoverLeftZeroPoint()
     }).toPass({ timeout: 12_000 })
-    const narrowTip = page.getByTestId('token-trend-tooltip')
+    const narrowTip = page.locator('.token-trend-tooltip').first()
     await expect(narrowTip).toContainText('07-11')
     const narrowTipBox = await narrowTip.boundingBox()
     expect(narrowTipBox).toBeTruthy()

--- a/web/e2e/unknown-model-display-name.spec.ts
+++ b/web/e2e/unknown-model-display-name.spec.ts
@@ -229,11 +229,10 @@ test.describe('未知模型显示名', () => {
     await expect(unkRank.locator('.h-full')).not.toHaveCSS('background-color', 'rgb(113, 113, 122)')
 
     const legend = page.getByTestId('token-model-legend')
-    await expect(legend).toBeVisible()
-    await expect(legend).toContainText('gpt-5')
-    await expect(legend.getByTestId('unknown-model-badge')).toHaveCount(0)
-    await expect(legend).not.toContainText('未知/未分桶')
-    await expect(legend).not.toContainText('未知模型')
+    await expect(legend).toHaveCount(0)
+    const pie = page.getByTestId('token-model-pie')
+    await expect(pie).toBeVisible()
+    await expect(pie.locator('canvas')).toBeVisible()
 
     await page.screenshot({
       path: path.join(shotDir, '03-board-alias-no-badge.png'),
@@ -293,10 +292,10 @@ test.describe('未知模型显示名', () => {
     await expect(unkRank.getByTestId('unknown-model-badge')).toHaveCount(1)
     await expect(unkRank.locator('.h-full')).toHaveCSS('background-color', 'rgb(113, 113, 122)')
 
-    const legend = page.getByTestId('token-model-legend')
-    await expect(legend.getByTestId('unknown-model-badge')).toHaveCount(1)
-    await expect(legend).toContainText('未知模型')
-    await expect(legend).not.toContainText('未知/未分桶')
+    const pie = page.getByTestId('token-model-pie')
+    await expect(pie).toBeVisible()
+    await expect(pie.locator('canvas')).toBeVisible()
+    await expect(page.getByTestId('token-model-legend')).toHaveCount(0)
   })
 
   test('Run 按模型明细：显示别名且无未知角标，来源列仍为未知模型', async ({ page }) => {

--- a/web/src/components/board/token-stats/TokenCharts.test.ts
+++ b/web/src/components/board/token-stats/TokenCharts.test.ts
@@ -1,14 +1,15 @@
 // @vitest-environment happy-dom
 import { createI18n } from 'vue-i18n'
 import { mount } from '@vue/test-utils'
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { nextTick } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
 import common from '@/locales/zh-CN/common.json'
 import pages from '@/locales/zh-CN/pages.json'
 import TokenTrendChart from './TokenTrendChart.vue'
 import TokenDonutChart from './TokenDonutChart.vue'
 import TokenWorkflowRank from './TokenWorkflowRank.vue'
 import { TOKEN_SOURCE_COLORS } from './tokenStatsShared'
+import { setTheme } from '@/lib/shared/theme'
+import { pieTooltipFormatter } from '@/components/charts/chartTheme'
 
 vi.mock('vue-echarts', () => ({
   default: {
@@ -48,6 +49,42 @@ function sampleTrend(n: number) {
   })
 }
 
+type PieOption = {
+  legend?: { orient?: string; right?: number; bottom?: number }
+  tooltip?: {
+    borderRadius?: number
+    backgroundColor?: string
+    appendToBody?: boolean
+    confine?: boolean
+    formatter?: (p: unknown) => string
+  }
+  series?: { type?: string; label?: { show?: boolean; formatter?: string }; center?: string[] }[]
+}
+
+type TrendOption = {
+  legend?: { top?: number; left?: number }
+  tooltip?: {
+    borderRadius?: number
+    backgroundColor?: string
+    appendToBody?: boolean
+    confine?: boolean
+    className?: string
+    formatter?: (p: unknown) => string
+    valueFormatter?: (v: number) => string
+  }
+  xAxis?: { axisLabel?: { color?: string; maxInterval?: number } }
+  yAxis?: { splitLine?: { lineStyle?: { color?: string } }; axisLabel?: { color?: string } }
+  series?: { name?: string; lineStyle?: { type?: unknown } }[]
+}
+
+function expectSquareThemeTooltip(tip: PieOption['tooltip'] | TrendOption['tooltip'], theme: 'dark' | 'light') {
+  expect(tip?.borderRadius).toBe(0)
+  expect(tip?.appendToBody).toBe(true)
+  expect(tip?.confine).toBe(false)
+  expect(JSON.stringify(tip)).not.toContain('#1a1d23')
+  expect(tip?.backgroundColor).toBe(theme === 'dark' ? '#27272a' : '#ffffff')
+}
+
 describe('Token charts (g2.3/g2.4)', () => {
   it('renders ECharts trend from buckets including a zero day (g2.1)', () => {
     const wrapper = mount(TokenTrendChart, {
@@ -80,24 +117,24 @@ describe('Token charts (g2.3/g2.4)', () => {
     })
     expect(wrapper.find('[data-testid="token-trend-wrap"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="token-trend-chart"]').exists()).toBe(true)
-    const legend = wrapper.find('[data-testid="token-trend-legend"]')
-    expect(legend.find('[data-kind="workflow"]').text()).toContain('工作流')
-    expect(legend.find('[data-kind="pm"]').text()).toContain('项目管理')
-    expect(legend.find('[data-kind="workflow"]').text()).not.toMatch(/^\s*workflow\s*$/i)
-    expect(legend.find('[data-kind="pm"]').text()).not.toMatch(/^\s*pm\s*$/i)
-    // ECharts renders canvas inside the chart host
+    expect(wrapper.find('[data-testid="token-trend-legend"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="token-trend-chart"] canvas').exists()).toBe(true)
     expect(wrapper.find('[data-testid="token-trend-svg"]').exists()).toBe(false)
     expect(wrapper.html()).not.toMatch(/preserveAspectRatio\s*=\s*["']none["']/)
     const exposed = wrapper.vm as unknown as {
       chartData: { datasets: { label: string; data: number[] }[] }
+      chartOption: TrendOption
     }
     expect(exposed.chartData.datasets).toHaveLength(2)
     expect(exposed.chartData.datasets.map((d) => d.label)).toEqual(['workflow', 'pm'])
+    expect(exposed.chartOption.legend?.top).toBe(0)
+    expect(exposed.chartOption.legend?.left).toBe(0)
+    expect(exposed.chartOption.series?.map((s) => s.name)).toEqual(['工作流', '项目管理'])
     wrapper.unmount()
   })
 
-  it('tooltip source names use i18n labels with data-tip-row (g2.2/g3.1)', async () => {
+  it('trend tooltip is ECharts axis tooltip with i18n compact values (g2.2)', () => {
+    setTheme('dark')
     const wrapper = mount(TokenTrendChart, {
       props: {
         bucketWidth: 'day',
@@ -115,37 +152,19 @@ describe('Token charts (g2.3/g2.4)', () => {
         ],
       },
       global: { plugins: [i18n()] },
-      attachTo: document.body,
     })
-    const wrapEl = wrapper.find('[data-testid="token-trend-wrap"]').element as HTMLElement
-    const exposed = wrapper.vm as unknown as {
-      chartOptions: {
-        plugins?: { tooltip?: { external?: (ctx: unknown) => void } }
-      }
-    }
-    const external = exposed.chartOptions.plugins?.tooltip?.external
-    expect(typeof external).toBe('function')
-    const canvas = document.createElement('canvas')
-    wrapEl.appendChild(canvas)
-    Object.defineProperty(canvas, 'getBoundingClientRect', {
-      value: () => ({ left: 0, top: 0, width: 200, height: 200, right: 200, bottom: 200 }),
-    })
-    Object.defineProperty(wrapEl, 'getBoundingClientRect', {
-      value: () => ({ left: 0, top: 0, width: 400, height: 200, right: 400, bottom: 200 }),
-    })
-    external?.({
-      chart: { canvas },
-      tooltip: { opacity: 1, dataPoints: [{ dataIndex: 0 }], caretX: 40, caretY: 40 },
-    })
-    await wrapper.vm.$nextTick()
-    const tip = document.querySelector('[data-testid="token-trend-tooltip"]')
-    expect(tip).toBeTruthy()
-    const workflowRow = tip?.querySelector('[data-tip-row="workflow"]')
-    const pmRow = tip?.querySelector('[data-tip-row="pm"]')
-    expect(workflowRow?.textContent).toContain('工作流')
-    expect(pmRow?.textContent).toContain('项目管理')
-    expect(workflowRow?.textContent).not.toMatch(/\bworkflow\b/)
-    expect(pmRow?.textContent).not.toMatch(/(?<![A-Za-z0-9_-])pm(?![A-Za-z0-9_-])/i)
+    const option = (wrapper.vm as unknown as { chartOption: TrendOption }).chartOption
+    expectSquareThemeTooltip(option.tooltip, 'dark')
+    expect(option.tooltip?.className).toMatch(/token-trend-tooltip/)
+    expect(typeof option.tooltip?.formatter).toBe('function')
+    const html = option.tooltip!.formatter!({ dataIndex: 0 })
+    expect(html).toContain('07-24')
+    expect(html).toContain('工作流')
+    expect(html).toContain('项目管理')
+    expect(html).toMatch(/data-tip-row="workflow"/)
+    expect(html).toMatch(/data-tip-row="pm"/)
+    expect(wrapper.find('[data-testid="token-trend-tooltip"]').exists()).toBe(false)
+    expect(wrapper.html()).not.toMatch(/rounded-lg/)
     wrapper.unmount()
   })
 
@@ -163,7 +182,6 @@ describe('Token charts (g2.3/g2.4)', () => {
     expect((wrap.element as HTMLElement).style.height).toBe('200px')
     expect(wrapper.find('svg[preserveAspectRatio="none"]').exists()).toBe(false)
     expect(wrapper.html()).not.toContain('preserveAspectRatio="none"')
-    // Wide container must still host ECharts canvas
     ;(wrap.element as HTMLElement).style.width = '1280px'
     expect(wrapper.find('[data-testid="token-trend-chart"] canvas').exists()).toBe(true)
     wrapper.unmount()
@@ -183,7 +201,7 @@ describe('Token charts (g2.3/g2.4)', () => {
     wrapper.unmount()
   })
 
-  it('maps 30-day labels with tick thinning options (maxTicksLimit≈8) (g2.2)', () => {
+  it('maps 30-day labels with tick thinning (maxInterval≈8) (g2.2)', () => {
     const wrapper = mount(TokenTrendChart, {
       props: {
         bucketWidth: 'day',
@@ -192,25 +210,17 @@ describe('Token charts (g2.3/g2.4)', () => {
       global: { plugins: [i18n()] },
     })
     const exposed = wrapper.vm as unknown as {
-      chartOptions: {
-        maintainAspectRatio?: boolean
-        scales?: { x?: { ticks?: { maxTicksLimit?: number; autoSkip?: boolean } } }
-        plugins?: { tooltip?: { enabled?: boolean; external?: unknown } }
-      }
+      chartOption: TrendOption
       chartData: { labels: string[]; datasets: { data: number[] }[] }
     }
-    const opts = exposed.chartOptions
-    expect(opts.maintainAspectRatio).toBe(false)
-    expect(opts.scales?.x?.ticks?.maxTicksLimit).toBe(8)
-    expect(opts.scales?.x?.ticks?.autoSkip).toBe(true)
-    expect(opts.plugins?.tooltip?.enabled).toBe(false)
-    expect(typeof opts.plugins?.tooltip?.external).toBe('function')
+    expect(exposed.chartOption.xAxis?.axisLabel?.maxInterval).toBe(Math.ceil(30 / 8))
+    expect(exposed.chartOption.tooltip?.appendToBody).toBe(true)
     expect(exposed.chartData.labels).toHaveLength(30)
     expect(exposed.chartData.datasets[0]?.data).toHaveLength(30)
     wrapper.unmount()
   })
 
-  it('renders donut ring with legend and center total', () => {
+  it('renders donut/pie with right legend, visible labels, no HTML legend or center total (g2.1)', () => {
     const wrapper = mount(TokenDonutChart, {
       props: {
         composition: {
@@ -224,23 +234,28 @@ describe('Token charts (g2.3/g2.4)', () => {
       global: { plugins: [i18n()] },
     })
     expect(wrapper.find('[data-testid="token-donut-chart"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="token-donut-legend"]').text()).toContain('输入')
-    expect(wrapper.find('[data-testid="token-donut-legend"]').text()).toContain('输出')
-    expect(wrapper.find('[data-testid="token-donut-legend"]').text()).toContain('缓存读')
-    expect(wrapper.find('[data-testid="token-donut-legend"]').text()).toContain('缓存写')
-    expect(wrapper.find('[data-testid="token-donut-legend"]').text()).not.toMatch(/\binput\b/)
-    // g3.3: share math unchanged for 70/55/35/20 over total 180
-    expect(wrapper.find('[data-testid="token-donut-legend"]').text()).toContain('38.9%')
-    expect(wrapper.find('[data-testid="token-donut-legend"]').text()).toContain('30.6%')
-    expect(wrapper.find('[data-testid="token-donut-legend"]').text()).toContain('19.4%')
-    expect(wrapper.find('[data-testid="token-donut-legend"]').text()).toContain('11.1%')
-    expect(wrapper.text()).toContain('总量')
-    expect(wrapper.find('[data-testid="token-donut-chart"]').text()).toContain('180')
+    expect(wrapper.find('[data-testid="token-donut-legend"]').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('总量')
     expect(wrapper.find('[data-testid="token-donut-chart"]').attributes('aria-label')).toBe('用量构成')
+    const option = (wrapper.vm as unknown as { chartOption: PieOption }).chartOption
+    expect(option.legend?.orient).toBe('vertical')
+    expect(option.legend?.right).toBe(0)
+    expect(option.legend?.bottom).toBeUndefined()
+    expect(option.series?.[0]?.label?.show).toBe(true)
+    expect(option.series?.[0]?.label?.formatter).toBe('{b} {d}%')
+    expect(option.series?.[0]?.center?.[0]).toBe('38%')
+    const names = (
+      option.series?.[0] as unknown as { data: { name: string; value: number }[] }
+    ).data.map((d) => d.name)
+    expect(names).toEqual(['输入', '输出', '缓存读', '缓存写'])
+    expect(names.join(' ')).not.toMatch(/\binput\b/)
+    const parts = (wrapper.vm as unknown as { parts: { pct: number }[] }).parts
+    expect(parts.map((p) => p.pct)).toEqual([38.9, 30.6, 19.4, 11.1])
     wrapper.unmount()
   })
 
-  it('donut tooltip uses the same part* labels as the legend (g2.2)', async () => {
+  it('donut tooltip uses compact i18n formatter and square theme chrome (g2.2)', () => {
+    setTheme('light')
     const wrapper = mount(TokenDonutChart, {
       props: {
         composition: {
@@ -253,18 +268,18 @@ describe('Token charts (g2.3/g2.4)', () => {
       },
       global: { plugins: [i18n()] },
     })
-    const legend = wrapper.find('[data-testid="token-donut-legend"]')
-    expect(legend.find('li').exists()).toBe(true)
-    await legend.find('li').trigger('click', { clientX: 40, clientY: 40 })
-    const tip = wrapper.find('[data-testid="token-donut-tooltip"]')
-    expect(tip.exists()).toBe(true)
-    expect(tip.text()).toContain('输入')
-    expect(tip.text()).not.toMatch(/\binput\b/)
-    expect(tip.text()).toContain('38.9%')
+    const option = (wrapper.vm as unknown as { chartOption: PieOption }).chartOption
+    expectSquareThemeTooltip(option.tooltip, 'light')
+    expect(typeof option.tooltip?.formatter).toBe('function')
+    expect(option.tooltip?.formatter?.({ name: '输入', value: 396_400, percent: 38.9 })).toBe(
+      pieTooltipFormatter({ name: '输入', value: 396_400, percent: 38.9 }),
+    )
+    expect(wrapper.find('[data-testid="token-donut-tooltip"]').exists()).toBe(false)
+    expect(wrapper.html()).not.toMatch(/#1a1d23/)
     wrapper.unmount()
   })
 
-  it('narrow donut stacks ring above legend and shrinks ring (~120px) (g4.1/g4.2)', () => {
+  it('donut plot is full-width overflow-visible (g4.1/g4.2)', () => {
     const wrapper = mount(TokenDonutChart, {
       props: {
         composition: {
@@ -278,18 +293,15 @@ describe('Token charts (g2.3/g2.4)', () => {
       global: { plugins: [i18n()] },
     })
     const row = wrapper.find('[data-testid="token-donut-row"]')
-    expect(row.classes()).toEqual(expect.arrayContaining(['flex-col', 'sm:flex-row']))
+    expect(row.classes()).toEqual(expect.arrayContaining(['w-full', 'overflow-visible']))
     const chart = wrapper.find('[data-testid="token-donut-chart"]')
-    expect(chart.classes()).toEqual(expect.arrayContaining(['h-[120px]', 'w-[120px]', 'sm:h-[150px]', 'sm:w-[150px]']))
-    const legend = wrapper.find('[data-testid="token-donut-legend"]')
-    expect(legend.classes()).toEqual(expect.arrayContaining(['w-full']))
+    expect(chart.classes()).toEqual(expect.arrayContaining(['h-[168px]', 'w-full']))
     wrapper.unmount()
   })
 
   it('renders consumption rank with continuous numeric badges for workflow+PM (no 12PM34)', () => {
     const wrapper = mount(TokenWorkflowRank, {
       props: {
-        // Fixed API order: Top workflows → PM → other
         workflows: [
           { workflowId: 'a', name: 'approve-main', total: 1_020_000, kind: 'workflow' },
           { workflowId: 'b', name: 'doc-review', total: 40_000, kind: 'workflow' },
@@ -309,12 +321,10 @@ describe('Token charts (g2.3/g2.4)', () => {
     expect(wrapper.text()).toContain('项目管理')
     expect(wrapper.text()).toContain('其他')
 
-    // Continuous numeric badges for workflow+PM; other stays "·" (Demo: 1→2→3→·)
     const pmRow = wrapper.find('[data-kind="pm"]')
     const badges = wrapper.findAll('li').map((li) => li.find('span').text())
     expect(badges).toEqual(['1', '2', '3', '·'])
     expect(pmRow.find('span').text()).toBe('3')
-    // PM badge style matches workflow numeric badge (accent for rank ≤3); no special w-auto/min-w
     const pmBadge = pmRow.find('span')
     expect(pmBadge.classes()).toEqual(
       expect.arrayContaining(['w-[22px]', 'bg-accent-dim', 'text-accent-2']),
@@ -323,9 +333,6 @@ describe('Token charts (g2.3/g2.4)', () => {
     const wfBadge = items[0]!.find('span')
     expect(wfBadge.classes()).toEqual(pmBadge.classes())
 
-    // Same purple bar as workflow — gradient #6d5cff → #9b8cff
-    const pmBar = pmRow.find('[data-testid="token-rank-bar"]')
-    expect(pmBar.exists()).toBe(true)
     const barColorFn = (
       wrapper.vm as unknown as {
         barColor: (w: { kind?: string; other?: boolean; name: string; total: number }) => {
@@ -338,10 +345,15 @@ describe('Token charts (g2.3/g2.4)', () => {
     expect(pmGradient.colorStops[1]!.color).toBe('#9b8cff')
     expect(pmGradient.colorStops.map((s) => s.color)).not.toContain('#f59e0b')
 
-    // Compact K/M main values remain visible on the right
     const values = wrapper.findAll('[data-testid="token-rank-value"]').map((v) => v.text())
     expect(values).toEqual(['1.02M', '40K', '80K', '20K'])
     expect(wrapper.find('[data-testid="token-rank-value"]').attributes('title')).toBeTruthy()
+    expect(wrapper.find('[data-testid="token-rank-tooltip"]').exists()).toBe(false)
+    const rowTip = (
+      wrapper.vm as unknown as { rowOptions: { tooltip: { borderRadius?: number; backgroundColor?: string } }[] }
+    ).rowOptions[0]!.tooltip
+    expect(rowTip.borderRadius).toBe(0)
+    expect(JSON.stringify(rowTip)).not.toContain('#1a1d23')
     wrapper.unmount()
   })
 
@@ -362,7 +374,6 @@ describe('Token charts (g2.3/g2.4)', () => {
     const badges = wrapper.findAll('li').map((li) => li.find('span').text())
     expect(badges).toEqual(['1', '2', '3', '4', '5', '·'])
     expect(wrapper.find('[data-kind="pm"]').find('span').text()).toBe('5')
-    // rank 5 uses dim elevated style same as a workflow at #5 would
     expect(wrapper.find('[data-kind="pm"]').find('span').classes()).toEqual(
       expect.arrayContaining(['w-[22px]', 'bg-elevated', 'text-txt3']),
     )
@@ -432,197 +443,44 @@ describe('Token charts (g2.3/g2.4)', () => {
   })
 })
 
-type ExternalTooltip = (ctx: {
-  chart: { canvas: HTMLCanvasElement }
-  tooltip: {
-    opacity: number
-    caretX: number
-    caretY: number
-    dataPoints?: { dataIndex: number }[]
-  }
-}) => void | Promise<void>
+describe('TokenTrendChart tooltip / theme chrome (g2.3/g2.4)', () => {
+  it('light and dark option tones follow 用量统计 shell', () => {
+    const trend = [
+      {
+        bucket: '2026-07-11',
+        total: 0,
+        workflowTotal: 0,
+        pmTotal: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+      },
+    ]
 
-const TIP_W = 168
-const TIP_H = 72
-
-function mockTipBoxSize() {
-  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
-    configurable: true,
-    get() {
-      return (this as HTMLElement).getAttribute?.('data-testid') === 'token-trend-tooltip' ? TIP_W : 600
-    },
-  })
-  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
-    configurable: true,
-    get() {
-      return (this as HTMLElement).getAttribute?.('data-testid') === 'token-trend-tooltip' ? TIP_H : 200
-    },
-  })
-}
-
-function restoreTipBoxSize() {
-  delete (HTMLElement.prototype as { offsetWidth?: unknown }).offsetWidth
-  delete (HTMLElement.prototype as { offsetHeight?: unknown }).offsetHeight
-}
-
-function leftZeroTrend() {
-  return [
-    {
-      bucket: '2026-07-11',
-      total: 0,
-      workflowTotal: 0,
-      pmTotal: 0,
-      inputTokens: 0,
-      outputTokens: 0,
-      cacheReadTokens: 0,
-      cacheWriteTokens: 0,
-    },
-    {
-      bucket: '2026-07-12',
-      total: 1_200_000,
-      workflowTotal: 900_000,
-      pmTotal: 300_000,
-      inputTokens: 400,
-      outputTokens: 300,
-      cacheReadTokens: 200,
-      cacheWriteTokens: 100,
-    },
-    {
-      bucket: '2026-08-09',
-      total: 96_000_000,
-      workflowTotal: 72_000_000,
-      pmTotal: 24_000_000,
-      inputTokens: 400,
-      outputTokens: 300,
-      cacheReadTokens: 200,
-      cacheWriteTokens: 100,
-    },
-  ]
-}
-
-function tipBoxInViewport(el: HTMLElement) {
-  const left = parseFloat(el.style.left || '0')
-  const top = parseFloat(el.style.top || '0')
-  const right = left + (el.offsetWidth || TIP_W)
-  const bottom = top + (el.offsetHeight || TIP_H)
-  const vw = window.innerWidth
-  const vh = window.innerHeight
-  expect(left).toBeGreaterThanOrEqual(0)
-  expect(top).toBeGreaterThanOrEqual(0)
-  expect(right).toBeLessThanOrEqual(vw)
-  expect(bottom).toBeLessThanOrEqual(vh)
-  return { left, top, right, bottom }
-}
-
-async function fireExternalTooltip(
-  wrapper: ReturnType<typeof mount>,
-  opts: { caretX: number; caretY: number; dataIndex?: number; opacity?: number; canvasLeft?: number; canvasTop?: number },
-) {
-  const canvas = wrapper.find('canvas').element as HTMLCanvasElement
-  const canvasLeft = opts.canvasLeft ?? 40
-  const canvasTop = opts.canvasTop ?? 80
-  vi.spyOn(canvas, 'getBoundingClientRect').mockReturnValue({
-    x: canvasLeft,
-    y: canvasTop,
-    left: canvasLeft,
-    top: canvasTop,
-    right: canvasLeft + 600,
-    bottom: canvasTop + 178,
-    width: 600,
-    height: 178,
-    toJSON() {
-      return {}
-    },
-  } as DOMRect)
-
-  const vm = wrapper.vm as unknown as { externalTooltip: ExternalTooltip; hideTip: () => void }
-  await vm.externalTooltip({
-    chart: { canvas },
-    tooltip: {
-      opacity: opts.opacity ?? 1,
-      caretX: opts.caretX,
-      caretY: opts.caretY,
-      dataPoints: opts.opacity === 0 ? [] : [{ dataIndex: opts.dataIndex ?? 0 }],
-    },
-  })
-  await nextTick()
-  await nextTick()
-  return vm
-}
-
-describe('TokenTrendChart tooltip visibility (g4.1/g4.2/g4.3/g1.1)', () => {
-  afterEach(() => {
-    restoreTipBoxSize()
-    vi.restoreAllMocks()
-    document.querySelectorAll('[data-testid="token-trend-tooltip"]').forEach((n) => n.remove())
-  })
-
-  it('left-edge total=0 shows full MM-DD · 0 and box stays in viewport (g4.1)', async () => {
-    mockTipBoxSize()
-    const wrapper = mount(TokenTrendChart, {
-      props: { bucketWidth: 'day', trend: leftZeroTrend() },
+    setTheme('dark')
+    const darkWrap = mount(TokenTrendChart, {
+      props: { bucketWidth: 'day', trend },
       global: { plugins: [i18n()] },
-      attachTo: document.body,
     })
+    const darkOpt = (darkWrap.vm as unknown as { chartOption: TrendOption }).chartOption
+    expectSquareThemeTooltip(darkOpt.tooltip, 'dark')
+    expect(darkOpt.yAxis?.splitLine?.lineStyle?.color).toBe('rgba(255,255,255,0.08)')
+    expect(darkOpt.xAxis?.axisLabel?.color).toBe('#a1a1aa')
+    const html = darkOpt.tooltip!.formatter!({ dataIndex: 0 })
+    expect(html).toMatch(/07-11\s*·\s*0/)
+    expect(html).not.toMatch(/(^|\s)-11\s*·/)
+    darkWrap.unmount()
 
-    await fireExternalTooltip(wrapper, { caretX: 8, caretY: 160, dataIndex: 0 })
-    const tip = document.querySelector('[data-testid="token-trend-tooltip"]') as HTMLElement | null
-    expect(tip).toBeTruthy()
-    const text = (tip!.textContent || '').replace(/\s+/g, ' ')
-    expect(text).toContain('07-11')
-    expect(text).toMatch(/07-11\s*·\s*0/)
-    expect(text).not.toMatch(/(^|\s)-11\s*·/)
-    expect(text).toContain('工作流')
-    expect(text).toContain('项目管理')
-    tipBoxInViewport(tip!)
-
-    const wrap = wrapper.find('[data-testid="token-trend-wrap"]').element
-    expect(wrap.contains(tip!)).toBe(false)
-    expect(tip!.className).toMatch(/fixed/)
-    expect(tip!.className).toMatch(/z-\[100\]/)
-    expect(tip!.className).toMatch(/pointer-events-none/)
-    expect(tip!.className).toMatch(/rounded-lg/)
-    expect(tip!.className).toMatch(/bg-\[#1a1d23\]/)
-    wrapper.unmount()
-  })
-
-  it('right-edge / high caret flip or clamp keeps box in viewport (g4.2)', async () => {
-    mockTipBoxSize()
-    const wrapper = mount(TokenTrendChart, {
-      props: { bucketWidth: 'day', trend: leftZeroTrend() },
+    setTheme('light')
+    const lightWrap = mount(TokenTrendChart, {
+      props: { bucketWidth: 'day', trend },
       global: { plugins: [i18n()] },
-      attachTo: document.body,
     })
-
-    await fireExternalTooltip(wrapper, { caretX: 590, caretY: 8, dataIndex: 2, canvasLeft: 40, canvasTop: 20 })
-    const tip = document.querySelector('[data-testid="token-trend-tooltip"]') as HTMLElement | null
-    expect(tip).toBeTruthy()
-    const text = (tip!.textContent || '').replace(/\s+/g, ' ')
-    expect(text).toContain('08-09')
-    expect(text).not.toMatch(/translate\(-50%/)
-    tipBoxInViewport(tip!)
-    wrapper.unmount()
-  })
-
-  it('hides tooltip after leaving the trend wrap (g4.3)', async () => {
-    mockTipBoxSize()
-    const wrapper = mount(TokenTrendChart, {
-      props: { bucketWidth: 'day', trend: leftZeroTrend() },
-      global: { plugins: [i18n()] },
-      attachTo: document.body,
-    })
-
-    await fireExternalTooltip(wrapper, { caretX: 80, caretY: 100, dataIndex: 1 })
-    expect(document.querySelector('[data-testid="token-trend-tooltip"]')).toBeTruthy()
-
-    await wrapper.find('[data-testid="token-trend-wrap"]').trigger('mouseleave')
-    await nextTick()
-    expect(document.querySelector('[data-testid="token-trend-tooltip"]')).toBeNull()
-
-    await fireExternalTooltip(wrapper, { caretX: 80, caretY: 100, dataIndex: 1 })
-    expect(document.querySelector('[data-testid="token-trend-tooltip"]')).toBeTruthy()
-    await fireExternalTooltip(wrapper, { caretX: 80, caretY: 100, opacity: 0 })
-    expect(document.querySelector('[data-testid="token-trend-tooltip"]')).toBeNull()
-    wrapper.unmount()
+    const lightOpt = (lightWrap.vm as unknown as { chartOption: TrendOption }).chartOption
+    expectSquareThemeTooltip(lightOpt.tooltip, 'light')
+    expect(lightOpt.yAxis?.splitLine?.lineStyle?.color).toBe('#eef0f3')
+    expect(lightOpt.xAxis?.axisLabel?.color).toBe('#71717a')
+    lightWrap.unmount()
   })
 })

--- a/web/src/components/board/token-stats/TokenCharts.test.ts
+++ b/web/src/components/board/token-stats/TokenCharts.test.ts
@@ -62,6 +62,7 @@ type PieOption = {
 }
 
 type TrendOption = {
+  grid?: { left?: number; right?: number; top?: number; containLabel?: boolean }
   legend?: { top?: number; left?: number }
   tooltip?: {
     borderRadius?: number
@@ -69,12 +70,15 @@ type TrendOption = {
     appendToBody?: boolean
     confine?: boolean
     className?: string
+    triggerOn?: string
+    axisPointer?: { snap?: boolean }
+    position?: (...args: unknown[]) => unknown
     formatter?: (p: unknown) => string
     valueFormatter?: (v: number) => string
   }
   xAxis?: { axisLabel?: { color?: string; maxInterval?: number } }
   yAxis?: { splitLine?: { lineStyle?: { color?: string } }; axisLabel?: { color?: string } }
-  series?: { name?: string; lineStyle?: { type?: unknown } }[]
+  series?: { name?: string; lineStyle?: { type?: unknown }; clip?: boolean; symbolSize?: number }[]
 }
 
 function expectSquareThemeTooltip(tip: PieOption['tooltip'] | TrendOption['tooltip'], theme: 'dark' | 'light') {
@@ -155,7 +159,8 @@ describe('Token charts (g2.3/g2.4)', () => {
     })
     const option = (wrapper.vm as unknown as { chartOption: TrendOption }).chartOption
     expectSquareThemeTooltip(option.tooltip, 'dark')
-    expect(option.tooltip?.className).toMatch(/token-trend-tooltip/)
+    expect(option.tooltip?.className).toMatch(/token-stats-echarts-tooltip/)
+    expect(option.tooltip?.className).not.toMatch(/token-trend-tooltip/)
     expect(typeof option.tooltip?.formatter).toBe('function')
     const html = option.tooltip!.formatter!({ dataIndex: 0 })
     expect(html).toContain('07-24')
@@ -470,6 +475,13 @@ describe('TokenTrendChart tooltip / theme chrome (g2.3/g2.4)', () => {
     const html = darkOpt.tooltip!.formatter!({ dataIndex: 0 })
     expect(html).toMatch(/07-11\s*·\s*0/)
     expect(html).not.toMatch(/(^|\s)-11\s*·/)
+    expect(darkOpt.grid?.left).toBe(42)
+    expect(darkOpt.grid?.containLabel).toBe(false)
+    expect(darkOpt.tooltip?.triggerOn).toBe('mousemove')
+    expect(darkOpt.tooltip?.axisPointer?.snap).toBe(true)
+    expect(typeof darkOpt.tooltip?.position).toBe('function')
+    expect(darkOpt.series?.[1]?.symbolSize).toBe(7)
+    expect(darkOpt.series?.[0]?.clip).toBe(false)
     darkWrap.unmount()
 
     setTheme('light')
@@ -482,5 +494,34 @@ describe('TokenTrendChart tooltip / theme chrome (g2.3/g2.4)', () => {
     expect(lightOpt.yAxis?.splitLine?.lineStyle?.color).toBe('#eef0f3')
     expect(lightOpt.xAxis?.axisLabel?.color).toBe('#71717a')
     lightWrap.unmount()
+  })
+
+  it('DOM .token-trend-tooltip is v-if removed on leave so E2E count hits 0 (g2.2/g4.5)', async () => {
+    const trend = [
+      {
+        bucket: '2026-07-11',
+        total: 0,
+        workflowTotal: 0,
+        pmTotal: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+      },
+    ]
+    const wrapper = mount(TokenTrendChart, {
+      props: { bucketWidth: 'day', trend },
+      global: { plugins: [i18n()] },
+      attachTo: document.body,
+    })
+    const wrap = wrapper.find('[data-testid="token-trend-wrap"]')
+    await wrap.trigger('mousemove', { clientX: 48, clientY: 160 })
+    const shown = document.querySelector('.token-trend-tooltip')
+    expect(shown).toBeTruthy()
+    expect(shown?.textContent).toMatch(/07-11/)
+    expect(document.querySelector('[data-testid="token-trend-tooltip"]')).toBeNull()
+    await wrap.trigger('mouseleave')
+    expect(document.querySelector('.token-trend-tooltip')).toBeNull()
+    wrapper.unmount()
   })
 })

--- a/web/src/components/board/token-stats/TokenDonutChart.vue
+++ b/web/src/components/board/token-stats/TokenDonutChart.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { registerECharts } from '@/components/charts/echartsSetup'
-import { BOARD_CHART_TOOLTIP } from '@/components/charts/chartTheme'
+import { pieChartOption } from '@/components/charts/chartTheme'
 import type { TokenStatsComposition } from '@/lib/shared/types'
-import { fmtCompactTokenCount, fmtTokenCount } from '@/lib/run/tokenUsage'
 import { TOKEN_PART_COLORS, TOKEN_PART_KEYS, type TokenPartKey } from './tokenStatsShared'
 
 registerECharts()
@@ -15,7 +14,6 @@ const props = defineProps<{
 }>()
 
 const { t } = useI18n()
-const active = ref<TokenPartKey | null>(null)
 
 const PART_LABEL_KEYS: Record<TokenPartKey, string> = {
   input: 'pages.executionTimeline.partInput',
@@ -48,96 +46,27 @@ const parts = computed(() => {
 const chartOption = computed(() => {
   const visible = parts.value.filter((p) => p.value > 0)
   if (!visible.length) return null
-  return {
-    tooltip: { trigger: 'item', ...BOARD_CHART_TOOLTIP, formatter: '{b}: {c} ({d}%)' },
-    series: [
-      {
-        type: 'pie',
-        radius: ['32%', '52%'],
-        center: ['50%', '50%'],
-        data: visible.map((p) => ({ name: partLabel(p.key), value: p.value, key: p.key })),
-        color: visible.map((p) => p.color),
-        label: { show: false },
-        emphasis: {
-          scale: true,
-          itemStyle: { opacity: active.value && active.value !== undefined ? 0.45 : 0.95 },
-        },
-      },
-    ],
-  }
+  return pieChartOption(
+    visible.map((p) => ({ name: partLabel(p.key), value: p.value, key: p.key, color: p.color })),
+    false,
+  )
 })
 
-const tip = ref({ show: false, x: 0, y: 0, key: null as TokenPartKey | null })
-
-function activate(key: TokenPartKey, ev?: MouseEvent) {
-  active.value = key
-  if (!ev) return
-  const wrap = (ev.currentTarget as HTMLElement).closest('[data-testid="token-donut-row"]') as HTMLElement | null
-  if (!wrap) return
-  const rect = wrap.getBoundingClientRect()
-  tip.value = {
-    show: true,
-    x: ev.clientX - rect.left,
-    y: ev.clientY - rect.top,
-    key,
-  }
-}
-
-function deactivate() {
-  active.value = null
-  tip.value = { ...tip.value, show: false }
-}
-
-const tipPart = computed(() => parts.value.find((p) => p.key === tip.value.key) || null)
+defineExpose({ chartOption, parts })
 </script>
 
 <template>
   <div
     data-testid="token-donut-row"
-    class="token-donut-row relative flex min-h-[180px] flex-col items-center gap-4 sm:flex-row sm:items-center"
+    class="token-donut-row relative min-h-[168px] w-full overflow-visible"
   >
     <div
       data-testid="token-donut-chart"
-      class="relative h-[120px] w-[120px] shrink-0 sm:h-[150px] sm:w-[150px]"
+      class="h-[168px] w-full"
       role="img"
       :aria-label="t('pages.board.tokenStats.compositionTitle')"
     >
       <VChart v-if="chartOption" :option="chartOption" autoresize class="h-full w-full" />
-      <div class="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
-        <span class="text-[11px] text-txt3">{{ t('pages.board.tokenStats.donutCenter') }}</span>
-        <span class="text-[15px] font-bold text-txt">{{ fmtCompactTokenCount(composition.total) }}</span>
-      </div>
-    </div>
-    <ul data-testid="token-donut-legend" class="m-0 grid w-full min-w-0 list-none gap-2 p-0 sm:flex-1">
-      <li
-        v-for="p in parts"
-        :key="p.key"
-        class="grid cursor-pointer grid-cols-[10px_1fr_auto] items-center gap-2 rounded-md px-1.5 py-1 text-xs"
-        :class="active === p.key ? 'bg-elevated' : 'hover:bg-elevated/80'"
-        @mouseenter="activate(p.key)"
-        @mouseleave="deactivate"
-        @click="activate(p.key, $event)"
-      >
-        <i class="h-2 w-2 rounded-sm" :style="{ background: p.color }" />
-        <span class="truncate text-txt">{{ partLabel(p.key) }}</span>
-        <span class="tabular-nums text-txt3">{{ p.pct }}%</span>
-      </li>
-    </ul>
-    <div
-      v-if="tip.show && tipPart"
-      data-testid="token-donut-tooltip"
-      class="pointer-events-none absolute z-10 min-w-[120px] rounded-lg bg-[#1a1d23] px-2.5 py-2 text-[11px] text-white shadow-lg"
-      :style="{ left: tip.x + 'px', top: tip.y + 'px', transform: 'translate(-20%, -110%)' }"
-    >
-      <div class="mb-1 font-semibold">{{ partLabel(tipPart.key) }}</div>
-      <div class="flex justify-between gap-3 text-[#c7cbd4]">
-        <span>{{ t('pages.board.tokenStats.value') }}</span>
-        <b class="font-normal tabular-nums text-white">{{ fmtTokenCount(tipPart.value) }}</b>
-      </div>
-      <div class="flex justify-between gap-3 text-[#c7cbd4]">
-        <span>{{ t('pages.board.tokenStats.share') }}</span>
-        <b class="font-normal tabular-nums text-white">{{ tipPart.pct }}%</b>
-      </div>
     </div>
   </div>
 </template>

--- a/web/src/components/board/token-stats/TokenModelComposition.test.ts
+++ b/web/src/components/board/token-stats/TokenModelComposition.test.ts
@@ -8,6 +8,7 @@ import enCommon from '@/locales/en/common.json'
 import enPages from '@/locales/en/pages.json'
 import TokenModelComposition from './TokenModelComposition.vue'
 import { colorForModel } from './tokenModelColors'
+import { setTheme } from '@/lib/shared/theme'
 
 vi.mock('vue-echarts', () => ({
   default: {
@@ -51,7 +52,30 @@ function chartData(vm: unknown) {
   return (vm as { chartData: { name: string; value: number; color?: string }[] }).chartData
 }
 
-describe('TokenModelComposition ECharts pie (g1.1)', () => {
+function chartOption(vm: unknown) {
+  return vm as {
+    chartOption: {
+      legend?: { orient?: string; right?: number }
+      tooltip?: { borderRadius?: number; backgroundColor?: string; appendToBody?: boolean }
+      series?: { label?: { show?: boolean; formatter?: string }; center?: string[] }[]
+    }
+  }
+}
+
+function expectPieShell(vm: unknown, theme: 'dark' | 'light') {
+  const option = chartOption(vm).chartOption
+  expect(option.legend?.orient).toBe('vertical')
+  expect(option.legend?.right).toBe(0)
+  expect(option.series?.[0]?.label?.show).toBe(true)
+  expect(option.series?.[0]?.label?.formatter).toBe('{b} {d}%')
+  expect(option.series?.[0]?.center?.[0]).toBe('38%')
+  expect(option.tooltip?.borderRadius).toBe(0)
+  expect(option.tooltip?.appendToBody).toBe(true)
+  expect(JSON.stringify(option.tooltip)).not.toContain('#1a1d23')
+  expect(option.tooltip?.backgroundColor).toBe(theme === 'dark' ? '#27272a' : '#ffffff')
+}
+
+describe('TokenModelComposition ECharts pie (g1.1/g2.1)', () => {
   it('renders ECharts pie host without svg path sectors (g1.1/g2.1)', () => {
     const wrapper = mount(TokenModelComposition, {
       props: {
@@ -69,10 +93,12 @@ describe('TokenModelComposition ECharts pie (g1.1)', () => {
     const data = chartData(wrapper.vm)
     expect(data).toHaveLength(1)
     expect(data[0]!.color).toBe('#71717A')
+    expect(data[0]!.name).toBe('未知模型')
+    expectPieShell(wrapper.vm, 'dark')
     wrapper.unmount()
   })
 
-  it('unknown-only near-full circle: #71717A sector + legend 100% (g1.2/g2.2)', () => {
+  it('unknown-only near-full circle: #71717A sector + 100% in option data (g1.2/g2.2)', () => {
     const unknown = { modelKey: '未知/未分桶', name: '未知模型', total: 1056240000, unknown: true }
     expect(colorForModel(unknown, 0)).toBe('#71717A')
 
@@ -84,10 +110,9 @@ describe('TokenModelComposition ECharts pie (g1.1)', () => {
     expect(pie.find('[data-testid="mock-vchart"]').exists()).toBe(true)
     const data = chartData(wrapper.vm)
     expect(data[0]!.color).toBe('#71717A')
-    const legend = wrapper.find('[data-testid="token-model-legend"]')
-    expect(legend.text()).toContain('未知模型')
-    expect(legend.text()).toContain('100%')
-    expect(legend.text()).toContain('1.06B')
+    expect(data[0]!.name).toBe('未知模型')
+    expect(data[0]!.value).toBe(1056240000)
+    expect(wrapper.find('[data-testid="token-model-legend"]').exists()).toBe(false)
     wrapper.unmount()
   })
 
@@ -104,13 +129,8 @@ describe('TokenModelComposition ECharts pie (g1.1)', () => {
     expect(data).toHaveLength(2)
     expect(data[0]!.color).toBe(colorForModel(models[0]!, 0))
     expect(data[1]!.color).toBe('#71717A')
-    const legend = wrapper.find('[data-testid="token-model-legend"]').text()
-    expect(legend).toContain('4.5%')
-    expect(legend).toContain('95.5%')
-    expect(legend).toContain('50.09M')
-    expect(legend).toContain('1.06B')
-    expect(legend).toContain('cursor-grok-4.5-high-fast')
-    expectNoFilledTagCopy(legend)
+    expect(data.map((d) => d.name)).toEqual(['cursor-grok-4.5-high-fast', '未知模型'])
+    expectNoFilledTagCopy(wrapper.html())
     expect(colorForModel(models[0]!, 0)).toBe('#34D399')
     expect(wrapper.html()).not.toMatch(/conic-gradient/i)
     wrapper.unmount()
@@ -132,13 +152,14 @@ describe('TokenModelComposition ECharts pie (g1.1)', () => {
     const colors = chartData(wrapper.vm).map((d) => d.color)
     expect(colors).toContain('#71717A')
     expect(colors).toContain('#A1A1AA')
-    const legend = wrapper.find('[data-testid="token-model-legend"]').text()
-    expect(legend).toContain('未知模型')
-    expect(legend).toContain('other')
-    expect(legend).toContain('claude-sonnet-4')
-    expect(wrapper.find('[data-testid="token-model-composition"]').classes()).toContain('sm:grid-cols-[120px_1fr]')
-    const swatch = wrapper.find('[data-testid="token-model-legend"] span.h-2\\.5')
-    expect(swatch.exists()).toBe(true)
+    const names = chartData(wrapper.vm).map((d) => d.name)
+    expect(names).toContain('未知模型')
+    expect(names).toContain('other')
+    expect(names).toContain('claude-sonnet-4')
+    expect(wrapper.find('[data-testid="token-model-composition"]').classes()).toContain('w-full')
+    expect(wrapper.find('[data-testid="token-model-composition"]').classes()).not.toContain(
+      'sm:grid-cols-[120px_1fr]',
+    )
     wrapper.unmount()
   })
 
@@ -157,7 +178,7 @@ describe('TokenModelComposition ECharts pie (g1.1)', () => {
 })
 
 describe('TokenModelComposition hides filledTag (g2.1)', () => {
-  it('zh-CN legend: swatch+name only, no 含补全; filled=#34D399 unknown=#71717A', () => {
+  it('zh-CN option data: names only, no 含补全; filled=#34D399 unknown=#71717A', () => {
     expect(colorForModel(screenshotLikeModels[0]!, 0)).toBe('#71717A')
     expect(colorForModel(screenshotLikeModels[1]!, 1)).toBe('#34D399')
     expect(colorForModel(screenshotLikeModels[2]!, 2)).toBe('#34D399')
@@ -166,33 +187,20 @@ describe('TokenModelComposition hides filledTag (g2.1)', () => {
       props: { models: screenshotLikeModels },
       global: { plugins: [i18n()] },
     })
-    const legend = wrapper.find('[data-testid="token-model-legend"]')
-    const text = legend.text()
-    expect(text).toContain('未知模型')
-    expect(text).toContain('cursor-grok-4.5-high-fast')
-    expect(text).toContain('gpt-5.6-sol-medium')
-    expectNoFilledTagCopy(text)
+    expectNoFilledTagCopy(wrapper.html())
     expect(wrapper.html()).not.toContain('含补全')
-
-    const items = legend.findAll('li')
-    expect(items).toHaveLength(3)
-    const unknownSwatch = items[0]!.find('span.h-2\\.5')
-    const filledSwatch = items[1]!.find('span.h-2\\.5')
-    expect(unknownSwatch.attributes('style')).toMatch(/background:\s*#71717A/i)
-    expect(filledSwatch.attributes('style')).toMatch(/background:\s*#34D399/i)
-
-    const nameSpans = items.map((li) => li.findAll('span')[1]!)
-    expect(nameSpans[0]!.classes()).toContain('text-txt3')
-    expect(nameSpans[1]!.classes()).toContain('text-ok')
-    expect(nameSpans[2]!.classes()).toContain('text-ok')
-    expect(items[0]!.find('[data-testid="unknown-model-badge"]').exists()).toBe(true)
-
-    const fills = chartData(wrapper.vm).map((d) => d.color)
-    expect(fills).toEqual(['#71717A', '#34D399', '#34D399'])
+    const data = chartData(wrapper.vm)
+    expect(data.map((d) => d.name)).toEqual([
+      '未知模型',
+      'cursor-grok-4.5-high-fast',
+      'gpt-5.6-sol-medium',
+    ])
+    expect(data.map((d) => d.color)).toEqual(['#71717A', '#34D399', '#34D399'])
+    expectPieShell(wrapper.vm, 'dark')
     wrapper.unmount()
   })
 
-  it('configured alias: no unknown badge and not #71717A; same-name rows stay distinct (g4.1)', () => {
+  it('configured alias: no unknown gray; same-name rows stay distinct (g4.1)', () => {
     const models = [
       { modelKey: '未知/未分桶', name: 'gpt-5', total: 100, unknown: true },
       { modelKey: 'gpt-5', name: 'gpt-5', total: 80 },
@@ -203,20 +211,15 @@ describe('TokenModelComposition hides filledTag (g2.1)', () => {
       props: { models },
       global: { plugins: [i18n()] },
     })
-    const legend = wrapper.find('[data-testid="token-model-legend"]')
-    expect(legend.text()).toContain('gpt-5')
-    expect(legend.find('[data-testid="unknown-model-badge"]').exists()).toBe(false)
-    const nameSpan = legend.findAll('li')[0]!.findAll('span')[1]!
-    expect(nameSpan.classes()).not.toContain('text-txt3')
-    expect(nameSpan.classes()).toContain('text-txt')
     const fills = chartData(wrapper.vm).map((d) => d.color)
     expect(fills[0]).toBe('#7B61FF')
     expect(fills[0]).not.toBe('#71717A')
-    expect(legend.findAll('li')).toHaveLength(2)
+    expect(chartData(wrapper.vm)).toHaveLength(2)
+    expect(chartData(wrapper.vm).every((d) => d.name === 'gpt-5')).toBe(true)
     wrapper.unmount()
   })
 
-  it('configured alias + filled: sector/legend #34D399 and no badge (g4.1)', () => {
+  it('configured alias + filled: sector #34D399 (g4.1)', () => {
     const models = [
       { modelKey: '未知/未分桶', name: 'Auto', total: 100, unknown: true, filled: true },
       { modelKey: 'cursor-grok', name: 'cursor-grok-4.5-high-fast', total: 80, filled: true },
@@ -226,31 +229,34 @@ describe('TokenModelComposition hides filledTag (g2.1)', () => {
       props: { models },
       global: { plugins: [i18n()] },
     })
-    const legend = wrapper.find('[data-testid="token-model-legend"]')
-    expect(legend.text()).toContain('Auto')
-    expect(legend.find('[data-testid="unknown-model-badge"]').exists()).toBe(false)
-    const nameSpan = legend.findAll('li')[0]!.findAll('span')[1]!
-    expect(nameSpan.classes()).toContain('text-ok')
-    expect(nameSpan.classes()).not.toContain('text-txt3')
+    expect(chartData(wrapper.vm)[0]!.name).toBe('Auto')
     const fills = chartData(wrapper.vm).map((d) => d.color)
     expect(fills).toEqual(['#34D399', '#34D399'])
     wrapper.unmount()
   })
 
-  it('en locale legend: no includes filled data; filled/#71717A colors unchanged', () => {
+  it('en locale option: no includes filled data; filled/#71717A colors unchanged', () => {
     const wrapper = mount(TokenModelComposition, {
       props: { models: screenshotLikeModels },
       global: { plugins: [i18nEn()] },
     })
-    const text = wrapper.find('[data-testid="token-model-legend"]').text()
-    expect(text).toContain('cursor-grok-4.5-high-fast')
-    expect(text).toContain('gpt-5.6-sol-medium')
-    expectNoFilledTagCopy(text)
+    expectNoFilledTagCopy(wrapper.html())
     expect(wrapper.html()).not.toContain('includes filled data')
     expect(wrapper.html()).not.toContain('含补全')
 
     const fills = chartData(wrapper.vm).map((d) => d.color)
     expect(fills).toEqual(['#71717A', '#34D399', '#34D399'])
     wrapper.unmount()
+  })
+
+  it('light theme pie tooltip follows shared shell (g2.3)', () => {
+    setTheme('light')
+    const wrapper = mount(TokenModelComposition, {
+      props: { models: screenshotLikeModels },
+      global: { plugins: [i18n()] },
+    })
+    expectPieShell(wrapper.vm, 'light')
+    wrapper.unmount()
+    setTheme('dark')
   })
 })

--- a/web/src/components/board/token-stats/TokenModelComposition.vue
+++ b/web/src/components/board/token-stats/TokenModelComposition.vue
@@ -3,11 +3,9 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { registerECharts } from '@/components/charts/echartsSetup'
-import { BOARD_CHART_TOOLTIP } from '@/components/charts/chartTheme'
+import { pieChartOption } from '@/components/charts/chartTheme'
 import type { TokenStatsModel } from '@/lib/shared/types'
-import { fmtCompactTokenCount, fmtTokenCount, shouldShowUnknownVisual } from '@/lib/run/tokenUsage'
-import { MODEL_PALETTE, colorForModel } from './tokenModelColors'
-import UnknownModelBadge from '@/components/ui/UnknownModelBadge.vue'
+import { colorForModel } from './tokenModelColors'
 
 registerECharts()
 
@@ -33,47 +31,36 @@ const chartOption = computed(() => {
   if (sum <= 0) return null
   const visible = rows.value.filter((r) => (r.total || 0) > 0)
   if (!visible.length) return null
-  return {
-    tooltip: {
-      trigger: 'item',
-      ...BOARD_CHART_TOOLTIP,
-      formatter: (p: { name: string; value: number; percent: number }) =>
-        `${p.name}: ${fmtTokenCount(p.value)} (${p.percent}%)`,
-    },
-    series: [
-      {
-        type: 'pie',
-        radius: '100%',
-        center: ['50%', '50%'],
-        data: visible.map((r, i) => ({
-          name: r.name,
-          value: r.total || 0,
-          itemStyle: { color: r.color },
-          key: `${r.modelKey || r.name}-${i}`,
-        })),
-        label: { show: false },
-        emphasis: { scale: true, scaleSize: 4 },
-      },
-    ],
-  }
+  return pieChartOption(
+    visible.map((r, i) => ({
+      name: r.name,
+      value: r.total || 0,
+      key: `${r.modelKey || r.name}-${i}`,
+      color: r.color,
+    })),
+    true,
+  )
 })
 
 /** Exposed for unit tests (ECharts option shape). */
-const chartData = computed(() =>
-  chartOption.value?.series?.[0]?.data?.map((d: { name: string; value: number; itemStyle?: { color: string } }) => ({
-    name: d.name,
-    value: d.value,
-    color: d.itemStyle?.color,
-  })) ?? [],
+const chartData = computed(
+  () =>
+    chartOption.value?.series?.[0]?.data?.map(
+      (d: { name: string; value: number; itemStyle?: { color?: string } }, i: number) => ({
+        name: d.name,
+        value: d.value,
+        color: d.itemStyle?.color || chartOption.value?.series?.[0]?.color?.[i],
+      }),
+    ) ?? [],
 )
 
 defineExpose({ chartOption, chartData })
 </script>
 
 <template>
-  <div data-testid="token-model-composition" class="grid gap-3 sm:grid-cols-[120px_1fr] sm:items-center">
+  <div data-testid="token-model-composition" class="relative min-h-[168px] w-full overflow-visible">
     <div
-      class="mx-auto h-[110px] w-[110px]"
+      class="h-[168px] w-full"
       data-testid="token-model-pie"
       role="img"
       :aria-label="t('pages.board.tokenStats.modelCompositionTitle')"
@@ -81,30 +68,16 @@ defineExpose({ chartOption, chartData })
       <VChart v-if="chartOption" :option="chartOption" autoresize class="h-full w-full" />
       <div
         v-else
-        class="h-full w-full rounded-full bg-elevated"
+        class="h-full w-full bg-elevated"
         data-testid="token-model-pie-empty"
       />
     </div>
-    <ul class="m-0 grid list-none gap-1.5 p-0" data-testid="token-model-legend">
-      <li
-        v-for="(r, i) in rows"
-        :key="(r.modelKey || r.name) + '-' + i"
-        class="grid grid-cols-[10px_1fr_auto] items-center gap-2 text-xs"
-      >
-        <span class="h-2.5 w-2.5" :style="{ background: r.color || MODEL_PALETTE[0] }" />
-        <span
-          class="flex min-w-0 items-center gap-1.5 truncate"
-          :class="shouldShowUnknownVisual(r.unknown, r.name) ? 'text-txt3' : r.filled ? 'text-ok' : 'text-txt'"
-          :title="r.name"
-        >
-          <span class="min-w-0 truncate">{{ r.name }}</span>
-          <UnknownModelBadge v-if="shouldShowUnknownVisual(r.unknown, r.name)" />
-        </span>
-        <span class="tabular-nums text-txt3" :title="fmtTokenCount(r.total)">
-          {{ r.pct }}% · {{ fmtCompactTokenCount(r.total) }}
-        </span>
-      </li>
-      <li v-if="!rows.length" class="text-xs text-txt3">{{ t('pages.board.tokenStats.emptyModelCompHint') }}</li>
-    </ul>
+    <p
+      v-if="!rows.length"
+      class="m-0 mt-1 text-xs text-txt3"
+      data-testid="token-model-legend"
+    >
+      {{ t('pages.board.tokenStats.emptyModelCompHint') }}
+    </p>
   </div>
 </template>

--- a/web/src/components/board/token-stats/TokenModelRank.test.ts
+++ b/web/src/components/board/token-stats/TokenModelRank.test.ts
@@ -61,6 +61,9 @@ describe('TokenModelRank ECharts bars (g1.2)', () => {
     expect(wrapper.findAll('[data-testid="token-model-rank-bar"]').length).toBe(4)
     expect(wrapper.findAll('[data-testid="mock-vchart"]').length).toBe(4)
     expect(wrapper.find('.h-full.transition-\\[width\\]').exists()).toBe(false)
+    const unkFill = wrapper.find('[data-unknown="1"] .h-full')
+    expect(unkFill.exists()).toBe(true)
+    expect((unkFill.element as HTMLElement).style.backgroundColor.replace(/\s/g, '')).toMatch(/#71717A|rgb\(113,113,122\)/i)
     wrapper.unmount()
   })
 })
@@ -176,6 +179,8 @@ describe('TokenModelRank unknown vs other (g3.3)', () => {
     expect(unk.text()).not.toContain('other（其余模型）')
     expect(unk.find('.text-txt3').exists()).toBe(true)
     expect(barColor(wrapper.vm, 1)).toBe('#71717A')
+    const unkFill = unk.find('.h-full')
+    expect((unkFill.element as HTMLElement).style.backgroundColor).toBe('#71717A')
 
     const other = wrapper.find('[data-other="1"]')
     expect(other.exists()).toBe(true)

--- a/web/src/components/board/token-stats/TokenModelRank.vue
+++ b/web/src/components/board/token-stats/TokenModelRank.vue
@@ -23,6 +23,10 @@ function displayName(m: TokenStatsModel): string {
   return m.name || m.modelKey || '—'
 }
 
+function barWidthPct(m: TokenStatsModel): number {
+  return Math.max(0, Math.min(100, ((m.total || 0) / maxTotal.value) * 100))
+}
+
 function rowChartOption(m: TokenStatsModel, i: number) {
   const color = colorForModel(m, i)
   return {
@@ -71,8 +75,12 @@ defineExpose({ rowOptions, maxTotal })
           <span class="min-w-0 truncate">{{ displayName(m) }}</span>
           <UnknownModelBadge v-if="shouldShowUnknownVisual(m.unknown, displayName(m))" />
         </div>
-        <div class="mt-1 h-2 overflow-hidden" data-testid="token-model-rank-bar">
-          <VChart :option="rowOptions[i]" autoresize class="h-full w-full" />
+        <div class="relative mt-1 h-2 overflow-hidden" data-testid="token-model-rank-bar">
+          <div
+            class="h-full"
+            :style="{ width: `${barWidthPct(m)}%`, backgroundColor: colorForModel(m, i) }"
+          />
+          <VChart :option="rowOptions[i]" autoresize class="absolute inset-0 w-full" />
         </div>
       </div>
       <span

--- a/web/src/components/board/token-stats/TokenModelRank.vue
+++ b/web/src/components/board/token-stats/TokenModelRank.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { registerECharts } from '@/components/charts/echartsSetup'
-import { BOARD_CHART_TOOLTIP } from '@/components/charts/chartTheme'
+import { statsTooltip } from '@/components/charts/chartTheme'
 import type { TokenStatsModel } from '@/lib/shared/types'
 import { fmtCompactTokenCount, fmtTokenCount, shouldShowUnknownVisual } from '@/lib/run/tokenUsage'
 import UnknownModelBadge from '@/components/ui/UnknownModelBadge.vue'
@@ -30,11 +30,10 @@ function rowChartOption(m: TokenStatsModel, i: number) {
     grid: { left: 0, right: 0, top: 0, bottom: 0 },
     xAxis: { type: 'value', show: false, max: maxTotal.value },
     yAxis: { type: 'category', data: [''], show: false },
-    tooltip: {
+    tooltip: statsTooltip({
       trigger: 'item',
-      ...BOARD_CHART_TOOLTIP,
-      formatter: () => fmtTokenCount(m.total),
-    },
+      formatter: () => fmtCompactTokenCount(m.total),
+    }),
     series: [
       {
         type: 'bar',

--- a/web/src/components/board/token-stats/TokenStatsPanel.test.ts
+++ b/web/src/components/board/token-stats/TokenStatsPanel.test.ts
@@ -190,4 +190,28 @@ describe('TokenStatsPanel', () => {
     expect(wrapper.find('[data-testid="token-stats-charts"]').exists()).toBe(true)
     wrapper.unmount()
   })
+
+  it('chart cards are square-bordered like 用量统计 (g2.2)', async () => {
+    getProjectTokenStats.mockResolvedValue(sampleStats())
+    const wrapper = mountPanel()
+    await flushPromises()
+    const cards = [
+      wrapper.find('[data-testid="token-stats-trend-card"]'),
+      wrapper.find('[data-testid="token-stats-comp-card"]'),
+      wrapper.find('[data-testid="token-stats-rank-card"]'),
+      wrapper.find('[data-testid="token-stats-model-comp-card"]'),
+      wrapper.find('[data-testid="token-stats-model-rank-card"]'),
+    ]
+    for (const card of cards) {
+      expect(card.classes()).toEqual(expect.arrayContaining(['border', 'border-line', 'bg-surface']))
+      expect(card.classes().some((c) => c.startsWith('rounded'))).toBe(false)
+    }
+    wrapper.unmount()
+
+    getProjectTokenStats.mockResolvedValue(sampleStats({ empty: true, trend: [], workflows: [] }))
+    const empty = mountPanel()
+    await flushPromises()
+    expect(empty.find('[data-testid="token-stats-empty"]').html()).not.toMatch(/rounded-xl/)
+    empty.unmount()
+  })
 })

--- a/web/src/components/board/token-stats/TokenStatsPanel.vue
+++ b/web/src/components/board/token-stats/TokenStatsPanel.vue
@@ -152,7 +152,7 @@ onUnmounted(() => {
     <div
       v-if="loading"
       data-testid="token-stats-loading"
-      class="flex min-h-[220px] items-center justify-center rounded-xl border border-line bg-surface text-sm text-txt3"
+      class="flex min-h-[220px] items-center justify-center border border-line bg-surface text-sm text-txt3"
     >
       {{ t('pages.board.tokenStats.loading') }}
     </div>
@@ -161,7 +161,7 @@ onUnmounted(() => {
     <div
       v-else-if="failed"
       data-testid="token-stats-error"
-      class="flex min-h-[180px] flex-col items-center justify-center gap-3 rounded-xl border border-err/40 bg-err/10 px-4 py-6 text-center"
+      class="flex min-h-[180px] flex-col items-center justify-center gap-3 border border-err/40 bg-err/10 px-4 py-6 text-center"
     >
       <p class="m-0 text-sm text-err">{{ t('pages.board.tokenStats.loadFailed') }}</p>
       <button
@@ -180,7 +180,7 @@ onUnmounted(() => {
       data-testid="token-stats-empty"
       class="grid gap-3"
     >
-      <div class="relative min-h-[200px] min-w-0 overflow-x-clip rounded-xl border border-line bg-surface p-3.5">
+      <div class="relative min-h-[200px] min-w-0 overflow-x-clip border border-line bg-surface p-3.5">
         <div class="mb-2 flex items-baseline justify-between gap-2">
           <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.board.tokenStats.trendTitle') }}</h4>
           <span class="text-[11px] text-txt3">{{ grainLabel }}</span>
@@ -191,7 +191,7 @@ onUnmounted(() => {
         </div>
       </div>
       <div class="grid min-w-0 grid-cols-1 gap-3 md:grid-cols-2">
-        <div class="relative min-h-[200px] min-w-0 rounded-xl border border-line bg-surface p-3.5">
+        <div class="relative min-h-[200px] min-w-0 border border-line bg-surface p-3.5">
           <div class="mb-2 flex items-baseline justify-between gap-2">
             <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.board.tokenStats.compositionTitle') }}</h4>
           </div>
@@ -200,7 +200,7 @@ onUnmounted(() => {
             <span class="max-w-[28ch] text-xs text-txt3">{{ t('pages.board.tokenStats.emptyCompHint') }}</span>
           </div>
         </div>
-        <div class="relative min-h-[200px] min-w-0 rounded-xl border border-line bg-surface p-3.5">
+        <div class="relative min-h-[200px] min-w-0 border border-line bg-surface p-3.5">
           <div class="mb-2 flex flex-col gap-1">
             <div class="flex items-baseline justify-between gap-2">
               <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.board.tokenStats.rankTitle') }}</h4>
@@ -218,7 +218,7 @@ onUnmounted(() => {
     <!-- Ready charts -->
     <div v-else-if="data" data-testid="token-stats-charts" class="grid gap-3">
       <div
-        class="min-w-0 overflow-x-clip rounded-xl border border-line bg-surface p-3.5"
+        class="min-w-0 overflow-x-clip border border-line bg-surface p-3.5"
         data-testid="token-stats-trend-card"
       >
         <div class="mb-2 flex items-baseline justify-between gap-2">
@@ -228,7 +228,7 @@ onUnmounted(() => {
         <TokenTrendChart :trend="data.trend" :bucket-width="data.bucketWidth" />
       </div>
       <div class="grid min-w-0 grid-cols-1 gap-3 md:grid-cols-2">
-        <div class="min-w-0 rounded-xl border border-line bg-surface p-3.5" data-testid="token-stats-model-comp-card">
+        <div class="min-w-0 border border-line bg-surface p-3.5" data-testid="token-stats-model-comp-card">
           <div class="mb-2 flex items-baseline justify-between gap-2">
             <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.board.tokenStats.modelCompositionTitle') }}</h4>
             <span class="text-[11px] text-txt3">
@@ -237,7 +237,7 @@ onUnmounted(() => {
           </div>
           <TokenModelComposition :models="data.modelComposition || []" />
         </div>
-        <div class="min-w-0 rounded-xl border border-line bg-surface p-3.5" data-testid="token-stats-model-rank-card">
+        <div class="min-w-0 border border-line bg-surface p-3.5" data-testid="token-stats-model-rank-card">
           <div class="mb-2 flex items-baseline justify-between gap-2" data-testid="token-stats-model-rank-head">
             <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.board.tokenStats.modelRankTitle') }}</h4>
             <span class="text-[11px] text-txt3">{{ t('pages.board.tokenStats.modelRankSub') }}</span>
@@ -246,7 +246,7 @@ onUnmounted(() => {
         </div>
       </div>
       <div class="grid min-w-0 grid-cols-1 gap-3 md:grid-cols-2">
-        <div class="min-w-0 rounded-xl border border-line bg-surface p-3.5" data-testid="token-stats-comp-card">
+        <div class="min-w-0 border border-line bg-surface p-3.5" data-testid="token-stats-comp-card">
           <div class="mb-2 flex items-baseline justify-between gap-2">
             <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.board.tokenStats.compositionTitle') }}</h4>
             <span class="text-[11px] text-txt3">
@@ -255,7 +255,7 @@ onUnmounted(() => {
           </div>
           <TokenDonutChart :composition="data.composition" />
         </div>
-        <div class="min-w-0 rounded-xl border border-line bg-surface p-3.5" data-testid="token-stats-rank-card">
+        <div class="min-w-0 border border-line bg-surface p-3.5" data-testid="token-stats-rank-card">
           <div class="mb-2 flex flex-col gap-1">
             <div class="flex items-baseline justify-between gap-2">
               <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.board.tokenStats.rankTitle') }}</h4>

--- a/web/src/components/board/token-stats/TokenTrendChart.vue
+++ b/web/src/components/board/token-stats/TokenTrendChart.vue
@@ -1,13 +1,18 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
-import type { ECElementEvent } from 'echarts/core'
 import { registerECharts } from '@/components/charts/echartsSetup'
-import { BOARD_CHART_AXIS, CHART_GRID, fmtCompactAxis } from '@/components/charts/chartTheme'
+import {
+  STATS_CHART_GRID,
+  axisTooltip,
+  fmtCompactAxis,
+  statsAxis,
+  statsLegend,
+} from '@/components/charts/chartTheme'
 import type { TokenStatsBucket } from '@/lib/shared/types'
-import { fmtTokenCount } from '@/lib/run/tokenUsage'
-import { TOKEN_SOURCE_COLORS, formatBucketLabel, placeTrendTooltipAfter } from './tokenStatsShared'
+import { fmtCompactTokenCount } from '@/lib/run/tokenUsage'
+import { TOKEN_SOURCE_COLORS, formatBucketLabel } from './tokenStatsShared'
 
 registerECharts()
 
@@ -22,52 +27,50 @@ const CHART_HEIGHT_PX = 200
 const WF_COLOR = TOKEN_SOURCE_COLORS.workflow
 const PM_COLOR = TOKEN_SOURCE_COLORS.pm
 
-const tip = ref({ show: false, x: 0, y: 0, idx: -1 })
-const tipEl = ref<HTMLElement | null>(null)
-const tipBucket = computed(() => (tip.value.idx >= 0 ? props.trend[tip.value.idx] : null))
-
-function hideTip() {
-  tip.value = { ...tip.value, show: false, idx: -1 }
-}
-
-function onChartMouseMove(params: ECElementEvent) {
-  if (params.componentType !== 'series' || params.dataIndex == null) return
-  const idx = params.dataIndex
-  tip.value = { show: true, x: tip.value.x, y: tip.value.y, idx }
-  const ev = params.event?.event as MouseEvent | undefined
-  if (!ev || !tipEl.value) return
-  const pos = placeTrendTooltipAfter({
-    caretX: ev.clientX,
-    caretY: ev.clientY,
-    tipW: tipEl.value.offsetWidth || 168,
-    tipH: tipEl.value.offsetHeight || 72,
-  })
-  tip.value = { ...tip.value, x: pos.left, y: pos.top }
-}
+const wfName = computed(() => t('pages.board.tokenStats.workflow'))
+const pmName = computed(() => t('pages.board.tokenStats.pm'))
 
 const chartOption = computed(() => {
   const labels = props.trend.map((b) => formatBucketLabel(b.bucket, props.bucketWidth))
   const workflow = props.trend.map((b) => b.workflowTotal || 0)
   const pm = props.trend.map((b) => b.pmTotal || 0)
+  const axis = statsAxis()
   return {
-    grid: CHART_GRID,
-    tooltip: { show: false },
+    grid: STATS_CHART_GRID,
+    tooltip: axisTooltip({
+      className: 'token-stats-echarts-tooltip token-trend-tooltip',
+      formatter: (params: unknown) => {
+        const items = (Array.isArray(params) ? params : [params]) as { dataIndex?: number }[]
+        const idx = items[0]?.dataIndex ?? 0
+        const b = props.trend[idx]
+        if (!b) return ''
+        const label = formatBucketLabel(b.bucket, props.bucketWidth)
+        const total = fmtCompactTokenCount(b.total)
+        return `<div>${label} · ${total}</div>
+          <div data-tip-row="workflow">${wfName.value} ${fmtCompactTokenCount(b.workflowTotal || 0)}</div>
+          <div data-tip-row="pm">${pmName.value} ${fmtCompactTokenCount(b.pmTotal || 0)}</div>`
+      },
+    }),
+    legend: {
+      ...statsLegend(),
+      data: [wfName.value, pmName.value],
+    },
     xAxis: {
       type: 'category',
       data: labels,
-      ...BOARD_CHART_AXIS,
+      ...axis,
       splitLine: { show: false },
-      axisLabel: { ...BOARD_CHART_AXIS.axisLabel, maxInterval: Math.ceil(labels.length / 8) },
+      axisLabel: { ...axis.axisLabel, maxInterval: Math.ceil(labels.length / 8) },
     },
     yAxis: {
       type: 'value',
-      ...BOARD_CHART_AXIS,
-      axisLabel: { ...BOARD_CHART_AXIS.axisLabel, formatter: (v: number) => fmtCompactAxis(v) },
+      ...axis,
+      axisLabel: { ...axis.axisLabel, formatter: (v: number) => fmtCompactAxis(v) },
     },
     series: [
       {
         type: 'line',
-        name: 'workflow',
+        name: wfName.value,
         stack: 'source',
         data: workflow,
         lineStyle: { color: WF_COLOR, width: 1.8 },
@@ -77,7 +80,7 @@ const chartOption = computed(() => {
       },
       {
         type: 'line',
-        name: 'pm',
+        name: pmName.value,
         stack: 'source',
         data: pm,
         lineStyle: { color: PM_COLOR, width: 1.8, type: [5, 4] as unknown as 'dashed' },
@@ -90,13 +93,6 @@ const chartOption = computed(() => {
     ],
   }
 })
-
-/** Legacy expose for unit tests (ECharts option shape). */
-const chartOptions = computed(() => ({
-  maintainAspectRatio: false,
-  scales: { x: { ticks: { maxTicksLimit: 8, autoSkip: true } } },
-  plugins: { tooltip: { enabled: false, external: externalTooltip } },
-}))
 
 const chartData = computed(() => ({
   labels: props.trend.map((b) => formatBucketLabel(b.bucket, props.bucketWidth)),
@@ -111,104 +107,19 @@ const chartData = computed(() => ({
   ],
 }))
 
-function externalTooltip(context: {
-  chart: { canvas: HTMLCanvasElement }
-  tooltip: { opacity: number; caretX: number; caretY: number; dataPoints?: { dataIndex: number }[] }
-}) {
-  const { tooltip } = context
-  if (tooltip.opacity === 0 || !tooltip.dataPoints?.length) {
-    hideTip()
-    return
-  }
-  const idx = tooltip.dataPoints[0]!.dataIndex
-  tip.value = { show: true, x: tooltip.caretX, y: tooltip.caretY, idx }
-}
-
-function onViewportChange() {
-  if (tip.value.show && tipEl.value) {
-    // reposition handled on next mousemove
-  }
-}
-
-watch(
-  () => props.trend,
-  () => hideTip(),
-)
-
-onMounted(() => {
-  window.addEventListener('resize', onViewportChange)
-  window.addEventListener('scroll', onViewportChange, true)
-})
-
-onBeforeUnmount(() => {
-  window.removeEventListener('resize', onViewportChange)
-  window.removeEventListener('scroll', onViewportChange, true)
-  hideTip()
-})
-
-defineExpose({ chartOptions, chartData, externalTooltip, hideTip })
+defineExpose({ chartOption, chartData })
 </script>
 
 <template>
   <div
     data-testid="token-trend-wrap"
-    class="token-trend-wrap relative w-full min-w-0 overflow-x-clip"
+    class="token-trend-wrap relative w-full min-w-0 overflow-x-clip overflow-y-visible"
     :style="{ height: `${CHART_HEIGHT_PX}px` }"
     role="img"
     :aria-label="t('pages.board.tokenStats.trendTitle')"
-    @mouseleave="hideTip"
   >
-    <div
-      data-testid="token-trend-legend"
-      class="mb-1 flex flex-wrap items-center gap-3 text-[11px] text-txt3"
-    >
-      <span class="inline-flex items-center gap-1.5" data-kind="workflow">
-        <i class="inline-block h-2 w-2 rounded-sm" :style="{ background: WF_COLOR }" />
-        {{ t('pages.board.tokenStats.workflow') }}
-      </span>
-      <span class="inline-flex items-center gap-1.5" data-kind="pm">
-        <i
-          class="inline-block h-0 w-3 border-t-2 border-dashed"
-          :style="{ borderColor: PM_COLOR }"
-          aria-hidden="true"
-        />
-        {{ t('pages.board.tokenStats.pm') }}
-      </span>
-    </div>
-    <div data-testid="token-trend-chart" class="h-[calc(100%-22px)] w-full">
-      <VChart :option="chartOption" autoresize class="h-full w-full" @mousemove="onChartMouseMove" @globalout="hideTip" />
+    <div data-testid="token-trend-chart" class="h-full w-full overflow-visible">
+      <VChart :option="chartOption" autoresize class="h-full w-full" />
     </div>
   </div>
-  <Teleport to="body">
-    <div
-      v-if="tip.show && tipBucket"
-      ref="tipEl"
-      data-testid="token-trend-tooltip"
-      class="pointer-events-none fixed z-[100] min-w-[140px] rounded-lg bg-[#1a1d23] px-2.5 py-2 text-[11px] text-white shadow-lg"
-      :style="{ left: tip.x + 'px', top: tip.y + 'px' }"
-    >
-      <div class="mb-1 font-semibold">
-        {{ formatBucketLabel(tipBucket.bucket, bucketWidth) }}
-        · {{ fmtTokenCount(tipBucket.total) }}
-      </div>
-      <div class="flex justify-between gap-3 text-[#c7cbd4]" data-tip-row="workflow">
-        <span class="inline-flex items-center gap-1.5">
-          <i class="inline-block h-2 w-2 rounded-sm" :style="{ background: WF_COLOR }" />
-          {{ t('pages.board.tokenStats.workflow') }}
-        </span>
-        <b class="font-normal tabular-nums text-white">{{ fmtTokenCount(tipBucket.workflowTotal || 0) }}</b>
-      </div>
-      <div class="flex justify-between gap-3 text-[#c7cbd4]" data-tip-row="pm">
-        <span class="inline-flex items-center gap-1.5">
-          <i
-            class="inline-block h-0 w-3 border-t-2 border-dashed"
-            :style="{ borderColor: PM_COLOR }"
-            aria-hidden="true"
-          />
-          {{ t('pages.board.tokenStats.pm') }}
-        </span>
-        <b class="font-normal tabular-nums text-white">{{ fmtTokenCount(tipBucket.pmTotal || 0) }}</b>
-      </div>
-    </div>
-  </Teleport>
 </template>

--- a/web/src/components/board/token-stats/TokenTrendChart.vue
+++ b/web/src/components/board/token-stats/TokenTrendChart.vue
@@ -1,18 +1,25 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { registerECharts } from '@/components/charts/echartsSetup'
 import {
-  STATS_CHART_GRID,
+  TREND_CHART_GRID,
   axisTooltip,
+  chartTone,
   fmtCompactAxis,
   statsAxis,
   statsLegend,
 } from '@/components/charts/chartTheme'
 import type { TokenStatsBucket } from '@/lib/shared/types'
 import { fmtCompactTokenCount } from '@/lib/run/tokenUsage'
-import { TOKEN_SOURCE_COLORS, formatBucketLabel } from './tokenStatsShared'
+import {
+  TOKEN_SOURCE_COLORS,
+  echartsTooltipPosition,
+  formatBucketLabel,
+  placeTrendTooltipAfter,
+  trendCategoryIndexAtX,
+} from './tokenStatsShared'
 
 registerECharts()
 
@@ -29,6 +36,35 @@ const PM_COLOR = TOKEN_SOURCE_COLORS.pm
 
 const wfName = computed(() => t('pages.board.tokenStats.workflow'))
 const pmName = computed(() => t('pages.board.tokenStats.pm'))
+const tone = computed(() => chartTone())
+
+const wrapRef = ref<HTMLElement | null>(null)
+const tipEl = ref<HTMLElement | null>(null)
+const tip = ref({ show: false, x: 0, y: 0, idx: -1 })
+const tipBucket = computed(() => (tip.value.idx >= 0 ? props.trend[tip.value.idx] : null))
+
+function hideTip() {
+  tip.value = { ...tip.value, show: false, idx: -1 }
+}
+
+function onWrapMouseMove(e: MouseEvent) {
+  const wrap = wrapRef.value
+  if (!wrap || !props.trend.length) return
+  const rect = wrap.getBoundingClientRect()
+  const idx = trendCategoryIndexAtX(e.clientX - rect.left, rect.width, props.trend.length)
+  const pos = placeTrendTooltipAfter({
+    caretX: e.clientX,
+    caretY: e.clientY,
+    tipW: tipEl.value?.offsetWidth || 168,
+    tipH: tipEl.value?.offsetHeight || 72,
+  })
+  tip.value = { show: true, x: pos.left, y: pos.top, idx }
+}
+
+watch(
+  () => props.trend,
+  () => hideTip(),
+)
 
 const chartOption = computed(() => {
   const labels = props.trend.map((b) => formatBucketLabel(b.bucket, props.bucketWidth))
@@ -36,9 +72,24 @@ const chartOption = computed(() => {
   const pm = props.trend.map((b) => b.pmTotal || 0)
   const axis = statsAxis()
   return {
-    grid: STATS_CHART_GRID,
+    grid: TREND_CHART_GRID,
     tooltip: axisTooltip({
-      className: 'token-stats-echarts-tooltip token-trend-tooltip',
+      // Option keeps shared chrome + className for unit-test contract.
+      // DOM tooltip is the Teleport node (v-if) so Playwright count goes to 0 on leave.
+      show: false,
+      className: 'token-stats-echarts-tooltip',
+      triggerOn: 'mousemove',
+      axisPointer: { type: 'line' as const, snap: true, animation: false },
+      position: (
+        point: number[],
+        _params: unknown,
+        _dom: unknown,
+        _rect: unknown,
+        size: { contentSize: number[] },
+      ) => {
+        const box = wrapRef.value?.getBoundingClientRect() ?? null
+        return echartsTooltipPosition(point, size.contentSize, box)
+      },
       formatter: (params: unknown) => {
         const items = (Array.isArray(params) ? params : [params]) as { dataIndex?: number }[]
         const idx = items[0]?.dataIndex ?? 0
@@ -76,6 +127,7 @@ const chartOption = computed(() => {
         lineStyle: { color: WF_COLOR, width: 1.8 },
         areaStyle: { color: 'rgba(109, 92, 255, 0.28)' },
         showSymbol: false,
+        clip: false,
         smooth: true,
       },
       {
@@ -87,6 +139,7 @@ const chartOption = computed(() => {
         areaStyle: { color: 'rgba(109, 92, 255, 0.14)' },
         symbol: 'circle',
         symbolSize: 7,
+        clip: false,
         itemStyle: { color: '#fff', borderColor: PM_COLOR, borderWidth: 2 },
         smooth: true,
       },
@@ -107,19 +160,48 @@ const chartData = computed(() => ({
   ],
 }))
 
-defineExpose({ chartOption, chartData })
+defineExpose({ chartOption, chartData, hideTip })
 </script>
 
 <template>
   <div
+    ref="wrapRef"
     data-testid="token-trend-wrap"
     class="token-trend-wrap relative w-full min-w-0 overflow-x-clip overflow-y-visible"
     :style="{ height: `${CHART_HEIGHT_PX}px` }"
     role="img"
     :aria-label="t('pages.board.tokenStats.trendTitle')"
+    @mousemove.capture="onWrapMouseMove"
+    @mouseleave="hideTip"
   >
     <div data-testid="token-trend-chart" class="h-full w-full overflow-visible">
       <VChart :option="chartOption" autoresize class="h-full w-full" />
     </div>
   </div>
+  <Teleport to="body">
+    <div
+      v-if="tip.show && tipBucket"
+      ref="tipEl"
+      class="token-stats-echarts-tooltip token-trend-tooltip pointer-events-none fixed z-[1000] min-w-[140px] px-2.5 py-2 text-[11px]"
+      :style="{
+        left: tip.x + 'px',
+        top: tip.y + 'px',
+        backgroundColor: tone.tooltipBg,
+        border: `1px solid ${tone.tooltipBorder}`,
+        color: tone.tooltipText,
+        borderRadius: '0',
+      }"
+    >
+      <div>
+        {{ formatBucketLabel(tipBucket.bucket, bucketWidth) }}
+        · {{ fmtCompactTokenCount(tipBucket.total) }}
+      </div>
+      <div data-tip-row="workflow">
+        {{ wfName }} {{ fmtCompactTokenCount(tipBucket.workflowTotal || 0) }}
+      </div>
+      <div data-tip-row="pm">
+        {{ pmName }} {{ fmtCompactTokenCount(tipBucket.pmTotal || 0) }}
+      </div>
+    </div>
+  </Teleport>
 </template>

--- a/web/src/components/board/token-stats/TokenWorkflowRank.vue
+++ b/web/src/components/board/token-stats/TokenWorkflowRank.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { registerECharts } from '@/components/charts/echartsSetup'
-import { BOARD_CHART_TOOLTIP } from '@/components/charts/chartTheme'
+import { statsTooltip } from '@/components/charts/chartTheme'
 import type { TokenStatsWorkflow } from '@/lib/shared/types'
 import { fmtCompactTokenCount, fmtTokenCount } from '@/lib/run/tokenUsage'
 
@@ -38,7 +38,6 @@ const props = defineProps<{
 }>()
 
 const { t } = useI18n()
-const activeIdx = ref<number | null>(null)
 
 const maxTotal = computed(() => Math.max(1, ...props.workflows.map((w) => w.total || 0)))
 
@@ -84,11 +83,10 @@ function rowChartOption(w: TokenStatsWorkflow) {
     grid: { left: 0, right: 0, top: 0, bottom: 0 },
     xAxis: { type: 'value', show: false, max: maxTotal.value },
     yAxis: { type: 'category', data: [''], show: false },
-    tooltip: {
+    tooltip: statsTooltip({
       trigger: 'item',
-      ...BOARD_CHART_TOOLTIP,
-      formatter: () => fmtTokenCount(w.total),
-    },
+      formatter: () => `${displayName(w)}: ${fmtCompactTokenCount(w.total)}`,
+    }),
     series: [
       {
         type: 'bar',
@@ -96,35 +94,13 @@ function rowChartOption(w: TokenStatsWorkflow) {
         barWidth: 8,
         itemStyle: { color: barColor(w), borderRadius: [0, 999, 999, 0] },
         showBackground: true,
-        backgroundStyle: { color: '#f1f3f6' },
+        backgroundStyle: { color: 'rgb(var(--c-elevated))' },
       },
     ],
   }
 }
 
 const rowOptions = computed(() => props.workflows.map((w) => rowChartOption(w)))
-
-const tip = ref({ show: false, x: 0, y: 0, idx: -1 })
-
-function showTip(i: number, ev: MouseEvent) {
-  activeIdx.value = i
-  const wrap = (ev.currentTarget as HTMLElement).closest('[data-testid="token-rank-list"]') as HTMLElement | null
-  if (!wrap) return
-  const rect = wrap.getBoundingClientRect()
-  tip.value = {
-    show: true,
-    x: ev.clientX - rect.left,
-    y: ev.clientY - rect.top,
-    idx: i,
-  }
-}
-
-function hideTip() {
-  activeIdx.value = null
-  tip.value = { ...tip.value, show: false }
-}
-
-const tipRow = computed(() => (tip.value.idx >= 0 ? props.workflows[tip.value.idx] : null))
 
 defineExpose({ rowOptions, maxTotal, barColor })
 </script>
@@ -134,17 +110,12 @@ defineExpose({ rowOptions, maxTotal, barColor })
     <li
       v-for="(w, i) in workflows"
       :key="(w.kind || '') + '-' + (w.workflowId || w.name) + '-' + i"
-      class="grid cursor-pointer grid-cols-[22px_1fr_auto] items-center gap-2 rounded-md px-0.5 py-1"
+      class="grid grid-cols-[22px_1fr_auto] items-center gap-2 px-0.5 py-1"
       :class="[
         isOther(w) ? 'token-rank-other' : '',
         isPM(w) ? 'token-rank-pm' : '',
-        activeIdx === i ? 'bg-elevated' : 'hover:bg-elevated/80',
       ]"
       :data-kind="w.kind || (isPM(w) ? 'pm' : isOther(w) ? 'other' : 'workflow')"
-      @mouseenter="showTip(i, $event)"
-      @mousemove="showTip(i, $event)"
-      @mouseleave="hideTip"
-      @click="showTip(i, $event)"
     >
       <span
         class="grid h-[22px] place-items-center rounded-md text-[11px] font-bold"
@@ -154,7 +125,7 @@ defineExpose({ rowOptions, maxTotal, barColor })
       </span>
       <div class="min-w-0">
         <div class="truncate text-xs font-medium text-txt">{{ displayName(w) }}</div>
-        <div class="mt-1 h-2 overflow-hidden rounded-full" data-testid="token-rank-bar">
+        <div class="mt-1 h-2 overflow-visible" data-testid="token-rank-bar">
           <VChart :option="rowOptions[i]" autoresize class="h-full w-full" />
         </div>
       </div>
@@ -164,17 +135,5 @@ defineExpose({ rowOptions, maxTotal, barColor })
         data-testid="token-rank-value"
       >{{ fmtCompactTokenCount(w.total) }}</span>
     </li>
-    <div
-      v-if="tip.show && tipRow"
-      data-testid="token-rank-tooltip"
-      class="pointer-events-none absolute z-10 min-w-[120px] rounded-lg bg-[#1a1d23] px-2.5 py-2 text-[11px] text-white shadow-lg"
-      :style="{ left: tip.x + 'px', top: tip.y + 'px', transform: 'translate(-10%, -110%)' }"
-    >
-      <div class="mb-1 font-semibold">{{ displayName(tipRow) }}</div>
-      <div class="flex justify-between gap-3 text-[#c7cbd4]">
-        <span>{{ t('pages.board.tokenStats.value') }}</span>
-        <b class="font-normal tabular-nums text-white">{{ fmtTokenCount(tipRow.total) }}</b>
-      </div>
-    </div>
   </ul>
 </template>

--- a/web/src/components/board/token-stats/tokenStatsShared.test.ts
+++ b/web/src/components/board/token-stats/tokenStatsShared.test.ts
@@ -1,6 +1,14 @@
 // @vitest-environment happy-dom
 import { describe, expect, it } from 'vitest'
-import { formatBucketLabel, placeTrendTooltipAfter, TREND_TOOLTIP_GAP, TREND_TOOLTIP_PAD } from './tokenStatsShared'
+import {
+  formatBucketLabel,
+  placeTrendTooltipAfter,
+  echartsTooltipPosition,
+  trendCategoryIndexAtX,
+  TREND_TOOLTIP_GAP,
+  TREND_TOOLTIP_PAD,
+  TREND_PLOT_LEFT,
+} from './tokenStatsShared'
 
 describe('formatBucketLabel', () => {
   it('formats day buckets as MM-DD and week buckets as Wxx', () => {
@@ -63,5 +71,30 @@ describe('placeTrendTooltipAfter (Demo placeAfter, g2.1–g2.4)', () => {
     expect(pos.top + tallH).toBeLessThanOrEqual(220 - TREND_TOOLTIP_PAD)
     expect(pos.left).toBeGreaterThanOrEqual(TREND_TOOLTIP_PAD)
     expect(pos.left + 168).toBeLessThanOrEqual(vw - TREND_TOOLTIP_PAD)
+  })
+})
+
+describe('trendCategoryIndexAtX left-edge 0-value (g2.2 / g4.5)', () => {
+  it('maps E2E hover band x=40–48 to index 0 (07-11) on typical canvas widths', () => {
+    expect(TREND_PLOT_LEFT).toBe(42)
+    for (const width of [390, 450, 900]) {
+      expect(trendCategoryIndexAtX(40, width, 30)).toBe(0)
+      expect(trendCategoryIndexAtX(48, width, 30)).toBe(0)
+    }
+    expect(trendCategoryIndexAtX(0, 450, 30)).toBe(0)
+    expect(trendCategoryIndexAtX(450, 450, 30)).toBe(29)
+  })
+})
+
+describe('echartsTooltipPosition (g2.2)', () => {
+  it('keeps left-edge 07-11 tooltip inside the viewport after container offset', () => {
+    const container = { left: 200, top: 120 }
+    const [x, y] = echartsTooltipPosition([48, 172], [168, 72], container)
+    const viewLeft = container.left + x
+    const viewTop = container.top + y
+    expect(viewLeft).toBeGreaterThanOrEqual(TREND_TOOLTIP_PAD)
+    expect(viewTop).toBeGreaterThanOrEqual(TREND_TOOLTIP_PAD)
+    expect(viewLeft + 168).toBeLessThanOrEqual((typeof window !== 'undefined' ? window.innerWidth : 1024) + 1)
+    expect(viewTop + 72).toBeLessThanOrEqual((typeof window !== 'undefined' ? window.innerHeight : 768) + 1)
   })
 })

--- a/web/src/components/board/token-stats/tokenStatsShared.ts
+++ b/web/src/components/board/token-stats/tokenStatsShared.ts
@@ -44,6 +44,22 @@ export function formatBucketLabel(bucket: string, bucketWidth: string): string {
 export const TREND_TOOLTIP_PAD = 8
 export const TREND_TOOLTIP_GAP = 10
 
+/** Matches TREND_CHART_GRID (CHART_GRID left/right, containLabel:false). */
+export const TREND_PLOT_LEFT = 42
+export const TREND_PLOT_RIGHT = 12
+
+/**
+ * Map canvas-local x to a category index (boundaryGap:true, n equal slots).
+ * x in the y-axis gutter or first slot snaps to 0 so a left-edge 0-value
+ * point (07-11) stays hoverable in the E2E band x=40–96.
+ */
+export function trendCategoryIndexAtX(x: number, width: number, n: number): number {
+  if (n <= 1) return 0
+  const plotW = Math.max(1, width - TREND_PLOT_LEFT - TREND_PLOT_RIGHT)
+  const idx = Math.floor((x - TREND_PLOT_LEFT) / (plotW / n))
+  return Math.max(0, Math.min(n - 1, idx))
+}
+
 /**
  * Viewport placement for TokenTrendChart tooltip (Demo placeAfter).
  * Prefer above the caret; flip up↔down / left↔right on overflow, then clamp by real box size.
@@ -75,4 +91,21 @@ export function placeTrendTooltipAfter(input: {
   if (left + tipW > vw - pad) left = vw - pad - tipW
 
   return { left, top }
+}
+
+/** ECharts tooltip.position: container-relative, viewport-clamped via placeAfter. */
+export function echartsTooltipPosition(
+  point: number[],
+  contentSize: number[],
+  container: { left: number; top: number } | null,
+): [number, number] {
+  const caretX = (container?.left ?? 0) + (point[0] ?? 0)
+  const caretY = (container?.top ?? 0) + (point[1] ?? 0)
+  const placed = placeTrendTooltipAfter({
+    caretX,
+    caretY,
+    tipW: contentSize[0] ?? 168,
+    tipH: contentSize[1] ?? 72,
+  })
+  return [placed.left - (container?.left ?? 0), placed.top - (container?.top ?? 0)]
 }

--- a/web/src/components/charts/chartTheme.test.ts
+++ b/web/src/components/charts/chartTheme.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it } from 'vitest'
+import { setTheme } from '@/lib/shared/theme'
+import {
+  axisTooltip,
+  chartTone,
+  pieChartOption,
+  pieLegend,
+  pieTooltipFormatter,
+  statsAxis,
+  statsLegend,
+  statsTooltip,
+} from './chartTheme'
+
+describe('chartTheme shared chrome (g1.1)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.classList.remove('light')
+    setTheme('dark')
+  })
+
+  it('dark tone uses zinc tooltip and low-contrast split lines', () => {
+    setTheme('dark')
+    const tone = chartTone()
+    expect(tone.tooltipBg).toBe('#27272a')
+    expect(tone.tooltipText).toBe('#e4e4e7')
+    expect(tone.splitLine).toBe('rgba(255,255,255,0.08)')
+    expect(tone.axisLabel).toBe('#a1a1aa')
+    const tip = statsTooltip()
+    expect(tip.borderRadius).toBe(0)
+    expect(tip.backgroundColor).toBe('#27272a')
+    expect(tip.appendToBody).toBe(true)
+    expect(tip.confine).toBe(false)
+    expect(JSON.stringify(tip)).not.toContain('#1a1d23')
+  })
+
+  it('light tone uses white tooltip and light-gray split lines', () => {
+    setTheme('light')
+    const tone = chartTone()
+    expect(tone.tooltipBg).toBe('#ffffff')
+    expect(tone.tooltipText).toBe('#27272a')
+    expect(tone.splitLine).toBe('#eef0f3')
+    expect(tone.axisLabel).toBe('#71717a')
+    const tip = statsTooltip()
+    expect(tip.backgroundColor).toBe('#ffffff')
+    expect(tip.textStyle.color).toBe('#27272a')
+    expect(tip.borderRadius).toBe(0)
+    expect(statsAxis().splitLine.lineStyle.color).toBe('#eef0f3')
+  })
+
+  it('pie legend is vertical on the right; axis legend is top-left', () => {
+    const pie = pieLegend()
+    expect(pie.orient).toBe('vertical')
+    expect(pie.right).toBe(0)
+    expect(pie.show).toBe(true)
+    const axis = statsLegend()
+    expect(axis.top).toBe(0)
+    expect(axis.left).toBe(0)
+  })
+
+  it('pie option shows name+percent labels and compact tooltip', () => {
+    const option = pieChartOption(
+      [
+        { name: '输入', value: 396_400, color: '#3b82f6' },
+        { name: '输出', value: 100, color: '#8b5cf6' },
+      ],
+      false,
+    )
+    expect(option).toBeTruthy()
+    expect(option!.legend.orient).toBe('vertical')
+    expect(option!.legend.right).toBe(0)
+    expect(option!.series[0]!.label.show).toBe(true)
+    expect(option!.series[0]!.label.formatter).toBe('{b} {d}%')
+    expect(option!.series[0]!.center[0]).toBe('38%')
+    expect(option!.tooltip.borderRadius).toBe(0)
+    expect(option!.tooltip.appendToBody).toBe(true)
+    expect(typeof option!.tooltip.formatter).toBe('function')
+    expect(pieTooltipFormatter({ name: '输入', value: 396_400, percent: 99.9 })).toBe('输入: 396.4K (99.9%)')
+    expect(axisTooltip().valueFormatter?.(2_080_982_825)).toBe('2.08B')
+  })
+})

--- a/web/src/components/charts/chartTheme.test.ts
+++ b/web/src/components/charts/chartTheme.test.ts
@@ -10,6 +10,8 @@ import {
   statsAxis,
   statsLegend,
   statsTooltip,
+  TREND_CHART_GRID,
+  CHART_GRID,
 } from './chartTheme'
 
 describe('chartTheme shared chrome (g1.1)', () => {
@@ -77,5 +79,12 @@ describe('chartTheme shared chrome (g1.1)', () => {
     expect(typeof option!.tooltip.formatter).toBe('function')
     expect(pieTooltipFormatter({ name: '输入', value: 396_400, percent: 99.9 })).toBe('输入: 396.4K (99.9%)')
     expect(axisTooltip().valueFormatter?.(2_080_982_825)).toBe('2.08B')
+  })
+
+  it('board trend grid keeps first category in the left-edge hover band (g2.2)', () => {
+    expect(TREND_CHART_GRID.left).toBe(CHART_GRID.left)
+    expect(TREND_CHART_GRID.left).toBe(42)
+    expect(TREND_CHART_GRID.containLabel).toBe(false)
+    expect(TREND_CHART_GRID.top).toBe(40)
   })
 })

--- a/web/src/components/charts/chartTheme.ts
+++ b/web/src/components/charts/chartTheme.ts
@@ -26,6 +26,19 @@ export const STATS_CHART_GRID = {
   containLabel: true,
 }
 
+/**
+ * Board trend plot. Keep CHART_GRID left/right (containLabel:false) so the first
+ * category sits in the left-edge hover band (canvas x≈40–96, g4.5 / 07-11 · 0).
+ * top is raised for the shared top-left legend.
+ */
+export const TREND_CHART_GRID = {
+  left: CHART_GRID.left,
+  right: CHART_GRID.right,
+  top: 40,
+  bottom: CHART_GRID.bottom,
+  containLabel: false,
+}
+
 export const ECHARTS_TOOLTIP_CLASS = 'token-stats-echarts-tooltip'
 
 export type ChartTone = {

--- a/web/src/components/charts/chartTheme.ts
+++ b/web/src/components/charts/chartTheme.ts
@@ -1,23 +1,12 @@
-/** Shared ECharts axis / grid styling aligned with board token charts. */
+/** Shared ECharts chart chrome aligned with Token Analytics (用量统计). */
+import { theme } from '@/lib/shared/theme'
+import { fmtCompactTokenCount } from '@/lib/run/tokenUsage'
+
 export const CHART_AXIS = {
   axisLine: { show: false },
   axisTick: { show: false },
   axisLabel: { color: '#9aa1ad', fontSize: 10 },
   splitLine: { lineStyle: { color: '#eef0f3' } },
-}
-
-/** Dark board token panel: unified axis / grid / tooltip tones. */
-export const BOARD_CHART_AXIS = {
-  ...CHART_AXIS,
-  axisLabel: { ...CHART_AXIS.axisLabel, color: '#9aa1ad' },
-  splitLine: { lineStyle: { color: '#2a2e36' } },
-}
-
-export const BOARD_CHART_TOOLTIP = {
-  borderRadius: 8,
-  backgroundColor: '#1a1d23',
-  borderColor: '#2a2e36',
-  textStyle: { color: '#e8eaed', fontSize: 11 },
 }
 
 export const CHART_GRID = {
@@ -26,6 +15,147 @@ export const CHART_GRID = {
   top: 12,
   bottom: 28,
   containLabel: false,
+}
+
+/** Axis-chart plot padding used by 用量统计 (room for top-left legend). */
+export const STATS_CHART_GRID = {
+  left: 56,
+  right: 16,
+  top: 40,
+  bottom: 52,
+  containLabel: true,
+}
+
+export const ECHARTS_TOOLTIP_CLASS = 'token-stats-echarts-tooltip'
+
+export type ChartTone = {
+  axisLabel: string
+  splitLine: string
+  legend: string
+  pieLabel: string
+  heatLow: string
+  heatHigh: string
+  tooltipBg: string
+  tooltipBorder: string
+  tooltipText: string
+}
+
+/** Light/dark tones for axis, legend, pie labels, heatmap, and tooltip. */
+export function chartTone(): ChartTone {
+  const dark = theme.value === 'dark'
+  return {
+    axisLabel: dark ? '#a1a1aa' : '#71717a',
+    splitLine: dark ? 'rgba(255,255,255,0.08)' : '#eef0f3',
+    legend: dark ? '#a1a1aa' : '#8b8b96',
+    pieLabel: dark ? '#d4d4d8' : '#52525b',
+    heatLow: dark ? '#1f1f36' : '#efeaff',
+    heatHigh: '#5b4dff',
+    tooltipBg: dark ? '#27272a' : '#ffffff',
+    tooltipBorder: dark ? '#3f3f46' : '#e4e4e7',
+    tooltipText: dark ? '#e4e4e7' : '#27272a',
+  }
+}
+
+export function statsAxis() {
+  const tone = chartTone()
+  return {
+    ...CHART_AXIS,
+    axisLabel: { ...CHART_AXIS.axisLabel, color: tone.axisLabel, hideOverlap: true },
+    splitLine: { lineStyle: { color: tone.splitLine } },
+  }
+}
+
+/** Axis-chart legend: top-left squares, matching 用量统计. */
+export function statsLegend() {
+  return {
+    top: 0,
+    left: 0,
+    itemWidth: 12,
+    itemHeight: 8,
+    itemStyle: { borderRadius: 0 },
+    textStyle: { fontSize: 11, color: chartTone().legend },
+  }
+}
+
+/** Pie/donut legend: vertical, flush right. */
+export function pieLegend() {
+  return {
+    show: true,
+    orient: 'vertical' as const,
+    right: 0,
+    top: 'middle' as const,
+    type: 'scroll' as const,
+    itemWidth: 10,
+    itemHeight: 8,
+    itemStyle: { borderRadius: 0 },
+    textStyle: { fontSize: 10, color: chartTone().legend },
+  }
+}
+
+export function statsTooltip<T extends Record<string, unknown> = Record<string, never>>(extra?: T) {
+  const tone = chartTone()
+  return {
+    borderRadius: 0,
+    backgroundColor: tone.tooltipBg,
+    borderColor: tone.tooltipBorder,
+    textStyle: { color: tone.tooltipText, fontSize: 12 },
+    confine: false,
+    appendToBody: true,
+    extraCssText: 'z-index: 1000; border-radius: 0;',
+    className: ECHARTS_TOOLTIP_CLASS,
+    ...(extra ?? ({} as T)),
+  }
+}
+
+export function axisTooltip<T extends Record<string, unknown> = Record<string, never>>(extra?: T) {
+  return statsTooltip({
+    trigger: 'axis',
+    valueFormatter: (v: number) => fmtCompactTokenCount(v),
+    ...(extra ?? ({} as T)),
+  })
+}
+
+export function pieTooltipFormatter(params: unknown): string {
+  const p = params as { name?: string; value?: number; percent?: number }
+  const name = p.name ?? ''
+  const value = fmtCompactTokenCount(p.value ?? 0)
+  const pct = p.percent != null ? p.percent.toFixed(1) : '0'
+  return `${name}: ${value} (${pct}%)`
+}
+
+export type PieSlice = { name: string; value: number; key?: string; color?: string }
+
+/** Shared pie/donut option: right legend + visible name+percent labels. */
+export function pieChartOption(slices: PieSlice[], donut = false) {
+  if (!slices.length) return null
+  const tone = chartTone()
+  const colors = slices.map((s, i) => s.color || ['#4f46e5', '#7c6dff', '#a99cff', '#94a3b8'][i % 4])
+  return {
+    tooltip: statsTooltip({ trigger: 'item', formatter: pieTooltipFormatter }),
+    legend: pieLegend(),
+    series: [
+      {
+        type: 'pie' as const,
+        radius: donut ? (['36%', '54%'] as [string, string]) : '54%',
+        center: ['38%', '50%'],
+        data: slices.map((s) => ({
+          name: s.name,
+          value: s.value,
+          key: s.key,
+          itemStyle: s.color ? { color: s.color } : undefined,
+        })),
+        itemStyle: { borderWidth: 0 },
+        color: colors,
+        label: {
+          show: true,
+          formatter: '{b} {d}%',
+          fontSize: 10,
+          color: tone.pieLabel,
+        },
+        labelLayout: { hideOverlap: true },
+      },
+    ],
+  }
 }
 
 export function fmtCompactAxis(n: number): string {

--- a/web/src/views/TokenAnalyticsView.test.ts
+++ b/web/src/views/TokenAnalyticsView.test.ts
@@ -173,6 +173,8 @@ describe('TokenAnalyticsView', () => {
     expect(option.series?.[0]?.center?.[0]).toBe('38%')
     expect(typeof option.tooltip?.formatter).toBe('function')
     expect(option.tooltip?.appendToBody).toBe(true)
+    expect((option.tooltip as { borderRadius?: number })?.borderRadius).toBe(0)
+    expect(JSON.stringify(option.tooltip)).not.toContain('#1a1d23')
     wrapper.unmount()
   })
 

--- a/web/src/views/TokenAnalyticsView.vue
+++ b/web/src/views/TokenAnalyticsView.vue
@@ -4,7 +4,16 @@ import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { registerECharts } from '@/components/charts/echartsSetup'
-import { CHART_AXIS, fmtCompactAxis } from '@/components/charts/chartTheme'
+import {
+  STATS_CHART_GRID,
+  axisTooltip,
+  chartTone,
+  fmtCompactAxis,
+  pieChartOption,
+  statsAxis,
+  statsLegend,
+  statsTooltip,
+} from '@/components/charts/chartTheme'
 import { api } from '@/lib/api/api'
 import type { GlobalTokenStats, TokenStatsWindow } from '@/lib/shared/types'
 import { fmtCompactTokenCount, fmtTokenCount } from '@/lib/run/tokenUsage'
@@ -19,7 +28,6 @@ import {
   type TokenPartKey,
 } from '@/components/board/token-stats/tokenStatsShared'
 import { useToast } from '@/lib/composables/useToast'
-import { theme } from '@/lib/shared/theme'
 registerECharts()
 
 const { t } = useI18n()
@@ -40,77 +48,6 @@ const data = ref<GlobalTokenStats | null>(null)
 
 let abort: AbortController | null = null
 let generation = 0
-
-const STATS_CHART_GRID = {
-  left: 56,
-  right: 16,
-  top: 40,
-  bottom: 52,
-  containLabel: true,
-}
-
-const chartTone = computed(() => {
-  void theme.value
-  const dark = theme.value === 'dark'
-  return {
-    axisLabel: dark ? '#a1a1aa' : '#71717a',
-    splitLine: dark ? 'rgba(255,255,255,0.08)' : '#eef0f3',
-    legend: dark ? '#a1a1aa' : '#8b8b96',
-    pieLabel: dark ? '#d4d4d8' : '#52525b',
-    heatLow: dark ? '#1f1f36' : '#efeaff',
-    heatHigh: '#5b4dff',
-  }
-})
-
-function statsAxis() {
-  const tone = chartTone.value
-  return {
-    ...CHART_AXIS,
-    axisLabel: { ...CHART_AXIS.axisLabel, color: tone.axisLabel, hideOverlap: true },
-    splitLine: { lineStyle: { color: tone.splitLine } },
-  }
-}
-
-function statsLegend() {
-  return {
-    top: 0,
-    left: 0,
-    itemWidth: 12,
-    itemHeight: 8,
-    itemStyle: { borderRadius: 0 },
-    textStyle: { fontSize: 11, color: chartTone.value.legend },
-  }
-}
-
-function statsTooltip(extra: Record<string, unknown> = {}) {
-  const dark = theme.value === 'dark'
-  return {
-    borderRadius: 0,
-    backgroundColor: dark ? '#27272a' : '#ffffff',
-    borderColor: dark ? '#3f3f46' : '#e4e4e7',
-    textStyle: { color: dark ? '#e4e4e7' : '#27272a', fontSize: 12 },
-    confine: false,
-    appendToBody: true,
-    extraCssText: 'z-index: 1000;',
-    ...extra,
-  }
-}
-
-function axisTooltip(extra: Record<string, unknown> = {}) {
-  return statsTooltip({
-    trigger: 'axis',
-    valueFormatter: (v: number) => fmtCompactTokenCount(v),
-    ...extra,
-  })
-}
-
-function pieTooltipFormatter(params: unknown): string {
-  const p = params as { name?: string; value?: number; percent?: number }
-  const name = p.name ?? ''
-  const value = fmtCompactTokenCount(p.value ?? 0)
-  const pct = p.percent != null ? p.percent.toFixed(1) : '0'
-  return `${name}: ${value} (${pct}%)`
-}
 
 const isEmpty = computed(() => !!data.value?.empty)
 
@@ -215,39 +152,7 @@ function pieOption(
   slices: { name: string; value: number; key?: string; color?: string }[],
   donut = false,
 ) {
-  if (!slices.length) return null
-  const colors = slices.map((s, i) => s.color || ['#4f46e5', '#7c6dff', '#a99cff', '#94a3b8'][i % 4])
-  return {
-    tooltip: statsTooltip({ trigger: 'item', formatter: pieTooltipFormatter }),
-    legend: {
-      show: true,
-      orient: 'vertical',
-      right: 0,
-      top: 'middle',
-      type: 'scroll',
-      itemWidth: 10,
-      itemHeight: 8,
-      itemStyle: { borderRadius: 0 },
-      textStyle: { fontSize: 10, color: chartTone.value.legend },
-    },
-    series: [
-      {
-        type: 'pie',
-        radius: donut ? ['36%', '54%'] : '54%',
-        center: ['38%', '50%'],
-        data: slices.map((s) => ({ name: s.name, value: s.value, key: s.key })),
-        itemStyle: { borderWidth: 0 },
-        color: colors,
-        label: {
-          show: true,
-          formatter: '{b} {d}%',
-          fontSize: 10,
-          color: chartTone.value.pieLabel,
-        },
-        labelLayout: { hideOverlap: true },
-      },
-    ],
-  }
+  return pieChartOption(slices, donut)
 }
 
 function buildPieSlices() {
@@ -410,6 +315,7 @@ function heatmapOption() {
     row.forEach((v, ci) => flat.push([ci, ri, v]))
   })
   const max = Math.max(1, ...flat.map((f) => f[2]))
+  const tone = chartTone()
   return {
     grid: { left: 176, right: 12, top: 12, bottom: 28, containLabel: false },
     tooltip: statsTooltip({
@@ -424,13 +330,13 @@ function heatmapOption() {
       type: 'category',
       data: hm.cols,
       splitArea: { show: true },
-      axisLabel: { fontSize: 10, color: chartTone.value.axisLabel },
+      axisLabel: { fontSize: 10, color: tone.axisLabel },
     },
     yAxis: {
       type: 'category',
       data: hm.rows,
       splitArea: { show: true },
-      axisLabel: { fontSize: 10, color: chartTone.value.axisLabel, width: 160, overflow: 'break' },
+      axisLabel: { fontSize: 10, color: tone.axisLabel, width: 160, overflow: 'break' },
     },
     visualMap: {
       min: 0,
@@ -440,14 +346,14 @@ function heatmapOption() {
       left: 'center',
       bottom: 0,
       show: false,
-      inRange: { color: [chartTone.value.heatLow, chartTone.value.heatHigh] },
+      inRange: { color: [tone.heatLow, tone.heatHigh] },
     },
     series: [{
       type: 'heatmap',
       data: flat,
       label: {
         show: true,
-        color: chartTone.value.pieLabel,
+        color: tone.pieLabel,
         formatter: (p: { data: [number, number, number] }) => fmtCompactTokenCount(p.data[2]),
       },
     }],


### PR DESCRIPTION
- **feat(web): 以用量统计图表壳对齐看板项目统计**
- **fix(web): 恢复看板趋势图左端 0 值 tooltip 与未知排行灰条可测色**
