### PR TITLE
feat(web): collapse workspace nav into a floating card with settings drill-in

### DIFF
--- a/web/e2e/notifications-center-main.ts
+++ b/web/e2e/notifications-center-main.ts
@@ -9,7 +9,7 @@ import { installIdleScrollbar } from '../src/lib/shared/idleScrollbar'
 import { installRoutePendingGuards } from '../src/lib/shared/routePending'
 import { installAuthGuard } from '../src/lib/shared/authGuard'
 import NotificationsView from '../src/views/NotificationsView.vue'
-import { sidebarNavGroups } from '../src/data/sidebarNav'
+import { shellNavPaths } from '../src/data/shellNavPaths'
 import {
   isBeforeBaseline,
   mapRunToNotification,
@@ -565,14 +565,12 @@ async function bootstrap() {
     '/gates',
     '/login',
   ])
-  const extraRoutes = sidebarNavGroups.flatMap((g) =>
-    g.items
-      .filter((item) => !known.has(item.to))
-      .map((item) => ({
-        path: item.to,
-        component: DummyPage,
-      })),
-  )
+  const extraRoutes = shellNavPaths()
+    .filter((to) => !known.has(to))
+    .map((to) => ({
+      path: to,
+      component: DummyPage,
+    }))
 
   const router = createRouter({
     history: createMemoryHistory(),

--- a/web/e2e/notifications-center.spec.ts
+++ b/web/e2e/notifications-center.spec.ts
@@ -80,10 +80,11 @@ test.describe('shell notification center (IA separation)', () => {
     await expect(page.getByTestId('nav-notifications-badge')).toHaveText('3')
     await expect(page.getByTestId('run-notifications-badge')).toHaveText('3')
 
-    // Sidebar dual entry still present alongside runs/gates
+    // Workspace dual entry: notifications + gates stay; runs live under settings chrome (plan g1.1)
     await expect(page.getByRole('link', { name: '通知' })).toBeVisible()
-    await expect(page.getByRole('link', { name: '运行' })).toBeVisible()
+    await expect(page.getByRole('link', { name: '设置' })).toBeVisible()
     await expect(page.getByRole('link', { name: '待审批' })).toBeVisible()
+    await expect(page.getByRole('link', { name: '运行' })).toHaveCount(0)
 
     await page.getByTestId('notifications-filter-unread').click()
     await expect(page.getByTestId('notifications-item')).toHaveCount(3)

--- a/web/e2e/shell-loading-main.ts
+++ b/web/e2e/shell-loading-main.ts
@@ -9,7 +9,7 @@ import { installIdleScrollbar } from '../src/lib/shared/idleScrollbar'
 import { installRoutePendingGuards } from '../src/lib/shared/routePending'
 import { installAuthGuard } from '../src/lib/shared/authGuard'
 import AppInlineError from '../src/components/ui/AppInlineError.vue'
-import { sidebarNavGroups } from '../src/data/sidebarNav'
+import { shellNavPaths } from '../src/data/shellNavPaths'
 
 installIdleScrollbar()
 
@@ -92,14 +92,12 @@ async function bootstrap() {
     },
   })
 
-  const extraRoutes = sidebarNavGroups.flatMap((g) =>
-    g.items
-      .filter((item) => item.to !== '/dashboard' && item.to !== '/runs')
-      .map((item) => ({
-        path: item.to,
-        component: DummyPage,
-      })),
-  )
+  const extraRoutes = shellNavPaths()
+    .filter((to) => to !== '/dashboard' && to !== '/runs')
+    .map((to) => ({
+      path: to,
+      component: DummyPage,
+    }))
 
   const router = createRouter({
     history: createMemoryHistory(),

--- a/web/e2e/token-analytics-main.ts
+++ b/web/e2e/token-analytics-main.ts
@@ -9,7 +9,7 @@ import { installIdleScrollbar } from '../src/lib/shared/idleScrollbar'
 import { installRoutePendingGuards } from '../src/lib/shared/routePending'
 import { installAuthGuard } from '../src/lib/shared/authGuard'
 import TokenAnalyticsView from '../src/views/TokenAnalyticsView.vue'
-import { sidebarNavGroups } from '../src/data/sidebarNav'
+import { shellNavPaths } from '../src/data/shellNavPaths'
 
 installIdleScrollbar()
 
@@ -161,14 +161,12 @@ async function bootstrap() {
   })
 
   const known = new Set(['/dashboard', '/stats', '/login'])
-  const extraRoutes = sidebarNavGroups.flatMap((g) =>
-    g.items
-      .filter((item) => !known.has(item.to))
-      .map((item) => ({
-        path: item.to,
-        component: DummyPage,
-      })),
-  )
+  const extraRoutes = shellNavPaths()
+    .filter((to) => !known.has(to))
+    .map((to) => ({
+      path: to,
+      component: DummyPage,
+    }))
 
   const router = createRouter({
     history: createMemoryHistory(),

--- a/web/e2e/token-analytics.spec.ts
+++ b/web/e2e/token-analytics.spec.ts
@@ -77,6 +77,7 @@ async function openStatsPage(page: import('@playwright/test').Page) {
   })
   await page.goto('/token-analytics.html')
   await expect(page.getByTestId('shell-main-dashboard')).toBeVisible({ timeout: 15_000 })
+  await page.getByRole('link', { name: '设置', exact: true }).click()
   await page.getByRole('link', { name: '统计', exact: true }).click()
   await expect(page.getByTestId('token-analytics-page')).toBeVisible({ timeout: 15_000 })
 }

--- a/web/e2e/workflow-favorites-main.ts
+++ b/web/e2e/workflow-favorites-main.ts
@@ -8,7 +8,7 @@ import { initLocale, setLocale } from '../src/lib/shared/locale'
 import { installIdleScrollbar } from '../src/lib/shared/idleScrollbar'
 import { installRoutePendingGuards } from '../src/lib/shared/routePending'
 import { installAuthGuard } from '../src/lib/shared/authGuard'
-import { sidebarNavGroups } from '../src/data/sidebarNav'
+import { shellNavPaths } from '../src/data/shellNavPaths'
 import { useWorkflowFavorites, WORKFLOW_FAVORITES_MAX } from '../src/lib/run/useWorkflowFavorites'
 import type { Workflow } from '../src/lib/shared/types'
 
@@ -274,14 +274,12 @@ async function bootstrap() {
     },
   })
 
-  const extraRoutes = sidebarNavGroups.flatMap((g) =>
-    g.items
-      .filter((item) => item.to !== '/dashboard' && item.to !== '/runs')
-      .map((item) => ({
-        path: item.to,
-        component: DummyPage,
-      })),
-  )
+  const extraRoutes = shellNavPaths()
+    .filter((to) => to !== '/dashboard' && to !== '/runs')
+    .map((to) => ({
+      path: to,
+      component: DummyPage,
+    }))
 
   const router = createRouter({
     history: createMemoryHistory(),

--- a/web/src/components/shell/AppShell.test.ts
+++ b/web/src/components/shell/AppShell.test.ts
@@ -180,6 +180,26 @@ describe('AppShell (no topbar + floating ball)', () => {
     wrapper.unmount()
   })
 
+  it('workspace shell uses dotted canvas and sidebar padding (plan g1.3)', () => {
+    const wrapper = mountShell()
+    expect(wrapper.find('[data-testid="app-shell-workspace"]').exists()).toBe(true)
+    expect(wrapper.find('.app-shell-dotgrid').exists()).toBe(true)
+    const slot = wrapper.find('[data-testid="app-shell-sidebar-slot"]')
+    expect(slot.classes()).toContain('py-[14px]')
+    expect(slot.classes()).toContain('pl-[14px]')
+    wrapper.unmount()
+  })
+
+  it('full pages skip dotted canvas and sidebar pad (plan g3.1)', () => {
+    routeState.meta = { full: true }
+    const wrapper = mountShell()
+    expect(wrapper.find('[data-testid="app-shell-full"]').exists()).toBe(true)
+    expect(wrapper.find('.app-shell-dotgrid').exists()).toBe(false)
+    const slot = wrapper.find('[data-testid="app-shell-sidebar-slot"]')
+    expect(slot.classes()).not.toContain('py-[14px]')
+    wrapper.unmount()
+  })
+
   it('mobile drawer stays md:hidden (g3.2 source lock)', () => {
     const src = readFileSync(
       join(dirname(fileURLToPath(import.meta.url)), 'AppShell.vue'),

--- a/web/src/components/shell/AppShell.vue
+++ b/web/src/components/shell/AppShell.vue
@@ -81,8 +81,18 @@ onUnmounted(() => stopShutdownPolling())
 </script>
 
 <template>
-  <div class="relative flex h-screen w-screen overflow-hidden bg-base text-txt">
-    <AppSidebar />
+  <div
+    class="relative flex h-screen w-screen overflow-hidden text-txt"
+    :class="full ? 'bg-base' : 'app-shell-dotgrid'"
+    :data-testid="full ? 'app-shell-full' : 'app-shell-workspace'"
+  >
+    <div
+      class="hidden h-full min-h-0 shrink-0 md:flex"
+      :class="!full && !sidebarHidden ? 'py-[14px] pl-[14px]' : ''"
+      data-testid="app-shell-sidebar-slot"
+    >
+      <AppSidebar />
+    </div>
 
     <div class="flex min-w-0 flex-1 flex-col">
       <div
@@ -130,7 +140,7 @@ onUnmounted(() => stopShutdownPolling())
         >
           <slot />
         </div>
-        <div v-else class="scroll-area safe-area-bottom h-full min-h-0 overflow-y-auto bg-base">
+        <div v-else class="scroll-area safe-area-bottom h-full min-h-0 overflow-y-auto">
           <div
             class="flex h-full min-h-0 flex-col px-4 py-4 md:px-6 md:py-6"
             :class="{ 'app-refresh-dim': dimContent }"

--- a/web/src/components/shell/AppSidebar.test.ts
+++ b/web/src/components/shell/AppSidebar.test.ts
@@ -9,6 +9,7 @@ import { __resetSidebarHiddenForTests } from '@/lib/shared/sidebarHidden'
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ path: '/dashboard', meta: {} }),
   RouterLink: { template: '<a><slot /></a>' },
 }))
 
@@ -123,6 +124,17 @@ describe('AppSidebar', () => {
     expect(aside.attributes('aria-hidden')).toBe('true')
     expect(wrapper.find('[data-testid="nav"]').exists()).toBe(true)
     expect(wrapper.html()).toContain('min-w-[232px]')
+    wrapper.unmount()
+  })
+
+  it('workspace desktop sidebar uses floating card shell (plan g1.3)', () => {
+    const wrapper = mountSidebar()
+    const aside = wrapper.find('[data-testid="app-desktop-sidebar"]')
+    expect(aside.attributes('data-floating')).toBe('true')
+    expect(aside.classes()).not.toContain('border-r')
+    const card = wrapper.find('[data-testid="app-sidebar-card"]')
+    expect(card.classes()).toContain('app-sidebar-card')
+    expect(card.classes()).toContain('bg-surface')
     wrapper.unmount()
   })
 

--- a/web/src/components/shell/AppSidebar.vue
+++ b/web/src/components/shell/AppSidebar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import AppSidebarNav from './AppSidebarNav.vue'
 import BrandLogo from './BrandLogo.vue'
@@ -16,7 +16,10 @@ import {
 
 const { t } = useI18n()
 const router = useRouter()
+const route = useRoute()
 const { user, clearUser } = useAuth()
+
+const floating = computed(() => route.meta.full !== true)
 
 const initials = computed(() => {
   const name = user.value?.username || '?'
@@ -42,13 +45,18 @@ async function onHideNav() {
 <template>
   <aside
     id="app-desktop-sidebar"
-    class="app-desktop-sidebar hidden h-full min-w-0 shrink-0 flex-col overflow-hidden bg-surface md:flex"
-    :class="sidebarHidden ? 'w-0 border-r-0' : 'w-[232px] border-r border-line'"
+    class="app-desktop-sidebar hidden h-full min-w-0 shrink-0 flex-col overflow-hidden md:flex"
+    :class="sidebarHidden ? 'w-0 border-r-0' : floating ? 'w-[232px]' : 'w-[232px] border-r border-line bg-surface'"
     data-testid="app-desktop-sidebar"
+    :data-floating="floating && !sidebarHidden ? 'true' : 'false'"
     :aria-hidden="sidebarHidden ? 'true' : undefined"
     :inert="sidebarHidden"
   >
-    <div class="flex h-full w-[232px] min-w-[232px] flex-col">
+    <div
+      class="flex h-full w-[232px] min-w-[232px] flex-col"
+      :class="floating ? 'app-sidebar-card bg-surface' : ''"
+      data-testid="app-sidebar-card"
+    >
       <div
         class="app-sidebar-brand-row flex h-14 items-center justify-between gap-2 pl-3.5 pr-2"
         data-testid="sidebar-brand-row"

--- a/web/src/components/shell/AppSidebarNav.test.ts
+++ b/web/src/components/shell/AppSidebarNav.test.ts
@@ -6,12 +6,14 @@ import common from '@/locales/zh-CN/common.json'
 import pages from '@/locales/zh-CN/pages.json'
 import nav from '@/locales/zh-CN/nav.json'
 
+const routeState = { path: '/dashboard', query: {} as Record<string, unknown>, meta: {} as Record<string, unknown> }
+
 vi.mock('vue-router', () => ({
-  useRoute: () => ({ path: '/runs', meta: {} }),
+  useRoute: () => routeState,
   RouterLink: {
     props: ['to'],
     template:
-      '<a :href="to" :data-to="to" @click="$emit(\'click\')"><slot /></a>',
+      '<a :href="typeof to === \'string\' ? to : (to.path || \'\')" :data-to="typeof to === \'string\' ? to : (to.path || \'\')" @click="$emit(\'click\')"><slot /></a>',
   },
 }))
 
@@ -100,6 +102,9 @@ beforeEach(() => {
   favMocks.displayItems.value = []
   favMocks.hydrateDisplay.mockResolvedValue(undefined)
   breakpointMocks.isMobile.value = false
+  routeState.path = '/dashboard'
+  routeState.query = {}
+  routeState.meta = {}
   vi.useFakeTimers()
 })
 
@@ -152,9 +157,15 @@ describe('AppSidebarNav', () => {
     await flushPromises()
     expect(wrapper.find('[data-testid="nav-quick-pipelines"]').exists()).toBe(false)
     expect(wrapper.text()).not.toContain('快捷流水线')
-    // Primary nav still present
+    // Primary workspace nav still present (plan g1.1)
     expect(wrapper.find('[data-to="/notifications"]').exists()).toBe(true)
     expect(wrapper.find('[data-to="/settings"]').exists()).toBe(true)
+    expect(wrapper.find('[data-to="/dashboard"]').exists()).toBe(true)
+    expect(wrapper.find('[data-to="/gates"]').exists()).toBe(true)
+    expect(wrapper.find('[data-to="/stats"]').exists()).toBe(false)
+    expect(wrapper.find('[data-to="/projects"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="nav-workspace-chrome"]').exists()).toBe(true)
+    expect(wrapper.text()).not.toContain('配置')
     wrapper.unmount()
     vi.useRealTimers()
   })
@@ -239,6 +250,67 @@ describe('AppSidebarNav', () => {
     expect(wrapper.find('[data-testid="nav-quick-pipeline-drag-handle"]').exists()).toBe(false)
     await wrapper.find('[data-testid="nav-quick-pipeline-item"]').trigger('click')
     expect(favMocks.getFavoriteWorkflow).toHaveBeenCalledWith('wf-1')
+    wrapper.unmount()
+    vi.useRealTimers()
+  })
+
+  it('settings chrome replaces workspace four items and hides quick pipelines (plan g2.1 / g1.2)', async () => {
+    routeState.path = '/projects'
+    favMocks.displayItems.value = [
+      {
+        workflowId: 'wf-1',
+        favoritedAt: 1,
+        name: '夜间回归',
+        projectId: 'p1',
+        projectName: 'checkout-service',
+        status: 'published',
+      },
+    ]
+    const wrapper = mountNav()
+    await flushPromises()
+    expect(wrapper.find('[data-testid="nav-settings-chrome"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="nav-workspace-chrome"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="nav-back-home"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="nav-back-home"]').attributes('data-to')).toBe('/dashboard')
+    expect(wrapper.find('[data-to="/projects"]').exists()).toBe(true)
+    expect(wrapper.find('[data-to="/runs"]').exists()).toBe(true)
+    expect(wrapper.find('[data-to="/stats"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="nav-settings-integrations"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="nav-quick-pipelines"]').exists()).toBe(false)
+    expect(wrapper.text()).toContain('返回首页')
+    expect(wrapper.text()).toContain('通用')
+    expect(wrapper.text()).toContain('平台规则')
+    expect(wrapper.text()).not.toContain('待审批')
+    wrapper.unmount()
+    vi.useRealTimers()
+  })
+
+  it('highlights projects for /projects/:id and general only on exact /settings (plan g2.2)', async () => {
+    routeState.path = '/projects/abc'
+    const wrapper = mountNav()
+    await flushPromises()
+    const projectLink = wrapper.find('[data-to="/projects"]')
+    expect(projectLink.classes()).toContain('active')
+    wrapper.unmount()
+
+    routeState.path = '/settings'
+    const general = mountNav()
+    await flushPromises()
+    const links = general.findAll('[data-to="/settings"]')
+    const generalLink = links.find((l) => l.text().includes('通用'))
+    expect(generalLink?.classes()).toContain('active')
+    expect(general.find('[data-to="/settings/platform-rules"]').classes()).not.toContain('active')
+    general.unmount()
+    vi.useRealTimers()
+  })
+
+  it('full pages do not insert settings chrome (plan g3.1)', async () => {
+    routeState.path = '/runs/run-1'
+    routeState.meta = { full: true }
+    const wrapper = mountNav()
+    await flushPromises()
+    expect(wrapper.find('[data-testid="nav-workspace-chrome"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="nav-settings-chrome"]').exists()).toBe(false)
     wrapper.unmount()
     vi.useRealTimers()
   })

--- a/web/src/components/shell/AppSidebarNav.vue
+++ b/web/src/components/shell/AppSidebarNav.vue
@@ -4,6 +4,13 @@ import { computed, ref, watch, onMounted, onBeforeUnmount } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Icon from '../ui/Icon.vue'
 import { sidebarNavGroups } from '@/data/sidebarNav'
+import {
+  isSettingsChrome,
+  settingsItemActive,
+  settingsItemKey,
+  settingsNavItems,
+  type SettingsNavItem,
+} from '@/data/settingsNav'
 import { usePendingGates } from '@/lib/inbox/usePendingGates'
 import { useRunTerminalNotifications } from '@/lib/run/useRunTerminalNotifications'
 import { useWorkflowFavorites } from '@/lib/run/useWorkflowFavorites'
@@ -73,6 +80,17 @@ watch(
 
 function isActive(to: string) {
   return route.path === to || route.path.startsWith(to + '/')
+}
+
+const settingsChrome = computed(() => isSettingsChrome(route.path, route.meta.full === true))
+
+function isSettingsItemActive(item: SettingsNavItem) {
+  return settingsItemActive(item, route.path, route.query)
+}
+
+function settingsLinkTo(item: SettingsNavItem) {
+  if (item.query) return { path: item.to, query: item.query }
+  return item.to
 }
 
 function onNavigate() {
@@ -195,19 +213,48 @@ function onHandlePointerDown(workflowId: string, event: PointerEvent) {
 }
 
 const primaryGroup = sidebarNavGroups[0]
-const configGroups = sidebarNavGroups.slice(1)
+const settingsItems = settingsNavItems
 </script>
 
 <template>
-  <nav class="scroll-area flex-1 overflow-y-auto px-3 py-2" data-testid="app-sidebar-nav">
-    <!-- Primary static nav (dashboard → notifications) -->
-    <div v-if="primaryGroup" class="mb-3">
-      <div
-        v-if="primaryGroup.titleKey"
-        class="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-txt3"
+  <nav
+    class="scroll-area flex-1 overflow-y-auto px-3 py-2"
+    data-testid="app-sidebar-nav"
+    :data-nav-mode="settingsChrome ? 'settings' : 'workspace'"
+  >
+    <!-- Settings chrome: back to home + category list (plan g2.1) -->
+    <div v-if="settingsChrome" class="mb-3" data-testid="nav-settings-chrome">
+      <RouterLink
+        to="/dashboard"
+        class="nav-item mb-2 text-txt3"
+        data-testid="nav-back-home"
+        @click="onNavigate"
       >
-        {{ t(primaryGroup.titleKey) }}
-      </div>
+        <Icon name="arrow-left" :size="16" />
+        <span class="flex-1 text-xs">{{ t('nav.backHome') }}</span>
+      </RouterLink>
+      <template v-for="(item, index) in settingsItems" :key="settingsItemKey(item, index)">
+        <div
+          v-if="item.groupKey"
+          class="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-txt3"
+        >
+          {{ t(item.groupKey) }}
+        </div>
+        <RouterLink
+          :to="settingsLinkTo(item)"
+          class="nav-item mb-0.5"
+          :class="{ active: isSettingsItemActive(item) }"
+          :data-testid="item.query?.integrations ? 'nav-settings-integrations' : undefined"
+          @click="onNavigate"
+        >
+          <Icon :name="item.icon" :size="17" />
+          <span class="flex-1">{{ t(item.labelKey) }}</span>
+        </RouterLink>
+      </template>
+    </div>
+
+    <!-- Workspace primary: four items (plan g1.1) -->
+    <div v-else-if="primaryGroup" class="mb-3" data-testid="nav-workspace-chrome">
       <RouterLink
         v-for="item in primaryGroup.items"
         :key="item.to"
@@ -220,14 +267,14 @@ const configGroups = sidebarNavGroups.slice(1)
         <span class="flex-1">{{ t(item.labelKey) }}</span>
         <span
           v-if="badgeFor(item.to)"
-          class="flex h-5 min-w-5 items-center justify-center rounded-full bg-accent px-1.5 text-[11px] font-semibold text-white"
+          class="force-radius-full flex h-5 min-w-5 items-center justify-center rounded-full bg-accent px-1.5 text-[11px] font-semibold text-white"
           :data-testid="item.to === '/notifications' ? 'nav-notifications-badge' : item.to === '/gates' ? 'nav-gates-badge' : undefined"
         >{{ badgeFor(item.to) }}</span>
       </RouterLink>
     </div>
 
-    <!-- Quick pipelines: only when there are favorites to show -->
-    <div v-if="displayItems.length" class="mb-3" data-testid="nav-quick-pipelines">
+    <!-- Quick pipelines: workspace only, and only when favorites exist (plan g1.2) -->
+    <div v-if="!settingsChrome && displayItems.length" class="mb-3" data-testid="nav-quick-pipelines">
       <div class="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-txt3">
         {{ t('nav.quickPipelines') }}
       </div>
@@ -288,27 +335,6 @@ const configGroups = sidebarNavGroups.slice(1)
       </div>
     </div>
 
-    <!-- Config group(s) -->
-    <div v-for="(g, gi) in configGroups" :key="'cfg-' + gi" class="mb-3">
-      <div v-if="g.titleKey" class="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-txt3">
-        {{ t(g.titleKey) }}
-      </div>
-      <RouterLink
-        v-for="item in g.items"
-        :key="item.to"
-        :to="item.to"
-        class="nav-item mb-0.5"
-        :class="{ active: isActive(item.to) }"
-        @click="onNavigate"
-      >
-        <Icon :name="item.icon" :size="17" />
-        <span class="flex-1">{{ t(item.labelKey) }}</span>
-        <span
-          v-if="badgeFor(item.to)"
-          class="flex h-5 min-w-5 items-center justify-center rounded-full bg-accent px-1.5 text-[11px] font-semibold text-white"
-        >{{ badgeFor(item.to) }}</span>
-      </RouterLink>
-    </div>
   </nav>
   <div
     v-if="dragState"

--- a/web/src/data/settingsNav.test.ts
+++ b/web/src/data/settingsNav.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isSettingsChrome,
+  settingsItemActive,
+  settingsNavItems,
+} from './settingsNav'
+import { shellNavPaths } from './shellNavPaths'
+
+describe('settingsNav (plan g2.1 / g2.2 / g2.3)', () => {
+  it('lists subnav in the confirmed order', () => {
+    expect(settingsNavItems.map((i) => i.labelKey)).toEqual([
+      'nav.projects',
+      'nav.runs',
+      'nav.stats',
+      'nav.artifacts',
+      'nav.agents',
+      'nav.sandboxes',
+      'nav.general',
+      'nav.platformRules',
+      'nav.integrations',
+    ])
+    expect(settingsNavItems.map((i) => i.to)).toEqual([
+      '/projects',
+      '/runs',
+      '/stats',
+      '/artifacts',
+      '/agents',
+      '/sandboxes',
+      '/settings',
+      '/settings/platform-rules',
+      '/settings',
+    ])
+  })
+
+  it('treats settings-state routes as chrome and skips full pages (plan g3.1)', () => {
+    expect(isSettingsChrome('/settings')).toBe(true)
+    expect(isSettingsChrome('/settings/platform-rules')).toBe(true)
+    expect(isSettingsChrome('/projects')).toBe(true)
+    expect(isSettingsChrome('/projects/abc')).toBe(true)
+    expect(isSettingsChrome('/runs')).toBe(true)
+    expect(isSettingsChrome('/dashboard')).toBe(false)
+    expect(isSettingsChrome('/gates')).toBe(false)
+    expect(isSettingsChrome('/notifications')).toBe(false)
+    expect(isSettingsChrome('/runs/rid', true)).toBe(false)
+    expect(isSettingsChrome('/sandboxes/sid/console', true)).toBe(false)
+  })
+
+  it('highlights prefix routes and exact general vs integrations (plan g2.2 / g2.3)', () => {
+    const projects = settingsNavItems[0]
+    const general = settingsNavItems.find((i) => i.labelKey === 'nav.general')!
+    const rules = settingsNavItems.find((i) => i.labelKey === 'nav.platformRules')!
+    const integ = settingsNavItems.find((i) => i.labelKey === 'nav.integrations')!
+    expect(settingsItemActive(projects, '/projects/p1', {})).toBe(true)
+    expect(settingsItemActive(projects, '/runs', {})).toBe(false)
+    expect(settingsItemActive(general, '/settings', {})).toBe(true)
+    expect(settingsItemActive(general, '/settings/platform-rules', {})).toBe(false)
+    expect(settingsItemActive(general, '/settings', { integrations: '1' })).toBe(false)
+    expect(settingsItemActive(rules, '/settings/platform-rules', {})).toBe(true)
+    expect(settingsItemActive(integ, '/settings', { integrations: '1' })).toBe(true)
+    expect(settingsItemActive(integ, '/settings', {})).toBe(false)
+  })
+
+  it('shellNavPaths includes both workspace and settings destinations', () => {
+    const paths = shellNavPaths()
+    expect(paths).toContain('/dashboard')
+    expect(paths).toContain('/settings')
+    expect(paths).toContain('/projects')
+    expect(paths).toContain('/settings/platform-rules')
+  })
+})

--- a/web/src/data/settingsNav.ts
+++ b/web/src/data/settingsNav.ts
@@ -1,0 +1,73 @@
+import type { SidebarNavItem } from './sidebarNav'
+
+export type SettingsNavItem = SidebarNavItem & {
+  exact?: boolean
+  query?: Record<string, string>
+  /** When set, a group label is rendered before this item. */
+  groupKey?: string
+}
+
+/**
+ * Settings-chrome subnav order (plan g2.1):
+ * Projects, Runs, Stats, Artifacts, Agents, Sandboxes, General, Platform rules, Integrations.
+ */
+export const settingsNavItems: SettingsNavItem[] = [
+  { to: '/projects', icon: 'folder', labelKey: 'nav.projects' },
+  { to: '/runs', icon: 'runs', labelKey: 'nav.runs' },
+  { to: '/stats', icon: 'chart', labelKey: 'nav.stats' },
+  { to: '/artifacts', icon: 'artifact', labelKey: 'nav.artifacts' },
+  { to: '/agents', icon: 'robot', labelKey: 'nav.agents' },
+  { to: '/sandboxes', icon: 'terminal', labelKey: 'nav.sandboxes' },
+  { to: '/settings', icon: 'settings', labelKey: 'nav.general', exact: true, groupKey: 'nav.groupPlatform' },
+  { to: '/settings/platform-rules', icon: 'doc', labelKey: 'nav.platformRules' },
+  {
+    to: '/settings',
+    icon: 'connector',
+    labelKey: 'nav.integrations',
+    exact: true,
+    query: { integrations: '1' },
+  },
+]
+
+export const SETTINGS_CHROME_PREFIXES = [
+  '/projects',
+  '/runs',
+  '/stats',
+  '/artifacts',
+  '/agents',
+  '/sandboxes',
+  '/settings',
+] as const
+
+/** Settings subnav on matching routes; full-page views keep workspace chrome (plan g3.1). */
+export function isSettingsChrome(path: string, full?: boolean): boolean {
+  if (full) return false
+  return SETTINGS_CHROME_PREFIXES.some((p) => path === p || path.startsWith(`${p}/`))
+}
+
+export function isIntegrationsQuery(raw: unknown): boolean {
+  if (Array.isArray(raw)) return raw.some((v) => isIntegrationsQuery(v))
+  return raw === '1' || raw === 'true'
+}
+
+export function settingsItemActive(
+  item: SettingsNavItem,
+  path: string,
+  query: Record<string, unknown> | { integrations?: unknown },
+): boolean {
+  const integrationsOn = isIntegrationsQuery((query as { integrations?: unknown }).integrations)
+  if (item.query?.integrations) {
+    return path === '/settings' && integrationsOn
+  }
+  if (item.exact) {
+    if (item.to === '/settings') return path === '/settings' && !integrationsOn
+    return path === item.to
+  }
+  return path === item.to || path.startsWith(`${item.to}/`)
+}
+
+export function settingsItemKey(item: SettingsNavItem, index: number): string {
+  if (item.query?.integrations) return 'integrations'
+  if (item.exact && item.to === '/settings') return 'general'
+  return `${item.to}-${index}`
+}

--- a/web/src/data/shellNavPaths.ts
+++ b/web/src/data/shellNavPaths.ts
@@ -1,0 +1,12 @@
+import { sidebarNavGroups } from './sidebarNav'
+import { settingsNavItems } from './settingsNav'
+
+/** Unique sidebar + settings paths for e2e dummy routers (plan g2.4 / g3.1). */
+export function shellNavPaths(): string[] {
+  return [
+    ...new Set([
+      ...sidebarNavGroups.flatMap((g) => g.items.map((i) => i.to)),
+      ...settingsNavItems.map((i) => i.to),
+    ]),
+  ]
+}

--- a/web/src/data/sidebarNav.test.ts
+++ b/web/src/data/sidebarNav.test.ts
@@ -1,36 +1,35 @@
 import { describe, expect, it } from 'vitest'
 import { sidebarNavGroups } from './sidebarNav'
 
-describe('sidebarNav', () => {
-  it('exposes dashboard and config groups', () => {
-    expect(sidebarNavGroups.length).toBeGreaterThanOrEqual(2)
-    expect(sidebarNavGroups[0].items.some((i) => i.to === '/dashboard')).toBe(true)
-    expect(sidebarNavGroups[0].items.some((i) => i.to === '/stats')).toBe(true)
-    expect(sidebarNavGroups[1].titleKey).toBe('nav.groupConfig')
-    expect(sidebarNavGroups[1].items.some((i) => i.to === '/settings')).toBe(true)
+describe('sidebarNav (plan g1.1)', () => {
+  it('workspace primary is exactly home / gates / notifications / settings', () => {
+    expect(sidebarNavGroups).toHaveLength(1)
+    expect(sidebarNavGroups[0].titleKey).toBeUndefined()
+    expect(sidebarNavGroups[0].items.map((i) => i.to)).toEqual([
+      '/dashboard',
+      '/gates',
+      '/notifications',
+      '/settings',
+    ])
   })
 
-  // plan g1.1: config group no longer exposes /integrations or /triggers
-  it('config group keeps agents/sandboxes/settings without integrations or triggers', () => {
-    const configTos = sidebarNavGroups[1].items.map((i) => i.to)
-    expect(configTos).toEqual(['/agents', '/sandboxes', '/settings'])
-    expect(configTos).not.toContain('/integrations')
-    expect(configTos).not.toContain('/triggers')
-  })
-
-  it('does not expose a global /board entry', () => {
+  it('does not expose collapsed pages or config group as workspace primary', () => {
     const allTos = sidebarNavGroups.flatMap((g) => g.items.map((i) => i.to))
+    expect(allTos).not.toContain('/stats')
+    expect(allTos).not.toContain('/projects')
+    expect(allTos).not.toContain('/runs')
+    expect(allTos).not.toContain('/artifacts')
+    expect(allTos).not.toContain('/agents')
+    expect(allTos).not.toContain('/sandboxes')
     expect(allTos).not.toContain('/board')
-    expect(allTos).toContain('/projects')
+    expect(allTos).not.toContain('/integrations')
+    expect(allTos).not.toContain('/triggers')
+    expect(sidebarNavGroups.some((g) => g.titleKey === 'nav.groupConfig')).toBe(false)
   })
 
-  it('exposes independent /notifications next to runs/gates without replacing them', () => {
-    const primary = sidebarNavGroups[0].items.map((i) => i.to)
-    expect(primary).toContain('/notifications')
-    expect(primary).toContain('/runs')
-    expect(primary).toContain('/gates')
-    expect(sidebarNavGroups[0].items.find((i) => i.to === '/notifications')?.labelKey).toBe(
-      'nav.notifications',
-    )
+  it('keeps notifications and gates label keys for badges (plan g1.2)', () => {
+    const items = sidebarNavGroups[0].items
+    expect(items.find((i) => i.to === '/notifications')?.labelKey).toBe('nav.notifications')
+    expect(items.find((i) => i.to === '/gates')?.labelKey).toBe('nav.gates')
   })
 })

--- a/web/src/data/sidebarNav.ts
+++ b/web/src/data/sidebarNav.ts
@@ -1,24 +1,13 @@
 export type SidebarNavItem = { to: string; icon: string; labelKey: string }
 export type SidebarNavGroup = { titleKey?: string; items: SidebarNavItem[] }
 
+/** Workspace primary nav: Home / Gates / Notifications / Settings only (plan g1.1). */
 export const sidebarNavGroups: SidebarNavGroup[] = [
   {
     items: [
       { to: '/dashboard', icon: 'dashboard', labelKey: 'nav.dashboard' },
-      { to: '/stats', icon: 'chart', labelKey: 'nav.stats' },
-      { to: '/projects', icon: 'folder', labelKey: 'nav.projects' },
-      { to: '/runs', icon: 'runs', labelKey: 'nav.runs' },
       { to: '/gates', icon: 'gate', labelKey: 'nav.gates' },
-      { to: '/artifacts', icon: 'artifact', labelKey: 'nav.artifacts' },
       { to: '/notifications', icon: 'bell', labelKey: 'nav.notifications' },
-    ],
-  },
-  {
-    titleKey: 'nav.groupConfig',
-    items: [
-      { to: '/agents', icon: 'robot', labelKey: 'nav.agents' },
-      { to: '/sandboxes', icon: 'terminal', labelKey: 'nav.sandboxes' },
-      // plan g1.1: integrations & triggers removed from sidebar; integrations live in settings modal
       { to: '/settings', icon: 'settings', labelKey: 'nav.settings' },
     ],
   },

--- a/web/src/locales/en/nav.json
+++ b/web/src/locales/en/nav.json
@@ -12,10 +12,14 @@
     "quickPipelines": "Quick pipelines",
     "quickPipelinesEmpty": "Star a pipeline to save a shortcut",
     "groupConfig": "Configuration",
+    "groupPlatform": "Platform",
     "agents": "Agent studio",
     "sandboxes": "Sandboxes",
     "integrations": "Integrations",
     "triggers": "Triggers",
-    "settings": "Settings"
+    "settings": "Settings",
+    "general": "General",
+    "platformRules": "Platform rules",
+    "backHome": "Back to home"
   }
 }

--- a/web/src/locales/zh-CN/nav.json
+++ b/web/src/locales/zh-CN/nav.json
@@ -12,10 +12,14 @@
     "quickPipelines": "快捷流水线",
     "quickPipelinesEmpty": "在流水线上点星标即可收藏",
     "groupConfig": "配置",
+    "groupPlatform": "平台配置",
     "agents": "Agent 管理",
     "sandboxes": "沙箱",
     "integrations": "集成",
     "triggers": "触发器",
-    "settings": "设置"
+    "settings": "设置",
+    "general": "通用",
+    "platformRules": "平台规则",
+    "backHome": "返回首页"
   }
 }

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -94,6 +94,15 @@ body {
   border-radius: 9999px !important;
 }
 
+/* Floating sidebar card + capsule nav (plan g1.3) — beat universal radius:0 */
+.force-radius-xl {
+  border-radius: 16px !important;
+}
+
+.force-radius-pill {
+  border-radius: 10px !important;
+}
+
 /* ghost scrollbar — idle-invisible (align AppModal / approved page.html) */
 * {
   scrollbar-width: thin;
@@ -140,6 +149,26 @@ html:not(.light) *.is-scrolling::-webkit-scrollbar {
   background: rgb(var(--c-base));
 }
 
+/* Workspace desktop: dotted canvas around the floating sidebar card (plan g1.3 / g3.1). */
+.app-shell-dotgrid {
+  background-color: rgb(var(--c-base));
+  background-image: radial-gradient(rgb(var(--c-line)) 0.85px, transparent 0.85px);
+  background-size: 16px 16px;
+}
+
+.app-sidebar-card {
+  border-radius: 16px !important;
+  box-shadow:
+    0 8px 28px rgb(0 0 0 / 22%),
+    0 0 0 1px rgb(var(--c-line));
+}
+
+html.light .app-sidebar-card {
+  box-shadow:
+    0 8px 28px rgba(40, 50, 70, 0.1),
+    0 0 0 1px rgba(40, 50, 70, 0.04);
+}
+
 @layer components {
   .card {
     @apply rounded-lg border border-line bg-surface;
@@ -174,11 +203,12 @@ html:not(.light) *.is-scrolling::-webkit-scrollbar {
     @apply inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-line bg-elevated px-2 py-0.5 text-xs text-txt2;
   }
   .nav-item {
-    @apply flex items-center gap-2.5 rounded-md px-3 py-2 text-sm text-txt2 transition
+    @apply flex items-center gap-2.5 px-3 py-[9px] text-sm text-txt2 transition
       hover:bg-elevated hover:text-txt;
+    border-radius: 10px !important;
   }
   .nav-item.active {
-    @apply bg-accent-dim text-txt;
+    @apply bg-elevated font-semibold text-txt;
   }
   /* Utility marker for scroll regions; idle-invisible comes from global rules above. */
   .scroll-area {

--- a/web/src/views/ProjectDetailView.metaLayout.test.ts
+++ b/web/src/views/ProjectDetailView.metaLayout.test.ts
@@ -70,7 +70,7 @@ describe('ProjectDetailView meta tab keeps existing chrome and save semantics (g
   })
 
   it('does not change AppShell height chain; short tabs use fill scroll (plan g2.1)', () => {
-    expect(shellSrc).toMatch(/class="relative flex h-screen w-screen overflow-hidden bg-base text-txt"/)
+    expect(shellSrc).toMatch(/class="relative flex h-screen w-screen overflow-hidden text-txt"/)
     expect(shellSrc).toMatch(/<main[\s\S]*class="relative min-h-0 flex-1 overflow-hidden"/)
     expect(detailSrc).toMatch(/tab === 'cronJobs'[\s\S]*?class="scroll-area flex min-h-0 flex-1 flex-col overflow-y-auto"/)
     expect(detailSrc).toMatch(/tab === 'notify' && project[\s\S]*?class="scroll-area min-h-0 flex-1 overflow-y-auto"/)


### PR DESCRIPTION
Keep only Home/Gates/Notifications/Settings on the workspace chrome, restyle the desktop sidebar as a floating card, and switch the same card to a back-home + category list once the user enters settings-state routes.

Co-authored-by: Cursor <cursoragent@cursor.com>
