### PR TITLE
fix(react): keep full Thought text without …(truncated)

### DIFF
--- a/server/internal/runtime/acp_react.go
+++ b/server/internal/runtime/acp_react.go
@@ -609,7 +609,8 @@ func reactCapReached(req NodeReq, history []models.ReactMessage) bool {
 
 // chatResultToEvents flattens a ChatResult into ordered AcpEvents for the run
 // timeline. Thin wrapper over the shared sandbox converter (single source of
-// truth for the event shape).
+// truth for the event shape). Do not add a second truncate path here — thought
+// fullness is owned by ChatResult.AcpEvents (plan g1.2).
 func chatResultToEvents(res *sandbox.ChatResult) []models.AcpEvent {
 	return res.AcpEvents()
 }

--- a/server/internal/runtime/acp_timeline.go
+++ b/server/internal/runtime/acp_timeline.go
@@ -206,6 +206,7 @@ func (s *acpTimelineStore) refreshFromSandbox(ctx context.Context, runID, nodeID
 	if err != nil || res == nil {
 		return // keep existing snapshot on transient bridge failures
 	}
+	// Same AcpEvents converter as live ReAct (plan g1.2) — full Thought, no fork.
 	s.upsert(runID, nodeID, res.AcpEvents())
 }
 

--- a/server/internal/runtime/acp_unit_test.go
+++ b/server/internal/runtime/acp_unit_test.go
@@ -1078,3 +1078,36 @@ func TestMergePromptImages(t *testing.T) {
 		}
 	})
 }
+
+// plan coverage: g1.2 — chatResultToEvents must stay a thin wrapper over
+// AcpEvents (no separate truncate copy). Long Thought equals full text.
+func TestChatResultToEventsSharesAcpEventsFullThought(t *testing.T) {
+	long := strings.Repeat("思", 2000) // >4000 UTF-8 bytes
+	if len(long) <= 4000 {
+		t.Fatalf("fixture too short: %d", len(long))
+	}
+	res := &sandbox.ChatResult{Thought: long, Narration: "ok"}
+	viaWrapper := chatResultToEvents(res)
+	viaShared := res.AcpEvents()
+	if len(viaWrapper) != len(viaShared) {
+		t.Fatalf("len wrapper=%d shared=%d", len(viaWrapper), len(viaShared))
+	}
+	for i := range viaWrapper {
+		if viaWrapper[i] != viaShared[i] {
+			t.Fatalf("event[%d] diverged: wrapper=%+v shared=%+v", i, viaWrapper[i], viaShared[i])
+		}
+	}
+	var thought string
+	for _, e := range viaWrapper {
+		if e.Kind == "thought" {
+			thought = e.Text
+			break
+		}
+	}
+	if thought != long {
+		t.Fatalf("wrapper thought len=%d want %d (must not re-truncate)", len(thought), len(long))
+	}
+	if strings.Contains(thought, "…(truncated)") {
+		t.Fatal("wrapper must not append truncated suffix")
+	}
+}

