### PR TITLE
fix(react): seed stream bubbles from last prompt turn only

### DIFF
--- a/server/internal/runtime/acp_provider.go
+++ b/server/internal/runtime/acp_provider.go
@@ -123,7 +123,9 @@ func (c *acpProvider) streamChat(ctx context.Context, acp *sandbox.ACPClient, re
 		}
 		events := chatResultToEvents(r)
 		if c.timeline != nil {
-			c.timeline.upsert(req.RunID, req.NodeID, events)
+			// Absolute current-turn snapshot from streamChat — always replace so
+			// a fresh turn cannot be blocked by a longer prior-turn photo.
+			c.timeline.replace(req.RunID, req.NodeID, events)
 		}
 		c.emit(req.RunID, req.NodeID, events, busy)
 	})

--- a/server/internal/runtime/acp_sandbox.go
+++ b/server/internal/runtime/acp_sandbox.go
@@ -44,10 +44,10 @@ func (c *acpProvider) deregisterLive(req NodeReq) {
 	}
 }
 
-// LiveNodeEvents reads the in-flight sandbox's full event log directly and
-// returns it as the run timeline. ok=false, err=nil when the node is not
-// currently running in a live sandbox (finished / never started here), so
-// callers fall back to the persisted snapshot. When a live sandbox is
+// LiveNodeEvents reads the in-flight sandbox's current-turn event snapshot
+// (last prompt_begin) for streaming bubble seeds. ok=false, err=nil when the
+// node is not currently running in a live sandbox (finished / never started
+// here), so callers fall back to the persisted snapshot. When a live sandbox is
 // registered but the bridge read fails, ok=false with a non-nil err so
 // callers can surface a distinguishable failure (never pretend live+empty).
 func (c *acpProvider) LiveNodeEvents(ctx context.Context, runID, nodeID string) ([]models.AcpEvent, bool, error) {
@@ -62,7 +62,7 @@ func (c *acpProvider) LiveNodeEvents(ctx context.Context, runID, nodeID string) 
 	if sb == nil {
 		return nil, false, nil
 	}
-	res, _, err := sandbox.FetchEventLog(ctx, sb.Host, sb.Port)
+	res, _, err := sandbox.FetchEventLogLastTurn(ctx, sb.Host, sb.Port)
 	if err != nil {
 		return nil, false, err
 	}
@@ -76,9 +76,10 @@ func (c *acpProvider) LiveNodeEvents(ctx context.Context, runID, nodeID string) 
 	return events, true, nil
 }
 
