### PR TITLE
feat(web): Token 分析「消耗最多的运行」表支持拖动列宽

### DIFF
--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -84,7 +84,8 @@
         "colTotal": "Total",
         "colInput": "Input",
         "colOutput": "Output",
-        "colDelta": "Change"
+        "colDelta": "Change",
+        "resizeCol": "Drag to resize the {col} column"
       },
       "filterApplied": "Filtered: {name}"
     },

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -84,7 +84,8 @@
         "colTotal": "总量",
         "colInput": "输入",
         "colOutput": "输出",
-        "colDelta": "变化"
+        "colDelta": "变化",
+        "resizeCol": "拖动调整{col}列宽"
       },
       "filterApplied": "已筛选：{name}"
     },

--- a/web/src/views/TokenAnalyticsView.test.ts
+++ b/web/src/views/TokenAnalyticsView.test.ts
@@ -227,6 +227,7 @@ describe('TokenAnalyticsView', () => {
   })
 
   it('truncates long multiline run titles to a single line in top runs table', async () => {
+    // plan coverage: g2.1 — 60-char cap, single line, tooltip for overflow
     const longTitle =
       '5. 迁移编号须严格递增，不得重用历史编号；6. 所有新增表结构变更必须配套 SQLite migration，禁止只改 Go struct；7. 关键路径必须有可重现的 Go tests。\n\n三、接口与安全\n对外 HTTP 接口保持向后兼容；敏感字段不得出现在日志。\n\n四、验收测试\n须覆盖主流程与边界，PR 不得带未测试的 Sendable 变更。'
     vi.mocked(api.getGlobalTokenStats).mockResolvedValue({
@@ -250,6 +251,7 @@ describe('TokenAnalyticsView', () => {
   })
 
   it('shows short run titles without ellipsis in top runs table', async () => {
+    // plan coverage: g2.1 — short titles keep full text, no tooltip
     const shortTitle = '我要讲解一个技术 或者一个产品 目前模板太少了'
     vi.mocked(api.getGlobalTokenStats).mockResolvedValue({
       ...sampleData,
@@ -265,6 +267,7 @@ describe('TokenAnalyticsView', () => {
   })
 
   it('navigates to run detail when clicking truncated run title', async () => {
+    // plan coverage: g2.1 — click truncated title still goes to /runs/:id
     const longTitle = 'A'.repeat(80)
     vi.mocked(api.getGlobalTokenStats).mockResolvedValue({
       ...sampleData,
@@ -275,6 +278,109 @@ describe('TokenAnalyticsView', () => {
     const runsTable = wrapper.find('[data-testid="token-analytics-runs-table"]')
     await runsTable.find('tbody button.text-accent-2').trigger('click')
     expect(pushMock).toHaveBeenCalledWith('/runs/r-long')
+    wrapper.unmount()
+  })
+
+  function firePointer(
+    el: Element,
+    type: 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel',
+    clientX: number,
+  ) {
+    el.dispatchEvent(
+      new PointerEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        clientX,
+        pointerId: 1,
+      }),
+    )
+  }
+
+  it('renders header sashes with i18n aria-label even when topRuns is empty', async () => {
+    // plan coverage: g1.1 / f5 — empty topRuns still shows four draggable headers
+    vi.mocked(api.getGlobalTokenStats).mockResolvedValue({ ...sampleData, topRuns: [] })
+    const wrapper = mount(TokenAnalyticsView, { global: { plugins: [i18n] } })
+    await flushPromises()
+    const runsTable = wrapper.find('[data-testid="token-analytics-runs-table"]')
+    expect(runsTable.text()).toContain('运行')
+    expect(runsTable.text()).toContain('项目')
+    expect(runsTable.text()).toContain('模型')
+    expect(runsTable.text()).toContain('总量')
+    for (const key of ['run', 'project', 'model', 'total'] as const) {
+      const sash = runsTable.find(`[data-testid="token-analytics-runs-col-sash-${key}"]`)
+      expect(sash.exists()).toBe(true)
+      expect(sash.classes()).toContain('cursor-col-resize')
+      expect(sash.attributes('role')).toBe('separator')
+      expect(sash.attributes('aria-label')).toMatch(/拖动调整/)
+    }
+    wrapper.unmount()
+  })
+
+  it('dragging a header sash changes that column width', async () => {
+    // plan coverage: g1.2 / g2.2 — pointer drag updates col style width
+    const wrapper = mount(TokenAnalyticsView, { global: { plugins: [i18n] } })
+    await flushPromises()
+    const sash = wrapper.find('[data-testid="token-analytics-runs-col-sash-run"]').element
+    const col = wrapper.find('[data-testid="token-analytics-runs-col-run"]')
+    expect(col.attributes('style')).toContain('220px')
+    firePointer(sash, 'pointerdown', 100)
+    firePointer(sash, 'pointermove', 160)
+    firePointer(sash, 'pointerup', 160)
+    await flushPromises()
+    expect(wrapper.find('[data-testid="token-analytics-runs-col-run"]').attributes('style')).toContain('280px')
+    wrapper.unmount()
+  })
+
+  it('resizes each of the four runs-table columns independently', async () => {
+    // plan coverage: g1.2 — run/project/model/total each have their own pixel width
+    const wrapper = mount(TokenAnalyticsView, { global: { plugins: [i18n] } })
+    await flushPromises()
+    const drags: Array<[string, number, number]> = [
+      ['run', 100, 150],
+      ['project', 100, 130],
+      ['model', 100, 90],
+      ['total', 100, 140],
+    ]
+    for (const [key, start, end] of drags) {
+      const sash = wrapper.find(`[data-testid="token-analytics-runs-col-sash-${key}"]`).element
+      firePointer(sash, 'pointerdown', start)
+      firePointer(sash, 'pointermove', end)
+      firePointer(sash, 'pointerup', end)
+    }
+    await flushPromises()
+    expect(wrapper.find('[data-testid="token-analytics-runs-col-run"]').attributes('style')).toContain('270px')
+    expect(wrapper.find('[data-testid="token-analytics-runs-col-project"]').attributes('style')).toContain('170px')
+    expect(wrapper.find('[data-testid="token-analytics-runs-col-model"]').attributes('style')).toContain('130px')
+    expect(wrapper.find('[data-testid="token-analytics-runs-col-total"]').attributes('style')).toContain('128px')
+    wrapper.unmount()
+  })
+
+  it('clamps column width at the minimum when dragging inward', async () => {
+    // plan coverage: g1.2 / g2.2 — drag below min width is clamped
+    const wrapper = mount(TokenAnalyticsView, { global: { plugins: [i18n] } })
+    await flushPromises()
+    const sash = wrapper.find('[data-testid="token-analytics-runs-col-sash-run"]').element
+    firePointer(sash, 'pointerdown', 400)
+    firePointer(sash, 'pointermove', -4000)
+    firePointer(sash, 'pointerup', -4000)
+    await flushPromises()
+    expect(wrapper.find('[data-testid="token-analytics-runs-col-run"]').attributes('style')).toContain('80px')
+    wrapper.unmount()
+  })
+
+  it('dragging a column sash does not navigate to the run', async () => {
+    // plan coverage: g1.3 / g2.2 — sash pointer drag must not call router.push
+    const wrapper = mount(TokenAnalyticsView, { global: { plugins: [i18n] } })
+    await flushPromises()
+    const sash = wrapper.find('[data-testid="token-analytics-runs-col-sash-run"]').element
+    firePointer(sash, 'pointerdown', 100)
+    firePointer(sash, 'pointermove', 140)
+    firePointer(sash, 'pointerup', 140)
+    await flushPromises()
+    expect(pushMock).not.toHaveBeenCalled()
+    const runsTable = wrapper.find('[data-testid="token-analytics-runs-table"]')
+    await runsTable.find('tbody button.text-accent-2').trigger('click')
+    expect(pushMock).toHaveBeenCalledWith('/runs/r1')
     wrapper.unmount()
   })
 })

--- a/web/src/views/TokenAnalyticsView.vue
+++ b/web/src/views/TokenAnalyticsView.vue
@@ -444,6 +444,63 @@ function goRun(runId: string) {
 
 const RUN_TITLE_MAX_DISPLAY = 60
 
+/** Session-only widths for the "highest-usage runs" table (g1.2). Refresh restores defaults. */
+type RunsColKey = 'run' | 'project' | 'model' | 'total'
+
+const RUNS_COL_DEFS = [
+  { key: 'run' as const, labelKey: 'pages.tokenAnalytics.tables.colRun', align: 'left' as const, defaultWidth: 220, minWidth: 80 },
+  { key: 'project' as const, labelKey: 'pages.tokenAnalytics.tables.colProject', align: 'left' as const, defaultWidth: 140, minWidth: 64 },
+  { key: 'model' as const, labelKey: 'pages.tokenAnalytics.tables.colModel', align: 'left' as const, defaultWidth: 140, minWidth: 64 },
+  { key: 'total' as const, labelKey: 'pages.tokenAnalytics.tables.colTotal', align: 'right' as const, defaultWidth: 88, minWidth: 56 },
+] as const
+
+const RUNS_COL_MIN: Record<RunsColKey, number> = {
+  run: 80,
+  project: 64,
+  model: 64,
+  total: 56,
+}
+
+const runsColWidths = ref<Record<RunsColKey, number>>({
+  run: 220,
+  project: 140,
+  model: 140,
+  total: 88,
+})
+const runsColDragging = ref<RunsColKey | null>(null)
+let runsColDragStartX = 0
+let runsColDragStartW = 0
+
+function clampRunsColWidth(key: RunsColKey, width: number): number {
+  return Math.max(RUNS_COL_MIN[key], width)
+}
+
+function runsColSashLabel(key: RunsColKey): string {
+  const def = RUNS_COL_DEFS.find((c) => c.key === key)!
+  return t('pages.tokenAnalytics.tables.resizeCol', { col: t(def.labelKey) })
+}
+
+function onRunsColSashPointerDown(key: RunsColKey, e: PointerEvent) {
+  runsColDragging.value = key
+  runsColDragStartX = e.clientX
+  runsColDragStartW = runsColWidths.value[key]
+  const el = e.currentTarget as HTMLElement
+  if (typeof el.setPointerCapture === 'function') el.setPointerCapture(e.pointerId)
+  e.preventDefault()
+  e.stopPropagation()
+}
+
+function onRunsColSashPointerMove(e: PointerEvent) {
+  const key = runsColDragging.value
+  if (!key) return
+  runsColWidths.value[key] = clampRunsColWidth(key, runsColDragStartW + (e.clientX - runsColDragStartX))
+  e.preventDefault()
+}
+
+function onRunsColSashPointerUp() {
+  runsColDragging.value = null
+}
+
 function runTitleReadable(raw: string): string {
   return displayRunTitle(raw).replace(/\s+/g, ' ').trim()
 }
@@ -463,6 +520,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   abort?.abort()
+  runsColDragging.value = null
 })
 
 watch([windowSel], () => void load())
@@ -735,28 +793,60 @@ watch([windowSel], () => void load())
           <div class="flex max-h-[280px] min-h-0 flex-col border border-line bg-surface p-3.5" data-testid="token-analytics-runs-table">
             <h2 class="m-0 mb-2 shrink-0 text-sm font-semibold">{{ t('pages.tokenAnalytics.tables.runs') }}</h2>
             <div class="token-analytics-table-scroll min-h-0 flex-1 overflow-auto">
-              <table class="w-full border-collapse text-xs">
+              <!-- plan coverage: g1.1 / g1.2 / g1.3 — header sashes, session col widths, truncate without misfire -->
+              <table
+                class="token-analytics-runs-grid min-w-full border-collapse text-xs"
+                :class="runsColDragging ? 'select-none' : ''"
+                data-testid="token-analytics-runs-grid"
+              >
+                <colgroup>
+                  <col
+                    v-for="col in RUNS_COL_DEFS"
+                    :key="col.key"
+                    :data-testid="`token-analytics-runs-col-${col.key}`"
+                    :style="{ width: `${runsColWidths[col.key]}px` }"
+                  />
+                </colgroup>
                 <thead>
                   <tr class="text-txt3">
-                    <th class="border-b border-line py-1.5 text-left font-semibold">{{ t('pages.tokenAnalytics.tables.colRun') }}</th>
-                    <th class="border-b border-line py-1.5 text-left font-semibold">{{ t('pages.tokenAnalytics.tables.colProject') }}</th>
-                    <th class="border-b border-line py-1.5 text-left font-semibold">{{ t('pages.tokenAnalytics.tables.colModel') }}</th>
-                    <th class="border-b border-line py-1.5 text-right font-semibold">{{ t('pages.tokenAnalytics.tables.colTotal') }}</th>
+                    <th
+                      v-for="col in RUNS_COL_DEFS"
+                      :key="col.key"
+                      class="relative select-none border-b border-line py-1.5 font-semibold"
+                      :class="col.align === 'right' ? 'text-right' : 'text-left'"
+                    >
+                      {{ t(col.labelKey) }}
+                      <div
+                        class="token-analytics-runs-col-sash absolute top-0 z-[2] h-full w-1.5 cursor-col-resize touch-none hover:bg-accent"
+                        :class="runsColDragging === col.key ? 'bg-accent' : ''"
+                        role="separator"
+                        aria-orientation="vertical"
+                        :aria-valuemin="col.minWidth"
+                        :aria-valuenow="runsColWidths[col.key]"
+                        :aria-label="runsColSashLabel(col.key)"
+                        :title="runsColSashLabel(col.key)"
+                        :data-testid="`token-analytics-runs-col-sash-${col.key}`"
+                        @pointerdown="onRunsColSashPointerDown(col.key, $event)"
+                        @pointermove="onRunsColSashPointerMove"
+                        @pointerup="onRunsColSashPointerUp"
+                        @pointercancel="onRunsColSashPointerUp"
+                      />
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
                   <tr v-for="r in data.topRuns" :key="r.runId" class="hover:bg-accent-dim/40">
-                    <td class="max-w-0 border-b border-line/60 py-1.5">
+                    <td class="overflow-hidden text-ellipsis whitespace-nowrap border-b border-line/60 py-1.5">
                       <button
                         type="button"
-                        class="block max-w-full truncate text-left text-accent-2"
+                        class="block w-full max-w-full truncate text-left text-accent-2"
                         :title="runTitleTooltip(r.title)"
                         @click="goRun(r.runId)"
                       >{{ runTitleDisplay(r.title) }}</button>
                     </td>
-                    <td class="border-b border-line/60 py-1.5">{{ r.projectName }}</td>
-                    <td class="border-b border-line/60 py-1.5">{{ r.modelName || r.modelKey }}</td>
-                    <td class="border-b border-line/60 py-1.5 text-right tabular-nums">{{ fmtCompactTokenCount(r.total) }}</td>
+                    <td class="overflow-hidden text-ellipsis whitespace-nowrap border-b border-line/60 py-1.5">{{ r.projectName }}</td>
+                    <td class="overflow-hidden text-ellipsis whitespace-nowrap border-b border-line/60 py-1.5">{{ r.modelName || r.modelKey }}</td>
+                    <td class="overflow-hidden whitespace-nowrap border-b border-line/60 py-1.5 text-right tabular-nums">{{ fmtCompactTokenCount(r.total) }}</td>
                   </tr>
                 </tbody>
               </table>
@@ -795,5 +885,12 @@ watch([windowSel], () => void load())
 .token-analytics-kpi-merge:focus .token-analytics-kpi-tip,
 .token-analytics-kpi-merge:focus-within .token-analytics-kpi-tip {
   display: block;
+}
+.token-analytics-runs-grid {
+  table-layout: fixed;
+  width: max-content;
+}
+.token-analytics-runs-col-sash {
+  right: -3px;
 }
 </style>


### PR DESCRIPTION
用户需要自行加宽运行名等列以辨认截断文本。列宽仅保存在当前页面会话，不改跳转与 60 字截断规则。

Co-authored-by: Cursor <cursoragent@cursor.com>
