### PR TITLE
fix(runtime): let shared settings.json pass auth gate

### DIFF
--- a/server/internal/runtime/acp_backend.go
+++ b/server/internal/runtime/acp_backend.go
@@ -135,7 +135,7 @@ func MergeAuthEnv(backend AcpBackend, env map[string]string) (map[string]string,
 }
 
 // SettingsFileExists reports whether settings.json is present at the root of the
-// Agent workspace. Dialog-test auth gate treats file presence as sufficient; content
+// given workspace. Auth gate treats file presence as sufficient; content
 // is not validated or rewritten by the gate.
 func SettingsFileExists(workDirSrc string) bool {
 	if workDirSrc == "" {
@@ -145,14 +145,37 @@ func SettingsFileExists(workDirSrc string) bool {
 	return err == nil
 }
 
-// PrepareAuthEnv merges auth keys from Agent workspace settings.json.env into env
+// ResolveSettingsWorkDir picks which workspace root's settings.json wins for the
+// auth gate, matching BuildConfigHome layering: Agent overlay if present, else
+// project-shared extend. Empty sharedWorkDir falls back to the Agent directory only.
+func ResolveSettingsWorkDir(agentWorkDir, sharedWorkDir string) string {
+	if SettingsFileExists(agentWorkDir) {
+		return agentWorkDir
+	}
+	if sharedWorkDir != "" && SettingsFileExists(sharedWorkDir) {
+		return sharedWorkDir
+	}
+	if agentWorkDir != "" {
+		return agentWorkDir
+	}
+	return sharedWorkDir
+}
+
+// PrepareAuthEnv merges auth keys from workspace settings.json.env into env
 // (explicit env wins, including empty overrides), then normalizes via mergeAuthEnv.
-// When settings.json exists in the workspace, the auth gate passes without requiring
+// Optional sharedWorkDir is the project-shared Agent workspace (extend layer);
+// when the Agent directory has no settings.json, the shared root is used instead.
+// When settings.json exists in either layer, the auth gate passes without requiring
 // Env keys; content is left to the backend/CLI.
-func PrepareAuthEnv(backend AcpBackend, env map[string]string, workDirSrc string) (map[string]string, error) {
-	settingsAuth := ReadSettingsAuthEnv(workDirSrc, backend)
+func PrepareAuthEnv(backend AcpBackend, env map[string]string, workDirSrc string, sharedWorkDir ...string) (map[string]string, error) {
+	base := ""
+	if len(sharedWorkDir) > 0 {
+		base = sharedWorkDir[0]
+	}
+	settingsDir := ResolveSettingsWorkDir(workDirSrc, base)
+	settingsAuth := ReadSettingsAuthEnv(settingsDir, backend)
 	merged := mergeSettingsAuthIntoEnv(env, settingsAuth)
-	requireAuth := !SettingsFileExists(workDirSrc)
+	requireAuth := !SettingsFileExists(settingsDir)
 	return mergeAuthEnv(backend, merged, requireAuth)
 }
 
@@ -251,7 +274,7 @@ func mergeAuthEnv(backend AcpBackend, env map[string]string, requireAuth bool) (
 	if val == "" {
 		if requireAuth {
 			return out, fmt.Errorf(
-				"鉴权未配置:请在 Agent 工作目录添加 settings.json，或在项目沙箱 env、Agent 环境变量中设置 %s",
+				"鉴权未配置:请在项目共享 Agent 工作目录或该 Agent 工作目录添加 settings.json，或在项目沙箱 env、Agent 环境变量中设置 %s",
 				strings.Join(spec.agentKeys, " 或 "),
 			)
 		}

--- a/server/internal/runtime/acp_backend_test.go
+++ b/server/internal/runtime/acp_backend_test.go
@@ -458,6 +458,9 @@ func TestPrepareAuthEnv_NeitherConfigured(t *testing.T) {
 	if !strings.Contains(err.Error(), "settings.json") {
 		t.Fatalf("error should mention settings.json: %v", err)
 	}
+	if !strings.Contains(err.Error(), "项目共享") {
+		t.Fatalf("error should mention 项目共享: %v", err)
+	}
 	if !strings.Contains(err.Error(), "APPROVING_CLAUDE_API_KEY") {
 		t.Fatalf("error should mention env keys: %v", err)
 	}
@@ -592,5 +595,111 @@ func TestPrepareAuthEnv_NoSettingsEnvConfigured(t *testing.T) {
 	}
 	if out["CURSOR_API_KEY"] != "crsr-env" {
 		t.Fatalf("CURSOR_API_KEY=%q", out["CURSOR_API_KEY"])
+	}
+}
+
+func TestResolveSettingsWorkDir(t *testing.T) {
+	agentDir := t.TempDir()
+	sharedDir := t.TempDir()
+
+	if got := ResolveSettingsWorkDir(agentDir, ""); got != agentDir {
+		t.Fatalf("empty shared: got %q want %q", got, agentDir)
+	}
+	if got := ResolveSettingsWorkDir(agentDir, sharedDir); got != agentDir {
+		t.Fatalf("neither file: got %q want agent %q", got, agentDir)
+	}
+
+	writeSettingsJSON(sharedDir, `{}`)
+	if got := ResolveSettingsWorkDir(agentDir, sharedDir); got != sharedDir {
+		t.Fatalf("shared only: got %q want %q", got, sharedDir)
+	}
+
+	writeSettingsJSON(agentDir, `{}`)
+	if got := ResolveSettingsWorkDir(agentDir, sharedDir); got != agentDir {
+		t.Fatalf("agent overlay wins: got %q want %q", got, agentDir)
+	}
+
+	if got := ResolveSettingsWorkDir("", sharedDir); got != sharedDir {
+		t.Fatalf("empty agent with shared file: got %q want %q", got, sharedDir)
+	}
+}
+
+func TestPrepareAuthEnv_SharedSettingsOnly(t *testing.T) {
+	agentDir := t.TempDir()
+	sharedDir := t.TempDir()
+	writeSettingsJSON(sharedDir, `{"env":{"ANTHROPIC_API_KEY":"sk-from-shared"}}`)
+
+	out, err := PrepareAuthEnv(BackendClaudeCode, map[string]string{}, agentDir, sharedDir)
+	if err != nil {
+		t.Fatalf("shared settings.json must pass gate: %v", err)
+	}
+	if out["ANTHROPIC_API_KEY"] != "sk-from-shared" {
+		t.Fatalf("ANTHROPIC_API_KEY=%q", out["ANTHROPIC_API_KEY"])
+	}
+}
+
+func TestPrepareAuthEnv_AgentOverlayBeatsShared(t *testing.T) {
+	agentDir := t.TempDir()
+	sharedDir := t.TempDir()
+	writeSettingsJSON(sharedDir, `{"env":{"ANTHROPIC_API_KEY":"from-shared"}}`)
+	writeSettingsJSON(agentDir, `{"env":{"ANTHROPIC_API_KEY":"from-agent"}}`)
+
+	out, err := PrepareAuthEnv(BackendClaudeCode, map[string]string{}, agentDir, sharedDir)
+	if err != nil {
+		t.Fatalf("PrepareAuthEnv: %v", err)
+	}
+	if out["ANTHROPIC_API_KEY"] != "from-agent" {
+		t.Fatalf("agent overlay should win: got %q", out["ANTHROPIC_API_KEY"])
+	}
+}
+
+func TestPrepareAuthEnv_AgentFileExistsIgnoresSharedKeys(t *testing.T) {
+	agentDir := t.TempDir()
+	sharedDir := t.TempDir()
+	// Agent file present but no auth keys; shared has keys — must NOT read shared keys
+	// (file-exists gate still passes via Agent file).
+	writeSettingsJSON(agentDir, `{"model":"claude-sonnet"}`)
+	writeSettingsJSON(sharedDir, `{"env":{"ANTHROPIC_API_KEY":"from-shared"}}`)
+
+	out, err := PrepareAuthEnv(BackendClaudeCode, map[string]string{}, agentDir, sharedDir)
+	if err != nil {
+		t.Fatalf("agent settings.json presence must pass: %v", err)
+	}
+	if out["ANTHROPIC_API_KEY"] != "" {
+		t.Fatalf("must not read shared env keys when agent file exists: got %q", out["ANTHROPIC_API_KEY"])
+	}
+}
+
+func TestPrepareAuthEnv_NeitherLayerNorEnv(t *testing.T) {
+	agentDir := t.TempDir()
+	sharedDir := t.TempDir()
+	_, err := PrepareAuthEnv(BackendClaudeCode, map[string]string{}, agentDir, sharedDir)
+	if err == nil {
+		t.Fatal("expected auth error when neither layer has settings.json")
+	}
+	if !strings.Contains(err.Error(), "项目共享") {
+		t.Fatalf("error should mention 项目共享: %v", err)
+	}
+	if !strings.Contains(err.Error(), "settings.json") {
+		t.Fatalf("error should mention settings.json: %v", err)
+	}
+}
+
+func TestPrepareAuthEnv_EmptySharedFallsBackToAgent(t *testing.T) {
+	agentDir := t.TempDir()
+	writeSettingsJSON(agentDir, `{"env":{"ANTHROPIC_API_KEY":"from-agent"}}`)
+
+	out, err := PrepareAuthEnv(BackendClaudeCode, map[string]string{}, agentDir, "")
+	if err != nil {
+		t.Fatalf("empty sharedWorkDir must fall back to agent: %v", err)
+	}
+	if out["ANTHROPIC_API_KEY"] != "from-agent" {
+		t.Fatalf("ANTHROPIC_API_KEY=%q", out["ANTHROPIC_API_KEY"])
+	}
+
+	emptyAgent := t.TempDir()
+	_, err = PrepareAuthEnv(BackendClaudeCode, map[string]string{}, emptyAgent, "")
+	if err == nil {
+		t.Fatal("expected error with empty shared and no agent settings")
 	}
 }

--- a/server/internal/runtime/acp_sandbox.go
+++ b/server/internal/runtime/acp_sandbox.go
@@ -326,7 +326,8 @@ func (c *acpProvider) spec(req NodeReq) (sandbox.Spec, error) {
 			env[k] = e.Value
 		}
 	}
-	merged, err := PrepareAuthEnv(c.backend, env, c.workDir(profile))
+	// Align auth gate with buildConfigHome BaseWorkDirSrc (project-shared workspace).
+	merged, err := PrepareAuthEnv(c.backend, env, c.workDir(profile), c.sharedWorkDir(req))
 	if err != nil {
 		return sandbox.Spec{}, err
 	}

--- a/server/internal/services/sandbox_test_pool.go
+++ b/server/internal/services/sandbox_test_pool.go
@@ -185,7 +185,8 @@ func (s *SandboxService) startContainer(id uint, name, profile, projectID, runID
 	}
 	backend := runtime.NormalizeBackend(agent.AcpBackend)
 	workDir := s.skills.WorkDir(profile)
-	merged, err := runtime.PrepareAuthEnv(backend, env, workDir)
+	// Align auth gate with BuildConfigHome: shared extend then Agent overlay.
+	merged, err := runtime.PrepareAuthEnv(backend, env, workDir, sharedWorkDir)
 	if err != nil {
 		fail(err)
 		return


### PR DESCRIPTION
Align PrepareAuthEnv with BuildConfigHome layering so project-shared
workspace settings.json can satisfy dialog-test and workflow Run auth
when the Agent directory has no file.

Co-authored-by: Cursor <cursoragent@cursor.com>
