### PR TITLE
fix(sandbox): do not abort startup when only one git token is set

### DIFF
--- a/sandbox-gateway/sandbox/scripts/startup.sh
+++ b/sandbox-gateway/sandbox/scripts/startup.sh
@@ -255,20 +255,29 @@ setup_repo_credentials() {
 }
 
 # 先按仓库 URL 配置 clone 所需凭据，再为所有已配置 token 补齐对端平台。
+# 末尾必须 return 0：set -e 下函数最后一行若是 `[ -n "$empty" ] && ...` 会以 1 退出，
+# 导致 startup.sh 在 glab 配置后直接崩掉（remote-dev 只注入 GITLAB_TOKEN 时必现）。
 configure_git_credentials() {
     if [ -n "$GIT_REPOS" ]; then
         IFS=',' read -ra _entries <<< "$GIT_REPOS"
         for _entry in "${_entries[@]}"; do
             [ -n "$_entry" ] || continue
             IFS='|' read -r _name _url _branch <<< "$_entry"
-            [ -n "$_url" ] && setup_repo_credentials "$_url"
+            if [ -n "$_url" ]; then
+                setup_repo_credentials "$_url"
+            fi
         done
         unset _entries _entry _name _url _branch
     elif [ -n "$GIT_CLONE_URL" ]; then
         setup_repo_credentials "$GIT_CLONE_URL"
     fi
-    [ -n "$GITLAB_TOKEN" ] && setup_bare_gitlab_credentials
-    [ -n "$GITHUB_TOKEN" ] && setup_bare_github_credentials
+    if [ -n "$GITLAB_TOKEN" ]; then
+        setup_bare_gitlab_credentials
+    fi
+    if [ -n "$GITHUB_TOKEN" ]; then
+        setup_bare_github_credentials
+    fi
+    return 0
 }
 
 repo_name_from_url() {

--- a/sandbox-gateway/scripts/test-git-auth.sh
+++ b/sandbox-gateway/scripts/test-git-auth.sh
@@ -155,4 +155,59 @@ if grep -q 'oauth2:.*@github.com' "$TMP/root/.git-credentials"; then
 fi
 echo "OK: mis-derived GITLAB_URL=https://github.com falls back to gitlab.com"
 
+# Single-sided tokens must not abort under set -e (function last-line && pitfall).
+rm -f "$HOME/gh.last" "$HOME/gh.token" "$HOME/glab.last" "$TMP/root/.git-credentials"
+GITHUB_TOKEN=""
+GITLAB_TOKEN="gl_only"
+GITHUB_URL=""
+GITLAB_URL="https://git.cocofhu.cc"
+GIT_REPOS="api|https://git.cocofhu.cc/team/api.git|main"
+GIT_CLONE_URL=""
+_GIT_CRED_RESET=0
+configure_git_credentials
+grep -q 'oauth2:gl_only@git.cocofhu.cc' "$TMP/root/.git-credentials"
+grep -q 'argv:auth login --hostname git.cocofhu.cc --token gl_only' "$HOME/glab.last"
+if [ -f "$HOME/gh.last" ]; then
+  echo "FAIL: GitLab-only should not invoke gh" >&2
+  exit 1
+fi
+echo "OK: GitLab-only token + GitLab clone does not abort"
+
+rm -f "$HOME/gh.last" "$HOME/gh.token" "$HOME/glab.last" "$TMP/root/.git-credentials"
+GITHUB_TOKEN="gh_only"
+GITLAB_TOKEN=""
+GITHUB_URL=""
+GITLAB_URL=""
+GIT_REPOS="app|https://github.com/acme/app.git|main"
+GIT_CLONE_URL=""
+_GIT_CRED_RESET=0
+configure_git_credentials
+grep -q 'x-access-token:gh_only@github.com' "$TMP/root/.git-credentials"
+grep -q 'argv:auth login --hostname github.com --with-token' "$HOME/gh.last"
+if [ -f "$HOME/glab.last" ]; then
+  echo "FAIL: GitHub-only should not invoke glab" >&2
+  exit 1
+fi
+echo "OK: GitHub-only token + GitHub clone does not abort"
+
+rm -f "$HOME/gh.last" "$HOME/gh.token" "$HOME/glab.last" "$TMP/root/.git-credentials"
+GITHUB_TOKEN=""
+GITLAB_TOKEN=""
+GITHUB_URL=""
+GITLAB_URL=""
+GIT_REPOS="pub|https://example.com/pub.git|"
+GIT_CLONE_URL=""
+_GIT_CRED_RESET=0
+configure_git_credentials
+echo "OK: empty tokens + GIT_REPOS does not abort"
+
+rm -f "$HOME/gh.last" "$HOME/gh.token" "$HOME/glab.last" "$TMP/root/.git-credentials"
+GITHUB_TOKEN=""
+GITLAB_TOKEN=""
+GIT_REPOS=""
+GIT_CLONE_URL=""
+_GIT_CRED_RESET=0
+configure_git_credentials
+echo "OK: empty tokens without repos does not abort"
+
 echo "OK: git auth unit smoke passed"


### PR DESCRIPTION
## Summary
- `configure_git_credentials` ended with `[ -n "$GITHUB_TOKEN" ] && setup_bare_github_credentials` under `set -e`.
- GitLab-only sandboxes (typical remote-dev) exited after glab login; code-server never started (CrashLoop on `main-66657359b42f`).
- Switch to `if`/`fi` + `return 0`, and add single-sided / empty-token regression cases.

## Test plan
- [x] bash sandbox-gateway/scripts/test-git-auth.sh
- [ ] Rebuild universal-sandbox-* and confirm GitLab-only sandbox reaches code-server on 7891
