### PR TITLE
fix(web): open home pipeline select panel below the trigger

### DIFF
--- a/web/src/components/dashboard/HomePipelineSelect.test.ts
+++ b/web/src/components/dashboard/HomePipelineSelect.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { createI18n } from 'vue-i18n'
 import { flushPromises, mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import common from '@/locales/zh-CN/common.json'
 import pages from '@/locales/zh-CN/pages.json'
 import HomePipelineSelect from './HomePipelineSelect.vue'
@@ -10,7 +10,7 @@ function mountSelect(props: {
   pipelines?: { id: string; name: string }[]
   modelValue?: string
   disabled?: boolean
-}) {
+} = {}) {
   const i18n = createI18n({
     legacy: false,
     locale: 'zh-CN',
@@ -25,34 +25,108 @@ function mountSelect(props: {
       modelValue: props.modelValue ?? 'wf-a',
       disabled: props.disabled ?? false,
     },
-    global: { plugins: [i18n] },
+    attachTo: document.body,
+    global: {
+      plugins: [i18n],
+      stubs: { Teleport: false },
+    },
   })
 }
 
 describe('HomePipelineSelect', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  // plan g2.2 — theme token class names
   it('uses theme token classes for panel surface and option states', async () => {
     const wrapper = mountSelect({})
     await flushPromises()
     await wrapper.get('[data-testid="home-pipeline-select-trigger"]').trigger('click')
     await flushPromises()
-    const panel = wrapper.get('[data-testid="home-pipeline-select-panel"]')
-    expect(panel.classes()).toContain('home-pipeline-select__panel')
-    const opt = wrapper.get('[data-testid="home-pipeline-select-option-wf-a"]')
-    expect(opt.classes()).toContain('home-pipeline-select__opt--current')
+    const panel = document.querySelector('[data-testid="home-pipeline-select-panel"]')
+    expect(panel).toBeTruthy()
+    expect(panel!.classList.contains('home-pipeline-select__panel')).toBe(true)
+    const opt = document.querySelector('[data-testid="home-pipeline-select-option-wf-a"]')
+    expect(opt).toBeTruthy()
+    expect(opt!.classList.contains('home-pipeline-select__opt--current')).toBe(true)
     wrapper.unmount()
   })
 
-  it('positions panel above trigger via upward panel class', async () => {
+  // plan g2.1 — downward placement (top below trigger), not bottom/upward
+  it('positions panel below trigger via top placement (not bottom/upward)', async () => {
     const wrapper = mountSelect({})
+    const triggerEl = wrapper.get('[data-testid="home-pipeline-select-trigger"]').element as HTMLElement
+    vi.spyOn(triggerEl, 'getBoundingClientRect').mockReturnValue({
+      top: 200,
+      bottom: 232,
+      left: 40,
+      right: 200,
+      width: 160,
+      height: 32,
+      x: 40,
+      y: 200,
+      toJSON() {
+        return {}
+      },
+    })
     await flushPromises()
     await wrapper.get('[data-testid="home-pipeline-select-trigger"]').trigger('click')
     await flushPromises()
-    const panel = wrapper.get('[data-testid="home-pipeline-select-panel"]')
-    expect(panel.classes()).toContain('home-pipeline-select__panel')
+    const panel = document.querySelector(
+      '[data-testid="home-pipeline-select-panel"]',
+    ) as HTMLElement | null
+    expect(panel).toBeTruthy()
+    expect(panel!.getAttribute('data-placement')).toBe('below')
+    expect(panel!.style.position).toBe('fixed')
+    // trigger bottom 232 + 6px gap → top 238 (downward); must not use bottom anchoring
+    expect(panel!.style.top).toBe('238px')
+    expect(panel!.style.bottom).toBe('')
+    // Teleported to body (escapes overflow clip)
+    expect(panel!.parentElement).toBe(document.body)
     wrapper.unmount()
   })
 
-  // plan g3.3 — search only looks at the already-filtered Home list
+  // plan g1.2 — panel remains visible when ancestors use overflow-y-auto
+  it('teleports panel to body so overflow clipping containers do not hide it', async () => {
+    const clip = document.createElement('div')
+    clip.className = 'home-shell__content'
+    clip.style.overflowY = 'auto'
+    clip.style.height = '120px'
+    document.body.appendChild(clip)
+
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const wrapper = mount(HomePipelineSelect, {
+      props: {
+        pipelines: [
+          { id: 'wf-a', name: '自我迭代PRO' },
+          { id: 'wf-b', name: 'AnimeFind迭代' },
+        ],
+        modelValue: 'wf-a',
+      },
+      attachTo: clip,
+      global: {
+        plugins: [i18n],
+        stubs: { Teleport: false },
+      },
+    })
+    await flushPromises()
+    await wrapper.get('[data-testid="home-pipeline-select-trigger"]').trigger('click')
+    await flushPromises()
+    const panel = document.querySelector('[data-testid="home-pipeline-select-panel"]')
+    expect(panel).toBeTruthy()
+    expect(clip.contains(panel)).toBe(false)
+    expect(document.body.contains(panel)).toBe(true)
+    expect(panel!.querySelector('[data-testid="home-pipeline-select-search"]')).toBeTruthy()
+    wrapper.unmount()
+    clip.remove()
+  })
+
+  // plan g2.2 — search only looks at the already-filtered Home list
   it('does not surface a pipeline omitted from props even when the query matches its name', async () => {
     const wrapper = mountSelect({
       pipelines: [{ id: 'wf-a', name: '自我迭代PRO' }],
@@ -61,10 +135,15 @@ describe('HomePipelineSelect', () => {
     await flushPromises()
     await wrapper.get('[data-testid="home-pipeline-select-trigger"]').trigger('click')
     await flushPromises()
-    await wrapper.get('[data-testid="home-pipeline-select-search"]').setValue('内部副本')
+    const search = document.querySelector(
+      '[data-testid="home-pipeline-select-search"]',
+    ) as HTMLInputElement
+    expect(search).toBeTruthy()
+    search.value = '内部副本'
+    search.dispatchEvent(new Event('input'))
     await flushPromises()
-    expect(wrapper.find('[data-testid="home-pipeline-select-option-wf-hidden"]').exists()).toBe(false)
-    expect(wrapper.find('[data-testid="home-pipeline-select-empty"]').exists()).toBe(true)
+    expect(document.querySelector('[data-testid="home-pipeline-select-option-wf-hidden"]')).toBeNull()
+    expect(document.querySelector('[data-testid="home-pipeline-select-empty"]')).toBeTruthy()
     wrapper.unmount()
   })
 })

--- a/web/src/components/dashboard/HomePipelineSelect.vue
+++ b/web/src/components/dashboard/HomePipelineSelect.vue
@@ -24,7 +24,10 @@ const search = ref('')
 const activeIndex = ref(0)
 const root = ref<HTMLElement | null>(null)
 const trigger = ref<HTMLButtonElement | null>(null)
+const panel = ref<HTMLElement | null>(null)
 const searchInput = ref<HTMLInputElement | null>(null)
+/** Fixed position below trigger (Teleport escapes .home-shell__content overflow). */
+const panelStyle = ref<Record<string, string>>({})
 
 const selectedName = computed(() => {
   if (!props.pipelines.length) return t('pages.dashboard.noPipelineShort')
@@ -64,24 +67,49 @@ function highlightName(name: string, q: string): string {
   )
 }
 
-function openPanel() {
+/** Place panel directly below the trigger (gap 6px). No upward flip. */
+function placePanelBelow() {
+  const trig = trigger.value
+  if (!trig) return
+  const r = trig.getBoundingClientRect()
+  const width = Math.min(320, Math.min(window.innerWidth * 0.78, window.innerWidth - 16))
+  let left = r.left
+  left = Math.max(8, Math.min(left, window.innerWidth - width - 8))
+  // plan g1.1 / g1.2 — top = trigger bottom + 6px (not bottom: calc(100% + 6px))
+  const top = r.bottom + 6
+  panelStyle.value = {
+    position: 'fixed',
+    top: `${Math.round(top)}px`,
+    left: `${Math.round(left)}px`,
+    width: `${Math.round(width)}px`,
+  }
+}
+
+function onScrollOrResize() {
+  if (open.value) placePanelBelow()
+}
+
+async function openPanel() {
   if (props.disabled || !props.pipelines.length) return
   open.value = true
   search.value = ''
   const idx = props.pipelines.findIndex((p) => p.id === props.modelValue)
   activeIndex.value = Math.max(0, idx)
-  nextTick(() => searchInput.value?.focus())
+  await nextTick()
+  placePanelBelow()
+  searchInput.value?.focus()
 }
 
 function closePanel() {
   open.value = false
+  panelStyle.value = {}
 }
 
 function togglePanel(e: MouseEvent) {
   e.stopPropagation()
   if (props.disabled || !props.pipelines.length) return
   if (open.value) closePanel()
-  else openPanel()
+  else void openPanel()
 }
 
 function choose(id: string) {
@@ -93,7 +121,7 @@ function choose(id: string) {
 function onDocClick(e: MouseEvent) {
   if (!open.value) return
   const target = e.target as Node
-  if (root.value?.contains(target)) return
+  if (root.value?.contains(target) || panel.value?.contains(target)) return
   closePanel()
 }
 
@@ -132,7 +160,7 @@ function onTriggerKeydown(e: KeyboardEvent) {
   if (props.disabled || !props.pipelines.length) return
   if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
     e.preventDefault()
-    if (!open.value) openPanel()
+    if (!open.value) void openPanel()
   }
   if (e.key === 'Escape' && open.value) {
     e.preventDefault()
@@ -147,8 +175,16 @@ watch(
   },
 )
 
-onMounted(() => document.addEventListener('click', onDocClick))
-onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
+onMounted(() => {
+  document.addEventListener('click', onDocClick)
+  window.addEventListener('resize', onScrollOrResize)
+  window.addEventListener('scroll', onScrollOrResize, true)
+})
+onBeforeUnmount(() => {
+  document.removeEventListener('click', onDocClick)
+  window.removeEventListener('resize', onScrollOrResize)
+  window.removeEventListener('scroll', onScrollOrResize, true)
+})
 </script>
 
 <template>
@@ -175,60 +211,67 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
       <span class="home-pipeline-select__chev" aria-hidden="true" />
     </button>
 
-    <div
-      v-if="open"
-      id="home-pipeline-select-panel"
-      class="home-pipeline-select__panel"
-      role="presentation"
-      data-testid="home-pipeline-select-panel"
-    >
-      <div class="home-pipeline-select__search-wrap">
-        <input
-          ref="searchInput"
-          v-model="search"
-          type="search"
-          class="home-pipeline-select__search"
-          data-testid="home-pipeline-select-search"
-          :placeholder="t('common.search.pipelinePlaceholder')"
-          autocomplete="off"
-          :aria-label="t('common.search.pipelinePlaceholder')"
-          @input="onSearchInput"
-          @keydown="onSearchKeydown"
-          @click.stop
-        />
-      </div>
+    <!-- Teleport to body so .home-shell__content overflow-y-auto cannot clip the downward panel (g1.2) -->
+    <Teleport to="body">
       <div
-        class="home-pipeline-select__list"
-        role="listbox"
-        :aria-label="t('pages.dashboard.pickPipeline')"
+        v-if="open"
+        ref="panel"
+        id="home-pipeline-select-panel"
+        class="home-pipeline-select__panel"
+        role="presentation"
+        data-testid="home-pipeline-select-panel"
+        data-placement="below"
+        :style="panelStyle"
+        @click.stop
       >
-        <template v-if="filtered.length">
-          <button
-            v-for="(p, i) in filtered"
-            :key="p.id"
-            type="button"
-            class="home-pipeline-select__opt"
-            role="option"
-            :class="{
-              'home-pipeline-select__opt--current': p.id === modelValue,
-              'home-pipeline-select__opt--active': i === activeIndex,
-            }"
-            :aria-selected="i === activeIndex"
-            :data-testid="`home-pipeline-select-option-${p.id}`"
-            @click.stop="choose(p.id)"
-          >
-            <span v-html="highlightName(p.name, search.trim())" />
-          </button>
-        </template>
+        <div class="home-pipeline-select__search-wrap">
+          <input
+            ref="searchInput"
+            v-model="search"
+            type="search"
+            class="home-pipeline-select__search"
+            data-testid="home-pipeline-select-search"
+            :placeholder="t('common.search.pipelinePlaceholder')"
+            autocomplete="off"
+            :aria-label="t('common.search.pipelinePlaceholder')"
+            @input="onSearchInput"
+            @keydown="onSearchKeydown"
+            @click.stop
+          />
+        </div>
         <div
-          v-else
-          class="home-pipeline-select__empty"
-          data-testid="home-pipeline-select-empty"
+          class="home-pipeline-select__list"
+          role="listbox"
+          :aria-label="t('pages.dashboard.pickPipeline')"
         >
-          {{ t('common.empty.noMatchingPipelines') }}
+          <template v-if="filtered.length">
+            <button
+              v-for="(p, i) in filtered"
+              :key="p.id"
+              type="button"
+              class="home-pipeline-select__opt"
+              role="option"
+              :class="{
+                'home-pipeline-select__opt--current': p.id === modelValue,
+                'home-pipeline-select__opt--active': i === activeIndex,
+              }"
+              :aria-selected="i === activeIndex"
+              :data-testid="`home-pipeline-select-option-${p.id}`"
+              @click.stop="choose(p.id)"
+            >
+              <span v-html="highlightName(p.name, search.trim())" />
+            </button>
+          </template>
+          <div
+            v-else
+            class="home-pipeline-select__empty"
+            data-testid="home-pipeline-select-empty"
+          >
+            {{ t('common.empty.noMatchingPipelines') }}
+          </div>
         </div>
       </div>
-    </div>
+    </Teleport>
   </div>
 </template>
 
@@ -282,15 +325,18 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
   flex-shrink: 0;
 }
 
+/* plan g1.1 — panel opens below trigger (top), never bottom/upward.
+   Teleported panel uses fixed coords from placePanelBelow(); keep top as
+   the documented downward default if styles apply without inline overrides. */
 .home-pipeline-select__panel {
-  position: absolute;
+  position: fixed;
   left: 0;
-  bottom: calc(100% + 6px);
+  top: calc(100% + 6px);
   width: min(320px, 78vw);
   border: 1px solid rgb(var(--c-line-strong));
   background: rgb(var(--c-elevated));
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
-  z-index: 20;
+  z-index: 60;
 }
 
 .home-pipeline-select__search-wrap {

--- a/web/src/views/DashboardView.test.ts
+++ b/web/src/views/DashboardView.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { createI18n } from 'vue-i18n'
-import { flushPromises, mount } from '@vue/test-utils'
+import { DOMWrapper, flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import common from '@/locales/zh-CN/common.json'
 import pages from '@/locales/zh-CN/pages.json'
@@ -81,11 +81,30 @@ function mountDashboard() {
     messages: { 'zh-CN': { ...common, ...pages } },
   })
   return mount(DashboardView, {
+    attachTo: document.body,
     global: {
       plugins: [i18n],
-      stubs: { Icon: true, RunLaunchModal: true, AppModal: HomePreviewAppModalStub },
+      stubs: {
+        Icon: true,
+        RunLaunchModal: true,
+        AppModal: HomePreviewAppModalStub,
+        Teleport: false,
+      },
     },
   })
+}
+
+/** HomePipelineSelect teleports its panel to document.body. */
+function teleported(testid: string) {
+  const el = document.querySelector(`[data-testid="${testid}"]`)
+  if (!el) {
+    throw new Error(`Unable to get [data-testid="${testid}"] (teleported to body)`)
+  }
+  return new DOMWrapper(el)
+}
+
+function teleportedExists(testid: string) {
+  return document.querySelector(`[data-testid="${testid}"]`) != null
 }
 
 function stubReducedMotion(matches: boolean) {
@@ -130,6 +149,7 @@ describe('DashboardView home composer', () => {
     localStorage.removeItem(HOME_COMPOSER_DRAFT_KEY)
     vi.useRealTimers()
     vi.unstubAllGlobals()
+    document.body.innerHTML = ''
   })
 
   it('renders composer and approve-first cards without a project gate', async () => {
@@ -294,7 +314,7 @@ describe('DashboardView home composer', () => {
     )
     await trigger.trigger('click')
     await flushPromises()
-    await wrapper.get('[data-testid="home-pipeline-select-option-wf-ap"]').trigger('click')
+    await teleported('home-pipeline-select-option-wf-ap').trigger('click')
     await flushPromises()
     expect(trigger.text()).toContain('自我迭代PRO')
     expect(wrapper.get('[data-testid="home-pipeline-card-wf-ap"]').classes()).toContain(
@@ -315,18 +335,18 @@ describe('DashboardView home composer', () => {
     await flushPromises()
     await wrapper.get('[data-testid="home-pipeline-select-trigger"]').trigger('click')
     await flushPromises()
-    const search = wrapper.get('[data-testid="home-pipeline-select-search"]')
+    const search = teleported('home-pipeline-select-search')
     await search.setValue('Lite')
     await flushPromises()
-    expect(wrapper.find('[data-testid="home-pipeline-select-option-wf-lite"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="home-pipeline-select-option-wf-ap"]').exists()).toBe(false)
+    expect(teleportedExists('home-pipeline-select-option-wf-lite')).toBe(true)
+    expect(teleportedExists('home-pipeline-select-option-wf-ap')).toBe(false)
     await search.setValue('nomatch-xyz')
     await flushPromises()
-    expect(wrapper.find('[data-testid="home-pipeline-select-empty"]').exists()).toBe(true)
-    expect(wrapper.get('[data-testid="home-pipeline-select-empty"]').text()).toContain('无匹配流水线')
+    expect(teleportedExists('home-pipeline-select-empty')).toBe(true)
+    expect(teleported('home-pipeline-select-empty').text()).toContain('无匹配流水线')
     await search.setValue('')
     await flushPromises()
-    expect(wrapper.find('[data-testid="home-pipeline-select-option-wf-ap"]').exists()).toBe(true)
+    expect(teleportedExists('home-pipeline-select-option-wf-ap')).toBe(true)
     wrapper.unmount()
   })
 
@@ -342,7 +362,7 @@ describe('DashboardView home composer', () => {
     await flushPromises()
     await wrapper.get('[data-testid="home-pipeline-select-trigger"]').trigger('click')
     await flushPromises()
-    const search = wrapper.get('[data-testid="home-pipeline-select-search"]')
+    const search = teleported('home-pipeline-select-search')
     await search.setValue('Lite')
     await flushPromises()
     await search.trigger('keydown', { key: 'Enter' })


### PR DESCRIPTION
The composer combobox used bottom anchoring which covered the Approving
brand; place the teleported panel under the trigger and lock it with tests.

Co-authored-by: Cursor <cursoragent@cursor.com>
