### PR TITLE
feat(web): allow mobile ReviewShell drawer to fill top/bottom

### DIFF
--- a/web/e2e/gate-mobile-fill.spec.ts
+++ b/web/e2e/gate-mobile-fill.spec.ts
@@ -37,9 +37,9 @@ async function mockApi(
   })
 }
 
-// plan_coverage: g2.1 mobile-fill no drawer-height=340; g3.2 e2e stage min + drag resize (leaf ids only).
+// plan_coverage: g2.1 default mid-split; g2.3 e2e full-top/full-bottom + drag-back.
 test.describe('Run 详情移动端 visual 定高预览', () => {
-  // plan_coverage: g2.1 / g3.2 — adaptive drawer<340, stage>160, handle drag grows drawer
+  // plan_coverage: g2.1 — adaptive drawer mid-split; preview + chat both visible
   test('390×844：n_open=0 确认并流转 + 取点，预览占满 stage', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 })
     await mockApi(page, [])
@@ -65,10 +65,10 @@ test.describe('Run 详情移动端 visual 定高预览', () => {
     ])
     expect(previewBox && drawerBox && rootBox && feedbackBox).toBeTruthy()
 
-    // Stage (preview) sits above the ReviewShell drawer; drawer is a sizable bottom panel.
+    // Stage (preview) sits above the ReviewShell drawer; default is mid-split (not extremes).
     expect(previewBox!.y).toBeLessThan(drawerBox!.y)
-    expect(previewBox!.height).toBeGreaterThan(160)
-    // Adaptive default is lower than the old fixed 340px so preview stays readable.
+    expect(previewBox!.height).toBeGreaterThan(44)
+    expect(drawerBox!.height).toBeGreaterThan(44)
     expect(drawerBox!.height).toBeLessThan(340)
     expect(drawerBox!.y + drawerBox!.height).toBeLessThanOrEqual(rootBox!.y + rootBox!.height + 1)
 
@@ -121,6 +121,68 @@ test.describe('Run 详情移动端 visual 定高预览', () => {
     // Inspect toggle remains available inside the preview shell.
     await expect(page.getByTestId('html-preview-inspect-bar')).toBeVisible()
     await expect(page.getByRole('button', { name: '取点标注' })).toBeVisible()
+  })
+
+  // plan_coverage: g2.3 — pull to full top / full bottom; handle remains; reverse drag restores panels
+  test('390×844：抽屉可拉满顶/底且手柄可反向拖回', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await mockApi(page, [])
+
+    await page.goto('/gate-mobile-fill.html')
+    await expect(page.getByTestId('gate-mobile-fill-root')).toBeVisible({ timeout: 10_000 })
+    const shell = page.getByTestId('review-shell')
+    const drawer = page.getByTestId('review-shell-sidebar')
+    const stage = page.getByTestId('review-shell-stage')
+    const handle = page.getByTestId('review-shell-drawer-handle')
+    await expect(handle).toBeVisible()
+
+    const shellBox = await shell.boundingBox()
+    expect(shellBox).toBeTruthy()
+    const shellH = shellBox!.height
+
+    async function dragHandleBy(dy: number) {
+      const box = await handle.boundingBox()
+      expect(box).toBeTruthy()
+      const cx = box!.x + box!.width / 2
+      const cy = box!.y + box!.height / 2
+      await page.mouse.move(cx, cy)
+      await page.mouse.down()
+      await page.mouse.move(cx, cy + dy, { steps: 12 })
+      await page.mouse.up()
+    }
+
+    // Full top: drag handle far upward → drawer ≈ shell height, stage collapsed
+    await dragHandleBy(-(shellH + 100))
+    const fullTopDrawer = await drawer.boundingBox()
+    const fullTopStage = await stage.boundingBox()
+    expect(fullTopDrawer).toBeTruthy()
+    expect(Math.abs(fullTopDrawer!.height - shellH)).toBeLessThanOrEqual(2)
+    expect(fullTopStage!.height).toBeLessThanOrEqual(2)
+    await expect(handle).toBeVisible()
+
+    // Drag back down → stage reappears
+    await dragHandleBy(Math.round(shellH * 0.4))
+    const midFromTop = await drawer.boundingBox()
+    const stageFromTop = await stage.boundingBox()
+    expect(midFromTop!.height).toBeLessThan(shellH - 10)
+    expect(midFromTop!.height).toBeGreaterThan(50)
+    expect(stageFromTop!.height).toBeGreaterThan(10)
+
+    // Full bottom: drag handle far downward → drawer ≈ 44px handle
+    await dragHandleBy(shellH + 100)
+    const fullBottomDrawer = await drawer.boundingBox()
+    const fullBottomStage = await stage.boundingBox()
+    expect(fullBottomDrawer).toBeTruthy()
+    expect(fullBottomDrawer!.height).toBeGreaterThanOrEqual(42)
+    expect(fullBottomDrawer!.height).toBeLessThanOrEqual(48)
+    expect(fullBottomStage!.height).toBeGreaterThan(shellH - 50)
+    await expect(handle).toBeVisible()
+
+    // Drag back up → chat/drawer expands again
+    await dragHandleBy(-Math.round(shellH * 0.35))
+    const midFromBottom = await drawer.boundingBox()
+    expect(midFromBottom!.height).toBeGreaterThan(60)
+    expect(midFromBottom!.height).toBeLessThan(shellH - 10)
   })
 
   test('390×844：n_open≥1 可继续发送，确认并流转禁用', async ({ page }) => {

--- a/web/src/components/run/ReviewShell.test.ts
+++ b/web/src/components/run/ReviewShell.test.ts
@@ -386,8 +386,8 @@ describe('ReviewShell sidebar width', () => {
   })
 })
 
