### PR TITLE
fix(web): clear in-scope right-angle borders with role radius tokens

### DIFF
--- a/web/src/components/agent/AgentChatTester.vue
+++ b/web/src/components/agent/AgentChatTester.vue
@@ -686,7 +686,7 @@ const toolIcon: Record<string, string> = { completed: 'check', failed: 'close', 
               <span v-if="launchMode === 'empty'" class="h-1.5 w-1.5 rounded-full bg-white" />
             </span>
             <div class="flex items-start gap-2.5 pr-6">
-              <span class="flex h-8 w-8 shrink-0 items-center justify-center border border-line bg-elevated text-txt2" :class="launchMode === 'empty' ? 'border-accent/35 bg-accent/15 text-accent-2' : ''">
+              <span class="rounded-full flex h-8 w-8 shrink-0 items-center justify-center border border-line bg-elevated text-txt2" :class="launchMode === 'empty' ? 'border-accent/35 bg-accent/15 text-accent-2' : ''">
                 <Icon name="folder" :size="16" />
               </span>
               <div>
@@ -710,7 +710,7 @@ const toolIcon: Record<string, string> = { completed: 'check', failed: 'close', 
               <span v-if="launchMode === 'clone'" class="h-1.5 w-1.5 rounded-full bg-white" />
             </span>
             <div class="flex items-start gap-2.5 pr-6">
-              <span class="flex h-8 w-8 shrink-0 items-center justify-center border border-line bg-elevated text-txt2" :class="launchMode === 'clone' ? 'border-accent/35 bg-accent/15 text-accent-2' : ''">
+              <span class="rounded-full flex h-8 w-8 shrink-0 items-center justify-center border border-line bg-elevated text-txt2" :class="launchMode === 'clone' ? 'border-accent/35 bg-accent/15 text-accent-2' : ''">
                 <Icon name="git" :size="16" />
               </span>
               <div>
@@ -786,7 +786,7 @@ const toolIcon: Record<string, string> = { completed: 'check', failed: 'close', 
               />
               <div
                 v-else
-                class="flex max-w-[200px] items-center gap-2 border border-line bg-elevated px-2 py-1.5"
+                class="rounded-md flex max-w-[200px] items-center gap-2 border border-line bg-elevated px-2 py-1.5"
                 data-testid="tester-history-file-chip"
                 :title="attachmentDisplayName(im, ii)"
               >
@@ -878,7 +878,7 @@ const toolIcon: Record<string, string> = { completed: 'check', failed: 'close', 
           />
           <div
             v-else
-            class="flex h-14 max-w-[160px] items-center gap-1.5 border border-line bg-elevated px-2"
+            class="rounded-lg flex h-14 max-w-[160px] items-center gap-1.5 border border-line bg-elevated px-2"
             data-testid="tester-pending-file-chip"
             :title="attachmentDisplayName(im, ii)"
           >

--- a/web/src/components/agent/AgentCreateWizard.vue
+++ b/web/src/components/agent/AgentCreateWizard.vue
@@ -62,13 +62,13 @@ const {
     <div v-if="open" class="wiz-root fixed inset-0 z-50 flex items-center justify-center p-4">
       <div class="absolute inset-0 bg-black/70" @click="close" />
       <div
-        class="wiz-modal relative z-10 flex w-full flex-col overflow-hidden border border-line bg-surface shadow-card"
+        class="rounded-xl wiz-modal relative z-10 flex w-full flex-col overflow-hidden border border-line bg-surface shadow-card"
         style="width: min(980px, 100%); height: min(700px, 94vh); border-radius: 16px"
         role="dialog"
         aria-modal="true"
       >
         <div class="wiz-head relative flex h-16 shrink-0 items-center gap-3.5 border-b border-line px-5">
-          <div class="hero-mark grid h-9 w-9 shrink-0 place-items-center border border-accent/55 text-accent-2">
+          <div class="rounded-md hero-mark grid h-9 w-9 shrink-0 place-items-center border border-accent/55 text-accent-2">
             <Icon name="robot" :size="20" />
           </div>
           <div class="min-w-0 flex-1">
@@ -132,7 +132,7 @@ const {
                     <input
                       id="wiz-name-input"
                       v-model="draft.name"
-                      class="w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent"
+                      class="rounded-md w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent"
                       :placeholder="t('pages.agentStudio.dialogs.createPlaceholder')"
                       @input="nameError = ''"
                     />
@@ -145,7 +145,7 @@ const {
                     <textarea
                       v-model="draft.description"
                       rows="3"
-                      class="w-full resize-y border border-line bg-base px-3 py-2 font-mono text-[12px] leading-6 text-txt outline-none focus:border-accent"
+                      class="rounded-md w-full resize-y border border-line bg-base px-3 py-2 font-mono text-[12px] leading-6 text-txt outline-none focus:border-accent"
                       :placeholder="t('pages.agentStudio.wizard.basics.descPlaceholder')"
                     />
                     <p class="mt-1.5 text-[11px] text-txt3">
@@ -161,7 +161,7 @@ const {
                       v-for="b in ACP_BACKENDS"
                       :key="b.id"
                       type="button"
-                      class="border px-3 py-3.5 text-center transition"
+                      class="rounded-lg border px-3 py-3.5 text-center transition"
                       :class="
                         draft.acpBackend === b.id
                           ? 'border-accent bg-accent-dim'
@@ -189,7 +189,7 @@ const {
                         role="radio"
                         :aria-checked="currentRegion === option.id"
                         :aria-label="`${t(option.labelKey)} (${option.id})`"
-                        class="border px-3 py-3 text-left transition"
+                        class="rounded-lg border px-3 py-3 text-left transition"
                         :class="
                           currentRegion === option.id
                             ? 'border-accent bg-accent-dim'
@@ -251,7 +251,7 @@ const {
                     <span
                       v-for="item in reviewItems"
                       :key="item.key"
-                      class="inline-flex items-center gap-1 border px-2 py-1 text-[11px]"
+                      class="rounded-md inline-flex items-center gap-1 border px-2 py-1 text-[11px]"
                       :class="chipClass(item.kind)"
                     >
                       {{ t(item.labelKey) }}
@@ -260,7 +260,7 @@ const {
                   </div>
                   <div
                     v-if="showAuthReminder"
-                    class="mt-4 border border-warn/35 bg-warn/10 px-3 py-2.5 text-[12px] leading-5 text-txt2"
+                    class="rounded-lg mt-4 border border-warn/35 bg-warn/10 px-3 py-2.5 text-[12px] leading-5 text-txt2"
                     role="status"
                   >
                     {{ t('pages.agentStudio.wizard.review.authReminderDetail') }}
@@ -296,7 +296,7 @@ const {
         </div>
 
         <div v-if="creating" class="absolute inset-0 z-20 grid place-items-center bg-black/50">
-          <div class="border border-line bg-surface px-6 py-4 text-[13px] text-txt2">
+          <div class="rounded-lg border border-line bg-surface px-6 py-4 text-[13px] text-txt2">
             {{ t('pages.agentStudio.wizard.creating') }}…
           </div>
         </div>
@@ -313,7 +313,7 @@ const {
       <div v-if="showAcpConfirm" class="fixed inset-0 z-[60] flex items-center justify-center p-4">
         <div class="absolute inset-0 bg-black/60" @click="cancelAcpSwitch" />
         <div
-          class="relative z-10 w-full max-w-[420px] border border-line bg-surface p-5 shadow-card"
+          class="rounded-xl relative z-10 w-full max-w-[420px] border border-line bg-surface p-5 shadow-card"
           style="border-radius: 16px"
         >
           <h3 class="m-0 text-[15px] font-semibold text-txt">
@@ -434,6 +434,7 @@ const {
   flex-shrink: 0;
   margin-top: 2px;
   border: 1.5px solid rgb(var(--c-line-strong));
+  border-radius: 9999px;
   background: transparent;
   display: grid;
   place-items: center;

--- a/web/src/components/agent/AgentDataPanel.vue
+++ b/web/src/components/agent/AgentDataPanel.vue
@@ -326,7 +326,7 @@ const showSkeleton = computed(
         v-if="loadDenied"
         role="status"
         data-testid="agent-data-denied"
-        class="border border-warn/40 bg-warn/10 px-5 py-10 text-center"
+        class="rounded-lg border border-warn/40 bg-warn/10 px-5 py-10 text-center"
       >
         <Icon name="lock" :size="22" class="mx-auto mb-3 text-warn" />
         <h3 class="text-sm font-semibold text-txt">{{ t('common.asyncState.permissionDeniedTitle') }}</h3>
@@ -339,7 +339,7 @@ const showSkeleton = computed(
         v-else-if="loadFailed"
         role="status"
         data-testid="agent-data-failed"
-        class="border border-err/40 bg-err/10 px-5 py-10 text-center"
+        class="rounded-lg border border-err/40 bg-err/10 px-5 py-10 text-center"
       >
         <h3 class="text-sm font-semibold text-txt">{{ t('common.asyncState.loadFailedTitle') }}</h3>
         <p class="mt-1 text-xs text-txt2">{{ t('common.asyncState.loadFailedDesc') }}</p>
@@ -479,7 +479,7 @@ const showSkeleton = computed(
         </p>
         <div
           v-if="showSkeleton"
-          class="overflow-x-auto border border-line"
+          class="rounded-lg overflow-x-auto border border-line"
           data-testid="agent-data-jobs-skeleton"
           aria-hidden="true"
         >

--- a/web/src/components/agent/AgentEnvPanel.vue
+++ b/web/src/components/agent/AgentEnvPanel.vue
@@ -138,7 +138,7 @@ watch(
     </div>
     <div v-else class="scroll-area flex-1 space-y-2 overflow-y-auto p-4">
       <div
-        class="callout mb-3 border border-dashed border-accent/45 bg-accent-dim/40 px-3 py-2.5 text-[12px] leading-6 text-txt2"
+        class="rounded-lg callout mb-3 border border-dashed border-accent/45 bg-accent-dim/40 px-3 py-2.5 text-[12px] leading-6 text-txt2"
         data-test="env-custom-config-callout"
       >
         {{ t('pages.agentStudio.env.customConfigCallout', { path: settingsPath }) }}
@@ -192,7 +192,7 @@ watch(
           <button class="text-txt3 hover:text-err" @click="draft.env.splice(i, 1)"><Icon name="close" :size="14" /></button>
         </div>
       </template>
-      <div v-if="currentRegionPolicy" class="border border-accent/30 bg-accent-dim/40 p-3">
+      <div v-if="currentRegionPolicy" class="rounded-lg border border-accent/30 bg-accent-dim/40 p-3">
         <div class="mb-2 text-[11px] text-txt3">{{ t('pages.agentStudio.region.managedByAcp') }}</div>
         <div class="flex items-center gap-1.5">
           <input :value="currentRegionPolicy.regionEnvKey" readonly :aria-label="t('pages.agentStudio.region.managedKey')" class="w-1/3 rounded border border-line bg-elevated px-2 py-1.5 font-mono text-[12px] text-txt3" />

--- a/web/src/components/agent/AgentFilesPanel.vue
+++ b/web/src/components/agent/AgentFilesPanel.vue
@@ -360,7 +360,7 @@ defineExpose({
               <span>{{ t('common.format.chars', { n: currentFile.content.length }) }}</span>
               <span
                 v-if="!isMobile && isMdPath(currentFile.path)"
-                class="border border-line bg-elevated px-1.5 text-[10px] text-txt2"
+                class="rounded-md border border-line bg-elevated px-1.5 text-[10px] text-txt2"
               >{{ t('pages.agentStudio.explorer.markdownBadge') }}</span>
               <span class="ml-auto truncate font-mono">{{ currentFile.path }}</span>
             </div>
@@ -420,7 +420,7 @@ defineExpose({
       <div
         v-if="isMobile && explorerMore"
         data-test="explorer-more-menu"
-        class="fixed z-[9999] min-w-[180px] border border-line bg-elevated py-1 shadow-card"
+        class="rounded-lg fixed z-[9999] min-w-[180px] border border-line bg-elevated py-1 shadow-card"
         :style="explorerMoreStyle"
         @click.stop
       >

--- a/web/src/components/agent/AgentMcpPanel.vue
+++ b/web/src/components/agent/AgentMcpPanel.vue
@@ -140,7 +140,7 @@ watch(
     </div>
 
     <div v-else class="scroll-area flex-1 space-y-3 overflow-y-auto p-4">
-      <div class="flex flex-wrap items-center gap-1.5 border border-line bg-elevated p-2.5" data-test="mcp-ops-bar">
+      <div class="rounded-lg flex flex-wrap items-center gap-1.5 border border-line bg-elevated p-2.5" data-test="mcp-ops-bar">
         <span class="mr-1 text-[11px] text-txt3">{{ t('pages.agentStudio.mcp.quickAddLabel') }}</span>
         <button
           v-if="!hasArtifactStore"
@@ -245,12 +245,12 @@ watch(
 
         <div
           v-if="isPlatformPresetName(m.name)"
-          class="mt-2.5 border border-dashed border-ok/35 bg-ok/5 p-2 text-[10.5px] leading-5 text-txt2"
+          class="rounded-lg mt-2.5 border border-dashed border-ok/35 bg-ok/5 p-2 text-[10.5px] leading-5 text-txt2"
           data-test="mcp-scope-note"
         >
           {{ t(`pages.agentStudio.mcp.scopeNote.${platformPresetKind(m.name)}`) }}
         </div>
-        <div v-else-if="isLegacyPmLeaderName(m.name)" class="mt-2.5 flex items-start gap-2 border border-dashed border-warn/40 bg-warn/10 p-2 text-[10.5px] leading-5 text-warn">
+        <div v-else-if="isLegacyPmLeaderName(m.name)" class="rounded-lg mt-2.5 flex items-start gap-2 border border-dashed border-warn/40 bg-warn/10 p-2 text-[10.5px] leading-5 text-warn">
           <Icon name="alert" :size="14" class="mt-0.5 shrink-0 text-warn" />
           <div>{{ t('pages.agentStudio.mcp.legacyPmEntryBadge') }}</div>
         </div>

--- a/web/src/components/agent/AgentMetaPanel.vue
+++ b/web/src/components/agent/AgentMetaPanel.vue
@@ -189,7 +189,7 @@ const derivedPaths = computed(() => {
             v-for="tile in metaGroupTiles"
             :key="tile.id"
             type="button"
-            class="flex min-h-[56px] items-start gap-2.5 border px-3 py-2.5 text-left transition"
+            class="rounded-lg flex min-h-[56px] items-start gap-2.5 border px-3 py-2.5 text-left transition"
             :class="tile.selected
               ? 'border-accent bg-accent-dim text-txt shadow-[inset_0_0_0_1px_rgba(99,102,241,0.25)]'
               : 'border-line bg-base text-txt2 hover:border-line-strong hover:bg-elevated hover:text-txt'"
@@ -210,7 +210,7 @@ const derivedPaths = computed(() => {
             </span>
           </button>
         </div>
-        <p v-else class="border border-dashed border-line px-3 py-3 text-[12px] text-txt3">
+        <p v-else class="rounded-lg border border-dashed border-line px-3 py-3 text-[12px] text-txt3">
           {{ t('pages.agentStudio.org.noGroups') }}
         </p>
       </div>
@@ -230,7 +230,7 @@ const derivedPaths = computed(() => {
             v-for="b in ACP_BACKENDS"
             :key="b.id"
             type="button"
-            class="border px-2 py-3 text-center transition"
+            class="rounded-lg border px-2 py-3 text-center transition"
             :class="draft.acpBackend === b.id ? 'border-accent bg-accent-dim text-txt' : 'border-line bg-base text-txt2 hover:border-line-strong'"
             @click="selectAcpBackend(b.id)"
           >
@@ -242,10 +242,10 @@ const derivedPaths = computed(() => {
       <div v-if="showMetaRegionBlock" class="border-t border-dashed border-line pt-4">
         <div class="text-[12px] font-medium text-txt2">
           {{ t('pages.agentStudio.meta.regionTitle') }}
-          <span class="ml-1.5 inline-block border border-accent/30 bg-accent-dim px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-accent-2">{{ t('pages.agentStudio.meta.regionNewBadge') }}</span>
+          <span class="rounded-md ml-1.5 inline-block border border-accent/30 bg-accent-dim px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-accent-2">{{ t('pages.agentStudio.meta.regionNewBadge') }}</span>
         </div>
         <p class="mb-2 text-[11px] text-txt3">{{ t('pages.agentStudio.meta.regionDesc') }}</p>
-        <p v-if="specialRegion" class="mb-2 border border-warn/35 bg-warn/10 px-2.5 py-2 font-mono text-[11px] text-warn">
+        <p v-if="specialRegion" class="mb-2 rounded-lg border border-warn/35 bg-warn/10 px-2.5 py-2 font-mono text-[11px] text-warn">
           {{ t('pages.agentStudio.region.special', { value: specialRegion }) }}
         </p>
         <div class="grid max-w-md grid-cols-2 gap-2" role="radiogroup" :aria-label="t('pages.agentStudio.region.title')">
@@ -253,7 +253,7 @@ const derivedPaths = computed(() => {
             v-for="r in metaRegionOptions"
             :key="r.id"
             type="button"
-            class="border px-2 py-3 text-center transition"
+            class="rounded-lg border px-2 py-3 text-center transition"
             :class="displayRegion === r.id ? 'border-accent bg-accent-dim text-txt' : 'border-line bg-base text-txt2 hover:border-line-strong'"
             role="radio"
             :aria-checked="displayRegion === r.id"

--- a/web/src/components/agent/AgentOrgSidebar.vue
+++ b/web/src/components/agent/AgentOrgSidebar.vue
@@ -355,7 +355,7 @@ function onDrop(e: DragEvent, row: OrgTreeRow) {
             class="ml-1 flex w-auto min-w-[18px] shrink-0 items-center justify-end"
           >
             <span
-              class="inline-flex h-4 min-w-[18px] items-center justify-end border border-line bg-base px-1 text-[10px] font-semibold tabular-nums text-txt3"
+              class="rounded-md inline-flex h-4 min-w-[18px] items-center justify-end border border-line bg-base px-1 text-[10px] font-semibold tabular-nums text-txt3"
             >{{ row.count }}</span>
           </span>
         </template>
@@ -388,7 +388,7 @@ function onDrop(e: DragEvent, row: OrgTreeRow) {
             class="ml-1 flex w-auto min-w-[18px] shrink-0 items-center justify-end"
           >
             <span
-              class="inline-flex h-4 min-w-[18px] items-center justify-end border border-line bg-base px-1 text-[10px] font-semibold tabular-nums text-txt3"
+              class="rounded-md inline-flex h-4 min-w-[18px] items-center justify-end border border-line bg-base px-1 text-[10px] font-semibold tabular-nums text-txt3"
             >{{ row.count }}</span>
           </span>
         </template>
@@ -415,7 +415,7 @@ function onDrop(e: DragEvent, row: OrgTreeRow) {
                   <span class="truncate text-txt">{{ row.name }}</span>
                   <span
                     v-if="row.multi"
-                    class="shrink-0 border border-accent-2/35 bg-accent/15 px-1 text-[9px] font-bold uppercase tracking-wide text-accent-2"
+                    class="rounded-md shrink-0 border border-accent-2/35 bg-accent/15 px-1 text-[9px] font-bold uppercase tracking-wide text-accent-2"
                   >{{ t('pages.agentStudio.org.multiGroup') }}</span>
                 </span>
               </span>
@@ -435,7 +435,7 @@ function onDrop(e: DragEvent, row: OrgTreeRow) {
       />
       <div
         v-if="ctx?.open"
-        class="fixed z-[9999] min-w-[180px] border border-line bg-elevated py-1 shadow-card"
+        class="rounded-lg fixed z-[9999] min-w-[180px] border border-line bg-elevated py-1 shadow-card"
         data-org-ctx-menu
         :data-org-ctx-kind="ctx.kind"
         :style="{ left: ctx.x + 'px', top: ctx.y + 'px' }"
@@ -488,7 +488,7 @@ function onDrop(e: DragEvent, row: OrgTreeRow) {
             {{ t('pages.agentStudio.org.assignProject') }}
             <span
               data-org-ctx-new
-              class="ml-auto border border-ok/40 px-1 text-[9px] font-bold uppercase tracking-wide text-ok"
+              class="rounded-md ml-auto border border-ok/40 px-1 text-[9px] font-bold uppercase tracking-wide text-ok"
             >{{ t('pages.agentStudio.org.assignNewBadge') }}</span>
           </button>
           <div data-org-ctx-sep class="my-1 h-px bg-line" />

--- a/web/src/components/agent/CreateAgentTeamWizard.vue
+++ b/web/src/components/agent/CreateAgentTeamWizard.vue
@@ -299,13 +299,13 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
     <div v-if="open" class="wiz-root fixed inset-0 z-50 flex items-center justify-center p-4">
       <div class="absolute inset-0 bg-black/70" @click="close" />
       <div
-        class="wiz-modal relative z-10 flex w-full flex-col overflow-hidden border border-line bg-surface shadow-card"
+        class="rounded-xl wiz-modal relative z-10 flex w-full flex-col overflow-hidden border border-line bg-surface shadow-card"
         style="width: min(980px, 100%); height: min(700px, 94vh); border-radius: 16px"
         role="dialog"
         aria-modal="true"
       >
         <div class="wiz-head relative flex h-16 shrink-0 items-center gap-3.5 border-b border-line px-5">
-          <div class="hero-mark grid h-9 w-9 shrink-0 place-items-center border border-accent/55 text-accent-2">
+          <div class="rounded-md hero-mark grid h-9 w-9 shrink-0 place-items-center border border-accent/55 text-accent-2">
             <Icon name="user" :size="20" />
           </div>
           <div class="min-w-0 flex-1">
@@ -373,7 +373,7 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
                       <input
                         id="team-wiz-project"
                         v-model="draft.projectName"
-                        class="w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent"
+                        class="rounded-md w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent"
                         @input="onProjectInput"
                       />
                     </label>
@@ -384,7 +384,7 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
                       </span>
                       <input
                         v-model="draft.prefix"
-                        class="w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent"
+                        class="rounded-md w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent"
                         @input="draft.prefixTouched = true; syncDerivedNames(draft)"
                       />
                     </label>
@@ -394,7 +394,7 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
                       <span class="mb-1.5 block text-[12px] font-medium text-txt2">{{ t('pages.agentStudio.teamWizard.team.rootGroup') }}</span>
                       <input
                         v-model="draft.rootGroupName"
-                        class="w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent"
+                        class="rounded-md w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent"
                         @input="draft.rootTouched = true"
                       />
                     </label>
@@ -402,7 +402,7 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
                       <span class="mb-1.5 block text-[12px] font-medium text-txt2">{{ t('pages.agentStudio.teamWizard.team.pipelineGroup') }}</span>
                       <input
                         v-model="draft.pipelineGroupName"
-                        class="w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent"
+                        class="rounded-md w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent"
                         @input="draft.pipelineTouched = true"
                       />
                       <p class="mt-1 text-[11px] text-txt3">{{ t('pages.agentStudio.teamWizard.team.pipelineHint') }}</p>
@@ -415,7 +415,7 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
                     </span>
                     <input
                       v-model="draft.pmName"
-                      class="w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent"
+                      class="rounded-md w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent"
                       @input="draft.pmTouched = true"
                     />
                   </label>
@@ -427,12 +427,12 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
                     <textarea
                       v-model="draft.background"
                       rows="6"
-                      class="w-full resize-y border border-line bg-base px-3 py-2 text-[13px] leading-6 text-txt outline-none focus:border-accent"
+                      class="rounded-md w-full resize-y border border-line bg-base px-3 py-2 text-[13px] leading-6 text-txt outline-none focus:border-accent"
                       :placeholder="t('pages.agentStudio.teamWizard.team.backgroundPlaceholder')"
                     />
                     <p class="mt-1.5 text-[11px] text-txt3">{{ t('pages.agentStudio.teamWizard.team.backgroundHint') }}</p>
                   </label>
-                  <div class="mt-4 border border-accent/35 bg-accent-dim/40 px-3 py-2.5 text-[12px] text-accent-2">
+                  <div class="rounded-lg mt-4 border border-accent/35 bg-accent-dim/40 px-3 py-2.5 text-[12px] text-accent-2">
                     {{ previewLine }}
                   </div>
                   <p v-if="fieldError" class="mt-3 text-[12px] text-err">{{ fieldError }}</p>
@@ -445,7 +445,7 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
                       v-for="b in ACP_BACKENDS"
                       :key="b.id"
                       type="button"
-                      class="border px-3 py-3.5 text-center transition"
+                      class="rounded-lg border px-3 py-3.5 text-center transition"
                       :class="draft.acpBackend === b.id ? 'border-accent bg-accent-dim' : 'border-line bg-base hover:border-line-strong'"
                       @click="selectAcp(b.id)"
                     >
@@ -460,7 +460,7 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
                         v-for="option in regionPolicy.options"
                         :key="option.id"
                         type="button"
-                        class="border px-3 py-3 text-left transition"
+                        class="rounded-lg border px-3 py-3 text-left transition"
                         :class="currentRegion === option.id ? 'border-accent bg-accent-dim' : 'border-line bg-base'"
                         @click="selectRegion(option.id)"
                       >
@@ -493,7 +493,7 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
                     <span class="mb-1.5 block text-[12px] font-medium text-txt2">{{ t('pages.agentStudio.teamWizard.git.url') }}</span>
                     <input
                       v-model="draft.gitUrl"
-                      class="w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent"
+                      class="rounded-md w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent"
                       placeholder="https://github.com/org/repo.git"
                     />
                   </label>
@@ -512,7 +512,7 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
                   <div
                     v-for="(m, i) in draft.mcp"
                     :key="i"
-                    class="mb-3 border border-line bg-elevated p-3"
+                    class="rounded-lg mb-3 border border-line bg-elevated p-3"
                   >
                     <div class="mb-2 flex items-center justify-between gap-2">
                       <span class="text-[12px] font-semibold text-txt">MCP #{{ i + 1 }}</span>
@@ -523,12 +523,12 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
                     <div class="mb-2 grid gap-2 md:grid-cols-2">
                       <input
                         v-model="m.name"
-                        class="border border-line bg-base px-2 py-1.5 text-[12px] text-txt outline-none focus:border-accent"
+                        class="rounded-md border border-line bg-base px-2 py-1.5 text-[12px] text-txt outline-none focus:border-accent"
                         :placeholder="t('pages.agentStudio.teamWizard.mcp.namePh')"
                       />
                       <select
                         v-model="m.transport"
-                        class="border border-line bg-base px-2 py-1.5 text-[12px] text-txt"
+                        class="rounded-md border border-line bg-base px-2 py-1.5 text-[12px] text-txt"
                       >
                         <option value="url">HTTP (url)</option>
                         <option value="command">stdio</option>
@@ -537,7 +537,7 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
                     <template v-if="m.transport === 'url'">
                       <input
                         v-model="m.url"
-                        class="mb-2 w-full border border-line bg-base px-2 py-1.5 font-mono text-[11px] text-txt outline-none focus:border-accent"
+                        class="rounded-md mb-2 w-full border border-line bg-base px-2 py-1.5 font-mono text-[11px] text-txt outline-none focus:border-accent"
                         placeholder="${APPROVING_ARTIFACT_URL}"
                       />
                       <div class="mb-1 flex items-center justify-between text-[11px] text-txt2">
@@ -547,14 +547,14 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
                         </button>
                       </div>
                       <div v-for="(h, hi) in m.headers" :key="hi" class="mb-1 grid grid-cols-[1fr_1.4fr_auto] gap-1">
-                        <input v-model="h.k" class="border border-line bg-base px-2 py-1 text-[11px]" placeholder="Header" />
-                        <input v-model="h.v" class="border border-line bg-base px-2 py-1 font-mono text-[11px]" placeholder="Value" />
+                        <input v-model="h.k" class="rounded-md border border-line bg-base px-2 py-1 text-[11px]" placeholder="Header" />
+                        <input v-model="h.v" class="rounded-md border border-line bg-base px-2 py-1 font-mono text-[11px]" placeholder="Value" />
                         <button type="button" class="px-2 text-[11px] text-txt3" @click="m.headers.splice(hi, 1)">×</button>
                       </div>
                     </template>
                     <template v-else>
-                      <input v-model="m.command" class="mb-2 w-full border border-line bg-base px-2 py-1.5 text-[12px]" placeholder="command" />
-                      <textarea v-model="m.args" rows="2" class="w-full border border-line bg-base px-2 py-1.5 font-mono text-[11px]" placeholder="args (one per line)" />
+                      <input v-model="m.command" class="rounded-md mb-2 w-full border border-line bg-base px-2 py-1.5 text-[12px]" placeholder="command" />
+                      <textarea v-model="m.args" rows="2" class="rounded-md w-full border border-line bg-base px-2 py-1.5 font-mono text-[11px]" placeholder="args (one per line)" />
                     </template>
                   </div>
                   <div class="flex flex-wrap gap-2">
@@ -573,8 +573,8 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
                     :key="i"
                     class="mb-2 grid grid-cols-[1fr_1.4fr_auto] gap-2"
                   >
-                    <input v-model="row.k" class="border border-line bg-base px-2 py-1.5 font-mono text-[12px]" placeholder="KEY" />
-                    <input v-model="row.v" class="border border-line bg-base px-2 py-1.5 font-mono text-[12px]" placeholder="value" />
+                    <input v-model="row.k" class="rounded-md border border-line bg-base px-2 py-1.5 font-mono text-[12px]" placeholder="KEY" />
+                    <input v-model="row.v" class="rounded-md border border-line bg-base px-2 py-1.5 font-mono text-[12px]" placeholder="value" />
                     <button type="button" class="text-[11px] text-txt3" @click="draft.env.splice(i, 1)">{{ t('pages.agentStudio.dialogs.delete') }}</button>
                   </div>
                   <AppButton size="sm" variant="outline" icon="plus" @click="draft.env.push({ k: '', v: '' })">
@@ -584,7 +584,7 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
 
                 <template v-else-if="currentStep.id === 'review'">
                   <p class="sec-meta">{{ t('pages.agentStudio.teamWizard.review.meta') }}</p>
-                  <div class="border border-line bg-elevated px-4 py-3 text-[13px] leading-7 text-txt2">
+                  <div class="rounded-lg border border-line bg-elevated px-4 py-3 text-[13px] leading-7 text-txt2">
                     <div>{{ t('pages.agentStudio.teamWizard.review.project') }}：<strong class="text-txt">{{ draft.projectName }}</strong></div>
                     <div>{{ t('pages.agentStudio.teamWizard.review.root') }}：<strong class="text-txt">{{ draft.rootGroupName }}</strong></div>
                     <div>{{ t('pages.agentStudio.teamWizard.review.pipeline') }}：<strong class="text-txt">{{ draft.pipelineGroupName }}</strong></div>
@@ -598,7 +598,7 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
                       {{ t('pages.agentStudio.teamWizard.review.roster') }}
                     </div>
                   </div>
-                  <div class="mt-3 border border-line bg-base px-3 py-2">
+                  <div class="rounded-lg mt-3 border border-line bg-base px-3 py-2">
                     <button type="button" class="mb-1 text-[12px] text-accent-2" @click="bgExpanded = !bgExpanded">
                       {{ t('pages.agentStudio.teamWizard.review.background') }}
                     </button>
@@ -609,7 +609,7 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
                   </div>
                   <p
                     v-if="!hasArtifact"
-                    class="mt-3 border border-warn/35 bg-warn/10 px-3 py-2 text-[12px] text-txt2"
+                    class="rounded-lg mt-3 border border-warn/35 bg-warn/10 px-3 py-2 text-[12px] text-txt2"
                   >
                     {{ t('pages.agentStudio.teamWizard.review.noArtifactWarn') }}
                   </p>

--- a/web/src/components/agent/EnvCredentialHelpModal.vue
+++ b/web/src/components/agent/EnvCredentialHelpModal.vue
@@ -96,7 +96,7 @@ function onChip(id: EnvCredentialHelpSection) {
         v-for="id in SECTIONS"
         :key="id"
         type="button"
-        class="border px-2 py-1 text-[11px]"
+        class="rounded-md border px-2 py-1 text-[11px]"
         :class="activeSection === id ? 'border-accent bg-accent-dim text-txt' : 'border-line bg-base text-txt2'"
         :data-help-chip="id"
         @click="onChip(id)"
@@ -124,7 +124,7 @@ function onChip(id: EnvCredentialHelpSection) {
       <p class="mb-2 mt-0 text-[13px] leading-[1.7] text-txt2">
         {{ t('pages.agentStudio.git.boundary') }}
       </p>
-      <div class="border border-line bg-base px-3 py-2.5 text-[12px] text-txt2">
+      <div class="rounded-md border border-line bg-base px-3 py-2.5 text-[12px] text-txt2">
         <b class="font-semibold text-txt">{{ t('pages.agentStudio.git.runtimeResolve') }}</b>
         — {{ t('pages.agentStudio.git.runtimeResolveHint') }}
       </div>

--- a/web/src/components/agent/ExplorerContextMenu.vue
+++ b/web/src/components/agent/ExplorerContextMenu.vue
@@ -55,7 +55,7 @@ function itemClass(disabled: boolean) {
   <Teleport to="body">
     <div
       v-if="open && target"
-      class="fixed z-[9999] min-w-[210px] border border-line bg-elevated py-1 shadow-card explorer-ctx-menu"
+      class="rounded-lg fixed z-[9999] min-w-[210px] border border-line bg-elevated py-1 shadow-card explorer-ctx-menu"
       :style="{ left: x + 'px', top: y + 'px' }"
       @click.stop
     >

--- a/web/src/components/agent/MarkdownSplitEditor.vue
+++ b/web/src/components/agent/MarkdownSplitEditor.vue
@@ -255,7 +255,7 @@ onBeforeUnmount(() => {
               v-model="fmFields.description"
               rows="2"
               :disabled="readonly"
-              class="w-full resize-y border border-line bg-base px-2 py-1 text-[12px] text-txt outline-none focus:border-accent disabled:opacity-60"
+              class="rounded-md w-full resize-y border border-line bg-base px-2 py-1 text-[12px] text-txt outline-none focus:border-accent disabled:opacity-60"
               @input="syncContentFromForm"
             />
           </div>
@@ -264,7 +264,7 @@ onBeforeUnmount(() => {
             <div class="flex items-center gap-2">
               <button
                 type="button"
-                class="relative h-[18px] w-8 border transition-colors"
+                class="rounded-lg relative h-[18px] w-8 border transition-colors"
                 :class="fmFields.alwaysApply ? 'border-accent bg-accent' : 'border-line-strong bg-overlay'"
                 :disabled="readonly"
                 aria-label="alwaysApply"
@@ -286,7 +286,7 @@ onBeforeUnmount(() => {
               v-model="fmFields.name"
               type="text"
               :disabled="readonly"
-              class="w-full border border-line bg-base px-2 py-1 text-[12px] text-txt outline-none focus:border-accent disabled:opacity-60"
+              class="rounded-md w-full border border-line bg-base px-2 py-1 text-[12px] text-txt outline-none focus:border-accent disabled:opacity-60"
               @input="syncContentFromForm"
             />
           </div>
@@ -296,7 +296,7 @@ onBeforeUnmount(() => {
               v-model="fmFields.description"
               rows="2"
               :disabled="readonly"
-              class="w-full resize-y border border-line bg-base px-2 py-1 text-[12px] text-txt outline-none focus:border-accent disabled:opacity-60"
+              class="rounded-md w-full resize-y border border-line bg-base px-2 py-1 text-[12px] text-txt outline-none focus:border-accent disabled:opacity-60"
               @input="syncContentFromForm"
             />
           </div>
@@ -306,7 +306,7 @@ onBeforeUnmount(() => {
     </div>
 
     <!-- stack: edit / preview toggle -->
-    <div v-if="isStack" class="mx-2.5 mb-2.5 mt-2 flex shrink-0 border border-line" role="tablist">
+    <div v-if="isStack" class="rounded-md overflow-hidden mx-2.5 mb-2.5 mt-2 flex shrink-0 border border-line" role="tablist">
       <button
         type="button"
         class="min-h-11 flex-1 text-[12px] transition"
@@ -347,7 +347,7 @@ onBeforeUnmount(() => {
       >
         <pre
           v-if="stackFmRaw"
-          class="mb-3 whitespace-pre-wrap border border-line bg-elevated px-2.5 py-2 font-mono text-[11px] leading-relaxed text-txt3"
+          class="rounded-md mb-3 whitespace-pre-wrap border border-line bg-elevated px-2.5 py-2 font-mono text-[11px] leading-relaxed text-txt3"
         >FRONTMATTER
 {{ stackFmRaw }}</pre>
         <div class="md" v-html="previewHtml" />

--- a/web/src/components/agent/McpConfigHelpModal.vue
+++ b/web/src/components/agent/McpConfigHelpModal.vue
@@ -57,7 +57,7 @@ function onChip(id: McpHelpSection) {
         v-for="id in SECTIONS"
         :key="id"
         type="button"
-        class="border px-2 py-1 text-[11px]"
+        class="rounded-md border px-2 py-1 text-[11px]"
         :class="activeSection === id ? 'border-accent bg-accent-dim text-txt' : 'border-line bg-base text-txt2'"
         :data-help-chip="id"
         :data-test="`mcp-help-chip-${id}`"
@@ -67,14 +67,14 @@ function onChip(id: McpHelpSection) {
       </button>
     </div>
 
-    <p class="mb-3 border border-line bg-base px-3 py-2.5 text-[12px] leading-[1.7] text-txt2" data-test="mcp-help-hint">
+    <p class="rounded-md mb-3 border border-line bg-base px-3 py-2.5 text-[12px] leading-[1.7] text-txt2" data-test="mcp-help-hint">
       {{ t('pages.agentStudio.mcp.hint', { configRoot: configRoot || '' }) }}
     </p>
 
     <section v-if="activeSection === 'run'" data-test="mcp-help-run" class="scroll-mt-2">
       <h3 class="mb-2 mt-0 flex items-center gap-1.5 text-[13px] font-semibold text-txt">
         {{ t('pages.agentStudio.mcp.runVarsTitle') }}
-        <span class="border border-info/35 px-1.5 py-px text-[10px] font-medium text-info">{{ t('pages.agentStudio.mcp.runScopeTag') }}</span>
+        <span class="rounded-md border border-info/35 px-1.5 py-px text-[10px] font-medium text-info">{{ t('pages.agentStudio.mcp.runScopeTag') }}</span>
       </h3>
       <div class="grid gap-2 font-mono text-[12px] text-txt3">
         <div><code class="text-accent-2">${APPROVING_ARTIFACT_URL}</code> — {{ t('pages.agentStudio.mcp.artifactUrl') }}</div>
@@ -87,7 +87,7 @@ function onChip(id: McpHelpSection) {
     <section v-else data-test="mcp-help-agent" class="scroll-mt-2">
       <h3 class="mb-2 mt-0 flex items-center gap-1.5 text-[13px] font-semibold text-txt">
         {{ t('pages.agentStudio.mcp.agentVarsTitle') }}
-        <span class="border border-ok/35 px-1.5 py-px text-[10px] font-medium text-ok">{{ t('pages.agentStudio.mcp.agentScopeTag') }}</span>
+        <span class="rounded-md border border-ok/35 px-1.5 py-px text-[10px] font-medium text-ok">{{ t('pages.agentStudio.mcp.agentScopeTag') }}</span>
       </h3>
       <div class="grid gap-2 font-mono text-[12px] text-txt3">
         <div><code class="text-accent-2">${APPROVING_MEMORY_URL}</code> / <code class="text-accent-2">${APPROVING_MEMORY_TOKEN}</code> — {{ t('pages.agentStudio.mcp.memoryVars') }}</div>

--- a/web/src/components/agent/TeamBootstrapPanel.vue
+++ b/web/src/components/agent/TeamBootstrapPanel.vue
@@ -124,7 +124,7 @@ function lineClass(kind: string) {
           {{ t('pages.agentStudio.teamWizard.progress.sub') }}
         </p>
       </div>
-      <span class="shrink-0 border px-2 py-1 text-[11px]" :class="badgeClass">{{ badgeText }}</span>
+      <span class="rounded-md shrink-0 border px-2 py-1 text-[11px]" :class="badgeClass">{{ badgeText }}</span>
     </div>
 
     <div
@@ -143,7 +143,7 @@ function lineClass(kind: string) {
           :class="lineClass(ev.kind)"
         >
           <template v-if="ev.kind === 'mcp'">
-            <div class="mcp-block border border-dashed border-warn/45 bg-warn/10 px-3 py-2 text-warn">
+            <div class="rounded-lg mcp-block border border-dashed border-warn/45 bg-warn/10 px-3 py-2 text-warn">
               {{ ev.message }}
             </div>
           </template>
@@ -161,7 +161,7 @@ function lineClass(kind: string) {
         <div
           v-for="(r, i) in session?.resources || []"
           :key="i"
-          class="mb-2 border border-line bg-elevated px-3 py-2 text-[12px]"
+          class="rounded-lg mb-2 border border-line bg-elevated px-3 py-2 text-[12px]"
           :class="session?.status === 'ready' ? 'border-ok/35' : ''"
         >
           <div class="font-semibold text-txt">{{ r.name }}</div>

--- a/web/src/components/agent/WizardApiKeyStepPanel.vue
+++ b/web/src/components/agent/WizardApiKeyStepPanel.vue
@@ -42,7 +42,7 @@ function setMode(mode: WizardAuthMode) {
 <template>
   <div>
     <p class="sec-meta">{{ t('pages.agentStudio.wizard.apiKey.meta') }}</p>
-    <div class="mb-3 border border-accent/30 bg-accent-dim/40 px-3 py-2.5 text-[12px] leading-5 text-txt2">
+    <div class="mb-3 rounded-lg border border-accent/30 bg-accent-dim/40 px-3 py-2.5 text-[12px] leading-5 text-txt2">
       {{
         t('pages.agentStudio.wizard.apiKey.backendBanner', {
           backend: acpBackend,
@@ -58,7 +58,7 @@ function setMode(mode: WizardAuthMode) {
     >
       <button
         type="button"
-        class="border px-3 py-3 text-left transition"
+        class="rounded-lg border px-3 py-3 text-left transition"
         :class="
           authMode === 'apiKey'
             ? 'border-accent bg-accent-dim'
@@ -75,7 +75,7 @@ function setMode(mode: WizardAuthMode) {
       </button>
       <button
         type="button"
-        class="border px-3 py-3 text-left transition"
+        class="rounded-lg border px-3 py-3 text-left transition"
         :class="
           authMode === 'customConfig'
             ? 'border-accent bg-accent-dim'
@@ -93,7 +93,7 @@ function setMode(mode: WizardAuthMode) {
     </div>
 
     <div v-if="authMode === 'apiKey'">
-      <div class="mb-4 border border-line bg-base p-3.5">
+      <div class="mb-4 rounded-lg border border-line bg-base p-3.5">
         <div class="text-[13px] font-semibold text-txt">
           <code class="text-accent-2">{{ primaryAuthKey }}</code>
         </div>
@@ -116,7 +116,7 @@ function setMode(mode: WizardAuthMode) {
             :href="link.url"
             target="_blank"
             rel="noopener noreferrer"
-            class="border border-accent/40 px-2 py-1 text-[11px] text-accent-2 hover:bg-accent-dim"
+            class="rounded-md border border-accent/40 px-2 py-1 text-[11px] text-accent-2 hover:bg-accent-dim"
           >
             {{ t(link.labelKey) }}
           </a>
@@ -130,7 +130,7 @@ function setMode(mode: WizardAuthMode) {
           :value="apiKeyInput"
           type="password"
           autocomplete="off"
-          class="w-full border border-line bg-base px-3 py-2 font-mono text-[12px] text-txt outline-none focus:border-accent"
+          class="w-full rounded-md border border-line bg-base px-3 py-2 font-mono text-[12px] text-txt outline-none focus:border-accent"
           :placeholder="t('pages.agentStudio.wizard.apiKey.inputPlaceholder')"
           data-test="api-key-input"
           @input="emit('update:apiKeyInput', ($event.target as HTMLInputElement).value)"
@@ -142,7 +142,7 @@ function setMode(mode: WizardAuthMode) {
     </div>
 
     <div v-else>
-      <div class="mb-4 border border-line bg-base p-3.5">
+      <div class="mb-4 rounded-lg border border-line bg-base p-3.5">
         <div class="text-[13px] font-semibold text-txt">
           {{ t('pages.agentStudio.wizard.apiKey.customConfig.cardTitle') }}
         </div>
@@ -160,7 +160,7 @@ function setMode(mode: WizardAuthMode) {
         <span class="mb-1.5 block text-[12px] font-medium text-txt2">
           {{ AGENT_SETTINGS_PATH }}
         </span>
-        <div class="h-[220px] border border-line" data-test="custom-config-editor-host">
+        <div class="h-[220px] overflow-hidden rounded-lg border border-line" data-test="custom-config-editor-host">
           <CodeEditor
             :model-value="customConfigContent"
             language="json"

--- a/web/src/components/board/RunBoardCard.vue
+++ b/web/src/components/board/RunBoardCard.vue
@@ -30,7 +30,7 @@ const nodeLine = computed(() => {
 <template>
   <button
     type="button"
-    class="run-board-card w-full border border-line bg-surface p-3 text-left transition hover:border-line-strong hover:bg-elevated focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent-2"
+    class="run-board-card w-full rounded-lg border border-line bg-surface p-3 text-left transition hover:border-line-strong hover:bg-elevated focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent-2"
     @click="emit('select', run)"
   >
     <div class="mb-2 flex items-start justify-between gap-2">

--- a/web/src/components/board/RunBoardColumn.vue
+++ b/web/src/components/board/RunBoardColumn.vue
@@ -56,7 +56,7 @@ function onActivateHeader() {
 
 <template>
   <div
-    class="flex min-h-[200px] flex-col border border-line bg-base"
+    class="flex min-h-[200px] flex-col overflow-hidden rounded-lg border border-line bg-base"
     :class="[accentClass[accent] || accentClass.extra, fill ? 'h-full' : '']"
     data-testid="run-board-column"
   >
@@ -76,7 +76,7 @@ function onActivateHeader() {
       <span class="text-[13px] font-semibold text-txt">{{ title }}</span>
       <span v-if="hint" class="text-[11px] text-txt3">{{ hint }}</span>
       <span
-        class="ml-auto inline-flex h-5 min-w-[22px] items-center justify-center border border-line bg-elevated px-1.5 text-[11px] font-semibold text-txt2"
+        class="ml-auto inline-flex h-5 min-w-[22px] items-center justify-center rounded border border-line bg-elevated px-1.5 text-[11px] font-semibold text-txt2"
         data-testid="run-board-column-count"
       >
         {{ badgeLabel() }}
@@ -89,7 +89,7 @@ function onActivateHeader() {
     >
       <template v-if="loading && !items.length">
         <div
-          class="border border-dashed border-line px-3 py-7 text-center text-xs text-txt3"
+          class="rounded-lg border border-dashed border-line px-3 py-7 text-center text-xs text-txt3"
           data-testid="run-board-column-loading"
         >
           {{ loadingText || '…' }}
@@ -100,7 +100,7 @@ function onActivateHeader() {
       </template>
       <div
         v-else
-        class="border border-dashed border-line px-3 py-7 text-center text-xs text-txt3"
+        class="rounded-lg border border-dashed border-line px-3 py-7 text-center text-xs text-txt3"
         data-testid="run-board-column-empty"
       >
         {{ emptyText }}

--- a/web/src/components/board/token-stats/TokenStatsPanel.test.ts
+++ b/web/src/components/board/token-stats/TokenStatsPanel.test.ts
@@ -191,7 +191,7 @@ describe('TokenStatsPanel', () => {
     wrapper.unmount()
   })
 
-  it('chart cards are square-bordered like 用量统计 (g2.2)', async () => {
+  it('chart cards use card radius rounded-lg (g2.2)', async () => {
     getProjectTokenStats.mockResolvedValue(sampleStats())
     const wrapper = mountPanel()
     await flushPromises()
@@ -203,15 +203,16 @@ describe('TokenStatsPanel', () => {
       wrapper.find('[data-testid="token-stats-model-rank-card"]'),
     ]
     for (const card of cards) {
-      expect(card.classes()).toEqual(expect.arrayContaining(['border', 'border-line', 'bg-surface']))
-      expect(card.classes().some((c) => c.startsWith('rounded'))).toBe(false)
+      expect(card.classes()).toEqual(
+        expect.arrayContaining(['rounded-lg', 'border', 'border-line', 'bg-surface']),
+      )
     }
     wrapper.unmount()
 
     getProjectTokenStats.mockResolvedValue(sampleStats({ empty: true, trend: [], workflows: [] }))
     const empty = mountPanel()
     await flushPromises()
-    expect(empty.find('[data-testid="token-stats-empty"]').html()).not.toMatch(/rounded-xl/)
+    expect(empty.find('[data-testid="token-stats-empty"]').html()).toMatch(/rounded-lg/)
     empty.unmount()
   })
 

--- a/web/src/components/board/token-stats/TokenStatsPanel.vue
+++ b/web/src/components/board/token-stats/TokenStatsPanel.vue
@@ -152,7 +152,7 @@ onUnmounted(() => {
     <div
       v-if="loading"
       data-testid="token-stats-loading"
-      class="flex min-h-[220px] items-center justify-center border border-line bg-surface text-sm text-txt3"
+      class="flex min-h-[220px] items-center justify-center rounded-lg border border-line bg-surface text-sm text-txt3"
     >
       {{ t('pages.board.tokenStats.loading') }}
     </div>
@@ -161,12 +161,12 @@ onUnmounted(() => {
     <div
       v-else-if="failed"
       data-testid="token-stats-error"
-      class="flex min-h-[180px] flex-col items-center justify-center gap-3 border border-err/40 bg-err/10 px-4 py-6 text-center"
+      class="flex min-h-[180px] flex-col items-center justify-center gap-3 rounded-lg border border-err/40 bg-err/10 px-4 py-6 text-center"
     >
       <p class="m-0 text-sm text-err">{{ t('pages.board.tokenStats.loadFailed') }}</p>
       <button
         type="button"
-        class="border border-err/40 px-3 py-1.5 text-xs text-err hover:bg-err/10"
+        class="rounded-md border border-err/40 px-3 py-1.5 text-xs text-err hover:bg-err/10"
         data-testid="token-stats-retry"
         @click="retry"
       >
@@ -180,7 +180,7 @@ onUnmounted(() => {
       data-testid="token-stats-empty"
       class="grid gap-3"
     >
-      <div class="relative min-h-[200px] min-w-0 overflow-x-clip border border-line bg-surface p-3.5">
+      <div class="relative min-h-[200px] min-w-0 overflow-x-clip rounded-lg border border-line bg-surface p-3.5">
         <div class="mb-2 flex items-baseline justify-between gap-2">
           <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.board.tokenStats.trendTitle') }}</h4>
           <span class="text-[11px] text-txt3">{{ grainLabel }}</span>
@@ -191,7 +191,7 @@ onUnmounted(() => {
         </div>
       </div>
       <div class="grid min-w-0 grid-cols-1 gap-3 md:grid-cols-2">
-        <div class="relative min-h-[200px] min-w-0 border border-line bg-surface p-3.5">
+        <div class="relative min-h-[200px] min-w-0 rounded-lg border border-line bg-surface p-3.5">
           <div class="mb-2 flex items-baseline justify-between gap-2">
             <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.board.tokenStats.compositionTitle') }}</h4>
           </div>
@@ -200,7 +200,7 @@ onUnmounted(() => {
             <span class="max-w-[28ch] text-xs text-txt3">{{ t('pages.board.tokenStats.emptyCompHint') }}</span>
           </div>
         </div>
-        <div class="relative min-h-[200px] min-w-0 border border-line bg-surface p-3.5">
+        <div class="relative min-h-[200px] min-w-0 rounded-lg border border-line bg-surface p-3.5">
           <div class="mb-2 flex flex-col gap-1">
             <div class="flex items-baseline justify-between gap-2">
               <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.board.tokenStats.rankTitle') }}</h4>
@@ -218,7 +218,7 @@ onUnmounted(() => {
     <!-- Ready charts -->
     <div v-else-if="data" data-testid="token-stats-charts" class="grid gap-3">
       <div
-        class="min-w-0 overflow-x-clip border border-line bg-surface p-3.5"
+        class="min-w-0 overflow-x-clip rounded-lg border border-line bg-surface p-3.5"
         data-testid="token-stats-trend-card"
       >
         <div class="mb-2 flex items-baseline justify-between gap-2">
@@ -228,7 +228,7 @@ onUnmounted(() => {
         <TokenTrendChart :trend="data.trend" :bucket-width="data.bucketWidth" />
       </div>
       <div class="grid min-w-0 grid-cols-1 gap-3 md:grid-cols-2">
-        <div class="min-w-0 border border-line bg-surface p-3.5" data-testid="token-stats-model-comp-card">
+        <div class="min-w-0 rounded-lg border border-line bg-surface p-3.5" data-testid="token-stats-model-comp-card">
           <div class="mb-2 flex items-baseline justify-between gap-2">
             <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.board.tokenStats.modelCompositionTitle') }}</h4>
             <span class="text-[11px] text-txt3">
@@ -237,7 +237,7 @@ onUnmounted(() => {
           </div>
           <TokenModelComposition :models="data.modelComposition || []" />
         </div>
-        <div class="min-w-0 border border-line bg-surface p-3.5" data-testid="token-stats-model-rank-card">
+        <div class="min-w-0 rounded-lg border border-line bg-surface p-3.5" data-testid="token-stats-model-rank-card">
           <div class="mb-2 flex items-baseline justify-between gap-2" data-testid="token-stats-model-rank-head">
             <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.board.tokenStats.modelRankTitle') }}</h4>
             <span class="text-[11px] text-txt3">{{ t('pages.board.tokenStats.modelRankSub') }}</span>
@@ -246,7 +246,7 @@ onUnmounted(() => {
         </div>
       </div>
       <div class="grid min-w-0 grid-cols-1 gap-3 md:grid-cols-2">
-        <div class="min-w-0 border border-line bg-surface p-3.5" data-testid="token-stats-comp-card">
+        <div class="min-w-0 rounded-lg border border-line bg-surface p-3.5" data-testid="token-stats-comp-card">
           <div class="mb-2 flex items-baseline justify-between gap-2">
             <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.board.tokenStats.compositionTitle') }}</h4>
             <span class="text-[11px] text-txt3">
@@ -255,7 +255,7 @@ onUnmounted(() => {
           </div>
           <TokenDonutChart :composition="data.composition" />
         </div>
-        <div class="min-w-0 border border-line bg-surface p-3.5" data-testid="token-stats-rank-card">
+        <div class="min-w-0 rounded-lg border border-line bg-surface p-3.5" data-testid="token-stats-rank-card">
           <div class="mb-2 flex flex-col gap-1">
             <div class="flex items-baseline justify-between gap-2">
               <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.board.tokenStats.rankTitle') }}</h4>

--- a/web/src/components/canvas/NodeInspector.vue
+++ b/web/src/components/canvas/NodeInspector.vue
@@ -471,7 +471,7 @@ function setSwitch(key: string, on: boolean) {
           </select>
           <div
             v-if="f.key === 'agent_profile' && agentProfileStale"
-            class="mt-2 border border-warn/40 bg-warn/10 px-2.5 py-2 text-[12px] leading-5 text-warn"
+            class="rounded-lg mt-2 border border-warn/40 bg-warn/10 px-2.5 py-2 text-[12px] leading-5 text-warn"
             data-testid="skill-profile-stale-banner"
           >
             <strong class="font-semibold">{{ t('pages.workflowEditor.inspector.staleBannerTitle') }}</strong>

--- a/web/src/components/canvas/OutputSourcesEditor.vue
+++ b/web/src/components/canvas/OutputSourcesEditor.vue
@@ -81,11 +81,11 @@ function onDrop(target: string) {
   <div>
     <div
       v-if="showMigration"
-      class="mb-3 border border-info/35 bg-info/10 px-3 py-2.5 text-[11px] leading-relaxed text-txt2"
+      class="rounded-lg mb-3 border border-info/35 bg-info/10 px-3 py-2.5 text-[11px] leading-relaxed text-txt2"
       v-html="t('pages.workflowEditor.inspector.outputSources.migrationBanner')"
     />
 
-    <div class="border border-line bg-base">
+    <div class="rounded-lg border border-line bg-base">
       <template v-if="selected.length">
         <div
           v-for="(template, i) in selected"
@@ -124,7 +124,7 @@ function onDrop(target: string) {
       <div
         v-if="!availableOptions.length"
         data-testid="output-sources-empty-available"
-        class="border border-dashed border-line px-3 py-4 text-[12px] leading-relaxed text-txt3"
+        class="rounded-lg border border-dashed border-line px-3 py-4 text-[12px] leading-relaxed text-txt3"
       >
         {{ t('pages.workflowEditor.inspector.outputSources.emptyAvailable') }}
       </div>
@@ -132,7 +132,7 @@ function onDrop(target: string) {
         v-for="opt in availableOptions"
         :key="opt.value"
         type="button"
-        class="mb-1 flex w-full items-center gap-2 border border-line bg-base px-2.5 py-1.5 text-left text-[12px] transition"
+        class="rounded-md mb-1 flex w-full items-center gap-2 border border-line bg-base px-2.5 py-1.5 text-left text-[12px] transition"
         :class="selectedSet.has(opt.value) ? 'cursor-not-allowed opacity-50' : 'hover:border-line-strong hover:bg-elevated'"
         :disabled="selectedSet.has(opt.value)"
         @click="add(opt.value)"

--- a/web/src/components/dashboard/HomePipelineSelect.vue
+++ b/web/src/components/dashboard/HomePipelineSelect.vue
@@ -290,6 +290,7 @@ onBeforeUnmount(() => {
   justify-content: space-between;
   gap: 8px;
   border: 1px solid rgb(var(--c-line));
+  border-radius: 8px;
   background: transparent;
   color: rgb(var(--c-accent-2));
   padding: 0 10px;
@@ -334,6 +335,8 @@ onBeforeUnmount(() => {
   top: calc(100% + 6px);
   width: min(320px, 78vw);
   border: 1px solid rgb(var(--c-line-strong));
+  border-radius: 12px;
+  overflow: hidden;
   background: rgb(var(--c-elevated));
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
   z-index: 60;
@@ -348,6 +351,7 @@ onBeforeUnmount(() => {
   width: 100%;
   height: 32px;
   border: 1px solid rgb(var(--c-line));
+  border-radius: 8px;
   background: rgb(var(--c-surface));
   color: rgb(var(--c-txt));
   padding: 0 10px;
@@ -373,6 +377,7 @@ onBeforeUnmount(() => {
   width: 100%;
   text-align: left;
   border: 0;
+  border-radius: 8px;
   background: transparent;
   color: rgb(var(--c-txt));
   padding: 8px 10px;

--- a/web/src/components/inbox/InboxPendingCard.vue
+++ b/web/src/components/inbox/InboxPendingCard.vue
@@ -66,7 +66,7 @@ function onOpenShare() {
 
 <template>
   <article
-    class="flex w-full shrink-0 flex-col border p-3 transition"
+    class="flex w-full shrink-0 flex-col rounded-lg border p-3 transition"
     :class="active ? 'border-accent/50 bg-accent-dim/40' : 'border-line bg-surface hover:bg-elevated'"
     data-testid="inbox-item-card"
     :data-starting="starting ? 'true' : undefined"
@@ -80,7 +80,7 @@ function onOpenShare() {
       @click="emit('select')"
     >
       <div
-        class="flex h-9 w-9 shrink-0 items-center justify-center"
+        class="flex h-9 w-9 shrink-0 items-center justify-center rounded-md"
         :class="iconClass"
       >
         <AppSpinner v-if="inProgress" :size="18" />
@@ -90,7 +90,7 @@ function onOpenShare() {
         <div class="truncate text-sm font-medium text-txt">{{ title }}</div>
         <div class="truncate text-[11px] text-txt3" :title="secondary">{{ secondary }}</div>
         <div class="mt-1 flex items-center gap-1.5">
-          <span class="border px-1.5 py-px text-[10px]" :class="badgeClass">{{ badgeText }}</span>
+          <span class="rounded border px-1.5 py-px text-[10px]" :class="badgeClass">{{ badgeText }}</span>
           <span class="text-[10px] text-txt3">{{ locale && timeLabel }}</span>
         </div>
         <div v-if="item.tags?.length" class="mt-1 flex flex-wrap gap-1.5">
@@ -106,7 +106,7 @@ function onOpenShare() {
     >
       <span
         role="status"
-        class="border border-line bg-elevated px-1.5 py-0.5 text-[10px] text-txt2"
+        class="rounded border border-line bg-elevated px-1.5 py-0.5 text-[10px] text-txt2"
         data-testid="gate-share-status"
       >
         {{ shareLabel }}
@@ -119,7 +119,7 @@ function onOpenShare() {
       >
         <button
           type="button"
-          class="inline-flex min-h-6 items-center gap-1 border border-accent/40 bg-accent/10 px-1.5 py-0.5 text-[10px] font-medium leading-[1.4] text-accent-2 hover:bg-accent/20 disabled:cursor-not-allowed disabled:opacity-45"
+          class="inline-flex min-h-6 items-center gap-1 rounded border border-accent/40 bg-accent/10 px-1.5 py-0.5 text-[10px] font-medium leading-[1.4] text-accent-2 hover:bg-accent/20 disabled:cursor-not-allowed disabled:opacity-45"
           data-testid="gate-share-copy-btn"
           :disabled="shareDisabled"
           :aria-label="t('pages.gatesInbox.share.copyLinkAria')"

--- a/web/src/components/onboarding/OnboardingWizard.vue
+++ b/web/src/components/onboarding/OnboardingWizard.vue
@@ -202,13 +202,13 @@ async function submitBootstrap() {
     <div v-if="open" class="fixed inset-0 z-50 flex items-center justify-center p-4" data-testid="onboarding-wizard">
       <div class="absolute inset-0 bg-black/70" data-testid="onboarding-backdrop" @click="suppressAndClose" />
       <div
-        class="relative z-10 flex w-full flex-col overflow-hidden border border-line bg-surface shadow-card"
+        class="rounded-xl relative z-10 flex w-full flex-col overflow-hidden border border-line bg-surface shadow-card"
         style="width: min(980px, 100%); height: min(640px, 92vh); border-radius: 16px"
         role="dialog"
         aria-modal="true"
       >
         <div class="relative flex h-16 shrink-0 items-center gap-3.5 border-b border-line px-5">
-          <div class="grid h-9 w-9 shrink-0 place-items-center border border-accent/55 text-accent-2">
+          <div class="rounded-md grid h-9 w-9 shrink-0 place-items-center border border-accent/55 text-accent-2">
             <Icon name="sparkles" :size="20" />
           </div>
           <div class="min-w-0 flex-1">
@@ -240,7 +240,7 @@ async function submitBootstrap() {
             <li>· {{ t('pages.onboarding.success.publishedLine') }}</li>
           </ul>
           <p
-            class="mt-4 border px-3 py-2 text-[12px]"
+            class="rounded-lg mt-4 border px-3 py-2 text-[12px]"
             :class="identityOk ? 'border-ok/35 bg-ok/10 text-ok' : 'border-warn/35 bg-warn/10 text-warn'"
             data-testid="onboarding-success-git-user"
           >
@@ -250,7 +250,7 @@ async function submitBootstrap() {
                 : t('pages.onboarding.success.gitUserSkip')
             }}
           </p>
-          <p class="mt-2 border border-ok/35 bg-ok/10 px-3 py-2 text-[12px] text-ok" data-testid="onboarding-success-preview">
+          <p class="rounded-lg mt-2 border border-ok/35 bg-ok/10 px-3 py-2 text-[12px] text-ok" data-testid="onboarding-success-preview">
             {{
               t('pages.onboarding.success.preview', {
                 vnc: draft.vncPreview
@@ -263,14 +263,14 @@ async function submitBootstrap() {
             }}
           </p>
           <p
-            class="mt-2 border px-3 py-2 text-[12px]"
+            class="rounded-lg mt-2 border px-3 py-2 text-[12px]"
             :class="gitOk ? 'border-ok/35 bg-ok/10 text-ok' : 'border-warn/35 bg-warn/10 text-warn'"
             data-testid="onboarding-success-git"
           >
             {{ gitOk ? t('pages.onboarding.success.gitOk') : t('pages.onboarding.success.gitSkip') }}
           </p>
           <p
-            class="mt-4 border px-3 py-2 text-[12px]"
+            class="rounded-lg mt-4 border px-3 py-2 text-[12px]"
             :class="repoOk ? 'border-ok/35 bg-ok/10 text-ok' : 'border-warn/35 bg-warn/10 text-warn'"
             data-testid="onboarding-success-repo"
           >
@@ -301,7 +301,7 @@ async function submitBootstrap() {
             >
               <div class="flex w-[18px] shrink-0 flex-col items-center">
                 <div
-                  class="mt-0.5 grid h-3.5 w-3.5 place-items-center border"
+                  class="mt-0.5 grid h-3.5 w-3.5 place-items-center rounded-full border"
                   :class="i < draft.step ? 'border-ok/55' : i === draft.step ? 'border-accent' : 'border-line-strong'"
                 >
                   <i
@@ -327,7 +327,7 @@ async function submitBootstrap() {
                       v-for="option in languageOptions"
                       :key="option.id"
                       type="button"
-                      class="border px-4 py-4 text-left transition"
+                      class="rounded-lg border px-4 py-4 text-left transition"
                       :class="
                         draft.language === option.id
                           ? 'border-accent bg-accent-dim'
@@ -352,18 +352,18 @@ async function submitBootstrap() {
                     <li>{{ t('pages.onboarding.overview.itemPreview') }}</li>
                   </ol>
                   <div class="mt-4 grid gap-3 sm:grid-cols-2">
-                    <div class="border border-line bg-base px-3 py-3">
+                    <div class="rounded-lg border border-line bg-base px-3 py-3">
                       <div class="text-[11px] uppercase text-txt3">{{ t('pages.onboarding.overview.agents') }}</div>
                       <div class="mt-1 text-[18px] font-semibold text-txt">6</div>
                       <p class="mt-1 text-[12px] text-txt2">{{ t('pages.onboarding.overview.agentsList') }}</p>
                     </div>
-                    <div class="border border-line bg-base px-3 py-3">
+                    <div class="rounded-lg border border-line bg-base px-3 py-3">
                       <div class="text-[11px] uppercase text-txt3">{{ t('pages.onboarding.overview.workflow') }}</div>
                       <div class="mt-1 text-[18px] font-semibold text-txt">{{ t('pages.onboarding.workflowName') }}</div>
                       <p class="mt-1 text-[12px] text-txt2">{{ t('pages.onboarding.overview.workflowHint') }}</p>
                     </div>
                   </div>
-                  <p class="mt-4 border border-accent/35 bg-accent-dim px-3 py-2 text-[12px] text-accent-2">
+                  <p class="rounded-lg mt-4 border border-accent/35 bg-accent-dim px-3 py-2 text-[12px] text-accent-2">
                     {{ t('pages.onboarding.overview.banner') }}
                   </p>
                 </template>
@@ -375,7 +375,7 @@ async function submitBootstrap() {
                       v-for="b in ACP_BACKENDS"
                       :key="b.id"
                       type="button"
-                      class="border px-3 py-3.5 text-center transition"
+                      class="rounded-lg border px-3 py-3.5 text-center transition"
                       :class="
                         draft.acpBackend === b.id
                           ? 'border-accent bg-accent-dim'
@@ -394,7 +394,7 @@ async function submitBootstrap() {
                         v-for="option in regionPolicy.options"
                         :key="option.id"
                         type="button"
-                        class="border px-3 py-3 text-left"
+                        class="rounded-lg border px-3 py-3 text-left"
                         :class="
                           draft.region === option.id
                             ? 'border-accent bg-accent-dim'
@@ -411,7 +411,7 @@ async function submitBootstrap() {
 
                 <template v-else-if="currentStep.id === 'apiKey'">
                   <p class="mt-2 text-[13px] text-txt2">{{ t('pages.onboarding.apiKey.meta') }}</p>
-                  <div class="mt-3 border border-accent/35 bg-accent-dim px-3 py-2 text-[12px] text-accent-2">
+                  <div class="rounded-lg mt-3 border border-accent/35 bg-accent-dim px-3 py-2 text-[12px] text-accent-2">
                     <code>{{ primaryAuthKey }}</code>
                     <span v-if="primaryAuthAlt" class="ml-2 text-txt3">/ {{ primaryAuthAlt }}</span>
                   </div>
@@ -425,7 +425,7 @@ async function submitBootstrap() {
                       :href="link.url"
                       target="_blank"
                       rel="noopener noreferrer"
-                      class="border border-line px-2 py-1 text-[11px] text-txt2 hover:border-line-strong hover:text-txt"
+                      class="rounded-md border border-line px-2 py-1 text-[11px] text-txt2 hover:border-line-strong hover:text-txt"
                     >{{ t(link.labelKey) }}</a>
                   </div>
                   <label class="mt-4 block">
@@ -437,7 +437,7 @@ async function submitBootstrap() {
                       v-model="draft.apiKey"
                       type="password"
                       autocomplete="off"
-                      class="w-full border border-line bg-base px-3 py-2 font-mono text-[13px] text-txt outline-none focus:border-accent"
+                      class="rounded-md w-full border border-line bg-base px-3 py-2 font-mono text-[13px] text-txt outline-none focus:border-accent"
                       data-testid="onboarding-api-key"
                       @input="keyError = false"
                     />
@@ -449,7 +449,7 @@ async function submitBootstrap() {
                 <template v-else-if="currentStep.id === 'git'">
                   <p class="mt-2 text-[13px] text-txt2">{{ t('pages.onboarding.git.meta') }}</p>
 
-                  <div class="mt-4 border border-line bg-base px-3 py-3">
+                  <div class="rounded-lg mt-4 border border-line bg-base px-3 py-3">
                     <div class="text-[11px] uppercase tracking-[0.06em] text-txt3">
                       {{ t('pages.onboarding.repo.section') }}
                     </div>
@@ -462,7 +462,7 @@ async function submitBootstrap() {
                         type="text"
                         autocomplete="off"
                         placeholder="https://github.com/org/repo.git"
-                        class="w-full border border-line bg-surface px-3 py-2 font-mono text-[13px] text-txt outline-none focus:border-accent"
+                        class="rounded-md w-full border border-line bg-surface px-3 py-2 font-mono text-[13px] text-txt outline-none focus:border-accent"
                         data-testid="onboarding-repo-url"
                       />
                     </label>
@@ -475,7 +475,7 @@ async function submitBootstrap() {
                         type="text"
                         autocomplete="off"
                         :placeholder="t('pages.onboarding.repo.branchPlaceholder')"
-                        class="w-full border border-line bg-surface px-3 py-2 font-mono text-[13px] text-txt outline-none focus:border-accent"
+                        class="rounded-md w-full border border-line bg-surface px-3 py-2 font-mono text-[13px] text-txt outline-none focus:border-accent"
                         data-testid="onboarding-repo-branch"
                       />
                     </label>
@@ -488,7 +488,7 @@ async function submitBootstrap() {
                     </p>
                   </div>
 
-                  <div class="mt-4 border border-line bg-base px-3 py-3">
+                  <div class="rounded-lg mt-4 border border-line bg-base px-3 py-3">
                     <div class="text-[11px] uppercase tracking-[0.06em] text-txt3">
                       {{ t('pages.onboarding.gitUser.section') }}
                     </div>
@@ -502,7 +502,7 @@ async function submitBootstrap() {
                           type="text"
                           autocomplete="off"
                           :placeholder="t('pages.onboarding.gitUser.namePlaceholder')"
-                          class="w-full border border-line bg-surface px-3 py-2 font-mono text-[13px] text-txt outline-none focus:border-accent"
+                          class="rounded-md w-full border border-line bg-surface px-3 py-2 font-mono text-[13px] text-txt outline-none focus:border-accent"
                           data-testid="onboarding-git-user-name"
                         />
                       </label>
@@ -515,7 +515,7 @@ async function submitBootstrap() {
                           type="email"
                           autocomplete="off"
                           :placeholder="t('pages.onboarding.gitUser.emailPlaceholder')"
-                          class="w-full border border-line bg-surface px-3 py-2 font-mono text-[13px] text-txt outline-none focus:border-accent"
+                          class="rounded-md w-full border border-line bg-surface px-3 py-2 font-mono text-[13px] text-txt outline-none focus:border-accent"
                           data-testid="onboarding-git-user-email"
                         />
                       </label>
@@ -523,14 +523,14 @@ async function submitBootstrap() {
                     <p class="mt-2 text-[11px] text-txt3">{{ t('pages.onboarding.gitUser.hint') }}</p>
                   </div>
 
-                  <div class="mt-4 border border-line bg-base px-3 py-3">
+                  <div class="rounded-lg mt-4 border border-line bg-base px-3 py-3">
                     <div class="text-[11px] uppercase tracking-[0.06em] text-txt3">
                       {{ t('pages.onboarding.preview.section') }}
                     </div>
                     <div class="mt-2.5 grid gap-2 sm:grid-cols-2">
                       <button
                         type="button"
-                        class="border px-3 py-3 text-left"
+                        class="rounded-lg border px-3 py-3 text-left"
                         :class="
                           draft.vncPreview
                             ? 'border-accent bg-accent-dim'
@@ -544,7 +544,7 @@ async function submitBootstrap() {
                       </button>
                       <button
                         type="button"
-                        class="border px-3 py-3 text-left"
+                        class="rounded-lg border px-3 py-3 text-left"
                         :class="
                           draft.browserMcp
                             ? 'border-accent bg-accent-dim'
@@ -567,7 +567,7 @@ async function submitBootstrap() {
                       v-for="g in ONBOARDING_GIT_TYPES"
                       :key="g.id"
                       type="button"
-                      class="border px-3 py-3 text-center"
+                      class="rounded-lg border px-3 py-3 text-center"
                       :class="
                         draft.gitCredentialType === g.id
                           ? 'border-accent bg-accent-dim'
@@ -585,7 +585,7 @@ async function submitBootstrap() {
                       v-model="draft.githubToken"
                       type="password"
                       autocomplete="off"
-                      class="w-full border border-line bg-base px-3 py-2 font-mono text-[13px] text-txt"
+                      class="rounded-md w-full border border-line bg-base px-3 py-2 font-mono text-[13px] text-txt"
                       data-testid="onboarding-github-token"
                     />
                   </label>
@@ -596,7 +596,7 @@ async function submitBootstrap() {
                         v-model="draft.gitlabToken"
                         type="password"
                         autocomplete="off"
-                        class="w-full border border-line bg-base px-3 py-2 font-mono text-[13px] text-txt"
+                        class="rounded-md w-full border border-line bg-base px-3 py-2 font-mono text-[13px] text-txt"
                         data-testid="onboarding-gitlab-token"
                       />
                     </label>
@@ -606,7 +606,7 @@ async function submitBootstrap() {
                         v-model="draft.gitlabUrl"
                         type="text"
                         placeholder="https://gitlab.example.com"
-                        class="w-full border border-line bg-base px-3 py-2 font-mono text-[13px] text-txt"
+                        class="rounded-md w-full border border-line bg-base px-3 py-2 font-mono text-[13px] text-txt"
                         data-testid="onboarding-gitlab-url"
                       />
                     </label>
@@ -617,7 +617,7 @@ async function submitBootstrap() {
                       <textarea
                         v-model="draft.gitSshPrivateKey"
                         rows="4"
-                        class="w-full border border-line bg-base px-3 py-2 font-mono text-[12px] text-txt"
+                        class="rounded-md w-full border border-line bg-base px-3 py-2 font-mono text-[12px] text-txt"
                         data-testid="onboarding-ssh-key"
                       />
                     </label>
@@ -626,7 +626,7 @@ async function submitBootstrap() {
                       <textarea
                         v-model="draft.gitSshKnownHosts"
                         rows="2"
-                        class="w-full border border-line bg-base px-3 py-2 font-mono text-[12px] text-txt"
+                        class="rounded-md w-full border border-line bg-base px-3 py-2 font-mono text-[12px] text-txt"
                       />
                     </label>
                   </div>
@@ -636,21 +636,21 @@ async function submitBootstrap() {
                 <template v-else-if="currentStep.id === 'review'">
                   <p class="mt-2 text-[13px] text-txt2">{{ t('pages.onboarding.review.meta') }}</p>
                   <div class="mt-3 flex flex-wrap gap-2 text-[12px]">
-                    <span class="border border-ok/35 bg-ok/10 px-2 py-1 text-ok">
+                    <span class="rounded-lg border border-ok/35 bg-ok/10 px-2 py-1 text-ok">
                       Backend · {{ ACP_BACKENDS.find((b) => b.id === draft.acpBackend)?.label }}
                     </span>
                     <span
                       v-if="regionPolicy && draft.region"
-                      class="border border-ok/35 bg-ok/10 px-2 py-1 text-ok"
+                      class="rounded-lg border border-ok/35 bg-ok/10 px-2 py-1 text-ok"
                     >Region · {{ draft.region }}</span>
                     <span
-                      class="border px-2 py-1"
+                      class="rounded-lg border px-2 py-1"
                       :class="draft.apiKey.trim() ? 'border-ok/35 bg-ok/10 text-ok' : 'border-warn/35 bg-warn/10 text-warn'"
                     >
                       API Key · {{ draft.apiKey.trim() ? t('pages.onboarding.review.keyOn') : t('pages.onboarding.review.keyOff') }}
                     </span>
                     <span
-                      class="border px-2 py-1"
+                      class="rounded-lg border px-2 py-1"
                       :class="repoOk ? 'border-ok/35 bg-ok/10 text-ok' : 'border-line text-txt2'"
                       data-testid="onboarding-review-repo"
                     >
@@ -658,7 +658,7 @@ async function submitBootstrap() {
                       {{ repoOk ? repoDirName : t('pages.onboarding.review.repoSkip') }}
                     </span>
                     <span
-                      class="border px-2 py-1"
+                      class="rounded-lg border px-2 py-1"
                       :class="identityOk ? 'border-ok/35 bg-ok/10 text-ok' : 'border-warn/35 bg-warn/10 text-warn'"
                       data-testid="onboarding-review-git-user"
                     >
@@ -666,25 +666,25 @@ async function submitBootstrap() {
                       {{ identityOk ? draft.gitUserName : t('pages.onboarding.review.gitUserOff') }}
                     </span>
                     <span
-                      class="border px-2 py-1"
+                      class="rounded-lg border px-2 py-1"
                       :class="draft.vncPreview ? 'border-ok/35 bg-ok/10 text-ok' : 'border-line text-txt2'"
                     >
                       {{ t('pages.onboarding.preview.vncLabel') }} · {{ draft.vncPreview ? t('pages.onboarding.review.flagOn') : t('pages.onboarding.review.flagOff') }}
                     </span>
                     <span
-                      class="border px-2 py-1"
+                      class="rounded-lg border px-2 py-1"
                       :class="draft.browserMcp ? 'border-ok/35 bg-ok/10 text-ok' : 'border-line text-txt2'"
                     >
                       {{ t('pages.onboarding.preview.browserLabel') }} · {{ draft.browserMcp ? t('pages.onboarding.review.flagOn') : t('pages.onboarding.review.flagOff') }}
                     </span>
                     <span
-                      class="border px-2 py-1"
+                      class="rounded-lg border px-2 py-1"
                       :class="gitOk ? 'border-ok/35 bg-ok/10 text-ok' : 'border-line text-txt2'"
                     >
                       Git · {{ gitOk ? draft.gitCredentialType : t('pages.onboarding.review.gitSkip') }}
                     </span>
-                    <span class="border border-ok/35 bg-ok/10 px-2 py-1 text-ok">{{ t('pages.onboarding.review.agentsChip') }}</span>
-                    <span class="border border-ok/35 bg-ok/10 px-2 py-1 text-ok">{{ t('pages.onboarding.review.wfChip') }}</span>
+                    <span class="rounded-lg border border-ok/35 bg-ok/10 px-2 py-1 text-ok">{{ t('pages.onboarding.review.agentsChip') }}</span>
+                    <span class="rounded-lg border border-ok/35 bg-ok/10 px-2 py-1 text-ok">{{ t('pages.onboarding.review.wfChip') }}</span>
                   </div>
                   <p v-if="!draft.apiKey.trim()" class="mt-3 text-[12px] text-warn">{{ t('pages.onboarding.review.needKey') }}</p>
                   <p class="mt-3 text-[12px] text-txt3">{{ t('pages.onboarding.review.featureHint') }}</p>

--- a/web/src/components/pm/PmChannelMultiPanel.vue
+++ b/web/src/components/pm/PmChannelMultiPanel.vue
@@ -162,10 +162,10 @@ const {
         </AppButton>
       </div>
 
-      <div v-if="!channelList.length" class="border border-dashed border-line-strong p-3.5 text-xs text-txt3">
+      <div v-if="!channelList.length" class="rounded-lg border border-dashed border-line-strong p-3.5 text-xs text-txt3">
         {{ t('pages.projectDetail.pm.channel.listEmpty') }}
       </div>
-      <div v-else class="border border-line">
+      <div v-else class="rounded-lg border border-line">
         <div
           class="grid grid-cols-[1fr_100px_140px_80px_120px] gap-3 border-b border-line bg-elevated px-3.5 py-2 text-[11px] uppercase tracking-wide text-txt3 max-md:grid-cols-2"
         >
@@ -184,7 +184,7 @@ const {
           <div class="min-w-0">
             <div class="flex flex-wrap items-center gap-2 text-[13px] font-medium text-txt">
               <span
-                class="border px-2 py-0.5 text-[11px]"
+                class="rounded-md border px-2 py-0.5 text-[11px]"
                 data-testid="channel-type-badge"
                 :class="
                   ch.type === 'wecom'
@@ -209,7 +209,7 @@ const {
               <span class="truncate">{{ ch.name || ch.appId }}</span>
               <span
                 v-if="ch.isPrimary"
-                class="border border-accent/55 bg-accent-dim px-2 py-0.5 text-[11px] text-accent-2"
+                class="rounded-md border border-accent/55 bg-accent-dim px-2 py-0.5 text-[11px] text-accent-2"
               >
                 {{ t('pages.projectDetail.pm.channel.rolePrimary') }}
               </span>
@@ -258,7 +258,7 @@ const {
         </div>
       </div>
 
-      <div class="mt-3 border border-info/35 bg-info/10 px-3 py-2.5 text-xs leading-snug text-txt2">
+      <div class="rounded-lg mt-3 border border-info/35 bg-info/10 px-3 py-2.5 text-xs leading-snug text-txt2">
         <strong class="text-info">{{ t('pages.projectDetail.pm.channel.compatTitle') }}</strong>
         {{ t('pages.projectDetail.pm.channel.compatHint') }}
       </div>
@@ -288,13 +288,13 @@ const {
         </AppButton>
       </div>
 
-      <div v-if="!isNew && !editingId" class="border border-dashed border-line-strong p-3.5 text-xs text-txt3">
+      <div v-if="!isNew && !editingId" class="rounded-lg border border-dashed border-line-strong p-3.5 text-xs text-txt3">
         {{ t('pages.projectDetail.pm.channel.editEmpty') }}
       </div>
 
       <template v-else>
         <div class="grid gap-4 lg:grid-cols-[1.15fr_.85fr]">
-          <div class="border border-line bg-surface p-4">
+          <div class="rounded-lg border border-line bg-surface p-4">
             <h3 class="m-0 text-[13px] font-semibold text-txt">
               {{ t('pages.projectDetail.pm.channel.basicsTitle') }}
             </h3>
@@ -309,7 +309,7 @@ const {
 
             <div class="mt-3">
               <span class="label">{{ t('pages.projectDetail.pm.channel.typeLabel') }}</span>
-              <div class="mt-1 flex border border-line" role="group" data-testid="channel-type-seg">
+              <div class="rounded-md overflow-hidden mt-1 flex border border-line" role="group" data-testid="channel-type-seg">
                 <button
                   type="button"
                   class="flex-1 px-3 py-2 text-[13px]"
@@ -436,7 +436,7 @@ const {
             </div>
             <p
               v-if="saveError"
-              class="mt-2 border border-err/45 bg-err/10 px-3 py-2 text-xs text-err"
+              class="rounded-lg mt-2 border border-err/45 bg-err/10 px-3 py-2 text-xs text-err"
               data-testid="channel-save-error"
             >
               {{ saveError }}
@@ -496,7 +496,7 @@ const {
               {{ t('pages.projectDetail.pm.channel.longConnHint') }}
             </p>
 
-            <div class="mt-3 border border-line p-3">
+            <div class="rounded-lg mt-3 border border-line p-3">
               <label class="flex cursor-pointer items-center gap-2.5 text-[13px] text-txt">
                 <AppSwitch
                   v-model="chCronDeliver"
@@ -567,7 +567,7 @@ const {
           </div>
 
           <div class="grid gap-4 content-start">
-            <div class="border border-line bg-surface p-4">
+            <div class="rounded-lg border border-line bg-surface p-4">
               <h3 class="m-0 text-[13px] font-semibold text-txt">
                 {{ t('pages.projectDetail.pm.channel.sessionCapsTitle') }}
               </h3>
@@ -594,21 +594,21 @@ const {
               </label>
             </div>
 
-            <div class="border border-line bg-surface p-4">
+            <div class="rounded-lg border border-line bg-surface p-4">
               <h3 class="m-0 text-[13px] font-semibold text-txt">
                 {{ t('pages.projectDetail.pm.channel.channelMcpsTitle') }}
               </h3>
               <p class="m-0 mb-2 mt-1 text-xs text-txt2">
                 {{ t('pages.projectDetail.pm.channel.channelMcpsHint') }}
               </p>
-              <div class="mb-3 border border-info/35 bg-info/10 px-3 py-2 text-xs text-txt2">
+              <div class="rounded-lg mb-3 border border-info/35 bg-info/10 px-3 py-2 text-xs text-txt2">
                 {{ t('pages.projectDetail.pm.channel.channelMcpsNote') }}
               </div>
               <div class="grid gap-2">
                 <label
                   v-for="opt in PM_MCP_OPTIONS"
                   :key="opt.id"
-                  class="flex cursor-pointer items-center justify-between gap-2 border border-line bg-base px-3 py-2.5 text-[13px]"
+                  class="rounded-md flex cursor-pointer items-center justify-between gap-2 border border-line bg-base px-3 py-2.5 text-[13px]"
                 >
                   <span class="flex items-center gap-2">
                     <AppSwitch
@@ -691,7 +691,7 @@ const {
         </AppButton>
       </div>
 
-      <div class="mb-3 flex items-center justify-between gap-2 border border-line bg-surface px-3.5 py-3">
+      <div class="rounded-lg mb-3 flex items-center justify-between gap-2 border border-line bg-surface px-3.5 py-3">
         <div>
           <div class="text-[13px] font-medium text-txt">
             {{ t('pages.projectDetail.pm.channel.notifyPolicyTitle') }}
@@ -700,15 +700,15 @@ const {
             {{ t('pages.projectDetail.pm.channel.notifyPolicyHint') }}
           </div>
         </div>
-        <span class="border border-line bg-elevated px-2 py-0.5 text-[12px] text-txt2">
+        <span class="rounded-md border border-line bg-elevated px-2 py-0.5 text-[12px] text-txt2">
           {{ t('pages.projectDetail.pm.channel.notifySelected', { n: notifySelected.length }) }}
         </span>
       </div>
 
-      <div v-if="!channelList.length" class="border border-dashed border-line-strong p-3.5 text-xs text-txt3">
+      <div v-if="!channelList.length" class="rounded-lg border border-dashed border-line-strong p-3.5 text-xs text-txt3">
         {{ t('pages.projectDetail.pm.channel.listEmpty') }}
       </div>
-      <div v-else class="border border-line">
+      <div v-else class="rounded-lg border border-line">
         <label
           v-for="ch in channelList"
           :key="ch.id"
@@ -725,13 +725,13 @@ const {
               <span>{{ ch.name || ch.appId }}</span>
               <span
                 v-if="ch.isPrimary"
-                class="border border-accent/55 bg-accent-dim px-2 py-0.5 text-[11px] text-accent-2"
+                class="rounded-md border border-accent/55 bg-accent-dim px-2 py-0.5 text-[11px] text-accent-2"
               >
                 {{ t('pages.projectDetail.pm.channel.rolePrimary') }}
               </span>
               <span
                 v-if="!ch.enabled"
-                class="border border-line px-2 py-0.5 text-[11px] text-txt3"
+                class="rounded-md border border-line px-2 py-0.5 text-[11px] text-txt3"
               >
                 {{ t('pages.projectDetail.pm.channel.statusOff') }}
               </span>
@@ -745,13 +745,13 @@ const {
 
       <div
         v-if="!notifySelected.length"
-        class="mt-2.5 border border-dashed border-line-strong bg-base p-3.5 text-xs text-txt3"
+        class="rounded-lg mt-2.5 border border-dashed border-line-strong bg-base p-3.5 text-xs text-txt3"
         data-testid="notify-empty-hint"
       >
         {{ t('pages.projectDetail.pm.channel.notifyEmpty') }}
       </div>
 
-      <div class="mt-4 border border-line" data-testid="channel-deliver-log">
+      <div class="rounded-lg mt-4 border border-line" data-testid="channel-deliver-log">
         <div class="border-b border-line bg-elevated px-3.5 py-2 text-[13px] font-medium text-txt">
           {{ t('pages.projectDetail.pm.channel.deliverLogTitle') }}
         </div>
@@ -764,7 +764,7 @@ const {
           class="flex items-start gap-2 border-b border-line px-3.5 py-2.5 last:border-b-0"
         >
           <span
-            class="shrink-0 border px-2 py-0.5 text-[11px]"
+            class="rounded-md shrink-0 border px-2 py-0.5 text-[11px]"
             :class="rec.status === 'ok' ? 'border-ok/40 text-ok' : 'border-err/45 text-err'"
           >
             {{ rec.status === 'ok' ? t('pages.projectDetail.pm.channel.deliverOk') : t('pages.projectDetail.pm.channel.deliverFail') }}
@@ -776,7 +776,7 @@ const {
         </div>
       </div>
 
-      <div class="mt-3 border border-warn/40 bg-warn/10 px-3 py-2.5 text-xs leading-snug text-txt2">
+      <div class="rounded-lg mt-3 border border-warn/40 bg-warn/10 px-3 py-2.5 text-xs leading-snug text-txt2">
         {{ t('pages.projectDetail.pm.channel.notifyFanoutHint') }}
       </div>
     </div>
@@ -787,7 +787,7 @@ const {
       class="fixed inset-0 z-40 flex items-center justify-center bg-black/55 p-6"
       data-testid="channel-delete-primary-modal"
     >
-      <div class="w-full max-w-md border border-line-strong bg-surface p-4 shadow-[var(--shadow-card)]">
+      <div class="rounded-xl w-full max-w-md border border-line-strong bg-surface p-4 shadow-[var(--shadow-card)]">
         <h3 class="m-0 text-sm font-semibold text-txt">
           {{ t('pages.projectDetail.pm.channel.deletePrimaryTitle') }}
         </h3>
@@ -797,7 +797,7 @@ const {
         <div class="mb-3.5 grid gap-2">
           <button
             type="button"
-            class="border px-3 py-2.5 text-left text-xs"
+            class="rounded-lg border px-3 py-2.5 text-left text-xs"
             :class="
               deleteMode === 'promote'
                 ? 'border-accent bg-accent-dim text-txt'
@@ -809,7 +809,7 @@ const {
           </button>
           <button
             type="button"
-            class="border px-3 py-2.5 text-left text-xs"
+            class="rounded-lg border px-3 py-2.5 text-left text-xs"
             :class="
               deleteMode === 'none'
                 ? 'border-accent bg-accent-dim text-txt'

--- a/web/src/components/pm/PmCronJobsPanel.vue
+++ b/web/src/components/pm/PmCronJobsPanel.vue
@@ -131,7 +131,7 @@ onMounted(() => void load())
     <div :class="showRefreshProgress ? 'opacity-[0.55]' : ''">
       <div
         v-if="showSkeleton"
-        class="overflow-x-auto border border-line"
+        class="rounded-lg overflow-x-auto border border-line"
         data-testid="cron-table-skeleton"
         aria-hidden="true"
       >
@@ -163,7 +163,7 @@ onMounted(() => void load())
         v-else-if="loadDenied"
         role="status"
         data-testid="cron-denied"
-        class="border border-warn/40 bg-warn/10 px-5 py-10 text-center"
+        class="rounded-lg border border-warn/40 bg-warn/10 px-5 py-10 text-center"
       >
         <Icon name="lock" :size="22" class="mx-auto mb-3 text-warn" />
         <h3 class="text-sm font-semibold text-txt">{{ t('common.asyncState.permissionDeniedTitle') }}</h3>
@@ -177,7 +177,7 @@ onMounted(() => void load())
         v-else-if="loadFailed"
         role="status"
         data-testid="cron-failed"
-        class="border border-err/40 bg-err/10 px-5 py-10 text-center"
+        class="rounded-lg border border-err/40 bg-err/10 px-5 py-10 text-center"
       >
         <h3 class="text-sm font-semibold text-txt">{{ t('common.asyncState.loadFailedTitle') }}</h3>
         <p class="mt-1 text-xs text-txt2">{{ t('common.asyncState.loadFailedDesc') }}</p>

--- a/web/src/components/pm/PmLeaderChat.vue
+++ b/web/src/components/pm/PmLeaderChat.vue
@@ -170,7 +170,7 @@ const {
     <AppButton @click="emit('openSettings')">{{ t('pages.projectDetail.pm.goSettings') }}</AppButton>
   </div>
 
-  <div v-else class="flex min-h-0 flex-1 overflow-hidden border border-line bg-base">
+  <div v-else class="rounded-lg flex min-h-0 flex-1 overflow-hidden border border-line bg-base">
     <!-- left rail -->
     <aside
       v-if="showThreadsAside"
@@ -207,7 +207,7 @@ const {
             <span class="min-w-0 truncate font-mono text-[12px]">{{ threadDisplayTitle(th) }}</span>
             <span
               v-if="isChannelThread(th)"
-              class="inline-flex shrink-0 items-center border px-1 text-[9px] font-bold tracking-wide leading-4"
+              class="rounded-md inline-flex shrink-0 items-center border px-1 text-[9px] font-bold tracking-wide leading-4"
               :class="channelBadgeClass(th)"
               data-testid="pm-qq-tag"
               :data-channel-kind="channelTypeOf(th)"
@@ -215,12 +215,12 @@ const {
             >{{ channelBadgeLabel(th) }}</span>
             <span
               v-if="th.unspoken"
-              class="inline-flex shrink-0 items-center border border-warn/45 px-1 text-[9px] leading-4 text-warn"
+              class="rounded-md inline-flex shrink-0 items-center border border-warn/45 px-1 text-[9px] leading-4 text-warn"
               data-testid="pm-unspoken-tag"
             >{{ t('pages.projectDetail.pm.unspoken') }}</span>
             <span
               v-else
-              class="inline-flex shrink-0 items-center border border-line bg-elevated px-1 text-[9px] font-bold tracking-wide leading-4 text-txt3"
+              class="rounded-md inline-flex shrink-0 items-center border border-line bg-elevated px-1 text-[9px] font-bold tracking-wide leading-4 text-txt3"
               data-testid="pm-web-tag"
             >{{ t('pages.projectDetail.pm.channelBadgeWeb') }}</span>
           </span>
@@ -268,7 +268,7 @@ const {
             <span class="min-w-0 truncate text-sm font-medium text-txt">{{ activeThreadTitle }}</span>
             <span
               v-if="activeIsChannel"
-              class="inline-flex shrink-0 items-center border px-1 text-[9px] font-bold tracking-wide leading-4"
+              class="rounded-md inline-flex shrink-0 items-center border px-1 text-[9px] font-bold tracking-wide leading-4"
               :class="channelBadgeClass(activeThread)"
               data-testid="pm-qq-tag-header"
               :data-channel-kind="channelTypeOf(activeThread)"
@@ -276,7 +276,7 @@ const {
             >{{ channelBadgeLabel(activeThread) }}</span>
             <span
               v-if="activeThread?.unspoken"
-              class="inline-flex shrink-0 items-center border border-warn/45 px-1 text-[9px] leading-4 text-warn"
+              class="rounded-md inline-flex shrink-0 items-center border border-warn/45 px-1 text-[9px] leading-4 text-warn"
               data-testid="pm-unspoken-tag-header"
             >{{ t('pages.projectDetail.pm.unspoken') }}</span>
           </div>
@@ -333,7 +333,7 @@ const {
               v-for="s in suggestions"
               :key="s"
               type="button"
-              class="border border-line bg-surface px-3 py-1 text-sm text-txt2 hover:bg-elevated hover:text-txt disabled:opacity-50"
+              class="rounded-md border border-line bg-surface px-3 py-1 text-sm text-txt2 hover:bg-elevated hover:text-txt disabled:opacity-50"
               :disabled="busy"
               @click="send(s)"
             >
@@ -354,12 +354,12 @@ const {
         <template v-for="m in messages" :key="m.id">
           <div
             v-if="isChannelHint(m)"
-            class="mx-auto flex max-w-[92%] items-start gap-2 self-center border border-warn/35 bg-warn/[0.08] px-3 py-2 text-[12px] text-txt"
+            class="rounded-lg mx-auto flex max-w-[92%] items-start gap-2 self-center border border-warn/35 bg-warn/[0.08] px-3 py-2 text-[12px] text-txt"
             :data-msg-id="m.id"
             data-testid="pm-channel-hint"
           >
             <span
-              class="shrink-0 border border-warn/35 px-1.5 py-px text-[10px] font-bold tracking-wide text-warn"
+              class="rounded-md shrink-0 border border-warn/35 px-1.5 py-px text-[10px] font-bold tracking-wide text-warn"
             >
               {{ t('pages.projectDetail.pm.channelHintLabel') }}
             </span>
@@ -372,7 +372,7 @@ const {
           </div>
           <div v-else-if="m.role === 'user'" class="flex gap-2.5 flex-row-reverse" :data-msg-id="m.id">
             <div
-              class="flex h-7 w-7 shrink-0 items-center justify-center border border-accent/20 bg-accent-dim text-[11px] font-semibold text-accent-2"
+              class="rounded-full flex h-7 w-7 shrink-0 items-center justify-center border border-accent/20 bg-accent-dim text-[11px] font-semibold text-accent-2"
             >
               {{ t('pages.projectDetail.pm.me') }}
             </div>
@@ -391,7 +391,7 @@ const {
                   />
                   <div
                     v-else
-                    class="flex max-w-[200px] items-center gap-2 border border-line bg-elevated px-2 py-1.5"
+                    class="rounded-lg flex max-w-[200px] items-center gap-2 border border-line bg-elevated px-2 py-1.5"
                     data-testid="pm-history-file-chip"
                     :title="attachmentDisplayName(im, ii)"
                   >
@@ -402,13 +402,13 @@ const {
               </div>
               <div
                 v-if="m.content"
-                class="border border-accent/35 bg-accent px-3 py-2 text-sm leading-6 text-white whitespace-pre-wrap"
+                class="rounded-lg border border-accent/35 bg-accent px-3 py-2 text-sm leading-6 text-white whitespace-pre-wrap"
               >
                 {{ m.content }}
               </div>
               <div
                 v-else-if="m.images?.length"
-                class="border border-accent/35 bg-accent px-3 py-2 text-sm leading-6 text-white/80"
+                class="rounded-lg border border-accent/35 bg-accent px-3 py-2 text-sm leading-6 text-white/80"
               >
                 {{ t('pages.projectDetail.pm.imagesOnly') }}
               </div>
@@ -417,14 +417,14 @@ const {
           </div>
           <div v-else-if="m.role === 'assistant'" class="flex gap-2.5" :data-msg-id="m.id">
             <div
-              class="flex h-7 w-7 shrink-0 items-center justify-center border border-accent/25 bg-accent/10 text-accent-2"
+              class="rounded-full flex h-7 w-7 shrink-0 items-center justify-center border border-accent/25 bg-accent/10 text-accent-2"
             >
               <Icon name="robot" :size="15" />
             </div>
             <div class="min-w-0 max-w-[85%]">
               <div
                 data-assistant-bubble
-                class="border border-line bg-elevated px-3 py-2 text-sm leading-6 text-txt"
+                class="rounded-md border border-line bg-elevated px-3 py-2 text-sm leading-6 text-txt"
               >
                 <div class="md" v-html="renderMarkdown(m.content)" />
                 <div
@@ -462,12 +462,12 @@ const {
             data-testid="pm-failed-partial"
           >
             <div
-              class="flex h-7 w-7 shrink-0 items-center justify-center border border-accent/25 bg-accent/10 text-accent-2"
+              class="rounded-full flex h-7 w-7 shrink-0 items-center justify-center border border-accent/25 bg-accent/10 text-accent-2"
             >
               <Icon name="robot" :size="15" />
             </div>
             <div class="min-w-0 max-w-[85%]">
-              <div class="border border-err/35 bg-err/[0.06] px-3 py-2 text-sm leading-6 text-txt">
+              <div class="rounded-lg border border-err/35 bg-err/[0.06] px-3 py-2 text-sm leading-6 text-txt">
                 <div class="mb-1.5 flex items-center gap-1.5 text-[11px] font-semibold text-red-400">
                   <Icon name="alert" :size="14" class="shrink-0" />
                   {{ t('pages.projectDetail.pm.failPartialKeptMeta') }}
@@ -480,7 +480,7 @@ const {
           <!-- Failure card hangs beside the user turn (after the bubble / partial). -->
           <div v-if="isFailedUser(m)" class="flex justify-start">
             <div
-              class="fail-card ml-[38px] max-w-[85%] flex flex-col gap-2 border border-err/35 bg-err/10 px-3 py-2.5"
+              class="rounded-lg fail-card ml-[38px] max-w-[85%] flex flex-col gap-2 border border-err/35 bg-err/10 px-3 py-2.5"
               role="alert"
             >
               <div class="flex items-start gap-2">
@@ -497,7 +497,7 @@ const {
               <div>
                 <button
                   type="button"
-                  class="border border-err/40 bg-transparent px-2.5 py-1 text-xs text-err hover:bg-err/15 disabled:opacity-50"
+                  class="rounded-md border border-err/40 bg-transparent px-2.5 py-1 text-xs text-err hover:bg-err/15 disabled:opacity-50"
                   :disabled="busy"
                   data-testid="pm-fail-retry"
                   @click="retryTurn(m.id)"
@@ -511,13 +511,13 @@ const {
 
         <div v-if="showStreamBubble" class="flex gap-2.5" data-testid="pm-stream-bubble">
           <div
-            class="flex h-7 w-7 shrink-0 items-center justify-center border border-accent/25 bg-accent/10 text-accent-2"
+            class="rounded-full flex h-7 w-7 shrink-0 items-center justify-center border border-accent/25 bg-accent/10 text-accent-2"
           >
             <Icon name="robot" :size="15" />
           </div>
           <div class="min-w-0 max-w-[85%]">
             <div
-              class="border bg-elevated px-3 py-2 text-sm text-txt"
+              class="rounded-lg border bg-elevated px-3 py-2 text-sm text-txt"
               :class="
                 finalizing
                   ? 'border-warn/35 shadow-[inset_0_0_0_1px_rgb(var(--color-warn)/0.08)]'
@@ -587,7 +587,7 @@ const {
             v-for="s in suggestions"
             :key="s"
             type="button"
-            class="border border-line bg-surface px-2.5 py-1 text-xs text-txt2 hover:bg-elevated hover:text-txt disabled:opacity-50"
+            class="rounded-md border border-line bg-surface px-2.5 py-1 text-xs text-txt2 hover:bg-elevated hover:text-txt disabled:opacity-50"
             :disabled="busy"
             @click="send(s)"
           >
@@ -599,9 +599,9 @@ const {
       </div>
 
       <div v-if="activeIsChannel" class="shrink-0 border-t border-line p-3" data-testid="pm-channel-readonly">
-        <div class="flex items-center gap-2.5 border border-accent-2/30 bg-accent/10 px-3.5 py-3">
+        <div class="rounded-lg flex items-center gap-2.5 border border-accent-2/30 bg-accent/10 px-3.5 py-3">
           <div
-            class="flex h-7 w-7 shrink-0 items-center justify-center border border-accent-2/35 bg-accent/15 text-accent-2"
+            class="rounded-full flex h-7 w-7 shrink-0 items-center justify-center border border-accent-2/35 bg-accent/15 text-accent-2"
             aria-hidden="true"
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -634,7 +634,7 @@ const {
             />
             <div
               v-else
-              class="flex h-14 max-w-[160px] items-center gap-1.5 border border-line bg-elevated px-2"
+              class="rounded-lg flex h-14 max-w-[160px] items-center gap-1.5 border border-line bg-elevated px-2"
               data-testid="pm-pending-file-chip"
               :title="attachmentDisplayName(im, ii)"
             >
@@ -673,7 +673,7 @@ const {
           <textarea
             v-model="input"
             rows="2"
-            class="scroll-area max-h-32 min-h-[40px] min-w-0 flex-1 resize-none border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent disabled:opacity-50"
+            class="rounded-md scroll-area max-h-32 min-h-[40px] min-w-0 flex-1 resize-none border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent disabled:opacity-50"
             :placeholder="t('pages.projectDetail.pm.inputPh')"
             :disabled="busy"
             @keydown.enter.exact.prevent="send()"
@@ -719,7 +719,7 @@ const {
   />
   <div
     v-if="channelCtx"
-    class="fixed z-50 min-w-[160px] border border-line bg-elevated py-1 shadow-card"
+    class="rounded-lg fixed z-50 min-w-[160px] border border-line bg-elevated py-1 shadow-card"
     data-testid="pm-channel-ctx-menu"
     role="menu"
     :style="{ left: `${channelCtx.x}px`, top: `${channelCtx.y}px` }"
@@ -745,7 +745,7 @@ const {
     aria-modal="true"
     @click.self="closeChannelDetail"
   >
-    <div class="w-full max-w-[360px] border border-line bg-surface shadow-card">
+    <div class="rounded-xl w-full max-w-[360px] border border-line bg-surface shadow-card">
       <div class="flex items-center justify-between border-b border-line px-3.5 py-3 text-[13px] font-semibold text-txt">
         <span>{{ t('pages.projectDetail.pm.channelDetailTitle') }}</span>
         <button
@@ -759,13 +759,13 @@ const {
       <div class="flex flex-col gap-3 p-3.5">
         <div>
           <div class="mb-1 text-[11px] text-txt3">{{ t('pages.projectDetail.pm.channelDetailLabelTitle') }}</div>
-          <div class="border border-line bg-base px-2.5 py-2 text-[13px] text-txt" data-testid="pm-channel-detail-title">
+          <div class="rounded-lg border border-line bg-base px-2.5 py-2 text-[13px] text-txt" data-testid="pm-channel-detail-title">
             {{ channelDetailTitle }}
           </div>
         </div>
         <div>
           <div class="mb-1 text-[11px] text-txt3">{{ t('pages.projectDetail.pm.channelDetailLabelSource') }}</div>
-          <div class="border border-line bg-base px-2.5 py-2 text-[13px] text-txt" data-testid="pm-channel-detail-source">
+          <div class="rounded-lg border border-line bg-base px-2.5 py-2 text-[13px] text-txt" data-testid="pm-channel-detail-source">
             {{ channelDetailSource }}
           </div>
         </div>

--- a/web/src/components/pm/PmSettingsPanel.vue
+++ b/web/src/components/pm/PmSettingsPanel.vue
@@ -224,7 +224,7 @@ void load()
 
 <template>
   <div
-    class="flex min-h-0 flex-1 flex-col overflow-hidden border border-line bg-surface shadow-[var(--shadow-card)]"
+    class="rounded-lg flex min-h-0 flex-1 flex-col overflow-hidden border border-line bg-surface shadow-[var(--shadow-card)]"
   >
     <div
       class="flex shrink-0 flex-wrap items-start justify-between gap-3 border-b border-line bg-elevated/55 px-4 py-3.5"
@@ -236,7 +236,7 @@ void load()
       </div>
       <div
         v-if="statusBadge"
-        class="inline-flex max-w-full items-center gap-1.5 whitespace-nowrap border px-2.5 py-1 text-xs"
+        class="rounded-md inline-flex max-w-full items-center gap-1.5 whitespace-nowrap border px-2.5 py-1 text-xs"
         :class="badgeClass"
         role="status"
       >
@@ -254,7 +254,7 @@ void load()
 
     <div class="scroll-area flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">
       <div
-        class="flex items-start gap-2.5 border border-accent-2/20 bg-accent-dim/85 px-3 py-2.5 text-[13px] leading-snug text-txt"
+        class="rounded-lg flex items-start gap-2.5 border border-accent-2/20 bg-accent-dim/85 px-3 py-2.5 text-[13px] leading-snug text-txt"
       >
         <svg
           class="mt-0.5 h-3.5 w-3.5 shrink-0 stroke-accent-2"

--- a/web/src/components/project/ProjectAgentSelect.vue
+++ b/web/src/components/project/ProjectAgentSelect.vue
@@ -245,6 +245,7 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
   justify-content: space-between;
   gap: 8px;
   border: 1px solid rgb(var(--c-line));
+  border-radius: 8px;
   background: rgb(var(--c-base));
   color: rgb(var(--c-txt));
   padding: 0 10px;
@@ -286,6 +287,8 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
   top: calc(100% + 6px);
   width: min(320px, 78vw);
   border: 1px solid rgb(var(--c-line-strong));
+  border-radius: 12px;
+  overflow: hidden;
   background: rgb(var(--c-elevated));
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
   z-index: 20;
@@ -300,6 +303,7 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
   width: 100%;
   height: 32px;
   border: 1px solid rgb(var(--c-line));
+  border-radius: 8px;
   background: rgb(var(--c-surface));
   color: rgb(var(--c-txt));
   padding: 0 10px;
@@ -325,6 +329,7 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
   width: 100%;
   text-align: left;
   border: 0;
+  border-radius: 8px;
   background: transparent;
   color: rgb(var(--c-txt));
   padding: 8px 10px;

--- a/web/src/components/project/ProjectAuditPanel.vue
+++ b/web/src/components/project/ProjectAuditPanel.vue
@@ -659,7 +659,7 @@ onUnmounted(() => {
   <div class="audit-panel" data-testid="project-audit-panel">
     <div
       v-if="denied || forceDenied"
-      class="flex min-h-0 flex-1 flex-col items-center justify-center gap-2 border border-dashed border-line bg-surface px-6 py-16 text-center"
+      class="rounded-lg flex min-h-0 flex-1 flex-col items-center justify-center gap-2 border border-dashed border-line bg-surface px-6 py-16 text-center"
       data-testid="project-audit-denied"
     >
       <div class="text-sm font-semibold text-txt">{{ t('pages.projectDetail.audit.deniedTitle') }}</div>

--- a/web/src/components/project/ProjectSharedAgentPanel.vue
+++ b/web/src/components/project/ProjectSharedAgentPanel.vue
@@ -296,7 +296,7 @@ onMounted(() => {
 
 <template>
   <div
-    class="flex min-h-0 flex-1 flex-col overflow-hidden border border-b-0 border-line bg-surface shadow-[var(--shadow-card)]"
+    class="rounded-lg flex min-h-0 flex-1 flex-col overflow-hidden border border-b-0 border-line bg-surface shadow-[var(--shadow-card)]"
     data-testid="project-shared-agent-panel"
   >
     <div
@@ -413,7 +413,7 @@ onMounted(() => {
                 v-for="b in ACP_BACKENDS"
                 :key="b.id"
                 type="button"
-                class="border px-2 py-3 text-center transition"
+                class="rounded-lg border px-2 py-3 text-center transition"
                 :class="
                   draft.acpBackend === b.id
                     ? 'border-accent bg-accent-dim text-txt'
@@ -434,7 +434,7 @@ onMounted(() => {
             <p class="mb-2 text-[11px] text-txt3">{{ t('pages.agentStudio.meta.regionDesc') }}</p>
             <p
               v-if="specialRegion"
-              class="mb-2 border border-warn/35 bg-warn/10 px-2.5 py-2 font-mono text-[11px] text-warn"
+              class="rounded-md mb-2 border border-warn/35 bg-warn/10 px-2.5 py-2 font-mono text-[11px] text-warn"
             >
               {{ t('pages.agentStudio.region.special', { value: specialRegion }) }}
             </p>
@@ -443,7 +443,7 @@ onMounted(() => {
                 v-for="r in metaRegionOptions"
                 :key="r.id"
                 type="button"
-                class="border px-2 py-3 text-center transition"
+                class="rounded-lg border px-2 py-3 text-center transition"
                 :class="
                   displayRegion === r.id
                     ? 'border-accent bg-accent-dim text-txt'
@@ -469,7 +469,7 @@ onMounted(() => {
             <input
               v-model="draft.projectId"
               spellcheck="false"
-              class="w-full border border-line bg-base px-3 py-2 font-mono text-[12px] text-txt outline-none focus:border-accent"
+              class="rounded-md w-full border border-line bg-base px-3 py-2 font-mono text-[12px] text-txt outline-none focus:border-accent"
               :placeholder="projectId"
             />
           </label>
@@ -481,7 +481,7 @@ onMounted(() => {
               v-model="draft.layout.configRoot"
               :placeholder="defaultConfigRootFor(draft.acpBackend)"
               spellcheck="false"
-              class="w-full border border-line bg-base px-3 py-2 font-mono text-[12px] text-txt outline-none focus:border-accent"
+              class="rounded-md w-full border border-line bg-base px-3 py-2 font-mono text-[12px] text-txt outline-none focus:border-accent"
               @input="configRootTouched = true"
             />
           </label>
@@ -492,7 +492,7 @@ onMounted(() => {
               v-model="draft.layout.workspaceDir"
               :placeholder="DEFAULT_WORKSPACE_DIR"
               spellcheck="false"
-              class="w-full border border-line bg-base px-3 py-2 font-mono text-[12px] text-txt outline-none focus:border-accent"
+              class="rounded-md w-full border border-line bg-base px-3 py-2 font-mono text-[12px] text-txt outline-none focus:border-accent"
             />
           </label>
         </div>
@@ -512,7 +512,7 @@ onMounted(() => {
                 data-test="shared-ssh-known-hosts"
                 rows="4"
                 spellcheck="false"
-                class="w-full border border-line bg-base px-3 py-2 font-mono text-[12px] text-txt outline-none focus:border-accent"
+                class="rounded-md w-full border border-line bg-base px-3 py-2 font-mono text-[12px] text-txt outline-none focus:border-accent"
                 :placeholder="t('pages.agentStudio.meta.sshKnownHostsPh')"
               />
             </label>
@@ -524,7 +524,7 @@ onMounted(() => {
                 data-test="shared-ssh-private-key"
                 rows="5"
                 spellcheck="false"
-                class="w-full border border-line bg-base px-3 py-2 font-mono text-[12px] text-txt outline-none focus:border-accent"
+                class="rounded-md w-full border border-line bg-base px-3 py-2 font-mono text-[12px] text-txt outline-none focus:border-accent"
                 :placeholder="t('pages.agentStudio.meta.sshPrivateKeyPh')"
                 :style="draft.gitSshPrivateKey ? { WebkitTextSecurity: 'disc' } as Record<string, string> : undefined"
               />
@@ -536,7 +536,7 @@ onMounted(() => {
           <div class="mb-1.5 text-[11px] uppercase tracking-wider text-txt3">
             {{ t('pages.agentStudio.meta.derivedPaths') }}
           </div>
-          <div class="overflow-hidden border border-line">
+          <div class="rounded-lg overflow-hidden border border-line">
             <table class="w-full text-left text-[12px]">
               <tbody>
                 <tr

--- a/web/src/components/project/RequirementDraftsPanel.vue
+++ b/web/src/components/project/RequirementDraftsPanel.vue
@@ -146,7 +146,7 @@ defineExpose({
 
 <template>
   <div
-    class="requirement-drafts flex h-full min-h-0 min-w-0 flex-1 flex-col border border-line bg-base"
+    class="rounded-lg requirement-drafts flex h-full min-h-0 min-w-0 flex-1 flex-col border border-line bg-base"
     data-testid="requirement-drafts-panel"
   >
     <!-- Top toolbar -->
@@ -218,7 +218,7 @@ defineExpose({
       <input
         v-model="query"
         type="search"
-        class="min-w-[160px] flex-1 border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent focus:shadow-[0_0_0_2px_rgba(123,97,255,0.3)]"
+        class="rounded-md min-w-[160px] flex-1 border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent focus:shadow-[0_0_0_2px_rgba(123,97,255,0.3)]"
         data-testid="requirement-drafts-search"
         :placeholder="t('pages.projectDetail.requirementDrafts.searchPh')"
         @input="onSearchInput"
@@ -249,7 +249,7 @@ defineExpose({
             v-for="d in items"
             :key="d.id"
             type="button"
-            class="relative block w-full border border-line px-3 py-2.5 text-left hover:bg-elevated"
+            class="rounded-lg relative block w-full border border-line px-3 py-2.5 text-left hover:bg-elevated"
             :class="d.id === selectedId ? 'bg-accent-dim' : 'bg-transparent'"
             :data-testid="`requirement-drafts-item-${d.id}`"
             @click="onPickDraft(d.id)"
@@ -263,11 +263,11 @@ defineExpose({
               <span class="min-w-0 truncate">{{ d.title }}</span>
             </div>
             <div class="flex flex-wrap items-center gap-2 text-[11px] text-txt3">
-              <span class="border border-line bg-elevated px-1.5 py-px text-txt2">
+              <span class="rounded-lg border border-line bg-elevated px-1.5 py-px text-txt2">
                 {{ kindLabel(d.kind) }}
               </span>
               <span
-                class="border px-1.5 py-px"
+                class="rounded-lg border px-1.5 py-px"
                 :class="
                   d.status === 'open'
                     ? 'border-info/40 text-info bg-elevated'
@@ -306,7 +306,7 @@ defineExpose({
                   {{ t('pages.projectDetail.requirementDrafts.editLabel') }}
                 </strong>
                 <span
-                  class="border px-1.5 py-px text-[11px]"
+                  class="rounded-md border px-1.5 py-px text-[11px]"
                   :class="
                     selectedStatus === 'open'
                       ? 'border-info/40 text-info bg-elevated'
@@ -322,7 +322,7 @@ defineExpose({
                 </span>
                 <span
                   v-if="isDirty"
-                  class="border border-warn/40 bg-elevated px-1.5 py-px text-[11px] text-warn"
+                  class="rounded-md border border-warn/40 bg-elevated px-1.5 py-px text-[11px] text-warn"
                   data-testid="requirement-drafts-dirty-chip"
                 >
                   {{ t('pages.projectDetail.requirementDrafts.unsaved') }}
@@ -382,7 +382,7 @@ defineExpose({
                 id="requirement-draft-title"
                 v-model="editTitle"
                 type="text"
-                class="w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent focus:shadow-[0_0_0_2px_rgba(123,97,255,0.3)]"
+                class="rounded-md w-full border border-line bg-base px-3 py-2 text-[13px] text-txt outline-none focus:border-accent focus:shadow-[0_0_0_2px_rgba(123,97,255,0.3)]"
                 data-testid="requirement-drafts-title"
                 :placeholder="t('pages.projectDetail.requirementDrafts.titlePh')"
               />
@@ -393,7 +393,7 @@ defineExpose({
 
             <!-- Schedule block (edit view) -->
             <div
-              class="rd-schedule mb-4 border border-accent bg-surface p-3"
+              class="rounded-lg rd-schedule mb-4 border border-accent bg-surface p-3"
               data-testid="requirement-drafts-schedule-block"
             >
               <div class="mb-2 text-[13px] font-medium text-txt">
@@ -407,7 +407,7 @@ defineExpose({
                   {{ t('pages.projectDetail.requirementDrafts.kindLabel') }}
                   <select
                     v-model="editKind"
-                    class="mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
+                    class="rounded-md mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
                     data-testid="requirement-drafts-schedule-kind"
                     :disabled="scheduleBusy"
                     @change="onScheduleKindChange"
@@ -425,7 +425,7 @@ defineExpose({
                   <input
                     v-model="editStartAt"
                     type="date"
-                    class="mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
+                    class="rounded-md mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
                     data-testid="requirement-drafts-schedule-start"
                     :disabled="scheduleBusy"
                     @change="onScheduleStartChange"
@@ -436,7 +436,7 @@ defineExpose({
                   <input
                     v-model="editDueAt"
                     type="date"
-                    class="mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
+                    class="rounded-md mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
                     data-testid="requirement-drafts-schedule-due"
                     :disabled="scheduleBusy"
                     @change="onScheduleDueChange"
@@ -449,7 +449,7 @@ defineExpose({
                     type="number"
                     min="0"
                     max="100"
-                    class="mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
+                    class="rounded-md mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
                     data-testid="requirement-drafts-schedule-progress"
                     :disabled="scheduleBusy"
                     @change="onScheduleProgressChange"
@@ -459,7 +459,7 @@ defineExpose({
                   {{ t('pages.projectDetail.requirementDrafts.parentLabel') }}
                   <select
                     v-model="editParentId"
-                    class="mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
+                    class="rounded-md mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
                     data-testid="requirement-drafts-schedule-parent"
                     :disabled="scheduleBusy"
                     @change="onScheduleParentChange"
@@ -487,7 +487,7 @@ defineExpose({
                 {{ t('pages.projectDetail.requirementDrafts.bodyLabel') }}
               </label>
               <div
-                class="rd-toolbar flex flex-wrap items-center gap-0.5 border border-b-0 border-line bg-elevated p-1.5"
+                class="rounded-lg rd-toolbar flex flex-wrap items-center gap-0.5 border border-b-0 border-line bg-elevated p-1.5"
                 data-testid="requirement-drafts-toolbar"
               >
                 <button
@@ -619,12 +619,12 @@ defineExpose({
               </div>
               <div
                 v-if="isMobile"
-                class="flex gap-1.5 border border-b-0 border-line bg-elevated p-1.5"
+                class="rounded-lg flex gap-1.5 border border-b-0 border-line bg-elevated p-1.5"
                 data-testid="requirement-drafts-mobile-switch"
               >
                 <button
                   type="button"
-                  class="flex-1 border px-2 py-1 text-xs"
+                  class="rounded-md flex-1 border px-2 py-1 text-xs"
                   :class="mobilePane === 'src' ? 'border-accent bg-accent-dim text-txt' : 'border-line text-txt2'"
                   data-testid="requirement-drafts-mobile-src"
                   @click="mobilePane = 'src'"
@@ -633,7 +633,7 @@ defineExpose({
                 </button>
                 <button
                   type="button"
-                  class="flex-1 border px-2 py-1 text-xs"
+                  class="rounded-md flex-1 border px-2 py-1 text-xs"
                   :class="mobilePane === 'prev' ? 'border-accent bg-accent-dim text-txt' : 'border-line text-txt2'"
                   data-testid="requirement-drafts-mobile-prev"
                   @click="mobilePane = 'prev'"
@@ -643,7 +643,7 @@ defineExpose({
               </div>
               <div
                 ref="splitEl"
-                class="rd-split flex min-h-[360px] flex-1 border border-line bg-surface"
+                class="rounded-lg rd-split flex min-h-[360px] flex-1 border border-line bg-surface"
                 :class="{
                   'rd-split-narrow': isMobile,
                   'rd-split-collapsed': previewCollapsed && !isMobile,
@@ -668,7 +668,7 @@ defineExpose({
                       ref="findInputEl"
                       v-model="findQuery"
                       type="search"
-                      class="min-w-0 flex-1 border border-line bg-base px-2 py-1 text-[12px] text-txt outline-none focus:border-accent"
+                      class="rounded-md min-w-0 flex-1 border border-line bg-base px-2 py-1 text-[12px] text-txt outline-none focus:border-accent"
                       data-testid="requirement-drafts-find-input"
                       :placeholder="t('pages.projectDetail.requirementDrafts.findPh')"
                       @keydown="onFindInputKeydown"
@@ -928,7 +928,7 @@ defineExpose({
               {{ t('pages.projectDetail.requirementDrafts.kindLabel') }}
               <select
                 v-model="editKind"
-                class="mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
+                class="rounded-md mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
                 data-testid="requirement-drafts-inspector-kind"
                 :disabled="scheduleBusy"
                 @change="onScheduleKindChange"
@@ -946,7 +946,7 @@ defineExpose({
               <input
                 v-model="editStartAt"
                 type="date"
-                class="mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
+                class="rounded-md mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
                 data-testid="requirement-drafts-inspector-start"
                 :disabled="scheduleBusy"
                 @change="onScheduleStartChange"
@@ -957,7 +957,7 @@ defineExpose({
               <input
                 v-model="editDueAt"
                 type="date"
-                class="mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
+                class="rounded-md mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
                 data-testid="requirement-drafts-inspector-due"
                 :disabled="scheduleBusy"
                 @change="onScheduleDueChange"
@@ -970,7 +970,7 @@ defineExpose({
                 type="number"
                 min="0"
                 max="100"
-                class="mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
+                class="rounded-md mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
                 data-testid="requirement-drafts-inspector-progress"
                 :disabled="scheduleBusy"
                 @change="onScheduleProgressChange"
@@ -980,7 +980,7 @@ defineExpose({
               {{ t('pages.projectDetail.requirementDrafts.parentLabel') }}
               <select
                 v-model="editParentId"
-                class="mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
+                class="rounded-md mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
                 data-testid="requirement-drafts-inspector-parent"
                 :disabled="scheduleBusy"
                 @change="onScheduleParentChange"
@@ -1037,13 +1037,13 @@ defineExpose({
           <div class="min-w-0 flex-1">
             <div class="text-[13px] font-medium text-txt">{{ m.title }}</div>
             <div class="mt-1 text-[11px] text-txt3">{{ m.dueAt || '—' }} · {{ m.progress }}%</div>
-            <div v-if="isRowSelected(m.id)" class="mt-3 grid gap-2 border border-line bg-surface p-3">
+            <div v-if="isRowSelected(m.id)" class="rounded-lg mt-3 grid gap-2 border border-line bg-surface p-3">
               <label class="block text-xs text-txt2">
                 {{ t('pages.projectDetail.requirementDrafts.dueAtLabel') }}
                 <input
                   v-model="editDueAt"
                   type="date"
-                  class="mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
+                  class="rounded-md mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
                   data-testid="requirement-drafts-milestone-due"
                   :disabled="scheduleBusy"
                   @change="onScheduleDueChange"
@@ -1057,7 +1057,7 @@ defineExpose({
                   type="number"
                   min="0"
                   max="100"
-                  class="mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
+                  class="rounded-md mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
                   data-testid="requirement-drafts-milestone-progress"
                   :disabled="scheduleBusy"
                   @change="onScheduleProgressChange"
@@ -1094,7 +1094,7 @@ defineExpose({
       <div class="mb-4 flex gap-2">
         <button
           type="button"
-          class="flex-1 border px-3 py-2 text-[13px]"
+          class="rounded-lg flex-1 border px-3 py-2 text-[13px]"
           :class="
             newModalKind === 'requirement'
               ? 'border-accent bg-accent-dim text-txt'
@@ -1107,7 +1107,7 @@ defineExpose({
         </button>
         <button
           type="button"
-          class="flex-1 border px-3 py-2 text-[13px]"
+          class="rounded-lg flex-1 border px-3 py-2 text-[13px]"
           :class="
             newModalKind === 'milestone'
               ? 'border-accent bg-accent-dim text-txt'
@@ -1127,7 +1127,7 @@ defineExpose({
         <input
           v-model="newModalDueAt"
           type="date"
-          class="mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
+          class="rounded-md mt-1 w-full border border-line bg-base px-2 py-1.5 text-[13px] text-txt outline-none focus:border-accent"
           data-testid="requirement-drafts-new-milestone-due"
         />
       </label>

--- a/web/src/components/run/AnnotationChip.vue
+++ b/web/src/components/run/AnnotationChip.vue
@@ -49,7 +49,7 @@ const showFieldLabel = computed(() => kind.value === 'field' && !!fieldLabel.val
 
 <template>
   <span
-    class="inline-flex max-w-full items-start gap-1 border px-1.5 py-0.5 text-[11px] leading-snug"
+    class="rounded-md inline-flex max-w-full items-start gap-1 border px-1.5 py-0.5 text-[11px] leading-snug"
     :class="chipClass"
     :title="ann.note || ann.url || path || ann.quote || ''"
     :data-testid="testId"
@@ -64,7 +64,7 @@ const showFieldLabel = computed(() => kind.value === 'field' && !!fieldLabel.val
         {{ ann.quote }}
         <span
           v-if="ann.truncated"
-          class="ml-1 inline-block border border-current px-0.5 text-[9px] opacity-80"
+          class="rounded-lg ml-1 inline-block border border-current px-0.5 text-[9px] opacity-80"
         >{{ t('pages.reviewComposer.chipTruncated') }}</span>
       </span>
       <span v-else-if="showFieldLabel" class="truncate">{{ fieldLabel }}</span>

--- a/web/src/components/run/AppPreviewPanel.vue
+++ b/web/src/components/run/AppPreviewPanel.vue
@@ -164,7 +164,7 @@ function selectPreview(key: string) {
       <p>{{ loadError }}</p>
       <button
         type="button"
-        class="mt-2 inline-flex min-h-11 items-center border border-line px-3 text-[12px] text-txt"
+        class="rounded-lg mt-2 inline-flex min-h-11 items-center border border-line px-3 text-[12px] text-txt"
         @click="retryLoadPorts"
       >
         {{ t('common.chatImage.retry') }}

--- a/web/src/components/run/ArtifactPreview.vue
+++ b/web/src/components/run/ArtifactPreview.vue
@@ -110,7 +110,7 @@ const {
       >
         <button
           type="button"
-          class="inline-flex items-center gap-0.5 border border-line bg-elevated px-1.5 py-px text-[10px] text-txt2 hover:border-line-strong hover:text-txt"
+          class="rounded-md inline-flex items-center gap-0.5 border border-line bg-elevated px-1.5 py-px text-[10px] text-txt2 hover:border-line-strong hover:text-txt"
           :class="{ 'border-accent/60 text-txt': versionMenuOpen }"
           :aria-expanded="versionMenuOpen ? 'true' : 'false'"
           aria-haspopup="listbox"
@@ -123,7 +123,7 @@ const {
         <div
           v-if="versionMenuOpen"
           role="listbox"
-          class="absolute right-0 top-full z-20 mt-1 min-w-[7.5rem] border border-line bg-surface py-0.5"
+          class="rounded-lg absolute right-0 top-full z-20 mt-1 min-w-[7.5rem] border border-line bg-surface py-0.5"
           data-testid="artifact-preview-version-menu"
         >
           <button
@@ -150,12 +150,12 @@ const {
       </div>
       <span
         v-if="viewingHistorical"
-        class="shrink-0 border border-line px-1 py-px text-[10px] text-txt3"
+        class="rounded-md shrink-0 border border-line px-1 py-px text-[10px] text-txt3"
         data-testid="artifact-preview-historical-readonly"
       >{{ t('pages.reactArtifactStage.readonlyBadge') }}</span>
       <div
         v-if="isStructuredPreview"
-        class="inline-flex shrink-0 border border-line"
+        class="rounded-md overflow-hidden inline-flex shrink-0 border border-line"
         data-testid="artifact-preview-mode-toggle"
         role="group"
         :aria-label="t('pages.artifactPreview.modeToggleAria')"
@@ -267,7 +267,7 @@ const {
         </div>
         <div
           v-else
-          class="flex h-full min-h-[320px] w-full items-center justify-center border border-line bg-base p-3"
+          class="rounded-lg flex h-full min-h-[320px] w-full items-center justify-center border border-line bg-base p-3"
           data-testid="artifact-preview-image-wrap"
         >
           <img
@@ -296,7 +296,7 @@ const {
           {{ t('pages.artifactPreview.loadFailed') }}
           <button
             type="button"
-            class="inline-flex min-h-11 items-center border border-line px-3 text-[12px] text-txt"
+            class="rounded-lg inline-flex min-h-11 items-center border border-line px-3 text-[12px] text-txt"
             @click="displayArtifact && loadContent(displayArtifact, { force: true })"
           >
             {{ t('pages.artifactPreview.retry') }}

--- a/web/src/components/run/ClarifyChat.vue
+++ b/web/src/components/run/ClarifyChat.vue
@@ -243,7 +243,7 @@ const {
                 />
                 <div
                   v-else
-                  class="flex max-w-[200px] items-center gap-2 border border-line bg-elevated px-2 py-1.5"
+                  class="rounded-md flex max-w-[200px] items-center gap-2 border border-line bg-elevated px-2 py-1.5"
                   data-testid="clarify-history-file-chip"
                   :title="imagePreviewLabel(t.images, ii)"
                 >
@@ -266,7 +266,7 @@ const {
                 />
                 <div
                   v-else
-                  class="flex max-w-[200px] items-center gap-2 border border-line bg-elevated px-2 py-1.5"
+                  class="rounded-md flex max-w-[200px] items-center gap-2 border border-line bg-elevated px-2 py-1.5"
                   data-testid="clarify-agent-file-chip"
                 >
                   <span class="shrink-0 text-[10px] font-medium uppercase tracking-wide text-info">DOC</span>
@@ -428,7 +428,7 @@ const {
                           @click="pick(curQuestion, o.id)"
                         >
                           <span
-                            class="flex h-4 w-4 shrink-0 items-center justify-center border"
+                            class="rounded-lg flex h-4 w-4 shrink-0 items-center justify-center border"
                             :class="[
                               curQuestion.allowMultiple ? 'rounded' : 'rounded-full',
                               isSelected(curQuestion.id, o.id) ? 'border-accent bg-accent text-white' : 'border-line-strong',
@@ -450,7 +450,7 @@ const {
                       >
                         <button
                           type="button"
-                          class="flex h-4 w-4 shrink-0 items-center justify-center border"
+                          class="rounded-lg flex h-4 w-4 shrink-0 items-center justify-center border"
                           :class="[
                             curQuestion.allowMultiple ? 'rounded' : 'rounded-full',
                             isOtherSelected(curQuestion.id) ? 'border-accent bg-accent text-white' : 'border-line-strong',
@@ -646,7 +646,7 @@ const {
           @remove="removeAnnotation(ai)"
         />
       </div>
-      <div v-if="attachNotice" class="mb-2 border border-err/40 bg-err/10 px-2.5 py-1.5 text-[12px] text-err" data-testid="clarify-attach-notice" role="alert">
+      <div v-if="attachNotice" class="rounded-md mb-2 border border-err/40 bg-err/10 px-2.5 py-1.5 text-[12px] text-err" data-testid="clarify-attach-notice" role="alert">
         {{ attachNotice }}
       </div>
       <div v-if="attachments.length" class="mb-2 flex flex-wrap gap-1.5">
@@ -664,7 +664,7 @@ const {
           />
           <div
             v-else
-            class="flex h-14 max-w-[160px] items-center gap-1.5 border border-line bg-elevated px-2"
+            class="rounded-lg flex h-14 max-w-[160px] items-center gap-1.5 border border-line bg-elevated px-2"
             :title="attachmentDisplayName(im, ii)"
             data-testid="clarify-pending-file-chip"
           >

--- a/web/src/components/run/ClarifyDemoFrame.test.ts
+++ b/web/src/components/run/ClarifyDemoFrame.test.ts
@@ -34,6 +34,20 @@ function mountFrame(props: { label: string; html: string; highlighted?: boolean;
 }
 
 describe('ClarifyDemoFrame', () => {
+  it('uses card-radius (12px) demo frame with enlarge control', () => {
+    const wrapper = mountFrame({
+      label: '方案 A',
+      html: '<!doctype html><html><body>demo</body></html>',
+    })
+    const root = wrapper.find('div.overflow-hidden')
+    expect(root.classes()).toContain('rounded-lg')
+    expect(root.classes()).not.toContain('rounded-none')
+    const enlargeBtn = wrapper.findAll('button').find((b) => b.text().includes('放大') || b.text().includes('Enlarge'))
+    expect(enlargeBtn).toBeTruthy()
+    expect(enlargeBtn!.classes().join(' ')).toMatch(/\brounded\b/)
+    wrapper.unmount()
+  })
+
   it('renders label and html preview', () => {
     const wrapper = mountFrame({
       label: '方案 A',

--- a/web/src/components/run/ClarifyDemoFrame.vue
+++ b/web/src/components/run/ClarifyDemoFrame.vue
@@ -21,7 +21,7 @@ function enlarge() {
 
 <template>
   <div
-    class="overflow-hidden border bg-elevated transition-colors"
+    class="overflow-hidden rounded-lg border bg-elevated transition-colors"
     :class="highlighted ? 'border-accent shadow-[0_0_0_1px_rgba(123,97,255,0.3)]' : 'border-line'"
   >
     <div class="flex items-center gap-1.5 border-b border-line px-2 py-1 text-[10px] text-txt3">

--- a/web/src/components/run/ClarifyProductStage.vue
+++ b/web/src/components/run/ClarifyProductStage.vue
@@ -77,7 +77,7 @@ const emit = defineEmits<{
       <button
         v-if="stageKind === 'loadFailed'"
         type="button"
-        class="mt-3.5 inline-flex items-center gap-1.5 border border-accent-2/40 bg-accent-dim px-3 py-1.5 text-[12px] text-accent-2 hover:border-accent-2/70"
+        class="rounded-lg mt-3.5 inline-flex items-center gap-1.5 border border-accent-2/40 bg-accent-dim px-3 py-1.5 text-[12px] text-accent-2 hover:border-accent-2/70"
         data-testid="clarify-product-retry"
         :disabled="loading"
         @click="emit('retry')"

--- a/web/src/components/run/CommentArtifactSidebar.vue
+++ b/web/src/components/run/CommentArtifactSidebar.vue
@@ -33,7 +33,7 @@ function switchTab(name: 'comments' | 'artifact') {
 
 <template>
   <div
-    class="flex min-h-0 flex-1 flex-col overflow-hidden border border-line bg-surface"
+    class="rounded-lg flex min-h-0 flex-1 flex-col overflow-hidden border border-line bg-surface"
     data-testid="comment-artifact-sidebar"
   >
     <div class="flex shrink-0 border-b border-line">
@@ -67,7 +67,7 @@ function switchTab(name: 'comments' | 'artifact') {
 
     <div
       v-if="artifactCommitted"
-      class="mx-3 mt-2 shrink-0 border border-warn/35 bg-warn/10 px-2.5 py-2 text-[12px] text-warn"
+      class="rounded-lg mx-3 mt-2 shrink-0 border border-warn/35 bg-warn/10 px-2.5 py-2 text-[12px] text-warn"
       data-testid="comment-artifact-committed-banner"
     >
       {{ t('pages.gateApproval.commentPins.committedBanner') }}
@@ -80,7 +80,7 @@ function switchTab(name: 'comments' | 'artifact') {
     >
       <div
         v-if="!sortedPins.length"
-        class="border border-dashed border-line px-3 py-7 text-center text-[13px] text-txt3"
+        class="rounded-lg border border-dashed border-line px-3 py-7 text-center text-[13px] text-txt3"
         data-testid="comment-pins-empty"
       >
         {{ t('pages.gateApproval.commentPins.empty') }}
@@ -89,14 +89,14 @@ function switchTab(name: 'comments' | 'artifact') {
         <div
           v-for="pin in sortedPins"
           :key="pin.id"
-          class="cursor-pointer border border-line bg-elevated p-2.5"
+          class="rounded-lg cursor-pointer border border-line bg-elevated p-2.5"
           :class="pin.id === selectedId ? 'border-accent bg-accent-dim' : 'hover:border-line-strong'"
           :data-testid="'comment-pin-item-' + pin.seq"
           @click="emit('select', pin.id)"
         >
           <div class="mb-1.5 flex items-center justify-between gap-2">
             <span class="font-mono text-xs text-accent">#{{ pin.seq }}</span>
-            <span class="border border-line px-1.5 text-[11px] text-txt2">
+            <span class="rounded-md border border-line px-1.5 text-[11px] text-txt2">
               {{ t('pages.gateApproval.commentPins.badgeLabel') }}
             </span>
           </div>
@@ -115,14 +115,14 @@ function switchTab(name: 'comments' | 'artifact') {
           <div class="mt-2 flex gap-1.5">
             <button
               type="button"
-              class="border border-line px-2 py-1 text-[11px] text-txt2 hover:text-txt"
+              class="rounded-md border border-line px-2 py-1 text-[11px] text-txt2 hover:text-txt"
               @click.stop="emit('edit', pin.id)"
             >
               {{ t('pages.gateApproval.commentPins.edit') }}
             </button>
             <button
               type="button"
-              class="border border-err/35 px-2 py-1 text-[11px] text-err hover:bg-err/10"
+              class="rounded-md border border-err/35 px-2 py-1 text-[11px] text-err hover:bg-err/10"
               data-testid="comment-pin-delete"
               @click.stop="emit('delete', pin.id)"
             >
@@ -146,7 +146,7 @@ function switchTab(name: 'comments' | 'artifact') {
         }}
       </div>
       <pre
-        class="max-h-[260px] overflow-auto border border-line bg-base p-2.5 font-mono text-[11px] leading-relaxed text-txt2 whitespace-pre-wrap"
+        class="rounded-lg max-h-[260px] overflow-auto border border-line bg-base p-2.5 font-mono text-[11px] leading-relaxed text-txt2 whitespace-pre-wrap"
         data-testid="comment-artifact-preview"
       >{{ previewText }}</pre>
       <button

--- a/web/src/components/run/CommentPinInspectCard.vue
+++ b/web/src/components/run/CommentPinInspectCard.vue
@@ -192,7 +192,7 @@ defineExpose({ placeCardNear })
   <div
     v-show="open"
     ref="cardRef"
-    class="comment-pin-inspect-card absolute z-20 flex max-h-[calc(100%-24px)] w-[320px] flex-col border border-line-strong bg-elevated shadow-[var(--shadow-card)]"
+    class="rounded-lg comment-pin-inspect-card absolute z-20 flex max-h-[calc(100%-24px)] w-[320px] flex-col border border-line-strong bg-elevated shadow-[var(--shadow-card)]"
     :style="cardStyle"
     data-testid="comment-pin-inspect-card"
     role="dialog"
@@ -212,7 +212,7 @@ defineExpose({ placeCardNear })
             <span class="w-9 shrink-0 text-txt3">{{ row.label }}</span>
             <span
               v-if="row.swatch"
-              class="inline-block h-2.5 w-2.5 shrink-0 border border-line"
+              class="rounded-lg inline-block h-2.5 w-2.5 shrink-0 border border-line"
               :style="{ background: row.swatch }"
             />
             <span class="min-w-0 truncate text-txt2">{{ row.value }}</span>
@@ -221,7 +221,7 @@ defineExpose({ placeCardNear })
       </div>
       <button
         type="button"
-        class="shrink-0 border border-line px-2 py-1 text-[11px] text-txt2 hover:text-txt"
+        class="rounded-md shrink-0 border border-line px-2 py-1 text-[11px] text-txt2 hover:text-txt"
         data-testid="comment-pin-card-close"
         @click="emit('close')"
       >
@@ -230,7 +230,7 @@ defineExpose({ placeCardNear })
     </div>
     <div class="flex min-h-0 flex-1 flex-col gap-2 overflow-auto px-3 py-2.5">
       <div
-        class="flex h-11 items-center justify-center border border-dashed border-line-strong bg-base text-[11px]"
+        class="rounded-lg flex h-11 items-center justify-center border border-dashed border-line-strong bg-base text-[11px]"
         :class="
           screenshotMissing
             ? 'border-warn/50 text-warn'
@@ -253,7 +253,7 @@ defineExpose({ placeCardNear })
       </div>
       <textarea
         v-model="comment"
-        class="min-h-[56px] w-full resize-y border border-line bg-base px-2.5 py-2 text-[13px] text-txt outline-none focus:border-accent"
+        class="rounded-md min-h-[56px] w-full resize-y border border-line bg-base px-2.5 py-2 text-[13px] text-txt outline-none focus:border-accent"
         rows="3"
         :placeholder="t('pages.gateApproval.commentPins.placeholder')"
         data-testid="comment-pin-input"
@@ -263,7 +263,7 @@ defineExpose({ placeCardNear })
     <div class="flex shrink-0 items-center justify-end gap-1.5 border-t border-line bg-elevated px-3 py-2.5">
       <button
         type="button"
-        class="border border-line px-3 py-1.5 text-xs font-medium text-txt2 hover:text-txt disabled:cursor-not-allowed disabled:opacity-45"
+        class="rounded-md border border-line px-3 py-1.5 text-xs font-medium text-txt2 hover:text-txt disabled:cursor-not-allowed disabled:opacity-45"
         :disabled="!canSubmit"
         data-testid="comment-pin-send-chat"
         @click="onSendChat"

--- a/web/src/components/run/DirectPreviewFrame.vue
+++ b/web/src/components/run/DirectPreviewFrame.vue
@@ -262,7 +262,7 @@ onUnmounted(() => {
       >{{ t('pages.appPreview.directOpenTab') }}</a>
       <div
         v-if="inlineTip || scriptTip"
-        class="basis-full border px-2.5 py-1.5 text-[11px] leading-snug"
+        class="rounded-md basis-full border px-2.5 py-1.5 text-[11px] leading-snug"
         :class="inlineTip ? 'border-err/40 bg-err/10 text-err' : 'border-warn/40 bg-warn/10 text-warn'"
         role="status"
         data-testid="direct-preview-tip"

--- a/web/src/components/run/ExecutionStatsPanel.vue
+++ b/web/src/components/run/ExecutionStatsPanel.vue
@@ -267,7 +267,7 @@ html.light .stats-panel {
       <!-- Single run -->
       <template v-if="statsTab === 'single'">
         <div class="mb-3.5 grid grid-cols-1 gap-2 md:grid-cols-3 xl:grid-cols-5">
-          <div class="border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-wall">
+          <div class="rounded-lg border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-wall">
             <div class="mb-1 text-[11px] text-txt3">{{ t('pages.executionStats.wallClock') }}</div>
             <div class="stats-kpi-value-wrap">
               <div
@@ -294,7 +294,7 @@ html.light .stats-panel {
             </div>
             <div class="mt-0.5 text-[10px] text-txt3">{{ t('pages.executionStats.wallHint') }}</div>
           </div>
-          <div class="border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-node-sum">
+          <div class="rounded-lg border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-node-sum">
             <div class="mb-1 text-[11px] text-txt3">{{ t('pages.executionStats.nodeSum') }}</div>
             <div class="stats-kpi-value-wrap">
               <div
@@ -321,7 +321,7 @@ html.light .stats-panel {
             </div>
             <div class="mt-0.5 text-[10px] text-txt3">{{ t('pages.executionStats.nodeSumHint') }}</div>
           </div>
-          <div class="border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-gap">
+          <div class="rounded-lg border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-gap">
             <div class="mb-1 text-[11px] text-txt3">{{ t('pages.executionStats.gap') }}</div>
             <div class="stats-kpi-value-wrap">
               <div
@@ -348,7 +348,7 @@ html.light .stats-panel {
             </div>
             <div class="mt-0.5 text-[10px] text-txt3">{{ t('pages.executionStats.gapHint') }}</div>
           </div>
-          <div class="border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-total-tokens">
+          <div class="rounded-lg border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-total-tokens">
             <div class="mb-1 text-[11px] text-txt3">{{ t('pages.executionStats.totalTokens') }}</div>
             <div class="stats-kpi-value-wrap">
               <div
@@ -400,7 +400,7 @@ html.light .stats-panel {
             </div>
             <div class="mt-0.5 text-[10px] text-txt3">{{ singleTokenHint }}</div>
           </div>
-          <div class="border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-token-rate">
+          <div class="rounded-lg border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-token-rate">
             <div class="mb-1 text-[11px] text-txt3">{{ t('pages.executionStats.tokenRate') }}</div>
             <div class="stats-kpi-value-wrap">
               <div
@@ -439,7 +439,7 @@ html.light .stats-panel {
 
         <div
           v-if="singleBottleneck"
-          class="mb-3 border border-err/35 bg-err/6 px-3 py-2.5"
+          class="rounded-lg mb-3 border border-err/35 bg-err/6 px-3 py-2.5"
         >
           <div class="mb-1.5 flex items-center justify-between gap-2">
             <span class="text-[11px] font-semibold uppercase tracking-wide text-err">
@@ -447,7 +447,7 @@ html.light .stats-panel {
             </span>
             <span
               v-if="singleBottleneck.item.hasHumanWait"
-              class="shrink-0 border border-warn/40 bg-warn/10 px-1.5 py-px text-[10px] text-warn"
+              class="rounded-md shrink-0 border border-warn/40 bg-warn/10 px-1.5 py-px text-[10px] text-warn"
             >
               {{ t('pages.executionStats.hasHumanWait') }}
             </span>
@@ -467,7 +467,7 @@ html.light .stats-panel {
           </div>
         </div>
 
-        <div class="mb-3.5 border border-line bg-surface p-3">
+        <div class="rounded-lg mb-3.5 border border-line bg-surface p-3">
           <StatsPieChart
             :items="singleItems"
             :center-value="fmtDuration(singleSummary.nodeSumSec)"
@@ -479,7 +479,7 @@ html.light .stats-panel {
 
         <div class="mb-3 flex flex-wrap items-center gap-2">
           <span class="text-[11px] text-txt3">{{ t('pages.executionStats.dimension') }}</span>
-          <div class="inline-flex border border-line bg-surface text-[12px]">
+          <div class="rounded-lg inline-flex border border-line bg-surface text-[12px]">
             <button
               v-for="opt in dimOptionsSingle"
               :key="opt.id"
@@ -505,7 +505,7 @@ html.light .stats-panel {
           <div
             v-for="it in singleItems"
             :key="it.key"
-            class="border bg-surface px-3 py-2.5"
+            class="rounded-lg border bg-surface px-3 py-2.5"
             :class="
               singleBottleneck && it.key === singleBottleneck.item.key
                 ? 'border-err/40'
@@ -526,19 +526,19 @@ html.light .stats-panel {
               </TruncatedTextTooltip>
               <span
                 v-if="it.isProcess && it.iteration && it.iteration > 1"
-                class="shrink-0 border border-warn/40 bg-warn/10 px-1.5 py-px text-[10px] text-warn"
+                class="rounded-md shrink-0 border border-warn/40 bg-warn/10 px-1.5 py-px text-[10px] text-warn"
               >
                 {{ t('common.iterationN', { n: it.iteration }) }}
               </span>
               <span
                 v-if="!it.isProcess && it.count > 1"
-                class="shrink-0 border border-info/40 bg-info/10 px-1.5 py-px text-[10px] text-info"
+                class="rounded-md shrink-0 border border-info/40 bg-info/10 px-1.5 py-px text-[10px] text-info"
               >
                 {{ t('pages.executionStats.mergeCount', { n: it.count }) }}
               </span>
               <span
                 v-if="it.hasHumanWait"
-                class="shrink-0 border border-warn/40 bg-warn/10 px-1.5 py-px text-[10px] text-warn"
+                class="rounded-md shrink-0 border border-warn/40 bg-warn/10 px-1.5 py-px text-[10px] text-warn"
               >
                 {{ t('pages.executionStats.hasHumanWait') }}
               </span>
@@ -575,7 +575,7 @@ html.light .stats-panel {
 
       <!-- Multi run -->
       <template v-else>
-        <div class="mb-3 border border-line bg-surface" data-testid="stats-multi-selection">
+        <div class="rounded-lg mb-3 border border-line bg-surface" data-testid="stats-multi-selection">
           <div class="flex items-center justify-between gap-3 border-b border-line px-3.5 py-2.5">
             <h3
               class="min-w-0 text-[12px] font-medium text-txt3"
@@ -597,7 +597,7 @@ html.light .stats-panel {
               </button>
               <button
                 type="button"
-                class="inline-flex items-center gap-1 border px-2.5 py-1 text-[12px] transition-colors"
+                class="rounded-md inline-flex items-center gap-1 border px-2.5 py-1 text-[12px] transition-colors"
                 :class="
                   pickerOpen
                     ? 'border-accent/50 bg-accent-dim text-accent-2'
@@ -682,7 +682,7 @@ html.light .stats-panel {
                 @click="toggleRun(c.id)"
               >
                 <span
-                  class="inline-block h-3.5 w-3.5 shrink-0 border"
+                  class="rounded-lg inline-block h-3.5 w-3.5 shrink-0 border"
                   :class="
                     selectedIds.has(c.id)
                       ? 'border-accent-2 bg-accent-2'
@@ -713,7 +713,7 @@ html.light .stats-panel {
         </div>
 
         <div class="mb-3.5 grid grid-cols-1 gap-2 md:grid-cols-3 xl:grid-cols-6">
-          <div class="border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-selected">
+          <div class="rounded-lg border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-selected">
             <div class="mb-1 text-[11px] text-txt3">{{ t('pages.executionStats.selectedRuns') }}</div>
             <div
               class="text-[16px] font-semibold tabular-nums text-txt"
@@ -722,7 +722,7 @@ html.light .stats-panel {
               {{ selectedCountDisplay }}
             </div>
           </div>
-          <div class="border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-avg-wall">
+          <div class="rounded-lg border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-avg-wall">
             <div class="mb-1 text-[11px] text-txt3">{{ t('pages.executionStats.avgWall') }}</div>
             <div class="stats-kpi-value-wrap">
               <div
@@ -752,7 +752,7 @@ html.light .stats-panel {
               </span>
             </div>
           </div>
-          <div class="border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-process-count">
+          <div class="rounded-lg border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-process-count">
             <div class="mb-1 text-[11px] text-txt3">{{ t('pages.executionStats.processCount') }}</div>
             <div
               class="text-[16px] font-semibold tabular-nums text-txt"
@@ -761,7 +761,7 @@ html.light .stats-panel {
               {{ multiReady ? multiSummary.processCount : t('pages.executionStats.dash') }}
             </div>
           </div>
-          <div class="border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-sum-tokens">
+          <div class="rounded-lg border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-sum-tokens">
             <div class="mb-1 text-[11px] text-txt3">{{ t('pages.executionStats.sumTokens') }}</div>
             <div class="stats-kpi-value-wrap">
               <div
@@ -793,7 +793,7 @@ html.light .stats-panel {
             </div>
             <div class="mt-0.5 text-[10px] text-txt3">{{ multiSumHint }}</div>
           </div>
-          <div class="border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-avg-tokens">
+          <div class="rounded-lg border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-avg-tokens">
             <div class="mb-1 text-[11px] text-txt3">{{ t('pages.executionStats.avgTokens') }}</div>
             <div class="stats-kpi-value-wrap">
               <div
@@ -825,7 +825,7 @@ html.light .stats-panel {
             </div>
             <div class="mt-0.5 text-[10px] text-txt3">{{ multiAvgHint }}</div>
           </div>
-          <div class="border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-multi-token-rate">
+          <div class="rounded-lg border border-line bg-surface px-3 py-2.5" data-testid="stats-kpi-multi-token-rate">
             <div class="mb-1 text-[11px] text-txt3">{{ t('pages.executionStats.tokenRate') }}</div>
             <div class="stats-kpi-value-wrap">
               <div
@@ -863,7 +863,7 @@ html.light .stats-panel {
           {{ t('pages.executionStats.multiPending') }}
         </p>
         <template v-else>
-        <div v-if="multiItems[0]" class="mb-3.5 border border-err/35 bg-err/6 px-3 py-2.5">
+        <div v-if="multiItems[0]" class="rounded-lg mb-3.5 border border-err/35 bg-err/6 px-3 py-2.5">
           <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-err">
             {{ t('pages.executionStats.topAvg') }}
           </div>
@@ -879,7 +879,7 @@ html.light .stats-panel {
 
         <div class="mb-3 flex flex-wrap items-center gap-2">
           <span class="text-[11px] text-txt3">{{ t('pages.executionStats.dimension') }}</span>
-          <div class="inline-flex border border-line bg-surface text-[12px]">
+          <div class="rounded-lg inline-flex border border-line bg-surface text-[12px]">
             <button
               v-for="opt in dimOptionsMulti"
               :key="opt.id"
@@ -897,7 +897,7 @@ html.light .stats-panel {
           </div>
         </div>
 
-        <div class="mb-3.5 border border-line bg-surface p-3">
+        <div class="rounded-lg mb-3.5 border border-line bg-surface p-3">
           <StatsPieChart
             :items="multiItems"
             :center-value="fmtDuration(multiSummary.wallSumSec ? multiItems.reduce((a, i) => a + i.durationSec, 0) : 0)"
@@ -922,7 +922,7 @@ html.light .stats-panel {
           <div
             v-for="(it, i) in multiItems"
             :key="it.key"
-            class="border bg-surface px-3 py-2.5"
+            class="rounded-lg border bg-surface px-3 py-2.5"
             :class="i === 0 ? 'border-err/40' : 'border-line'"
           >
             <div class="mb-1.5 flex items-center gap-2">
@@ -936,7 +936,7 @@ html.light .stats-panel {
               </TruncatedTextTooltip>
               <span
                 v-if="it.hasHumanWait"
-                class="shrink-0 border border-warn/40 bg-warn/10 px-1.5 py-px text-[10px] text-warn"
+                class="rounded-md shrink-0 border border-warn/40 bg-warn/10 px-1.5 py-px text-[10px] text-warn"
               >
                 {{ t('pages.executionStats.hasHumanWait') }}
               </span>

--- a/web/src/components/run/ExecutionTimeline.vue
+++ b/web/src/components/run/ExecutionTimeline.vue
@@ -399,7 +399,7 @@ const DOT: Record<string, string> = {
           </li>
         </ol>
         <div
-          class="mt-3 border border-line bg-elevated px-4 py-3"
+          class="rounded-lg mt-3 border border-line bg-elevated px-4 py-3"
           data-testid="timeline-footer"
         >
           <div class="flex flex-wrap items-center justify-between gap-2.5">

--- a/web/src/components/run/GateProductEditor.vue
+++ b/web/src/components/run/GateProductEditor.vue
@@ -459,13 +459,13 @@ defineExpose({
         {{ p.name }}
         <span
           v-if="p.readonly || isReadonlyArtifactKind(p.kind)"
-          class="ml-1.5 border border-line-strong bg-overlay px-1 py-px text-[10px] text-txt3"
+          class="rounded-md ml-1.5 border border-line-strong bg-overlay px-1 py-px text-[10px] text-txt3"
           data-testid="gate-readonly-badge"
           >{{ t('pages.gateApproval.readonlyBadge') }}</span
         >
         <span
           v-else
-          class="ml-1.5 border border-accent/35 bg-accent-dim px-1 py-px text-[10px] text-accent-2"
+          class="rounded-md ml-1.5 border border-accent/35 bg-accent-dim px-1 py-px text-[10px] text-accent-2"
           >{{ t('pages.gateApproval.primaryBadge') }}</span
         >
       </button>
@@ -473,7 +473,7 @@ defineExpose({
 
     <div
       v-if="externalChange"
-      class="mx-3 mt-3 flex items-start gap-2 border border-warn/35 bg-warn/10 px-3 py-2 text-xs text-warn"
+      class="rounded-md mx-3 mt-3 flex items-start gap-2 border border-warn/35 bg-warn/10 px-3 py-2 text-xs text-warn"
       data-testid="gate-external-change"
       role="status"
     >
@@ -483,7 +483,7 @@ defineExpose({
       </div>
       <button
         type="button"
-        class="shrink-0 border border-line-strong bg-elevated px-2.5 py-1 text-[11px] text-txt hover:bg-overlay"
+        class="rounded-md shrink-0 border border-line-strong bg-elevated px-2.5 py-1 text-[11px] text-txt hover:bg-overlay"
         @click="onRefreshExternal"
       >
         {{ t('pages.gateApproval.externalChangeRefresh') }}
@@ -491,7 +491,7 @@ defineExpose({
     </div>
 
     <div class="flex flex-wrap items-center justify-between gap-2 px-3 py-2">
-      <div class="inline-flex border border-line bg-elevated" role="group">
+      <div class="rounded-lg inline-flex border border-line bg-elevated" role="group">
         <button
           type="button"
           class="px-3 py-1 text-xs"
@@ -538,20 +538,20 @@ defineExpose({
 
     <div
       v-if="saveError"
-      class="mx-3 mb-2 border border-err/30 bg-err/10 px-3 py-2 text-xs text-err"
+      class="rounded-md mx-3 mb-2 border border-err/30 bg-err/10 px-3 py-2 text-xs text-err"
       data-testid="gate-save-error"
     >
       {{ saveError }}
     </div>
     <div
       v-if="saveOk"
-      class="mx-3 mb-2 border border-ok/30 bg-ok/10 px-3 py-2 text-xs text-ok"
+      class="rounded-md mx-3 mb-2 border border-ok/30 bg-ok/10 px-3 py-2 text-xs text-ok"
     >
       {{ t('pages.gateApproval.saveOk', { name: activeProduct?.name }) }}
     </div>
 
     <div
-      class="mx-3 mb-3 flex flex-col border border-line bg-surface"
+      class="rounded-lg mx-3 mb-3 flex flex-col border border-line bg-surface"
       :class="fillParent ? 'min-h-0 flex-1' : 'min-h-[240px]'"
     >
       <div
@@ -590,7 +590,7 @@ defineExpose({
         </span>
         <div
           v-if="mode === 'edit' && canEditActive && activeProduct && isStructuredArtifactName(activeProduct.name)"
-          class="inline-flex border border-line"
+          class="rounded-lg inline-flex border border-line"
         >
           <button
             type="button"
@@ -624,7 +624,7 @@ defineExpose({
           v-else-if="imageSrc"
           :src="imageSrc"
           :alt="activeProduct?.name || ''"
-          class="max-h-[320px] max-w-full border border-line object-contain"
+          class="rounded-lg max-h-[320px] max-w-full border border-line object-contain"
         />
         <div v-else class="text-center text-txt3">
           <div class="font-medium text-txt">{{ activeProduct?.name }}</div>
@@ -669,7 +669,7 @@ defineExpose({
         >
           <div
             v-if="isProposalsProduct"
-            class="border border-warn/35 bg-warn/10 px-3.5 py-3"
+            class="rounded-lg border border-warn/35 bg-warn/10 px-3.5 py-3"
             data-testid="gate-proposals-form-unsupported"
             role="status"
           >
@@ -693,7 +693,7 @@ defineExpose({
             <input
               v-model="formTitle"
               type="text"
-              class="w-full border border-line bg-base px-2.5 py-2 text-sm outline-none focus:border-accent-2 disabled:cursor-not-allowed disabled:opacity-55"
+              class="rounded-md w-full border border-line bg-base px-2.5 py-2 text-sm outline-none focus:border-accent-2 disabled:cursor-not-allowed disabled:opacity-55"
               data-testid="gate-form-title"
               :disabled="isProposalsProduct"
               @input="applyFormToDraft"
@@ -704,7 +704,7 @@ defineExpose({
             <textarea
               v-model="formSummary"
               rows="4"
-              class="w-full border border-line bg-base px-2.5 py-2 text-sm outline-none focus:border-accent-2 disabled:cursor-not-allowed disabled:opacity-55"
+              class="rounded-md w-full border border-line bg-base px-2.5 py-2 text-sm outline-none focus:border-accent-2 disabled:cursor-not-allowed disabled:opacity-55"
               data-testid="gate-form-summary"
               :disabled="isProposalsProduct"
               @input="applyFormToDraft"
@@ -810,7 +810,7 @@ defineExpose({
 
     <div
       v-if="excludedNames?.length"
-      class="mx-3 mb-3 border border-dashed border-line-strong bg-elevated px-3 py-2.5 text-[11px] text-txt3"
+      class="rounded-lg mx-3 mb-3 border border-dashed border-line-strong bg-elevated px-3 py-2.5 text-[11px] text-txt3"
       data-testid="gate-excluded-produces"
     >
       <b class="font-medium text-txt2">{{ t('pages.gateApproval.excludedTitle') }}</b>

--- a/web/src/components/run/GateShareLinkPanel.vue
+++ b/web/src/components/run/GateShareLinkPanel.vue
@@ -271,13 +271,13 @@ function close() {
     @close="close"
   >
     <div v-if="target" class="space-y-4 text-sm text-txt" data-testid="gate-share-panel-body">
-      <p class="border border-warn/35 bg-warn/10 px-3 py-2 text-[13px] text-warn" role="note">
+      <p class="rounded-lg border border-warn/35 bg-warn/10 px-3 py-2 text-[13px] text-warn" role="note">
         {{ t('pages.gatesInbox.share.safetyHint') }}
       </p>
 
       <p
         v-if="loopbackBlocked"
-        class="border border-err/40 bg-err/10 px-3 py-2 text-[13px] text-err"
+        class="rounded-lg border border-err/40 bg-err/10 px-3 py-2 text-[13px] text-err"
         role="alert"
         data-testid="gate-share-loopback-warning"
       >
@@ -285,7 +285,7 @@ function close() {
       </p>
       <p
         v-else
-        class="border border-ok/35 bg-ok/10 px-3 py-2 text-[13px] text-ok"
+        class="rounded-lg border border-ok/35 bg-ok/10 px-3 py-2 text-[13px] text-ok"
         role="note"
         data-testid="gate-share-origin-hint"
       >
@@ -305,7 +305,7 @@ function close() {
             v-for="tier in GATE_SHARE_TTL_TIERS"
             :key="tier"
             type="button"
-            class="min-h-11 border px-3 text-xs"
+            class="rounded-md min-h-11 border px-3 text-xs"
             :class="ttlTier === tier ? 'border-accent bg-accent text-white' : 'border-line text-txt2 hover:bg-elevated'"
             :aria-checked="ttlTier === tier ? 'true' : 'false'"
             role="radio"
@@ -330,7 +330,7 @@ function close() {
             v-for="preset in GATE_SHARE_PERMISSION_PRESETS"
             :key="preset"
             type="button"
-            class="flex min-h-11 items-start gap-3 border px-3 py-2.5 text-left"
+            class="rounded-lg flex min-h-11 items-start gap-3 border px-3 py-2.5 text-left"
             :class="
               permissionPreset === preset
                 ? 'border-accent bg-accent/10'
@@ -343,7 +343,7 @@ function close() {
             @click="permissionPreset = preset"
           >
             <span
-              class="mt-0.5 grid h-3.5 w-3.5 shrink-0 place-items-center border"
+              class="rounded-lg mt-0.5 grid h-3.5 w-3.5 shrink-0 place-items-center border"
               :class="permissionPreset === preset ? 'border-accent' : 'border-line-strong'"
               aria-hidden="true"
             >
@@ -386,7 +386,7 @@ function close() {
       <div v-else class="space-y-3">
         <div class="flex flex-wrap items-center gap-2" data-testid="gate-share-active-meta">
           <span
-            class="border border-accent/45 bg-accent/10 px-2 py-0.5 text-[11px] text-accent-2"
+            class="rounded-md border border-accent/45 bg-accent/10 px-2 py-0.5 text-[11px] text-accent-2"
             data-testid="gate-share-preset-chip"
           >
             {{ activePresetChip }}
@@ -397,7 +397,7 @@ function close() {
         </div>
         <label class="block text-xs font-medium text-txt2">{{ t('pages.gatesInbox.share.linkLabel') }}</label>
         <textarea
-          class="w-full border bg-elevated px-3 py-2 font-mono text-[12px] text-txt"
+          class="rounded-lg w-full border bg-elevated px-3 py-2 font-mono text-[12px] text-txt"
           :class="loopbackBlocked ? 'border-err/45' : 'border-line'"
           rows="3"
           readonly
@@ -430,7 +430,7 @@ function close() {
           </button>
           <button
             type="button"
-            class="inline-flex min-h-11 items-center border border-line px-3 text-xs text-txt2 hover:bg-elevated"
+            class="rounded-md inline-flex min-h-11 items-center border border-line px-3 text-xs text-txt2 hover:bg-elevated"
             data-testid="gate-share-regen"
             :disabled="busy"
             @click="confirmKind = 'regen'"
@@ -439,7 +439,7 @@ function close() {
           </button>
           <button
             type="button"
-            class="inline-flex min-h-11 items-center border border-err/40 px-3 text-xs text-err hover:bg-err/10"
+            class="rounded-md inline-flex min-h-11 items-center border border-err/40 px-3 text-xs text-err hover:bg-err/10"
             data-testid="gate-share-revoke"
             :disabled="busy"
             @click="confirmKind = 'revoke'"
@@ -451,7 +451,7 @@ function close() {
 
       <div
         v-if="confirmKind"
-        class="border border-line bg-elevated px-3 py-3"
+        class="rounded-lg border border-line bg-elevated px-3 py-3"
         data-testid="gate-share-confirm"
         role="alertdialog"
       >
@@ -474,7 +474,7 @@ function close() {
           </button>
           <button
             type="button"
-            class="min-h-11 border border-line px-3 text-xs text-txt2"
+            class="rounded-md min-h-11 border border-line px-3 text-xs text-txt2"
             data-testid="gate-share-confirm-cancel"
             @click="confirmKind = null"
           >

--- a/web/src/components/run/HardLoadLayer.vue
+++ b/web/src/components/run/HardLoadLayer.vue
@@ -88,7 +88,7 @@ defineExpose({ reset: startClock, elapsedSec, stuck })
     <p class="text-[13px] font-semibold text-txt" data-testid="hard-load-stage">{{ stageLabel }}</p>
     <div
       v-if="stuck"
-      class="max-w-[360px] border border-warn/40 bg-warn/10 px-2.5 py-2 text-[12px] text-warn"
+      class="rounded-lg max-w-[360px] border border-warn/40 bg-warn/10 px-2.5 py-2 text-[12px] text-warn"
       data-testid="hard-load-stuck"
     >
       {{ t('common.loading.stuck') }}
@@ -96,7 +96,7 @@ defineExpose({ reset: startClock, elapsedSec, stuck })
     <button
       v-if="stuck && showRetry"
       type="button"
-      class="mt-1 inline-flex min-h-11 min-w-[44px] items-center justify-center border border-line bg-surface px-3 text-[12px] font-medium text-txt hover:bg-elevated"
+      class="rounded-lg mt-1 inline-flex min-h-11 min-w-[44px] items-center justify-center border border-line bg-surface px-3 text-[12px] font-medium text-txt hover:bg-elevated"
       data-testid="hard-load-retry"
       @click="onRetry"
     >

--- a/web/src/components/run/LiveLogPanel.vue
+++ b/web/src/components/run/LiveLogPanel.vue
@@ -363,7 +363,7 @@ watch(
           v-if="snapshotTipOpen"
           :id="snapshotTipId"
           role="tooltip"
-          class="absolute left-0 top-[calc(100%+6px)] z-20 min-w-[220px] max-w-[280px] border border-line-strong bg-overlay px-2.5 py-2 text-left text-[11px] font-normal leading-snug text-txt2 shadow-lg normal-case"
+          class="rounded-xl absolute left-0 top-[calc(100%+6px)] z-20 min-w-[220px] max-w-[280px] border border-line-strong bg-overlay px-2.5 py-2 text-left text-[11px] font-normal leading-snug text-txt2 shadow-lg normal-case"
         >
           {{ t('pages.liveLog.snapshotTip') }}
         </span>
@@ -401,7 +401,7 @@ watch(
       <div
         v-else-if="showRehydrateError"
         data-testid="rehydrate-error"
-        class="mx-4 mt-8 border border-err/40 bg-err/[0.06] px-3.5 py-3.5 font-sans"
+        class="rounded-lg mx-4 mt-8 border border-err/40 bg-err/[0.06] px-3.5 py-3.5 font-sans"
       >
         <div class="mb-1.5 flex items-center gap-1.5 text-[12px] font-semibold text-err">
           <Icon name="alert" :size="14" />
@@ -413,7 +413,7 @@ watch(
         <button
           type="button"
           data-testid="retry-rehydrate"
-          class="inline-flex items-center gap-1 border border-transparent bg-accent px-3 py-1.5 text-[12px] font-medium text-white hover:bg-accent-2"
+          class="rounded-lg inline-flex items-center gap-1 border border-transparent bg-accent px-3 py-1.5 text-[12px] font-medium text-white hover:bg-accent-2"
           @click="emit('retry-rehydrate')"
         >
           {{ t('pages.liveLog.rehydrate.retry') }}
@@ -424,7 +424,7 @@ watch(
       <div
         v-if="showRehydrateWarn"
         data-testid="rehydrate-warn"
-        class="border border-warn/40 bg-warn/[0.06] px-3.5 py-3 font-sans"
+        class="rounded-lg border border-warn/40 bg-warn/[0.06] px-3.5 py-3 font-sans"
       >
         <div class="mb-1.5 flex items-center gap-1.5 text-[12px] font-semibold text-warn">
           <Icon name="alert" :size="14" />
@@ -435,7 +435,7 @@ watch(
         </p>
         <p
           data-testid="rehydrate-snapshot-hint"
-          class="m-0 border border-info/30 bg-info/[0.07] px-2.5 py-2 text-[11px] leading-snug text-txt2"
+          class="rounded-md m-0 border border-info/30 bg-info/[0.07] px-2.5 py-2 text-[11px] leading-snug text-txt2"
         >
           <strong class="font-semibold text-info">{{ t('pages.liveLog.rehydrate.snapshotHintLabel') }}</strong>
           {{ t('pages.liveLog.rehydrate.snapshotHint') }}
@@ -489,7 +489,7 @@ watch(
         >
           <div class="flex flex-col items-center">
             <div
-              class="z-[1] flex h-[22px] w-[22px] shrink-0 items-center justify-center border"
+              class="rounded-lg z-[1] flex h-[22px] w-[22px] shrink-0 items-center justify-center border"
               :class="stageClass(stage.state)"
             >
               <Icon
@@ -507,7 +507,7 @@ watch(
           <div class="pb-4 pt-0.5">
             <div class="flex flex-wrap items-center gap-2 text-[12px] font-medium" :class="stageTitleClass(stage.state)">
               <span>{{ t(stageTitleKey[stage.id]) }}</span>
-              <span class="border px-1.5 py-px text-[10px] uppercase tracking-wide" :class="badgeClass(stage.state)">
+              <span class="rounded-md border px-1.5 py-px text-[10px] uppercase tracking-wide" :class="badgeClass(stage.state)">
                 {{ t(stateBadgeKey[stage.state]) }}
               </span>
             </div>
@@ -517,7 +517,7 @@ watch(
         <div
           v-if="stageTimedOut && activeStageId"
           data-testid="boot-timeout-banner"
-          class="mt-1 border border-err/40 bg-err/[0.06] px-3 py-2.5"
+          class="rounded-lg mt-1 border border-err/40 bg-err/[0.06] px-3 py-2.5"
         >
           <div class="mb-1 flex items-center gap-1.5 text-[12px] font-semibold text-err">
             <Icon name="alert" :size="14" />
@@ -529,7 +529,7 @@ watch(
           <button
             type="button"
             data-testid="go-sandbox-log"
-            class="mt-2 inline-flex items-center gap-1 border border-accent/45 bg-accent-dim px-2.5 py-1 text-[11px] text-accent-2 hover:text-txt"
+            class="rounded-md mt-2 inline-flex items-center gap-1 border border-accent/45 bg-accent-dim px-2.5 py-1 text-[11px] text-accent-2 hover:text-txt"
             @click="emit('go-sandbox-log')"
           >
             {{ t('pages.liveLog.boot.timeout.goSandbox') }}

--- a/web/src/components/run/MermaidDiagram.vue
+++ b/web/src/components/run/MermaidDiagram.vue
@@ -158,14 +158,14 @@ onBeforeUnmount(() => {
     <div v-if="failed" class="space-y-2" data-testid="plan-diagram-fallback">
       <div class="text-[11px] text-txt2" data-testid="plan-diagram-fallback-hint">{{ t('pages.plan.diagramFallback') }}</div>
       <pre
-        class="overflow-x-auto border border-line bg-base p-2 font-mono text-[11px] leading-relaxed text-txt2 whitespace-pre-wrap"
+        class="rounded-lg overflow-x-auto border border-line bg-base p-2 font-mono text-[11px] leading-relaxed text-txt2 whitespace-pre-wrap"
         data-testid="plan-diagram-fallback-source"
       >{{ source }}</pre>
       <img
         v-if="fallbackUrl"
         :src="fallbackUrl"
         :alt="caption || 'diagram fallback'"
-        class="max-h-64 max-w-full border border-line object-contain"
+        class="rounded-lg max-h-64 max-w-full border border-line object-contain"
         data-testid="plan-diagram-fallback-img"
       />
     </div>

--- a/web/src/components/run/NovncPreviewPanel.vue
+++ b/web/src/components/run/NovncPreviewPanel.vue
@@ -584,7 +584,7 @@ onBeforeUnmount(() => {
             {{ t('pages.appPreview.novnc.fps') }}
           </template>
           <span
-            class="pointer-events-none absolute bottom-full right-0 z-20 mb-2 hidden w-[220px] border border-line-strong bg-overlay px-2.5 py-2 text-[10px] leading-snug text-txt2 shadow-card group-hover:block"
+            class="rounded-md pointer-events-none absolute bottom-full right-0 z-20 mb-2 hidden w-[220px] border border-line-strong bg-overlay px-2.5 py-2 text-[10px] leading-snug text-txt2 shadow-card group-hover:block"
           >
             {{ t('pages.appPreview.novnc.fpsTooltip') }}
           </span>
@@ -603,7 +603,7 @@ onBeforeUnmount(() => {
       </span>
       <div
         v-if="inlineTip"
-        class="basis-full border px-2.5 py-1.5 text-[11px] leading-snug"
+        class="rounded-md basis-full border px-2.5 py-1.5 text-[11px] leading-snug"
         :class="
           inlineTip.err
             ? 'border-err/40 bg-err/10 text-err'
@@ -744,13 +744,13 @@ onBeforeUnmount(() => {
         }}</span>
         <div
           v-if="previewStuck"
-          class="pointer-events-auto max-w-[360px] border border-warn/40 bg-warn/10 px-2.5 py-2 text-[12px] text-warn"
+          class="rounded-lg pointer-events-auto max-w-[360px] border border-warn/40 bg-warn/10 px-2.5 py-2 text-[12px] text-warn"
           data-testid="novnc-preview-stuck"
         >
           <p>{{ t('pages.appPreview.novnc.maybeStuck') }}</p>
           <button
             type="button"
-            class="mt-2 inline-flex min-h-11 items-center border border-line bg-surface px-3 text-[12px] font-medium text-txt"
+            class="rounded-lg mt-2 inline-flex min-h-11 items-center border border-line bg-surface px-3 text-[12px] font-medium text-txt"
             @click="reconnect"
           >
             {{ t('pages.appPreview.novnc.reconnect') }}

--- a/web/src/components/run/OutputResultCardBody.vue
+++ b/web/src/components/run/OutputResultCardBody.vue
@@ -135,7 +135,7 @@ const htmlPreviewState = computed<'loading' | 'load-error' | 'empty' | 'ready'>(
     <div v-if="loading && !htmlBody" class="text-[12px] text-txt3">…</div>
     <pre
       v-else
-      class="whitespace-pre-wrap border border-line bg-base p-2.5 font-mono text-[11px] leading-relaxed text-txt2"
+      class="rounded-lg whitespace-pre-wrap border border-line bg-base p-2.5 font-mono text-[11px] leading-relaxed text-txt2"
       :class="variant === 'detail' ? 'scroll-area max-h-48 overflow-y-auto' : ''"
     >{{ artifactHtml }}</pre>
   </template>

--- a/web/src/components/run/OutputResultCards.vue
+++ b/web/src/components/run/OutputResultCards.vue
@@ -178,7 +178,7 @@ function closeEnlarge() {
     <!-- Multi-card name+status list (g1.2 / g3.2): no max-height / own overflow. -->
     <div
       v-if="showList"
-      class="mb-3 border border-line bg-base"
+      class="rounded-lg mb-3 border border-line bg-base"
       role="listbox"
       :aria-label="t('pages.nodeOutput.outputCards.listTitle')"
       data-testid="output-result-list"
@@ -235,7 +235,7 @@ function closeEnlarge() {
           :class="currentCard.status === 'failed' ? 'text-err' : 'text-txt'"
         >{{ currentCard.title }}</span>
         <span
-          class="shrink-0 border border-line px-1.5 py-0.5 text-[10px] text-txt3"
+          class="rounded-md shrink-0 border border-line px-1.5 py-0.5 text-[10px] text-txt3"
           data-testid="output-result-detail-kind"
         >{{ detailKindLabel(currentCard) }}</span>
         <button

--- a/web/src/components/run/PlanView.vue
+++ b/web/src/components/run/PlanView.vue
@@ -228,7 +228,7 @@ function diagramJsonPath(section: string, list: PlanDiagram[], active: PlanDiagr
     <div v-if="hasDesign" class="mb-4 space-y-3" data-testid="plan-design">
       <div class="text-[11px] font-semibold uppercase tracking-wide text-txt3">{{ t('pages.plan.designTitle') }}</div>
 
-      <section v-if="doc.architecture" class="border border-line bg-base/40 p-3" data-testid="plan-sec-architecture">
+      <section v-if="doc.architecture" class="rounded-lg border border-line bg-base/40 p-3" data-testid="plan-sec-architecture">
         <div class="group flex items-center gap-2">
           <div class="text-[13px] font-semibold text-txt">{{ t('pages.plan.sections.architecture') }}</div>
           <AnnotateBtn json-path="architecture" :label="t('pages.plan.sections.architecture')" />
@@ -275,7 +275,7 @@ function diagramJsonPath(section: string, list: PlanDiagram[], active: PlanDiagr
         />
       </section>
 
-      <section v-if="doc.data_design" class="border border-line bg-base/40 p-3" data-testid="plan-sec-data">
+      <section v-if="doc.data_design" class="rounded-lg border border-line bg-base/40 p-3" data-testid="plan-sec-data">
         <div class="group flex items-center gap-2">
           <div class="text-[13px] font-semibold text-txt">{{ t('pages.plan.sections.dataDesign') }}</div>
           <AnnotateBtn json-path="data_design" :label="t('pages.plan.sections.dataDesign')" />
@@ -388,7 +388,7 @@ function diagramJsonPath(section: string, list: PlanDiagram[], active: PlanDiagr
         />
       </section>
 
-      <section v-if="doc.interfaces?.length" class="border border-line bg-base/40 p-3" data-testid="plan-sec-interfaces">
+      <section v-if="doc.interfaces?.length" class="rounded-lg border border-line bg-base/40 p-3" data-testid="plan-sec-interfaces">
         <div class="text-[13px] font-semibold text-txt">{{ t('pages.plan.sections.interfaces') }}</div>
         <ul class="mt-2 space-y-1.5">
           <li v-for="(it, ii) in doc.interfaces" :key="it.name || ii" class="text-[12px] text-txt2">
@@ -405,7 +405,7 @@ function diagramJsonPath(section: string, list: PlanDiagram[], active: PlanDiagr
         </ul>
       </section>
 
-      <section v-if="doc.components?.length" class="border border-line bg-base/40 p-3" data-testid="plan-sec-components">
+      <section v-if="doc.components?.length" class="rounded-lg border border-line bg-base/40 p-3" data-testid="plan-sec-components">
         <div class="text-[13px] font-semibold text-txt">{{ t('pages.plan.sections.components') }}</div>
         <ul class="mt-2 space-y-1.5">
           <li v-for="(c, ci) in doc.components" :key="c.name || ci" class="text-[12px] text-txt2">
@@ -422,7 +422,7 @@ function diagramJsonPath(section: string, list: PlanDiagram[], active: PlanDiagr
         </ul>
       </section>
 
-      <section v-if="doc.interaction" class="border border-line bg-base/40 p-3" data-testid="plan-sec-interaction">
+      <section v-if="doc.interaction" class="rounded-lg border border-line bg-base/40 p-3" data-testid="plan-sec-interaction">
         <div class="group flex items-center gap-2">
           <div class="text-[13px] font-semibold text-txt">{{ t('pages.plan.sections.interaction') }}</div>
           <AnnotateBtn json-path="interaction" :label="t('pages.plan.sections.interaction')" />
@@ -468,7 +468,7 @@ function diagramJsonPath(section: string, list: PlanDiagram[], active: PlanDiagr
         />
       </section>
 
-      <section v-if="doc.test_design?.trim()" class="border border-line bg-base/40 p-3" data-testid="plan-sec-test">
+      <section v-if="doc.test_design?.trim()" class="rounded-lg border border-line bg-base/40 p-3" data-testid="plan-sec-test">
         <div class="group flex items-center gap-2">
           <div class="text-[13px] font-semibold text-txt">{{ t('pages.plan.sections.testDesign') }}</div>
           <AnnotateBtn json-path="test_design" :label="t('pages.plan.sections.testDesign')" />

--- a/web/src/components/run/PublicAppPreviewPanel.vue
+++ b/web/src/components/run/PublicAppPreviewPanel.vue
@@ -225,7 +225,7 @@ function retry() {
         <p>{{ t('pages.publicGate.appPreviewNoPorts') }}</p>
         <button
           type="button"
-          class="mt-1 inline-flex min-h-11 items-center border border-line px-3 text-[12px] text-txt"
+          class="rounded-lg mt-1 inline-flex min-h-11 items-center border border-line px-3 text-[12px] text-txt"
           data-testid="public-gate-app-preview-retry"
           @click="retry"
         >
@@ -273,7 +273,7 @@ function retry() {
           <p>{{ ticketError }}</p>
           <button
             type="button"
-            class="mt-1 inline-flex min-h-11 items-center border border-line px-3 text-[12px] text-txt"
+            class="rounded-lg mt-1 inline-flex min-h-11 items-center border border-line px-3 text-[12px] text-txt"
             data-testid="public-gate-app-preview-retry"
             @click="retry"
           >

--- a/web/src/components/run/ReactArtifactStage.vue
+++ b/web/src/components/run/ReactArtifactStage.vue
@@ -769,7 +769,7 @@ onBeforeUnmount(() => {
               >
                 <button
                   type="button"
-                  class="inline-flex items-center gap-0.5 border border-line bg-elevated px-1.5 py-px text-[10px] text-txt2 hover:border-line-strong hover:text-txt"
+                  class="rounded-md inline-flex items-center gap-0.5 border border-line bg-elevated px-1.5 py-px text-[10px] text-txt2 hover:border-line-strong hover:text-txt"
                   :class="{ 'border-accent/60 text-txt': versionMenuFor === a.name }"
                   :aria-expanded="versionMenuFor === a.name ? 'true' : 'false'"
                   aria-haspopup="listbox"
@@ -782,7 +782,7 @@ onBeforeUnmount(() => {
                 <div
                   v-if="versionMenuFor === a.name"
                   role="listbox"
-                  class="absolute right-0 bottom-full z-20 mb-1 min-w-[7.5rem] border border-line bg-surface py-0.5"
+                  class="rounded-lg absolute right-0 bottom-full z-20 mb-1 min-w-[7.5rem] border border-line bg-surface py-0.5"
                   data-testid="react-artifact-version-menu"
                 >
                   <button

--- a/web/src/components/run/ReviewComposer.vue
+++ b/web/src/components/run/ReviewComposer.vue
@@ -295,7 +295,7 @@ function onConfirm() {
         <button
           v-if="!coldSession && showGateCancel"
           type="button"
-          class="inline-flex items-center justify-center gap-1.5 border border-line bg-elevated px-3 py-2 text-sm font-medium text-txt2"
+          class="rounded-lg inline-flex items-center justify-center gap-1.5 border border-line bg-elevated px-3 py-2 text-sm font-medium text-txt2"
           data-testid="gate-react-cancel"
           title="Cancel"
           @click="emit('cancel')"

--- a/web/src/components/run/RunClarifyPanel.vue
+++ b/web/src/components/run/RunClarifyPanel.vue
@@ -110,7 +110,7 @@ defineExpose({
       </div>
       <StatusPill status="failed" />
     </div>
-    <div class="mb-3 border border-err/40 bg-err/5 p-3.5">
+    <div class="rounded-lg mb-3 border border-err/40 bg-err/5 p-3.5">
       <div class="mb-2 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-err">
         <Icon name="alert" :size="14" />
         {{ t('pages.runDetail.clarifyFailed.errorTitle') }}

--- a/web/src/components/run/RunSandboxEnvPanel.vue
+++ b/web/src/components/run/RunSandboxEnvPanel.vue
@@ -21,7 +21,7 @@ const items = computed(() => props.entries || [])
       {{ t('pages.runDetail.sandboxEnv.empty') }}
     </div>
     <div v-else class="scroll-area min-h-0 flex-1 overflow-y-auto p-3">
-      <div class="overflow-hidden border border-line">
+      <div class="rounded-lg overflow-hidden border border-line">
         <div
           class="hidden gap-2 border-b border-line bg-elevated/55 px-3 py-2 text-[11px] font-semibold uppercase tracking-wider text-txt3 sm:grid sm:grid-cols-[minmax(0,1.2fr)_minmax(0,1.6fr)_72px]"
         >

--- a/web/src/components/run/RunSandboxPanel.vue
+++ b/web/src/components/run/RunSandboxPanel.vue
@@ -69,7 +69,7 @@ const { t } = useI18n()
         <span>{{ sbxLog.error }}</span>
         <button
           type="button"
-          class="mt-2 inline-flex min-h-11 items-center border border-line px-3 text-[12px] text-txt"
+          class="rounded-lg mt-2 inline-flex min-h-11 items-center border border-line px-3 text-[12px] text-txt"
           @click="emit('refresh')"
         >
           {{ t('common.chatImage.retry') }}

--- a/web/src/components/run/SelectionAddToChat.vue
+++ b/web/src/components/run/SelectionAddToChat.vue
@@ -42,7 +42,7 @@ function onAdd() {
       v-show="enabled && visible"
       data-selection-add-to-chat
       data-testid="selection-add-to-chat"
-      class="fixed z-50 inline-flex items-center border border-accent-2/55 bg-elevated shadow-lg"
+      class="rounded-lg fixed z-50 inline-flex items-center border border-accent-2/55 bg-elevated shadow-lg"
       :style="style"
       role="toolbar"
       aria-label="选区操作"

--- a/web/src/components/run/StructuredProductPanel.vue
+++ b/web/src/components/run/StructuredProductPanel.vue
@@ -325,7 +325,7 @@ const pending = computed(() => props.nodeRun.status === 'pending')
             v-if="isVisual && eligibleVersions.length >= 2"
             v-model="selectedIteration"
             @change="onVersionChange"
-            class="border border-line bg-elevated px-2 py-1 text-xs text-txt outline-none focus:border-accent"
+            class="rounded-md border border-line bg-elevated px-2 py-1 text-xs text-txt outline-none focus:border-accent"
             data-testid="structured-product-version-select"
             aria-label="选择视觉产物版本"
           >
@@ -343,7 +343,7 @@ const pending = computed(() => props.nodeRun.status === 'pending')
             v-for="tab in productTabs"
             :key="tab.name"
             type="button"
-            class="border px-2 py-0.5 text-[11px]"
+            class="rounded-md border px-2 py-0.5 text-[11px]"
             :class="
               selectedArtifactName === tab.name
                 ? 'border-accent bg-accent/10 text-accent-2'
@@ -364,10 +364,10 @@ const pending = computed(() => props.nodeRun.status === 'pending')
       :class="isVisual && rawHtml ? 'flex flex-col overflow-hidden px-4' : 'overflow-y-auto px-4 pb-4'"
       data-testid="structured-product-preview"
     >
-      <div v-if="isVisual && rawHtml" class="relative min-h-0 flex-1 border border-line">
+      <div v-if="isVisual && rawHtml" class="rounded-lg relative min-h-0 flex-1 border border-line">
         <div
           v-if="isHistoricalPreview"
-          class="absolute left-2 top-2 z-10 border border-warn/50 bg-base/95 px-2 py-1 text-xs text-warn"
+          class="rounded-md absolute left-2 top-2 z-10 border border-warn/50 bg-base/95 px-2 py-1 text-xs text-warn"
           data-testid="structured-product-historical-banner"
         >
           历史版本 · 只读

--- a/web/src/components/run/TokenUsageByModelTable.vue
+++ b/web/src/components/run/TokenUsageByModelTable.vue
@@ -92,7 +92,7 @@ function barTitle(row: { inputTokens: number; outputTokens: number; cacheReadTok
   <div
     v-if="total != null"
     data-testid="run-token-by-model"
-    class="mt-3 overflow-x-clip border border-line bg-surface"
+    class="rounded-lg mt-3 overflow-x-clip border border-line bg-surface"
   >
     <div class="flex items-baseline justify-between gap-2 border-b border-line px-2.5 py-2">
       <h4 class="m-0 text-[13px] font-semibold text-txt">{{ t('pages.tokenByModel.modelTableTitle') }}</h4>
@@ -124,7 +124,7 @@ function barTitle(row: { inputTokens: number; outputTokens: number; cacheReadTok
           >{{ modelLabel(row.modelKey, row.unknown) }}</span>
           <UnknownModelBadge v-if="showUnknownVisual(row.modelKey, row.unknown)" />
           <span
-            class="inline-flex shrink-0 items-center border px-1.5 py-px text-[10.5px] leading-none"
+            class="rounded-lg inline-flex shrink-0 items-center border px-1.5 py-px text-[10.5px] leading-none"
             :class="
               row.unknown && !row.filled
                 ? 'border-warn/35 bg-warn/8 text-warn'
@@ -169,7 +169,7 @@ function barTitle(row: { inputTokens: number; outputTokens: number; cacheReadTok
 
         <!-- 英文全称四分量 auto-fit 网格（≤320px 自然降为 2/1 列） -->
         <div
-          class="grid gap-px border border-line bg-line"
+          class="rounded-lg grid gap-px border border-line bg-line"
           style="grid-template-columns: repeat(auto-fit, minmax(96px, 1fr))"
         >
           <div class="min-w-0 bg-base px-1.5 py-1">

--- a/web/src/components/run/gateApproval/GateApprovalContentFit.vue
+++ b/web/src/components/run/gateApproval/GateApprovalContentFit.vue
@@ -152,7 +152,7 @@ const {
             >
               <div
                 ref="gateStageEl"
-                class="border border-line"
+                class="rounded-lg border border-line"
                 :class="
                   isMobile
                     ? 'scroll-area min-h-0 overflow-x-hidden overflow-y-auto'

--- a/web/src/components/run/gateApproval/GateApprovalDesktopBody.vue
+++ b/web/src/components/run/gateApproval/GateApprovalDesktopBody.vue
@@ -267,7 +267,7 @@ const {
         </div>
         <div
           v-else-if="isVisualBody && productHtml"
-          class="overflow-x-hidden border border-line"
+          class="rounded-lg overflow-x-hidden border border-line"
           data-testid="comment-pin-desktop-split"
         >
           <div

--- a/web/src/components/run/gateApproval/GateApprovalMobileFill.vue
+++ b/web/src/components/run/gateApproval/GateApprovalMobileFill.vue
@@ -142,7 +142,7 @@ const {
             data-testid="mobile-fill-scroll"
           >
             <div
-              class="flex min-h-0 flex-1 flex-col overflow-hidden border border-line"
+              class="rounded-lg flex min-h-0 flex-1 flex-col overflow-hidden border border-line"
               data-testid="mobile-fill-preview"
             >
               <div

--- a/web/src/components/run/product/FeedbackRoundCard.vue
+++ b/web/src/components/run/product/FeedbackRoundCard.vue
@@ -113,13 +113,13 @@ function turnBody(text: string | undefined): string {
     <section
       v-if="agentSummary"
       data-testid="feedback-agent-summary"
-      class="border border-line border-l-2 border-l-info bg-info/10 px-3 py-2.5"
+      class="rounded-lg border border-line border-l-2 border-l-info bg-info/10 px-3 py-2.5"
     >
       <div class="mb-1.5 flex flex-wrap items-center gap-2">
         <div class="text-[10px] font-semibold uppercase tracking-wider text-txt3">
           {{ t('pages.product.feedback.agentSummary') }}
         </div>
-        <span class="border border-info/40 bg-info/10 px-1.5 py-0.5 text-[10px] text-info">
+        <span class="rounded-md border border-info/40 bg-info/10 px-1.5 py-0.5 text-[10px] text-info">
           {{ t('pages.product.feedback.agentSummaryTag') }}
         </span>
       </div>

--- a/web/src/components/shell/AppShell.vue
+++ b/web/src/components/shell/AppShell.vue
@@ -155,7 +155,7 @@ onUnmounted(() => stopShutdownPolling())
           v-if="offline"
           class="absolute inset-0 z-40 flex items-center justify-center bg-base/75 backdrop-blur-sm"
         >
-          <div class="border border-line bg-surface px-8 py-6 text-center shadow-card">
+          <div class="rounded-lg border border-line bg-surface px-8 py-6 text-center shadow-card">
             <Icon name="alert" :size="28" class="mx-auto mb-3 text-txt3" />
             <h4 class="text-base font-semibold">{{ t('common.shutdown.offlineTitle') }}</h4>
             <p class="mt-2 text-sm text-txt3">{{ t('common.shutdown.offlineDesc') }}</p>
@@ -168,7 +168,7 @@ onUnmounted(() => stopShutdownPolling())
 
     <div
       v-if="drainToast.visible"
-      class="pointer-events-none fixed bottom-6 right-6 z-50 max-w-sm border border-err/40 bg-elevated px-4 py-3 text-sm text-txt2 shadow-card"
+      class="rounded-lg pointer-events-none fixed bottom-6 right-6 z-50 max-w-sm border border-err/40 bg-elevated px-4 py-3 text-sm text-txt2 shadow-card"
     >
       <strong class="mb-1 block font-semibold text-err">{{ t('common.shutdown.actionUnavailable') }}</strong>
       {{ drainToast.text }}

--- a/web/src/components/shell/AppSidebarNav.vue
+++ b/web/src/components/shell/AppSidebarNav.vue
@@ -311,7 +311,7 @@ const settingsItems = settingsNavItems
                 <span class="truncate text-[11px] text-txt3" :title="item.projectName">{{ item.projectName }}</span>
                 <span
                   v-if="item.status === 'draft'"
-                  class="shrink-0 border border-warn/35 bg-warn/10 px-1.5 py-px text-[10px] text-warn"
+                  class="rounded-md shrink-0 border border-warn/35 bg-warn/10 px-1.5 py-px text-[10px] text-warn"
                 >{{ t('common.status.draft') }}</span>
               </div>
             </div>

--- a/web/src/components/shell/FloatingNavBall.vue
+++ b/web/src/components/shell/FloatingNavBall.vue
@@ -113,7 +113,7 @@ onBeforeUnmount(() => {
   >
     <button
       type="button"
-      class="flex h-12 w-12 items-center justify-center border border-line bg-surface text-txt shadow-card transition hover:-translate-y-px hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none"
+      class="flex h-12 w-12 items-center justify-center rounded-full border border-line bg-surface text-txt shadow-card transition hover:-translate-y-px hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none"
       data-testid="floating-nav-ball"
       :aria-label="isMobile ? t('shell.aria.openNav') : t('shell.aria.showNav')"
       :title="isMobile ? t('shell.aria.openNav') : t('shell.aria.showNav')"

--- a/web/src/components/shell/RunOutputPptModal.vue
+++ b/web/src/components/shell/RunOutputPptModal.vue
@@ -142,7 +142,7 @@ function openArtifacts() {
     </div>
     <div
       v-else-if="loadError"
-      class="border border-err/35 bg-err/8 px-3 py-3 text-sm text-err"
+      class="rounded-lg border border-err/35 bg-err/8 px-3 py-3 text-sm text-err"
       data-testid="run-output-load-error"
       role="alert"
     >
@@ -150,7 +150,7 @@ function openArtifacts() {
     </div>
     <div
       v-else-if="!hasCards"
-      class="flex min-h-[360px] flex-col items-center justify-center border border-line bg-base px-4 py-10 text-center"
+      class="rounded-lg flex min-h-[360px] flex-col items-center justify-center border border-line bg-base px-4 py-10 text-center"
       data-testid="run-output-empty"
     >
       <strong class="mb-1.5 block text-[13px] text-txt">{{
@@ -161,7 +161,7 @@ function openArtifacts() {
       <div class="mt-4 flex flex-wrap items-center justify-center gap-2">
         <button
           type="button"
-          class="border border-transparent bg-accent px-3 py-2 text-[13px] text-white hover:brightness-110"
+          class="rounded-lg border border-transparent bg-accent px-3 py-2 text-[13px] text-white hover:brightness-110"
           data-testid="run-output-empty-open-run"
           @click="openRunDetail"
         >
@@ -169,7 +169,7 @@ function openArtifacts() {
         </button>
         <button
           type="button"
-          class="border border-line bg-transparent px-3 py-2 text-[13px] text-txt2 hover:border-line-strong hover:text-txt"
+          class="rounded-md border border-line bg-transparent px-3 py-2 text-[13px] text-txt2 hover:border-line-strong hover:text-txt"
           data-testid="run-output-empty-open-artifacts"
           @click="openArtifacts"
         >
@@ -179,7 +179,7 @@ function openArtifacts() {
     </div>
     <div
       v-else
-      class="flex h-[min(62vh,560px)] min-h-[420px] flex-col overflow-hidden border border-line"
+      class="rounded-lg flex h-[min(62vh,560px)] min-h-[420px] flex-col overflow-hidden border border-line"
       data-testid="run-output-result-cards"
     >
       <div
@@ -188,13 +188,13 @@ function openArtifacts() {
       >
         <span>{{ t('shell.runNotifications.focusOutputPrefix') }}</span>
         <strong class="text-txt">{{ focusNodeLabel || focusNodeId || '—' }}</strong>
-        <span class="border border-ok/35 bg-ok/8 px-2 py-0.5 text-[11px] text-ok">{{
+        <span class="rounded-md border border-ok/35 bg-ok/8 px-2 py-0.5 text-[11px] text-ok">{{
           t('shell.runNotifications.focusOutputType')
         }}</span>
-        <span class="border border-line bg-base px-2 py-0.5 text-[11px] text-txt2">{{
+        <span class="rounded-md border border-line bg-base px-2 py-0.5 text-[11px] text-txt2">{{
           t('shell.runNotifications.focusOutputSource')
         }}</span>
-        <span class="border border-line bg-base px-2 py-0.5 text-[11px] text-txt2">{{
+        <span class="rounded-md border border-line bg-base px-2 py-0.5 text-[11px] text-txt2">{{
           t('shell.runNotifications.focusOutputAligned')
         }}</span>
       </div>
@@ -206,7 +206,7 @@ function openArtifacts() {
     <template #footer>
       <button
         type="button"
-        class="border border-transparent bg-accent px-3 py-2 text-[13px] text-white hover:brightness-110"
+        class="rounded-lg border border-transparent bg-accent px-3 py-2 text-[13px] text-white hover:brightness-110"
         data-testid="run-output-mark-read"
         @click="markRead"
       >

--- a/web/src/components/shell/ShellChromeControls.vue
+++ b/web/src/components/shell/ShellChromeControls.vue
@@ -204,7 +204,7 @@ defineExpose({
     >
       <span
         v-if="isDraining()"
-        class="inline-flex items-center gap-1.5 border border-warn/45 bg-warn/10 px-2.5 py-1 text-xs font-medium text-warn"
+        class="rounded-md inline-flex items-center gap-1.5 border border-warn/45 bg-warn/10 px-2.5 py-1 text-xs font-medium text-warn"
         :title="t('shell.shutdown.drainingTitle')"
       >
         <span class="inline-flex h-1.5 w-1.5 animate-pulse rounded-full bg-warn" />
@@ -259,7 +259,7 @@ defineExpose({
     <Teleport to="body">
       <div
         v-if="panelOpen"
-        class="z-[60] flex max-h-[min(420px,70vh)] flex-col border border-line-strong bg-elevated shadow-card"
+        class="rounded-lg z-[60] flex max-h-[min(420px,70vh)] flex-col border border-line-strong bg-elevated shadow-card"
         role="menu"
         :aria-label="t('shell.runNotifications.title')"
         data-testid="run-notifications-panel"
@@ -275,7 +275,7 @@ defineExpose({
             <button
               v-if="unreadCount > 0"
               type="button"
-              class="border border-line bg-transparent px-2 py-0.5 text-[11px] text-txt2 hover:border-accent hover:text-accent"
+              class="rounded-md border border-line bg-transparent px-2 py-0.5 text-[11px] text-txt2 hover:border-accent hover:text-accent"
               data-testid="run-notifications-mark-all"
               @click="onMarkAllRead"
             >
@@ -314,7 +314,7 @@ defineExpose({
             />
             <div class="mb-1 flex items-center gap-2">
               <span
-                class="shrink-0 border px-1.5 py-0.5 text-[10px] font-semibold"
+                class="rounded-md shrink-0 border px-1.5 py-0.5 text-[10px] font-semibold"
                 :class="
                   item.status === 'failed'
                     ? 'border-err/45 text-err'
@@ -352,7 +352,7 @@ defineExpose({
           </div>
           <button
             type="button"
-            class="w-full border border-line bg-transparent px-3 py-2 text-[13px] text-accent-2 hover:border-accent hover:bg-accent-dim hover:text-accent"
+            class="rounded-md w-full border border-line bg-transparent px-3 py-2 text-[13px] text-accent-2 hover:border-accent hover:bg-accent-dim hover:text-accent"
             data-testid="run-notifications-view-all"
             @click="viewAll"
           >

--- a/web/src/components/shell/StatusMetrics.vue
+++ b/web/src/components/shell/StatusMetrics.vue
@@ -121,7 +121,7 @@ function onBlurTip(id: string) {
         </svg>
         <span class="sm-val text-xs leading-none text-txt">{{ fmtCompactTokenCount(cumulative) }}</span>
         <span
-          class="sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden -translate-x-1/2 whitespace-nowrap border border-line-strong bg-overlay px-2.5 py-1.5 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
+          class="rounded-md sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden -translate-x-1/2 whitespace-nowrap border border-line-strong bg-overlay px-2.5 py-1.5 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
           role="tooltip"
         >
           {{ t('shell.statusMetrics.tokens') }}: <span class="font-mono">{{ fmtFull(cumulative) }}</span>
@@ -143,7 +143,7 @@ function onBlurTip(id: string) {
         </svg>
         <span class="sm-val text-xs leading-none text-txt">{{ fmtFiveMinuteRate(rate) }}</span>
         <span
-          class="sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden -translate-x-1/2 whitespace-nowrap border border-line-strong bg-overlay px-2.5 py-1.5 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
+          class="rounded-md sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden -translate-x-1/2 whitespace-nowrap border border-line-strong bg-overlay px-2.5 py-1.5 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
           role="tooltip"
         >
           {{ t('shell.statusMetrics.rate') }}: <span class="font-mono">{{ fmtFull(rate) }}</span>
@@ -166,7 +166,7 @@ function onBlurTip(id: string) {
         </svg>
         <span class="sm-val text-xs leading-none text-txt">{{ fmtCompactTokenCount(peak) }}</span>
         <span
-          class="sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden -translate-x-1/2 whitespace-nowrap border border-line-strong bg-overlay px-2.5 py-1.5 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
+          class="rounded-md sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden -translate-x-1/2 whitespace-nowrap border border-line-strong bg-overlay px-2.5 py-1.5 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
           role="tooltip"
         >
           {{ t('shell.statusMetrics.peak') }}: <span class="font-mono">{{ fmtFull(peak) }}</span>
@@ -189,7 +189,7 @@ function onBlurTip(id: string) {
         </svg>
         <span class="sm-val text-xs leading-none text-txt">{{ running }}</span>
         <span
-          class="sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden -translate-x-1/2 whitespace-nowrap border border-line-strong bg-overlay px-2.5 py-1.5 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
+          class="rounded-md sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden -translate-x-1/2 whitespace-nowrap border border-line-strong bg-overlay px-2.5 py-1.5 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
           role="tooltip"
         >
           {{ t('shell.statusMetrics.running') }}: <span class="font-mono">{{ running }}</span>
@@ -211,7 +211,7 @@ function onBlurTip(id: string) {
         </svg>
         <span class="sm-val text-xs leading-none text-txt">{{ queued }}</span>
         <span
-          class="sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden -translate-x-1/2 whitespace-nowrap border border-line-strong bg-overlay px-2.5 py-1.5 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
+          class="rounded-md sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden -translate-x-1/2 whitespace-nowrap border border-line-strong bg-overlay px-2.5 py-1.5 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
           role="tooltip"
         >
           {{ t('shell.statusMetrics.queued') }}: <span class="font-mono">{{ queued }}</span>
@@ -256,7 +256,7 @@ function onBlurTip(id: string) {
       </span>
       <span
         v-if="!usePortaledCompactTip"
-        class="sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden min-w-[180px] -translate-x-1/2 border border-line-strong bg-overlay px-2.5 py-2 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
+        class="rounded-md sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden min-w-[180px] -translate-x-1/2 border border-line-strong bg-overlay px-2.5 py-2 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
         role="tooltip"
       >
         <div>{{ t('shell.statusMetrics.tokens') }}: <span class="font-mono">{{ fmtFull(cumulative) }}</span></div>
@@ -271,7 +271,7 @@ function onBlurTip(id: string) {
       <div
         v-show="compactTipVisible"
         ref="compactTip"
-        class="sm-tip pointer-events-none z-[60] min-w-[180px] border border-line-strong bg-overlay px-2.5 py-2 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
+        class="rounded-md sm-tip pointer-events-none z-[60] min-w-[180px] border border-line-strong bg-overlay px-2.5 py-2 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
         role="tooltip"
         data-testid="status-metrics-compact-tip"
         data-placement="above"

--- a/web/src/components/ui/AppInlineError.vue
+++ b/web/src/components/ui/AppInlineError.vue
@@ -20,14 +20,14 @@ const { t } = useI18n()
 </script>
 
 <template>
-  <div class="border border-err/45 bg-base p-5 text-left" data-testid="app-inline-error">
+  <div class="rounded-lg border border-err/45 bg-base p-5 text-left" data-testid="app-inline-error">
     <h3 class="m-0 mb-1.5 text-sm font-semibold text-err">
       {{ title || t('common.loading.failed') }}
     </h3>
     <p v-if="message" class="m-0 mb-3 text-[13px] text-txt2">{{ message }}</p>
     <button
       type="button"
-      class="inline-flex min-h-[44px] items-center justify-center bg-accent px-3 py-2 text-[13px] text-white outline-none hover:bg-accent-2 focus-visible:ring-2 focus-visible:ring-accent/40"
+      class="inline-flex min-h-[44px] items-center justify-center rounded-md bg-accent px-3 py-2 text-[13px] text-white outline-none hover:bg-accent-2 focus-visible:ring-2 focus-visible:ring-accent/40"
       data-testid="app-inline-error-retry"
       @click="$emit('retry')"
     >

--- a/web/src/components/ui/AppSwitch.test.ts
+++ b/web/src/components/ui/AppSwitch.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import AppSwitch from './AppSwitch.vue'
 
 describe('AppSwitch', () => {
-  it('renders square accent track when on', () => {
+  it('renders capsule accent track when on', () => {
     const w = mount(AppSwitch, {
       props: { modelValue: true },
       attrs: { 'aria-label': 'Enable feature' },
@@ -13,8 +13,8 @@ describe('AppSwitch', () => {
     expect(btn.attributes('aria-checked')).toBe('true')
     expect(btn.attributes('aria-label')).toBe('Enable feature')
     expect(btn.classes().join(' ')).toContain('bg-accent')
-    expect(btn.classes().join(' ')).toContain('rounded-none')
-    expect(btn.classes().join(' ')).not.toContain('rounded-full')
+    expect(btn.classes().join(' ')).toContain('rounded-full')
+    expect(btn.classes().join(' ')).not.toContain('rounded-none')
     w.unmount()
   })
 

--- a/web/src/components/ui/AppSwitch.vue
+++ b/web/src/components/ui/AppSwitch.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 /**
- * Square accent switch (role=switch) — shared boolean control.
- * On: bg-accent track + white square thumb on the right (attachment style).
+ * Capsule accent switch (role=switch) — shared boolean control.
+ * On: bg-accent track + white thumb on the right.
  * Off: border-line-strong / bg-base + thumb on the left (Pm enable semantics).
  * Callers pass aria-label / class / data-testid via attribute fallthrough.
  */
@@ -34,7 +34,7 @@ function onKeydown(e: KeyboardEvent) {
   <button
     type="button"
     role="switch"
-    class="relative h-[22px] w-10 shrink-0 rounded-none border transition disabled:cursor-not-allowed disabled:opacity-45"
+    class="relative h-[22px] w-10 shrink-0 rounded-full border transition disabled:cursor-not-allowed disabled:opacity-45"
     :class="modelValue ? 'border-accent bg-accent' : 'border-line-strong bg-base'"
     :aria-checked="modelValue"
     :aria-disabled="disabled ? 'true' : undefined"
@@ -44,7 +44,7 @@ function onKeydown(e: KeyboardEvent) {
     @keydown="onKeydown"
   >
     <span
-      class="pointer-events-none absolute top-0.5 h-4 w-4 rounded-none transition-all"
+      class="pointer-events-none absolute top-0.5 h-4 w-4 rounded-full transition-all"
       :class="modelValue ? 'left-[18px] bg-white' : 'left-0.5 bg-txt2'"
     />
   </button>

--- a/web/src/components/ui/ChatImageThumb.vue
+++ b/web/src/components/ui/ChatImageThumb.vue
@@ -159,13 +159,13 @@ function onPreviewClick() {
 <template>
   <div
     v-if="loadFailed"
-    class="flex flex-col gap-1.5 border border-err/40 bg-err/[0.08] p-2"
+    class="flex flex-col gap-1.5 rounded-md border border-err/40 bg-err/[0.08] p-2"
     :class="[failCardClass, thumbClass]"
     :data-testid="testId"
     data-image-failed="1"
   >
     <div
-      class="flex h-7 w-7 items-center justify-center border border-err/35 text-red-300"
+      class="flex h-7 w-7 items-center justify-center rounded border border-err/35 text-red-300"
       aria-hidden="true"
     >
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7">
@@ -181,7 +181,7 @@ function onPreviewClick() {
     >{{ label }}</div>
     <button
       type="button"
-      class="bg-accent px-2.5 py-1 text-left text-[12px] text-white hover:brightness-110"
+      class="rounded-md bg-accent px-2.5 py-1 text-left text-[12px] text-white hover:brightness-110"
       :data-testid="retryTestId"
       @click.stop="retryLoad"
     >
@@ -191,7 +191,7 @@ function onPreviewClick() {
   <button
     v-else-if="mode === 'previewable'"
     type="button"
-    class="group relative cursor-pointer overflow-hidden border border-line transition hover:border-accent focus-visible:border-accent focus-visible:outline-none"
+    class="group relative cursor-pointer overflow-hidden rounded-md border border-line transition hover:border-accent focus-visible:border-accent focus-visible:outline-none"
     :class="[sizeClass, thumbClass]"
     :data-testid="testId"
     :aria-label="t('common.chatImage.previewAria', { label })"
@@ -212,7 +212,7 @@ function onPreviewClick() {
   </button>
   <div
     v-else
-    class="relative overflow-hidden border border-line"
+    class="relative overflow-hidden rounded-md border border-line"
     :class="[sizeClass, thumbClass]"
     :data-testid="testId"
   >

--- a/web/src/components/ui/CompositeImageStrip.vue
+++ b/web/src/components/ui/CompositeImageStrip.vue
@@ -245,7 +245,7 @@ function onError(key: string, src: string) {
       <!-- Permanent failure: empty src, known-missing, or @error; no retry, no HTTP/path details -->
       <div
         v-if="item.status === 'failed'"
-        class="flex flex-col items-center justify-center gap-1 border border-err/35 bg-err/[0.06] px-2 py-2 text-center"
+        class="rounded-lg flex flex-col items-center justify-center gap-1 border border-err/35 bg-err/[0.06] px-2 py-2 text-center"
         :class="cardClass"
         data-image-failed="1"
         data-testid="composite-image-failed"
@@ -263,7 +263,7 @@ function onError(key: string, src: string) {
       <!-- Has src: loading overlay until load/complete/timeout; showImg gates orphan auto GET. -->
       <div
         v-else
-        class="relative overflow-hidden border border-line"
+        class="rounded-lg relative overflow-hidden border border-line"
         :class="item.status === 'loading' ? cardClass : sizeClass"
         :data-testid="item.status === 'loading' ? 'composite-image-loading' : 'composite-image-ok'"
         :role="item.status === 'loading' ? 'status' : undefined"

--- a/web/src/components/ui/HtmlPreview.vue
+++ b/web/src/components/ui/HtmlPreview.vue
@@ -703,7 +703,7 @@ watch(needsMessageListener, (enabled, wasEnabled) => {
         />
         <div
           v-else
-          class="w-[390px] shrink-0 overflow-hidden border border-line bg-white shadow-lg"
+          class="w-[390px] shrink-0 overflow-hidden rounded-lg border border-line bg-white shadow-lg"
           :class="fitContent && !fillParent ? '' : 'h-full'"
           :style="fitContent && !fillParent ? { height: contentHeight + 'px' } : undefined"
         >

--- a/web/src/components/ui/LangSelect.vue
+++ b/web/src/components/ui/LangSelect.vue
@@ -93,7 +93,7 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
       :class="
         variant === 'ghost'
           ? ['h-8 gap-1.5 border-0 bg-transparent px-2 text-xs', open ? 'bg-elevated text-txt' : '']
-          : ['gap-2 border border-line bg-surface px-3 py-1.5 text-sm', open ? 'border-accent/60 text-txt' : '']
+          : ['gap-2 rounded-md border border-line bg-surface px-3 py-1.5 text-sm', open ? 'border-accent/60 text-txt' : '']
       "
       :aria-label="t('shell.langSelect')"
       aria-haspopup="listbox"

--- a/web/src/components/ui/Pagination.vue
+++ b/web/src/components/ui/Pagination.vue
@@ -184,6 +184,7 @@ function onPageSizeChange(event: Event) {
   align-items: center;
   gap: 6px;
   border: 1px solid rgb(var(--c-line));
+  border-radius: 8px;
   background: rgb(var(--c-elevated));
   color: rgb(var(--c-txt));
   padding: 6px 10px;
@@ -207,6 +208,7 @@ function onPageSizeChange(event: Event) {
   min-width: 32px;
   height: 32px;
   border: 1px solid rgb(var(--c-line));
+  border-radius: 8px;
   background: rgb(var(--c-elevated));
   color: rgb(var(--c-txt2));
   font-size: 12px;
@@ -244,6 +246,7 @@ function onPageSizeChange(event: Event) {
 }
 .pg-size-select {
   border: 1px solid rgb(var(--c-line));
+  border-radius: 8px;
   background: rgb(var(--c-elevated));
   color: rgb(var(--c-txt));
   padding: 6px 8px;

--- a/web/src/components/ui/ParagraphInput.vue
+++ b/web/src/components/ui/ParagraphInput.vue
@@ -73,7 +73,7 @@ onMounted(() => nextTick(autoGrow))
   <div data-testid="paragraph-input-root" :data-text-only="textOnly ? '1' : '0'">
     <div
       v-if="!textOnly && notice?.kind === 'error'"
-      class="mb-2 border border-err/40 bg-err/10 px-2.5 py-1.5 text-[12px] text-err"
+      class="mb-2 rounded-lg border border-err/40 bg-err/10 px-2.5 py-1.5 text-[12px] text-err"
       data-testid="paragraph-attach-notice"
       role="alert"
     >
@@ -94,7 +94,7 @@ onMounted(() => nextTick(autoGrow))
         />
         <div
           v-else
-          class="flex h-14 max-w-[160px] items-center gap-1.5 border border-line bg-elevated px-2"
+          class="flex h-14 max-w-[160px] items-center gap-1.5 rounded-md border border-line bg-elevated px-2"
           data-testid="paragraph-pending-file-chip"
           :title="attachmentDisplayName(im, ii)"
         >

--- a/web/src/components/ui/PipelineFilter.vue
+++ b/web/src/components/ui/PipelineFilter.vue
@@ -99,7 +99,7 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
   <div ref="root" class="relative w-full md:w-auto" data-testid="pipeline-filter">
     <button
       type="button"
-      class="flex w-full min-h-[44px] items-center gap-2 border border-line bg-surface px-3 py-1.5 text-sm text-txt2 transition hover:bg-elevated md:min-h-0 md:w-auto"
+      class="flex w-full min-h-[44px] items-center gap-2 rounded-md border border-line bg-surface px-3 py-1.5 text-sm text-txt2 transition hover:bg-elevated md:min-h-0 md:w-auto"
       :class="{ 'border-accent/60 text-txt': modelValue }"
       @click.stop="toggle"
     >

--- a/web/src/components/ui/PriorityBadge.vue
+++ b/web/src/components/ui/PriorityBadge.vue
@@ -32,7 +32,7 @@ const pad = computed(() => (props.size === 'sm' ? 'px-2 py-0.5 text-[11px]' : 'p
 
 <template>
   <span
-    class="inline-flex items-center gap-1.5 whitespace-nowrap border font-semibold tracking-wide"
+    class="rounded-lg inline-flex items-center gap-1.5 whitespace-nowrap border font-semibold tracking-wide"
     :class="[cls, pad]"
     :title="hideTitle ? undefined : t('common.priority.label')"
   >

--- a/web/src/components/ui/PrioritySegmented.vue
+++ b/web/src/components/ui/PrioritySegmented.vue
@@ -38,7 +38,7 @@ function btnClass(value: RunPriority) {
 
 <template>
   <div
-    class="grid grid-cols-3 border border-line bg-base"
+    class="grid grid-cols-3 overflow-hidden rounded-md border border-line bg-base"
     role="radiogroup"
     :aria-label="t('common.priority.label')"
     :aria-disabled="disabled || undefined"

--- a/web/src/components/ui/ProjectFilter.vue
+++ b/web/src/components/ui/ProjectFilter.vue
@@ -95,7 +95,7 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
   <div ref="root" class="relative w-full md:w-auto" data-testid="project-filter">
     <button
       type="button"
-      class="flex w-full min-h-[44px] items-center gap-2 border border-line bg-surface px-3 py-1.5 text-sm text-txt2 transition hover:bg-elevated md:min-h-0 md:w-auto"
+      class="flex w-full min-h-[44px] items-center gap-2 rounded-md border border-line bg-surface px-3 py-1.5 text-sm text-txt2 transition hover:bg-elevated md:min-h-0 md:w-auto"
       :class="{ 'border-accent/60 text-txt': modelValue || open }"
       @click.stop="toggle"
     >
@@ -106,7 +106,7 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
     </button>
     <div
       v-if="open"
-      class="scroll-area absolute left-0 right-0 z-40 mt-1 max-h-72 overflow-auto rounded-md border border-line-strong bg-surface p-1 shadow-lg md:left-auto md:right-0 md:w-64"
+      class="scroll-area absolute left-0 right-0 z-40 mt-1 max-h-72 overflow-auto rounded-lg border border-line-strong bg-surface p-1 shadow-lg md:left-auto md:right-0 md:w-64"
       data-testid="project-filter-panel"
       @click.stop
     >

--- a/web/src/components/ui/StatusFilter.vue
+++ b/web/src/components/ui/StatusFilter.vue
@@ -92,7 +92,7 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
   <div ref="root" class="relative w-full md:w-auto">
     <button
       type="button"
-      class="flex w-full min-h-[44px] items-center gap-2 border border-line bg-surface px-3 py-1.5 text-sm text-txt2 transition hover:bg-elevated md:min-h-0 md:w-auto"
+      class="flex w-full min-h-[44px] items-center gap-2 rounded-md border border-line bg-surface px-3 py-1.5 text-sm text-txt2 transition hover:bg-elevated md:min-h-0 md:w-auto"
       :class="{ 'border-accent/60 text-txt': hasFilter }"
       @click.stop="toggle"
     >

--- a/web/src/components/ui/TagFilter.vue
+++ b/web/src/components/ui/TagFilter.vue
@@ -180,7 +180,7 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
   <div ref="root" class="relative w-full md:w-auto" data-testid="tag-filter">
     <button
       type="button"
-      class="flex w-full min-h-[44px] items-center gap-2 border border-line bg-surface px-3 py-1.5 text-sm text-txt2 transition hover:bg-elevated md:min-h-0 md:w-auto"
+      class="flex w-full min-h-[44px] items-center gap-2 rounded-md border border-line bg-surface px-3 py-1.5 text-sm text-txt2 transition hover:bg-elevated md:min-h-0 md:w-auto"
       :class="{ 'border-accent/60 text-txt': hasFilter || open }"
       :aria-expanded="open"
       aria-haspopup="true"

--- a/web/src/components/ui/ToastHost.vue
+++ b/web/src/components/ui/ToastHost.vue
@@ -16,7 +16,7 @@ const { toasts } = useToast()
         <div
           v-for="t in toasts"
           :key="t.id"
-          class="border border-line bg-elevated px-4 py-2.5 text-[13px] font-medium text-txt shadow-card"
+          class="rounded-lg border border-line bg-elevated px-4 py-2.5 text-[13px] font-medium text-txt shadow-card"
           :class="{
             'border-ok/40 text-ok': t.type === 'success',
             'border-err/40 text-err': t.type === 'error',

--- a/web/src/components/ui/TokenUsageByModelTip.vue
+++ b/web/src/components/ui/TokenUsageByModelTip.vue
@@ -88,7 +88,7 @@ defineExpose({ toggle, close, isOpen })
   <div v-if="total != null" class="relative inline-flex" data-testid="token-by-model-tip-host">
     <button
       type="button"
-      class="usage-trigger inline-flex items-center gap-1 border border-line bg-elevated px-2 py-0.5 font-mono text-xs tabular-nums text-txt2 hover:border-accent/40 hover:text-txt"
+      class="usage-trigger inline-flex items-center gap-1 rounded-md border border-line bg-elevated px-2 py-0.5 font-mono text-xs tabular-nums text-txt2 hover:border-accent/40 hover:text-txt"
       data-testid="token-by-model-trigger"
       :aria-expanded="isOpen"
       @click.stop="toggle"
@@ -100,7 +100,7 @@ defineExpose({ toggle, close, isOpen })
       role="dialog"
       :aria-label="t('pages.tokenByModel.tipTitle')"
       data-testid="token-by-model-tip"
-      class="absolute right-0 top-[calc(100%+8px)] z-30 w-[min(320px,calc(100vw-24px))] border border-line bg-[#111827] px-3 py-2.5 text-left text-[#f9fafb] shadow-lg"
+      class="absolute right-0 top-[calc(100%+8px)] z-30 w-[min(320px,calc(100vw-24px))] rounded-lg border border-line bg-[#111827] px-3 py-2.5 text-left text-[#f9fafb] shadow-lg"
     >
       <div class="mb-2 flex items-center justify-between gap-2">
         <span class="text-[11px] font-semibold tracking-wide text-[#9ca3af]">
@@ -108,7 +108,7 @@ defineExpose({ toggle, close, isOpen })
         </span>
         <button
           type="button"
-          class="border border-white/10 px-2 py-0.5 text-[11px] text-[#9ca3af] hover:text-white"
+          class="rounded-md border border-white/10 px-2 py-0.5 text-[11px] text-[#9ca3af] hover:text-white"
           data-testid="token-by-model-close"
           @click.stop="close"
         >
@@ -123,7 +123,7 @@ defineExpose({ toggle, close, isOpen })
         <div
           v-for="row in rows"
           :key="row.modelKey"
-          class="border border-white/10 bg-white/5 px-2 py-1.5"
+          class="rounded-md border border-white/10 bg-white/5 px-2 py-1.5"
           :data-model="row.modelKey"
           :data-filled="row.filled ? '1' : '0'"
         >

--- a/web/src/components/ui/UnknownModelBadge.vue
+++ b/web/src/components/ui/UnknownModelBadge.vue
@@ -6,7 +6,7 @@ const { t } = useI18n()
 
 <template>
   <span
-    class="inline-flex shrink-0 items-center border border-line bg-elevated px-1.5 py-0.5 text-[10px] leading-none text-txt3"
+    class="rounded-md inline-flex shrink-0 items-center border border-line bg-elevated px-1.5 py-0.5 text-[10px] leading-none text-txt3"
     data-testid="unknown-model-badge"
   >
     {{ t('pages.tokenByModel.unknownBadge') }}

--- a/web/src/components/workflow/RunLaunchModal.vue
+++ b/web/src/components/workflow/RunLaunchModal.vue
@@ -394,7 +394,7 @@ async function startRun() {
         >
           <span
             ref="checkIconEl"
-            class="check-icon-wrap flex h-7 w-7 shrink-0 items-center justify-center border border-ok/30 bg-ok/10 text-ok"
+            class="rounded-full check-icon-wrap flex h-7 w-7 shrink-0 items-center justify-center border border-ok/30 bg-ok/10 text-ok"
           >
             <Icon name="check" :size="16" />
           </span>
@@ -483,7 +483,7 @@ async function startRun() {
             </AppButton>
           </div>
           <p class="text-[11px] leading-relaxed text-txt3">{{ t('pages.runLaunch.envHint') }}</p>
-          <div v-if="envRows.length" class="overflow-hidden border border-line bg-base">
+          <div v-if="envRows.length" class="rounded-lg overflow-hidden border border-line bg-base">
             <div class="hidden gap-2 border-b border-line bg-elevated/55 px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-txt3 sm:grid sm:grid-cols-[minmax(0,1.1fr)_minmax(0,1.4fr)_72px_36px]">
               <span>{{ t('pages.runLaunch.envKey') }}</span>
               <span>{{ t('pages.runLaunch.envValue') }}</span>

--- a/web/src/components/workflow/WorkflowApiTab.vue
+++ b/web/src/components/workflow/WorkflowApiTab.vue
@@ -217,7 +217,7 @@ onMounted(loadKeys)
           <h3 class="mb-3 text-base font-semibold text-txt">{{ t('pages.workflowApi.inputsTitle') }}</h3>
           <p class="mb-4 text-[13px] text-txt2">{{ t('pages.workflowApi.inputsDesc') }}</p>
           <div v-if="!askFields.length" class="rounded-md border border-line bg-surface px-4 py-6 text-center text-[13px] text-txt3">{{ t('pages.workflowApi.noAskVars') }}</div>
-          <table v-else class="w-full border border-line text-[13px]">
+          <table v-else class="rounded-lg w-full border border-line text-[13px]">
             <thead class="bg-elevated text-[11px] uppercase tracking-wider text-txt3">
               <tr>
                 <th class="px-4 py-2 text-left font-medium">name</th>

--- a/web/src/styles/radiusZeroClearance.test.ts
+++ b/web/src/styles/radiusZeroClearance.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+/**
+ * Radius zero-clearance gate (plan g4): no rounded-none leftovers in product
+ * sources, plus hard contracts for home / switch / demo / analytics / login.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const srcRoot = join(here, '..')
+
+const SCAN_EXTS = new Set(['.vue', '.ts', '.css'])
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    if (name === 'node_modules' || name === 'dist') continue
+    const full = join(dir, name)
+    const st = statSync(full)
+    if (st.isDirectory()) {
+      walk(full, out)
+      continue
+    }
+    const lower = name.toLowerCase()
+    // Skip *.test.ts / *.spec.ts; keep product .ts/.vue/.css
+    if (/\.(test|spec)\.ts$/.test(lower)) continue
+    const dot = lower.lastIndexOf('.')
+    const ext = dot >= 0 ? lower.slice(dot) : ''
+    if (!SCAN_EXTS.has(ext)) continue
+    out.push(full)
+  }
+  return out
+}
+
+function read(relFromSrc: string): string {
+  return readFileSync(join(srcRoot, relFromSrc), 'utf8')
+}
+
+describe('radius zero clearance', () => {
+  it('has no rounded-none in web/src product .vue / non-test .ts / .css', () => {
+    const hits: string[] = []
+    for (const file of walk(srcRoot)) {
+      const text = readFileSync(file, 'utf8')
+      if (!text.includes('rounded-none')) continue
+      // Line-level report for actionable failures
+      text.split(/\r?\n/).forEach((line, i) => {
+        if (line.includes('rounded-none')) {
+          hits.push(`${relative(srcRoot, file)}:${i + 1}:${line.trim().slice(0, 160)}`)
+        }
+      })
+    }
+    expect(hits).toEqual([])
+  })
+
+  it('DashboardView home composer uses shell 16px and toolbar controls 8px', () => {
+    const src = read('views/DashboardView.vue')
+    expect(src).toMatch(/\.home-composer\s*\{[^}]*border-radius:\s*16px/s)
+    expect(src).toMatch(/\.home-composer__plus\s*\{[^}]*border-radius:\s*8px/s)
+    expect(src).toMatch(/\.home-composer__send\s*\{[^}]*border-radius:\s*8px/s)
+    expect(src).not.toMatch(/home-composer__plus[^"]*rounded-none/)
+    expect(src).not.toMatch(/thumb-class="rounded-none"/)
+  })
+
+  it('AppSwitch uses capsule rounded-full (not rounded-none)', () => {
+    const src = read('components/ui/AppSwitch.vue')
+    expect(src).toMatch(/role="switch"[^>]*class="[^"]*\brounded-full\b/)
+    expect(src).not.toMatch(/rounded-none/)
+  })
+
+  it('ClarifyDemoFrame root uses card radius rounded-lg', () => {
+    const src = read('components/run/ClarifyDemoFrame.vue')
+    expect(src).toMatch(/class="[^"]*\brounded-lg\b[^"]*border/)
+  })
+
+  it('TokenAnalyticsView filter selects and clear use control rounded', () => {
+    const src = read('views/TokenAnalyticsView.vue')
+    expect(src).toMatch(
+      /v-model="projectSel"\s+class="[^"]*\brounded\b[^"]*\bborder border-line\b/,
+    )
+    expect(src).toMatch(
+      /v-model="modelSel"\s+class="[^"]*\brounded\b[^"]*\bborder border-line\b/,
+    )
+    expect(src).toMatch(
+      /<button[^>]*class="[^"]*\brounded\b[^"]*"[^>]*@click="clearFilters"/,
+    )
+  })
+
+  it('LoginView login card uses shell radius rounded-xl', () => {
+    const src = read('views/LoginView.vue')
+    expect(src).toMatch(/class="[^"]*\brounded-xl\b[^"]*border border-line bg-surface/)
+  })
+
+  it('HomePipelineSelect trigger 8px and panel 12px', () => {
+    const src = read('components/dashboard/HomePipelineSelect.vue')
+    expect(src).toMatch(/\.home-pipeline-select__trigger\s*\{[^}]*border-radius:\s*8px/s)
+    expect(src).toMatch(/\.home-pipeline-select__panel\s*\{[^}]*border-radius:\s*12px/s)
+    expect(src).toMatch(/\.home-pipeline-select__search\s*\{[^}]*border-radius:\s*8px/s)
+  })
+})

--- a/web/src/views/AgentStudioView.vue
+++ b/web/src/views/AgentStudioView.vue
@@ -549,7 +549,7 @@ const {
           v-if="tab !== 'files' && isMobile && tab !== 'data'"
           class="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 px-5 py-8 text-center"
         >
-          <div class="flex h-10 w-10 items-center justify-center border border-info/35 bg-info/10 text-info">
+          <div class="rounded-md flex h-10 w-10 items-center justify-center border border-info/35 bg-info/10 text-info">
             <Icon name="alert" :size="20" />
           </div>
           <h3 class="text-[14px] font-semibold text-txt">{{ t('pages.agentStudio.mobile.desktopOnlyTitle') }}</h3>
@@ -558,7 +558,7 @@ const {
           </p>
           <button
             type="button"
-            class="min-h-11 border border-line bg-transparent px-4 text-[13px] text-txt2 hover:border-accent hover:text-txt"
+            class="rounded-md min-h-11 border border-line bg-transparent px-4 text-[13px] text-txt2 hover:border-accent hover:text-txt"
             data-testid="studio-mobile-back-files"
             @click="requestStudioTab('files')"
           >
@@ -661,7 +661,7 @@ const {
             type="text"
             autocomplete="off"
             :placeholder="t('pages.agentStudio.org.manageSearchPlaceholder')"
-            class="w-full border border-line bg-base py-2 pl-8 pr-8 text-[13px] text-txt outline-none transition focus:border-accent"
+            class="rounded-md w-full border border-line bg-base py-2 pl-8 pr-8 text-[13px] text-txt outline-none transition focus:border-accent"
             data-test="manage-search"
           />
           <button
@@ -682,7 +682,7 @@ const {
               : t('pages.agentStudio.org.manageTotalCount', { total: agentNames.length })
           }}
         </p>
-        <div v-if="manageSearchActive && !filteredManageNames.length" class="border border-dashed border-line px-4 py-8 text-center">
+        <div v-if="manageSearchActive && !filteredManageNames.length" class="rounded-lg border border-dashed border-line px-4 py-8 text-center">
           <Icon name="search" :size="20" class="mx-auto mb-2 text-txt3" />
           <p class="text-[13px] font-medium text-txt">{{ t('pages.agentStudio.org.manageNoMatchTitle') }}</p>
           <p class="mt-1 text-[12px] text-txt3">{{ t('pages.agentStudio.org.manageNoMatchDesc') }}</p>
@@ -695,7 +695,7 @@ const {
           v-for="name in filteredManageNames"
           :key="name"
           :data-manage-agent="name"
-          class="flex items-center gap-2 border px-2.5 py-2 transition"
+          class="rounded-lg flex items-center gap-2 border px-2.5 py-2 transition"
           :class="
             manageFocusAgent === name
               ? 'border-accent/40 bg-accent-dim shadow-[inset_0_0_0_1px_rgba(99,102,241,0.35)]'
@@ -732,7 +732,7 @@ const {
       :width="420"
       @close="closeRenameBlocked"
     >
-      <div class="border border-warn/40 bg-warn/10 px-3.5 py-3 text-[13px] leading-6 text-warn">
+      <div class="rounded-lg border border-warn/40 bg-warn/10 px-3.5 py-3 text-[13px] leading-6 text-warn">
         <div class="mb-1.5 text-[14px] font-semibold text-txt">{{ t('pages.agentStudio.org.renameBlockedMessage') }}</div>
         <p>{{ t('pages.agentStudio.org.renameBlockedBody') }}</p>
         <p class="mt-2 text-[12px] text-txt2">{{ t('pages.agentStudio.org.renameBlockedHint') }}</p>
@@ -848,7 +848,7 @@ const {
                       data-org-project
                     >({{ row.projectLabel }})</span>
                   </span>
-                  <span class="ml-auto inline-flex h-4 min-w-[18px] shrink-0 items-center justify-end border border-line bg-base px-1 text-[10px] font-semibold tabular-nums text-txt3">{{ row.count }}</span>
+                  <span class="rounded-md ml-auto inline-flex h-4 min-w-[18px] shrink-0 items-center justify-end border border-line bg-base px-1 text-[10px] font-semibold tabular-nums text-txt3">{{ row.count }}</span>
                 </button>
               </template>
               <template v-else-if="row.kind === 'ungrouped-header'">
@@ -861,7 +861,7 @@ const {
                   <Icon name="chevron-right" :size="12" class="shrink-0 text-txt3" :class="row.collapsed ? '' : 'rotate-90'" />
                   <Icon name="folder" :size="14" class="shrink-0 text-txt3" />
                   <span class="truncate font-medium text-txt2">{{ t('pages.agentStudio.org.ungrouped') }}</span>
-                  <span class="ml-auto inline-flex h-4 min-w-[18px] shrink-0 items-center justify-end border border-line bg-base px-1 text-[10px] font-semibold tabular-nums text-txt3">{{ row.count }}</span>
+                  <span class="rounded-md ml-auto inline-flex h-4 min-w-[18px] shrink-0 items-center justify-end border border-line bg-base px-1 text-[10px] font-semibold tabular-nums text-txt3">{{ row.count }}</span>
                 </button>
               </template>
               <template v-else>
@@ -879,14 +879,14 @@ const {
                       <span class="truncate text-txt">{{ row.name }}</span>
                       <span
                         v-if="row.multi"
-                        class="shrink-0 border border-accent-2/35 bg-accent/15 px-1 text-[9px] font-bold uppercase tracking-wide text-accent-2"
+                        class="rounded-md shrink-0 border border-accent-2/35 bg-accent/15 px-1 text-[9px] font-bold uppercase tracking-wide text-accent-2"
                       >{{ t('pages.agentStudio.org.multiGroup') }}</span>
                     </span>
                   </span>
                 </button>
               </template>
             </div>
-            <p class="mx-1 mt-2 border border-dashed border-line-strong/60 bg-white/[0.015] px-2.5 py-2 text-[11px] leading-relaxed text-txt3">
+            <p class="rounded-md mx-1 mt-2 border border-dashed border-line-strong/60 bg-white/[0.015] px-2.5 py-2 text-[11px] leading-relaxed text-txt3">
               {{ t('pages.agentStudio.mobile.orgSheetHint') }}
             </p>
           </div>
@@ -967,7 +967,7 @@ const {
           {{ t('pages.agentStudio.org.clearSensitive.selectNone') }}
         </AppButton>
       </div>
-      <div class="max-h-60 overflow-auto border border-line" data-test="clear-sensitive-modal">
+      <div class="rounded-lg max-h-60 overflow-auto border border-line" data-test="clear-sensitive-modal">
         <label
           v-for="hit in clearSensitiveHits"
           :key="hit.key"
@@ -1009,13 +1009,13 @@ const {
       @close="closeBatchConflict"
     >
       <p class="text-[13px] leading-6 text-txt2">{{ t('pages.agentStudio.exportImport.batchConflict.intro') }}</p>
-      <ul class="mt-2 max-h-32 overflow-auto border border-line bg-base px-3 py-2 text-[12px] text-txt">
+      <ul class="rounded-md mt-2 max-h-32 overflow-auto border border-line bg-base px-3 py-2 text-[12px] text-txt">
         <li v-for="n in batchConflictNames" :key="n" class="font-mono">{{ n }}</li>
       </ul>
       <div class="mt-3 flex flex-col gap-2">
         <button
           type="button"
-          class="w-full border border-accent/50 bg-accent-dim px-3 py-2.5 text-left"
+          class="rounded-lg w-full border border-accent/50 bg-accent-dim px-3 py-2.5 text-left"
           @click="confirmBatchRename"
         >
           <div class="text-[13px] font-medium text-txt">{{ t('pages.agentStudio.exportImport.batchConflict.rename') }}</div>
@@ -1023,7 +1023,7 @@ const {
         </button>
         <button
           type="button"
-          class="w-full border border-err/40 bg-base px-3 py-2.5 text-left hover:bg-err/10"
+          class="rounded-lg w-full border border-err/40 bg-base px-3 py-2.5 text-left hover:bg-err/10"
           @click="confirmBatchOverwrite"
         >
           <div class="text-[13px] font-medium text-err">{{ t('pages.agentStudio.exportImport.batchConflict.overwrite') }}</div>
@@ -1031,7 +1031,7 @@ const {
         </button>
         <button
           type="button"
-          class="w-full border border-line bg-base px-3 py-2.5 text-left hover:bg-elevated"
+          class="rounded-md w-full border border-line bg-base px-3 py-2.5 text-left hover:bg-elevated"
           @click="closeBatchConflict"
         >
           <div class="text-[13px] font-medium text-txt">{{ t('pages.agentStudio.exportImport.batchConflict.cancel') }}</div>
@@ -1065,7 +1065,7 @@ const {
       <div class="mt-3 flex flex-col gap-2">
         <button
           type="button"
-          class="w-full border px-3 py-2.5 text-left transition"
+          class="rounded-lg w-full border px-3 py-2.5 text-left transition"
           :class="importConflictAction === 'overwrite' ? 'border-accent/50 bg-accent-dim' : 'border-line bg-base hover:bg-elevated'"
           @click="selectImportConflict('overwrite')"
         >
@@ -1074,7 +1074,7 @@ const {
         </button>
         <button
           type="button"
-          class="w-full border px-3 py-2.5 text-left transition"
+          class="rounded-lg w-full border px-3 py-2.5 text-left transition"
           :class="importConflictAction === 'rename' ? 'border-accent/50 bg-accent-dim' : 'border-line bg-base hover:bg-elevated'"
           @click="selectImportConflict('rename')"
         >
@@ -1083,7 +1083,7 @@ const {
         </button>
         <button
           type="button"
-          class="w-full border px-3 py-2.5 text-left transition"
+          class="rounded-lg w-full border px-3 py-2.5 text-left transition"
           :class="importConflictAction === 'cancel' ? 'border-accent/50 bg-accent-dim' : 'border-line bg-base hover:bg-elevated'"
           @click="selectImportConflict('cancel')"
         >
@@ -1126,7 +1126,7 @@ const {
       <div
         v-if="isMobile && showFullNameTip"
         data-test="agent-name-tip"
-        class="fixed z-[9999] border border-line bg-elevated px-3 py-2.5 text-[12.5px] text-txt shadow-card"
+        class="rounded-lg fixed z-[9999] border border-line bg-elevated px-3 py-2.5 text-[12.5px] text-txt shadow-card"
         :style="fullNameTipStyle"
         @click.stop
       >
@@ -1163,7 +1163,7 @@ const {
           <label
             v-for="p in projects"
             :key="p.id"
-            class="flex cursor-pointer items-center gap-2.5 border border-line bg-base px-2.5 py-2"
+            class="rounded-lg flex cursor-pointer items-center gap-2.5 border border-line bg-base px-2.5 py-2"
             :class="assignTargetId === p.id ? 'border-accent bg-accent-dim' : ''"
           >
             <input v-model="assignTargetId" type="radio" class="accent-accent" :value="p.id" />
@@ -1198,7 +1198,7 @@ const {
     >
       <div class="space-y-2 text-[13px] leading-6 text-txt2">
         <p>{{ t('pages.agentStudio.project.assignCoverLead', { n: assignDiffBound.length }) }}</p>
-        <div class="border border-warn/35 bg-warn/10 px-3 py-2.5 text-[12px]">
+        <div class="rounded-lg border border-warn/35 bg-warn/10 px-3 py-2.5 text-[12px]">
           <b class="text-warn">{{ t('pages.agentStudio.project.assignCoverWarn') }}</b>
           <ul class="mt-1.5 list-disc space-y-1 pl-5">
             <li>{{ t('pages.agentStudio.project.switchItemMemory') }}</li>
@@ -1281,7 +1281,7 @@ const {
       <div
         v-if="toastMsg"
         data-test="studio-toast"
-        class="fixed bottom-5 right-5 z-[10000] border border-line bg-elevated px-3.5 py-2 text-[12px] text-txt2 shadow-card"
+        class="rounded-lg fixed bottom-5 right-5 z-[10000] border border-line bg-elevated px-3.5 py-2 text-[12px] text-txt2 shadow-card"
       >
         {{ toastMsg }}
       </div>

--- a/web/src/views/BoardView.vue
+++ b/web/src/views/BoardView.vue
@@ -159,13 +159,13 @@ onUnmounted(() => {
     <div class="min-h-0 flex-1 overflow-y-auto">
     <div
       v-if="error && error !== 'missing_project'"
-      class="mb-4 flex flex-wrap items-center justify-between gap-2 border border-err/40 bg-err/10 px-3 py-2 text-[13px] text-err"
+      class="mb-4 flex flex-wrap items-center justify-between gap-2 rounded-lg border border-err/40 bg-err/10 px-3 py-2 text-[13px] text-err"
       data-testid="board-load-error"
     >
       <span>{{ t('pages.board.loadFailed') }}</span>
       <button
         type="button"
-        class="border border-err/40 px-2.5 py-1 text-xs text-err hover:bg-err/10"
+        class="rounded-md border border-err/40 px-2.5 py-1 text-xs text-err hover:bg-err/10"
         data-testid="board-retry"
         @click="load()"
       >
@@ -182,7 +182,7 @@ onUnmounted(() => {
           v-for="key in (['queued', 'failed', 'cancelled'] as const)"
           :key="key"
           type="button"
-          class="inline-flex items-center gap-1.5 border px-2.5 py-1 text-xs transition"
+          class="rounded-md inline-flex items-center gap-1.5 border px-2.5 py-1 text-xs transition"
           :class="
             extraEnabled[key]
               ? 'border-accent-2/45 bg-accent-dim text-txt'
@@ -192,7 +192,7 @@ onUnmounted(() => {
           @click="toggleExtra(key)"
         >
           <span
-            class="inline-block h-2 w-2 border"
+            class="inline-block h-2 w-2 rounded-full border"
             :class="extraEnabled[key] ? 'border-accent-2 bg-accent-2' : 'border-line-strong bg-transparent'"
           />
           {{ t(`common.status.${key}`) }}

--- a/web/src/views/DashboardView.fill.test.ts
+++ b/web/src/views/DashboardView.fill.test.ts
@@ -63,8 +63,8 @@ describe('DashboardView home chat layout', () => {
     expect(src).not.toMatch(/fonts\.googleapis|fonts\.gstatic|cdn\.jsdelivr/)
   })
 
-  // plan g1.4 / g2.4 — right-angle Open Design composer with toolbar zone
-  it('uses right-angle Open Design composer with toolbar partition', () => {
+  // plan g1 — shell composer 16px + control toolbar 8px (no right-angle Open Design)
+  it('uses shell-radius Open Design composer with toolbar partition', () => {
     expect(src).toMatch(/home-composer/)
     expect(src).toMatch(/home-composer__toolbar/)
     expect(src).toMatch(/home-composer__plus/)
@@ -76,6 +76,9 @@ describe('DashboardView home chat layout', () => {
     expect(src).not.toMatch(/<select[^>]*home-pipeline-select/)
     expect(src).toMatch(/data-testid="home-composer-send"/)
     expect(src).toMatch(/<textarea/)
+    expect(src).toMatch(/\.home-composer\s*\{[^}]*border-radius:\s*16px/s)
+    expect(src).toMatch(/\.home-composer__plus\s*\{[^}]*border-radius:\s*8px/s)
+    expect(src).toMatch(/\.home-composer__send\s*\{[^}]*border-radius:\s*8px/s)
   })
 
   // review — 无 subtitle；流水线卡片脱离全局 .card；圆角 Token 12px
@@ -85,8 +88,10 @@ describe('DashboardView home chat layout', () => {
     expect(src).not.toMatch(/class="[^"]*\bcard\b[^"]*home-shell__card|class="home-shell__card[^"]*\bcard\b/)
     expect(src).toMatch(/\.home-shell__card\s*\{[^}]*border-radius:\s*12px/s)
     expect(src).toMatch(/home-shell__card--selected/)
-    expect(src).toMatch(/rounded-none bg-err[\s\S]{0,80}data-testid="home-attach-remove"/)
-    expect(src).not.toMatch(/rounded-full bg-err[\s\S]{0,80}data-testid="home-attach-remove"/)
+    expect(src).toMatch(/rounded bg-err[\s\S]{0,80}data-testid="home-attach-remove"/)
+    expect(src).not.toMatch(/rounded-none bg-err[\s\S]{0,80}data-testid="home-attach-remove"/)
+    expect(src).toMatch(/thumb-class="rounded"/)
+    expect(src).not.toMatch(/thumb-class="rounded-none"/)
   })
 
   // plan g2 / g3 — no filter hint; caret opacity settle; placeholder typewriter

--- a/web/src/views/DashboardView.test.ts
+++ b/web/src/views/DashboardView.test.ts
@@ -198,14 +198,13 @@ describe('DashboardView home composer', () => {
     wrapper.unmount()
   })
 
-  // plan g1.4 — pipeline cards are square (no global .card / rounded-lg)
-  it('renders right-angle pipeline cards', async () => {
+  // plan g1 — pipeline cards use card-role 12px via scoped CSS (not global .card)
+  it('renders rounded pipeline cards via home-shell__card', async () => {
     const wrapper = mountDashboard()
     await flushPromises()
     const card = wrapper.get('[data-testid="home-pipeline-card-wf-ap"]')
     expect(card.classes()).toContain('home-shell__card')
     expect(card.classes()).not.toContain('card')
-    expect(card.classes()).not.toContain('rounded-lg')
     expect(card.classes()).toContain('border')
     wrapper.unmount()
   })

--- a/web/src/views/DashboardView.vue
+++ b/web/src/views/DashboardView.vue
@@ -355,7 +355,7 @@ onBeforeUnmount(() => {
       <div class="mt-[30px] w-full">
         <p
           v-if="attachNotice"
-          class="mb-2 border border-err/40 bg-err/10 px-3 py-1.5 text-[12px] text-err"
+          class="mb-2 rounded border border-err/40 bg-err/10 px-3 py-1.5 text-[12px] text-err"
           data-testid="home-attach-notice"
           role="alert"
         >
@@ -371,7 +371,7 @@ onBeforeUnmount(() => {
               v-if="isImageAttachment(im)"
               mode="previewable"
               size="sm"
-              thumb-class="rounded-none"
+              thumb-class="rounded"
               :src="imgSrc(im)"
               :label="attachmentDisplayName(im, ii)"
               :alt="attachmentDisplayName(im, ii)"
@@ -380,7 +380,7 @@ onBeforeUnmount(() => {
             />
             <div
               v-else
-              class="flex h-9 max-w-[160px] items-center gap-1.5 border border-line bg-elevated px-2.5"
+              class="flex h-9 max-w-[160px] items-center gap-1.5 rounded border border-line bg-elevated px-2.5"
               :title="attachmentDisplayName(im, ii)"
               data-testid="home-pending-file-chip"
             >
@@ -391,7 +391,7 @@ onBeforeUnmount(() => {
             </div>
             <button
               type="button"
-              class="absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-none bg-err text-white"
+              class="absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded bg-err text-white"
               data-testid="home-attach-remove"
               @click.stop="removeAttachment(ii)"
             >
@@ -400,7 +400,7 @@ onBeforeUnmount(() => {
           </div>
         </div>
         <form
-          class="home-composer flex w-full flex-col border"
+          class="home-composer flex w-full flex-col overflow-hidden border"
           data-testid="home-composer"
           @submit="onComposerSubmit"
         >
@@ -480,13 +480,13 @@ onBeforeUnmount(() => {
 
       <div
         v-if="loadError"
-        class="mt-6 flex w-full flex-wrap items-center justify-between gap-2 border border-err/40 bg-err/10 px-3 py-2 text-[13px] text-err"
+        class="mt-6 flex w-full flex-wrap items-center justify-between gap-2 rounded border border-err/40 bg-err/10 px-3 py-2 text-[13px] text-err"
         data-testid="dashboard-load-error"
       >
         <span>{{ t('pages.board.loadFailed') }}</span>
         <button
           type="button"
-          class="border border-err/40 px-2.5 py-1 text-xs text-err hover:bg-err/10"
+          class="rounded-md border border-err/40 px-2.5 py-1 text-xs text-err hover:bg-err/10"
           data-testid="dashboard-retry"
           @click="load()"
         >
@@ -502,7 +502,7 @@ onBeforeUnmount(() => {
         <p class="text-sm text-txt3">{{ t('pages.dashboard.noPipelines') }}</p>
         <button
           type="button"
-          class="mt-3 border border-line px-3 py-1.5 text-[13px] text-txt2 hover:bg-elevated"
+          class="mt-3 rounded-md border border-line px-3 py-1.5 text-[13px] text-txt2 hover:bg-elevated"
           data-testid="home-go-projects"
           @click="goProjects"
         >
@@ -548,7 +548,7 @@ onBeforeUnmount(() => {
             :key="p.id"
             type="button"
             role="listitem"
-            class="home-shell__card w-48 shrink-0 overflow-hidden border border-line p-0 text-left"
+            class="home-shell__card w-48 shrink-0 overflow-hidden rounded-lg border border-line p-0 text-left"
             :class="p.id === selected?.id ? 'home-shell__card--selected' : 'hover:border-line-strong'"
             :data-testid="`home-pipeline-card-${p.id}`"
             @click="selectPipeline(p.id)"
@@ -670,10 +670,12 @@ onBeforeUnmount(() => {
   }
 }
 
-/* g1.2 — right-angle composer (input + toolbar) */
+/* plan g1.1 — shell/hero composer 16px; overflow+bg+radius same layer */
 .home-composer {
   border-color: rgb(var(--c-line));
   background: rgb(var(--c-surface));
+  border-radius: 16px;
+  overflow: hidden;
 }
 
 :global(html.light) .home-composer {
@@ -713,6 +715,7 @@ onBeforeUnmount(() => {
 .home-composer__plus {
   border-color: rgb(var(--c-line));
   background: transparent;
+  border-radius: 8px;
   transition: border-color 0.15s ease, color 0.15s ease, background-color 0.15s ease;
 }
 
@@ -725,6 +728,7 @@ onBeforeUnmount(() => {
 .home-composer__send {
   background: rgb(var(--c-txt));
   color: rgb(var(--c-base));
+  border-radius: 8px;
 }
 
 :global(html.light) .home-composer__send {
@@ -797,6 +801,7 @@ onBeforeUnmount(() => {
   width: 36px;
   height: 36px;
   border: 1px solid rgb(var(--c-line));
+  border-radius: 8px;
   background: color-mix(in srgb, rgb(var(--c-surface)) 92%, transparent);
   backdrop-filter: blur(6px);
   color: rgb(var(--c-txt2));

--- a/web/src/views/GatesInboxView.vue
+++ b/web/src/views/GatesInboxView.vue
@@ -336,7 +336,7 @@ const {
         <div
           v-for="n in SKELETON_CARDS"
           :key="'skel-m-' + n"
-          class="flex w-full shrink-0 flex-col gap-2 border border-line bg-surface p-3"
+          class="flex w-full shrink-0 flex-col gap-2 rounded-lg border border-line bg-surface p-3"
         >
           <div class="flex items-start gap-3">
             <div class="h-9 w-9 shrink-0 bg-elevated animate-pulse" />
@@ -618,7 +618,7 @@ const {
       <div
         v-for="n in SKELETON_CARDS"
         :key="'skel-d-' + n"
-        class="flex w-full max-w-[320px] shrink-0 flex-col gap-2 border border-line bg-surface p-3"
+        class="flex w-full max-w-[320px] shrink-0 flex-col gap-2 rounded-lg border border-line bg-surface p-3"
       >
         <div class="flex items-start gap-3">
           <div class="h-9 w-9 shrink-0 bg-elevated animate-pulse" />

--- a/web/src/views/LoginView.vue
+++ b/web/src/views/LoginView.vue
@@ -54,7 +54,7 @@ async function onSubmit() {
 
 <template>
   <div class="flex min-h-full items-center justify-center bg-base px-4 py-8 [background:radial-gradient(ellipse_80%_60%_at_50%_0%,rgba(123,97,255,.08),transparent),rgb(var(--c-base))]">
-    <div class="w-full max-w-[400px] border border-line bg-surface p-7 shadow-card">
+    <div class="w-full max-w-[400px] overflow-hidden rounded-xl border border-line bg-surface p-7 shadow-card">
       <div class="mb-7 flex flex-col items-center text-center">
         <BrandLogo size="lg" align="center" />
       </div>
@@ -65,14 +65,14 @@ async function onSubmit() {
 
         <div
           v-if="route.query.redirect"
-          class="mb-4 flex items-center gap-1.5 border border-info/25 bg-info/10 px-2.5 py-2 text-xs text-info"
+          class="mb-4 flex items-center gap-1.5 rounded-lg border border-info/25 bg-info/10 px-2.5 py-2 text-xs text-info"
         >
           <Icon name="chevron-right" :size="14" class="rotate-[-45deg]" />
           {{ t('pages.login.redirectHint') }} <code class="font-mono text-[11px] text-txt2">{{ redirectTarget }}</code>
         </div>
 
-        <div v-if="error" class="mb-4 border border-err/30 bg-err/10 px-3 py-2.5 text-[13px] text-err">{{ error }}</div>
-        <div v-if="rateLimited" class="mb-4 border border-warn/30 bg-warn/10 px-3 py-2.5 text-[13px] text-warn">
+        <div v-if="error" class="mb-4 rounded-lg border border-err/30 bg-err/10 px-3 py-2.5 text-[13px] text-err">{{ error }}</div>
+        <div v-if="rateLimited" class="mb-4 rounded-lg border border-warn/30 bg-warn/10 px-3 py-2.5 text-[13px] text-warn">
           {{ t('pages.login.rateLimited') }}
         </div>
 
@@ -85,7 +85,7 @@ async function onSubmit() {
               type="text"
               autocomplete="username"
               placeholder="admin"
-              class="w-full border border-line bg-base px-3 py-2 text-sm text-txt outline-none transition focus:border-accent focus:shadow-[0_0_0_2px_rgba(123,97,255,.3)]"
+              class="w-full rounded border border-line bg-base px-3 py-2 text-sm text-txt outline-none transition focus:border-accent focus:shadow-[0_0_0_2px_rgba(123,97,255,.3)]"
               :class="fieldError ? 'border-err' : ''"
             />
           </div>
@@ -97,7 +97,7 @@ async function onSubmit() {
               type="password"
               autocomplete="current-password"
               placeholder="••••••••"
-              class="w-full border border-line bg-base px-3 py-2 text-sm text-txt outline-none transition focus:border-accent focus:shadow-[0_0_0_2px_rgba(123,97,255,.3)]"
+              class="w-full rounded border border-line bg-base px-3 py-2 text-sm text-txt outline-none transition focus:border-accent focus:shadow-[0_0_0_2px_rgba(123,97,255,.3)]"
               :class="fieldError ? 'border-err' : ''"
             />
           </div>
@@ -108,9 +108,9 @@ async function onSubmit() {
 
         <!-- Compact hint: avoid a large footer stealing LCP from brand-logo__name -->
         <p class="mt-6 border-t border-line pt-4 text-center text-[10px] text-txt3">
-          Demo <kbd class="border border-line bg-elevated px-1 font-mono text-[10px]">admin</kbd>
+          Demo <kbd class="rounded border border-line bg-elevated px-1 font-mono text-[10px]">admin</kbd>
           /
-          <kbd class="border border-line bg-elevated px-1 font-mono text-[10px]">demo1234</kbd>
+          <kbd class="rounded border border-line bg-elevated px-1 font-mono text-[10px]">demo1234</kbd>
         </p>
       </template>
     </div>

--- a/web/src/views/NotificationsView.vue
+++ b/web/src/views/NotificationsView.vue
@@ -171,14 +171,14 @@ defineExpose({
       </div>
       <div class="flex flex-wrap items-center gap-2">
         <span
-          class="border border-accent/45 bg-accent-dim px-2.5 py-1 text-xs text-accent-2"
+          class="rounded-md border border-accent/45 bg-accent-dim px-2.5 py-1 text-xs text-accent-2"
           data-testid="notifications-unread-count"
         >
           {{ t('shell.runNotifications.unreadCount', { n: unreadCount }) }}
         </span>
         <button
           type="button"
-          class="min-h-11 border border-line bg-transparent px-3 text-[12px] text-txt2 hover:border-accent hover:text-accent disabled:opacity-40"
+          class="rounded-md min-h-11 border border-line bg-transparent px-3 text-[12px] text-txt2 hover:border-accent hover:text-accent disabled:opacity-40"
           data-testid="notifications-mark-all"
           :disabled="unreadCount === 0"
           @click="markAllRead()"
@@ -248,7 +248,7 @@ defineExpose({
               aria-hidden="true"
             />
             <span
-              class="shrink-0 border px-1.5 py-0.5 text-[10px] font-semibold"
+              class="rounded-md shrink-0 border px-1.5 py-0.5 text-[10px] font-semibold"
               :class="
                 item.status === 'failed' ? 'border-err/45 text-err' : 'border-ok/40 text-ok'
               "

--- a/web/src/views/PlatformRulesView.vue
+++ b/web/src/views/PlatformRulesView.vue
@@ -269,7 +269,7 @@ onMounted(loadAll)
       v-else-if="loadDenied"
       role="status"
       data-testid="platform-rules-denied"
-      class="border border-warn/40 bg-warn/10 px-5 py-10 text-center"
+      class="rounded-lg border border-warn/40 bg-warn/10 px-5 py-10 text-center"
     >
       <Icon name="lock" :size="22" class="mx-auto mb-3 text-warn" />
       <h3 class="text-sm font-semibold text-txt">{{ t('common.asyncState.permissionDeniedTitle') }}</h3>
@@ -292,7 +292,7 @@ onMounted(loadAll)
       v-else-if="loadFailed"
       role="status"
       data-testid="platform-rules-failed"
-      class="border border-err/40 bg-err/10 px-5 py-10 text-center"
+      class="rounded-lg border border-err/40 bg-err/10 px-5 py-10 text-center"
     >
       <h3 class="text-sm font-semibold text-txt">{{ t('common.asyncState.loadFailedTitle') }}</h3>
       <p class="mt-1 text-xs text-txt2">{{ t('common.asyncState.loadFailedDesc') }}</p>
@@ -382,8 +382,8 @@ onMounted(loadAll)
             </span>
           </div>
           <p class="mt-3 text-[12px] leading-relaxed text-txt3">{{ t('pages.platformRules.mobileReadonlyHint') }}</p>
-          <div v-if="error" class="mt-3 border border-err/30 bg-err/10 px-3 py-2 text-sm text-err">{{ error }}</div>
-          <div v-else-if="mobileSummary" class="mt-4 border border-line bg-base px-3 py-2">
+          <div v-if="error" class="rounded-lg mt-3 border border-err/30 bg-err/10 px-3 py-2 text-sm text-err">{{ error }}</div>
+          <div v-else-if="mobileSummary" class="rounded-lg mt-4 border border-line bg-base px-3 py-2">
             <div class="mb-1 text-[11px] uppercase tracking-wider text-txt3">{{ t('pages.platformRules.summaryTitle') }}</div>
             <pre class="whitespace-pre-wrap break-words font-mono text-[12px] leading-relaxed text-txt2">{{ mobileSummary }}</pre>
           </div>
@@ -413,21 +413,21 @@ onMounted(loadAll)
           <h4 class="text-[11px] font-semibold uppercase tracking-wider text-txt3">{{ t('pages.platformRules.priorityTitle') }}</h4>
           <ol class="mt-3 space-y-3 text-[12px]">
             <li class="flex gap-2">
-              <span class="flex h-5 w-5 shrink-0 items-center justify-center border border-line text-[10px] text-txt3">1</span>
+              <span class="rounded-full flex h-5 w-5 shrink-0 items-center justify-center border border-line text-[10px] text-txt3">1</span>
               <div>
                 <div class="font-medium text-txt">{{ t('pages.platformRules.priorityAgent') }}</div>
                 <div class="font-mono text-[10px] text-txt3">profiles/&lt;agent&gt;/platform-rules/</div>
               </div>
             </li>
             <li class="flex gap-2">
-              <span class="flex h-5 w-5 shrink-0 items-center justify-center border border-accent/40 bg-accent-dim text-[10px] text-accent-2">2</span>
+              <span class="rounded-full flex h-5 w-5 shrink-0 items-center justify-center border border-accent/40 bg-accent-dim text-[10px] text-accent-2">2</span>
               <div>
                 <div class="font-medium text-accent-2">{{ t('pages.platformRules.priorityGlobal') }}</div>
                 <div class="font-mono text-[10px] text-txt3">data/platform-rules/</div>
               </div>
             </li>
             <li class="flex gap-2">
-              <span class="flex h-5 w-5 shrink-0 items-center justify-center border border-line text-[10px] text-txt3">3</span>
+              <span class="rounded-full flex h-5 w-5 shrink-0 items-center justify-center border border-line text-[10px] text-txt3">3</span>
               <div>
                 <div class="font-medium text-txt">{{ t('pages.platformRules.priorityEmbed') }}</div>
                 <div class="font-mono text-[10px] text-txt3">go:embed skills_embed/</div>
@@ -438,9 +438,9 @@ onMounted(loadAll)
         <div class="border-b border-line px-3 py-3">
           <h4 class="text-[11px] font-semibold uppercase tracking-wider text-txt3">{{ t('pages.platformRules.injectTitle') }}</h4>
           <div class="mt-2 space-y-2 text-[11px] text-txt2">
-            <div class="border border-line bg-base px-2 py-1.5">1. {{ t('pages.platformRules.injectAgentDir') }}</div>
+            <div class="rounded-lg border border-line bg-base px-2 py-1.5">1. {{ t('pages.platformRules.injectAgentDir') }}</div>
             <div class="text-center text-txt3">↓</div>
-            <div class="border border-accent/30 bg-accent-dim px-2 py-1.5 text-txt">2. {{ t('pages.platformRules.injectPlatformRules') }}</div>
+            <div class="rounded-lg border border-accent/30 bg-accent-dim px-2 py-1.5 text-txt">2. {{ t('pages.platformRules.injectPlatformRules') }}</div>
           </div>
         </div>
         <div class="px-3 py-3">

--- a/web/src/views/ProjectDetailView.heightChain.test.ts
+++ b/web/src/views/ProjectDetailView.heightChain.test.ts
@@ -50,7 +50,7 @@ describe('ProjectDetailView pmLeader fill-height chain (g2.2 / g2.3)', () => {
   })
 
   it('PmLeaderChat uses flex-1 overflow-hidden with internal message scroller (g2.3)', () => {
-    expect(pmChatSrc).toMatch(/class="flex min-h-0 flex-1 overflow-hidden border border-line bg-base"/)
+    expect(pmChatSrc).toMatch(/class="rounded-lg flex min-h-0 flex-1 overflow-hidden border border-line bg-base"/)
     expect(pmChatSrc).toMatch(/class="scroll-area min-h-0 flex-1 space-y-3 overflow-y-auto p-4"/)
   })
 })

--- a/web/src/views/ProjectDetailView.vue
+++ b/web/src/views/ProjectDetailView.vue
@@ -236,7 +236,7 @@ const {
         v-else-if="loadDenied"
         role="status"
         data-testid="project-detail-denied"
-        class="border border-warn/40 bg-warn/10 px-5 py-10 text-center"
+        class="rounded-lg border border-warn/40 bg-warn/10 px-5 py-10 text-center"
       >
         <Icon name="lock" :size="22" class="mx-auto mb-3 text-warn" />
         <h3 class="text-sm font-semibold text-txt">{{ t('common.asyncState.permissionDeniedTitle') }}</h3>
@@ -249,7 +249,7 @@ const {
         v-else-if="loadFailed"
         role="status"
         data-testid="project-detail-failed"
-        class="border border-err/40 bg-err/10 px-5 py-10 text-center"
+        class="rounded-lg border border-err/40 bg-err/10 px-5 py-10 text-center"
       >
         <h3 class="text-sm font-semibold text-txt">{{ t('common.asyncState.loadFailedTitle') }}</h3>
         <p class="mt-1 text-xs text-txt2">{{ t('common.asyncState.loadFailedDesc') }}</p>
@@ -285,7 +285,7 @@ const {
       <div
         v-if="showPmMemoryMigration"
         data-testid="pm-memory-migration-banner"
-        class="mb-3 flex flex-col gap-2 border border-warn/35 bg-warn/10 px-3 py-2.5 sm:flex-row sm:items-center sm:justify-between"
+        class="rounded-lg mb-3 flex flex-col gap-2 border border-warn/35 bg-warn/10 px-3 py-2.5 sm:flex-row sm:items-center sm:justify-between"
       >
         <div class="min-w-0">
           <div class="text-[12px] font-medium text-txt">{{ t('pages.projectDetail.pm.memoryMigratedTitle') }}</div>
@@ -316,7 +316,7 @@ const {
           <div
             v-for="n in 4"
             :key="'wf-skel-m-' + n"
-            class="flex flex-col gap-3 border border-line bg-surface p-3"
+            class="rounded-lg flex flex-col gap-3 border border-line bg-surface p-3"
           >
             <div class="flex items-start justify-between gap-3">
               <div class="min-w-0 flex-1 space-y-2">
@@ -328,7 +328,7 @@ const {
             <div class="h-8 w-full bg-elevated animate-pulse" />
           </div>
         </div>
-        <div v-else-if="tab === 'workflows'" class="overflow-hidden border border-line">
+        <div v-else-if="tab === 'workflows'" class="rounded-lg overflow-hidden border border-line">
           <div class="grid grid-cols-5 gap-3 border-b border-line bg-elevated px-3 py-2">
             <div v-for="n in 5" :key="'wf-th-' + n" class="h-2.5 bg-elevated animate-pulse" />
           </div>
@@ -340,7 +340,7 @@ const {
             <div class="h-3 w-1/2 bg-elevated animate-pulse" />
           </div>
         </div>
-        <div v-else class="space-y-3 border border-line bg-surface p-4">
+        <div v-else class="rounded-lg space-y-3 border border-line bg-surface p-4">
           <div class="h-4 w-40 bg-elevated animate-pulse" />
           <div class="h-24 w-full bg-elevated animate-pulse" />
           <div class="h-10 w-full bg-elevated animate-pulse" />
@@ -514,7 +514,7 @@ const {
                 data-testid="wf-notify-saving"
               >{{ t('common.buttons.saving') }}</span>
               <div class="max-w-full overflow-x-auto">
-                <div class="inline-flex w-max max-w-none border border-line text-[11px]">
+                <div class="rounded-lg inline-flex w-max max-w-none border border-line text-[11px]">
                   <button
                     type="button"
                     class="shrink-0 whitespace-nowrap px-2 py-1 transition"
@@ -883,7 +883,7 @@ const {
         <!-- Empty: same shell as sandbox tab -->
         <div
           v-if="!varRows.length"
-          class="flex min-h-[360px] flex-1 flex-col border border-b-0 border-line bg-surface shadow-[var(--shadow-card)]"
+          class="rounded-lg flex min-h-[360px] flex-1 flex-col border border-b-0 border-line bg-surface shadow-[var(--shadow-card)]"
           data-testid="workflow-vars-empty-shell"
         >
           <div class="flex flex-1 flex-col items-center justify-center">
@@ -902,7 +902,7 @@ const {
         <!-- Data: head / scroll rows / foot stick to shell bottom -->
         <div
           v-else
-          class="flex min-h-0 flex-1 flex-col overflow-hidden border border-b-0 border-line bg-surface shadow-[var(--shadow-card)]"
+          class="rounded-lg flex min-h-0 flex-1 flex-col overflow-hidden border border-b-0 border-line bg-surface shadow-[var(--shadow-card)]"
           data-testid="workflow-vars-data-panel"
         >
           <div
@@ -933,7 +933,7 @@ const {
                 <!-- Value control matrix by type -->
                 <div
                   v-if="row.type === 'bool'"
-                  class="flex min-w-0 overflow-hidden border border-line"
+                  class="rounded-lg flex min-w-0 overflow-hidden border border-line"
                 >
                   <button
                     type="button"
@@ -1056,7 +1056,7 @@ const {
       <!-- Project info (meta) tab: fill remaining main area (no page void under card) -->
       <div v-else-if="tab === 'meta'" class="flex min-h-0 flex-1 flex-col">
         <div
-          class="flex flex-1 flex-col overflow-hidden border border-line bg-surface shadow-[var(--shadow-card)]"
+          class="rounded-lg flex flex-1 flex-col overflow-hidden border border-line bg-surface shadow-[var(--shadow-card)]"
         >
           <div class="shrink-0 border-b border-line bg-elevated/55 px-4 py-3.5">
             <h2 class="m-0 text-sm font-semibold text-txt">

--- a/web/src/views/ProjectListView.vue
+++ b/web/src/views/ProjectListView.vue
@@ -156,7 +156,7 @@ onMounted(() => {
           v-else-if="loadDenied"
           role="status"
           data-testid="project-list-denied"
-          class="border border-warn/40 bg-warn/10 px-5 py-10 text-center"
+          class="rounded-lg border border-warn/40 bg-warn/10 px-5 py-10 text-center"
         >
           <Icon name="lock" :size="22" class="mx-auto mb-3 text-warn" />
           <h3 class="text-sm font-semibold text-txt">{{ t('common.asyncState.permissionDeniedTitle') }}</h3>
@@ -170,7 +170,7 @@ onMounted(() => {
           v-else-if="loadFailed"
           role="status"
           data-testid="project-list-failed"
-          class="border border-err/40 bg-err/10 px-5 py-10 text-center"
+          class="rounded-lg border border-err/40 bg-err/10 px-5 py-10 text-center"
         >
           <h3 class="text-sm font-semibold text-txt">{{ t('common.asyncState.loadFailedTitle') }}</h3>
           <p class="mt-1 text-xs text-txt2">{{ t('common.asyncState.loadFailedDesc') }}</p>

--- a/web/src/views/PublicGateApprovalView.vue
+++ b/web/src/views/PublicGateApprovalView.vue
@@ -1053,7 +1053,7 @@ defineExpose({ loadPreview, loadUpstreamFull, openUpstreamModal })
     >
       <div class="flex items-center gap-2">
         <span
-          class="border border-line bg-elevated px-2 py-0.5 text-[11px] text-txt2"
+          class="rounded-md border border-line bg-elevated px-2 py-0.5 text-[11px] text-txt2"
           data-testid="public-gate-badge"
         >
           {{
@@ -1080,7 +1080,7 @@ defineExpose({ loadPreview, loadUpstreamFull, openUpstreamModal })
         </span>
         <span
           v-if="isActive && !doneKind"
-          class="border border-accent/45 bg-accent/10 px-2 py-0.5 text-[11px] text-accent-2"
+          class="rounded-md border border-accent/45 bg-accent/10 px-2 py-0.5 text-[11px] text-accent-2"
           data-testid="public-gate-preset-chip"
         >
           {{ presetChipLabel }}
@@ -1115,7 +1115,7 @@ defineExpose({ loadPreview, loadUpstreamFull, openUpstreamModal })
       <h1 class="text-lg font-semibold">{{ t('pages.publicGate.networkError') }}</h1>
       <button
         type="button"
-        class="inline-flex min-h-11 items-center justify-center border border-line bg-surface px-4 text-sm font-medium text-txt"
+        class="rounded-lg inline-flex min-h-11 items-center justify-center border border-line bg-surface px-4 text-sm font-medium text-txt"
         data-testid="public-gate-network-retry"
         @click="loadPreview()"
       >
@@ -1232,7 +1232,7 @@ defineExpose({ loadPreview, loadUpstreamFull, openUpstreamModal })
           <div class="flex h-full min-h-0 flex-col" data-testid="public-gate-sidebar">
             <div
               v-if="showReactOnlyDeadend"
-              class="flex flex-1 flex-col items-center justify-center gap-2 border border-dashed border-line-strong bg-elevated px-6 py-10 text-center"
+              class="rounded-lg flex flex-1 flex-col items-center justify-center gap-2 border border-dashed border-line-strong bg-elevated px-6 py-10 text-center"
               data-testid="public-gate-react-only-deadend"
               role="status"
             >
@@ -1305,7 +1305,7 @@ defineExpose({ loadPreview, loadUpstreamFull, openUpstreamModal })
               v-model="reviewerName"
               type="text"
               maxlength="80"
-              class="w-[8rem] border border-line bg-elevated px-2 py-1 text-xs text-txt"
+              class="rounded-md w-[8rem] border border-line bg-elevated px-2 py-1 text-xs text-txt"
               data-testid="public-gate-name"
               :placeholder="t('pages.publicGate.namePh')"
               autocomplete="name"
@@ -1314,7 +1314,7 @@ defineExpose({ loadPreview, loadUpstreamFull, openUpstreamModal })
               v-model="comment"
               type="text"
               maxlength="4000"
-              class="min-w-[10rem] flex-1 border border-line bg-elevated px-2 py-1 text-xs text-txt md:w-[16rem] md:flex-none"
+              class="rounded-md min-w-[10rem] flex-1 border border-line bg-elevated px-2 py-1 text-xs text-txt md:w-[16rem] md:flex-none"
               data-testid="public-gate-comment"
               :placeholder="t('pages.publicGate.commentPh')"
             />

--- a/web/src/views/RunDetailView.vue
+++ b/web/src/views/RunDetailView.vue
@@ -380,7 +380,7 @@ const {
         role="dialog"
         tabindex="-1"
         :aria-label="t('pages.runDetail.priorityTitle')"
-        class="fixed z-40 border border-line-strong bg-surface p-3.5 shadow-card outline-none"
+        class="rounded-lg fixed z-40 border border-line-strong bg-surface p-3.5 shadow-card outline-none"
         :style="priorityPopoverStyle"
       >
         <h3 class="mb-2.5 text-[13px] font-semibold text-txt">{{ t('pages.runDetail.priorityTitle') }}</h3>
@@ -398,14 +398,14 @@ const {
         </div>
         <div
           v-if="priorityError"
-          class="mt-2.5 flex items-start gap-1.5 border border-err/30 bg-err/10 px-2.5 py-2 text-[12px] text-err"
+          class="rounded-lg mt-2.5 flex items-start gap-1.5 border border-err/30 bg-err/10 px-2.5 py-2 text-[12px] text-err"
         >
           <Icon name="alert" :size="14" class="mt-0.5 shrink-0" />
           <span>{{ priorityError }}</span>
         </div>
         <div
           v-else-if="priorityOk"
-          class="mt-2.5 border border-ok/30 bg-ok/10 px-2.5 py-2 text-[12px] text-ok"
+          class="rounded-lg mt-2.5 border border-ok/30 bg-ok/10 px-2.5 py-2 text-[12px] text-ok"
         >
           {{ t('pages.runDetail.prioritySaved') }}
         </div>

--- a/web/src/views/SandboxConsoleView.vue
+++ b/web/src/views/SandboxConsoleView.vue
@@ -304,12 +304,12 @@ onBeforeUnmount(() => {
       <span class="truncate text-[13px] font-medium text-txt">{{ sandboxTitle }}</span>
     </div>
     <div class="flex flex-1 flex-col items-center px-5 py-8 text-center">
-      <div class="mb-3 flex h-10 w-10 items-center justify-center border border-info/35 bg-info/10 text-info">⌁</div>
+      <div class="rounded-lg mb-3 flex h-10 w-10 items-center justify-center border border-info/35 bg-info/10 text-info">⌁</div>
       <h3 class="text-[14px] font-semibold text-txt">{{ t('pages.sandboxConsole.mobile.title') }}</h3>
       <p class="mt-2 max-w-[32ch] text-[12.5px] leading-relaxed text-txt2">{{ t('pages.sandboxConsole.mobile.desc') }}</p>
       <button
         type="button"
-        class="mt-4 min-h-11 border border-line bg-transparent px-4 text-[13px] text-txt2 hover:border-accent hover:text-txt"
+        class="rounded-md mt-4 min-h-11 border border-line bg-transparent px-4 text-[13px] text-txt2 hover:border-accent hover:text-txt"
         data-testid="sandbox-console-peek"
         @click="showSessionPeek = !showSessionPeek"
       >
@@ -318,7 +318,7 @@ onBeforeUnmount(() => {
     </div>
     <div
       v-if="showSessionPeek"
-      class="mx-4 mb-6 border border-line bg-surface p-3 text-left"
+      class="rounded-lg mx-4 mb-6 border border-line bg-surface p-3 text-left"
       data-testid="sandbox-console-summary"
     >
       <div class="mb-2 text-[11px] uppercase tracking-wider text-txt3">{{ t('pages.sandboxConsole.mobile.summaryLabel') }}</div>
@@ -476,7 +476,7 @@ onBeforeUnmount(() => {
             <p>{{ logError }}</p>
             <button
               type="button"
-              class="mt-2 inline-flex min-h-11 items-center border border-line px-3 text-[12px] text-txt"
+              class="rounded-lg mt-2 inline-flex min-h-11 items-center border border-line px-3 text-[12px] text-txt"
               @click="fetchLog"
             >
               {{ t('common.chatImage.retry') }}

--- a/web/src/views/SandboxListView.vue
+++ b/web/src/views/SandboxListView.vue
@@ -509,7 +509,7 @@ onBeforeUnmount(() => {
             </template>
             <tr v-else-if="loadDenied">
               <td colspan="8" class="px-4 py-10 text-center">
-                <div role="status" data-testid="sandbox-list-denied" class="border border-warn/40 bg-warn/10 px-5 py-8">
+                <div role="status" data-testid="sandbox-list-denied" class="rounded-lg border border-warn/40 bg-warn/10 px-5 py-8">
                   <Icon name="lock" :size="22" class="mx-auto mb-3 text-warn" />
                   <h3 class="text-sm font-semibold text-txt">{{ t('common.asyncState.permissionDeniedTitle') }}</h3>
                   <p class="mt-1 text-xs text-txt2">{{ t('common.asyncState.permissionDeniedDesc') }}</p>
@@ -521,7 +521,7 @@ onBeforeUnmount(() => {
             </tr>
             <tr v-else-if="initialLoadFailed">
               <td colspan="8" class="px-4 py-10 text-center">
-                <div role="status" data-testid="sandbox-list-failed" class="border border-err/40 bg-err/10 px-5 py-8">
+                <div role="status" data-testid="sandbox-list-failed" class="rounded-lg border border-err/40 bg-err/10 px-5 py-8">
                   <h3 class="text-sm font-semibold text-txt">{{ t('common.asyncState.loadFailedTitle') }}</h3>
                   <p class="mt-1 text-xs text-txt2">{{ t('common.asyncState.loadFailedDesc') }}</p>
                   <AppButton class="mt-4" variant="outline" data-testid="sandbox-list-retry" @click="load({ showLoading: true })">
@@ -617,7 +617,7 @@ onBeforeUnmount(() => {
       <div v-else-if="detailView" class="space-y-5">
         <section>
           <h3 class="mb-2.5 text-[12px] font-semibold uppercase tracking-wider text-txt3">{{ t('pages.sandboxes.detail.sectionMeta') }}</h3>
-          <div class="border border-line bg-base">
+          <div class="rounded-lg border border-line bg-base">
             <div
               v-for="row in detailMetaRows"
               :key="row.key"
@@ -635,7 +635,7 @@ onBeforeUnmount(() => {
         <section>
           <h3 class="mb-1 text-[12px] font-semibold uppercase tracking-wider text-txt3">{{ t('pages.sandboxes.detail.sectionProxy') }}</h3>
           <p class="mb-2.5 text-[11px] leading-snug text-txt3">{{ t('pages.sandboxes.detail.sectionProxyHint') }}</p>
-          <div class="border border-line bg-base">
+          <div class="rounded-lg border border-line bg-base">
             <div
               v-for="row in detailProxyRows"
               :key="row.key"
@@ -646,7 +646,7 @@ onBeforeUnmount(() => {
               <span class="flex shrink-0 items-center gap-1.5 self-center">
                 <button
                   type="button"
-                  class="border border-line px-2 py-0.5 text-[11px] text-txt2 hover:border-line-strong hover:text-txt"
+                  class="rounded-md border border-line px-2 py-0.5 text-[11px] text-txt2 hover:border-line-strong hover:text-txt"
                   :class="{ 'border-ok/40 text-ok': copiedKey === 'proxy-' + row.key }"
                   @click="copyText('proxy-' + row.key, row.value)"
                 >{{ copiedKey === 'proxy-' + row.key ? t('pages.sandboxes.detail.copied') : t('pages.sandboxes.detail.copy') }}</button>
@@ -654,7 +654,7 @@ onBeforeUnmount(() => {
                   v-if="row.preview"
                   type="button"
                   data-testid="sandbox-vnc-open-preview"
-                  class="border border-accent bg-accent px-2 py-0.5 text-[11px] text-white hover:brightness-110"
+                  class="rounded-md border border-accent bg-accent px-2 py-0.5 text-[11px] text-white hover:brightness-110"
                   @click="openSandboxVncPreview(detailView.id)"
                 >{{ t('pages.sandboxes.detail.proxy.openPreview') }}</button>
               </span>
@@ -666,14 +666,14 @@ onBeforeUnmount(() => {
           <h3 class="mb-1 text-[12px] font-semibold uppercase tracking-wider text-txt3">{{ t('pages.sandboxes.detail.sectionEndpoints') }}</h3>
           <div
             data-testid="sandbox-endpoints-notice"
-            class="mb-2.5 border border-[rgb(var(--c-info)/0.45)] bg-[rgb(var(--c-info)/0.14)] px-3 py-2 text-[12px] leading-snug text-txt"
+            class="rounded-lg mb-2.5 border border-[rgb(var(--c-info)/0.45)] bg-[rgb(var(--c-info)/0.14)] px-3 py-2 text-[12px] leading-snug text-txt"
           >{{ t('pages.sandboxes.detail.endpointsNotice') }}</div>
           <p class="mb-2.5 text-[11px] leading-snug text-txt3">{{ t('pages.sandboxes.detail.sectionEndpointsHint') }}</p>
           <div
             v-if="!detailEndpointRows.length"
-            class="border border-dashed border-line-strong bg-base px-3 py-4 text-center text-[12px] text-txt3"
+            class="rounded-lg border border-dashed border-line-strong bg-base px-3 py-4 text-center text-[12px] text-txt3"
           >{{ t('pages.sandboxes.detail.endpointsEmpty') }}</div>
-          <div v-else class="border border-line bg-base">
+          <div v-else class="rounded-lg border border-line bg-base">
             <div
               v-for="row in detailEndpointRows"
               :key="row.key"
@@ -683,7 +683,7 @@ onBeforeUnmount(() => {
               <div class="min-w-0 break-all font-mono leading-snug text-txt">{{ row.value }}</div>
               <button
                 type="button"
-                class="shrink-0 self-center border border-line px-2 py-0.5 text-[11px] text-txt2 hover:border-line-strong hover:text-txt"
+                class="rounded-md shrink-0 self-center border border-line px-2 py-0.5 text-[11px] text-txt2 hover:border-line-strong hover:text-txt"
                 :class="{ 'border-ok/40 text-ok': copiedKey === 'ep-' + row.key }"
                 @click="copyText('ep-' + row.key, row.value)"
               >{{ copiedKey === 'ep-' + row.key ? t('pages.sandboxes.detail.copied') : t('pages.sandboxes.detail.copy') }}</button>

--- a/web/src/views/SettingsView.vue
+++ b/web/src/views/SettingsView.vue
@@ -337,7 +337,7 @@ onBeforeUnmount(() => {
       v-else-if="loadDenied"
       role="status"
       data-testid="settings-denied"
-      class="border border-warn/40 bg-warn/10 px-5 py-10 text-center"
+      class="rounded-lg border border-warn/40 bg-warn/10 px-5 py-10 text-center"
     >
       <Icon name="lock" :size="22" class="mx-auto mb-3 text-warn" />
       <h3 class="text-sm font-semibold text-txt">{{ t('common.asyncState.permissionDeniedTitle') }}</h3>
@@ -351,7 +351,7 @@ onBeforeUnmount(() => {
       v-else-if="loadFailed"
       role="status"
       data-testid="settings-failed"
-      class="border border-err/40 bg-err/10 px-5 py-10 text-center"
+      class="rounded-lg border border-err/40 bg-err/10 px-5 py-10 text-center"
     >
       <h3 class="text-sm font-semibold text-txt">{{ t('common.asyncState.loadFailedTitle') }}</h3>
       <p class="mt-1 text-xs text-txt2">{{ t('common.asyncState.loadFailedDesc') }}</p>
@@ -374,7 +374,7 @@ onBeforeUnmount(() => {
         </div>
 
         <div v-if="group.id === 'capacity'" class="border-b border-line px-4 py-3.5">
-          <div class="border border-line bg-base px-3.5 py-3">
+          <div class="rounded-lg border border-line bg-base px-3.5 py-3">
             <div class="mb-2.5 flex items-baseline justify-between gap-3">
               <span class="text-xs text-txt2">{{ t('pages.settings.capacity.activeSandboxes') }}</span>
               <span class="text-[22px] font-bold tabular-nums leading-none text-txt">
@@ -383,12 +383,12 @@ onBeforeUnmount(() => {
             </div>
 
             <div class="mb-2.5 flex flex-wrap gap-2">
-              <span class="inline-flex items-center gap-1.5 border border-line bg-elevated px-2.5 py-1 text-[11px] text-txt2">
+              <span class="rounded-md inline-flex items-center gap-1.5 border border-line bg-elevated px-2.5 py-1 text-[11px] text-txt2">
                 <span class="h-1.5 w-1.5 shrink-0 bg-info" />
                 {{ t('pages.settings.capacity.test') }} <strong class="tabular-nums text-txt">{{ usage.testCount }}</strong>
                 <span class="text-[10px] text-txt3">/ {{ testLimit }} {{ t('pages.settings.capacity.limit') }}</span>
               </span>
-              <span class="inline-flex items-center gap-1.5 border border-line bg-elevated px-2.5 py-1 text-[11px] text-txt2">
+              <span class="rounded-md inline-flex items-center gap-1.5 border border-line bg-elevated px-2.5 py-1 text-[11px] text-txt2">
                 <span class="h-1.5 w-1.5 shrink-0 bg-accent-2" />
                 {{ t('pages.settings.capacity.run') }} <strong class="tabular-nums text-txt">{{ runCount }}</strong>
                 <span class="text-[10px] text-txt3">/ {{ runLimit }} {{ t('pages.settings.capacity.concurrency') }}</span>

--- a/web/src/views/TokenAnalyticsView.vue
+++ b/web/src/views/TokenAnalyticsView.vue
@@ -535,7 +535,7 @@ watch([windowSel], () => void load())
           <p class="mt-1 text-xs text-txt3">{{ t('pages.tokenAnalytics.subtitle') }}</p>
         </div>
         <div
-          class="flex gap-1 bg-elevated p-1"
+          class="flex gap-1 rounded bg-elevated p-1"
           role="group"
           :aria-label="t('pages.board.tokenStats.windowAria')"
           data-testid="token-analytics-window"
@@ -544,7 +544,7 @@ watch([windowSel], () => void load())
             v-for="w in WINDOWS"
             :key="w"
             type="button"
-            class="px-2.5 py-1.5 text-xs"
+            class="rounded px-2.5 py-1.5 text-xs"
             :class="windowSel === w ? 'bg-surface font-semibold text-txt shadow-sm' : 'text-txt3'"
             :data-testid="`token-analytics-window-${w}`"
             @click="windowSel = w"
@@ -579,15 +579,15 @@ watch([windowSel], () => void load())
         >
           {{ t('pages.tokenAnalytics.sourcePm') }}
         </button>
-        <select v-model="projectSel" class="border border-line bg-surface px-2 py-1.5 text-xs text-txt2" @change="load()">
+        <select v-model="projectSel" class="rounded border border-line bg-surface px-2 py-1.5 text-xs text-txt2" @change="load()">
           <option value="">{{ t('pages.tokenAnalytics.projectAll') }}</option>
           <option v-for="p in data?.filterOptions.projects || []" :key="p.key" :value="p.key">{{ p.name }}</option>
         </select>
-        <select v-model="modelSel" class="border border-line bg-surface px-2 py-1.5 text-xs text-txt2" @change="load()">
+        <select v-model="modelSel" class="rounded border border-line bg-surface px-2 py-1.5 text-xs text-txt2" @change="load()">
           <option value="">{{ t('pages.tokenAnalytics.modelAll') }}</option>
           <option v-for="m in data?.filterOptions.models || []" :key="m.key" :value="m.key">{{ m.name }}</option>
         </select>
-        <button type="button" class="border border-line bg-surface px-2.5 py-1.5 text-xs text-txt2" @click="clearFilters">
+        <button type="button" class="rounded border border-line bg-surface px-2.5 py-1.5 text-xs text-txt2" @click="clearFilters">
           {{ t('pages.tokenAnalytics.clearFilters') }}
         </button>
       </div>
@@ -605,13 +605,13 @@ watch([windowSel], () => void load())
       </div>
       <template v-else-if="data">
         <section id="overview" class="mb-3 grid grid-cols-1 gap-2.5 sm:grid-cols-2 xl:grid-cols-3" data-testid="token-analytics-kpis">
-          <div class="border border-line bg-surface p-3.5" data-testid="token-analytics-kpi-total">
+          <div class="rounded-lg border border-line bg-surface p-3.5" data-testid="token-analytics-kpi-total">
             <div class="text-[11px] text-txt3">{{ t('pages.tokenAnalytics.kpiTotal') }}</div>
             <div class="mt-1 text-[22px] font-bold tabular-nums">{{ fmtCompactTokenCount(data.kpi.total) }}</div>
             <div class="mt-1 text-[11px]" :class="deltaClass">{{ deltaLabel }}</div>
           </div>
           <div
-            class="token-analytics-kpi-merge relative border border-line bg-surface p-3.5 outline-none"
+            class="token-analytics-kpi-merge relative rounded-lg border border-line bg-surface p-3.5 outline-none"
             tabindex="0"
             data-testid="token-analytics-kpi-merge"
           >
@@ -625,7 +625,7 @@ watch([windowSel], () => void load())
               <b class="text-base font-bold tabular-nums text-txt">{{ fmtCompactTokenCount(data.kpi.outputTokens) }}</b>
             </div>
             <div
-              class="token-analytics-kpi-tip absolute left-3.5 top-[calc(100%-8px)] z-10 hidden min-w-[200px] border border-line bg-elevated p-2.5 text-xs shadow-md"
+              class="token-analytics-kpi-tip absolute left-3.5 top-[calc(100%-8px)] z-10 hidden min-w-[200px] rounded-lg border border-line bg-elevated p-2.5 text-xs shadow-md"
               data-testid="token-analytics-kpi-detail"
             >
               <div class="flex justify-between gap-4 py-0.5">
@@ -646,7 +646,7 @@ watch([windowSel], () => void load())
               </div>
             </div>
           </div>
-          <div class="border border-line bg-surface p-3.5" data-testid="token-analytics-kpi-scope">
+          <div class="rounded-lg border border-line bg-surface p-3.5" data-testid="token-analytics-kpi-scope">
             <div class="text-[11px] text-txt3">{{ t('pages.tokenAnalytics.kpiScope') }}</div>
             <div class="mt-1 text-[22px] font-bold">{{ t('pages.tokenAnalytics.kpiProjects', { n: data.kpi.projectCount }) }}</div>
             <div class="mt-1 text-[11px] text-txt3">
@@ -656,7 +656,7 @@ watch([windowSel], () => void load())
           </div>
         </section>
 
-        <section id="lines" class="mb-3 border border-line bg-surface p-3.5" data-testid="token-analytics-lines">
+        <section id="lines" class="mb-3 rounded-lg border border-line bg-surface p-3.5" data-testid="token-analytics-lines">
           <h2 class="m-0 text-sm font-semibold">
             {{ t('pages.tokenAnalytics.charts.lines') }}
             <em class="ml-2 text-[11px] font-normal text-txt3">{{ t('pages.tokenAnalytics.charts.linesHint') }}</em>
@@ -678,7 +678,7 @@ watch([windowSel], () => void load())
           </div>
         </section>
 
-        <section id="pies" class="mb-3 border border-line bg-surface p-3.5" data-testid="token-analytics-pies">
+        <section id="pies" class="mb-3 rounded-lg border border-line bg-surface p-3.5" data-testid="token-analytics-pies">
           <h2 class="m-0 text-sm font-semibold">
             {{ t('pages.tokenAnalytics.charts.pies') }}
             <em class="ml-2 text-[11px] font-normal text-txt3">{{ t('pages.tokenAnalytics.charts.piesHint') }}</em>
@@ -702,7 +702,7 @@ watch([windowSel], () => void load())
           </div>
         </section>
 
-        <section id="bars" class="mb-3 border border-line bg-surface p-3.5" data-testid="token-analytics-bars">
+        <section id="bars" class="mb-3 rounded-lg border border-line bg-surface p-3.5" data-testid="token-analytics-bars">
           <h2 class="m-0 text-sm font-semibold">
             {{ t('pages.tokenAnalytics.charts.bars') }}
             <em class="ml-2 text-[11px] font-normal text-txt3">{{ t('pages.tokenAnalytics.charts.barsHint') }}</em>
@@ -718,7 +718,7 @@ watch([windowSel], () => void load())
           </div>
         </section>
 
-        <section id="area" class="mb-3 border border-line bg-surface p-3.5" data-testid="token-analytics-area">
+        <section id="area" class="mb-3 rounded-lg border border-line bg-surface p-3.5" data-testid="token-analytics-area">
           <h2 class="m-0 text-sm font-semibold">
             {{ t('pages.tokenAnalytics.charts.area') }}
             <em class="ml-2 text-[11px] font-normal text-txt3">{{ t('pages.tokenAnalytics.charts.areaHint') }}</em>
@@ -740,14 +740,14 @@ watch([windowSel], () => void load())
           </div>
         </section>
 
-        <section id="heat" class="mb-3 border border-line bg-surface p-3.5" data-testid="token-analytics-heat">
+        <section id="heat" class="mb-3 rounded-lg border border-line bg-surface p-3.5" data-testid="token-analytics-heat">
           <h2 class="m-0 text-sm font-semibold">{{ t('pages.tokenAnalytics.charts.heat') }}</h2>
           <div class="token-analytics-plot mt-2 h-[240px] overflow-visible" data-testid="token-analytics-plot-heat">
             <VChart v-if="heatmapOption()" :option="heatmapOption()!" autoresize class="h-full w-full" />
           </div>
         </section>
 
-        <section id="nodeWf" class="mb-3 border border-line bg-surface p-3.5" data-testid="token-analytics-node-wf">
+        <section id="nodeWf" class="mb-3 rounded-lg border border-line bg-surface p-3.5" data-testid="token-analytics-node-wf">
           <h2 class="m-0 text-sm font-semibold">{{ t('pages.tokenAnalytics.charts.nodeWf') }}</h2>
           <div class="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
             <div>
@@ -762,7 +762,7 @@ watch([windowSel], () => void load())
         </section>
 
         <section id="tables" class="grid grid-cols-1 gap-2.5 lg:grid-cols-2">
-          <div class="flex max-h-[280px] min-h-0 flex-col border border-line bg-surface p-3.5">
+          <div class="rounded-lg flex max-h-[280px] min-h-0 flex-col border border-line bg-surface p-3.5">
             <h2 class="m-0 mb-2 shrink-0 text-sm font-semibold">{{ t('pages.tokenAnalytics.tables.projects') }}</h2>
             <div class="token-analytics-table-scroll min-h-0 flex-1 overflow-auto">
               <table class="w-full border-collapse text-xs">
@@ -791,7 +791,7 @@ watch([windowSel], () => void load())
               </table>
             </div>
           </div>
-          <div class="flex max-h-[280px] min-h-0 flex-col border border-line bg-surface p-3.5" data-testid="token-analytics-runs-table">
+          <div class="flex max-h-[280px] min-h-0 flex-col rounded-lg border border-line bg-surface p-3.5" data-testid="token-analytics-runs-table">
             <h2 class="m-0 mb-2 shrink-0 text-sm font-semibold">{{ t('pages.tokenAnalytics.tables.runs') }}</h2>
             <div class="token-analytics-table-scroll min-h-0 flex-1 overflow-auto">
               <!-- plan coverage: g1.1 / g1.2 / g1.3 — header sashes, session col widths, truncate without misfire -->

--- a/web/src/views/WorkflowEditorView.vue
+++ b/web/src/views/WorkflowEditorView.vue
@@ -516,12 +516,12 @@ function deleteEdge() {
       <span class="truncate text-[13px] font-medium text-txt">{{ wf.name }}</span>
     </div>
     <div class="flex flex-1 flex-col items-center px-5 py-8 text-center">
-      <div class="mb-3 flex h-10 w-10 items-center justify-center border border-info/35 bg-info/10 text-info">◇</div>
+      <div class="rounded-lg mb-3 flex h-10 w-10 items-center justify-center border border-info/35 bg-info/10 text-info">◇</div>
       <h3 class="text-[14px] font-semibold text-txt">{{ t('pages.workflowEditor.mobile.title') }}</h3>
       <p class="mt-2 max-w-[32ch] text-[12.5px] leading-relaxed text-txt2">{{ t('pages.workflowEditor.mobile.desc') }}</p>
       <button
         type="button"
-        class="mt-4 min-h-11 border border-line bg-transparent px-4 text-[13px] text-txt2 hover:border-accent hover:text-txt"
+        class="rounded-md mt-4 min-h-11 border border-line bg-transparent px-4 text-[13px] text-txt2 hover:border-accent hover:text-txt"
         data-testid="workflow-editor-peek"
         @click="showFlowPeek = !showFlowPeek"
       >
@@ -530,7 +530,7 @@ function deleteEdge() {
     </div>
     <div
       v-if="showFlowPeek"
-      class="mx-4 mb-6 border border-line bg-surface p-3 text-left"
+      class="rounded-lg mx-4 mb-6 border border-line bg-surface p-3 text-left"
       data-testid="workflow-editor-summary"
     >
       <div class="mb-2 text-[11px] uppercase tracking-wider text-txt3">{{ t('pages.workflowEditor.mobile.summaryLabel') }}</div>
@@ -595,7 +595,7 @@ function deleteEdge() {
       <button
         v-if="hydrateFailed"
         type="button"
-        class="ml-auto border border-err/40 px-2.5 py-1 text-xs text-err hover:bg-err/10"
+        class="rounded-md ml-auto border border-err/40 px-2.5 py-1 text-xs text-err hover:bg-err/10"
         data-testid="workflow-editor-hydrate-retry"
         @click="loadExistingWorkflow"
       >
@@ -670,7 +670,7 @@ function deleteEdge() {
           <p class="text-[13px] text-err">{{ t('pages.workflowEditor.loadFailed') }}</p>
           <button
             type="button"
-            class="inline-flex min-h-11 items-center border border-line bg-surface px-3 text-[12px] font-medium text-txt hover:bg-elevated"
+            class="rounded-lg inline-flex min-h-11 items-center border border-line bg-surface px-3 text-[12px] font-medium text-txt hover:bg-elevated"
             data-testid="workflow-editor-hydrate-retry-canvas"
             @click="loadExistingWorkflow"
           >


### PR DESCRIPTION
Apply 8/12/16/full radii to independent four-border surfaces (home composer,
AppSwitch capsule, demo cards, analytics filters/KPIs, login, and remaining
views/components), remove rounded-none leftovers, and lock clearance with
radiusZeroClearance vitest gate for downstream plan_coverage evidence.

Co-authored-by: Cursor <cursoragent@cursor.com>