--- a/server/internal/sandbox/events.go
+++ b/server/internal/sandbox/events.go
@@ -171,7 +171,10 @@ func (r *ChatResult) AcpEvents() []models.AcpEvent {
 	var ev []models.AcpEvent
 	t := 0
 	if r.Thought != "" {
-		ev = append(ev, models.AcpEvent{T: t, Kind: "thought", Text: textutil.TruncateBytes(r.Thought, 4000, "…(truncated)")})
+		// ReAct / timeline / hard-refresh seed all consume this event: keep the
+		// full Thought so UIs never see …(truncated). Message narration still
+		// truncates below (8000 bytes).
+		ev = append(ev, models.AcpEvent{T: t, Kind: "thought", Text: r.Thought})
 		t++
 	}
 	if r.Plan != nil && len(r.Plan.Entries) > 0 {

--- a/server/internal/sandbox/events_test.go
+++ b/server/internal/sandbox/events_test.go
@@ -125,7 +125,9 @@ func TestTruncateTextEvents(t *testing.T) {
 	}
 }
 
-func TestAcpEventsThoughtUTF8Boundary(t *testing.T) {
+func TestAcpEventsThoughtFullTextNoTruncate(t *testing.T) {
+	// plan coverage: g1.1 / g2.2 — Thought >4000 bytes must equal full text,
+	// with no …(truncated) / ...(truncated) suffix (Chinese UTF-8 sample).
 	sample := eventsChineseBoundarySample()
 	if len(sample) <= 4000 {
 		t.Fatalf("sample too short for boundary test: %d bytes", len(sample))
@@ -134,17 +136,48 @@ func TestAcpEventsThoughtUTF8Boundary(t *testing.T) {
 	if len(ev) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(ev))
 	}
+	if ev[0].Kind != "thought" {
+		t.Fatalf("kind = %q want thought", ev[0].Kind)
+	}
+	if ev[0].Text != sample {
+		t.Fatalf("thought text must equal full Thought (%d bytes), got %d bytes", len(sample), len(ev[0].Text))
+	}
 	if !utf8.ValidString(ev[0].Text) {
 		t.Fatalf("AcpEvents invalid UTF-8: %q", ev[0].Text)
 	}
-	for _, n := range []int{3998, 4000, 4001} {
-		got := textutil.TruncateBytes(sample, n, "…(truncated)")
-		if !utf8.ValidString(got) {
-			t.Fatalf("n=%d: invalid UTF-8: %q", n, got)
-		}
-		if strings.Contains(got, "\uFFFD") {
-			t.Fatalf("n=%d: contains replacement char: %q", n, got)
-		}
+	if strings.Contains(ev[0].Text, "…(truncated)") || strings.Contains(ev[0].Text, "...(truncated)") {
+		t.Fatalf("thought must not contain truncated suffix: %q", ev[0].Text[len(ev[0].Text)-32:])
+	}
+	// Exactly 4000 bytes: still full, no suffix.
+	exact := strings.Repeat("a", 4000)
+	evExact := (&ChatResult{Thought: exact}).AcpEvents()
+	if len(evExact) != 1 || evExact[0].Text != exact {
+		t.Fatalf("exactly-4000 thought must be unchanged")
+	}
+	// Short thought unchanged.
+	evShort := (&ChatResult{Thought: "short"}).AcpEvents()
+	if len(evShort) != 1 || evShort[0].Text != "short" {
+		t.Fatalf("short thought = %q", evShort[0].Text)
+	}
+	// Empty thought: no thought event.
+	if len((&ChatResult{}).AcpEvents()) != 0 {
+		t.Fatalf("empty ChatResult should yield no events")
+	}
+	// Message >8000 still truncated (out of scope for thought, regression lock).
+	longMsg := strings.Repeat("m", 8001)
+	evMsg := (&ChatResult{Narration: longMsg}).AcpEvents()
+	if len(evMsg) != 1 || evMsg[0].Kind != "message" {
+		t.Fatalf("expected 1 message event")
+	}
+	if evMsg[0].Text == longMsg {
+		t.Fatalf("message >8000 should still truncate")
+	}
+	if !strings.HasSuffix(evMsg[0].Text, "…(truncated)") {
+		t.Fatalf("message truncate suffix missing: %q", evMsg[0].Text[len(evMsg[0].Text)-20:])
+	}
+	wantMsg := textutil.TruncateBytes(longMsg, 8000, "…(truncated)")
+	if evMsg[0].Text != wantMsg {
+		t.Fatalf("message truncate mismatch")
 	}
 }
 

--- a/web/src/components/run/ClarifyChat.test.ts
+++ b/web/src/components/run/ClarifyChat.test.ts
@@ -1053,6 +1053,34 @@ describe('ClarifyChat', () => {
       wrapper.unmount()
     })
 
+    // plan coverage: g2.1 — frontend must render full Thought (>4000 bytes), no …(truncated)
+    it('renders full long thought without truncated suffix (g2.1)', async () => {
+      const longThought = `${'思'.repeat(2000)}结尾标记END`
+      expect(new TextEncoder().encode(longThought).length).toBeGreaterThan(4000)
+      const wrapper = mountChat({ draft: '请复审' })
+      await clickSend(wrapper)
+      const vm = wrapper.vm as unknown as {
+        applyReviewFrame: (f: Record<string, unknown>) => void
+        applyAcpEvents: (e: { kind: string; text: string }[], nodeId?: string) => void
+      }
+      vm.applyReviewFrame({
+        event: 'turn_begin',
+        nodeId: 'react-1',
+        item: { text: '请复审' },
+      })
+      await flushPromises()
+      vm.applyAcpEvents([{ kind: 'thought', text: longThought }], 'react-1')
+      await flushPromises()
+
+      const thoughtBody = wrapper.find('[data-testid="clarify-thought"] .whitespace-pre-wrap')
+      expect(thoughtBody.exists()).toBe(true)
+      expect(thoughtBody.text()).toBe(longThought)
+      expect(thoughtBody.text()).toContain('结尾标记END')
+      expect(thoughtBody.text()).not.toContain('…(truncated)')
+      expect(thoughtBody.text()).not.toContain('...(truncated)')
+      wrapper.unmount()
+    })
+
     it('turn_done removes 输出中 status while keeping thought+message', async () => {
       const wrapper = mountChat({ draft: '请复审' })
       await clickSend(wrapper)

--- a/web/src/components/run/GateReactStreamPanel.vue
+++ b/web/src/components/run/GateReactStreamPanel.vue
@@ -165,7 +165,7 @@ function onThoughtToggle(e: Event) {
           :interrupted="!!interrupted && !streaming"
         />
       </summary>
-      <div class="whitespace-pre-wrap border-t border-dashed border-line px-2 pb-1.5 pt-1 font-mono leading-5">
+      <div class="whitespace-pre-wrap break-words border-t border-dashed border-line px-2 pb-1.5 pt-1 font-mono leading-5 [overflow-wrap:anywhere]">
         {{ revealedThought }}
       </div>
     </details>

--- a/web/src/components/run/ReviewComposer.test.ts
+++ b/web/src/components/run/ReviewComposer.test.ts
@@ -91,6 +91,25 @@ describe('ReviewComposer gate busy status (C-tier)', () => {
     wrapper.unmount()
   })
 
+  // plan coverage: g2.1 — GateReactStreamPanel renders full Thought, no secondary truncate
+  it('renders full long thought without truncated suffix (g2.1)', async () => {
+    const longThought = `${'思'.repeat(2000)}结尾标记END`
+    expect(new TextEncoder().encode(longThought).length).toBeGreaterThan(4000)
+    const wrapper = mountGate({
+      thinking: true,
+      streamThought: longThought,
+    })
+    await flushPromises()
+    const thoughtBody = wrapper.find('[data-testid="gate-react-thought"] .whitespace-pre-wrap')
+    expect(thoughtBody.exists()).toBe(true)
+    expect(thoughtBody.text()).toBe(longThought)
+    expect(thoughtBody.text()).toContain('结尾标记END')
+    expect(thoughtBody.text()).not.toContain('…(truncated)')
+    expect(thoughtBody.classes().join(' ')).toMatch(/overflow-wrap:anywhere/)
+    expect(thoughtBody.classes()).toContain('break-words')
+    wrapper.unmount()
+  })
+
   it('message switches status to 输出中, collapses thought, shows caret', async () => {
     const wrapper = mountGate({
       thinking: true,


### PR DESCRIPTION
AcpEvents no longer TruncateBytes thought at 4000 so ReAct live,
timeline, and hard-refresh seeds show the complete reasoning.

Co-authored-by: Cursor <cursoragent@cursor.com>
