### PR TITLE
fix(sandbox): destroy gateway instance when reconcile drops list rows

### DIFF
--- a/server/internal/sandbox/manager.go
+++ b/server/internal/sandbox/manager.go
@@ -549,12 +549,13 @@ func (m *Manager) Status(ctx context.Context, id string) string {
 // managedLabelFilter is the gateway ?label= filter for approving sandboxes.
 func managedLabelFilter() string { return managedByLabel + ":" + managedByValue }
 
+// CorrelationNameKey is the label that binds a gateway sandbox to the
+// pre-allocated local placeholder name (see NewContainerName / Spec.Name).
+func CorrelationNameKey() string { return cfNameLabel }
+
 // List returns the gateway ids of all approving-managed sandboxes.
 func (m *Manager) List(ctx context.Context) ([]string, error) {
-	if m.gw == nil {
-		return nil, nil
-	}
-	all, err := m.gw.List(ctx, managedLabelFilter())
+	all, err := m.ListManaged(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -565,12 +566,17 @@ func (m *Manager) List(ctx context.Context) ([]string, error) {
 	return ids, nil
 }
 
+// ListManaged returns approving-managed gateway sandboxes (id/status/labels).
+func (m *Manager) ListManaged(ctx context.Context) ([]GWSandbox, error) {
+	if m.gw == nil {
+		return nil, nil
+	}
+	return m.gw.List(ctx, managedLabelFilter())
+}
+
 // ListStatuses returns an id→status map for all approving-managed sandboxes.
 func (m *Manager) ListStatuses(ctx context.Context) (map[string]string, error) {
-	if m.gw == nil {
-		return map[string]string{}, nil
-	}
-	all, err := m.gw.List(ctx, managedLabelFilter())
+	all, err := m.ListManaged(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -579,6 +585,26 @@ func (m *Manager) ListStatuses(ctx context.Context) (map[string]string, error) {
 		out[all[i].ID] = normalizeGWStatus(all[i].Status)
 	}
 	return out, nil
+}
+
+// DestroyByCorrelationName destroys every managed gateway sandbox whose
+// approving.name label equals corr (best effort). Used when a local row still
+// carries the pre-adopt placeholder name so Status/DestroyByName cannot address
+// the real gateway id.
+func (m *Manager) DestroyByCorrelationName(ctx context.Context, corr string) {
+	corr = strings.TrimSpace(corr)
+	if m.gw == nil || corr == "" {
+		return
+	}
+	all, err := m.ListManaged(ctx)
+	if err != nil {
+		return
+	}
+	for i := range all {
+		if all[i].Labels[cfNameLabel] == corr {
+			_ = m.DestroyByName(ctx, all[i].ID)
+		}
+	}
 }
 
 // ExecPTY opens an interactive PTY shell on the sandbox over SSH. Caller must

--- a/server/internal/sandbox/sandboxtest/fakegw.go
+++ b/server/internal/sandbox/sandboxtest/fakegw.go
@@ -104,6 +104,27 @@ func (fg *FakeGateway) SetStatus(id, status string) {
 	r.status = status
 }
 
+// SetLabel sets a single label on an existing seeded sandbox (no-op if missing).
+func (fg *FakeGateway) SetLabel(id, key, value string) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+	rec := fg.recs[id]
+	if rec == nil {
+		return
+	}
+	if rec.labels == nil {
+		rec.labels = map[string]string{}
+	}
+	rec.labels[key] = value
+}
+
+// Has reports whether the fake still knows about id (not yet Destroyed).
+func (fg *FakeGateway) Has(id string) bool {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+	return fg.recs[id] != nil
+}
+
 // Seed registers a running sandbox by id (convenience for SetStatus(id,"running")).
 func (fg *FakeGateway) Seed(id string) { fg.SetStatus(id, "running") }
 

--- a/server/internal/services/sandbox_service_test.go
+++ b/server/internal/services/sandbox_service_test.go
@@ -444,6 +444,7 @@ func TestSandboxReconcileOnStartup(t *testing.T) {
 
 	// run-purpose row -> destroyed on startup.
 	db.Create(&models.Sandbox{Name: "approving-sb-run", Purpose: "run", Status: "running", RunID: "rid"})
+	ds.setStatus("approving-sb-run", "running")
 	// test running -> attached and kept.
 	db.Create(&models.Sandbox{Name: "approving-sb-live", Purpose: "test", Status: "running"})
 	ds.setStatus("approving-sb-live", "running")
@@ -466,6 +467,101 @@ func TestSandboxReconcileOnStartup(t *testing.T) {
 	}
 	if err := db.Where("name = ?", "approving-sb-dead").First(&models.Sandbox{}).Error; err != gorm.ErrRecordNotFound {
 		t.Fatal("dead row should be gone")
+	}
+	// g1.1/g1.2: recycled names are Destroy'd; g1.3: unmanaged orphans Destroy'd.
+	if ds.fg.Has("approving-sb-run") {
+		t.Fatal("run gateway sandbox should be destroyed (g1.1)")
+	}
+	if ds.fg.Has("approving-sb-orphan") {
+		t.Fatal("orphan gateway sandbox should be destroyed (g1.3)")
+	}
+	if !ds.fg.Has("approving-sb-live") {
+		t.Fatal("live gateway sandbox must remain")
+	}
+}
+
+// TestSandboxReconcileDestroysNonRunningGateway covers g1.1+g1.2: a non-running
+// local row whose Name is the gateway id must Destroy the gateway instance
+// before the list row is deleted, and must not leave the id in tracked so the
+// orphan pass cannot skip it.
+func TestSandboxReconcileDestroysNonRunningGateway(t *testing.T) {
+	db := newTestDB(t)
+	ds := &dockerState{}
+	s := newSandboxService(t, db, ds)
+	ctx := context.Background()
+
+	// error / stopped rows still have a control-plane record protecting resources.
+	db.Create(&models.Sandbox{Name: "gw-error", Purpose: "test", Status: "error"})
+	ds.setStatus("gw-error", "error")
+	db.Create(&models.Sandbox{Name: "gw-stopped", Purpose: "agent", Status: "stopped"})
+	ds.setStatus("gw-stopped", "stopped")
+	db.Create(&models.Sandbox{Name: "gw-pm-dead", Purpose: "pm", Status: "error"})
+	ds.setStatus("gw-pm-dead", "error")
+
+	s.ReconcileOnStartup(ctx)
+
+	for _, name := range []string{"gw-error", "gw-stopped", "gw-pm-dead"} {
+		if err := db.Where("name = ?", name).First(&models.Sandbox{}).Error; err != gorm.ErrRecordNotFound {
+			t.Fatalf("%s local row should be gone", name)
+		}
+		if ds.fg.Has(name) {
+			t.Fatalf("%s gateway sandbox should be destroyed (g1.1/g1.2)", name)
+		}
+	}
+}
+
+// TestSandboxReconcileCreatingGrace covers g1.3 brief-window protection: a
+// young creating row with placeholder Name keeps its correlated gateway
+// sandbox (approving.name label) from orphan Destroy.
+func TestSandboxReconcileCreatingGrace(t *testing.T) {
+	db := newTestDB(t)
+	ds := &dockerState{}
+	s := newSandboxService(t, db, ds)
+	ctx := context.Background()
+
+	placeholder := "approving-sb-ph-young"
+	gwID := "gw-inflight-001"
+	db.Create(&models.Sandbox{
+		Name: placeholder, Purpose: "test", Status: "creating",
+		CreatedAt: time.Now(),
+	})
+	ds.setStatus(gwID, "pending")
+	ds.fg.SetLabel(gwID, sandbox.CorrelationNameKey(), placeholder)
+
+	s.ReconcileOnStartup(ctx)
+
+	if err := db.Where("name = ?", placeholder).First(&models.Sandbox{}).Error; err != nil {
+		t.Fatal("young creating row should be kept")
+	}
+	if !ds.fg.Has(gwID) {
+		t.Fatal("correlated in-flight gateway sandbox must not be destroyed")
+	}
+}
+
+// TestSandboxReconcileAbandonedCreating destroys stale creating rows and the
+// gateway sandbox still labeled with the placeholder Name.
+func TestSandboxReconcileAbandonedCreating(t *testing.T) {
+	db := newTestDB(t)
+	ds := &dockerState{}
+	s := newSandboxService(t, db, ds)
+	ctx := context.Background()
+
+	placeholder := "approving-sb-ph-old"
+	gwID := "gw-abandoned-001"
+	db.Create(&models.Sandbox{
+		Name: placeholder, Purpose: "test", Status: "creating",
+		CreatedAt: time.Now().Add(-time.Hour),
+	})
+	ds.setStatus(gwID, "running")
+	ds.fg.SetLabel(gwID, sandbox.CorrelationNameKey(), placeholder)
+
+	s.ReconcileOnStartup(ctx)
+
+	if err := db.Where("name = ?", placeholder).First(&models.Sandbox{}).Error; err != gorm.ErrRecordNotFound {
+		t.Fatal("abandoned creating row should be gone")
+	}
+	if ds.fg.Has(gwID) {
+		t.Fatal("correlated abandoned gateway sandbox should be destroyed")
 	}
 }
 

--- a/server/internal/services/sandbox_test_pool.go
+++ b/server/internal/services/sandbox_test_pool.go
@@ -544,34 +544,47 @@ func (s *SandboxService) sweepOnce(ctx context.Context) {
 	}
 }
 
-// ReconcileOnStartup syncs DB rows with live Docker state after a restart and
-// drops orphan containers not tracked in the DB.
+// reconcileCreatingGrace keeps young "creating" rows (and their correlated
+// gateway sandboxes) through startup reconcile so an in-flight Create that
+// has not yet adopted the gateway id into Name is not destroyed. Aligns with
+// sandbox-gateway orphanGC.minAge (10m default).
+const reconcileCreatingGrace = 10 * time.Minute
+
+// ReconcileOnStartup syncs DB rows with live gateway state after a restart and
+// drops orphan managed sandboxes not tracked in the DB. Dropping a local row
+// always Destroy()s the gateway instance first so sandbox_gateway.sandboxes
+// (and the workload it protects) cannot outlive the platform list.
 func (s *SandboxService) ReconcileOnStartup(ctx context.Context) {
 	var rows []models.Sandbox
 	if err := s.db.Find(&rows).Error; err != nil {
 		return
 	}
+	// tracked = gateway ids / names that must survive the orphan pass.
+	// Only rows we keep are recorded — recycled names must not block Destroy.
 	tracked := map[string]bool{}
+	// protectedCorr = placeholder Names of in-grace creating rows; orphan pass
+	// skips gateway sandboxes labeled approving.name=<placeholder>.
+	protectedCorr := map[string]bool{}
 	for i := range rows {
 		row := &rows[i]
-		tracked[row.Name] = true
 		// Per-run node sandboxes are owned by the runtime provider; after a
 		// restart their driving goroutine is gone, so any surviving container
 		// is an orphan. Destroy it and drop the record.
 		if row.Purpose == "run" {
-			s.archiveLog(ctx, row.Name)
-			_ = s.mgr.DestroyByName(ctx, row.Name)
-			if row.HomeDir != "" {
-				_ = os.RemoveAll(row.HomeDir)
-			}
-			if row.RunID != "" {
-				s.host.UnregisterRun(row.RunID)
-			}
-			s.db.Delete(&models.Sandbox{}, row.ID)
+			s.destroyLocalSandbox(ctx, row)
+			continue
+		}
+		// Young creating rows still use a placeholder Name; the gateway id is
+		// adopted only after Create succeeds. Keep them and protect the
+		// correlated gateway sandbox from the orphan sweep.
+		if row.Status == "creating" && time.Since(row.CreatedAt) < reconcileCreatingGrace {
+			tracked[row.Name] = true
+			protectedCorr[row.Name] = true
 			continue
 		}
 		switch s.mgr.Status(ctx, row.Name) {
 		case "running":
+			tracked[row.Name] = true
 			if sb, err := s.mgr.Attach(ctx, row.Name); err == nil {
 				upd := map[string]any{"status": "running", "host": sb.Host, "acp_port": sb.Port, "code_server_port": sb.CodeServerPort}
 				if row.DestroyAt == nil {
@@ -581,22 +594,45 @@ func (s *SandboxService) ReconcileOnStartup(ctx context.Context) {
 				s.db.Model(&models.Sandbox{}).Where("id = ?", row.ID).Updates(upd)
 			}
 		default:
-			// Container gone: drop the record and free its run token.
-			if row.RunID != "" {
-				s.host.UnregisterRun(row.RunID)
-			}
-			s.db.Delete(&models.Sandbox{}, row.ID)
+			// Non-running (creating past grace / error / stopped / not_found):
+			// Destroy gateway first, then drop the list row (g1.1).
+			s.destroyLocalSandbox(ctx, row)
 		}
 	}
-	// Destroy orphan containers (present in docker, absent from DB).
-	if names, err := s.mgr.List(ctx); err == nil {
-		for _, n := range names {
-			if !tracked[n] {
-				_ = s.mgr.DestroyByName(ctx, n)
-				log.Info().Str("name", n).Msg("destroyed orphan sandbox container")
-			}
-		}
+	// Recycle managed gateway sandboxes with no surviving local Name (g1.3).
+	managed, err := s.mgr.ListManaged(ctx)
+	if err != nil {
+		return
 	}
+	corrKey := sandbox.CorrelationNameKey()
+	for i := range managed {
+		sb := &managed[i]
+		if tracked[sb.ID] {
+			continue
+		}
+		if corr := sb.Labels[corrKey]; corr != "" && protectedCorr[corr] {
+			continue
+		}
+		_ = s.mgr.DestroyByName(ctx, sb.ID)
+		log.Info().Str("name", sb.ID).Msg("destroyed orphan sandbox container")
+	}
+}
+
+// destroyLocalSandbox tears down the gateway instance (by Name and by
+// approving.name correlation) then deletes the local list row.
+func (s *SandboxService) destroyLocalSandbox(ctx context.Context, row *models.Sandbox) {
+	s.archiveLog(ctx, row.Name)
+	_ = s.mgr.DestroyByName(ctx, row.Name)
+	// Placeholder Name cannot address the real gateway id; also destroy by
+	// correlation label so leaked control-plane rows are not left behind.
+	s.mgr.DestroyByCorrelationName(ctx, row.Name)
+	if row.HomeDir != "" {
+		_ = os.RemoveAll(row.HomeDir)
+	}
+	if row.RunID != "" {
+		s.host.UnregisterRun(row.RunID)
+	}
+	s.db.Delete(&models.Sandbox{}, row.ID)
 }
 
 func (s *SandboxService) isBusyRow(row *models.Sandbox) bool {


### PR DESCRIPTION
ReconcileOnStartup previously deleted non-running local rows without
calling Destroy, and put recycled names into tracked so orphan sweep
skipped them — leaving sandbox_gateway.sandboxes (and workloads) behind.
Destroy before delete, track only kept names, recycle unmanaged sandboxes,
and protect in-flight creating rows via approving.name correlation.

Co-authored-by: Cursor <cursoragent@cursor.com>
