### PR TITLE
fix(web): home composer sends with Ctrl/⌘+Enter instead of Enter

### DIFF
--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -20,6 +20,7 @@
       "noPipelineShort": "No pipeline",
       "needText": "Describe the goal or attach a file first",
       "send": "Send",
+      "sendShortcut": "Ctrl/⌘ + Enter to send",
       "missingRequired": "Fill required launch fields before starting",
       "cardFallback": "Approve pre-dev clarification",
       "scrollLeft": "Scroll left",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -20,6 +20,7 @@
       "noPipelineShort": "未选择流水线",
       "needText": "请先描述目标或附加文件",
       "send": "发送",
+      "sendShortcut": "Ctrl/⌘ + Enter 发送",
       "missingRequired": "启动前还需填写必填项",
       "cardFallback": "Approve 开发前澄清",
       "scrollLeft": "向左滚动",

--- a/web/src/views/DashboardView.fill.test.ts
+++ b/web/src/views/DashboardView.fill.test.ts
@@ -90,12 +90,15 @@ describe('DashboardView home chat layout', () => {
   })
 
   // plan g2 / g3 — no filter hint; caret opacity settle; placeholder typewriter
+  // plan g1.1 / g2.2 — Ctrl/Meta+Enter send (no shiftKey-only Enter-to-send)
   it('omits filter hint and keeps caret settle + placeholder typewriter', () => {
     expect(src).not.toMatch(/data-testid="home-filter-hint"/)
     expect(src).not.toMatch(/filterHint/)
     expect(src).toMatch(/home-brand__cursor--gone/)
     expect(src).toMatch(/data-testid="home-composer-placeholder"/)
-    expect(src).toMatch(/shiftKey/)
+    expect(src).toMatch(/ctrlKey\s*\|\|\s*e\.metaKey|e\.metaKey\s*\|\|\s*e\.ctrlKey/)
+    expect(src).toMatch(/sendShortcut/)
+    expect(src).not.toMatch(/if \(e\.key !== 'Enter' \|\| e\.shiftKey\) return/)
     expect(src).toMatch(/prefers-reduced-motion/)
   })
 

--- a/web/src/views/DashboardView.test.ts
+++ b/web/src/views/DashboardView.test.ts
@@ -413,18 +413,55 @@ describe('DashboardView home composer', () => {
     wrapper.unmount()
   })
 
-  // plan g2.3 — Enter submits; Shift+Enter does not
-  it('Enter submits and Shift+Enter keeps the draft for a new line', async () => {
+  // plan g1.1 / g2.2 — Ctrl/⌘+Enter submits; bare Enter / Shift+Enter do not
+  it('Ctrl/Meta+Enter submits; bare Enter and Shift+Enter keep the draft for a new line', async () => {
     const wrapper = mountDashboard()
     await flushPromises()
     const input = wrapper.get('[data-testid="home-composer-input"]')
     await input.setValue('一行需求')
+
     await input.trigger('keydown', { key: 'Enter', shiftKey: true })
     await flushPromises()
     expect(mocks.startRun).not.toHaveBeenCalled()
-    await input.trigger('keydown', { key: 'Enter', shiftKey: false })
+
+    await input.trigger('keydown', { key: 'Enter' })
     await flushPromises()
-    expect(mocks.startRun).toHaveBeenCalled()
+    expect(mocks.startRun).not.toHaveBeenCalled()
+
+    await input.trigger('keydown', { key: 'Enter', metaKey: true })
+    await flushPromises()
+    expect(mocks.startRun).toHaveBeenCalledTimes(1)
+    mocks.startRun.mockClear()
+
+    await input.setValue('再发一条')
+    await input.trigger('keydown', { key: 'Enter', ctrlKey: true })
+    await flushPromises()
+    expect(mocks.startRun).toHaveBeenCalledTimes(1)
+    wrapper.unmount()
+  })
+
+  // plan g1.2 — IME composing ignores Ctrl/⌘+Enter
+  it('does not submit while IME is composing even with Ctrl/Meta+Enter', async () => {
+    const wrapper = mountDashboard()
+    await flushPromises()
+    const input = wrapper.get('[data-testid="home-composer-input"]')
+    await input.setValue('组合输入中')
+    await input.trigger('compositionstart')
+    await input.trigger('keydown', { key: 'Enter', ctrlKey: true })
+    await flushPromises()
+    expect(mocks.startRun).not.toHaveBeenCalled()
+    await input.trigger('keydown', { key: 'Enter', metaKey: true, isComposing: true })
+    await flushPromises()
+    expect(mocks.startRun).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  // plan g2.1 — send button exposes Ctrl/⌘+Enter shortcut title
+  it('send button title advertises Ctrl/⌘+Enter shortcut', async () => {
+    const wrapper = mountDashboard()
+    await flushPromises()
+    const send = wrapper.get('[data-testid="home-composer-send"]')
+    expect(send.attributes('title')).toMatch(/Ctrl\/⌘\s*\+\s*Enter/)
     wrapper.unmount()
   })
 

--- a/web/src/views/DashboardView.vue
+++ b/web/src/views/DashboardView.vue
@@ -202,8 +202,10 @@ function onTextInput() {
 }
 
 function onComposerKeydown(e: KeyboardEvent) {
-  if (e.key !== 'Enter' || e.shiftKey) return
+  // plan g1.1 — Ctrl/⌘+Enter sends; bare Enter / Shift+Enter insert newline
+  if (e.key !== 'Enter') return
   if (composing.value || e.isComposing || e.keyCode === 229) return
+  if (!(e.ctrlKey || e.metaKey)) return
   e.preventDefault()
   void send()
 }
@@ -468,6 +470,7 @@ onBeforeUnmount(() => {
               data-testid="home-composer-send"
               :disabled="sending || !canSend"
               :aria-label="t('pages.dashboard.send')"
+              :title="t('pages.dashboard.sendShortcut')"
             >
               <Icon name="arrow-up" :size="16" />
             </button>


### PR DESCRIPTION
Avoid accidental startRun while drafting multi-line requirements; bare Enter and Shift+Enter insert newlines, click send unchanged.

Co-authored-by: Cursor <cursoragent@cursor.com>
