### PR TITLE
feat(stats): 用量统计默认时间窗改为全部历史

### DIFF
--- a/server/internal/handlers/project_test.go
+++ b/server/internal/handlers/project_test.go
@@ -239,6 +239,14 @@ func TestGetProjectTokenStats(t *testing.T) {
 		t.Fatalf("want empty true: %s", w.Body.String())
 	}
 
+	w = hn.do("GET", "/api/projects/"+id+"/token-stats?timezone=UTC", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("omit window: %d %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"window":"30d"`) {
+		t.Fatalf("project token-stats omitted window must stay 30d: %s", w.Body.String())
+	}
+
 	must := func(err error) {
 		t.Helper()
 		if err != nil {

--- a/server/internal/handlers/stats.go
+++ b/server/internal/handlers/stats.go
@@ -11,7 +11,7 @@ import (
 )
 
 // GetGlobalTokenStats returns cross-project token analytics for /stats.
-// Query: window=24h|7d|30d|90d|all (default 30d), timezone, utcOffsetMinutes,
+// Query: window=24h|7d|30d|90d|all (default all), timezone, utcOffsetMinutes,
 // source=all|workflow|pm, projectId, modelKey.
 func (h *Handlers) GetGlobalTokenStats(c *gin.Context) {
 	if h.Projects == nil {
@@ -20,7 +20,7 @@ func (h *Handlers) GetGlobalTokenStats(c *gin.Context) {
 	}
 
 	q := services.GlobalTokenStatsQuery{
-		Window:    c.DefaultQuery("window", services.TokenStatsWindow30d),
+		Window:    c.DefaultQuery("window", services.TokenStatsWindowAll),
 		Timezone:  c.Query("timezone"),
 		Source:    c.DefaultQuery("source", services.GlobalTokenStatsSourceAll),
 		ProjectID: strings.TrimSpace(c.Query("projectId")),

--- a/server/internal/handlers/stats_test.go
+++ b/server/internal/handlers/stats_test.go
@@ -1,0 +1,39 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/cocofhu/approving/internal/services"
+)
+
+func TestGetGlobalTokenStatsOmitsWindowDefaultsAll(t *testing.T) {
+	hn := newHarness(t)
+
+	w := hn.do("GET", "/api/stats/token?timezone=UTC", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("omit window: %d %s", w.Code, w.Body.String())
+	}
+	var got services.GlobalTokenStatsResult
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v body=%s", err, w.Body.String())
+	}
+	if got.Window != services.TokenStatsWindowAll {
+		t.Fatalf("GET /stats/token omitted window want all, got %q", got.Window)
+	}
+	if got.BucketWidth != services.TokenStatsBucketWeek {
+		t.Fatalf("all should use week buckets, got %q", got.BucketWidth)
+	}
+
+	w = hn.do("GET", "/api/stats/token?window=30d&timezone=UTC", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("explicit 30d: %d %s", w.Code, w.Body.String())
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode 30d: %v", err)
+	}
+	if got.Window != services.TokenStatsWindow30d {
+		t.Fatalf("explicit window=30d want 30d, got %q", got.Window)
+	}
+}

--- a/server/internal/services/global_token_stats.go
+++ b/server/internal/services/global_token_stats.go
@@ -160,7 +160,7 @@ func (s *ProjectService) GlobalTokenStats(ctx context.Context, q GlobalTokenStat
 
 	window := strings.TrimSpace(q.Window)
 	if window == "" {
-		window = TokenStatsWindow30d
+		window = TokenStatsWindowAll
 	}
 	spec, err := parseTokenStatsWindow(window)
 	if err != nil {

--- a/server/internal/services/global_token_stats_test.go
+++ b/server/internal/services/global_token_stats_test.go
@@ -345,4 +345,26 @@ func TestGlobalTokenStats24hEmptyWindow(t *testing.T) {
 	}
 }
 
+func TestGlobalTokenStatsOmitsWindowDefaultsAll(t *testing.T) {
+	db, err := database.OpenSQLiteTest(filepath.Join(t.TempDir(), "global_token_omit_window.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewProjectService(db)
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	res, err := s.GlobalTokenStats(context.Background(), GlobalTokenStatsQuery{
+		Timezone: "UTC",
+		Now:      now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Window != TokenStatsWindowAll {
+		t.Fatalf("omitted window want all, got %s", res.Window)
+	}
+	if res.BucketWidth != TokenStatsBucketWeek {
+		t.Fatalf("all should use week buckets, got %s", res.BucketWidth)
+	}
+}
+
 func aliasPtr(s string) *string { return &s }

--- a/web/src/lib/api/api.test.ts
+++ b/web/src/lib/api/api.test.ts
@@ -440,3 +440,20 @@ describe('api.patchWorkflowHomeVisibility', () => {
     expect(body.title).toBe('用户第一句话')
   })
 })
+
+describe('getGlobalTokenStats window fallback (g1.2)', () => {
+  it('omits window by falling back to all, not 30d', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ window: 'all', empty: true }))
+    await api.getGlobalTokenStats({})
+    const url = String(fetchMock.mock.calls[0]?.[0])
+    expect(url).toMatch(/\/stats\/token\?/)
+    expect(new URL(url, 'http://localhost').searchParams.get('window')).toBe('all')
+  })
+
+  it('passes an explicit window through', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ window: '30d', empty: true }))
+    await api.getGlobalTokenStats({ window: '30d' })
+    const url = String(fetchMock.mock.calls[0]?.[0])
+    expect(new URL(url, 'http://localhost').searchParams.get('window')).toBe('30d')
+  })
+})

