### PR TITLE
feat(stats): 时间窗增加近 24 小时并按小时切桶

### DIFF
--- a/server/internal/handlers/project.go
+++ b/server/internal/handlers/project.go
@@ -180,7 +180,7 @@ func (h *Handlers) DeleteProject(c *gin.Context) {
 }
 
 // GetProjectTokenStats returns trend/composition/workflows for board Token charts.
-// Query: window=7d|30d|90d|all (default 30d), timezone=IANA (preferred),
+// Query: window=24h|7d|30d|90d|all (default 30d), timezone=IANA (preferred),
 // utcOffsetMinutes=int (fallback fixed offset, east of UTC positive).
 func (h *Handlers) GetProjectTokenStats(c *gin.Context) {
 	if h.Projects == nil {

--- a/server/internal/handlers/stats.go
+++ b/server/internal/handlers/stats.go
@@ -11,7 +11,7 @@ import (
 )
 
 // GetGlobalTokenStats returns cross-project token analytics for /stats.
-// Query: window=7d|30d|90d|all (default 30d), timezone, utcOffsetMinutes,
+// Query: window=24h|7d|30d|90d|all (default 30d), timezone, utcOffsetMinutes,
 // source=all|workflow|pm, projectId, modelKey.
 func (h *Handlers) GetGlobalTokenStats(c *gin.Context) {
 	if h.Projects == nil {

--- a/server/internal/services/global_token_stats.go
+++ b/server/internal/services/global_token_stats.go
@@ -15,15 +15,15 @@ const (
 	GlobalTokenStatsSourceWorkflow = "workflow"
 	GlobalTokenStatsSourcePM       = "pm"
 
-	globalTokenStatsTopProjects = 10
-	globalTokenStatsTopModels   = 10
+	globalTokenStatsTopProjects  = 10
+	globalTokenStatsTopModels    = 10
 	globalTokenStatsTopWorkflows = 10
-	globalTokenStatsTopRuns     = 20
+	globalTokenStatsTopRuns      = 20
 )
 
 // GlobalTokenStatsQuery filters cross-project token aggregation.
 type GlobalTokenStatsQuery struct {
-	Window           string // 7d|30d|90d|all
+	Window           string // 24h|7d|30d|90d|all
 	Timezone         string
 	UTCOffsetMinutes *int
 	Source           string // all|workflow|pm
@@ -107,23 +107,23 @@ type GlobalTokenStatsFilterOptions struct {
 
 // GlobalTokenStatsResult is GET /api/stats/token payload.
 type GlobalTokenStatsResult struct {
-	Window         string                        `json:"window"`
-	BucketWidth    string                        `json:"bucketWidth"`
-	Timezone       string                        `json:"timezone"`
-	Empty          bool                          `json:"empty"`
-	KPI            GlobalTokenStatsKPI           `json:"kpi"`
-	Trend          []TokenStatsBucket            `json:"trend"`
-	PrevTrend      []TokenStatsBucket            `json:"prevTrend"`
-	Composition    TokenStatsComposition         `json:"composition"`
-	Projects       []GlobalTokenStatsProjectRow  `json:"projects"`
-	ModelRanking   []TokenStatsModel             `json:"modelRanking"`
-	NodeTypes      []GlobalTokenStatsNamedBucket `json:"nodeTypes"`
-	Workflows      []TokenStatsWorkflow          `json:"workflows"`
-	Heatmap        GlobalTokenStatsHeatmap       `json:"heatmap"`
-	TopRuns        []GlobalTokenStatsRunRow      `json:"topRuns"`
-	ProjectTrends  []GlobalTokenStatsSeries      `json:"projectTrends"`
-	ModelTrends    []GlobalTokenStatsSeries      `json:"modelTrends"`
-	FilterOptions  GlobalTokenStatsFilterOptions `json:"filterOptions"`
+	Window        string                        `json:"window"`
+	BucketWidth   string                        `json:"bucketWidth"`
+	Timezone      string                        `json:"timezone"`
+	Empty         bool                          `json:"empty"`
+	KPI           GlobalTokenStatsKPI           `json:"kpi"`
+	Trend         []TokenStatsBucket            `json:"trend"`
+	PrevTrend     []TokenStatsBucket            `json:"prevTrend"`
+	Composition   TokenStatsComposition         `json:"composition"`
+	Projects      []GlobalTokenStatsProjectRow  `json:"projects"`
+	ModelRanking  []TokenStatsModel             `json:"modelRanking"`
+	NodeTypes     []GlobalTokenStatsNamedBucket `json:"nodeTypes"`
+	Workflows     []TokenStatsWorkflow          `json:"workflows"`
+	Heatmap       GlobalTokenStatsHeatmap       `json:"heatmap"`
+	TopRuns       []GlobalTokenStatsRunRow      `json:"topRuns"`
+	ProjectTrends []GlobalTokenStatsSeries      `json:"projectTrends"`
+	ModelTrends   []GlobalTokenStatsSeries      `json:"modelTrends"`
+	FilterOptions GlobalTokenStatsFilterOptions `json:"filterOptions"`
 }
 
 type globalProjOpt struct {
@@ -162,10 +162,11 @@ func (s *ProjectService) GlobalTokenStats(ctx context.Context, q GlobalTokenStat
 	if window == "" {
 		window = TokenStatsWindow30d
 	}
-	days, bucketWidth, err := parseTokenStatsWindow(window)
+	spec, err := parseTokenStatsWindow(window)
 	if err != nil {
 		return GlobalTokenStatsResult{}, err
 	}
+	bucketWidth := spec.bucketWidth
 
 	loc, tzLabel, err := resolveTokenStatsLocation(q.Timezone, q.UTCOffsetMinutes)
 	if err != nil {
@@ -185,8 +186,8 @@ func (s *ProjectService) GlobalTokenStats(ctx context.Context, q GlobalTokenStat
 	projectFilter := strings.TrimSpace(q.ProjectID)
 	modelFilter := strings.TrimSpace(q.ModelKey)
 
-	curWin := buildWindowSlice(nowLocal, days)
-	prevWin := buildPrevWindowSlice(curWin, days)
+	curWin := buildWindowSlice(nowLocal, spec)
+	prevWin := buildPrevWindowSlice(curWin, spec)
 
 	rows, err := s.loadGlobalTokenUsageRows(ctx)
 	if err != nil {
@@ -228,19 +229,19 @@ func (s *ProjectService) GlobalTokenStats(ctx context.Context, q GlobalTokenStat
 
 	if len(filtered) == 0 {
 		return GlobalTokenStatsResult{
-			Window:      window,
-			BucketWidth: bucketWidth,
-			Timezone:    tzLabel,
-			Empty:       true,
-			KPI:         GlobalTokenStatsKPI{},
-			Trend:       []TokenStatsBucket{},
-			PrevTrend:   []TokenStatsBucket{},
-			Projects:    []GlobalTokenStatsProjectRow{},
-			ModelRanking: []TokenStatsModel{},
-			NodeTypes:   []GlobalTokenStatsNamedBucket{},
-			Workflows:   []TokenStatsWorkflow{},
-			Heatmap:     GlobalTokenStatsHeatmap{Rows: []string{}, Cols: []string{}, Grid: [][]int64{}},
-			TopRuns:     []GlobalTokenStatsRunRow{},
+			Window:        window,
+			BucketWidth:   bucketWidth,
+			Timezone:      tzLabel,
+			Empty:         true,
+			KPI:           GlobalTokenStatsKPI{},
+			Trend:         []TokenStatsBucket{},
+			PrevTrend:     []TokenStatsBucket{},
+			Projects:      []GlobalTokenStatsProjectRow{},
+			ModelRanking:  []TokenStatsModel{},
+			NodeTypes:     []GlobalTokenStatsNamedBucket{},
+			Workflows:     []TokenStatsWorkflow{},
+			Heatmap:       GlobalTokenStatsHeatmap{Rows: []string{}, Cols: []string{}, Grid: [][]int64{}},
+			TopRuns:       []GlobalTokenStatsRunRow{},
 			ProjectTrends: []GlobalTokenStatsSeries{},
 			ModelTrends:   []GlobalTokenStatsSeries{},
 			FilterOptions: buildFilterOptions(projSeen, modelSeen),
@@ -252,10 +253,10 @@ func (s *ProjectService) GlobalTokenStats(ctx context.Context, q GlobalTokenStat
 
 	if len(curRows) == 0 {
 		out := GlobalTokenStatsResult{
-			Window:      window,
-			BucketWidth: bucketWidth,
-			Timezone:    tzLabel,
-			Empty:       true,
+			Window:        window,
+			BucketWidth:   bucketWidth,
+			Timezone:      tzLabel,
+			Empty:         true,
 			FilterOptions: buildFilterOptions(projSeen, modelSeen),
 		}
 		out.Trend = fillTrendBuckets(nowLocal, curWin, bucketWidth, map[string]*tokenBucketAgg{})
@@ -267,7 +268,13 @@ func (s *ProjectService) GlobalTokenStats(ctx context.Context, q GlobalTokenStat
 
 	kpi := buildGlobalKPI(curAgg, prevAgg)
 	trend := bucketsFromAgg(curAgg.buckets, nowLocal, curWin, bucketWidth)
-	prevTrend := bucketsFromAgg(prevAgg.buckets, nowLocal.AddDate(0, 0, -days), prevWin, bucketWidth)
+	prevNow := nowLocal
+	if spec.duration > 0 {
+		prevNow = nowLocal.Add(-spec.duration)
+	} else if spec.days > 0 {
+		prevNow = nowLocal.AddDate(0, 0, -spec.days)
+	}
+	prevTrend := bucketsFromAgg(prevAgg.buckets, prevNow, prevWin, bucketWidth)
 
 	projRows, projTrends := buildProjectStats(curAgg, prevAgg, globalTokenStatsTopProjects)
 	modelRank, modelTrends := buildGlobalModelStats(curAgg, prevAgg, unknownAliases, globalTokenStatsTopModels)
@@ -297,21 +304,32 @@ func (s *ProjectService) GlobalTokenStats(ctx context.Context, q GlobalTokenStat
 	}, nil
 }
 
-func buildWindowSlice(nowLocal time.Time, days int) windowSlice {
-	if days <= 0 {
+func buildWindowSlice(nowLocal time.Time, spec tokenStatsWindowSpec) windowSlice {
+	if spec.duration > 0 {
+		return windowSlice{start: nowLocal.Add(-spec.duration), end: nowLocal, hasStart: true}
+	}
+	if spec.days <= 0 {
 		return windowSlice{hasStart: false}
 	}
-	startDay := truncateLocalDay(nowLocal).AddDate(0, 0, -(days - 1))
-	end := nowLocal
-	return windowSlice{start: startDay, end: end, hasStart: true}
+	// Inclusive local-day window: today and the previous (days-1) local days.
+	startDay := truncateLocalDay(nowLocal).AddDate(0, 0, -(spec.days - 1))
+	return windowSlice{start: startDay, end: nowLocal, hasStart: true}
 }
 
-func buildPrevWindowSlice(cur windowSlice, days int) windowSlice {
-	if !cur.hasStart || days <= 0 {
+func buildPrevWindowSlice(cur windowSlice, spec tokenStatsWindowSpec) windowSlice {
+	if !cur.hasStart {
+		return windowSlice{hasStart: false}
+	}
+	if spec.duration > 0 {
+		prevEnd := cur.start.Add(-time.Nanosecond)
+		prevStart := cur.start.Add(-spec.duration)
+		return windowSlice{start: prevStart, end: prevEnd, hasStart: true}
+	}
+	if spec.days <= 0 {
 		return windowSlice{hasStart: false}
 	}
 	prevEnd := cur.start.Add(-time.Nanosecond)
-	prevStart := truncateLocalDay(prevEnd).AddDate(0, 0, -(days - 1))
+	prevStart := truncateLocalDay(prevEnd).AddDate(0, 0, -(spec.days - 1))
 	return windowSlice{start: prevStart, end: prevEnd, hasStart: true}
 }
 
@@ -415,16 +433,16 @@ type globalAgg struct {
 }
 
 type globalProjectAgg struct {
-	name                    string
-	total                   int64
-	input, output           int64
-	cacheRead, cacheWrite   int64
+	name                  string
+	total                 int64
+	input, output         int64
+	cacheRead, cacheWrite int64
 }
 
 type globalRunAgg struct {
 	runID, title, projectID, projectName, workflowName string
-	total                                            int64
-	topModelKey, topModelName                        string
+	total                                              int64
+	topModelKey, topModelName                          string
 }
 
 // rebucketGlobalModelKey merges per-project unknown usage into the configured default model.
@@ -656,10 +674,10 @@ func buildGlobalKPI(cur, prev *globalAgg) GlobalTokenStatsKPI {
 
 func buildProjectStats(cur, prev *globalAgg, topN int) ([]GlobalTokenStatsProjectRow, []GlobalTokenStatsSeries) {
 	type item struct {
-		id              string
-		name            string
-		total           int64
-		in, out         int64
+		id                    string
+		name                  string
+		total                 int64
+		in, out               int64
 		cacheRead, cacheWrite int64
 	}
 	list := make([]item, 0, len(cur.projects))
@@ -715,10 +733,10 @@ func projectTrendFromBuckets(buckets map[string]*tokenBucketAgg) []TokenStatsBuc
 	for _, k := range keys {
 		b := buckets[k]
 		out = append(out, TokenStatsBucket{
-			Bucket: k,
-			Total:  b.input + b.output + b.cacheRead + b.cacheWrite,
+			Bucket:        k,
+			Total:         b.input + b.output + b.cacheRead + b.cacheWrite,
 			WorkflowTotal: b.workflow,
-			PmTotal: b.pm,
+			PmTotal:       b.pm,
 		})
 	}
 	return out
@@ -780,8 +798,14 @@ func buildGlobalWorkflowRank(cur *globalAgg) []TokenStatsWorkflow {
 }
 
 func buildHeatmap(cur *globalAgg, topModels, topProjects int) GlobalTokenStatsHeatmap {
-	type mItem struct{ key, name string; total int64 }
-	type pItem struct{ id, name string; total int64 }
+	type mItem struct {
+		key, name string
+		total     int64
+	}
+	type pItem struct {
+		id, name string
+		total    int64
+	}
 
 	modelList := make([]mItem, 0, len(cur.models))
 	for k, a := range cur.models {
@@ -925,7 +949,7 @@ func buildTopRuns(cur *globalAgg, unknownAliases map[string]string, topN int) []
 			RunID: it.runID, Title: title,
 			ProjectID: it.projectID, ProjectName: it.projectName,
 			WorkflowName: it.workflowName,
-			ModelKey: it.topModelKey, ModelName: name,
+			ModelKey:     it.topModelKey, ModelName: name,
 			Total: it.total,
 		})
 	}

--- a/server/internal/services/global_token_stats_test.go
+++ b/server/internal/services/global_token_stats_test.go
@@ -250,4 +250,99 @@ func TestGlobalTokenStatsModelFilterAfterRebucket(t *testing.T) {
 	}
 }
 
+func TestGlobalTokenStats24hPrevWindowDelta(t *testing.T) {
+	db, err := database.OpenSQLiteTest(filepath.Join(t.TempDir(), "global_token_24h.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewProjectService(db)
+	must := func(v any) {
+		t.Helper()
+		if err := db.Create(v).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ptr := func(tt time.Time) *time.Time { return &tt }
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC) // 20:00 Shanghai
+	proj, err := s.Create("G24h", "", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	must(&models.WorkflowDef{ID: "wf-g24", ProjectID: proj.ID, Name: "main", Status: "draft", Version: 1})
+
+	// Previous 24h: [Jul 23 20:00, Jul 24 20:00) Shanghai — 100 tokens at Jul 24 10:00.
+	prevTS := time.Date(2026, 7, 24, 10, 0, 0, 0, loc).UTC()
+	must(&models.Run{ID: "run-prev", WorkflowID: "wf-g24", WorkflowName: "main", Status: "completed", StartedAt: prevTS, Title: "Prev"})
+	must(&models.StateRun{
+		RunID: "run-prev", NodeID: "n1", NodeType: "agent", Status: "completed",
+		StartedAt: ptr(prevTS),
+		Usage:     &models.TokenUsage{InputTokens: 100},
+	})
+	// Current 24h: [Jul 24 20:00, Jul 25 20:00] — 200 tokens at Jul 25 08:00.
+	curTS := time.Date(2026, 7, 25, 8, 0, 0, 0, loc).UTC()
+	must(&models.Run{ID: "run-cur", WorkflowID: "wf-g24", WorkflowName: "main", Status: "completed", StartedAt: curTS, Title: "Cur"})
+	must(&models.StateRun{
+		RunID: "run-cur", NodeID: "n1", NodeType: "agent", Status: "completed",
+		StartedAt: ptr(curTS),
+		Usage:     &models.TokenUsage{InputTokens: 200},
+	})
+
+	res, err := s.GlobalTokenStats(context.Background(), GlobalTokenStatsQuery{
+		Window:   TokenStatsWindow24h,
+		Timezone: "Asia/Shanghai",
+		Now:      now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Empty {
+		t.Fatal("expected non-empty")
+	}
+	if res.Window != TokenStatsWindow24h || res.BucketWidth != TokenStatsBucketHour {
+		t.Fatalf("window=%s bucketWidth=%s", res.Window, res.BucketWidth)
+	}
+	if res.KPI.Total != 200 {
+		t.Fatalf("kpi.total=%d want 200", res.KPI.Total)
+	}
+	if res.KPI.PrevTotal == nil || *res.KPI.PrevTotal != 100 {
+		t.Fatalf("kpi.prevTotal=%v want 100", res.KPI.PrevTotal)
+	}
+	if res.KPI.DeltaPct == nil || *res.KPI.DeltaPct != 100 {
+		t.Fatalf("kpi.deltaPct=%v want 100", res.KPI.DeltaPct)
+	}
+	if len(res.Trend) != 25 {
+		t.Fatalf("trend len=%d want 25 hour buckets", len(res.Trend))
+	}
+	if len(res.PrevTrend) != 25 {
+		t.Fatalf("prevTrend len=%d want 25", len(res.PrevTrend))
+	}
+}
+
+func TestGlobalTokenStats24hEmptyWindow(t *testing.T) {
+	db, err := database.OpenSQLiteTest(filepath.Join(t.TempDir(), "global_token_24h_empty.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewProjectService(db)
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	if _, err := s.Create("EmptyG24h", "", nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	res, err := s.GlobalTokenStats(context.Background(), GlobalTokenStatsQuery{
+		Window:   TokenStatsWindow24h,
+		Timezone: "Asia/Shanghai",
+		Now:      now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Empty {
+		t.Fatalf("expected empty, got total=%d", res.KPI.Total)
+	}
+}
+
 func aliasPtr(s string) *string { return &s }

--- a/server/internal/services/project_token_stats.go
+++ b/server/internal/services/project_token_stats.go
@@ -14,11 +14,13 @@ import (
 
 // Token-stats window presets and errors.
 const (
+	TokenStatsWindow24h = "24h"
 	TokenStatsWindow7d  = "7d"
 	TokenStatsWindow30d = "30d"
 	TokenStatsWindow90d = "90d"
 	TokenStatsWindowAll = "all"
 
+	TokenStatsBucketHour = "hour"
 	TokenStatsBucketDay  = "day"
 	TokenStatsBucketWeek = "week"
 
@@ -39,13 +41,13 @@ var (
 
 // TokenStatsQuery is the input for project-level token chart aggregation.
 type TokenStatsQuery struct {
-	Window           string // 7d|30d|90d|all
+	Window           string // 24h|7d|30d|90d|all
 	Timezone         string // preferred IANA name
 	UTCOffsetMinutes *int   // fallback fixed offset (east of UTC positive)
 	Now              time.Time
 }
 
-// TokenStatsBucket is one day or week bucket with totals, source split, and
+// TokenStatsBucket is one hour, day, or week bucket with totals, source split, and
 // four components (sum of all reported sources in the bucket).
 type TokenStatsBucket struct {
 	Bucket           string `json:"bucket"`
@@ -143,10 +145,11 @@ func (s *ProjectService) TokenStats(ctx context.Context, projectID string, q Tok
 	if window == "" {
 		window = TokenStatsWindow30d
 	}
-	days, bucketWidth, err := parseTokenStatsWindow(window)
+	spec, err := parseTokenStatsWindow(window)
 	if err != nil {
 		return TokenStatsResult{}, err
 	}
+	bucketWidth := spec.bucketWidth
 
 	loc, tzLabel, err := resolveTokenStatsLocation(q.Timezone, q.UTCOffsetMinutes)
 	if err != nil {
@@ -164,14 +167,11 @@ func (s *ProjectService) TokenStats(ctx context.Context, projectID string, q Tok
 		return TokenStatsResult{}, err
 	}
 
-	var windowStart time.Time
-	var hasStart bool
-	if days > 0 {
-		// Inclusive local-day window: today and the previous (days-1) local days.
-		startDay := truncateLocalDay(nowLocal).AddDate(0, 0, -(days - 1))
-		windowStart = startDay
-		hasStart = true
-	}
+	win := buildWindowSlice(nowLocal, spec)
+	windowStart := win.start
+	hasStart := win.hasStart
+	windowEnd := win.end
+	hasEnd := spec.duration > 0
 
 	type agg struct {
 		input, output, cacheRead, cacheWrite int64
@@ -193,6 +193,9 @@ func (s *ProjectService) TokenStats(ctx context.Context, projectID string, q Tok
 		}
 		local := row.ts.In(loc)
 		if hasStart && local.Before(windowStart) {
+			continue
+		}
+		if hasEnd && local.After(windowEnd) {
 			continue
 		}
 		hasAny = true
@@ -309,18 +312,28 @@ func (s *ProjectService) TokenStats(ctx context.Context, projectID string, q Tok
 	return out, nil
 }
 
-func parseTokenStatsWindow(window string) (days int, bucketWidth string, err error) {
+// tokenStatsWindowSpec is the parsed window preset.
+// Calendar windows (7d/30d/90d) use days; rolling 24h uses duration; all uses neither.
+type tokenStatsWindowSpec struct {
+	days        int
+	duration    time.Duration
+	bucketWidth string
+}
+
+func parseTokenStatsWindow(window string) (tokenStatsWindowSpec, error) {
 	switch window {
+	case TokenStatsWindow24h:
+		return tokenStatsWindowSpec{duration: 24 * time.Hour, bucketWidth: TokenStatsBucketHour}, nil
 	case TokenStatsWindow7d:
-		return 7, TokenStatsBucketDay, nil
+		return tokenStatsWindowSpec{days: 7, bucketWidth: TokenStatsBucketDay}, nil
 	case TokenStatsWindow30d:
-		return 30, TokenStatsBucketDay, nil
+		return tokenStatsWindowSpec{days: 30, bucketWidth: TokenStatsBucketDay}, nil
 	case TokenStatsWindow90d:
-		return 90, TokenStatsBucketDay, nil
+		return tokenStatsWindowSpec{days: 90, bucketWidth: TokenStatsBucketDay}, nil
 	case TokenStatsWindowAll:
-		return 0, TokenStatsBucketWeek, nil
+		return tokenStatsWindowSpec{bucketWidth: TokenStatsBucketWeek}, nil
 	default:
-		return 0, "", ErrInvalidTokenStatsWindow
+		return tokenStatsWindowSpec{}, ErrInvalidTokenStatsWindow
 	}
 }
 
@@ -355,7 +368,15 @@ func truncateLocalDay(t time.Time) time.Time {
 	return time.Date(y, m, d, 0, 0, 0, 0, t.Location())
 }
 
+func truncateLocalHour(t time.Time) time.Time {
+	y, m, d := t.Date()
+	return time.Date(y, m, d, t.Hour(), 0, 0, 0, t.Location())
+}
+
 func bucketKey(local time.Time, width string) string {
+	if width == TokenStatsBucketHour {
+		return local.Format("2006-01-02T15")
+	}
 	if width == TokenStatsBucketWeek {
 		y, w := local.ISOWeek()
 		return fmt.Sprintf("%04d-W%02d", y, w)
@@ -363,7 +384,41 @@ func bucketKey(local time.Time, width string) string {
 	return local.Format("2006-01-02")
 }
 
+func fillHourBucketKeys(nowLocal, windowStart time.Time, hasStart bool, present map[string]struct{}) []string {
+	start := truncateLocalHour(nowLocal)
+	if hasStart {
+		start = truncateLocalHour(windowStart)
+	} else {
+		for k := range present {
+			t, ok := parseHourKey(k, nowLocal.Location())
+			if !ok {
+				continue
+			}
+			if t.Before(start) {
+				start = t
+			}
+		}
+	}
+	end := truncateLocalHour(nowLocal)
+	var keys []string
+	for t := start; !t.After(end); t = t.Add(time.Hour) {
+		keys = append(keys, bucketKey(t, TokenStatsBucketHour))
+	}
+	return keys
+}
+
+func parseHourKey(key string, loc *time.Location) (time.Time, bool) {
+	t, err := time.ParseInLocation("2006-01-02T15", key, loc)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
 func fillBucketKeys(nowLocal, windowStart time.Time, hasStart bool, width string, present map[string]struct{}) []string {
+	if width == TokenStatsBucketHour {
+		return fillHourBucketKeys(nowLocal, windowStart, hasStart, present)
+	}
 	if width == TokenStatsBucketWeek {
 		var start time.Time
 		if hasStart {

--- a/server/internal/services/project_token_stats_test.go
+++ b/server/internal/services/project_token_stats_test.go
@@ -302,6 +302,76 @@ func TestTokenStatsAggregation(t *testing.T) {
 		if err != ErrInvalidTokenStatsWindow {
 			t.Fatalf("err=%v", err)
 		}
+		_, err = s.TokenStats(context.Background(), proj.ID, TokenStatsQuery{
+			Window: "1d", Timezone: "UTC", Now: now,
+		})
+		if err != ErrInvalidTokenStatsWindow {
+			t.Fatalf("1d err=%v", err)
+		}
+	})
+
+	t.Run("24h_rolling_hour_buckets_excludes_older", func(t *testing.T) {
+		// now = 2026-07-25 20:00 Shanghai; 24h start = 2026-07-24 20:00.
+		// dayIn (07-24 10:00) is outside; dayToday (07-25 08:00) is inside.
+		res, err := s.TokenStats(context.Background(), proj.ID, TokenStatsQuery{
+			Window: TokenStatsWindow24h, Timezone: "Asia/Shanghai", Now: now,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.Empty {
+			t.Fatal("expected non-empty 24h window")
+		}
+		if res.Window != TokenStatsWindow24h {
+			t.Fatalf("window=%s", res.Window)
+		}
+		if res.BucketWidth != TokenStatsBucketHour {
+			t.Fatalf("bucketWidth=%s want hour", res.BucketWidth)
+		}
+		if res.Composition.Total != 8 {
+			t.Fatalf("24h composition.total=%d want 8 (only in-progress a2)", res.Composition.Total)
+		}
+		if len(res.Trend) != 25 {
+			t.Fatalf("want 25 hour buckets for rolling 24h, got %d", len(res.Trend))
+		}
+		if res.Trend[0].Bucket != "2026-07-24T20" {
+			t.Fatalf("first hour bucket=%s want 2026-07-24T20", res.Trend[0].Bucket)
+		}
+		if res.Trend[len(res.Trend)-1].Bucket != "2026-07-25T20" {
+			t.Fatalf("last hour bucket=%s want 2026-07-25T20", res.Trend[len(res.Trend)-1].Bucket)
+		}
+		var hour08 *TokenStatsBucket
+		var nonzero int
+		for i := range res.Trend {
+			b := &res.Trend[i]
+			if b.Total != 0 {
+				nonzero++
+			}
+			if b.Bucket == "2026-07-25T08" {
+				hour08 = b
+			}
+		}
+		if hour08 == nil || hour08.Total != 8 {
+			t.Fatalf("2026-07-25T08 = %+v want total 8", hour08)
+		}
+		if nonzero != 1 {
+			t.Fatalf("missing hours should fill 0; nonzero buckets=%d", nonzero)
+		}
+	})
+
+	t.Run("24h_empty_no_forged_series", func(t *testing.T) {
+		res, err := s.TokenStats(context.Background(), emptyProj.ID, TokenStatsQuery{
+			Window: TokenStatsWindow24h, Timezone: "Asia/Shanghai", Now: now,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !res.Empty {
+			t.Fatal("expected empty")
+		}
+		if len(res.Trend) != 0 {
+			t.Fatalf("empty 24h must not forge zero trend, got %d buckets", len(res.Trend))
+		}
 	})
 
 	t.Run("pm_usage_in_trend_composition_rank", func(t *testing.T) {
@@ -526,7 +596,6 @@ func itoa(n int) string {
 	}
 	return string(b[i:])
 }
-
 
 func sumModelTotals(rows []TokenStatsModel) int64 {
 	var n int64
@@ -787,4 +856,179 @@ func TestBuildModelStatsUnknownAlias(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestParseTokenStatsWindow(t *testing.T) {
+	spec, err := parseTokenStatsWindow(TokenStatsWindow24h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec.duration != 24*time.Hour || spec.bucketWidth != TokenStatsBucketHour || spec.days != 0 {
+		t.Fatalf("24h spec=%+v", spec)
+	}
+	spec, err = parseTokenStatsWindow(TokenStatsWindow7d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec.days != 7 || spec.bucketWidth != TokenStatsBucketDay || spec.duration != 0 {
+		t.Fatalf("7d spec=%+v", spec)
+	}
+	spec, err = parseTokenStatsWindow("")
+	if err != ErrInvalidTokenStatsWindow {
+		t.Fatalf("empty window err=%v spec=%+v", err, spec)
+	}
+	for _, bad := range []string{"1d", "1y", "today"} {
+		if _, err := parseTokenStatsWindow(bad); err != ErrInvalidTokenStatsWindow {
+			t.Fatalf("%s err=%v", bad, err)
+		}
+	}
+}
+
+func TestBuildWindowSlice24h(t *testing.T) {
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 25, 20, 30, 0, 0, loc)
+	spec := tokenStatsWindowSpec{duration: 24 * time.Hour, bucketWidth: TokenStatsBucketHour}
+	cur := buildWindowSlice(now, spec)
+	wantStart := time.Date(2026, 7, 24, 20, 30, 0, 0, loc)
+	if !cur.hasStart || !cur.start.Equal(wantStart) || !cur.end.Equal(now) {
+		t.Fatalf("24h cur=%+v want start=%v end=%v", cur, wantStart, now)
+	}
+	prev := buildPrevWindowSlice(cur, spec)
+	wantPrevStart := time.Date(2026, 7, 23, 20, 30, 0, 0, loc)
+	wantPrevEnd := wantStart.Add(-time.Nanosecond)
+	if !prev.hasStart || !prev.start.Equal(wantPrevStart) || !prev.end.Equal(wantPrevEnd) {
+		t.Fatalf("24h prev=%+v want start=%v end=%v", prev, wantPrevStart, wantPrevEnd)
+	}
+
+	spec7 := tokenStatsWindowSpec{days: 7, bucketWidth: TokenStatsBucketDay}
+	cur7 := buildWindowSlice(now, spec7)
+	want7Start := time.Date(2026, 7, 19, 0, 0, 0, 0, loc)
+	if !cur7.start.Equal(want7Start) {
+		t.Fatalf("7d calendar start=%v want %v", cur7.start, want7Start)
+	}
+}
+
+func TestFillBucketKeysHourCrossMidnight(t *testing.T) {
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 25, 2, 15, 0, 0, loc)
+	start := now.Add(-24 * time.Hour)
+	keys := fillBucketKeys(now, start, true, TokenStatsBucketHour, nil)
+	if len(keys) != 25 {
+		t.Fatalf("len=%d want 25", len(keys))
+	}
+	if keys[0] != "2026-07-24T02" {
+		t.Fatalf("first=%s want 2026-07-24T02", keys[0])
+	}
+	if keys[len(keys)-1] != "2026-07-25T02" {
+		t.Fatalf("last=%s want 2026-07-25T02", keys[len(keys)-1])
+	}
+	seen := map[string]struct{}{}
+	var has24, has25 bool
+	for _, k := range keys {
+		if _, ok := seen[k]; ok {
+			t.Fatalf("duplicate hour key %s", k)
+		}
+		seen[k] = struct{}{}
+		if len(k) >= 10 && k[:10] == "2026-07-24" {
+			has24 = true
+		}
+		if len(k) >= 10 && k[:10] == "2026-07-25" {
+			has25 = true
+		}
+	}
+	if !has24 || !has25 {
+		t.Fatalf("expected cross-midnight hour keys, got %v", keys)
+	}
+	if _, ok := seen["2026-07-24T23"]; !ok {
+		t.Fatal("missing 2026-07-24T23 (zero-fill hour across midnight)")
+	}
+}
+
+func TestTokenStats24hHourFillAcrossMidnight(t *testing.T) {
+	db, err := database.OpenSQLiteTest(filepath.Join(t.TempDir(), "token_stats_24h.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewProjectService(db)
+	proj, err := s.Create("Tok24h", "", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	must := func(v any) {
+		t.Helper()
+		if err := db.Create(v).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ptr := func(tt time.Time) *time.Time { return &tt }
+	// now = 02:15 July 25 local → window [01:15 July 24, 02:15 July 25] wait: 02:15-24h = 02:15 July 24.
+	now := time.Date(2026, 7, 24, 18, 15, 0, 0, time.UTC) // 2026-07-25 02:15 Shanghai
+	must(&models.WorkflowDef{ID: "wf-24", ProjectID: proj.ID, Name: "hourly", Status: "draft", Version: 1})
+
+	before := time.Date(2026, 7, 24, 1, 0, 0, 0, loc).UTC() // 01:00 July 24 — outside
+	must(&models.Run{ID: "run-before", WorkflowID: "wf-24", WorkflowName: "hourly", Status: "completed", StartedAt: before})
+	must(&models.StateRun{
+		RunID: "run-before", NodeID: "n1", Status: "completed", StartedAt: ptr(before),
+		Usage: &models.TokenUsage{InputTokens: 999},
+	})
+
+	h22 := time.Date(2026, 7, 24, 22, 10, 0, 0, loc).UTC()
+	must(&models.Run{ID: "run-22", WorkflowID: "wf-24", WorkflowName: "hourly", Status: "completed", StartedAt: h22})
+	must(&models.StateRun{
+		RunID: "run-22", NodeID: "n1", Status: "completed", StartedAt: ptr(h22),
+		Usage: &models.TokenUsage{InputTokens: 100},
+	})
+
+	h01 := time.Date(2026, 7, 25, 1, 5, 0, 0, loc).UTC()
+	must(&models.Run{ID: "run-01", WorkflowID: "wf-24", WorkflowName: "hourly", Status: "completed", StartedAt: h01})
+	must(&models.StateRun{
+		RunID: "run-01", NodeID: "n1", Status: "completed", StartedAt: ptr(h01),
+		Usage: &models.TokenUsage{InputTokens: 50},
+	})
+
+	after := time.Date(2026, 7, 25, 3, 0, 0, 0, loc).UTC() // after now
+	must(&models.Run{ID: "run-after", WorkflowID: "wf-24", WorkflowName: "hourly", Status: "completed", StartedAt: after})
+	must(&models.StateRun{
+		RunID: "run-after", NodeID: "n1", Status: "completed", StartedAt: ptr(after),
+		Usage: &models.TokenUsage{InputTokens: 777},
+	})
+
+	res, err := s.TokenStats(context.Background(), proj.ID, TokenStatsQuery{
+		Window: TokenStatsWindow24h, Timezone: "Asia/Shanghai", Now: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Empty || res.Composition.Total != 150 {
+		t.Fatalf("total=%d empty=%v want 150", res.Composition.Total, res.Empty)
+	}
+	byKey := map[string]TokenStatsBucket{}
+	for _, b := range res.Trend {
+		byKey[b.Bucket] = b
+	}
+	if byKey["2026-07-24T22"].Total != 100 {
+		t.Fatalf("hour 22 = %+v", byKey["2026-07-24T22"])
+	}
+	if byKey["2026-07-25T01"].Total != 50 {
+		t.Fatalf("hour 01 = %+v", byKey["2026-07-25T01"])
+	}
+	if byKey["2026-07-24T23"].Total != 0 {
+		t.Fatalf("missing hour 23 should be 0, got %+v", byKey["2026-07-24T23"])
+	}
+	if _, ok := byKey["2026-07-24T01"]; ok && byKey["2026-07-24T01"].Total == 999 {
+		t.Fatal("usage before window start must be excluded")
+	}
+	if byKey["2026-07-25T03"].Total == 777 {
+		t.Fatal("usage after now must be excluded")
+	}
 }

--- a/web/e2e/board-token-stats.spec.ts
+++ b/web/e2e/board-token-stats.spec.ts
@@ -79,6 +79,45 @@ const STATS_7D = {
   ],
 }
 
+const STATS_24H = {
+  ...STATS_30D,
+  window: '24h',
+  bucketWidth: 'hour',
+  trend: [
+    {
+      bucket: '2026-07-24T20',
+      total: 40,
+      workflowTotal: 30,
+      pmTotal: 10,
+      inputTokens: 16,
+      outputTokens: 12,
+      cacheReadTokens: 8,
+      cacheWriteTokens: 4,
+    },
+    {
+      bucket: '2026-07-24T21',
+      total: 0,
+      workflowTotal: 0,
+      pmTotal: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    },
+    {
+      bucket: '2026-07-25T08',
+      total: 80,
+      workflowTotal: 60,
+      pmTotal: 20,
+      inputTokens: 32,
+      outputTokens: 24,
+      cacheReadTokens: 16,
+      cacheWriteTokens: 8,
+    },
+  ],
+  composition: { ...STATS_30D.composition, total: 120 },
+}
+
 const STATS_ALL = {
   window: 'all',
   bucketWidth: 'week',
@@ -181,6 +220,14 @@ test.describe('看板 Token 统计图', () => {
       if (failNext) {
         failNext = false
         await route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ error: 'timeout' }) })
+        return
+      }
+      if (w === '24h') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(STATS_24H),
+        })
         return
       }
       if (w === '7d') {

--- a/web/e2e/token-analytics-main.ts
+++ b/web/e2e/token-analytics-main.ts
@@ -103,7 +103,10 @@ window.fetch = async (input: RequestInfo | URL) => {
     )
   }
   if (url.includes('/stats/token')) {
-    return new Response(JSON.stringify(MOCK_STATS), {
+    const parsed = new URL(url, 'http://localhost')
+    const w = parsed.searchParams.get('window') || '30d'
+    const bucketWidth = w === '24h' ? 'hour' : w === 'all' ? 'week' : 'day'
+    return new Response(JSON.stringify({ ...MOCK_STATS, window: w, bucketWidth }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
     })

--- a/web/e2e/token-analytics.spec.ts
+++ b/web/e2e/token-analytics.spec.ts
@@ -66,10 +66,13 @@ const MOCK_STATS = {
 
 async function openStatsPage(page: import('@playwright/test').Page) {
   await routeApi(page, '**/api/stats/token**', async (route) => {
+    const url = new URL(route.request().url())
+    const w = url.searchParams.get('window') || '30d'
+    const bucketWidth = w === '24h' ? 'hour' : w === 'all' ? 'week' : 'day'
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify(MOCK_STATS),
+      body: JSON.stringify({ ...MOCK_STATS, window: w, bucketWidth }),
     })
   })
   await page.goto('/token-analytics.html')

--- a/web/src/components/board/token-stats/TokenStatsPanel.test.ts
+++ b/web/src/components/board/token-stats/TokenStatsPanel.test.ts
@@ -214,4 +214,44 @@ describe('TokenStatsPanel', () => {
     expect(empty.find('[data-testid="token-stats-empty"]').html()).not.toMatch(/rounded-xl/)
     empty.unmount()
   })
+
+  it('puts 近 24 小时 first, keeps default 30d, requests window=24h, and shows grainHour (g2.3/g2.5)', async () => {
+    getProjectTokenStats.mockResolvedValue(sampleStats())
+    const wrapper = mountPanel()
+    await flushPromises()
+    const winBtns = wrapper.find('[data-testid="token-stats-windows"]').findAll('button')
+    expect(winBtns.map((b) => b.text())).toEqual(['近 24 小时', '近 7 天', '近 30 天', '近 90 天', '全部历史'])
+    expect(wrapper.find('[data-testid="token-stats-window-24h"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="token-stats-window-30d"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.find('[data-testid="token-stats-window-24h"]').attributes('aria-selected')).toBe('false')
+    expect(wrapper.text()).toContain('按日聚合 · 本地时区')
+
+    getProjectTokenStats.mockResolvedValueOnce(
+      sampleStats({
+        window: '24h',
+        bucketWidth: 'hour',
+        trend: [
+          {
+            bucket: '2026-07-24T20',
+            total: 12,
+            inputTokens: 6,
+            outputTokens: 4,
+            cacheReadTokens: 1,
+            cacheWriteTokens: 1,
+          },
+        ],
+      }),
+    )
+    await wrapper.find('[data-testid="token-stats-window-24h"]').trigger('click')
+    await flushPromises()
+    expect(getProjectTokenStats).toHaveBeenLastCalledWith(
+      'proj-1',
+      expect.objectContaining({ window: '24h' }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+    expect(wrapper.find('[data-testid="token-stats-window-24h"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.find('[data-testid="token-stats-window-badge"]').text()).toContain('近 24 小时')
+    expect(wrapper.text()).toContain('按小时聚合 · 本地时区')
+    wrapper.unmount()
+  })
 })

--- a/web/src/components/board/token-stats/TokenStatsPanel.vue
+++ b/web/src/components/board/token-stats/TokenStatsPanel.vue
@@ -17,7 +17,7 @@ const props = defineProps<{
 
 const { t } = useI18n()
 
-const WINDOWS: TokenStatsWindow[] = ['7d', '30d', '90d', 'all']
+const WINDOWS: TokenStatsWindow[] = ['24h', '7d', '30d', '90d', 'all']
 
 const windowSel = ref<TokenStatsWindow>('30d')
 const loading = ref(true)
@@ -31,9 +31,9 @@ const windowLabel = computed(() => t(`pages.board.tokenStats.windows.${windowSel
 
 const grainLabel = computed(() => {
   if (!data.value) return ''
-  return data.value.bucketWidth === 'week'
-    ? t('pages.board.tokenStats.grainWeek')
-    : t('pages.board.tokenStats.grainDay')
+  if (data.value.bucketWidth === 'hour') return t('pages.board.tokenStats.grainHour')
+  if (data.value.bucketWidth === 'week') return t('pages.board.tokenStats.grainWeek')
+  return t('pages.board.tokenStats.grainDay')
 })
 
 const isEmpty = computed(() => !!data.value?.empty)

--- a/web/src/components/board/token-stats/tokenStatsShared.test.ts
+++ b/web/src/components/board/token-stats/tokenStatsShared.test.ts
@@ -15,6 +15,13 @@ describe('formatBucketLabel', () => {
     expect(formatBucketLabel('2026-07-11', 'day')).toBe('07-11')
     expect(formatBucketLabel('2026-W30', 'week')).toBe('W30')
   })
+
+  it('formats hour buckets as HH:00 distinct from day/week (g2.4)', () => {
+    expect(formatBucketLabel('2026-07-24T14', 'hour')).toBe('14:00')
+    expect(formatBucketLabel('2026-07-25T00', 'hour')).toBe('00:00')
+    expect(formatBucketLabel('2026-07-24T14', 'hour')).not.toBe('07-24')
+    expect(formatBucketLabel('2026-07-24T14', 'day')).toBe('2026-07-24T14')
+  })
 })
 
 describe('placeTrendTooltipAfter (Demo placeAfter, g2.1–g2.4)', () => {

--- a/web/src/components/board/token-stats/tokenStatsShared.ts
+++ b/web/src/components/board/token-stats/tokenStatsShared.ts
@@ -28,6 +28,12 @@ export function clientTimezoneParams(): { timezone?: string; utcOffsetMinutes: n
 }
 
 export function formatBucketLabel(bucket: string, bucketWidth: string): string {
+  if (bucketWidth === 'hour') {
+    // 2026-07-24T14 → 14:00 (distinct from day MM-DD / week Wxx)
+    const hour = /^(\d{4})-(\d{2})-(\d{2})T(\d{2})$/.exec(bucket)
+    if (hour) return `${hour[4]}:00`
+    return bucket
+  }
   if (bucketWidth === 'week') {
     // 2026-W30 → W30
     const m = /^(\d{4})-W(\d{2})$/.exec(bucket)

--- a/web/src/lib/shared/types.ts
+++ b/web/src/lib/shared/types.ts
@@ -196,7 +196,7 @@ export interface ProjectAuditStats {
 }
 
 /** Preset windows for board TokenStatsPanel (matches GET /token-stats). */
-export type TokenStatsWindow = '7d' | '30d' | '90d' | 'all'
+export type TokenStatsWindow = '24h' | '7d' | '30d' | '90d' | 'all'
 
 export interface TokenStatsBucket {
   bucket: string
@@ -248,7 +248,7 @@ export interface TokenStatsModel {
 /** Response of GET /projects/:id/token-stats */
 export interface ProjectTokenStats {
   window: TokenStatsWindow | string
-  bucketWidth: 'day' | 'week' | string
+  bucketWidth: 'hour' | 'day' | 'week' | string
   timezone: string
   /** true when no reported Usage in the window — do not draw forged zero charts */
   empty: boolean
@@ -322,7 +322,7 @@ export interface GlobalTokenStatsFilterOption {
 
 export interface GlobalTokenStats {
   window: TokenStatsWindow | string
-  bucketWidth: 'day' | 'week' | string
+  bucketWidth: 'hour' | 'day' | 'week' | string
   timezone: string
   empty: boolean
   kpi: GlobalTokenStatsKPI

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -100,6 +100,7 @@
         "title": "Token stats",
         "windowAria": "Time window",
         "windows": {
+          "24h": "Last 24 hours",
           "7d": "Last 7 days",
           "30d": "Last 30 days",
           "90d": "Last 90 days",
@@ -115,6 +116,7 @@
         "rankHint": "\"Other\" = remaining workflows outside the top (not Project Management). Project Management is a separate row.",
         "grainDay": "Daily · local timezone",
         "grainWeek": "Weekly · local timezone",
+        "grainHour": "Hourly · local timezone",
         "compTotal": "Total {n}",
         "donutCenter": "Total",
         "other": "Other",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -100,6 +100,7 @@
         "title": "Token 统计",
         "windowAria": "时间窗",
         "windows": {
+          "24h": "近 24 小时",
           "7d": "近 7 天",
           "30d": "近 30 天",
           "90d": "近 90 天",
@@ -115,6 +116,7 @@
         "rankHint": "「其他」= 未进 Top 的其余工作流合计（不是项目管理）。项目管理单独成行。",
         "grainDay": "按日聚合 · 本地时区",
         "grainWeek": "按周聚合 · 本地时区",
+        "grainHour": "按小时聚合 · 本地时区",
         "compTotal": "合计 {n}",
         "donutCenter": "总量",
         "other": "其他",

--- a/web/src/views/TokenAnalyticsView.test.ts
+++ b/web/src/views/TokenAnalyticsView.test.ts
@@ -277,4 +277,44 @@ describe('TokenAnalyticsView', () => {
     expect(pushMock).toHaveBeenCalledWith('/runs/r-long')
     wrapper.unmount()
   })
+
+  it('puts 近 24 小时 first, keeps default 30d, and requests window=24h on click (g2.1/g2.2)', async () => {
+    const wrapper = mount(TokenAnalyticsView, { global: { plugins: [i18n] } })
+    await flushPromises()
+    const group = wrapper.find('[data-testid="token-analytics-window"]')
+    const labels = group.findAll('button').map((b) => b.text())
+    expect(labels).toEqual(['近 24 小时', '近 7 天', '近 30 天', '近 90 天', '全部历史'])
+    expect(wrapper.find('[data-testid="token-analytics-window-30d"]').classes()).toContain('bg-surface')
+    expect(wrapper.find('[data-testid="token-analytics-window-24h"]').classes()).not.toContain('bg-surface')
+    expect(api.getGlobalTokenStats).toHaveBeenCalledWith(
+      expect.objectContaining({ window: '30d' }),
+      expect.anything(),
+    )
+
+    vi.mocked(api.getGlobalTokenStats).mockClear()
+    vi.mocked(api.getGlobalTokenStats).mockResolvedValue({
+      ...sampleData,
+      window: '24h',
+      bucketWidth: 'hour',
+      trend: [
+        {
+          bucket: '2026-07-24T20',
+          total: 40,
+          workflowTotal: 30,
+          pmTotal: 10,
+          inputTokens: 20,
+          outputTokens: 10,
+          cacheReadTokens: 5,
+          cacheWriteTokens: 5,
+        },
+      ],
+    })
+    await wrapper.find('[data-testid="token-analytics-window-24h"]').trigger('click')
+    await flushPromises()
+    expect(api.getGlobalTokenStats).toHaveBeenCalledWith(
+      expect.objectContaining({ window: '24h' }),
+      expect.anything(),
+    )
+    wrapper.unmount()
+  })
 })

--- a/web/src/views/TokenAnalyticsView.vue
+++ b/web/src/views/TokenAnalyticsView.vue
@@ -34,7 +34,7 @@ const { t } = useI18n()
 const router = useRouter()
 const toast = useToast()
 
-const WINDOWS: TokenStatsWindow[] = ['7d', '30d', '90d', 'all']
+const WINDOWS: TokenStatsWindow[] = ['24h', '7d', '30d', '90d', 'all']
 
 const windowSel = ref<TokenStatsWindow>('30d')
 const sourceSel = ref<'all' | 'workflow' | 'pm'>('all')
@@ -488,6 +488,7 @@ watch([windowSel], () => void load())
             type="button"
             class="px-2.5 py-1.5 text-xs"
             :class="windowSel === w ? 'bg-surface font-semibold text-txt shadow-sm' : 'text-txt3'"
+            :data-testid="`token-analytics-window-${w}`"
             @click="windowSel = w"
           >
             {{ t(`pages.board.tokenStats.windows.${w}`) }}


### PR DESCRIPTION
用量统计页与看板 Token 统计共享 24h 窗口；后端滚动取数、缺小时补 0，默认仍为近 30 天。

Co-authored-by: Cursor <cursoragent@cursor.com>
