### PR TITLE
fix(react): keep pending-queue annotations on re-edit

### DIFF
--- a/server/internal/engine/review_session.go
+++ b/server/internal/engine/review_session.go
@@ -156,10 +156,20 @@ func (e *Engine) ReviewSessionSnapshotFor(runID, producerID string) (ReviewSessi
 		Items:   s.queueSnapshotLocked(),
 	}
 	if s.active != nil {
+		images := s.active.Images
+		if images == nil {
+			images = []models.PromptImage{}
+		}
+		annotations := s.active.Annotations
+		if annotations == nil {
+			annotations = []models.ReactAnnotation{}
+		}
+		// Align with ReviewSessionsForRun / turn_begin: include images + annotations.
 		snap.ActiveItem = map[string]any{
 			"id":          s.active.ID,
 			"text":        s.active.Text,
-			"annotations": s.active.Annotations,
+			"images":      images,
+			"annotations": annotations,
 		}
 	}
 	return snap, true

--- a/server/internal/engine/review_session.go
+++ b/server/internal/engine/review_session.go
@@ -344,9 +344,21 @@ func (s *reviewSession) queueSnapshot() []map[string]any {
 func (s *reviewSession) queueSnapshotLocked() []map[string]any {
 	out := make([]map[string]any, 0, len(s.queue))
 	for _, it := range s.queue {
+		images := it.Images
+		if images == nil {
+			images = []models.PromptImage{}
+		}
+		annotations := it.Annotations
+		if annotations == nil {
+			annotations = []models.ReactAnnotation{}
+		}
+		// Waiting items must carry images + annotations (same fields as turn_begin)
+		// so refresh / queue_state reconcile does not drop annotation chips.
 		out = append(out, map[string]any{
-			"id":   it.ID,
-			"text": it.Text,
+			"id":          it.ID,
+			"text":        it.Text,
+			"images":      images,
+			"annotations": annotations,
 		})
 	}
 	return out

--- a/server/internal/engine/review_session_test.go
+++ b/server/internal/engine/review_session_test.go
@@ -192,3 +192,69 @@ func TestReviewQueueRemoveAndReorder(t *testing.T) {
 	_ = eng.CancelReviewSession(run.ID, "prop")
 	_ = eng.waitReviewReadyForTest(run.ID, "prop", 5*time.Second)
 }
+
+// TestQueueSnapshotIncludesAnnotationsAndImages: waiting queue_state items must
+// carry annotations + images (plan g1.1) so clients can refill chips after edit.
+func TestQueueSnapshotIncludesAnnotationsAndImages(t *testing.T) {
+	eng, db, provider := setupReviewEngine(t, true)
+	hold := make(chan struct{})
+	provider.reviseHold = hold
+
+	run, err := eng.StartRun("review-wf", map[string]any{"idea": "登录"}, "test")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitReactPause(t, db, run.ID, "prop")
+	waitRunStatus(t, db, run.ID, "waiting_human")
+
+	// Occupy active slot so the next enqueue stays waiting.
+	if _, err := eng.EnqueueReviewTurn(run.ID, "prop", "active-hold", nil, nil, "node", ""); err != nil {
+		t.Fatalf("enqueue active: %v", err)
+	}
+	anns := []models.ReactAnnotation{
+		{JSONPath: "summary", Label: "摘要", Selector: "#hero", Quote: "摘录"},
+	}
+	// Images need blob store in this harness; assert empty images key + annotations.
+	if _, err := eng.EnqueueReviewTurn(run.ID, "prop", "带标注排队", nil, anns, "node", ""); err != nil {
+		t.Fatalf("enqueue annotated: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		snap, ok := eng.ReviewSessionSnapshotFor(run.ID, "prop")
+		if ok && snap.Waiting >= 1 && len(snap.Items) >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	snap, ok := eng.ReviewSessionSnapshotFor(run.ID, "prop")
+	if !ok || len(snap.Items) < 1 {
+		t.Fatalf("expected waiting items, snap=%+v", snap)
+	}
+	var found map[string]any
+	for _, it := range snap.Items {
+		if text, _ := it["text"].(string); text == "带标注排队" {
+			found = it
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("annotated waiting item missing: %+v", snap.Items)
+	}
+	gotAnns, ok := found["annotations"].([]models.ReactAnnotation)
+	if !ok || len(gotAnns) != 1 || gotAnns[0].JSONPath != "summary" || gotAnns[0].Selector != "#hero" {
+		t.Fatalf("annotations not in snapshot: %+v (type %T)", found["annotations"], found["annotations"])
+	}
+	gotImgs, ok := found["images"].([]models.PromptImage)
+	if !ok || gotImgs == nil {
+		t.Fatalf("images key missing or wrong type: %+v (type %T)", found["images"], found["images"])
+	}
+	if len(gotImgs) != 0 {
+		t.Fatalf("expected empty images slice, got %+v", gotImgs)
+	}
+
+	close(hold)
+	_ = eng.CancelReviewSession(run.ID, "prop")
+	_ = eng.waitReviewReadyForTest(run.ID, "prop", 5*time.Second)
+}

--- a/server/internal/gateshare/public_events_test.go
+++ b/server/internal/gateshare/public_events_test.go
@@ -82,3 +82,49 @@ func TestFilterPublicBrokerFrameReviewTurnBegin(t *testing.T) {
 		t.Fatalf("payload: %s", s)
 	}
 }
+
+func TestFilterPublicBrokerFrameQueueStateKeepsAnnotations(t *testing.T) {
+	raw, _ := json.Marshal(map[string]any{
+		"type":    "review",
+		"runId":   "run-secret",
+		"nodeId":  "research1",
+		"event":   "queue_state",
+		"waiting": 1,
+		"busy":    false,
+		"items": []any{
+			map[string]any{
+				"id":   "q-wait",
+				"text": "公共排队带标注",
+				"annotations": []any{
+					map[string]any{"selector": "#pub-hero", "label": "公共点", "jsonPath": "goals[0]"},
+				},
+				"images": []any{map[string]any{"data": "BBBB", "mimeType": "image/png"}},
+			},
+		},
+	})
+	out, ok := FilterPublicBrokerFrame(raw, "research1")
+	if !ok {
+		t.Fatal("expected queue_state frame")
+	}
+	s := string(out)
+	if strings.Contains(s, "run-secret") || strings.Contains(s, "BBBB") || strings.Contains(s, "images") {
+		t.Fatalf("leaked: %s", s)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	items, _ := parsed["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("items=%+v", parsed["items"])
+	}
+	row, _ := items[0].(map[string]any)
+	anns, _ := row["annotations"].([]any)
+	if len(anns) != 1 {
+		t.Fatalf("annotations missing: %+v", row)
+	}
+	ann, _ := anns[0].(map[string]any)
+	if ann["selector"] != "#pub-hero" || ann["label"] != "公共点" {
+		t.Fatalf("ann fields: %+v", ann)
+	}
+}

--- a/server/internal/gateshare/sanitize.go
+++ b/server/internal/gateshare/sanitize.go
@@ -39,9 +39,12 @@ type PreviewAnnotation struct {
 }
 
 // PreviewQueueItem is a leak-free pending-send row for polling resume.
+// Annotations are kept (sanitized) so public refresh / WS reconcile can show
+// the 批注 badge and refill chips on re-edit; images stay dropped (same as ActiveItem).
 type PreviewQueueItem struct {
-	ID   string `json:"id,omitempty"`
-	Text string `json:"text,omitempty"`
+	ID          string              `json:"id,omitempty"`
+	Text        string              `json:"text,omitempty"`
+	Annotations []PreviewAnnotation `json:"annotations,omitempty"`
 }
 
 // PreviewActiveItem is a leak-free in-flight turn hint (no images / blob URLs).
@@ -243,6 +246,8 @@ func SanitizeTurns(msgs []models.ReactMessage) []PreviewTurn {
 }
 
 // SanitizeQueueItems redacts pending FIFO rows for the public ReAct sidebar.
+// Carries sanitized annotations (aligned with ActiveItem) so poll/WS waiting
+// rows keep 批注 badges and edit refill; drops images to avoid blob/URL leaks.
 func SanitizeQueueItems(items []map[string]any) []PreviewQueueItem {
 	if len(items) == 0 {
 		return nil
@@ -256,10 +261,15 @@ func SanitizeQueueItems(items []map[string]any) []PreviewQueueItem {
 		text, _ := it["text"].(string)
 		text = capTurnText(SanitizeDescription(text))
 		id = strings.TrimSpace(id)
-		if id == "" && text == "" {
+		anns := annotationsFromAny(it["annotations"])
+		if id == "" && text == "" && len(anns) == 0 {
 			continue
 		}
-		out = append(out, PreviewQueueItem{ID: id, Text: text})
+		item := PreviewQueueItem{ID: id, Text: text}
+		if len(anns) > 0 {
+			item.Annotations = anns
+		}
+		out = append(out, item)
 	}
 	if len(out) == 0 {
 		return nil
@@ -275,12 +285,36 @@ func SanitizeActiveItem(m map[string]any) *PreviewActiveItem {
 	id, _ := m["id"].(string)
 	text, _ := m["text"].(string)
 	item := &PreviewActiveItem{
-		ID:   strings.TrimSpace(id),
-		Text: capTurnText(SanitizeDescription(text)),
+		ID:          strings.TrimSpace(id),
+		Text:        capTurnText(SanitizeDescription(text)),
+		Annotations: annotationsFromAny(m["annotations"]),
 	}
-	switch anns := m["annotations"].(type) {
+	if item.ID == "" && item.Text == "" && len(item.Annotations) == 0 {
+		return nil
+	}
+	return item
+}
+
+// annotationsFromAny parses ReactAnnotation slices from JSON-decoded maps or typed slices.
+func annotationsFromAny(v any) []PreviewAnnotation {
+	switch anns := v.(type) {
 	case []models.ReactAnnotation:
-		item.Annotations = sanitizeAnnotations(anns)
+		return sanitizeAnnotations(anns)
+	case []PreviewAnnotation:
+		if len(anns) == 0 {
+			return nil
+		}
+		parsed := make([]models.ReactAnnotation, 0, len(anns))
+		for _, a := range anns {
+			parsed = append(parsed, models.ReactAnnotation{
+				Selector: a.Selector,
+				JSONPath: a.JSONPath,
+				Label:    a.Label,
+				Note:     a.Note,
+				Quote:    a.Quote,
+			})
+		}
+		return sanitizeAnnotations(parsed)
 	case []any:
 		parsed := make([]models.ReactAnnotation, 0, len(anns))
 		for _, raw := range anns {
@@ -296,12 +330,10 @@ func SanitizeActiveItem(m map[string]any) *PreviewActiveItem {
 				Quote:    stringMapField(am, "quote"),
 			})
 		}
-		item.Annotations = sanitizeAnnotations(parsed)
-	}
-	if item.ID == "" && item.Text == "" && len(item.Annotations) == 0 {
+		return sanitizeAnnotations(parsed)
+	default:
 		return nil
 	}
-	return item
 }
 
 func capTurnText(text string) string {

--- a/server/internal/gateshare/sanitize_test.go
+++ b/server/internal/gateshare/sanitize_test.go
@@ -13,6 +13,46 @@ func mustFuture() time.Time {
 	return time.Now().Add(24 * time.Hour)
 }
 
+func TestSanitizeQueueItemsKeepsAnnotationsDropsImages(t *testing.T) {
+	items := SanitizeQueueItems([]map[string]any{
+		{
+			"id":   "q-ann",
+			"text": "改标题 http://10.1.2.3/api/runs/x",
+			"annotations": []any{
+				map[string]any{
+					"selector": "#title",
+					"label":    "标题",
+					"jsonPath": "goals[0]",
+					"url":      "http://127.0.0.1:8080/preview/x",
+				},
+			},
+			"images": []any{map[string]any{"url": "blob:http://127.0.0.1/abc", "mimeType": "image/png"}},
+		},
+		{
+			"id": "q-ann-only",
+			"annotations": []models.ReactAnnotation{
+				{Selector: "#hero", Label: "仅标注"},
+			},
+		},
+	})
+	if len(items) != 2 {
+		t.Fatalf("items=%d %+v", len(items), items)
+	}
+	if strings.Contains(items[0].Text, "10.1.2.3") {
+		t.Fatalf("text leak: %s", items[0].Text)
+	}
+	if len(items[0].Annotations) != 1 || items[0].Annotations[0].Selector != "#title" {
+		t.Fatalf("ann: %+v", items[0].Annotations)
+	}
+	if len(items[1].Annotations) != 1 || items[1].Annotations[0].Label != "仅标注" {
+		t.Fatalf("ann-only: %+v", items[1])
+	}
+	raw, _ := json.Marshal(items)
+	if strings.Contains(string(raw), "blob:") || strings.Contains(string(raw), "images") || strings.Contains(string(raw), "127.0.0.1") {
+		t.Fatalf("queue sanitize leak: %s", raw)
+	}
+}
+
 func TestSanitizeTurnsDropsIdentityAndCaps(t *testing.T) {
 	msgs := []models.ReactMessage{
 		{Role: "agent", Text: "请审阅 page.html，勿访问 http://10.1.2.3/api/runs/abc", At: "2026-08-01T00:00:00Z"},
@@ -229,11 +269,21 @@ func TestBuildReviewPreviewDTOIncludesQueueState(t *testing.T) {
 		ReactSessionAlive: true,
 		SessionBusy:       true,
 		Waiting:           1,
-		QueueItems:        []map[string]any{{"id": "q1", "text": "请改标题，勿访问 http://10.1.2.3/api/runs/x"}},
+		QueueItems: []map[string]any{{
+			"id":   "q1",
+			"text": "请改标题，勿访问 http://10.1.2.3/api/runs/x",
+			"annotations": []any{
+				map[string]any{"selector": "#title", "label": "标题", "jsonPath": "goals[0]"},
+			},
+			"images": []any{map[string]any{"url": "blob:http://127.0.0.1/queue"}},
+		}},
 		ActiveItem: map[string]any{
 			"id":     "q1",
 			"text":   "请改标题，勿访问 http://10.1.2.3/api/runs/x",
 			"images": []any{map[string]any{"url": "blob:http://127.0.0.1/abc"}},
+			"annotations": []any{
+				map[string]any{"selector": "#hero", "label": "进行中"},
+			},
 		},
 		ProductKind: ProductKindStructured,
 		ProductName: "research.json",
@@ -244,9 +294,18 @@ func TestBuildReviewPreviewDTOIncludesQueueState(t *testing.T) {
 	if strings.Contains(dto.QueueItems[0].Text, "10.1.2.3") || strings.Contains(dto.ActiveItem.Text, "/api/runs") {
 		t.Fatalf("queue leak: %+v %+v", dto.QueueItems[0], dto.ActiveItem)
 	}
+	if len(dto.QueueItems[0].Annotations) != 1 || dto.QueueItems[0].Annotations[0].Selector != "#title" {
+		t.Fatalf("queue items must keep sanitized annotations: %+v", dto.QueueItems[0])
+	}
+	if len(dto.ActiveItem.Annotations) != 1 || dto.ActiveItem.Annotations[0].Selector != "#hero" {
+		t.Fatalf("activeItem annotations: %+v", dto.ActiveItem)
+	}
 	raw, _ := json.Marshal(dto)
 	if strings.Contains(string(raw), "blob:") || strings.Contains(string(raw), "127.0.0.1") {
 		t.Fatalf("activeItem leaked images/host: %s", raw)
+	}
+	if strings.Contains(string(raw), `"images"`) {
+		t.Fatalf("public queue/active must not leak images key: %s", raw)
 	}
 }
 

--- a/web/src/components/run/GateApproval.test.ts
+++ b/web/src/components/run/GateApproval.test.ts
@@ -20,6 +20,8 @@ const apiMocks = vi.hoisted(() => ({
   listGatePrimaryArtifacts: vi.fn(),
   gateReactRevise: vi.fn(),
   gateReactCancel: vi.fn(),
+  gateReactQueueRemove: vi.fn(),
+  gateReactQueueReorder: vi.fn(),
 }))
 
 /** Plain ref-like so template auto-unwrap works (needs __v_isRef). */
@@ -44,6 +46,8 @@ vi.mock('@/lib/api/api', async () => {
       listGatePrimaryArtifacts: apiMocks.listGatePrimaryArtifacts,
       gateReactRevise: apiMocks.gateReactRevise,
       gateReactCancel: apiMocks.gateReactCancel,
+      gateReactQueueRemove: apiMocks.gateReactQueueRemove,
+      gateReactQueueReorder: apiMocks.gateReactQueueReorder,
     },
   }
 })
@@ -3134,6 +3138,93 @@ describe('GateApproval mobileFillRemaining layout', () => {
     })
     await flushPromises()
     expect(wrapper.find('[data-testid="gate-react-queue"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('gate queue_state frame annotations refill on edit; draft chips stash (plan g1.2/g1.3/g2.2)', async () => {
+    breakpointMocks.isMobile.value = false
+    apiMocks.gateReactRevise.mockResolvedValue({ status: 'accepted', waiting: 1 })
+    apiMocks.gateReactQueueRemove.mockResolvedValue({})
+    const proposalsDoc = {
+      context: '选型',
+      proposals: [
+        { id: 'p1', title: '方案甲', summary: '共享壳', recommended: true },
+        { id: 'p2', title: '方案乙', summary: '另起炉灶' },
+      ],
+    }
+    apiMocks.artifactContent.mockResolvedValue({ content: JSON.stringify(proposalsDoc) })
+    const wrapper = mountApproval({
+      fillPreview: true,
+      gate: baseGate({
+        nodeId: 'pick-proposal',
+        reactSessionAlive: true,
+        reactUpstreamNodeId: 'proposal',
+        actions: [
+          { id: 'p1', label: '方案甲' },
+          { id: 'p2', label: '方案乙' },
+        ],
+        form: [],
+      }),
+      run: baseRun({
+        nodes: [
+          {
+            id: 'pick-proposal',
+            type: 'proposal_select',
+            label: '选方案',
+            position: { x: 0, y: 0 },
+            config: { from: 'proposals.json' },
+          },
+        ],
+        artifacts: [
+          {
+            id: 'a-proposals',
+            name: 'proposals.json',
+            kind: 'json',
+            nodeId: 'proposal',
+            runId: 'run-1',
+            workflowName: 'wf',
+            sizeBytes: 10,
+            createdAt: '2026-07-18T00:00:00Z',
+          },
+        ],
+      }),
+    })
+    await flushPromises()
+    const vm = wrapper.vm as any
+    // Authoritative frame only (no local hit): annotations must survive rebuild.
+    vm.applyReviewFrame?.({
+      event: 'queue_state',
+      nodeId: 'proposal',
+      waiting: 1,
+      busy: false,
+      items: [
+        {
+          id: 'gate-q-1',
+          text: '门禁排队带标注',
+          images: [],
+          annotations: [{ label: '门禁点', selector: '#gate-hero', jsonPath: 'proposals[0].title' }],
+        },
+      ],
+    })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="gate-react-queue"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="gate-react-queue"]').text()).toMatch(/批注/)
+
+    // Composer has different chips — edit must stash them, not force-clear.
+    vm.reactAnnotations = [{ label: '草稿门禁点', selector: '#draft-chip' }]
+    vm.reactText = '门禁草稿'
+    await flushPromises()
+    await wrapper.find('[data-testid="clarify-queue-edit"]').trigger('click')
+    await flushPromises()
+
+    expect(vm.reactText).toBe('门禁排队带标注')
+    expect(vm.reactAnnotations).toEqual([
+      { label: '门禁点', selector: '#gate-hero', jsonPath: 'proposals[0].title' },
+    ])
+    // Stashed draft still on queue with its chip badge.
+    expect(wrapper.find('[data-testid="gate-react-queue"]').text()).toContain('门禁草稿')
+    expect(wrapper.find('[data-testid="gate-react-queue"]').text()).toMatch(/批注/)
+    expect(apiMocks.gateReactQueueRemove).toHaveBeenCalledWith('run-1', 'pick-proposal', 'gate-q-1')
     wrapper.unmount()
   })
 

--- a/web/src/components/run/GateApproval.test.ts
+++ b/web/src/components/run/GateApproval.test.ts
@@ -3228,6 +3228,97 @@ describe('GateApproval mobileFillRemaining layout', () => {
     wrapper.unmount()
   })
 
+  it('gate edit stash race still refills from snapshot (review v2)', async () => {
+    breakpointMocks.isMobile.value = false
+    apiMocks.gateReactQueueRemove.mockResolvedValue({})
+    const proposalsDoc = {
+      context: '选型',
+      proposals: [
+        { id: 'p1', title: '方案甲', summary: '共享壳', recommended: true },
+        { id: 'p2', title: '方案乙', summary: '另起炉灶' },
+      ],
+    }
+    apiMocks.artifactContent.mockResolvedValue({ content: JSON.stringify(proposalsDoc) })
+    const wrapper = mountApproval({
+      fillPreview: true,
+      gate: baseGate({
+        nodeId: 'pick-proposal',
+        reactSessionAlive: true,
+        reactUpstreamNodeId: 'proposal',
+        actions: [
+          { id: 'p1', label: '方案甲' },
+          { id: 'p2', label: '方案乙' },
+        ],
+        form: [],
+      }),
+      run: baseRun({
+        nodes: [
+          {
+            id: 'pick-proposal',
+            type: 'proposal_select',
+            label: '选方案',
+            position: { x: 0, y: 0 },
+            config: { from: 'proposals.json' },
+          },
+        ],
+        artifacts: [
+          {
+            id: 'a-proposals',
+            name: 'proposals.json',
+            kind: 'json',
+            nodeId: 'proposal',
+            runId: 'run-1',
+            workflowName: 'wf',
+            sizeBytes: 10,
+            createdAt: '2026-07-18T00:00:00Z',
+          },
+        ],
+      }),
+    })
+    await flushPromises()
+    const vm = wrapper.vm as any
+    vm.applyReviewFrame?.({
+      event: 'queue_state',
+      nodeId: 'proposal',
+      waiting: 1,
+      busy: false,
+      items: [
+        {
+          id: 'gate-q-race',
+          text: '竞态目标带标注',
+          images: [],
+          annotations: [{ label: '目标点', selector: '#race-target' }],
+        },
+      ],
+    })
+    await flushPromises()
+    vm.reactAnnotations = [{ label: '草稿点', selector: '#draft' }]
+    vm.reactText = '竞态草稿'
+    // After stash, queue_state drops the edit target — must still refill from snapshot.
+    apiMocks.gateReactRevise.mockImplementation(async () => {
+      vm.applyReviewFrame?.({
+        event: 'queue_state',
+        nodeId: 'proposal',
+        waiting: 1,
+        busy: false,
+        items: [
+          {
+            id: 'stashed-draft',
+            text: '竞态草稿',
+            annotations: [{ label: '草稿点', selector: '#draft' }],
+          },
+        ],
+      })
+      return { status: 'accepted', waiting: 1 }
+    })
+    await wrapper.find('[data-testid="clarify-queue-edit"]').trigger('click')
+    await flushPromises()
+    expect(vm.reactText).toBe('竞态目标带标注')
+    expect(vm.reactAnnotations).toEqual([{ label: '目标点', selector: '#race-target' }])
+    expect(apiMocks.gateReactQueueRemove).toHaveBeenCalledWith('run-1', 'pick-proposal', 'gate-q-race')
+    wrapper.unmount()
+  })
+
   it('applyAcpEvents returns false when not thinking/inFlight (g1.2 false applied)', async () => {
     breakpointMocks.isMobile.value = false
     const pageHtml = '<!doctype html><html><body><h1>gate</h1></body></html>'

--- a/web/src/components/run/GateApproval.vue
+++ b/web/src/components/run/GateApproval.vue
@@ -46,6 +46,8 @@ const {
   applyReviewFrame,
   applyAcpEvents,
   cancelReactRevise,
+  reactQueued,
+  editReactQueuedItem,
 } = useGateApproval(props, emit)
 
 defineExpose({
@@ -55,6 +57,8 @@ defineExpose({
   cancelReactRevise,
   reactAnnotations,
   reactText,
+  reactQueued,
+  editReactQueuedItem,
 })
 </script>
 

--- a/web/src/components/run/ReviewComposer.vue
+++ b/web/src/components/run/ReviewComposer.vue
@@ -5,6 +5,7 @@ import Icon from '../ui/Icon.vue'
 import ClarifyChat from './ClarifyChat.vue'
 import ParagraphInput from '../ui/ParagraphInput.vue'
 import GateReactStreamPanel from './GateReactStreamPanel.vue'
+import PendingSendQueuePanel, { type PendingQueueRow } from './PendingSendQueuePanel.vue'
 import type { ClarifyTurn, ClarifyImage, ReactAnnotation, AcpEvent } from '@/lib/shared/types'
 import AnnotationChip from './AnnotationChip.vue'
 
@@ -55,7 +56,9 @@ const props = withDefaults(
      * Gate sandbox-aligned session UX (same surface as GateApproval mobile-fill /
      * content-fit): pending-send queue, streaming agent text, Cancel.
      */
-    queued?: { text: string }[]
+    queued?: PendingQueueRow[]
+    queueNotice?: string | null
+    queueToast?: string | null
     thinking?: boolean
     streamText?: string
     /** ACP thought rail (separate from streamText). */
@@ -84,6 +87,8 @@ const props = withDefaults(
     seedHumanText: '',
     seedHumanImages: () => [],
     queued: () => [],
+    queueNotice: null,
+    queueToast: null,
     thinking: false,
     streamText: '',
     streamThought: '',
@@ -98,6 +103,9 @@ const emit = defineEmits<{
   (e: 'cancel'): void
   (e: 'queue-remove', itemId: string | undefined, index: number): void
   (e: 'queue-reorder', itemIds: string[]): void
+  (e: 'queue-edit', index: number): void
+  (e: 'queue-cancel-item', index: number): void
+  (e: 'queue-reorder-indexes', fromIndex: number, toIndex: number): void
 }>()
 
 const chatRef = ref<{
@@ -147,7 +155,14 @@ const showGateCancel = computed(
   () => props.thinking || (props.queued?.length ?? 0) > 0,
 )
 
-const gateQueued = computed(() => props.queued ?? [])
+const gateQueued = computed<PendingQueueRow[]>(() =>
+  (props.queued ?? []).map((q) => ({
+    id: q.id,
+    text: q.text,
+    images: q.images ?? [],
+    annotations: q.annotations ?? [],
+  })),
+)
 
 /**
  * Footer hint (hot path only — cold path unmounts input/send and omits this hint):
@@ -289,22 +304,16 @@ function onConfirm() {
         </button>
       </div>
       <template v-if="!coldSession">
-        <div
+        <PendingSendQueuePanel
           v-if="gateQueued.length"
-          class="mt-2 rounded border border-line bg-base/40 px-2 py-1.5"
-          data-testid="gate-react-queue"
-        >
-          <div class="mb-1 text-[11px] text-txt3">
-            {{ t('pages.agentChatTester.queue', { n: gateQueued.length }) }}
-          </div>
-          <div
-            v-for="(q, qi) in gateQueued"
-            :key="qi"
-            class="truncate text-[12px] text-txt2"
-          >
-            {{ qi + 1 }}. {{ q.text }}
-          </div>
-        </div>
+          panel-test-id="gate-react-queue"
+          :items="gateQueued"
+          :notice="queueNotice"
+          :toast="queueToast"
+          @cancel="(i) => emit('queue-cancel-item', i)"
+          @edit="(i) => emit('queue-edit', i)"
+          @reorder="(from, to) => emit('queue-reorder-indexes', from, to)"
+        />
         <GateReactStreamPanel
           :thinking="thinking"
           :stream-text="streamText"

--- a/web/src/components/run/clarifySessionUx.probe.test.ts
+++ b/web/src/components/run/clarifySessionUx.probe.test.ts
@@ -350,20 +350,143 @@ describe('[approving] ClarifyChat clarify-path UX (non-reviewMode)', () => {
     w.unmount()
   })
 
-  it('edit refills composer; draft conflict blocks overwrite', async () => {
+  it('edit refills composer; draft with chips is stashed onto queue', async () => {
     const w = mountClarify()
     await sendText(w, '排队原文')
     await w.find('textarea').setValue('未发送草稿')
     await w.find('[data-testid="clarify-queue-edit"]').trigger('click')
     await flushPromises()
-    expect(w.find('[data-testid="clarify-queue-notice"]').exists()).toBe(true)
-    expect(w.find('textarea').element.value).toBe('未发送草稿')
+    // Draft stashed onto queue; queued item refilled into composer.
+    expect(w.find('textarea').element.value).toBe('排队原文')
+    expect(w.find('[data-testid="clarify-review-queue"]').exists()).toBe(true)
+    expect(w.find('[data-testid="clarify-queue-item"]').text()).toContain('未发送草稿')
+    w.unmount()
+  })
 
-    await w.find('textarea').setValue('')
+  it('edit refills annotation chips from queued item (plan g1.3)', async () => {
+    const anns: ReactAnnotation[] = [
+      { label: 'Hero', selector: '#hero', jsonPath: 'summary', quote: '摘录' },
+    ]
+    const w = mount(ClarifyChat, {
+      props: {
+        runId: 'run-1',
+        nodeId: 'clarify',
+        iteration: 1,
+        turns: [],
+        done: false,
+        active: true,
+        reviewMode: false,
+        annotateEnabled: true,
+        hideFinish: true,
+        sendLabel: '发送澄清回复',
+        draft: '带标注排队',
+        annotations: anns,
+      },
+      global: {
+        plugins: [
+          createI18n({
+            legacy: false,
+            locale: 'zh-CN',
+            messages: { 'zh-CN': { ...common, ...pages } },
+          }),
+        ],
+        stubs: { Icon: true, ClarifyDemoFrame: true },
+      },
+    })
+    await w.find('[data-testid="clarify-send-label"]').trigger('click')
+    await flushPromises()
+    expect(w.find('[data-testid="clarify-review-queue"]').text()).toMatch(/批注/)
     await w.find('[data-testid="clarify-queue-edit"]').trigger('click')
     await flushPromises()
-    expect(w.find('textarea').element.value).toBe('排队原文')
-    expect(w.find('[data-testid="clarify-review-queue"]').exists()).toBe(false)
+    expect(w.find('textarea').element.value).toBe('带标注排队')
+    // Composer chips restored (AnnotationChip renders path/quote; label may be omitted when quote set).
+    const chip = w.find('[data-testid="clarify-annotation-chip"]')
+    expect(chip.exists()).toBe(true)
+    expect(chip.text()).toMatch(/summary|摘录|Hero/)
+    expect(w.emitted('queue-remove')).toBeFalsy() // local ghost has no server id
+    w.unmount()
+  })
+
+  it('applyQueueState prefers frame annotations without local hit (plan g1.2)', async () => {
+    const w = mountClarify()
+    const vm = w.vm as unknown as {
+      applyQueueState: (
+        waiting: number,
+        items: {
+          id?: string
+          text?: string
+          images?: { data: string; mimeType: string }[]
+          annotations?: ReactAnnotation[]
+        }[] | null,
+        busy?: boolean,
+        activeItem?: unknown,
+      ) => void
+    }
+    vm.applyQueueState(
+      1,
+      [
+        {
+          id: 'q-frame-1',
+          text: '仅帧权威',
+          annotations: [{ label: '字段', jsonPath: 'goals[0]', selector: '.goal' }],
+          images: [],
+        },
+      ],
+      false,
+      null,
+    )
+    await nextTick()
+    const queue = w.find('[data-testid="clarify-review-queue"]')
+    expect(queue.exists()).toBe(true)
+    expect(queue.text()).toContain('仅帧权威')
+    expect(queue.text()).toMatch(/批注/)
+    await w.find('[data-testid="clarify-queue-edit"]').trigger('click')
+    await flushPromises()
+    expect(w.find('textarea').element.value).toBe('仅帧权威')
+    expect(w.find('[data-testid="clarify-annotation-chip"]').text()).toContain('字段')
+    w.unmount()
+  })
+
+  it('edit with composer chips stashes them; queued chips refill (plan g2.1)', async () => {
+    const queuedAnns: ReactAnnotation[] = [{ label: '队列点', selector: '#queued' }]
+    const draftAnns: ReactAnnotation[] = [{ label: '草稿点', selector: '#draft' }]
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const w = mount(ClarifyChat, {
+      props: {
+        runId: 'run-1',
+        nodeId: 'clarify',
+        iteration: 1,
+        turns: [],
+        done: false,
+        active: true,
+        reviewMode: false,
+        annotateEnabled: true,
+        hideFinish: true,
+        sendLabel: '发送澄清回复',
+        draft: '队列正文',
+        annotations: queuedAnns,
+      },
+      global: {
+        plugins: [i18n],
+        stubs: { Icon: true, ClarifyDemoFrame: true },
+      },
+    })
+    await w.find('[data-testid="clarify-send-label"]').trigger('click')
+    await flushPromises()
+    // Put new chips into composer while queue holds the first item.
+    await w.setProps({ draft: '新草稿', annotations: draftAnns })
+    await nextTick()
+    await w.find('[data-testid="clarify-queue-edit"]').trigger('click')
+    await flushPromises()
+    // Composer has queued item chips; draft chips live on the queue row.
+    expect(w.find('textarea').element.value).toBe('队列正文')
+    expect(w.find('[data-testid="clarify-annotation-chip"]').text()).toContain('队列点')
+    expect(w.find('[data-testid="clarify-queue-item"]').text()).toContain('新草稿')
+    expect(w.find('[data-testid="clarify-review-queue"]').text()).toMatch(/批注/)
     w.unmount()
   })
 

--- a/web/src/components/run/gateApproval/GateApprovalComposer.vue
+++ b/web/src/components/run/gateApproval/GateApprovalComposer.vue
@@ -28,6 +28,8 @@ const { s } = useGateApprovalCtx()
     :pass-label="t('pages.clarify.confirmFlow')"
     :reject-label="s.composerRejectLabel"
     :queued="s.reactQueued"
+    :queue-notice="s.reactQueueNotice"
+    :queue-toast="s.reactQueueToast"
     :thinking="s.reactThinking"
     :stream-text="s.reactStreamText"
     :stream-thought="s.reactStreamThought"
@@ -36,5 +38,8 @@ const { s } = useGateApprovalCtx()
     @send="s.onComposerReject"
     @finish="s.onComposerPass"
     @cancel="s.cancelReactRevise"
+    @queue-edit="s.editReactQueuedItem"
+    @queue-cancel-item="s.cancelReactQueuedItem"
+    @queue-reorder-indexes="s.reorderReactQueuedItems"
   />
 </template>

--- a/web/src/lib/inbox/gateShareLink.ts
+++ b/web/src/lib/inbox/gateShareLink.ts
@@ -221,23 +221,34 @@ export type PublicGatePreviewTurn = {
   text?: string
   at?: string
   interrupted?: boolean
+  images?: Array<{
+    data?: string
+    mimeType?: string
+    name?: string
+    ref?: string
+  }>
   annotations?: Array<{
     selector?: string
     jsonPath?: string
     label?: string
     note?: string
     quote?: string
+    url?: string
+    truncated?: boolean
   }>
 }
 
 export type PublicGateQueueItem = {
   id?: string
   text?: string
+  images?: PublicGatePreviewTurn['images']
+  annotations?: PublicGatePreviewTurn['annotations']
 }
 
 export type PublicGateActiveItem = {
   id?: string
   text?: string
+  images?: PublicGatePreviewTurn['images']
   annotations?: PublicGatePreviewTurn['annotations']
 }
 

--- a/web/src/lib/inbox/useClarifyChat.ts
+++ b/web/src/lib/inbox/useClarifyChat.ts
@@ -33,6 +33,18 @@ import { imgSrc } from '@/lib/shared/compositeText'
 import { useChatImagePreview } from '@/lib/composables/useChatImagePreview'
 import type { Ref } from 'vue'
 
+/** Element-level clone so queue rows never share annotation object refs with composer. */
+function cloneReactAnnotations(anns?: ReactAnnotation[] | null): ReactAnnotation[] {
+  if (!anns?.length) return []
+  return anns.map((a) => ({ ...a }))
+}
+
+/** Element-level clone for attachment lists (same contract as annotations). */
+function cloneClarifyImages(imgs?: ClarifyImage[] | null): ClarifyImage[] {
+  if (!imgs?.length) return []
+  return imgs.map((im) => ({ ...im }))
+}
+
 export type ClarifyChatProps = {
   runId: string
   nodeId: string
@@ -424,8 +436,8 @@ function editQueuedItem(index: number) {
   // re-enqueue it first so chips are never discarded to unblock edit.
   if (hasComposerDraft()) {
     const t = draft.value.trim()
-    const imgs = attachments.value.slice()
-    const anns = annotations.value.slice()
+    const imgs = cloneClarifyImages(attachments.value)
+    const anns = cloneReactAnnotations(annotations.value)
     const over = findOversizedAttachments(imgs)
     if (over.length) {
       attachNotice.value = formatSendRejectMessage(
@@ -444,8 +456,8 @@ function editQueuedItem(index: number) {
 
   const item = queued.value.splice(index, 1)[0]
   draft.value = item.text
-  attachments.value = (item.images ?? []).slice()
-  annotations.value = (item.annotations ?? []).slice()
+  attachments.value = cloneClarifyImages(item.images)
+  annotations.value = cloneReactAnnotations(item.annotations)
   attachNotice.value = null
   syncQueueThinking()
   nextTick(autoGrow)
@@ -621,7 +633,7 @@ function sendMessage(text: string, imgs: ClarifyImage[] = [], anns: ReactAnnotat
   if ((!t && imgs.length === 0 && anns.length === 0) || props.done || !props.active) return
   // Enqueue only — bubbles materialize on turn_begin (AgentChatTester / Demo).
   // Busy may still enqueue; never open a concurrent turn via optimistic pending.
-  queued.value.push({ text: t, images: imgs, annotations: anns.slice() })
+  queued.value.push({ text: t, images: imgs, annotations: cloneReactAnnotations(anns) })
   thinking.value = true
   emit('send', t, imgs, anns)
   stickToBottom.value = true
@@ -631,8 +643,8 @@ function sendMessage(text: string, imgs: ClarifyImage[] = [], anns: ReactAnnotat
 
 function sendFromComposer() {
   const t = draft.value.trim()
-  const imgs = attachments.value.slice()
-  const anns = annotations.value.slice()
+  const imgs = cloneClarifyImages(attachments.value)
+  const anns = cloneReactAnnotations(annotations.value)
   if ((!t && imgs.length === 0 && anns.length === 0) || props.done || !props.active) return
   const over = findOversizedAttachments(imgs)
   if (over.length) {
@@ -972,13 +984,13 @@ function applyQueueState(
         ? queued.value.find((q) => q.id === id) ?? queued.value.find((q) => !q.id && q.text === text)
         : queued.value.find((q) => q.text === text)
       // Prefer frame images/annotations (authoritative); local only when frame omits.
-      // Always slice so composer refill never shares array refs with the queue row.
+      // Clone elements so composer refill never shares object refs with the queue row.
       const images = Array.isArray(it.images)
-        ? it.images.slice()
-        : (local?.images?.slice() ?? [])
+        ? cloneClarifyImages(it.images)
+        : cloneClarifyImages(local?.images)
       const annotations = Array.isArray(it.annotations)
-        ? it.annotations.slice()
-        : (local?.annotations?.slice() ?? [])
+        ? cloneReactAnnotations(it.annotations)
+        : cloneReactAnnotations(local?.annotations)
       return {
         id: id ?? local?.id,
         text,
@@ -1065,7 +1077,12 @@ function applyReviewFrame(frame: {
   message?: string
   interrupted?: boolean
   waiting?: number
-  items?: { id?: string; text?: string }[]
+  items?: {
+    id?: string
+    text?: string
+    images?: ClarifyImage[]
+    annotations?: ReactAnnotation[]
+  }[]
   busy?: boolean
   activeItem?: {
     id?: string

--- a/web/src/lib/inbox/useClarifyChat.ts
+++ b/web/src/lib/inbox/useClarifyChat.ts
@@ -417,16 +417,35 @@ function reorderQueuedItems(fromIndex: number, toIndex: number) {
 }
 
 function editQueuedItem(index: number) {
-  if (hasComposerDraft()) {
-    queueNotice.value = translate('pages.clarify.queueEditBlocked')
-    return
-  }
   if (index < 0 || index >= queued.value.length) return
   queueNotice.value = null
+
+  // Composer already has an unsent draft (text / attachments / annotation chips):
+  // re-enqueue it first so chips are never discarded to unblock edit.
+  if (hasComposerDraft()) {
+    const t = draft.value.trim()
+    const imgs = attachments.value.slice()
+    const anns = annotations.value.slice()
+    const over = findOversizedAttachments(imgs)
+    if (over.length) {
+      attachNotice.value = formatSendRejectMessage(
+        over.map((im, i) => attachmentDisplayName(im, i)),
+        SITE_ATTACH_MAX_MIB,
+      )
+      return
+    }
+    draft.value = ''
+    attachments.value = []
+    annotations.value = []
+    attachNotice.value = null
+    sendMessage(t, imgs, anns)
+    // Append keeps the target index stable.
+  }
+
   const item = queued.value.splice(index, 1)[0]
   draft.value = item.text
-  attachments.value = item.images.slice()
-  annotations.value = item.annotations.slice()
+  attachments.value = (item.images ?? []).slice()
+  annotations.value = (item.annotations ?? []).slice()
   attachNotice.value = null
   syncQueueThinking()
   nextTick(autoGrow)
@@ -922,7 +941,12 @@ function settleAfterTurnEnd() {
  */
 function applyQueueState(
   waiting: number,
-  items: { id?: string; text?: string }[] | null,
+  items: {
+    id?: string
+    text?: string
+    images?: ClarifyImage[]
+    annotations?: ReactAnnotation[]
+  }[] | null,
   busy?: boolean,
   activeItem?: {
     id?: string
@@ -947,11 +971,19 @@ function applyQueueState(
       const local = id
         ? queued.value.find((q) => q.id === id) ?? queued.value.find((q) => !q.id && q.text === text)
         : queued.value.find((q) => q.text === text)
+      // Prefer frame images/annotations (authoritative); local only when frame omits.
+      // Always slice so composer refill never shares array refs with the queue row.
+      const images = Array.isArray(it.images)
+        ? it.images.slice()
+        : (local?.images?.slice() ?? [])
+      const annotations = Array.isArray(it.annotations)
+        ? it.annotations.slice()
+        : (local?.annotations?.slice() ?? [])
       return {
         id: id ?? local?.id,
         text,
-        images: local?.images ?? [],
-        annotations: local?.annotations ?? [],
+        images,
+        annotations,
       }
     })
     const maxLocal = liveAgentIdx.value >= 0 || busy ? rebuilt.length : rebuilt.length + 1

--- a/web/src/lib/inbox/useGateApproval.ts
+++ b/web/src/lib/inbox/useGateApproval.ts
@@ -42,6 +42,18 @@ import { type PlanDoc } from '@/components/run/PlanView.vue'
 import { type ProposalsDoc } from '@/components/run/ProposalSelectView.vue'
 import { isStructuredArtifactName } from '@/components/run/StructuredArtifactView.vue'
 
+/** Element-level clone so queue rows never share annotation object refs with composer. */
+function cloneReactAnnotations(anns?: ReactAnnotation[] | null): ReactAnnotation[] {
+  if (!anns?.length) return []
+  return anns.map((a) => ({ ...a }))
+}
+
+/** Element-level clone for attachment lists (same contract as annotations). */
+function cloneClarifyImages(imgs?: ClarifyImage[] | null): ClarifyImage[] {
+  if (!imgs?.length) return []
+  return imgs.map((im) => ({ ...im }))
+}
+
 export type GateApprovalProps = {
   gate: Gate
   run?: Run
@@ -1278,11 +1290,18 @@ async function editReactQueuedItem(index: number) {
   if (index < 0 || index >= reactQueued.value.length) return
   reactQueueNotice.value = null
 
+  // Snapshot before stash / queue_state race so we never lose the edit target.
+  const target = reactQueued.value[index]
+  const targetSnapshot = {
+    id: target?.id,
+    text: target?.text ?? '',
+    images: cloneClarifyImages(target?.images),
+    annotations: cloneReactAnnotations(target?.annotations),
+  }
+
   // Composer already has an unsent draft (incl. annotation chips / pick):
   // re-enqueue it first so chips are never discarded to unblock edit.
   if (hasReactComposerDraft()) {
-    const targetId = reactQueued.value[index]?.id
-    const targetText = reactQueued.value[index]?.text
     if (props.run?.id) {
       if (usesPreviewIssues.value) {
         await sendHotReject()
@@ -1295,23 +1314,40 @@ async function editReactQueuedItem(index: number) {
       const body = reactText.value.trim()
       reactQueued.value.push({
         text: body || (reactAnnotations.value.length || reactImages.value.length ? '(annotate)' : body),
-        images: reactImages.value.slice(),
-        annotations: reactAnnotations.value.slice(),
+        images: cloneClarifyImages(reactImages.value),
+        annotations: cloneReactAnnotations(reactAnnotations.value),
       })
       clearUnifiedDraft()
       reactThinking.value = true
     }
-    // Re-locate target after append (index stable unless queue_state raced).
-    index = targetId
-      ? reactQueued.value.findIndex((q) => q.id === targetId)
-      : reactQueued.value.findIndex((q) => q.text === targetText)
-    if (index < 0) return
+    // Re-locate target after append (prefer stable id; text fallback).
+    index = targetSnapshot.id
+      ? reactQueued.value.findIndex((q) => q.id === targetSnapshot.id)
+      : reactQueued.value.findIndex((q) => q.text === targetSnapshot.text)
+    if (index < 0) {
+      // queue_state raced: target missing locally — refill from pre-stash snapshot.
+      reactText.value = targetSnapshot.text === '(annotate)' ? '' : targetSnapshot.text
+      reactImages.value = cloneClarifyImages(targetSnapshot.images)
+      reactAnnotations.value = cloneReactAnnotations(targetSnapshot.annotations)
+      syncReactQueueThinking()
+      showReactQueueToast(t('pages.clarify.queueEditRefilled'))
+      if (targetSnapshot.id && props.run?.id) {
+        try {
+          await api.gateReactQueueRemove(props.run.id, props.gate.nodeId, targetSnapshot.id)
+        } catch (e: any) {
+          reactError.value = e?.message || t('pages.gateApproval.reactRevise.failed')
+        }
+      } else if (!targetSnapshot.id) {
+        reactQueueNotice.value = t('pages.clarify.queueEditLost')
+      }
+      return
+    }
   }
 
   const item = reactQueued.value.splice(index, 1)[0]
   reactText.value = item.text === '(annotate)' ? '' : item.text
-  reactImages.value = (item.images ?? []).slice()
-  reactAnnotations.value = (item.annotations ?? []).slice()
+  reactImages.value = cloneClarifyImages(item.images)
+  reactAnnotations.value = cloneReactAnnotations(item.annotations)
   syncReactQueueThinking()
   showReactQueueToast(t('pages.clarify.queueEditRefilled'))
   if (item.id && props.run?.id) {
@@ -1462,11 +1498,11 @@ function applyReviewFrame(frame: {
               reactQueued.value.find((q) => !q.id && q.text === text)
             : reactQueued.value.find((q) => q.text === text)
           const images = Array.isArray(it.images)
-            ? it.images.slice()
-            : (local?.images?.slice() ?? [])
+            ? cloneClarifyImages(it.images)
+            : cloneClarifyImages(local?.images)
           const annotations = Array.isArray(it.annotations)
-            ? it.annotations.slice()
-            : (local?.annotations?.slice() ?? [])
+            ? cloneReactAnnotations(it.annotations)
+            : cloneReactAnnotations(local?.annotations)
           return {
             id: id ?? local?.id,
             text,
@@ -1617,8 +1653,8 @@ async function sendReactRevise() {
   const body = reactText.value.trim()
   reactQueued.value.push({
     text: body,
-    images: reactImages.value.slice(),
-    annotations: reactAnnotations.value.slice(),
+    images: cloneClarifyImages(reactImages.value),
+    annotations: cloneReactAnnotations(reactAnnotations.value),
   })
   reactThinking.value = true
   reactSending.value = true
@@ -1629,7 +1665,7 @@ async function sendReactRevise() {
       props.gate.nodeId,
       body,
       reactImages.value,
-      reactAnnotations.value.slice(),
+      cloneReactAnnotations(reactAnnotations.value),
     )
     clearUnifiedDraft()
     emit('react-revised')
@@ -1699,19 +1735,19 @@ async function sendHotReject() {
   reactError.value = null
   const body = reactText.value.trim()
   const issueImages = collectUnifiedIssueImages()
-  const anns = reactAnnotations.value.slice()
+  const anns = cloneReactAnnotations(reactAnnotations.value)
   const reviseImages = issueImages.map((im) => ({ data: im.data, mimeType: im.mimeType }))
   const draftSnap = {
     text: reactText.value,
-    images: reactImages.value.slice(),
-    anns: anns.slice(),
+    images: cloneClarifyImages(reactImages.value),
+    anns: cloneReactAnnotations(anns),
     selector: pickedSelector.value,
     elementImage: pickedElementImage.value,
   }
   reactQueued.value.push({
     text: body || '(annotate)',
     images: reviseImages.map((im) => ({ data: im.data, mimeType: im.mimeType })),
-    annotations: anns.slice(),
+    annotations: cloneReactAnnotations(anns),
   })
   reactThinking.value = true
   try {

--- a/web/src/lib/inbox/useGateApproval.ts
+++ b/web/src/lib/inbox/useGateApproval.ts
@@ -1275,16 +1275,43 @@ async function reorderReactQueuedItems(fromIndex: number, toIndex: number) {
 }
 
 async function editReactQueuedItem(index: number) {
-  if (hasReactComposerDraft()) {
-    reactQueueNotice.value = t('pages.clarify.queueEditBlocked')
-    return
-  }
   if (index < 0 || index >= reactQueued.value.length) return
   reactQueueNotice.value = null
+
+  // Composer already has an unsent draft (incl. annotation chips / pick):
+  // re-enqueue it first so chips are never discarded to unblock edit.
+  if (hasReactComposerDraft()) {
+    const targetId = reactQueued.value[index]?.id
+    const targetText = reactQueued.value[index]?.text
+    if (props.run?.id) {
+      if (usesPreviewIssues.value) {
+        await sendHotReject()
+      } else {
+        await sendReactRevise()
+      }
+      if (reactError.value) return
+    } else {
+      // Local-only stash when no run (unit probes): keep chips on the queue.
+      const body = reactText.value.trim()
+      reactQueued.value.push({
+        text: body || (reactAnnotations.value.length || reactImages.value.length ? '(annotate)' : body),
+        images: reactImages.value.slice(),
+        annotations: reactAnnotations.value.slice(),
+      })
+      clearUnifiedDraft()
+      reactThinking.value = true
+    }
+    // Re-locate target after append (index stable unless queue_state raced).
+    index = targetId
+      ? reactQueued.value.findIndex((q) => q.id === targetId)
+      : reactQueued.value.findIndex((q) => q.text === targetText)
+    if (index < 0) return
+  }
+
   const item = reactQueued.value.splice(index, 1)[0]
-  reactText.value = item.text
-  reactImages.value = item.images.slice()
-  reactAnnotations.value = item.annotations.slice()
+  reactText.value = item.text === '(annotate)' ? '' : item.text
+  reactImages.value = (item.images ?? []).slice()
+  reactAnnotations.value = (item.annotations ?? []).slice()
   syncReactQueueThinking()
   showReactQueueToast(t('pages.clarify.queueEditRefilled'))
   if (item.id && props.run?.id) {
@@ -1332,13 +1359,28 @@ function settleReactAfterTurnEnd() {
 function applyReviewFrame(frame: {
   event?: string
   nodeId?: string
-  item?: { id?: string; text?: string }
+  item?: {
+    id?: string
+    text?: string
+    images?: ClarifyImage[]
+    annotations?: ReactAnnotation[]
+  }
   interrupted?: boolean
   message?: string
   waiting?: number
-  items?: { id?: string; text?: string }[]
+  items?: {
+    id?: string
+    text?: string
+    images?: ClarifyImage[]
+    annotations?: ReactAnnotation[]
+  }[]
   busy?: boolean
-  activeItem?: { id?: string; text?: string } | null
+  activeItem?: {
+    id?: string
+    text?: string
+    images?: ClarifyImage[]
+    annotations?: ReactAnnotation[]
+  } | null
 }) {
   const producer = props.gate.reactUpstreamNodeId
   if (producer && frame.nodeId && frame.nodeId !== producer) return
@@ -1411,6 +1453,7 @@ function applyReviewFrame(frame: {
       }
       if (items) {
         // Preserve server id so turn_done can distinguish ghost vs real waiters.
+        // Prefer frame images/annotations; local only when frame omits; always slice.
         const rebuilt = items.map((it) => {
           const text = it.text ?? ''
           const id = typeof it.id === 'string' && it.id ? it.id : undefined
@@ -1418,11 +1461,17 @@ function applyReviewFrame(frame: {
             ? reactQueued.value.find((q) => q.id === id) ??
               reactQueued.value.find((q) => !q.id && q.text === text)
             : reactQueued.value.find((q) => q.text === text)
+          const images = Array.isArray(it.images)
+            ? it.images.slice()
+            : (local?.images?.slice() ?? [])
+          const annotations = Array.isArray(it.annotations)
+            ? it.annotations.slice()
+            : (local?.annotations?.slice() ?? [])
           return {
             id: id ?? local?.id,
             text,
-            images: local?.images ?? [],
-            annotations: local?.annotations ?? [],
+            images,
+            annotations,
           }
         })
         const maxLocal = reactInFlight.value || busy ? rebuilt.length : rebuilt.length + 1

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -2655,7 +2655,7 @@
       "queueCancelled": "Removed: “{text}”",
       "queueReordered": "Order updated",
       "queueEditRefilled": "Moved back to the composer — send again to re-queue",
-      "queueEditBlocked": "The composer already has an unsent draft. Clear or send it before re-editing a queued item.",
+      "queueEditBlocked": "An attachment is too large to move the current draft onto the queue. Fix attachments first.",
       "queueAttachmentBadge": "Files×{n}",
       "queueAnnotationBadge": "Note"
     },

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -2656,6 +2656,7 @@
       "queueReordered": "Order updated",
       "queueEditRefilled": "Moved back to the composer — send again to re-queue",
       "queueEditBlocked": "An attachment is too large to move the current draft onto the queue. Fix attachments first.",
+      "queueEditLost": "Draft was queued, but the item to edit could not be found. Click the pencil on the queue row again.",
       "queueAttachmentBadge": "Files×{n}",
       "queueAnnotationBadge": "Note"
     },

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -2655,7 +2655,7 @@
       "queueCancelled": "已取消：「{text}」",
       "queueReordered": "顺序已更新",
       "queueEditRefilled": "已回填输入区，修改后再次发送即可入队",
-      "queueEditBlocked": "输入区已有未发送草稿，请先清空或发送后再重新编辑队列项。",
+      "queueEditBlocked": "附件过大，无法将当前草稿移入队列后再编辑。请先处理附件。",
       "queueAttachmentBadge": "附件×{n}",
       "queueAnnotationBadge": "批注"
     },

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -2656,6 +2656,7 @@
       "queueReordered": "顺序已更新",
       "queueEditRefilled": "已回填输入区，修改后再次发送即可入队",
       "queueEditBlocked": "附件过大，无法将当前草稿移入队列后再编辑。请先处理附件。",
+      "queueEditLost": "当前草稿已入队，但未能定位要编辑的队列项。请从队列中再次点击铅笔。",
       "queueAttachmentBadge": "附件×{n}",
       "queueAnnotationBadge": "批注"
     },

--- a/web/src/views/PublicGateApprovalView.test.ts
+++ b/web/src/views/PublicGateApprovalView.test.ts
@@ -17,6 +17,8 @@ const mocks = vi.hoisted(() => ({
   decide: vi.fn(),
   reply: vi.fn(),
   cancel: vi.fn(),
+  queueRemove: vi.fn(),
+  queueReorder: vi.fn(),
 }))
 
 class FakeWebSocket {
@@ -53,6 +55,8 @@ vi.mock('@/lib/inbox/gateShareLink', async () => {
       decide: mocks.decide,
       reply: mocks.reply,
       cancel: mocks.cancel,
+      queueRemove: mocks.queueRemove,
+      queueReorder: mocks.queueReorder,
       eventsWsUrl: () => 'ws://test/public/gate-approvals/events',
     },
   }
@@ -491,6 +495,62 @@ describe('PublicGateApprovalView workbench', () => {
     await flushPromises()
     expect(w.text()).toContain('流式产出正文')
     expect(w.find('[data-testid="clarify-stream-caret"]').exists()).toBe(true)
+  })
+
+  it('public poll/WS queueItems keep annotations badge and refill on edit (plan g1/f4)', async () => {
+    window.location.hash = `#t=${'ee'.repeat(32)}`
+    mocks.preview.mockResolvedValue({
+      status: 'active',
+      kind: 'review',
+      nonce: 'n-q-ann',
+      reactSessionAlive: true,
+      sessionBusy: false,
+      waiting: 1,
+      queueItems: [
+        {
+          id: 'pub-q-1',
+          text: '公共排队带标注',
+          annotations: [{ label: '公共点', selector: '#pub-hero', jsonPath: 'goals[0]' }],
+        },
+      ],
+      actions: { confirm: 'confirm', reply: 'reply', cancel: 'cancel' },
+      turns: [{ role: 'agent', text: '请复审', at: '2026-08-01T00:00:00Z' }],
+    })
+    mocks.cancel.mockResolvedValue({})
+    const w = mountView()
+    await flushPromises()
+    await flushPromises()
+    expect(w.text()).toMatch(/批注/)
+    expect(w.text()).toContain('公共排队带标注')
+
+    // WS reconcile with annotations-only frame (no local hit) must keep badge.
+    const sock = FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
+    expect(sock).toBeTruthy()
+    sock.emit({
+      type: 'review',
+      event: 'queue_state',
+      nodeId: 'public-gate',
+      waiting: 1,
+      busy: false,
+      items: [
+        {
+          id: 'pub-q-1',
+          text: '公共排队带标注',
+          annotations: [{ label: '公共点', selector: '#pub-hero', jsonPath: 'goals[0]' }],
+        },
+      ],
+    })
+    await flushPromises()
+    expect(w.text()).toMatch(/批注/)
+
+    await w.find('[data-testid="clarify-queue-edit"]').trigger('click')
+    await flushPromises()
+    expect((w.get('[data-testid="clarify-input"]').element as HTMLTextAreaElement).value).toBe(
+      '公共排队带标注',
+    )
+    const anns = (w.vm as unknown as { annotations: Array<{ label?: string; selector?: string }> })
+      .annotations
+    expect(anns).toEqual([{ label: '公共点', selector: '#pub-hero', jsonPath: 'goals[0]' }])
   })
 
   it('unavailable states keep dark chrome without confirm/send', async () => {


### PR DESCRIPTION
## Summary
- Preserve annotation chips (and images on the engine snapshot) when re-editing pending-send queue items in ClarifyChat, Gate hot-edit, and public gate approval.
- Make `queue_state` waiting items the authoritative source for `annotations`/`images`; public sanitize keeps annotations and still drops images to avoid blob/URL leaks.
- When the composer already has chips, stash the current draft onto the queue instead of forcing the user to delete annotations before edit; Gate edit also snapshots the target so a stash race still refills.

## Test plan
- [ ] Clarify: enqueue an item with annotations → click re-edit → composer chips match enqueue payload
- [ ] Gate / public page: `queue_state` with no local hit still shows 批注 badge and refill on pencil
- [ ] Composer already has chips: re-edit stashes the draft and refills the queued item (chips not discarded)
- [ ] Public sanitize: annotations kept, images not leaked
- [ ] Existing text refill / cancel / reorder cases still pass