--- a/web/src/lib/api/clients/statsClient.ts
+++ b/web/src/lib/api/clients/statsClient.ts
@@ -13,7 +13,7 @@ export type GlobalTokenStatsParams = {
 export const statsClient = {
   getGlobalTokenStats: (params: GlobalTokenStatsParams, opts?: { signal?: AbortSignal }) => {
     const q = new URLSearchParams()
-    q.set('window', params.window || '30d')
+    q.set('window', params.window || 'all')
     if (params.timezone) q.set('timezone', params.timezone)
     if (params.utcOffsetMinutes != null && Number.isFinite(params.utcOffsetMinutes)) {
       q.set('utcOffsetMinutes', String(Math.round(params.utcOffsetMinutes)))

--- a/web/src/views/TokenAnalyticsView.test.ts
+++ b/web/src/views/TokenAnalyticsView.test.ts
@@ -42,7 +42,7 @@ import { api } from '@/lib/api/api'
 import { displayRunTitle } from '@/lib/run/runTitle'
 
 const sampleData = {
-  window: '30d',
+  window: 'all',
   bucketWidth: 'day',
   timezone: 'Asia/Shanghai',
   empty: false,
@@ -106,7 +106,7 @@ describe('TokenAnalyticsView', () => {
     wrapper.unmount()
   })
 
-  it('shows default input/output rows without cache labels or slash pairs', async () => {
+  it('shows default input/output rows without cache labels or slash pairs (g2.1)', async () => {
     const wrapper = mount(TokenAnalyticsView, { global: { plugins: [i18n] } })
     await flushPromises()
     const merge = wrapper.find('[data-testid="token-analytics-kpi-merge"]')
@@ -123,7 +123,7 @@ describe('TokenAnalyticsView', () => {
     wrapper.unmount()
   })
 
-  it('shows four-part KPI detail on hover and focus', async () => {
+  it('shows four-part KPI detail on hover and focus (g2.1)', async () => {
     const wrapper = mount(TokenAnalyticsView, { global: { plugins: [i18n] } })
     await flushPromises()
     expect(wrapper.find('[data-testid="token-analytics-kpi-detail"]').exists()).toBe(true)
@@ -278,18 +278,45 @@ describe('TokenAnalyticsView', () => {
     wrapper.unmount()
   })
 
-  it('puts 近 24 小时 first, keeps default 30d, and requests window=24h on click (g2.1/g2.2)', async () => {
+  it('defaults to 全部历史 and first request uses window=all (g1.1/g2.2)', async () => {
     const wrapper = mount(TokenAnalyticsView, { global: { plugins: [i18n] } })
     await flushPromises()
     const group = wrapper.find('[data-testid="token-analytics-window"]')
     const labels = group.findAll('button').map((b) => b.text())
     expect(labels).toEqual(['近 24 小时', '近 7 天', '近 30 天', '近 90 天', '全部历史'])
-    expect(wrapper.find('[data-testid="token-analytics-window-30d"]').classes()).toContain('bg-surface')
-    expect(wrapper.find('[data-testid="token-analytics-window-24h"]').classes()).not.toContain('bg-surface')
+    expect(wrapper.find('[data-testid="token-analytics-window-all"]').classes()).toContain('bg-surface')
+    expect(wrapper.find('[data-testid="token-analytics-window-all"]').text()).toBe('全部历史')
+    expect(wrapper.find('[data-testid="token-analytics-window-30d"]').classes()).not.toContain('bg-surface')
     expect(api.getGlobalTokenStats).toHaveBeenCalledWith(
-      expect.objectContaining({ window: '30d' }),
+      expect.objectContaining({ window: 'all' }),
       expect.anything(),
     )
+    wrapper.unmount()
+  })
+
+  it('keeps source/project/model filters defaulting to all (g2.1)', async () => {
+    const wrapper = mount(TokenAnalyticsView, { global: { plugins: [i18n] } })
+    await flushPromises()
+    const filters = wrapper.find('[data-testid="token-analytics-filters"]')
+    expect(filters.text()).toContain('来源：全部')
+    expect(filters.text()).toContain('项目：全部')
+    expect(filters.text()).toContain('模型：全部')
+    const sourceAll = filters.findAll('button').find((b) => b.text() === '来源：全部')
+    expect(sourceAll?.classes()).toContain('bg-accent-dim')
+    const selects = filters.findAll('select')
+    expect(selects).toHaveLength(2)
+    expect((selects[0].element as HTMLSelectElement).value).toBe('')
+    expect((selects[1].element as HTMLSelectElement).value).toBe('')
+    wrapper.unmount()
+  })
+
+  it('puts 近 24 小时 first, still switches windows, and requests window=24h on click (g2.1)', async () => {
+    const wrapper = mount(TokenAnalyticsView, { global: { plugins: [i18n] } })
+    await flushPromises()
+    const group = wrapper.find('[data-testid="token-analytics-window"]')
+    const labels = group.findAll('button').map((b) => b.text())
+    expect(labels).toEqual(['近 24 小时', '近 7 天', '近 30 天', '近 90 天', '全部历史'])
+    expect(wrapper.find('[data-testid="token-analytics-window-all"]').classes()).toContain('bg-surface')
 
     vi.mocked(api.getGlobalTokenStats).mockClear()
     vi.mocked(api.getGlobalTokenStats).mockResolvedValue({
@@ -313,6 +340,17 @@ describe('TokenAnalyticsView', () => {
     await flushPromises()
     expect(api.getGlobalTokenStats).toHaveBeenCalledWith(
       expect.objectContaining({ window: '24h' }),
+      expect.anything(),
+    )
+    expect(wrapper.find('[data-testid="token-analytics-window-24h"]').classes()).toContain('bg-surface')
+    expect(wrapper.find('[data-testid="token-analytics-window-all"]').classes()).not.toContain('bg-surface')
+
+    vi.mocked(api.getGlobalTokenStats).mockClear()
+    vi.mocked(api.getGlobalTokenStats).mockResolvedValue({ ...sampleData, window: '30d' })
+    await wrapper.find('[data-testid="token-analytics-window-30d"]').trigger('click')
+    await flushPromises()
+    expect(api.getGlobalTokenStats).toHaveBeenCalledWith(
+      expect.objectContaining({ window: '30d' }),
       expect.anything(),
     )
     wrapper.unmount()

--- a/web/src/views/TokenAnalyticsView.vue
+++ b/web/src/views/TokenAnalyticsView.vue
@@ -36,7 +36,7 @@ const toast = useToast()
 
 const WINDOWS: TokenStatsWindow[] = ['24h', '7d', '30d', '90d', 'all']
 
-const windowSel = ref<TokenStatsWindow>('30d')
+const windowSel = ref<TokenStatsWindow>('all')
 const sourceSel = ref<'all' | 'workflow' | 'pm'>('all')
 const projectSel = ref('')
 const modelSel = ref('')


### PR DESCRIPTION
首次进入用量统计页按 window=all 取数，并与全局接口省略 window 的回退对齐；项目看板仍默认近 30 天。

Co-authored-by: Cursor <cursoragent@cursor.com>