-// plan_coverage leaves (mobile drawer fix): g1.1 drag events, g1.2 hit area, g1.3 aria/locale,
-// g1.4 adaptive default + stage min, g3.1 unit tests — use leaf ids only in test_result.
+// plan_coverage leaves: g1.1 clamp constants; g1.2 flex/minHeight; g1.3 aria;
+// g2.1 default ~38%; g2.2 unit extremes + drag-back — use leaf ids only in test_result.
 describe('ReviewShell mobile drawer', () => {
   beforeEach(() => {
     localStorage.clear()
@@ -400,68 +400,198 @@ describe('ReviewShell mobile drawer', () => {
     vi.restoreAllMocks()
   })
 
-  // plan_coverage: g1.4 — adaptive default height + stage≥160 clamp
-  it('adaptive default height preserves stage min and stays below old 340 default', async () => {
+  // plan_coverage: g2.1 — adaptive default ~38% mid-split, not full-top/full-bottom
+  it('adaptive default height is mid-split (~38%) and not an extreme', async () => {
     const w = mountMobileShell({}, 600)
     await w.vm.$nextTick()
     const style = drawerHeightStyle(w)
     const match = style.match(/height:\s*(\d+)px/)
     expect(match).toBeTruthy()
     const drawerH = Number(match![1])
-    expect(drawerH).toBeLessThan(340)
-    expect(drawerH).toBeGreaterThanOrEqual(180)
-    // stage = shell 600 - drawer should stay >= STAGE_MIN 160
-    expect(600 - drawerH).toBeGreaterThanOrEqual(160)
+    // min(38% of 600, drawerHeight 280) = 228
+    expect(drawerH).toBe(228)
+    expect(drawerH).toBeGreaterThan(44)
+    expect(drawerH).toBeLessThan(600)
+    // No localStorage persistence for drawer height
+    expect(localStorage.length).toBe(0)
     w.unmount()
   })
 
-  // plan_coverage: g1.2 / g1.3 — 44px hit area, touch-action:none, horizontal separator aria + 拖动文案
-  it('drawer handle has touch-action none and expanded hit area', () => {
-    const w = mountMobileShell()
-    const handle = w.get('[data-testid="review-shell-drawer-handle"]')
-    expect(handle.classes()).toContain('review-shell-drawer-handle')
-    expect(handle.attributes('role')).toBe('separator')
-    expect(handle.attributes('aria-orientation')).toBe('horizontal')
-    expect(handle.attributes('aria-label')).toContain('拖动')
-    w.unmount()
-  })
-
-  // plan_coverage: g1.1 — pointer capture, preventDefault, scroll lock while dragging
-  it('dragging drawer handle changes height and locks scroll', async () => {
+  // plan_coverage: g1.3 — valuemin=handle(44), valuemax=shellH, scroll lock class
+  it('drawer handle aria range is [handleMin, shellH] with scroll lock while dragging', async () => {
     const w = mountMobileShell({}, 600)
     await w.vm.$nextTick()
-    const before = Number((drawerHeightStyle(w).match(/height:\s*(\d+)px/) || [])[1])
-    const handle = w.get('[data-testid="review-shell-drawer-handle"]').element
-    firePointer(handle, 'pointerdown', 200, 500)
-    firePointer(handle, 'pointermove', 200, 420)
+    const handle = w.get('[data-testid="review-shell-drawer-handle"]')
+    expect(handle.attributes('role')).toBe('separator')
+    expect(handle.attributes('aria-orientation')).toBe('horizontal')
+    expect(handle.attributes('aria-valuemin')).toBe('44')
+    expect(handle.attributes('aria-valuemax')).toBe('600')
+    expect(handle.attributes('aria-label')).toContain('拖动')
+
+    const el = handle.element
+    firePointer(el, 'pointerdown', 200, 500)
     await w.vm.$nextTick()
-    const after = Number((drawerHeightStyle(w).match(/height:\s*(\d+)px/) || [])[1])
-    expect(after).toBeGreaterThan(before)
     expect(document.body.classList.contains('review-shell-drawer-dragging')).toBe(true)
-    firePointer(handle, 'pointerup', 200, 420)
+    firePointer(el, 'pointerup', 200, 500)
     await w.vm.$nextTick()
     expect(document.body.classList.contains('review-shell-drawer-dragging')).toBe(false)
     w.unmount()
   })
 
-  it('clamps drawer drag to shell budget on short viewports', async () => {
+  // plan_coverage: g1.1 / g2.2 — drag up to shell height (full top)
+  it('dragging up clamps drawer to full shell height', async () => {
+    const w = mountMobileShell({}, 600)
+    await w.vm.$nextTick()
+    const handle = w.get('[data-testid="review-shell-drawer-handle"]').element
+    firePointer(handle, 'pointerdown', 200, 400)
+    firePointer(handle, 'pointermove', 200, -400)
+    await w.vm.$nextTick()
+    const end = Number((drawerHeightStyle(w).match(/height:\s*(\d+)px/) || [])[1])
+    expect(end).toBe(600)
+    firePointer(handle, 'pointerup', 200, -400)
+    w.unmount()
+  })
+
+  // plan_coverage: g1.1 / g2.2 — drag down to handle-only (full bottom)
+  it('dragging down clamps drawer to handle hit min (44px)', async () => {
+    const w = mountMobileShell({}, 600)
+    await w.vm.$nextTick()
+    const handle = w.get('[data-testid="review-shell-drawer-handle"]').element
+    firePointer(handle, 'pointerdown', 200, 300)
+    firePointer(handle, 'pointermove', 200, 900)
+    await w.vm.$nextTick()
+    const end = Number((drawerHeightStyle(w).match(/height:\s*(\d+)px/) || [])[1])
+    expect(end).toBe(44)
+    firePointer(handle, 'pointerup', 200, 900)
+    w.unmount()
+  })
+
+  // plan_coverage: g2.2 — reverse drag from both extremes restores mid range
+  it('can drag back from full-top and full-bottom extremes', async () => {
+    const w = mountMobileShell({}, 600)
+    await w.vm.$nextTick()
+    const handle = w.get('[data-testid="review-shell-drawer-handle"]').element
+
+    // Full top then drag down
+    firePointer(handle, 'pointerdown', 200, 400)
+    firePointer(handle, 'pointermove', 200, -400)
+    firePointer(handle, 'pointerup', 200, -400)
+    await w.vm.$nextTick()
+    expect(Number((drawerHeightStyle(w).match(/height:\s*(\d+)px/) || [])[1])).toBe(600)
+
+    firePointer(handle, 'pointerdown', 200, 50)
+    firePointer(handle, 'pointermove', 200, 250)
+    firePointer(handle, 'pointerup', 200, 250)
+    await w.vm.$nextTick()
+    const afterFromTop = Number((drawerHeightStyle(w).match(/height:\s*(\d+)px/) || [])[1])
+    expect(afterFromTop).toBeLessThan(600)
+    expect(afterFromTop).toBeGreaterThan(44)
+
+    // Full bottom then drag up
+    firePointer(handle, 'pointerdown', 200, 300)
+    firePointer(handle, 'pointermove', 200, 900)
+    firePointer(handle, 'pointerup', 200, 900)
+    await w.vm.$nextTick()
+    expect(Number((drawerHeightStyle(w).match(/height:\s*(\d+)px/) || [])[1])).toBe(44)
+
+    firePointer(handle, 'pointerdown', 200, 700)
+    firePointer(handle, 'pointermove', 200, 500)
+    firePointer(handle, 'pointerup', 200, 500)
+    await w.vm.$nextTick()
+    const afterFromBottom = Number((drawerHeightStyle(w).match(/height:\s*(\d+)px/) || [])[1])
+    expect(afterFromBottom).toBeGreaterThan(44)
+    expect(afterFromBottom).toBeLessThan(600)
+    w.unmount()
+  })
+
+  // plan_coverage: g1.1 — short viewport: clamp within shell, no overflow
+  it('clamps drawer within short viewport without overflowing shell', async () => {
     const w = mountMobileShell({}, 360)
     await w.vm.$nextTick()
     const handle = w.get('[data-testid="review-shell-drawer-handle"]').element
-    const start = Number((drawerHeightStyle(w).match(/height:\s*(\d+)px/) || [])[1])
     firePointer(handle, 'pointerdown', 200, 300)
     firePointer(handle, 'pointermove', 200, 50)
     await w.vm.$nextTick()
     const end = Number((drawerHeightStyle(w).match(/height:\s*(\d+)px/) || [])[1])
-    expect(end).toBeGreaterThan(start)
-    expect(360 - end).toBeGreaterThanOrEqual(160)
+    expect(end).toBeLessThanOrEqual(360)
+    expect(end).toBeGreaterThanOrEqual(44)
+    firePointer(handle, 'pointerup', 200, 50)
     w.unmount()
   })
 
-  it('stage section enforces min height on mobile', () => {
+  // plan_coverage: g1.2 — no stage minHeight:160; aside shrink-0
+  it('mobile stage has no 160px minHeight and drawer is shrink-0', () => {
     const w = mountMobileShell()
     const stage = w.get('[data-testid="review-shell-stage"]')
-    expect(stage.attributes('style')).toMatch(/min-height:\s*160px/)
+    expect(stage.attributes('style') || '').not.toMatch(/min-height/)
+    const aside = w.get('[data-testid="review-shell-sidebar"]')
+    expect(aside.classes()).toContain('shrink-0')
+    w.unmount()
+  })
+
+  // plan_coverage: g2.1 — resize keeps full-top / full-bottom extremes
+  it('resize preserves full-top and full-bottom extremes', async () => {
+    const observers: ResizeObserverCallback[] = []
+    class MockResizeObserver {
+      constructor(cb: ResizeObserverCallback) {
+        observers.push(cb)
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal('ResizeObserver', MockResizeObserver)
+
+    let shellHeight = 600
+    Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+      configurable: true,
+      value() {
+        return {
+          x: 0,
+          y: 0,
+          top: 0,
+          left: 0,
+          bottom: shellHeight,
+          right: 390,
+          width: 390,
+          height: shellHeight,
+          toJSON() {
+            return {}
+          },
+        }
+      },
+    })
+    const w = mountShell({ mobile: true })
+    await w.vm.$nextTick()
+    const handle = w.get('[data-testid="review-shell-drawer-handle"]').element
+
+    // Drag to full top, then grow shell → stay full top
+    firePointer(handle, 'pointerdown', 200, 400)
+    firePointer(handle, 'pointermove', 200, -400)
+    firePointer(handle, 'pointerup', 200, -400)
+    await w.vm.$nextTick()
+    expect(Number((drawerHeightStyle(w).match(/height:\s*(\d+)px/) || [])[1])).toBe(600)
+
+    shellHeight = 800
+    for (const cb of observers) {
+      cb([], {} as ResizeObserver)
+    }
+    await w.vm.$nextTick()
+    expect(Number((drawerHeightStyle(w).match(/height:\s*(\d+)px/) || [])[1])).toBe(800)
+
+    // Drag to full bottom, then grow shell → stay handle-only
+    firePointer(handle, 'pointerdown', 200, 100)
+    firePointer(handle, 'pointermove', 200, 900)
+    firePointer(handle, 'pointerup', 200, 900)
+    await w.vm.$nextTick()
+    expect(Number((drawerHeightStyle(w).match(/height:\s*(\d+)px/) || [])[1])).toBe(44)
+
+    shellHeight = 900
+    for (const cb of observers) {
+      cb([], {} as ResizeObserver)
+    }
+    await w.vm.$nextTick()
+    expect(Number((drawerHeightStyle(w).match(/height:\s*(\d+)px/) || [])[1])).toBe(44)
     w.unmount()
   })
 })

--- a/web/src/components/run/ReviewShell.vue
+++ b/web/src/components/run/ReviewShell.vue
@@ -9,18 +9,17 @@ import { useI18n } from 'vue-i18n'
  * draggable via sash, clamped to [240, min(480, shell−stageMin−sash)],
  * optionally persisted per storageKey.
  * Narrow: vertical with a bottom drawer (draggable height); no horizontal sash.
+ * Mobile drawer clamps to [handle hit min, shell height] so it can fill top/bottom.
  */
 
 const SIDEBAR_MIN = 240
 const SIDEBAR_MAX = 480
+/** Desktop stage floor only — mobile drawer no longer reserves STAGE_MIN. */
 const STAGE_MIN = 160
 const SASH_WIDTH = 4
 const DRAG_THRESHOLD_PX = 3
 
-/** Mobile drawer floor (content area, excluding handle). */
-const DRAWER_MIN = 180
-const DRAWER_MAX_RATIO = 0.75
-/** Visual handle bar is thin; hit target is expanded to this minimum. */
+/** Visual handle bar is thin; hit target / drawer floor is this minimum. */
 const HANDLE_HIT_MIN = 44
 
 const props = withDefaults(
@@ -85,34 +84,35 @@ function effectiveShellHeight(): number {
 }
 
 function effectiveDrawerMax(shellH = effectiveShellHeight()): number {
-  return Math.floor(shellH * DRAWER_MAX_RATIO)
+  return Math.max(0, Math.round(shellH))
 }
 
+/** Floor is the visible handle hit target; never exceed shell on short viewports. */
 function effectiveDrawerMin(shellH = effectiveShellHeight()): number {
   const max = effectiveDrawerMax(shellH)
-  const stageCap = Math.max(0, shellH - STAGE_MIN)
-  return Math.min(DRAWER_MIN, max, stageCap)
+  return Math.min(HANDLE_HIT_MIN, max)
 }
 
-/** Clamp drawer height while guaranteeing stage ≥ STAGE_MIN. */
+/** Clamp drawer height to [handleMin, shellH] — full top / full bottom allowed. */
 function clampDrawerHeight(px: number, shellH = effectiveShellHeight()): number {
   const min = effectiveDrawerMin(shellH)
   const max = effectiveDrawerMax(shellH)
-  const stageCap = Math.max(min, shellH - STAGE_MIN)
-  const ceiling = Math.min(max, stageCap)
-  return Math.max(min, Math.min(ceiling, Math.round(px)))
+  return Math.max(min, Math.min(max, Math.round(px)))
 }
 
-/** Adaptive default: ~38% of shell, never squeezing stage below STAGE_MIN. */
+/** Adaptive default: ~38% of shell (and props hint), clamped to the new range. */
 function defaultDrawerHeight(shellH = effectiveShellHeight()): number {
-  const stageCap = shellH - STAGE_MIN
-  const preferred = Math.min(Math.round(shellH * 0.38), props.drawerHeight, stageCap)
+  const preferred = Math.min(Math.round(shellH * 0.38), props.drawerHeight)
   return clampDrawerHeight(preferred, shellH)
 }
+
+/** Last shell height used for mobile drawer clamp — preserves full-top / full-bottom on resize. */
+let lastDrawerShellH = 0
 
 function initDrawerHeight() {
   if (!props.mobile) return
   height.value = defaultDrawerHeight()
+  lastDrawerShellH = effectiveShellHeight()
 }
 
 /** Read stored width; returns null for missing/illegal/out-of-[240,480] values. */
@@ -155,7 +155,24 @@ function onShellSizeChange() {
   if (sashDragging.value) return
   if (props.mobile) {
     if (!drawerDragging.value) {
-      height.value = clampDrawerHeight(height.value)
+      const shellH = effectiveShellHeight()
+      const min = effectiveDrawerMin(shellH)
+      const max = effectiveDrawerMax(shellH)
+      if (lastDrawerShellH > 0) {
+        const prevMin = effectiveDrawerMin(lastDrawerShellH)
+        const prevMax = effectiveDrawerMax(lastDrawerShellH)
+        // Keep extreme semantics across shell resize (rotate / parent grow).
+        if (height.value >= prevMax - 1) {
+          height.value = max
+        } else if (height.value <= prevMin + 1) {
+          height.value = min
+        } else {
+          height.value = clampDrawerHeight(height.value, shellH)
+        }
+      } else {
+        height.value = clampDrawerHeight(height.value, shellH)
+      }
+      lastDrawerShellH = shellH
     }
     return
   }
@@ -188,6 +205,7 @@ function onPointerUp() {
   if (!drawerDragging.value) return
   drawerDragging.value = false
   setDrawerDraggingUi(false)
+  lastDrawerShellH = effectiveShellHeight()
 }
 
 function setSashDraggingUi(on: boolean) {
@@ -276,7 +294,6 @@ onBeforeUnmount(() => {
     <section
       class="flex min-h-0 flex-1 flex-col overflow-hidden"
       :class="mobile ? 'min-w-0 border-b border-line' : 'review-shell-stage'"
-      :style="mobile ? { minHeight: `${STAGE_MIN}px` } : undefined"
       data-testid="review-shell-stage"
     >
       <slot name="stage" />
@@ -303,7 +320,7 @@ onBeforeUnmount(() => {
 
     <aside
       class="flex min-h-0 flex-col bg-surface"
-      :class="mobile ? 'w-full' : 'shrink-0'"
+      :class="mobile ? 'w-full shrink-0' : 'shrink-0'"
       :style="
         mobile
           ? {


### PR DESCRIPTION
## Summary
- Let the mobile ReviewShell drawer drag the full height range `[handle 44px, shell height]`, so users can fill the top (chat only) or fill the bottom (preview only, handle remains).
- Default open height stays ~38% of the shell (mid split); no localStorage persistence.
- Desktop horizontal sash clamp `[240, 480]` is unchanged.

## Test plan
- [x] `npx vitest run src/components/run/ReviewShell.test.ts` — 21 passed (extremes, reverse drag, resize, desktop sash)
- [x] Playwright `e2e/gate-mobile-fill.spec.ts` — 3/3 passed at 390×844 (mid-split, fill top/bottom, drag back)
- [ ] CI checks on this PR pass


Made with [Cursor](https://cursor.com)