### PR TITLE
feat(web): persist composer/run drafts in IndexedDB

### DIFF
--- a/web/LIB_DOMAIN_MAP.json
+++ b/web/LIB_DOMAIN_MAP.json
@@ -86,6 +86,7 @@
       "canvasLayout.ts",
       "canvasPath.ts",
       "dialogueAcpDelivery.ts",
+      "draftIdb.ts",
       "exportStructuredArtifact.ts",
       "homeApproveHandoff.ts",
       "homeComposerDraft.ts",
@@ -178,7 +179,7 @@
     "inbox": 20,
     "pm": 6,
     "project": 4,
-    "run": 52,
+    "run": 53,
     "shared": 37
   }
 }

--- a/web/src/lib/project/useProjectDetail.test.ts
+++ b/web/src/lib/project/useProjectDetail.test.ts
@@ -45,9 +45,9 @@ vi.mock('@/lib/composables/useProjectContext', () => ({
 }))
 
 vi.mock('@/lib/run/runDraft', () => ({
-  mergeRunDraft: (_id: string, seed: Record<string, string>) => ({ inputs: seed, images: {}, restored: false }),
-  saveRunDraft: vi.fn(),
-  clearRunDraft: vi.fn(),
+  mergeRunDraft: async (_id: string, seed: Record<string, string>) => ({ inputs: seed, images: {}, restored: false }),
+  saveRunDraft: vi.fn(async () => 'ok'),
+  clearRunDraft: vi.fn(async () => {}),
 }))
 
 vi.mock('@/lib/run/useWorkflowImport', () => ({

--- a/web/src/lib/project/useProjectDetail.ts
+++ b/web/src/lib/project/useProjectDetail.ts
@@ -680,7 +680,8 @@ async function saveRunDraftClick() {
   const result = await saveRunDraft(target.id, { ...runInputs.value }, images)
   if (result === 'ok') toast.success(t('common.toast.draftSaved'))
   else if (result === 'quota_exceeded' || result === 'partial') {
-    toast.error(t('common.toast.draftTooLarge'))
+    // Text already on disk / fields persisted — warn per F4 (review v3), not error.
+    toast.warn(t('common.toast.draftTooLarge'))
   } else toast.error(t('common.toast.draftSaveFailed'))
 }
 

--- a/web/src/lib/project/useProjectDetail.ts
+++ b/web/src/lib/project/useProjectDetail.ts
@@ -652,7 +652,7 @@ function openEdit(w: Workflow) {
   openWorkflow(w)
 }
 
-function openRun(w: Workflow) {
+async function openRun(w: Workflow) {
   closeMenu()
   runTarget.value = w
   draftRestored.value = false
@@ -664,23 +664,24 @@ function openRun(w: Workflow) {
     imgSeed[f.key] = []
   }
   const keys = runFields.value.map((f) => f.key)
-  const merged = mergeRunDraft(w.id, seed, imgSeed, keys)
+  const merged = await mergeRunDraft(w.id, seed, imgSeed, keys)
   runInputs.value = merged.inputs
   runImages.value = merged.images
   draftRestored.value = merged.restored
 }
 
-function saveRunDraftClick() {
+async function saveRunDraftClick() {
   const target = runTarget.value
   if (!target) return
   const images: Record<string, ClarifyImage[]> = {}
   for (const [k, v] of Object.entries(runImages.value)) {
     images[k] = v ? [...v] : []
   }
-  const result = saveRunDraft(target.id, { ...runInputs.value }, images)
+  const result = await saveRunDraft(target.id, { ...runInputs.value }, images)
   if (result === 'ok') toast.success(t('common.toast.draftSaved'))
-  else if (result === 'quota_exceeded') toast.error(t('common.toast.draftTooLarge'))
-  else toast.error(t('common.toast.draftSaveFailed'))
+  else if (result === 'quota_exceeded' || result === 'partial') {
+    toast.error(t('common.toast.draftTooLarge'))
+  } else toast.error(t('common.toast.draftSaveFailed'))
 }
 
 function closeRunModal() {
@@ -692,7 +693,7 @@ function onRunStayed() {
 }
 
 function onRunStarted() {
-  if (runTarget.value) clearRunDraft(runTarget.value.id)
+  if (runTarget.value) void clearRunDraft(runTarget.value.id)
 }
 
 function onViewRun(runId: string) {

--- a/web/src/lib/run/draftCapacity.test.ts
+++ b/web/src/lib/run/draftCapacity.test.ts
@@ -55,6 +55,47 @@ describe('draft capacity vs send gate (plan g3.1 / g3.2)', () => {
     expect(result).toBe('ok')
   })
 
+  it('MemoryBackend accepts near-SITE_ATTACH_MAX_BYTES Blob without materializing huge base64 (review v4 / g3.1)', async () => {
+    const idb = createMemoryDraftIdb()
+    __setDraftIdbBackendForTests(idb)
+    // Stub Blob sized near the send gate — avoids allocating ~50MiB or slow btoa (review v4).
+    const nearMax = SITE_ATTACH_MAX_BYTES - 1024
+    const data = {
+      size: nearMax,
+      type: 'application/octet-stream',
+      arrayBuffer: async () => new ArrayBuffer(0),
+      slice() {
+        return this
+      },
+    } as unknown as Blob
+    await idb.putHome(
+      {
+        id: 'current',
+        schemaVersion: '1',
+        savedAt: Date.now(),
+        pipelineId: 'wf-near',
+        text: 'near-max',
+      },
+      [
+        {
+          id: 'home:current:0',
+          ownerKind: 'home',
+          ownerId: 'current',
+          mimeType: 'application/octet-stream',
+          data,
+          sizeBytes: nearMax,
+          sortIndex: 0,
+        },
+      ],
+    )
+    const got = await idb.getHome()
+    expect(got?.record.text).toBe('near-max')
+    expect(got?.attachments[0]?.sizeBytes).toBe(nearMax)
+    expect(got?.attachments[0]?.data.size).toBe(nearMax)
+    expect(nearMax).toBeLessThan(SITE_ATTACH_MAX_BYTES)
+    expect(nearMax).toBeGreaterThan(SITE_ATTACH_MAX_BYTES * 0.9)
+  })
+
   it('send gate still rejects over SITE_ATTACH_MAX_BYTES', () => {
     const overB64 = 'A'.repeat(Math.ceil(((SITE_ATTACH_MAX_BYTES + 1024) * 4) / 3))
     const over: ClarifyImage = { data: overB64, mimeType: 'image/png' }

--- a/web/src/lib/run/draftCapacity.test.ts
+++ b/web/src/lib/run/draftCapacity.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  SITE_ATTACH_MAX_BYTES,
+  attachmentByteLength,
+  findOversizedAttachments,
+} from '../shared/attachments'
+import type { ClarifyImage } from '../shared/types'
+import {
+  __resetDraftIdbForTests,
+  __setDraftIdbBackendForTests,
+  createMemoryDraftIdb,
+  type DraftIdbBackend,
+} from './draftIdb'
+import {
+  __resetHomeComposerDraftMigrationForTests,
+  saveHomeComposerDraft,
+} from './homeComposerDraft'
+
+describe('draft capacity vs send gate (plan g3.1 / g3.2)', () => {
+  let store: Record<string, string>
+
+  beforeEach(() => {
+    store = {}
+    __setDraftIdbBackendForTests(createMemoryDraftIdb())
+    __resetHomeComposerDraftMigrationForTests()
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => {
+        store[k] = v
+      },
+      removeItem: (k: string) => {
+        delete store[k]
+      },
+      get length() {
+        return Object.keys(store).length
+      },
+      key: (i: number) => Object.keys(store)[i] ?? null,
+    })
+  })
+
+  afterEach(() => {
+    __resetDraftIdbForTests()
+    __resetHomeComposerDraftMigrationForTests()
+    vi.unstubAllGlobals()
+  })
+
+  it('IDB save accepts attachment under SITE_ATTACH_MAX_BYTES', async () => {
+    // ~1MiB decoded — under 50MiB gate, would historically blow localStorage
+    const raw = 'A'.repeat(1024 * 1024)
+    const data = btoa(raw)
+    const im: ClarifyImage = { data, mimeType: 'image/png', name: 'shot.png' }
+    expect(attachmentByteLength(im)).toBeLessThan(SITE_ATTACH_MAX_BYTES)
+    expect(findOversizedAttachments([im])).toEqual([])
+    const result = await saveHomeComposerDraft('cap', [im], 'wf-ap')
+    expect(result).toBe('ok')
+  })
+
+  it('send gate still rejects over SITE_ATTACH_MAX_BYTES', () => {
+    const overB64 = 'A'.repeat(Math.ceil(((SITE_ATTACH_MAX_BYTES + 1024) * 4) / 3))
+    const over: ClarifyImage = { data: overB64, mimeType: 'image/png' }
+    expect(attachmentByteLength(over)).toBeGreaterThan(SITE_ATTACH_MAX_BYTES)
+    expect(findOversizedAttachments([over]).length).toBe(1)
+  })
+
+  it('repeated quota failures return quota_exceeded each time (caller dedupes toast)', async () => {
+    const failing: DraftIdbBackend = {
+      ...createMemoryDraftIdb(),
+      putHome: async () => {
+        const err = new Error('quota') as Error & { name: string; code: number }
+        err.name = 'QuotaExceededError'
+        err.code = 22
+        throw err
+      },
+    }
+    __setDraftIdbBackendForTests(failing)
+    const r1 = await saveHomeComposerDraft('a', [{ data: btoa('x'), mimeType: 'image/png' }], 'wf')
+    const r2 = await saveHomeComposerDraft('ab', [{ data: btoa('y'), mimeType: 'image/png' }], 'wf')
+    expect(r1).toBe('quota_exceeded')
+    expect(r2).toBe('quota_exceeded')
+  })
+})

--- a/web/src/lib/run/draftIdb.ts
+++ b/web/src/lib/run/draftIdb.ts
@@ -63,15 +63,17 @@ export function __resetDraftIdbForTests(): void {
 
 export function createMemoryDraftIdb(): DraftIdbBackend {
   let home: HomeDraftRecord | null = null
-  const homeAtt: DraftAttachmentRecord[] = []
+  let homeAtt: DraftAttachmentRecord[] = []
   const runs = new Map<string, RunDraftRecord>()
   const runAtt = new Map<string, DraftAttachmentRecord[]>()
 
   return {
     async putHome(record, attachments) {
-      home = { ...record }
-      homeAtt.length = 0
-      homeAtt.push(...attachments.map((a) => ({ ...a })))
+      // Atomic snapshot replace (mirrors single-tx native put).
+      const nextHome = { ...record }
+      const nextAtt = attachments.map((a) => ({ ...a }))
+      home = nextHome
+      homeAtt = nextAtt
     },
     async getHome() {
       if (!home) return null
@@ -79,14 +81,13 @@ export function createMemoryDraftIdb(): DraftIdbBackend {
     },
     async deleteHome() {
       home = null
-      homeAtt.length = 0
+      homeAtt = []
     },
     async putRun(record, attachments) {
-      runs.set(record.workflowId, { ...record })
-      runAtt.set(
-        record.workflowId,
-        attachments.map((a) => ({ ...a })),
-      )
+      const nextRec = { ...record }
+      const nextAtt = attachments.map((a) => ({ ...a }))
+      runs.set(nextRec.workflowId, nextRec)
+      runAtt.set(nextRec.workflowId, nextAtt)
     },
     async getRun(workflowId) {
       const record = runs.get(workflowId)
@@ -194,17 +195,57 @@ function txDone(tx: IDBTransaction): Promise<void> {
   })
 }
 
-async function deleteAttachmentsFor(
+/**
+ * Replace owner attachments + main record in a single readwrite transaction.
+ * All mutations are queued in the getAllKeys onsuccess callback so the tx cannot
+ * auto-commit between delete and put (review v1 atomicity).
+ */
+function replaceDraftInTx(
   db: IDBDatabase,
+  storeNames: string[],
   ownerKind: DraftOwnerKind,
   ownerId: string,
+  putMain: (tx: IDBTransaction) => void,
+  attachments: DraftAttachmentRecord[],
 ): Promise<void> {
-  const tx = db.transaction(ATTACHMENTS_STORE, 'readwrite')
-  const store = tx.objectStore(ATTACHMENTS_STORE)
-  const index = store.index('byOwner')
-  const keys = await idbReq(index.getAllKeys([ownerKind, ownerId]))
-  for (const key of keys) store.delete(key)
-  await txDone(tx)
+  const tx = db.transaction(storeNames, 'readwrite')
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const fail = (err: unknown) => {
+      if (settled) return
+      settled = true
+      try {
+        tx.abort()
+      } catch {
+        /* already finished */
+      }
+      reject(err instanceof Error ? err : new Error(String(err)))
+    }
+    tx.oncomplete = () => {
+      if (settled) return
+      settled = true
+      resolve()
+    }
+    tx.onerror = () => fail(tx.error || new Error('idb tx failed'))
+    tx.onabort = () => {
+      if (settled) return
+      settled = true
+      reject(tx.error || new Error('idb tx aborted'))
+    }
+    const attStore = tx.objectStore(ATTACHMENTS_STORE)
+    const index = attStore.index('byOwner')
+    const keysReq = index.getAllKeys([ownerKind, ownerId])
+    keysReq.onerror = () => fail(keysReq.error || new Error('idb getAllKeys failed'))
+    keysReq.onsuccess = () => {
+      try {
+        for (const key of keysReq.result) attStore.delete(key)
+        putMain(tx)
+        for (const a of attachments) attStore.put(a)
+      } catch (e) {
+        fail(e)
+      }
+    }
+  })
 }
 
 async function loadAttachments(
@@ -219,17 +260,25 @@ async function loadAttachments(
   return rows.slice().sort((a, b) => (a.sortIndex ?? 0) - (b.sortIndex ?? 0))
 }
 
+/**
+ * Replace home/run draft + attachments in one IDB transaction.
+ * Failure rolls back — previous attachments stay intact (review v1).
+ */
 function createNativeBackend(): DraftIdbBackend {
   return {
     async putHome(record, attachments) {
       const db = await openNativeDb()
       if (!db) throw new Error('IndexedDB unavailable')
-      await deleteAttachmentsFor(db, 'home', HOME_DRAFT_ID)
-      const tx = db.transaction([HOME_DRAFT_STORE, ATTACHMENTS_STORE], 'readwrite')
-      tx.objectStore(HOME_DRAFT_STORE).put(record)
-      const attStore = tx.objectStore(ATTACHMENTS_STORE)
-      for (const a of attachments) attStore.put(a)
-      await txDone(tx)
+      await replaceDraftInTx(
+        db,
+        [HOME_DRAFT_STORE, ATTACHMENTS_STORE],
+        'home',
+        HOME_DRAFT_ID,
+        (tx) => {
+          tx.objectStore(HOME_DRAFT_STORE).put(record)
+        },
+        attachments,
+      )
     },
     async getHome() {
       const db = await openNativeDb()
@@ -246,20 +295,30 @@ function createNativeBackend(): DraftIdbBackend {
     async deleteHome() {
       const db = await openNativeDb()
       if (!db) return
-      await deleteAttachmentsFor(db, 'home', HOME_DRAFT_ID)
-      const tx = db.transaction(HOME_DRAFT_STORE, 'readwrite')
-      tx.objectStore(HOME_DRAFT_STORE).delete(HOME_DRAFT_ID)
-      await txDone(tx)
+      await replaceDraftInTx(
+        db,
+        [HOME_DRAFT_STORE, ATTACHMENTS_STORE],
+        'home',
+        HOME_DRAFT_ID,
+        (tx) => {
+          tx.objectStore(HOME_DRAFT_STORE).delete(HOME_DRAFT_ID)
+        },
+        [],
+      )
     },
     async putRun(record, attachments) {
       const db = await openNativeDb()
       if (!db) throw new Error('IndexedDB unavailable')
-      await deleteAttachmentsFor(db, 'run', record.workflowId)
-      const tx = db.transaction([RUN_DRAFT_STORE, ATTACHMENTS_STORE], 'readwrite')
-      tx.objectStore(RUN_DRAFT_STORE).put(record)
-      const attStore = tx.objectStore(ATTACHMENTS_STORE)
-      for (const a of attachments) attStore.put(a)
-      await txDone(tx)
+      await replaceDraftInTx(
+        db,
+        [RUN_DRAFT_STORE, ATTACHMENTS_STORE],
+        'run',
+        record.workflowId,
+        (tx) => {
+          tx.objectStore(RUN_DRAFT_STORE).put(record)
+        },
+        attachments,
+      )
     },
     async getRun(workflowId) {
       const db = await openNativeDb()
@@ -276,10 +335,16 @@ function createNativeBackend(): DraftIdbBackend {
     async deleteRun(workflowId) {
       const db = await openNativeDb()
       if (!db) return
-      await deleteAttachmentsFor(db, 'run', workflowId)
-      const tx = db.transaction(RUN_DRAFT_STORE, 'readwrite')
-      tx.objectStore(RUN_DRAFT_STORE).delete(workflowId)
-      await txDone(tx)
+      await replaceDraftInTx(
+        db,
+        [RUN_DRAFT_STORE, ATTACHMENTS_STORE],
+        'run',
+        workflowId,
+        (tx) => {
+          tx.objectStore(RUN_DRAFT_STORE).delete(workflowId)
+        },
+        [],
+      )
     },
   }
 }

--- a/web/src/lib/run/draftIdb.ts
+++ b/web/src/lib/run/draftIdb.ts
@@ -1,0 +1,291 @@
+/**
+ * IndexedDB persistence for home / run drafts (plan g1.1).
+ * Attachments stored as Blob; injectable backend for unit tests.
+ */
+
+export const DRAFT_IDB_NAME = 'approving-drafts'
+export const DRAFT_IDB_VERSION = 1
+export const HOME_DRAFT_STORE = 'homeDraft'
+export const RUN_DRAFT_STORE = 'runDraft'
+export const ATTACHMENTS_STORE = 'attachments'
+export const HOME_DRAFT_ID = 'current'
+
+export type DraftOwnerKind = 'home' | 'run'
+
+export interface HomeDraftRecord {
+  id: string
+  schemaVersion: string
+  savedAt: number
+  pipelineId: string
+  text: string
+}
+
+export interface RunDraftRecord {
+  workflowId: string
+  savedAt: number
+  inputsJson: string
+}
+
+export interface DraftAttachmentRecord {
+  id: string
+  ownerKind: DraftOwnerKind
+  ownerId: string
+  name?: string
+  mimeType: string
+  data: Blob
+  sizeBytes?: number
+  fieldKey?: string
+  sortIndex: number
+}
+
+export interface DraftIdbBackend {
+  putHome(record: HomeDraftRecord, attachments: DraftAttachmentRecord[]): Promise<void>
+  getHome(): Promise<{ record: HomeDraftRecord; attachments: DraftAttachmentRecord[] } | null>
+  deleteHome(): Promise<void>
+  putRun(record: RunDraftRecord, attachments: DraftAttachmentRecord[]): Promise<void>
+  getRun(workflowId: string): Promise<{ record: RunDraftRecord; attachments: DraftAttachmentRecord[] } | null>
+  deleteRun(workflowId: string): Promise<void>
+}
+
+let injected: DraftIdbBackend | null = null
+let dbPromise: Promise<IDBDatabase | null> | null = null
+
+/** Test-only: swap the storage backend (memory / failing stubs). */
+export function __setDraftIdbBackendForTests(backend: DraftIdbBackend | null): void {
+  injected = backend
+  dbPromise = null
+}
+
+export function __resetDraftIdbForTests(): void {
+  injected = null
+  dbPromise = null
+}
+
+export function createMemoryDraftIdb(): DraftIdbBackend {
+  let home: HomeDraftRecord | null = null
+  const homeAtt: DraftAttachmentRecord[] = []
+  const runs = new Map<string, RunDraftRecord>()
+  const runAtt = new Map<string, DraftAttachmentRecord[]>()
+
+  return {
+    async putHome(record, attachments) {
+      home = { ...record }
+      homeAtt.length = 0
+      homeAtt.push(...attachments.map((a) => ({ ...a })))
+    },
+    async getHome() {
+      if (!home) return null
+      return { record: { ...home }, attachments: homeAtt.map((a) => ({ ...a })) }
+    },
+    async deleteHome() {
+      home = null
+      homeAtt.length = 0
+    },
+    async putRun(record, attachments) {
+      runs.set(record.workflowId, { ...record })
+      runAtt.set(
+        record.workflowId,
+        attachments.map((a) => ({ ...a })),
+      )
+    },
+    async getRun(workflowId) {
+      const record = runs.get(workflowId)
+      if (!record) return null
+      return {
+        record: { ...record },
+        attachments: (runAtt.get(workflowId) || []).map((a) => ({ ...a })),
+      }
+    },
+    async deleteRun(workflowId) {
+      runs.delete(workflowId)
+      runAtt.delete(workflowId)
+    },
+  }
+}
+
+function isQuotaError(e: unknown): boolean {
+  const err = e as { name?: string; code?: number }
+  return err?.name === 'QuotaExceededError' || err?.code === 22
+}
+
+export function base64ToBlob(b64: string, mimeType: string): Blob {
+  const binary = atob(b64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  return new Blob([bytes], { type: mimeType || 'application/octet-stream' })
+}
+
+/** Convert base64 attachments; skip corrupt payloads instead of failing the whole save. */
+export function tryBase64ToBlob(b64: string, mimeType: string): Blob | null {
+  try {
+    return base64ToBlob(b64, mimeType)
+  } catch {
+    return null
+  }
+}
+
+export async function blobToBase64(blob: Blob): Promise<string> {
+  const buf = await blob.arrayBuffer()
+  const bytes = new Uint8Array(buf)
+  let binary = ''
+  const chunk = 0x8000
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk))
+  }
+  return btoa(binary)
+}
+
+function openNativeDb(): Promise<IDBDatabase | null> {
+  if (dbPromise) return dbPromise
+  dbPromise = new Promise((resolve) => {
+    if (typeof indexedDB === 'undefined') {
+      resolve(null)
+      return
+    }
+    let req: IDBOpenDBRequest
+    try {
+      req = indexedDB.open(DRAFT_IDB_NAME, DRAFT_IDB_VERSION)
+    } catch {
+      resolve(null)
+      return
+    }
+    req.onerror = () => resolve(null)
+    req.onupgradeneeded = () => {
+      const db = req.result
+      if (!db.objectStoreNames.contains(HOME_DRAFT_STORE)) {
+        db.createObjectStore(HOME_DRAFT_STORE, { keyPath: 'id' })
+      }
+      if (!db.objectStoreNames.contains(RUN_DRAFT_STORE)) {
+        db.createObjectStore(RUN_DRAFT_STORE, { keyPath: 'workflowId' })
+      }
+      if (!db.objectStoreNames.contains(ATTACHMENTS_STORE)) {
+        const store = db.createObjectStore(ATTACHMENTS_STORE, { keyPath: 'id' })
+        store.createIndex('byOwner', ['ownerKind', 'ownerId'], { unique: false })
+      }
+    }
+    req.onsuccess = () => {
+      const db = req.result
+      db.onversionchange = () => {
+        try {
+          db.close()
+        } catch {
+          /* ignore */
+        }
+        dbPromise = null
+      }
+      resolve(db)
+    }
+  })
+  return dbPromise
+}
+
+function idbReq<T>(req: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error || new Error('idb request failed'))
+  })
+}
+
+function txDone(tx: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error || new Error('idb tx failed'))
+    tx.onabort = () => reject(tx.error || new Error('idb tx aborted'))
+  })
+}
+
+async function deleteAttachmentsFor(
+  db: IDBDatabase,
+  ownerKind: DraftOwnerKind,
+  ownerId: string,
+): Promise<void> {
+  const tx = db.transaction(ATTACHMENTS_STORE, 'readwrite')
+  const store = tx.objectStore(ATTACHMENTS_STORE)
+  const index = store.index('byOwner')
+  const keys = await idbReq(index.getAllKeys([ownerKind, ownerId]))
+  for (const key of keys) store.delete(key)
+  await txDone(tx)
+}
+
+async function loadAttachments(
+  db: IDBDatabase,
+  ownerKind: DraftOwnerKind,
+  ownerId: string,
+): Promise<DraftAttachmentRecord[]> {
+  const tx = db.transaction(ATTACHMENTS_STORE, 'readonly')
+  const index = tx.objectStore(ATTACHMENTS_STORE).index('byOwner')
+  const rows = (await idbReq(index.getAll([ownerKind, ownerId]))) as DraftAttachmentRecord[]
+  await txDone(tx)
+  return rows.slice().sort((a, b) => (a.sortIndex ?? 0) - (b.sortIndex ?? 0))
+}
+
+function createNativeBackend(): DraftIdbBackend {
+  return {
+    async putHome(record, attachments) {
+      const db = await openNativeDb()
+      if (!db) throw new Error('IndexedDB unavailable')
+      await deleteAttachmentsFor(db, 'home', HOME_DRAFT_ID)
+      const tx = db.transaction([HOME_DRAFT_STORE, ATTACHMENTS_STORE], 'readwrite')
+      tx.objectStore(HOME_DRAFT_STORE).put(record)
+      const attStore = tx.objectStore(ATTACHMENTS_STORE)
+      for (const a of attachments) attStore.put(a)
+      await txDone(tx)
+    },
+    async getHome() {
+      const db = await openNativeDb()
+      if (!db) return null
+      const tx = db.transaction(HOME_DRAFT_STORE, 'readonly')
+      const record = (await idbReq(tx.objectStore(HOME_DRAFT_STORE).get(HOME_DRAFT_ID))) as
+        | HomeDraftRecord
+        | undefined
+      await txDone(tx)
+      if (!record) return null
+      const attachments = await loadAttachments(db, 'home', HOME_DRAFT_ID)
+      return { record, attachments }
+    },
+    async deleteHome() {
+      const db = await openNativeDb()
+      if (!db) return
+      await deleteAttachmentsFor(db, 'home', HOME_DRAFT_ID)
+      const tx = db.transaction(HOME_DRAFT_STORE, 'readwrite')
+      tx.objectStore(HOME_DRAFT_STORE).delete(HOME_DRAFT_ID)
+      await txDone(tx)
+    },
+    async putRun(record, attachments) {
+      const db = await openNativeDb()
+      if (!db) throw new Error('IndexedDB unavailable')
+      await deleteAttachmentsFor(db, 'run', record.workflowId)
+      const tx = db.transaction([RUN_DRAFT_STORE, ATTACHMENTS_STORE], 'readwrite')
+      tx.objectStore(RUN_DRAFT_STORE).put(record)
+      const attStore = tx.objectStore(ATTACHMENTS_STORE)
+      for (const a of attachments) attStore.put(a)
+      await txDone(tx)
+    },
+    async getRun(workflowId) {
+      const db = await openNativeDb()
+      if (!db) return null
+      const tx = db.transaction(RUN_DRAFT_STORE, 'readonly')
+      const record = (await idbReq(tx.objectStore(RUN_DRAFT_STORE).get(workflowId))) as
+        | RunDraftRecord
+        | undefined
+      await txDone(tx)
+      if (!record) return null
+      const attachments = await loadAttachments(db, 'run', workflowId)
+      return { record, attachments }
+    },
+    async deleteRun(workflowId) {
+      const db = await openNativeDb()
+      if (!db) return
+      await deleteAttachmentsFor(db, 'run', workflowId)
+      const tx = db.transaction(RUN_DRAFT_STORE, 'readwrite')
+      tx.objectStore(RUN_DRAFT_STORE).delete(workflowId)
+      await txDone(tx)
+    },
+  }
+}
+
+export function getDraftIdb(): DraftIdbBackend {
+  return injected || createNativeBackend()
+}
+
+export { isQuotaError }

--- a/web/src/lib/run/homeComposerDraft.test.ts
+++ b/web/src/lib/run/homeComposerDraft.test.ts
@@ -144,6 +144,58 @@ describe('homeComposerDraft', () => {
     expect(result).toBe('partial')
   })
 
+  it('quota put failure keeps prior IDB attachments intact (review v1)', async () => {
+    await saveHomeComposerDraft(
+      'old draft',
+      [{ data: btoa('keep-me'), mimeType: 'image/png', name: 'old.png' }],
+      'wf-ap',
+    )
+    const failing: DraftIdbBackend = {
+      ...backend,
+      putHome: async () => {
+        const err = new Error('quota') as Error & { name: string; code: number }
+        err.name = 'QuotaExceededError'
+        err.code = 22
+        throw err
+      },
+    }
+    __setDraftIdbBackendForTests(failing)
+    const result = await saveHomeComposerDraft(
+      'newer text',
+      [{ data: btoa('huge'), mimeType: 'image/png' }],
+      'wf-ap',
+    )
+    expect(result).toBe('quota_exceeded')
+    // Direct IDB read still has previous attachments (atomic put rolled back / never mutated).
+    const packed = await backend.getHome()
+    expect(packed?.record.text).toBe('old draft')
+    expect(packed?.attachments).toHaveLength(1)
+    expect(await blobLikeToB64(packed!.attachments[0]!.data)).toBe(btoa('keep-me'))
+  })
+
+  it('load prefers newer LS text-fallback over stale IDB draft (review v2 / F4)', async () => {
+    await saveHomeComposerDraft(
+      'stale idb',
+      [{ data: btoa('img'), mimeType: 'image/png' }],
+      'wf-old',
+    )
+    const packed = await backend.getHome()
+    expect(packed).not.toBeNull()
+    // Simulate quota fallback writing newer text to LS while IDB keeps old complete draft.
+    store[HOME_COMPOSER_DRAFT_KEY] = JSON.stringify({
+      schemaVersion: '1',
+      savedAt: (packed!.record.savedAt || 0) + 1000,
+      pipelineId: 'wf-new',
+      text: 'fresh after quota',
+      attachments: [],
+    })
+    __resetHomeComposerDraftMigrationForTests()
+    const draft = await loadHomeComposerDraft()
+    expect(draft?.text).toBe('fresh after quota')
+    expect(draft?.pipelineId).toBe('wf-new')
+    expect(draft?.attachments).toEqual([])
+  })
+
   it('saves attachment within 50MiB gate without quota toast path (plan g3.1)', async () => {
     // ~64KiB payload — well under SITE_ATTACH_MAX_BYTES; proves IDB accepts binary attachments
     const data = btoa('x'.repeat(64 * 1024))
@@ -153,3 +205,11 @@ describe('homeComposerDraft', () => {
     expect(draft?.attachments[0]?.data).toBe(data)
   })
 })
+
+async function blobLikeToB64(blob: Blob): Promise<string> {
+  const buf = await blob.arrayBuffer()
+  const bytes = new Uint8Array(buf)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]!)
+  return btoa(binary)
+}

--- a/web/src/lib/run/homeComposerDraft.test.ts
+++ b/web/src/lib/run/homeComposerDraft.test.ts
@@ -1,16 +1,27 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   HOME_COMPOSER_DRAFT_KEY,
+  __resetHomeComposerDraftMigrationForTests,
   clearHomeComposerDraft,
   loadHomeComposerDraft,
   saveHomeComposerDraft,
 } from './homeComposerDraft'
+import {
+  __resetDraftIdbForTests,
+  __setDraftIdbBackendForTests,
+  createMemoryDraftIdb,
+  type DraftIdbBackend,
+} from './draftIdb'
 
 describe('homeComposerDraft', () => {
   let store: Record<string, string>
+  let backend: DraftIdbBackend
 
   beforeEach(() => {
     store = {}
+    backend = createMemoryDraftIdb()
+    __setDraftIdbBackendForTests(backend)
+    __resetHomeComposerDraftMigrationForTests()
     vi.stubGlobal('localStorage', {
       getItem: (k: string) => store[k] ?? null,
       setItem: (k: string, v: string) => {
@@ -19,108 +30,126 @@ describe('homeComposerDraft', () => {
       removeItem: (k: string) => {
         delete store[k]
       },
+      get length() {
+        return Object.keys(store).length
+      },
+      key: (i: number) => Object.keys(store)[i] ?? null,
     })
   })
 
   afterEach(() => {
+    __resetDraftIdbForTests()
+    __resetHomeComposerDraftMigrationForTests()
     vi.unstubAllGlobals()
   })
 
-  it('saves and loads a full draft payload (plan g1.1 / g1.2)', () => {
-    const result = saveHomeComposerDraft(
+  it('saves and loads a full draft payload via IDB (plan g1.1 / g1.2)', async () => {
+    const result = await saveHomeComposerDraft(
       '做登录页',
-      [{ data: 'abc', mimeType: 'image/png', name: 'shot.png' }],
+      [{ data: btoa('abc'), mimeType: 'image/png', name: 'shot.png' }],
       'wf-ap',
     )
     expect(result).toBe('ok')
-    const draft = loadHomeComposerDraft()
+    const draft = await loadHomeComposerDraft()
     expect(draft).toMatchObject({
       schemaVersion: '1',
       pipelineId: 'wf-ap',
       text: '做登录页',
-      attachments: [{ data: 'abc', mimeType: 'image/png', name: 'shot.png' }],
+      attachments: [{ data: btoa('abc'), mimeType: 'image/png', name: 'shot.png' }],
     })
     expect(typeof draft?.savedAt).toBe('number')
-    expect(store[HOME_COMPOSER_DRAFT_KEY]).toBeTruthy()
-  })
-
-  it('clears instead of writing an empty shell (plan g1.3)', () => {
-    saveHomeComposerDraft('x', [], 'wf-ap')
-    expect(loadHomeComposerDraft()).not.toBeNull()
-    const result = saveHomeComposerDraft('   ', [], 'wf-ap')
-    expect(result).toBe('ok')
-    expect(loadHomeComposerDraft()).toBeNull()
     expect(store[HOME_COMPOSER_DRAFT_KEY]).toBeUndefined()
   })
 
-  it('keeps draft when only attachments remain', () => {
-    saveHomeComposerDraft('', [{ data: 'x', mimeType: 'image/png' }], 'wf-ap')
-    expect(loadHomeComposerDraft()?.attachments).toHaveLength(1)
+  it('clears instead of writing an empty shell (plan g1.2 / F5)', async () => {
+    await saveHomeComposerDraft('x', [], 'wf-ap')
+    expect(await loadHomeComposerDraft()).not.toBeNull()
+    const result = await saveHomeComposerDraft('   ', [], 'wf-ap')
+    expect(result).toBe('ok')
+    expect(await loadHomeComposerDraft()).toBeNull()
   })
 
-  it('returns null for corrupt JSON (plan g1.2)', () => {
+  it('keeps draft when only attachments remain', async () => {
+    await saveHomeComposerDraft('', [{ data: btoa('x'), mimeType: 'image/png' }], 'wf-ap')
+    expect((await loadHomeComposerDraft())?.attachments).toHaveLength(1)
+  })
+
+  it('returns null when IDB empty and legacy corrupt', async () => {
     store[HOME_COMPOSER_DRAFT_KEY] = '{not json'
-    expect(loadHomeComposerDraft()).toBeNull()
+    expect(await loadHomeComposerDraft()).toBeNull()
   })
 
-  it('returns null for missing required fields', () => {
+  it('returns null for missing required fields in legacy', async () => {
     store[HOME_COMPOSER_DRAFT_KEY] = JSON.stringify({ text: 'ok' })
-    expect(loadHomeComposerDraft()).toBeNull()
+    expect(await loadHomeComposerDraft()).toBeNull()
   })
 
-  it('clearHomeComposerDraft removes the key', () => {
-    saveHomeComposerDraft('x', [], 'wf-ap')
-    clearHomeComposerDraft()
-    expect(loadHomeComposerDraft()).toBeNull()
+  it('clearHomeComposerDraft removes the record', async () => {
+    await saveHomeComposerDraft('x', [], 'wf-ap')
+    await clearHomeComposerDraft()
+    expect(await loadHomeComposerDraft()).toBeNull()
   })
 
-  it('returns quota_exceeded when setItem throws QuotaExceededError', () => {
-    vi.stubGlobal('localStorage', {
-      getItem: () => null,
-      setItem: () => {
+  it('migrates legacy localStorage key into IDB then deletes it (plan g2.1)', async () => {
+    store[HOME_COMPOSER_DRAFT_KEY] = JSON.stringify({
+      schemaVersion: '1',
+      savedAt: 1000,
+      pipelineId: 'wf-ap',
+      text: '旧草稿',
+      attachments: [{ data: btoa('img'), mimeType: 'image/png', name: 'a.png' }],
+    })
+    const draft = await loadHomeComposerDraft()
+    expect(draft?.text).toBe('旧草稿')
+    expect(draft?.attachments).toHaveLength(1)
+    expect(store[HOME_COMPOSER_DRAFT_KEY]).toBeUndefined()
+  })
+
+  it('falls back to text-only when IDB put throws QuotaExceededError (plan g1.2)', async () => {
+    const failing: DraftIdbBackend = {
+      ...backend,
+      putHome: async () => {
         const err = new Error('quota') as Error & { name: string; code: number }
         err.name = 'QuotaExceededError'
         err.code = 22
         throw err
       },
-      removeItem: () => {},
-    })
-    const result = saveHomeComposerDraft(
-      'big',
-      [{ data: 'xxxx', mimeType: 'image/png' }],
+    }
+    __setDraftIdbBackendForTests(failing)
+    const result = await saveHomeComposerDraft(
+      'keep text',
+      [{ data: btoa('huge'), mimeType: 'image/png' }],
       'wf-ap',
     )
     expect(result).toBe('quota_exceeded')
+    expect(store[HOME_COMPOSER_DRAFT_KEY]).toBeTruthy()
+    const parsed = JSON.parse(store[HOME_COMPOSER_DRAFT_KEY])
+    expect(parsed.text).toBe('keep text')
+    expect(parsed.attachments).toEqual([])
+    expect(parsed.pipelineId).toBe('wf-ap')
   })
 
-  it('falls back to text-only when attachments exceed quota', () => {
-    let calls = 0
-    const mem: Record<string, string> = {}
-    vi.stubGlobal('localStorage', {
-      getItem: (k: string) => mem[k] ?? null,
-      setItem: (k: string, v: string) => {
-        calls++
-        if (calls === 1) {
-          const err = new Error('quota') as Error & { name: string; code: number }
-          err.name = 'QuotaExceededError'
-          err.code = 22
-          throw err
-        }
-        mem[k] = v
+  it('returns partial when IDB unavailable but text fallback works', async () => {
+    const failing: DraftIdbBackend = {
+      ...backend,
+      putHome: async () => {
+        throw new Error('idb down')
       },
-      removeItem: (k: string) => {
-        delete mem[k]
-      },
-    })
-    const result = saveHomeComposerDraft(
-      'keep text',
-      [{ data: 'huge', mimeType: 'image/png' }],
+    }
+    __setDraftIdbBackendForTests(failing)
+    const result = await saveHomeComposerDraft(
+      'text only path',
+      [{ data: btoa('pic'), mimeType: 'image/png' }],
       'wf-ap',
     )
-    expect(result).toBe('quota_exceeded')
-    const draft = loadHomeComposerDraft()
-    expect(draft?.text).toBe('keep text')
-    expect(draft?.attachments).toEqual([])
-    expect(draft?.pipelineId).toBe('wf-ap')
+    expect(result).toBe('partial')
+  })
+
+  it('saves attachment within 50MiB gate without quota toast path (plan g3.1)', async () => {
+    // ~64KiB payload — well under SITE_ATTACH_MAX_BYTES; proves IDB accepts binary attachments
+    const data = btoa('x'.repeat(64 * 1024))
+    const result = await saveHomeComposerDraft('big-enough', [{ data, mimeType: 'image/png' }], 'wf-ap')
+    expect(result).toBe('ok')
+    const draft = await loadHomeComposerDraft()
+    expect(draft?.attachments[0]?.data).toBe(data)
   })
 })

--- a/web/src/lib/run/homeComposerDraft.ts
+++ b/web/src/lib/run/homeComposerDraft.ts
@@ -1,6 +1,15 @@
 import type { ClarifyImage } from '../shared/types'
+import {
+  HOME_DRAFT_ID,
+  blobToBase64,
+  getDraftIdb,
+  isQuotaError,
+  tryBase64ToBlob,
+  type DraftAttachmentRecord,
+  type HomeDraftRecord,
+} from './draftIdb'
 
-/** localStorage key for the home Dashboard composer draft (independent of runDraft / pipeline memory). */
+/** Legacy localStorage key — migrate once then delete (plan g2.1). */
 export const HOME_COMPOSER_DRAFT_KEY = 'approving.home.composerDraft'
 
 export const HOME_COMPOSER_DRAFT_SCHEMA = '1'
@@ -20,7 +29,15 @@ export interface HomeComposerDraft {
   attachments: HomeDraftAttachment[]
 }
 
-export type SaveHomeComposerDraftResult = 'ok' | 'quota_exceeded' | 'error'
+/** ok = full save; partial = text persisted, attachments only in memory; quota_exceeded / error. */
+export type SaveHomeComposerDraftResult = 'ok' | 'partial' | 'quota_exceeded' | 'error'
+
+let homeMigrationDone = false
+
+/** Test-only: re-run legacy localStorage migration. */
+export function __resetHomeComposerDraftMigrationForTests(): void {
+  homeMigrationDone = false
+}
 
 function isAttachment(v: unknown): v is HomeDraftAttachment {
   if (!v || typeof v !== 'object') return false
@@ -68,28 +85,6 @@ export function isHomeComposerDraftEmpty(text: string, attachments: ClarifyImage
   return !text.trim() && attachments.length === 0
 }
 
-export function loadHomeComposerDraft(): HomeComposerDraft | null {
-  try {
-    const raw = localStorage.getItem(HOME_COMPOSER_DRAFT_KEY)
-    if (!raw) return null
-    return parseDraft(raw)
-  } catch {
-    return null
-  }
-}
-
-export function clearHomeComposerDraft(): void {
-  try {
-    localStorage.removeItem(HOME_COMPOSER_DRAFT_KEY)
-  } catch {
-    /* ignore private mode */
-  }
-}
-
-/**
- * Persist home composer draft. Empty content clears the key instead of writing a shell.
- * Returns ok | quota_exceeded | error (aligned with runDraft).
- */
 function toPersistableAttachments(attachments: ClarifyImage[]): HomeDraftAttachment[] {
   const out: HomeDraftAttachment[] = []
   for (const im of attachments) {
@@ -101,14 +96,147 @@ function toPersistableAttachments(attachments: ClarifyImage[]): HomeDraftAttachm
   return out
 }
 
-export function saveHomeComposerDraft(
+function toIdbAttachments(attachments: HomeDraftAttachment[]): DraftAttachmentRecord[] {
+  const out: DraftAttachmentRecord[] = []
+  let i = 0
+  for (const a of attachments) {
+    const blob = tryBase64ToBlob(a.data, a.mimeType)
+    if (!blob) continue
+    const rec: DraftAttachmentRecord = {
+      id: `home:${HOME_DRAFT_ID}:${i}`,
+      ownerKind: 'home',
+      ownerId: HOME_DRAFT_ID,
+      mimeType: a.mimeType,
+      data: blob,
+      sizeBytes: blob.size,
+      sortIndex: i,
+    }
+    if (a.name) rec.name = a.name
+    out.push(rec)
+    i++
+  }
+  return out
+}
+
+async function fromIdbAttachments(rows: DraftAttachmentRecord[]): Promise<HomeDraftAttachment[]> {
+  const out: HomeDraftAttachment[] = []
+  for (const row of rows) {
+    const data = await blobToBase64(row.data)
+    const next: HomeDraftAttachment = { mimeType: row.mimeType, data }
+    if (row.name) next.name = row.name
+    out.push(next)
+  }
+  return out
+}
+
+function readLegacyLocalStorage(): HomeComposerDraft | null {
+  try {
+    const raw = localStorage.getItem(HOME_COMPOSER_DRAFT_KEY)
+    if (!raw) return null
+    return parseDraft(raw)
+  } catch {
+    return null
+  }
+}
+
+function writeLegacyTextFallback(draft: HomeComposerDraft): SaveHomeComposerDraftResult {
+  try {
+    localStorage.setItem(HOME_COMPOSER_DRAFT_KEY, JSON.stringify(draft))
+    return draft.attachments.length > 0 ? 'partial' : 'ok'
+  } catch (e: unknown) {
+    if (isQuotaError(e)) {
+      if (draft.attachments.length > 0 || draft.text) {
+        try {
+          const slim: HomeComposerDraft = { ...draft, attachments: [] }
+          localStorage.setItem(HOME_COMPOSER_DRAFT_KEY, JSON.stringify(slim))
+          return 'quota_exceeded'
+        } catch (e2: unknown) {
+          if (isQuotaError(e2)) return 'quota_exceeded'
+          return 'error'
+        }
+      }
+      return 'quota_exceeded'
+    }
+    return 'error'
+  }
+}
+
+function clearLegacyLocalStorage(): void {
+  try {
+    localStorage.removeItem(HOME_COMPOSER_DRAFT_KEY)
+  } catch {
+    /* ignore private mode */
+  }
+}
+
+async function migrateLegacyHomeIfNeeded(): Promise<void> {
+  if (homeMigrationDone) return
+  homeMigrationDone = true
+  const legacy = readLegacyLocalStorage()
+  if (!legacy) return
+  try {
+    const idb = getDraftIdb()
+    const existing = await idb.getHome()
+    if (existing) {
+      clearLegacyLocalStorage()
+      return
+    }
+    const record: HomeDraftRecord = {
+      id: HOME_DRAFT_ID,
+      schemaVersion: legacy.schemaVersion || HOME_COMPOSER_DRAFT_SCHEMA,
+      savedAt: legacy.savedAt,
+      pipelineId: legacy.pipelineId,
+      text: legacy.text,
+    }
+    await idb.putHome(record, toIdbAttachments(legacy.attachments))
+    clearLegacyLocalStorage()
+  } catch {
+    /* migration failure must not block editing — leave legacy key */
+  }
+}
+
+export async function loadHomeComposerDraft(): Promise<HomeComposerDraft | null> {
+  await migrateLegacyHomeIfNeeded()
+  try {
+    const packed = await getDraftIdb().getHome()
+    if (packed) {
+      return {
+        schemaVersion: packed.record.schemaVersion || HOME_COMPOSER_DRAFT_SCHEMA,
+        savedAt: packed.record.savedAt,
+        pipelineId: packed.record.pipelineId,
+        text: packed.record.text,
+        attachments: await fromIdbAttachments(packed.attachments),
+      }
+    }
+  } catch {
+    /* fall through to legacy */
+  }
+  return readLegacyLocalStorage()
+}
+
+export async function clearHomeComposerDraft(): Promise<void> {
+  try {
+    await getDraftIdb().deleteHome()
+  } catch {
+    /* ignore */
+  }
+  clearLegacyLocalStorage()
+}
+
+/**
+ * Persist home composer draft to IndexedDB (attachments as Blob).
+ * Empty content clears the record instead of writing a shell.
+ * On IDB failure: text(+pipeline) may fall back to localStorage → partial / quota_exceeded.
+ */
+export async function saveHomeComposerDraft(
   text: string,
   attachments: ClarifyImage[],
   pipelineId: string,
-): SaveHomeComposerDraftResult {
+): Promise<SaveHomeComposerDraftResult> {
+  await migrateLegacyHomeIfNeeded()
   const persistable = toPersistableAttachments(attachments)
   if (isHomeComposerDraftEmpty(text, persistable as ClarifyImage[])) {
-    clearHomeComposerDraft()
+    await clearHomeComposerDraft()
     return 'ok'
   }
   const payload: HomeComposerDraft = {
@@ -118,29 +246,25 @@ export function saveHomeComposerDraft(
     text,
     attachments: persistable,
   }
+  const record: HomeDraftRecord = {
+    id: HOME_DRAFT_ID,
+    schemaVersion: payload.schemaVersion,
+    savedAt: payload.savedAt,
+    pipelineId: payload.pipelineId,
+    text: payload.text,
+  }
   try {
-    localStorage.setItem(HOME_COMPOSER_DRAFT_KEY, JSON.stringify(payload))
+    await getDraftIdb().putHome(record, toIdbAttachments(persistable))
+    clearLegacyLocalStorage()
     return 'ok'
   } catch (e: unknown) {
-    const err = e as { name?: string; code?: number }
-    if (err?.name === 'QuotaExceededError' || err?.code === 22) {
-      // Prefer text + pipeline when attachments blow the quota.
-      if (attachments.length > 0) {
-        try {
-          const slim: HomeComposerDraft = {
-            ...payload,
-            attachments: [],
-          }
-          localStorage.setItem(HOME_COMPOSER_DRAFT_KEY, JSON.stringify(slim))
-          return 'quota_exceeded'
-        } catch (e2: unknown) {
-          const err2 = e2 as { name?: string; code?: number }
-          if (err2?.name === 'QuotaExceededError' || err2?.code === 22) return 'quota_exceeded'
-          return 'error'
-        }
-      }
-      return 'quota_exceeded'
+    const fallback: HomeComposerDraft = { ...payload, attachments: [] }
+    const fb = writeLegacyTextFallback(fallback)
+    if (isQuotaError(e)) {
+      return fb === 'ok' || fb === 'partial' ? 'quota_exceeded' : fb
     }
-    return 'error'
+    if (fb === 'error' || fb === 'quota_exceeded') return fb
+    // IDB unavailable: text on LS; attachments stay in memory → partial when images present
+    return persistable.length > 0 ? 'partial' : 'ok'
   }
 }

--- a/web/src/lib/run/homeComposerDraft.ts
+++ b/web/src/lib/run/homeComposerDraft.ts
@@ -178,7 +178,10 @@ async function migrateLegacyHomeIfNeeded(): Promise<void> {
     const idb = getDraftIdb()
     const existing = await idb.getHome()
     if (existing) {
-      clearLegacyLocalStorage()
+      // Keep newer LS text-fallback for load to prefer (review v2); only drop stale LS.
+      if (legacy.savedAt <= existing.record.savedAt) {
+        clearLegacyLocalStorage()
+      }
       return
     }
     const record: HomeDraftRecord = {
@@ -195,23 +198,39 @@ async function migrateLegacyHomeIfNeeded(): Promise<void> {
   }
 }
 
+async function draftFromIdb(packed: {
+  record: HomeDraftRecord
+  attachments: DraftAttachmentRecord[]
+}): Promise<HomeComposerDraft> {
+  return {
+    schemaVersion: packed.record.schemaVersion || HOME_COMPOSER_DRAFT_SCHEMA,
+    savedAt: packed.record.savedAt,
+    pipelineId: packed.record.pipelineId,
+    text: packed.record.text,
+    attachments: await fromIdbAttachments(packed.attachments),
+  }
+}
+
 export async function loadHomeComposerDraft(): Promise<HomeComposerDraft | null> {
   await migrateLegacyHomeIfNeeded()
+  const legacy = readLegacyLocalStorage()
   try {
     const packed = await getDraftIdb().getHome()
-    if (packed) {
-      return {
-        schemaVersion: packed.record.schemaVersion || HOME_COMPOSER_DRAFT_SCHEMA,
-        savedAt: packed.record.savedAt,
-        pipelineId: packed.record.pipelineId,
-        text: packed.record.text,
-        attachments: await fromIdbAttachments(packed.attachments),
+    if (packed && legacy) {
+      // Prefer newer savedAt so quota-fallback LS text wins over stale IDB (review v2 / F4).
+      if (legacy.savedAt > packed.record.savedAt) {
+        return legacy
       }
+      clearLegacyLocalStorage()
+      return draftFromIdb(packed)
+    }
+    if (packed) {
+      return draftFromIdb(packed)
     }
   } catch {
     /* fall through to legacy */
   }
-  return readLegacyLocalStorage()
+  return legacy
 }
 
 export async function clearHomeComposerDraft(): Promise<void> {

--- a/web/src/lib/run/runDraft.test.ts
+++ b/web/src/lib/run/runDraft.test.ts
@@ -147,4 +147,47 @@ describe('runDraft (IndexedDB)', () => {
     expect(parsed.inputs.a).toBe('keep')
     expect(parsed.images).toEqual({})
   })
+
+  it('quota put failure keeps prior run attachments intact (review v1)', async () => {
+    await saveRunDraft(
+      WF,
+      { a: 'old' },
+      { p: [{ data: btoa('keep-run'), mimeType: 'image/png', name: 'r.png' }] },
+    )
+    const failing: DraftIdbBackend = {
+      ...backend,
+      putRun: async () => {
+        const err = new Error('quota') as Error & { name: string; code: number }
+        err.name = 'QuotaExceededError'
+        err.code = 22
+        throw err
+      },
+    }
+    __setDraftIdbBackendForTests(failing)
+    const result = await saveRunDraft(
+      WF,
+      { a: 'newer' },
+      { p: [{ data: btoa('huge'), mimeType: 'image/png' }] },
+    )
+    expect(result).toBe('quota_exceeded')
+    const packed = await backend.getRun(WF)
+    expect(packed?.record.inputsJson).toContain('old')
+    expect(packed?.attachments).toHaveLength(1)
+  })
+
+  it('load prefers newer LS fields over stale IDB run draft (review v2 / F4)', async () => {
+    await saveRunDraft(WF, { a: 'stale-idb' }, { p: [{ data: btoa('img'), mimeType: 'image/png' }] })
+    const packed = await backend.getRun(WF)
+    expect(packed).not.toBeNull()
+    store[`run-draft:${WF}`] = JSON.stringify({
+      workflowId: WF,
+      savedAt: packed!.record.savedAt + 1000,
+      inputs: { a: 'fresh-ls' },
+      images: {},
+    })
+    __resetRunDraftMigrationForTests()
+    const draft = await loadRunDraft(WF)
+    expect(draft?.inputs.a).toBe('fresh-ls')
+    expect(draft?.images).toEqual({})
+  })
 })

--- a/web/src/lib/run/runDraft.test.ts
+++ b/web/src/lib/run/runDraft.test.ts
@@ -1,6 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ClarifyImage } from '../shared/types'
-import { clearRunDraft, loadRunDraft, mergeRunDraft, saveRunDraft } from './runDraft'
+import {
+  __resetDraftIdbForTests,
+  __setDraftIdbBackendForTests,
+  createMemoryDraftIdb,
+  type DraftIdbBackend,
+} from './draftIdb'
+import {
+  __resetRunDraftMigrationForTests,
+  clearRunDraft,
+  loadRunDraft,
+  mergeRunDraft,
+  saveRunDraft,
+} from './runDraft'
 
 const WF = 'wf-test-001'
 
@@ -12,11 +24,15 @@ function seed() {
   }
 }
 
-describe('mergeRunDraft', () => {
+describe('runDraft (IndexedDB)', () => {
   let store: Record<string, string>
+  let backend: DraftIdbBackend
 
   beforeEach(() => {
     store = {}
+    backend = createMemoryDraftIdb()
+    __setDraftIdbBackendForTests(backend)
+    __resetRunDraftMigrationForTests()
     vi.stubGlobal('localStorage', {
       getItem: (k: string) => store[k] ?? null,
       setItem: (k: string, v: string) => {
@@ -25,62 +41,110 @@ describe('mergeRunDraft', () => {
       removeItem: (k: string) => {
         delete store[k]
       },
+      get length() {
+        return Object.keys(store).length
+      },
+      key: (i: number) => Object.keys(store)[i] ?? null,
     })
   })
 
   afterEach(() => {
+    __resetDraftIdbForTests()
+    __resetRunDraftMigrationForTests()
     vi.unstubAllGlobals()
   })
 
-  it('merges draft values by key over defaults', () => {
-    saveRunDraft(WF, { a: 'draft-a', b: 'draft-b' }, { p: [{ data: 'x', mimeType: 'image/png' }] })
-    const { inputs, images, restored } = mergeRunDraft(WF, seed().inputs, seed().images, seed().keys)
+  it('merges draft values by key over defaults (plan g1.3)', async () => {
+    await saveRunDraft(WF, { a: 'draft-a', b: 'draft-b' }, {
+      p: [{ data: btoa('x'), mimeType: 'image/png' }],
+    })
+    const { inputs, images, restored } = await mergeRunDraft(
+      WF,
+      seed().inputs,
+      seed().images,
+      seed().keys,
+    )
     expect(restored).toBe(true)
     expect(inputs.a).toBe('draft-a')
     expect(inputs.b).toBe('draft-b')
-    expect(images.p).toEqual([{ data: 'x', mimeType: 'image/png' }])
+    expect(images.p?.[0]).toMatchObject({ data: btoa('x'), mimeType: 'image/png' })
   })
 
-  it('ignores extra keys in draft not present in current fields', () => {
-    saveRunDraft(WF, { a: 'x', removed: 'gone' }, {})
-    const { inputs, restored } = mergeRunDraft(WF, seed().inputs, seed().images, ['a', 'b'])
+  it('ignores extra keys in draft not present in current fields', async () => {
+    await saveRunDraft(WF, { a: 'x', removed: 'gone' }, {})
+    const { inputs, restored } = await mergeRunDraft(WF, seed().inputs, seed().images, ['a', 'b'])
     expect(restored).toBe(true)
     expect(inputs.a).toBe('x')
     expect(inputs).not.toHaveProperty('removed')
     expect(inputs.b).toBe('default-b')
   })
 
-  it('uses defaults for fields missing in draft', () => {
-    saveRunDraft(WF, { a: 'only-a' }, {})
-    const { inputs, images } = mergeRunDraft(WF, seed().inputs, seed().images, seed().keys)
+  it('uses defaults for fields missing in draft', async () => {
+    await saveRunDraft(WF, { a: 'only-a' }, {})
+    const { inputs, images } = await mergeRunDraft(WF, seed().inputs, seed().images, seed().keys)
     expect(inputs.b).toBe('default-b')
     expect(images.p).toEqual([])
   })
 
-  it('silently degrades when stored JSON is corrupt', () => {
+  it('silently degrades when stored legacy JSON is corrupt', async () => {
     store[`run-draft:${WF}`] = '{not json'
-    const { inputs, restored } = mergeRunDraft(WF, seed().inputs, seed().images, seed().keys)
+    const { inputs, restored } = await mergeRunDraft(WF, seed().inputs, seed().images, seed().keys)
     expect(restored).toBe(false)
     expect(inputs).toEqual(seed().inputs)
   })
 
-  it('allows empty values to overwrite existing draft content', () => {
-    saveRunDraft(WF, { a: 'filled' }, {})
-    const result = saveRunDraft(WF, { a: '', b: '' }, { p: [] })
+  it('clears empty draft instead of writing a shell (plan F5)', async () => {
+    await saveRunDraft(WF, { a: 'filled' }, {})
+    const result = await saveRunDraft(WF, { a: '', b: '' }, { p: [] })
     expect(result).toBe('ok')
-    const draft = loadRunDraft(WF)
-    expect(draft?.inputs.a).toBe('')
-    expect(draft?.inputs.b).toBe('')
+    expect(await loadRunDraft(WF)).toBeNull()
   })
 
-  it('returns restored=false when no draft exists', () => {
-    const { restored } = mergeRunDraft(WF, seed().inputs, seed().images, seed().keys)
+  it('returns restored=false when no draft exists', async () => {
+    const { restored } = await mergeRunDraft(WF, seed().inputs, seed().images, seed().keys)
     expect(restored).toBe(false)
   })
 
-  it('clearRunDraft removes stored draft', () => {
-    saveRunDraft(WF, { a: 'x' }, {})
-    clearRunDraft(WF)
-    expect(loadRunDraft(WF)).toBeNull()
+  it('clearRunDraft removes stored draft', async () => {
+    await saveRunDraft(WF, { a: 'x' }, {})
+    await clearRunDraft(WF)
+    expect(await loadRunDraft(WF)).toBeNull()
+  })
+
+  it('migrates legacy run-draft:* keys then deletes them (plan g2.1)', async () => {
+    store[`run-draft:${WF}`] = JSON.stringify({
+      workflowId: WF,
+      savedAt: 1,
+      inputs: { a: 'from-ls' },
+      images: { p: [{ data: btoa('pic'), mimeType: 'image/png' }] },
+    })
+    const draft = await loadRunDraft(WF)
+    expect(draft?.inputs.a).toBe('from-ls')
+    expect(draft?.images.p).toHaveLength(1)
+    expect(store[`run-draft:${WF}`]).toBeUndefined()
+  })
+
+  it('falls back to text when IDB quota exceeded (plan g1.3)', async () => {
+    const failing: DraftIdbBackend = {
+      ...backend,
+      putRun: async () => {
+        const err = new Error('quota') as Error & { name: string; code: number }
+        err.name = 'QuotaExceededError'
+        err.code = 22
+        throw err
+      },
+    }
+    __setDraftIdbBackendForTests(failing)
+    const result = await saveRunDraft(
+      WF,
+      { a: 'keep' },
+      { p: [{ data: btoa('huge'), mimeType: 'image/png' }] },
+    )
+    expect(result).toBe('quota_exceeded')
+    const raw = store[`run-draft:${WF}`]
+    expect(raw).toBeTruthy()
+    const parsed = JSON.parse(raw)
+    expect(parsed.inputs.a).toBe('keep')
+    expect(parsed.images).toEqual({})
   })
 })

--- a/web/src/lib/run/runDraft.ts
+++ b/web/src/lib/run/runDraft.ts
@@ -1,4 +1,12 @@
 import type { ClarifyImage } from '../shared/types'
+import {
+  blobToBase64,
+  getDraftIdb,
+  isQuotaError,
+  tryBase64ToBlob,
+  type DraftAttachmentRecord,
+  type RunDraftRecord,
+} from './draftIdb'
 
 export interface RunDraftPayload {
   workflowId: string
@@ -7,13 +15,36 @@ export interface RunDraftPayload {
   images: Record<string, ClarifyImage[]>
 }
 
-export type SaveRunDraftResult = 'ok' | 'quota_exceeded' | 'error'
+/** ok = full save; partial = fields persisted without images; quota_exceeded / error. */
+export type SaveRunDraftResult = 'ok' | 'partial' | 'quota_exceeded' | 'error'
 
-function draftKey(workflowId: string): string {
-  return `run-draft:${workflowId}`
+const LEGACY_PREFIX = 'run-draft:'
+
+let runMigrationDone = false
+
+/** Test-only: re-run legacy localStorage migration. */
+export function __resetRunDraftMigrationForTests(): void {
+  runMigrationDone = false
 }
 
-export function loadRunDraft(workflowId: string): RunDraftPayload | null {
+function draftKey(workflowId: string): string {
+  return `${LEGACY_PREFIX}${workflowId}`
+}
+
+function listLegacyKeys(): string[] {
+  const keys: string[] = []
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i)
+      if (k && k.startsWith(LEGACY_PREFIX)) keys.push(k)
+    }
+  } catch {
+    /* ignore */
+  }
+  return keys
+}
+
+function readLegacy(workflowId: string): RunDraftPayload | null {
   try {
     const raw = localStorage.getItem(draftKey(workflowId))
     if (!raw) return null
@@ -23,40 +54,191 @@ export function loadRunDraft(workflowId: string): RunDraftPayload | null {
   }
 }
 
-export function clearRunDraft(workflowId: string): void {
-  localStorage.removeItem(draftKey(workflowId))
+function clearLegacy(workflowId: string): void {
+  try {
+    localStorage.removeItem(draftKey(workflowId))
+  } catch {
+    /* ignore */
+  }
 }
 
-export function saveRunDraft(
+function writeLegacyTextFallback(payload: RunDraftPayload): SaveRunDraftResult {
+  const slim: RunDraftPayload = {
+    ...payload,
+    images: {},
+  }
+  try {
+    localStorage.setItem(draftKey(payload.workflowId), JSON.stringify(slim))
+    const hadImages = Object.values(payload.images).some((arr) => (arr || []).length > 0)
+    return hadImages ? 'partial' : 'ok'
+  } catch (e: unknown) {
+    if (isQuotaError(e)) return 'quota_exceeded'
+    return 'error'
+  }
+}
+
+function flattenImages(
+  workflowId: string,
+  images: Record<string, ClarifyImage[]>,
+): DraftAttachmentRecord[] {
+  const out: DraftAttachmentRecord[] = []
+  let sortIndex = 0
+  for (const [fieldKey, list] of Object.entries(images)) {
+    for (const im of list || []) {
+      if (!im.data) continue
+      const blob = tryBase64ToBlob(im.data, im.mimeType)
+      if (!blob) continue
+      const rec: DraftAttachmentRecord = {
+        id: `run:${workflowId}:${fieldKey}:${sortIndex}`,
+        ownerKind: 'run',
+        ownerId: workflowId,
+        mimeType: im.mimeType,
+        data: blob,
+        sizeBytes: blob.size,
+        fieldKey,
+        sortIndex,
+      }
+      if (im.name) rec.name = im.name
+      out.push(rec)
+      sortIndex++
+    }
+  }
+  return out
+}
+
+async function inflateImages(rows: DraftAttachmentRecord[]): Promise<Record<string, ClarifyImage[]>> {
+  const images: Record<string, ClarifyImage[]> = {}
+  const sorted = rows.slice().sort((a, b) => (a.sortIndex ?? 0) - (b.sortIndex ?? 0))
+  for (const row of sorted) {
+    const key = row.fieldKey || '_'
+    if (!images[key]) images[key] = []
+    const data = await blobToBase64(row.data)
+    const im: ClarifyImage = { mimeType: row.mimeType, data }
+    if (row.name) im.name = row.name
+    if (row.sizeBytes != null) im.sizeBytes = row.sizeBytes
+    images[key].push(im)
+  }
+  return images
+}
+
+function isRunDraftEmpty(inputs: Record<string, string>, images: Record<string, ClarifyImage[]>): boolean {
+  const hasText = Object.values(inputs).some((v) => String(v ?? '').trim())
+  if (hasText) return false
+  for (const list of Object.values(images)) {
+    if ((list || []).some((im) => !!im.data)) return false
+  }
+  return true
+}
+
+async function migrateLegacyRunIfNeeded(): Promise<void> {
+  if (runMigrationDone) return
+  runMigrationDone = true
+  const keys = listLegacyKeys()
+  if (keys.length === 0) return
+  const idb = getDraftIdb()
+  for (const key of keys) {
+    const workflowId = key.slice(LEGACY_PREFIX.length)
+    if (!workflowId) continue
+    const legacy = readLegacy(workflowId)
+    if (!legacy) {
+      clearLegacy(workflowId)
+      continue
+    }
+    try {
+      const existing = await idb.getRun(workflowId)
+      if (existing) {
+        clearLegacy(workflowId)
+        continue
+      }
+      const record: RunDraftRecord = {
+        workflowId,
+        savedAt: legacy.savedAt || Date.now(),
+        inputsJson: JSON.stringify(legacy.inputs || {}),
+      }
+      await idb.putRun(record, flattenImages(workflowId, legacy.images || {}))
+      clearLegacy(workflowId)
+    } catch {
+      /* leave legacy key on failure */
+    }
+  }
+}
+
+export async function loadRunDraft(workflowId: string): Promise<RunDraftPayload | null> {
+  await migrateLegacyRunIfNeeded()
+  try {
+    const packed = await getDraftIdb().getRun(workflowId)
+    if (packed) {
+      let inputs: Record<string, string> = {}
+      try {
+        inputs = JSON.parse(packed.record.inputsJson || '{}') as Record<string, string>
+      } catch {
+        inputs = {}
+      }
+      return {
+        workflowId: packed.record.workflowId,
+        savedAt: packed.record.savedAt,
+        inputs,
+        images: await inflateImages(packed.attachments),
+      }
+    }
+  } catch {
+    /* fall through */
+  }
+  return readLegacy(workflowId)
+}
+
+export async function clearRunDraft(workflowId: string): Promise<void> {
+  try {
+    await getDraftIdb().deleteRun(workflowId)
+  } catch {
+    /* ignore */
+  }
+  clearLegacy(workflowId)
+}
+
+export async function saveRunDraft(
   workflowId: string,
   inputs: Record<string, string>,
   images: Record<string, ClarifyImage[]>,
-): SaveRunDraftResult {
+): Promise<SaveRunDraftResult> {
+  await migrateLegacyRunIfNeeded()
+  if (isRunDraftEmpty(inputs, images)) {
+    await clearRunDraft(workflowId)
+    return 'ok'
+  }
   const payload: RunDraftPayload = {
     workflowId,
     savedAt: Date.now(),
     inputs,
     images,
   }
+  const record: RunDraftRecord = {
+    workflowId,
+    savedAt: payload.savedAt,
+    inputsJson: JSON.stringify(inputs),
+  }
   try {
-    localStorage.setItem(draftKey(workflowId), JSON.stringify(payload))
+    await getDraftIdb().putRun(record, flattenImages(workflowId, images))
+    clearLegacy(workflowId)
     return 'ok'
   } catch (e: unknown) {
-    const err = e as { name?: string; code?: number }
-    if (err?.name === 'QuotaExceededError' || err?.code === 22) {
-      return 'quota_exceeded'
+    const fb = writeLegacyTextFallback(payload)
+    if (isQuotaError(e)) {
+      return fb === 'ok' || fb === 'partial' ? 'quota_exceeded' : fb
     }
-    return 'error'
+    if (fb === 'error' || fb === 'quota_exceeded') return fb
+    const hadImages = Object.values(images).some((arr) => (arr || []).some((im) => !!im.data))
+    return hadImages ? 'partial' : 'ok'
   }
 }
 
-export function mergeRunDraft(
+export async function mergeRunDraft(
   workflowId: string,
   seedInputs: Record<string, string>,
   seedImages: Record<string, ClarifyImage[]>,
   fieldKeys: string[],
-): { inputs: Record<string, string>; images: Record<string, ClarifyImage[]>; restored: boolean } {
-  const draft = loadRunDraft(workflowId)
+): Promise<{ inputs: Record<string, string>; images: Record<string, ClarifyImage[]>; restored: boolean }> {
+  const draft = await loadRunDraft(workflowId)
   if (!draft) {
     return { inputs: { ...seedInputs }, images: { ...seedImages }, restored: false }
   }

--- a/web/src/lib/run/runDraft.ts
+++ b/web/src/lib/run/runDraft.ts
@@ -147,7 +147,10 @@ async function migrateLegacyRunIfNeeded(): Promise<void> {
     try {
       const existing = await idb.getRun(workflowId)
       if (existing) {
-        clearLegacy(workflowId)
+        // Keep newer LS text-fallback for load to prefer (review v2); only drop stale LS.
+        if ((legacy.savedAt || 0) <= existing.record.savedAt) {
+          clearLegacy(workflowId)
+        }
         continue
       }
       const record: RunDraftRecord = {
@@ -165,26 +168,42 @@ async function migrateLegacyRunIfNeeded(): Promise<void> {
 
 export async function loadRunDraft(workflowId: string): Promise<RunDraftPayload | null> {
   await migrateLegacyRunIfNeeded()
+  const legacy = readLegacy(workflowId)
   try {
     const packed = await getDraftIdb().getRun(workflowId)
+    if (packed && legacy) {
+      // Prefer newer savedAt so quota-fallback LS fields win over stale IDB (review v2 / F4).
+      if ((legacy.savedAt || 0) > packed.record.savedAt) {
+        return legacy
+      }
+      clearLegacy(workflowId)
+      return draftFromIdbRun(packed)
+    }
     if (packed) {
-      let inputs: Record<string, string> = {}
-      try {
-        inputs = JSON.parse(packed.record.inputsJson || '{}') as Record<string, string>
-      } catch {
-        inputs = {}
-      }
-      return {
-        workflowId: packed.record.workflowId,
-        savedAt: packed.record.savedAt,
-        inputs,
-        images: await inflateImages(packed.attachments),
-      }
+      return draftFromIdbRun(packed)
     }
   } catch {
     /* fall through */
   }
-  return readLegacy(workflowId)
+  return legacy
+}
+
+async function draftFromIdbRun(packed: {
+  record: RunDraftRecord
+  attachments: DraftAttachmentRecord[]
+}): Promise<RunDraftPayload> {
+  let inputs: Record<string, string> = {}
+  try {
+    inputs = JSON.parse(packed.record.inputsJson || '{}') as Record<string, string>
+  } catch {
+    inputs = {}
+  }
+  return {
+    workflowId: packed.record.workflowId,
+    savedAt: packed.record.savedAt,
+    inputs,
+    images: await inflateImages(packed.attachments),
+  }
 }
 
 export async function clearRunDraft(workflowId: string): Promise<void> {

--- a/web/src/lib/run/useHomeApproveChat.test.ts
+++ b/web/src/lib/run/useHomeApproveChat.test.ts
@@ -50,7 +50,17 @@ vi.mock('@/lib/api/api', async () => {
 })
 
 import { useHomeApproveChat, HOME_PIPELINE_MEMORY_KEY, HOME_COMPOSER_DRAFT_DEBOUNCE_MS } from './useHomeApproveChat'
-import { HOME_COMPOSER_DRAFT_KEY, saveHomeComposerDraft, loadHomeComposerDraft } from './homeComposerDraft'
+import {
+  HOME_COMPOSER_DRAFT_KEY,
+  __resetHomeComposerDraftMigrationForTests,
+  saveHomeComposerDraft,
+  loadHomeComposerDraft,
+} from './homeComposerDraft'
+import {
+  __resetDraftIdbForTests,
+  __setDraftIdbBackendForTests,
+  createMemoryDraftIdb,
+} from './draftIdb'
 
 const approveWf: Workflow = {
   id: 'wf-ap',
@@ -130,12 +140,16 @@ describe('useHomeApproveChat', () => {
       nodeRuns: { ap: { nodeId: 'ap', status: 'waiting_human' } },
     })
     mocks.reactReply.mockResolvedValue({ status: 'ok' })
+    __setDraftIdbBackendForTests(createMemoryDraftIdb())
+    __resetHomeComposerDraftMigrationForTests()
     localStorage.removeItem(HOME_PIPELINE_MEMORY_KEY)
     localStorage.removeItem(HOME_COMPOSER_DRAFT_KEY)
   })
 
   afterEach(() => {
     vi.useRealTimers()
+    __resetDraftIdbForTests()
+    __resetHomeComposerDraftMigrationForTests()
     localStorage.removeItem(HOME_PIPELINE_MEMORY_KEY)
     localStorage.removeItem(HOME_COMPOSER_DRAFT_KEY)
   })
@@ -287,12 +301,14 @@ describe('useHomeApproveChat', () => {
 
   // plan g2.1 — silent restore + toast when non-empty draft exists
   it('restores composer draft on mount and toasts once', async () => {
-    saveHomeComposerDraft('未发送草稿', [{ data: 'img', mimeType: 'image/png', name: 'a.png' }], 'wf-ap')
+    const imgData = btoa('img')
+    await saveHomeComposerDraft('未发送草稿', [{ data: imgData, mimeType: 'image/png', name: 'a.png' }], 'wf-ap')
     mocks.listWorkflows.mockResolvedValue([approveWf, approveWfB])
     const chat = withSetup(() => useHomeApproveChat())
+    await flushPromises()
     await chat.load()
     expect(chat.draft.value).toBe('未发送草稿')
-    expect(chat.attachments.value).toEqual([{ data: 'img', mimeType: 'image/png', name: 'a.png' }])
+    expect(chat.attachments.value).toEqual([{ data: imgData, mimeType: 'image/png', name: 'a.png' }])
     expect(chat.selectedId.value).toBe('wf-ap')
     expect(mocks.toastSuccess).toHaveBeenCalledWith('草稿已恢复')
   })
@@ -300,6 +316,7 @@ describe('useHomeApproveChat', () => {
   // plan g2.1 — no toast when no draft
   it('does not toast restore when there is no composer draft', async () => {
     const chat = withSetup(() => useHomeApproveChat())
+    await flushPromises()
     await chat.load()
     expect(chat.draft.value).toBe('')
     expect(mocks.toastSuccess).not.toHaveBeenCalled()
@@ -308,9 +325,10 @@ describe('useHomeApproveChat', () => {
   // plan g2.4 — draft pipeline beats lastPipeline memory
   it('prefers draft pipeline over HOME_PIPELINE_MEMORY_KEY', async () => {
     localStorage.setItem(HOME_PIPELINE_MEMORY_KEY, 'wf-lite')
-    saveHomeComposerDraft('草稿管道优先', [], 'wf-ap')
+    await saveHomeComposerDraft('草稿管道优先', [], 'wf-ap')
     mocks.listWorkflows.mockResolvedValue([approveWf, approveWfB])
     const chat = withSetup(() => useHomeApproveChat())
+    await flushPromises()
     await chat.load()
     expect(chat.selectedId.value).toBe('wf-ap')
     expect(chat.draft.value).toBe('草稿管道优先')
@@ -318,10 +336,11 @@ describe('useHomeApproveChat', () => {
 
   // plan g2.4 — unavailable draft pipeline still restores text/attachments
   it('restores text when draft pipeline is unavailable', async () => {
-    saveHomeComposerDraft('管道已下线', [{ data: 'x', mimeType: 'image/png' }], 'wf-gone')
+    await saveHomeComposerDraft('管道已下线', [{ data: btoa('x'), mimeType: 'image/png' }], 'wf-gone')
     localStorage.setItem(HOME_PIPELINE_MEMORY_KEY, 'wf-lite')
     mocks.listWorkflows.mockResolvedValue([approveWf, approveWfB])
     const chat = withSetup(() => useHomeApproveChat())
+    await flushPromises()
     await chat.load()
     expect(chat.draft.value).toBe('管道已下线')
     expect(chat.attachments.value).toHaveLength(1)
@@ -334,19 +353,22 @@ describe('useHomeApproveChat', () => {
     vi.useFakeTimers()
     mocks.listWorkflows.mockResolvedValue([approveWf, approveWfB])
     const chat = withSetup(() => useHomeApproveChat())
+    await flushPromises()
     await chat.load()
     chat.draft.value = 'a'
     chat.draft.value = 'ab'
     chat.draft.value = 'abc'
-    expect(loadHomeComposerDraft()).toBeNull()
+    expect(await loadHomeComposerDraft()).toBeNull()
     await vi.advanceTimersByTimeAsync(HOME_COMPOSER_DRAFT_DEBOUNCE_MS)
-    expect(loadHomeComposerDraft()?.text).toBe('abc')
+    await flushPromises()
+    expect((await loadHomeComposerDraft())?.text).toBe('abc')
     chat.selectPipeline('wf-lite')
-    chat.attachments.value = [{ data: 'z', mimeType: 'image/png' }]
+    chat.attachments.value = [{ data: btoa('z'), mimeType: 'image/png' }]
     await vi.advanceTimersByTimeAsync(HOME_COMPOSER_DRAFT_DEBOUNCE_MS)
-    const saved = loadHomeComposerDraft()
+    await flushPromises()
+    const saved = await loadHomeComposerDraft()
     expect(saved?.pipelineId).toBe('wf-lite')
-    expect(saved?.attachments).toEqual([{ data: 'z', mimeType: 'image/png' }])
+    expect(saved?.attachments?.[0]).toMatchObject({ data: btoa('z'), mimeType: 'image/png' })
   })
 
   // plan g2.2 — unmount flushes pending debounce so quick leave still persists
@@ -367,18 +389,21 @@ describe('useHomeApproveChat', () => {
     const app = createApp(Comp)
     app.use(i18n)
     app.mount(document.createElement('div'))
+    await flushPromises()
     await result.load()
     result.draft.value = '离开前未防抖落盘'
-    expect(loadHomeComposerDraft()).toBeNull()
+    expect(await loadHomeComposerDraft()).toBeNull()
     app.unmount()
-    expect(loadHomeComposerDraft()?.text).toBe('离开前未防抖落盘')
+    await flushPromises()
+    expect((await loadHomeComposerDraft())?.text).toBe('离开前未防抖落盘')
   })
 
   // plan g2.4 — empty pipeline list must not drop draft preference before load
   it('keeps draft pipeline preference while pipeline list is still empty', async () => {
-    saveHomeComposerDraft('等列表', [], 'wf-lite')
+    await saveHomeComposerDraft('等列表', [], 'wf-lite')
     mocks.listWorkflows.mockResolvedValue([approveWf, approveWfB])
     const chat = withSetup(() => useHomeApproveChat())
+    await flushPromises()
     // Before load: preference from hydrate must survive empty pipelines watch.
     expect(chat.draft.value).toBe('等列表')
     await chat.load()
@@ -387,13 +412,15 @@ describe('useHomeApproveChat', () => {
 
   // plan g2.3 — clear draft after successful startRun
   it('clears local composer draft after successful send', async () => {
-    saveHomeComposerDraft('will clear', [], 'wf-ap')
+    await saveHomeComposerDraft('will clear', [], 'wf-ap')
     const chat = withSetup(() => useHomeApproveChat())
+    await flushPromises()
     await chat.load()
     expect(chat.draft.value).toBe('will clear')
     await chat.send()
     await nextTick()
-    expect(loadHomeComposerDraft()).toBeNull()
+    await flushPromises()
+    expect(await loadHomeComposerDraft()).toBeNull()
     expect(chat.draft.value).toBe('')
   })
 
@@ -418,22 +445,55 @@ describe('useHomeApproveChat', () => {
     mocks.listWorkflows.mockResolvedValue([missing])
     vi.useFakeTimers()
     const chat = withSetup(() => useHomeApproveChat())
+    await flushPromises()
     await chat.load()
     chat.draft.value = '仍要保留'
     await vi.advanceTimersByTimeAsync(HOME_COMPOSER_DRAFT_DEBOUNCE_MS)
+    await flushPromises()
     await chat.send()
     expect(chat.launchOpen.value).toBe(true)
-    expect(loadHomeComposerDraft()?.text).toBe('仍要保留')
+    expect((await loadHomeComposerDraft())?.text).toBe('仍要保留')
   })
 
   // plan g2.3 — clear on onLaunchStarted
   it('clears composer draft when onLaunchStarted runs after RunLaunch', async () => {
-    saveHomeComposerDraft('launch clear', [], 'wf-ap')
+    await saveHomeComposerDraft('launch clear', [], 'wf-ap')
     const chat = withSetup(() => useHomeApproveChat())
+    await flushPromises()
     await chat.load()
     await chat.onLaunchStarted('run-99')
-    expect(loadHomeComposerDraft()).toBeNull()
+    await flushPromises()
+    expect(await loadHomeComposerDraft()).toBeNull()
     expect(chat.draft.value).toBe('')
+  })
+
+  // plan g3.2 — auto-save quota toast only once
+  it('toasts draftTooLarge only once across consecutive auto-saves (plan g3.2)', async () => {
+    const { __setDraftIdbBackendForTests: setBackend, createMemoryDraftIdb: mem } = await import('./draftIdb')
+    const base = mem()
+    setBackend({
+      ...base,
+      putHome: async () => {
+        const err = new Error('quota') as Error & { name: string; code: number }
+        err.name = 'QuotaExceededError'
+        err.code = 22
+        throw err
+      },
+    })
+    vi.useFakeTimers()
+    mocks.listWorkflows.mockResolvedValue([approveWf])
+    const chat = withSetup(() => useHomeApproveChat())
+    await flushPromises()
+    await chat.load()
+    chat.draft.value = 'a'
+    chat.attachments.value = [{ data: btoa('x'), mimeType: 'image/png' }]
+    await vi.advanceTimersByTimeAsync(HOME_COMPOSER_DRAFT_DEBOUNCE_MS)
+    await flushPromises()
+    chat.draft.value = 'ab'
+    await vi.advanceTimersByTimeAsync(HOME_COMPOSER_DRAFT_DEBOUNCE_MS)
+    await flushPromises()
+    expect(mocks.toastWarn).toHaveBeenCalledTimes(1)
+    expect(mocks.toastWarn).toHaveBeenCalledWith('草稿过大，请减少图片或文字')
   })
 
   // plan g3.1 / g3.3 — showOnHome=false is hidden even when published approve-first

--- a/web/src/lib/run/useHomeApproveChat.ts
+++ b/web/src/lib/run/useHomeApproveChat.ts
@@ -83,6 +83,8 @@ export function useHomeApproveChat() {
   let preferredDraftPipelineId = ''
   /** Toast once after a non-empty restore. */
   let restoreToastShown = false
+  /** Auto-save quota / partial toast once per session (plan g2.2 / F4). */
+  let quotaToastShown = false
 
   const pipelines = computed(() =>
     workflows.value.filter((w) => isPublishedApproveFirst(w) && !!w.showOnHome),
@@ -102,15 +104,22 @@ export function useHomeApproveChat() {
   }))
   const canSend = computed(() => !!draft.value.trim() || attach.attachments.value.length > 0)
 
-  function flushComposerDraftSave() {
+  async function flushComposerDraftSave() {
     if (suppressSave) return
-    const result = saveHomeComposerDraft(
+    const result = await saveHomeComposerDraft(
       draft.value,
       attach.attachments.value,
       selectedId.value || preferredDraftPipelineId || '',
     )
-    if (result === 'quota_exceeded') toast.error(t('common.toast.draftTooLarge'))
-    else if (result === 'error') toast.error(t('common.toast.draftSaveFailed'))
+    if (result === 'ok') return
+    if (result === 'quota_exceeded' || result === 'partial') {
+      if (!quotaToastShown) {
+        quotaToastShown = true
+        toast.warn(t('common.toast.draftTooLarge'))
+      }
+    } else if (result === 'error') {
+      toast.error(t('common.toast.draftSaveFailed'))
+    }
   }
 
   function scheduleComposerDraftSave() {
@@ -118,7 +127,7 @@ export function useHomeApproveChat() {
     if (saveTimer) clearTimeout(saveTimer)
     saveTimer = setTimeout(() => {
       saveTimer = null
-      flushComposerDraftSave()
+      void flushComposerDraftSave()
     }, HOME_COMPOSER_DRAFT_DEBOUNCE_MS)
   }
 
@@ -127,20 +136,20 @@ export function useHomeApproveChat() {
       clearTimeout(saveTimer)
       saveTimer = null
     }
-    clearHomeComposerDraft()
+    void clearHomeComposerDraft()
     preferredDraftPipelineId = ''
   }
 
   /**
-   * Silent restore from localStorage (plan g2.1).
+   * Restore from IndexedDB (with legacy localStorage migration) (plan g2.1).
    * Pipeline selection: draft pipeline > lastPipeline memory > list default (g2.4).
    */
-  function hydrateComposerDraft() {
-    const stored = loadHomeComposerDraft()
+  async function hydrateComposerDraft() {
+    const stored = await loadHomeComposerDraft()
     if (!stored) return
     const hasContent = !!stored.text.trim() || stored.attachments.length > 0
     if (!hasContent) {
-      clearHomeComposerDraft()
+      await clearHomeComposerDraft()
       return
     }
 
@@ -149,8 +158,18 @@ export function useHomeApproveChat() {
       draft.value = stored.text
       attach.attachments.value = stored.attachments.map((im) => ({ ...im }))
       if (stored.pipelineId) {
-        preferredDraftPipelineId = stored.pipelineId
-        selectedId.value = stored.pipelineId
+        const list = pipelines.value
+        if (list.length === 0) {
+          // List not loaded yet — keep preference for pipelines watch (plan g2.4).
+          preferredDraftPipelineId = stored.pipelineId
+          selectedId.value = stored.pipelineId
+        } else if (list.some((w) => w.id === stored.pipelineId)) {
+          preferredDraftPipelineId = stored.pipelineId
+          selectedId.value = stored.pipelineId
+        } else {
+          // Stale draft pipeline after list is known — do not clobber current selection.
+          preferredDraftPipelineId = ''
+        }
       }
       if (!restoreToastShown) {
         restoreToastShown = true
@@ -217,8 +236,8 @@ export function useHomeApproveChat() {
     writeLastPipelineId(id)
   }
 
-  function seedLaunch(wf: Workflow) {
-    const seeded = seedAskLaunchFields(wf)
+  async function seedLaunch(wf: Workflow) {
+    const seeded = await seedAskLaunchFields(wf)
     launchTarget.value = wf
     runFields.value = seeded.fields
     runInputs.value = seeded.inputs
@@ -272,7 +291,7 @@ export function useHomeApproveChat() {
       const missing = missingRequiredAskField(wf)
       if (missing) {
         toast.warn(t('pages.dashboard.missingRequired'))
-        seedLaunch(wf)
+        await seedLaunch(wf)
         return
       }
       const res = await api.startRun(wf.id, {}, 'manual', 'normal', [], {
@@ -290,7 +309,7 @@ export function useHomeApproveChat() {
       const msg = String(e?.message || e)
       if (msg.includes('缺少必填项')) {
         toast.warn(t('pages.dashboard.missingRequired'))
-        seedLaunch(wf)
+        await seedLaunch(wf)
         return
       }
       toast.error(msg)
@@ -318,8 +337,11 @@ export function useHomeApproveChat() {
   }
 
   onMounted(() => {
-    hydrateComposerDraft()
-    void load()
+    // Hydrate first so draft preference is set before the workflow list settles (plan g2.4).
+    void (async () => {
+      await hydrateComposerDraft()
+      await load()
+    })()
   })
   onUnmounted(() => {
     loadAbort?.abort()
@@ -327,7 +349,7 @@ export function useHomeApproveChat() {
     if (saveTimer) {
       clearTimeout(saveTimer)
       saveTimer = null
-      flushComposerDraftSave()
+      void flushComposerDraftSave()
     }
   })
 

--- a/web/src/lib/run/useWorkflowAskInputs.ts
+++ b/web/src/lib/run/useWorkflowAskInputs.ts
@@ -47,12 +47,12 @@ export function missingRequiredAskField(wf: Pick<Workflow, 'nodes'>): InputField
   return askFieldsFromWorkflow(wf).find((f) => f.required && isAskValueBlank(f.type, f.default || ''))
 }
 
-export function seedAskLaunchFields(wf: Pick<Workflow, 'id' | 'nodes'>): {
+export async function seedAskLaunchFields(wf: Pick<Workflow, 'id' | 'nodes'>): Promise<{
   fields: InputField[]
   inputs: Record<string, string>
   images: Record<string, ClarifyImage[]>
   restored: boolean
-} {
+}> {
   const fields = askFieldsFromWorkflow(wf)
   const seed: Record<string, string> = {}
   const imgSeed: Record<string, ClarifyImage[]> = {}
@@ -60,7 +60,7 @@ export function seedAskLaunchFields(wf: Pick<Workflow, 'id' | 'nodes'>): {
     seed[f.key] = f.default || (f.type === 'select' ? fieldOptions(f)[0] || '' : '')
     imgSeed[f.key] = []
   }
-  const merged = mergeRunDraft(
+  const merged = await mergeRunDraft(
     wf.id,
     seed,
     imgSeed,

--- a/web/src/lib/run/useWorkflowRunLaunch.test.ts
+++ b/web/src/lib/run/useWorkflowRunLaunch.test.ts
@@ -7,13 +7,13 @@ import { useWorkflowRunLaunch } from './useWorkflowRunLaunch'
 import type { Workflow } from '@/lib/shared/types'
 
 vi.mock('@/lib/run/runDraft', () => ({
-  mergeRunDraft: (_id: string, seed: Record<string, string>, images: Record<string, unknown>) => ({
+  mergeRunDraft: async (_id: string, seed: Record<string, string>, images: Record<string, unknown>) => ({
     inputs: seed,
     images,
     restored: false,
   }),
-  saveRunDraft: vi.fn(() => 'ok'),
-  clearRunDraft: vi.fn(),
+  saveRunDraft: vi.fn(async () => 'ok'),
+  clearRunDraft: vi.fn(async () => {}),
 }))
 
 function withSetup<T>(fn: () => T): T {
@@ -66,18 +66,18 @@ beforeEach(() => {
 })
 
 describe('useWorkflowRunLaunch', () => {
-  it('openLaunch pre-fills ask fields and opens the modal without changing route', () => {
+  it('openLaunch pre-fills ask fields and opens the modal without changing route', async () => {
     const launch = withSetup(() => useWorkflowRunLaunch())
-    launch.openLaunch(baseWf())
+    await launch.openLaunch(baseWf())
     expect(launch.open.value).toBe(true)
     expect(launch.target.value?.id).toBe('wf-1')
     expect(launch.runFields.value.map((f) => f.key)).toEqual(['branch'])
     expect(launch.runInputs.value.branch).toBe('main')
   })
 
-  it('openLaunch still opens when there are no ask fields', () => {
+  it('openLaunch still opens when there are no ask fields', async () => {
     const launch = withSetup(() => useWorkflowRunLaunch())
-    launch.openLaunch(
+    await launch.openLaunch(
       baseWf({
         nodes: [{ id: 'n1', type: 'input', label: '输入', config: { variables: [] } } as any],
       }),

--- a/web/src/lib/run/useWorkflowRunLaunch.ts
+++ b/web/src/lib/run/useWorkflowRunLaunch.ts
@@ -20,8 +20,8 @@ export function useWorkflowRunLaunch() {
   const toast = useToast()
   const { t } = useI18n()
 
-  function openLaunch(workflow: Workflow) {
-    const seeded = seedAskLaunchFields(workflow)
+  async function openLaunch(workflow: Workflow) {
+    const seeded = await seedAskLaunchFields(workflow)
     target.value = workflow
     runFields.value = seeded.fields
     runInputs.value = seeded.inputs
@@ -35,21 +35,22 @@ export function useWorkflowRunLaunch() {
     target.value = null
   }
 
-  function saveRunDraftClick() {
+  async function saveRunDraftClick() {
     const wf = target.value
     if (!wf) return
     const images: Record<string, ClarifyImage[]> = {}
     for (const [k, v] of Object.entries(runImages.value)) {
       images[k] = v ? [...v] : []
     }
-    const result = saveRunDraft(wf.id, { ...runInputs.value }, images)
+    const result = await saveRunDraft(wf.id, { ...runInputs.value }, images)
     if (result === 'ok') toast.success(t('common.toast.draftSaved'))
-    else if (result === 'quota_exceeded') toast.error(t('common.toast.draftTooLarge'))
-    else toast.error(t('common.toast.draftSaveFailed'))
+    else if (result === 'quota_exceeded' || result === 'partial') {
+      toast.error(t('common.toast.draftTooLarge'))
+    } else toast.error(t('common.toast.draftSaveFailed'))
   }
 
   function onStarted() {
-    if (target.value) clearRunDraft(target.value.id)
+    if (target.value) void clearRunDraft(target.value.id)
   }
 
   return {

--- a/web/src/lib/run/useWorkflowRunLaunch.ts
+++ b/web/src/lib/run/useWorkflowRunLaunch.ts
@@ -45,7 +45,8 @@ export function useWorkflowRunLaunch() {
     const result = await saveRunDraft(wf.id, { ...runInputs.value }, images)
     if (result === 'ok') toast.success(t('common.toast.draftSaved'))
     else if (result === 'quota_exceeded' || result === 'partial') {
-      toast.error(t('common.toast.draftTooLarge'))
+      // Text already on disk / fields persisted — warn per F4 (review v3), not error.
+      toast.warn(t('common.toast.draftTooLarge'))
     } else toast.error(t('common.toast.draftSaveFailed'))
   }
 

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -2523,7 +2523,7 @@
       "started": "Workflow started",
       "startedLabel": "Started workflow",
       "enterHint": "Press Enter to view run details",
-      "draftRestored": "Draft restored from localStorage (overrides workflow defaults)",
+      "draftRestored": "Draft restored from local storage (overrides workflow defaults)",
       "noFields": "Input node declares no fields.",
       "noFieldsWithHint": "Input node declares no fields; starting with empty params.",
       "locked": "Locked",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -2523,7 +2523,7 @@
       "started": "工作流已启动",
       "startedLabel": "已启动的工作流",
       "enterHint": "按 Enter 查看运行详情",
-      "draftRestored": "已从 localStorage 恢复草稿（覆盖工作流默认值）",
+      "draftRestored": "已从本地草稿恢复（覆盖工作流默认值）",
       "noFields": "该工作流的「输入」节点未声明任何输入字段。",
       "noFieldsWithHint": "该工作流的「输入」节点未声明任何输入字段,将以空参数启动。",
       "locked": "锁定",

--- a/web/src/views/WorkflowEditorView.vue
+++ b/web/src/views/WorkflowEditorView.vue
@@ -233,7 +233,7 @@ function askFields(): InputField[] {
   return askFieldsComputed.value
 }
 
-function openRun() {
+async function openRun() {
   if (graphError.value) {
     errorMsg.value = graphError.value
     return
@@ -247,23 +247,24 @@ function openRun() {
     imgSeed[f.key] = []
   }
   const keys = runFields.value.map((f) => f.key)
-  const merged = mergeRunDraft(wf.id, seed, imgSeed, keys)
+  const merged = await mergeRunDraft(wf.id, seed, imgSeed, keys)
   runInputs.value = merged.inputs
   runImages.value = merged.images
   draftRestored.value = merged.restored
   showRun.value = true
 }
 
-function saveRunDraftClick() {
+async function saveRunDraftClick() {
   if (!wf.id) return
   const images: Record<string, ClarifyImage[]> = {}
   for (const [k, v] of Object.entries(runImages.value)) {
     images[k] = v ? [...v] : []
   }
-  const result = saveRunDraft(wf.id, { ...runInputs.value }, images)
+  const result = await saveRunDraft(wf.id, { ...runInputs.value }, images)
   if (result === 'ok') toast.success(t('common.toast.draftSaved'))
-  else if (result === 'quota_exceeded') toast.error(t('common.toast.draftTooLarge'))
-  else toast.error(t('common.toast.draftSaveFailed'))
+  else if (result === 'quota_exceeded' || result === 'partial') {
+    toast.error(t('common.toast.draftTooLarge'))
+  } else toast.error(t('common.toast.draftSaveFailed'))
 }
 
 async function beforeRunStart() {
@@ -276,7 +277,7 @@ async function beforeRunStart() {
 }
 
 function onRunStarted() {
-  clearRunDraft(wf.id)
+  void clearRunDraft(wf.id)
 }
 
 function onViewRun(runId: string) {

--- a/web/src/views/WorkflowEditorView.vue
+++ b/web/src/views/WorkflowEditorView.vue
@@ -263,7 +263,8 @@ async function saveRunDraftClick() {
   const result = await saveRunDraft(wf.id, { ...runInputs.value }, images)
   if (result === 'ok') toast.success(t('common.toast.draftSaved'))
   else if (result === 'quota_exceeded' || result === 'partial') {
-    toast.error(t('common.toast.draftTooLarge'))
+    // Text already on disk / fields persisted — warn per F4 (review v3), not error.
+    toast.warn(t('common.toast.draftTooLarge'))
   } else toast.error(t('common.toast.draftSaveFailed'))
 }
 


### PR DESCRIPTION
## Summary
- 首页 composer 与 run 草稿改为 IndexedDB（`approving-drafts`），附件按 Blob 存储，容量对齐 50MiB 附件门概；刷新后可恢复文字和图片。
- 一次性迁移旧 localStorage 键（`approving.home.composerDraft`、`run-draft:*`），成功后删除以免继续占满小配额。
- 配额/存储不可用时文字回退、附件留内存；自动保存只提示一次；手动保存 `partial`/`quota_exceeded` 用 warn。
- putHome/putRun 单事务原子替换，失败不丢旧附件；load/migrate 按 savedAt 取较新者。
- 登记 `draftIdb.ts` 到 `LIB_DOMAIN_MAP`，修复 web 单测域清单。

## Test plan
- [ ] `web` CI：lint / vue-tsc / vitest --coverage / build
- [ ] `web-e2e` CI
- [ ] 首页贴不超过 50MiB 的图后继续输入，不应出现「草稿过大」
- [ ] 刷新后文字和图片都在
- [ ] 仅有旧 LS 草稿时刷新可恢复，迁移后旧键消失
- [ ] 存储写满/不可用时文字可读回，自动保存不连弹