-// LiveNodeEventsPage reads a page of events from the in-flight sandbox.
-// Fetch failures return ok=false with a non-nil err (aligned with
-// LiveNodeEvents) — never live=true with an empty page that masks the error.
+// LiveNodeEventsPage reads a page of current-turn events from the in-flight
+// sandbox (streaming seed path). Fetch failures return ok=false with a non-nil
+// err (aligned with LiveNodeEvents) — never live=true with an empty page that
+// masks the error.
 func (c *acpProvider) LiveNodeEventsPage(ctx context.Context, runID, nodeID, cursor string, limit int) ([]models.AcpEvent, string, bool, bool, error) {
 	if c.timeline != nil {
 		if ev, next, more, live, ok := c.timeline.page(runID, nodeID, cursor, limit); ok {
@@ -98,7 +99,8 @@ func (c *acpProvider) LiveNodeEventsPage(ctx context.Context, runID, nodeID, cur
 	if page == nil {
 		return nil, "", false, false, fmt.Errorf("event log page unavailable")
 	}
-	events := sandbox.AggregateFrames(page.Events)
+	// Page may span multiple recent turns; seed/timeline only keep the last.
+	events := sandbox.AggregateLastTurnFrames(page.Events)
 	if c.timeline != nil {
 		c.timeline.upsert(runID, nodeID, events)
 	}

--- a/server/internal/runtime/acp_timeline.go
+++ b/server/internal/runtime/acp_timeline.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -12,7 +13,10 @@ import (
 
 // acpTimelineEntry is the platform-side in-memory ACP timeline snapshot for one
 // run+node while the sandbox session is live. It is the authoritative read path
-// for nodeEvents during execution; cold FetchEventLog is a supplement only.
+// for nodeEvents during execution; cold FetchEventLogLastTurn is a supplement
+// only. Snapshots are current-turn rails (last prompt_begin), never a
+// full-session concatenation — otherwise hard-refresh seeds stitch prior turns
+// into the live streaming bubble.
 type acpTimelineEntry struct {
 	events    []models.AcpEvent
 	live      bool
@@ -49,6 +53,24 @@ func (s *acpTimelineStore) begin(runID, nodeID string) {
 	e.updatedAt = time.Now()
 }
 
+// replace unconditionally installs events (live streamChat absolute snapshots).
+func (s *acpTimelineStore) replace(runID, nodeID string, events []models.AcpEvent) {
+	if s == nil {
+		return
+	}
+	key := timelineKey(runID, nodeID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.entries[key]
+	if !ok {
+		e = &acpTimelineEntry{live: true}
+		s.entries[key] = e
+	}
+	e.ready = true
+	e.events = append([]models.AcpEvent(nil), events...)
+	e.updatedAt = time.Now()
+}
+
 func (s *acpTimelineStore) upsert(runID, nodeID string, events []models.AcpEvent) {
 	if s == nil {
 		return
@@ -62,30 +84,68 @@ func (s *acpTimelineStore) upsert(runID, nodeID string, events []models.AcpEvent
 		s.entries[key] = e
 	}
 	e.ready = true
-	e.events = pickLongerEvents(e.events, events)
+	e.events = mergeTurnEvents(e.events, events)
 	e.updatedAt = time.Now()
 }
 
-func pickLongerEvents(prev, incoming []models.AcpEvent) []models.AcpEvent {
-	if len(incoming) > len(prev) {
+// mergeTurnEvents merges timeline snapshots for the current ReAct turn.
+//
+// Within a turn, prefer the longer message/thought rails (growth / avoid stale
+// shorter ingest). Across turns — when the message rail resets to empty or
+// rails diverge (neither is a prefix of the other) — take incoming so a new
+// prompt's snapshot can replace the previous turn (or a stale full-session photo).
+func mergeTurnEvents(prev, incoming []models.AcpEvent) []models.AcpEvent {
+	if len(incoming) == 0 {
+		if len(prev) == 0 {
+			return nil
+		}
+		return prev
+	}
+	if len(prev) == 0 {
 		return append([]models.AcpEvent(nil), incoming...)
 	}
-	if len(incoming) == len(prev) && len(incoming) > 0 {
-		if lastT(incoming) >= lastT(prev) {
-			return append([]models.AcpEvent(nil), incoming...)
-		}
+
+	prevMsg, prevThought := eventRails(prev)
+	inMsg, inThought := eventRails(incoming)
+
+	// Strong reset: message rail emptied → new prompt_begin turn.
+	if prevMsg != "" && inMsg == "" {
+		return append([]models.AcpEvent(nil), incoming...)
 	}
-	if len(prev) == 0 && len(incoming) == 0 {
-		return nil
+
+	// Same-turn growth: prev rails are prefixes of incoming.
+	if strings.HasPrefix(inMsg, prevMsg) && strings.HasPrefix(inThought, prevThought) {
+		return append([]models.AcpEvent(nil), incoming...)
 	}
-	return prev
+	// Stale shorter snapshot of the same turn: incoming is a prefix of prev
+	// (also covers omitted thought/message on a partial re-read).
+	if strings.HasPrefix(prevMsg, inMsg) && strings.HasPrefix(prevThought, inThought) {
+		return prev
+	}
+	// Divergent rails (new turn content that does not continue prior text).
+	return append([]models.AcpEvent(nil), incoming...)
 }
 
-func lastT(events []models.AcpEvent) int {
-	if len(events) == 0 {
-		return 0
+// pickLongerEvents is retained for tests / callers that only need length-based
+// merge; prefer mergeTurnEvents for timeline ingest.
+func pickLongerEvents(prev, incoming []models.AcpEvent) []models.AcpEvent {
+	return mergeTurnEvents(prev, incoming)
+}
+
+func eventRails(events []models.AcpEvent) (message, thought string) {
+	for _, ev := range events {
+		switch ev.Kind {
+		case "message":
+			if ev.Text != "" {
+				message = ev.Text
+			}
+		case "thought":
+			if ev.Text != "" {
+				thought = ev.Text
+			}
+		}
 	}
-	return events[len(events)-1].T
+	return message, thought
 }
 
 func (s *acpTimelineStore) stop(runID, nodeID string) {
@@ -140,7 +200,9 @@ func (s *acpTimelineStore) ingestLoop(ctx context.Context, runID, nodeID, host s
 }
 
 func (s *acpTimelineStore) refreshFromSandbox(ctx context.Context, runID, nodeID, host string, port int) {
-	res, _, err := sandbox.FetchEventLog(ctx, host, port)
+	// Last turn only — full-session FetchEventLog would lock a concatenated
+	// photo into the timeline via upsert and poison hard-refresh seeds.
+	res, _, err := sandbox.FetchEventLogLastTurn(ctx, host, port)
 	if err != nil || res == nil {
 		return // keep existing snapshot on transient bridge failures
 	}

--- a/server/internal/runtime/acp_timeline_test.go
+++ b/server/internal/runtime/acp_timeline_test.go
@@ -60,8 +60,62 @@ func TestPickLongerEvents(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("want longer incoming, got %d", len(got))
 	}
-	if len(pickLongerEvents(in, prev)) != 2 {
-		t.Fatal("shorter incoming must not shrink snapshot")
+	// Same-turn stale shorter must not shrink.
+	if got := pickLongerEvents(in, prev); len(got) != 2 {
+		t.Fatalf("shorter same-turn incoming must not shrink snapshot, got %d", len(got))
+	}
+}
+
+func TestMergeTurnEventsAllowsNewTurnToReplace(t *testing.T) {
+	prev := []models.AcpEvent{
+		{T: 0, Kind: "thought", Text: "turn1-thought"},
+		{T: 1, Kind: "message", Text: "turn1-full-session-or-prior"},
+	}
+	incoming := []models.AcpEvent{
+		{T: 0, Kind: "thought", Text: "turn2-thought"},
+		{T: 1, Kind: "message", Text: "turn2-partial"},
+	}
+	got := mergeTurnEvents(prev, incoming)
+	if len(got) != 2 || got[1].Text != "turn2-partial" {
+		t.Fatalf("divergent new turn must replace prior photo, got %+v", got)
+	}
+
+	// Empty rails after a prior turn (prompt just began) must also replace.
+	emptyTurn := []models.AcpEvent{}
+	// empty incoming keeps prev (no seed yet) — use explicit empty message event set via replace path.
+	reset := []models.AcpEvent{{T: 0, Kind: "message", Text: ""}}
+	// Text "" is ignored by eventRails; simulate reset with thought-only new turn:
+	thoughtOnly := []models.AcpEvent{{T: 0, Kind: "thought", Text: "new"}}
+	got = mergeTurnEvents(prev, thoughtOnly)
+	if len(got) != 1 || got[0].Text != "new" {
+		t.Fatalf("new-turn thought-only must replace prior message photo, got %+v", got)
+	}
+	_ = emptyTurn
+	_ = reset
+}
+
+func TestMergeTurnEventsEmptyMessageResetsPrior(t *testing.T) {
+	prev := []models.AcpEvent{{T: 0, Kind: "message", Text: "prior-turn-body"}}
+	// Incoming has thought but cleared message rail → new turn.
+	incoming := []models.AcpEvent{{T: 0, Kind: "thought", Text: "thinking-now"}}
+	got := mergeTurnEvents(prev, incoming)
+	msg, thought := eventRails(got)
+	if msg != "" || thought != "thinking-now" {
+		t.Fatalf("want message cleared and thought current, got msg=%q thought=%q", msg, thought)
+	}
+}
+
+func TestTimelineReplaceOverridesLongerPrior(t *testing.T) {
+	s := newAcpTimelineStore()
+	s.upsert("r", "n", []models.AcpEvent{
+		{T: 0, Kind: "message", Text: "stitched-turn1-turn2-photo"},
+	})
+	s.replace("r", "n", []models.AcpEvent{
+		{T: 0, Kind: "message", Text: "turn2-only"},
+	})
+	e, ok := s.get("r", "n")
+	if !ok || len(e.events) != 1 || e.events[0].Text != "turn2-only" {
+		t.Fatalf("replace must install current-turn snapshot, got %+v ok=%v", e.events, ok)
 	}
 }
 

--- a/server/internal/sandbox/coverage_extra_test.go
+++ b/server/internal/sandbox/coverage_extra_test.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -44,5 +45,85 @@ func TestAggregateFrames(t *testing.T) {
 	ev := AggregateFrames(frames)
 	if len(ev) == 0 {
 		t.Fatal("expected aggregated events")
+	}
+}
+
+// TestAggregateLastTurnFrames_MultiTurnSeed covers the hard-refresh bug:
+// two turns of message/thought must seed only the last turn's rails.
+func TestAggregateLastTurnFrames_MultiTurnSeed(t *testing.T) {
+	frames := []json.RawMessage{
+		json.RawMessage(`{"type":"prompt_begin","promptText":"q1"}`),
+		json.RawMessage(`{"type":"session_update","update":{"sessionUpdate":"agent_thought_chunk","content":{"text":"think-1"}}}`),
+		json.RawMessage(`{"type":"session_update","update":{"sessionUpdate":"agent_message_chunk","content":{"text":"answer-1"}}}`),
+		json.RawMessage(`{"type":"prompt_begin","promptText":"q2"}`),
+		json.RawMessage(`{"type":"session_update","update":{"sessionUpdate":"agent_thought_chunk","content":{"text":"think-2"}}}`),
+		json.RawMessage(`{"type":"session_update","update":{"sessionUpdate":"agent_message_chunk","content":{"text":"answer-2-partial"}}}`),
+	}
+
+	full := AggregateFrames(frames)
+	var fullMsg, fullThought string
+	for _, e := range full {
+		if e.Kind == "message" {
+			fullMsg = e.Text
+		}
+		if e.Kind == "thought" {
+			fullThought = e.Text
+		}
+	}
+	if fullMsg != "answer-1answer-2-partial" || fullThought != "think-1think-2" {
+		t.Fatalf("full aggregate sanity: msg=%q thought=%q", fullMsg, fullThought)
+	}
+
+	last := AggregateLastTurnFrames(frames)
+	var msg, thought string
+	for _, e := range last {
+		if e.Kind == "message" {
+			msg = e.Text
+		}
+		if e.Kind == "thought" {
+			thought = e.Text
+		}
+	}
+	if msg != "answer-2-partial" {
+		t.Fatalf("last-turn message = %q, want answer-2-partial (no turn1 stitch)", msg)
+	}
+	if thought != "think-2" {
+		t.Fatalf("last-turn thought = %q, want think-2 (no turn1 stitch)", thought)
+	}
+	if strings.Contains(msg, "answer-1") || strings.Contains(thought, "think-1") {
+		t.Fatal("last-turn seed must not contain first-turn text")
+	}
+}
+
+func TestFramesAfterLastPromptBegin_WrappedAndBare(t *testing.T) {
+	frames := []json.RawMessage{
+		json.RawMessage(`{"op":"event","data":{"type":"prompt_begin","promptText":"old"}}`),
+		json.RawMessage(`{"type":"session_update","update":{"sessionUpdate":"agent_message_chunk","content":{"text":"old-msg"}}}`),
+		json.RawMessage(`{"op":"event","data":{"type":"prompt_begin","promptText":"new"}}`),
+		json.RawMessage(`{"type":"session_update","update":{"sessionUpdate":"agent_message_chunk","content":{"text":"new-msg"}}}`),
+	}
+	cut := FramesAfterLastPromptBegin(frames)
+	if len(cut) != 2 {
+		t.Fatalf("want 2 frames after last prompt_begin, got %d", len(cut))
+	}
+	ev := AggregateFrames(cut)
+	var msg string
+	for _, e := range ev {
+		if e.Kind == "message" {
+			msg = e.Text
+		}
+	}
+	if msg != "new-msg" {
+		t.Fatalf("msg=%q", msg)
+	}
+}
+
+func TestFramesAfterLastPromptBegin_NoBeginKeepsAll(t *testing.T) {
+	frames := []json.RawMessage{
+		json.RawMessage(`{"type":"session_update","update":{"sessionUpdate":"agent_message_chunk","content":{"text":"only"}}}`),
+	}
+	cut := FramesAfterLastPromptBegin(frames)
+	if len(cut) != 1 {
+		t.Fatalf("want unchanged, got %d", len(cut))
 	}
 }

--- a/server/internal/sandbox/eventlog.go
+++ b/server/internal/sandbox/eventlog.go
@@ -24,6 +24,11 @@ import (
 //
 // Best-effort: callers treat a nil/empty result as "no live log available" and
 // fall back to the persisted final snapshot.
+//
+// NOTE: Full-session aggregation concatenates every turn's message/thought.
+// Streaming bubble seeds and timeline ingest must use FetchEventLogLastTurn /
+// AggregateLastTurnFrames instead — otherwise a hard refresh stitches the
+// previous turn into the live bubble.
 func FetchEventLog(ctx context.Context, host string, port int) (*ChatResult, string, error) {
 	all, sessionID, err := FetchEventLogRaw(ctx, host, port)
 	if err != nil {
@@ -31,6 +36,22 @@ func FetchEventLog(ctx context.Context, host string, port int) (*ChatResult, str
 	}
 	result := &ChatResult{}
 	for _, frame := range all {
+		dispatchFrame(frame, result)
+	}
+	return result, sessionID, nil
+}
+
+// FetchEventLogLastTurn is like FetchEventLog but only folds frames after the
+// last prompt_begin. Used for nodeEvents / timeline streaming seeds so the
+// live bubble never receives cross-turn narration. The sandbox still keeps the
+// full eventLog for console replay via FetchEventLog / FetchEventLogRaw.
+func FetchEventLogLastTurn(ctx context.Context, host string, port int) (*ChatResult, string, error) {
+	all, sessionID, err := FetchEventLogRaw(ctx, host, port)
+	if err != nil {
+		return nil, "", err
+	}
+	result := &ChatResult{}
+	for _, frame := range FramesAfterLastPromptBegin(all) {
 		dispatchFrame(frame, result)
 	}
 	return result, sessionID, nil
@@ -224,6 +245,47 @@ func AggregateFrames(frames []json.RawMessage) []models.AcpEvent {
 		dispatchFrame(frame, result)
 	}
 	return result.AcpEvents()
+}
+
+// AggregateLastTurnFrames folds only the last prompt_begin turn into AcpEvents.
+// Streaming seeds must use this (or FetchEventLogLastTurn) so message/thought
+// rails stay current-turn-only.
+func AggregateLastTurnFrames(frames []json.RawMessage) []models.AcpEvent {
+	return AggregateFrames(FramesAfterLastPromptBegin(frames))
+}
+
+// FramesAfterLastPromptBegin returns frames from the last prompt_begin onward
+// (inclusive). When no prompt_begin is present, frames are returned unchanged
+// (single-turn / legacy logs).
+func FramesAfterLastPromptBegin(frames []json.RawMessage) []json.RawMessage {
+	last := -1
+	for i, raw := range frames {
+		if frameIsPromptBegin(raw) {
+			last = i
+		}
+	}
+	if last < 0 {
+		return frames
+	}
+	return frames[last:]
+}
+
+func frameIsPromptBegin(raw json.RawMessage) bool {
+	data := raw
+	var env struct {
+		Op   string          `json:"op"`
+		Data json.RawMessage `json:"data"`
+	}
+	if json.Unmarshal(raw, &env) == nil && env.Op == "event" && len(env.Data) > 0 {
+		data = env.Data
+	}
+	var probe struct {
+		Type string `json:"type"`
+	}
+	if json.Unmarshal(data, &probe) != nil {
+		return false
+	}
+	return probe.Type == "prompt_begin"
 }
 
 // dispatchFrame folds one persisted event frame into the aggregate. Frames may

--- a/web/src/lib/inbox/useGatesInbox.ts
+++ b/web/src/lib/inbox/useGatesInbox.ts
@@ -1040,6 +1040,11 @@ function flushPendingAcpFrames() {
 /**
  * One-shot REST seed from LiveNodeEvents / persisted snapshot.
  * Returns true only when non-empty rails were actually applied (not merely buffered).
+ *
+ * Contract (multi-turn hard refresh): platform nodeEvents live seed is the
+ * current turn only — pickAcpRails / applyAcpEvents write those absolute rails
+ * into the live streaming bubble. Historical turns stay in transcript bubbles
+ * rebuilt by queue_state / persisted turns, never concatenated here.
  */
 async function seedClarifyAcpFromNodeEventsOnce(
   runId: string,

--- a/web/src/lib/run/pendingAcpBuffer.test.ts
+++ b/web/src/lib/run/pendingAcpBuffer.test.ts
@@ -18,6 +18,19 @@ describe('pickAcpRails', () => {
       ]),
     ).toEqual({ thought: 't1 extended', message: 'm1 more' })
   })
+
+  it('multi-turn seed: current-turn rails must not contain prior-turn text', () => {
+    // Server AggregateLastTurnFrames already drops turn1; client must treat
+    // seed events as absolute current-turn rails (overwrite, never concat).
+    const seed = pickAcpRails([
+      { kind: 'thought', text: 'think-2', t: 0 },
+      { kind: 'message', text: 'answer-2-partial', t: 1 },
+    ])
+    expect(seed.message).toBe('answer-2-partial')
+    expect(seed.thought).toBe('think-2')
+    expect(seed.message).not.toContain('answer-1')
+    expect(seed.thought).not.toContain('think-1')
+  })
 })
 
 describe('createPendingAcpBuffer', () => {

--- a/web/src/lib/run/streamResumeAcceptance.test.ts
+++ b/web/src/lib/run/streamResumeAcceptance.test.ts
@@ -81,6 +81,19 @@ describe('stream resume acceptance (g5.2 three surfaces × four scenarios)', () 
     expect(gatePanel).not.toMatch(/正在恢复对话/)
   })
 
+  it('g2.1 multi-turn: seed writes absolute rails into live bubble only', () => {
+    const inbox = readSrc('lib/inbox/useGatesInbox.ts')
+    const runWs = readSrc('lib/run/useRunDetailWs.ts')
+    const clarify = readSrc('lib/inbox/useClarifyChat.ts')
+    expect(inbox).toMatch(/current turn only/)
+    expect(runWs).toMatch(/current-turn only/)
+    // Absolute snapshot assignment (not += / append onto prior text).
+    expect(clarify).toMatch(/if \(ev\.kind === 'message' && ev\.text\) msg = ev\.text/)
+    expect(clarify).toMatch(/if \(ev\.kind === 'thought' && ev\.text\) thought = ev\.text/)
+    expect(clarify).not.toMatch(/msg \+= /)
+    expect(clarify).not.toMatch(/thought \+= /)
+  })
+
   it('g3: busy seed retry stops on content / idle', async () => {
     let content = false
     const reason = await runBusySeedRetry({

--- a/web/src/lib/run/useRunDetailWs.ts
+++ b/web/src/lib/run/useRunDetailWs.ts
@@ -163,6 +163,9 @@ export function useRunDetailWs(opts: {
   }
 
   async function seedDialogueNodeOnce(nodeId: string): Promise<boolean> {
+    // Live seed rails are current-turn only (server AggregateLastTurnFrames /
+    // timeline). Applied as absolute snapshot onto the live bubble — never
+    // appended onto prior-turn transcript text.
     let events = eventPages[nodeId]?.events as AcpEvent[] | undefined
     if (!events?.length) {
       try {


### PR DESCRIPTION
Hard refresh was aggregating the full sandbox eventLog into nodeEvents,
so the live bubble stitched the previous turn's message/thought. Cut seed
and timeline ingest at the last prompt_begin, allow current-turn replace,
and lock the contract with multi-turn unit tests.

Co-authored-by: Cursor <cursoragent@cursor.com>
