### PR TITLE
fix(web): keep ReAct live stream while session still replying

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1767,6 +1767,7 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -2202,6 +2203,7 @@
       "resolved": "https://registry.npmmirror.com/@vue-flow/core/-/core-1.48.2.tgz",
       "integrity": "sha512-raxhgKWE+G/mcEvXJjGFUDYW9rAI3GOtiHR3ZkNpwBWuIaCC1EYiBmKGwJOoNzVFgwO7COgErnK7i08i287AFA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vueuse/core": "^10.5.0",
         "d3-drag": "^3.0.0",
@@ -2245,6 +2247,7 @@
       "resolved": "https://registry.npmmirror.com/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
       "integrity": "sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.5.39",
         "@vue/shared": "3.5.39"
@@ -2486,6 +2489,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2756,6 +2760,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.11.12",
         "caniuse-lite": "^1.0.30001809",
@@ -3063,6 +3068,7 @@
       "resolved": "https://registry.npmmirror.com/cytoscape/-/cytoscape-3.34.1.tgz",
       "integrity": "sha512-Lr0RvH9H75y9ar8h9Toy6u4lxRSCcxUq+hHcQ26sVWo6BnaQp1gwEZOYqwuYTZhyW7npyKnNLP8oJ2p1/3OZ7g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -3472,6 +3478,7 @@
       "resolved": "https://registry.npmmirror.com/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3658,6 +3665,7 @@
       "resolved": "https://registry.npmmirror.com/echarts/-/echarts-6.1.0.tgz",
       "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "2.3.0",
         "zrender": "6.1.0"
@@ -3818,6 +3826,7 @@
       "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3878,6 +3887,7 @@
       "integrity": "sha512-dL9x9rBHqqNcByWiLOHK6L0SB97V82/NC0cZRn9cXPjM7pCuWlpQQP9bFH4vjBv80ej1ZpzAkuD8zWH1o9bZbA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "natural-compare": "^1.4.0",
@@ -4321,6 +4331,7 @@
       "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -4630,6 +4641,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4671,9 +4683,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -5437,6 +5449,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
@@ -6258,6 +6271,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6362,6 +6376,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6478,6 +6493,7 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -6594,6 +6610,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6607,6 +6624,7 @@
       "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.7",
@@ -6699,6 +6717,7 @@
       "resolved": "https://registry.npmmirror.com/vue/-/vue-3.5.39.tgz",
       "integrity": "sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.39",
         "@vue/compiler-sfc": "3.5.39",

--- a/web/package.json
+++ b/web/package.json
@@ -59,7 +59,7 @@
   "overrides": {
     "brace-expansion": "^5.0.9",
     "minimatch": "^10.2.5",
-    "js-yaml": "^4.3.1",
+    "js-yaml": "^4.3.2",
     "browserslist": "^4.28.7"
   },
   "license": "MIT"

--- a/web/src/components/run/ReviewComposer.test.ts
+++ b/web/src/components/run/ReviewComposer.test.ts
@@ -224,6 +224,26 @@ describe('ReviewComposer nested ClarifyChat delivery', () => {
     expect(vm.applyAcpEvents?.([{ kind: 'thought', text: 'buffer me' }], 'react-1')).toBe(false)
     wrapper.unmount()
   })
+
+  it('exposes isSessionBusy from nested ClarifyChat (g1.3)', async () => {
+    const wrapper = mountClarify()
+    await flushPromises()
+    const vm = wrapper.vm as any
+    expect(typeof vm.isSessionBusy).toBe('function')
+    expect(vm.isSessionBusy()).toBe(false)
+    vm.applyReviewFrame?.({
+      event: 'queue_state',
+      nodeId: 'react-1',
+      waiting: 0,
+      items: [],
+      busy: true,
+      activeItem: { text: '还是有很多直角按钮和面板啊' },
+    })
+    await flushPromises()
+    expect(vm.isSessionBusy()).toBe(true)
+    expect(wrapper.find('[data-testid="clarify-busy-placeholder"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
 })
 
 describe('ReviewComposer gate review semantics (send + confirm)', () => {

--- a/web/src/components/run/ReviewComposer.vue
+++ b/web/src/components/run/ReviewComposer.vue
@@ -113,6 +113,7 @@ const chatRef = ref<{
   applyAcpEvents: (events: AcpEvent[] | undefined, nodeId?: string) => boolean | void
   cancelReview: () => void
   discardLastQueued: () => void
+  isSessionBusy?: () => boolean
 } | null>(null)
 
 defineExpose({
@@ -133,6 +134,11 @@ defineExpose({
   cancelReview: () => chatRef.value?.cancelReview(),
   discardLastQueued: () => chatRef.value?.discardLastQueued(),
   isChatReady: () => !!chatRef.value,
+  /**
+   * Platform session busy from ClarifyChat (thinking / queued / live slot).
+   * Hosts gate soft-refresh on this — must not be missing through the composer (g1.3).
+   */
+  isSessionBusy: () => !!chatRef.value?.isSessionBusy?.(),
 })
 
 const { t } = useI18n()

--- a/web/src/components/run/clarifySessionUx.probe.test.ts
+++ b/web/src/components/run/clarifySessionUx.probe.test.ts
@@ -133,6 +133,70 @@ describe('[approving] ClarifyChat clarify-path UX (non-reviewMode)', () => {
     w.unmount()
   })
 
+  /**
+   * Screenshot repro (g1.1 / g3.1): Inbox 需求对齐 — persisted human only,
+   * session still busy, no agent body → must show 思考中… then resume message.
+   */
+  it('screenshot: persisted human + busy + no agent → thinking then resume message (g1.1/g3.1)', async () => {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const humanText = '还是有很多直角按钮和面板啊'
+    const w = mount(ClarifyChat, {
+      props: {
+        runId: 'run-1',
+        nodeId: 'clarify',
+        iteration: 1,
+        turns: [{ role: 'human', text: humanText, at: '2026-09-09T01:00:00Z' }],
+        done: false,
+        active: true,
+        reviewMode: true,
+        annotateEnabled: true,
+        hideFinish: false,
+        sendLabel: '发送回复',
+      },
+      global: {
+        plugins: [i18n],
+        stubs: { Icon: true, ClarifyDemoFrame: true },
+      },
+    })
+    await nextTick()
+    // Broken UI: header would stay at 共 1 条 with only the human bubble.
+    expect(w.text()).toContain(humanText)
+    expect(w.find('[data-testid="clarify-busy-placeholder"]').exists()).toBe(false)
+
+    const vm = w.vm as unknown as {
+      applyReviewFrame: (f: Record<string, unknown>) => void
+      applyAcpEvents: (e: { kind: string; text: string }[]) => void
+    }
+    vm.applyReviewFrame({
+      event: 'queue_state',
+      nodeId: 'clarify',
+      waiting: 0,
+      items: [],
+      busy: true,
+      activeItem: { text: humanText },
+    })
+    await nextTick()
+    // Live slot rebuilt despite human already in persisted turns.
+    const placeholder = w.find('[data-testid="clarify-busy-placeholder"]')
+    expect(placeholder.exists()).toBe(true)
+    expect(placeholder.text()).toContain('思考中')
+    // Must not stop at 共 1 条 — agent streaming bubble is present.
+    const humans = (w.text().match(new RegExp(humanText, 'g')) || []).length
+    expect(humans).toBeGreaterThanOrEqual(1)
+
+    vm.applyAcpEvents([{ kind: 'message', text: '好的，我会按圆角口径把按钮和面板改掉…' }])
+    await nextTick()
+    expect(w.find('[data-testid="clarify-busy-placeholder"]').exists()).toBe(false)
+    expect(w.text()).toContain('好的，我会按圆角口径把按钮和面板改掉…')
+    expect(w.find('[data-testid="clarify-busy-status"]').text()).toContain('输出中')
+    expect(w.find('[data-testid="clarify-stream-caret"]').exists()).toBe(true)
+    w.unmount()
+  })
+
   it('hard-refresh seed: thought-only then message after remount (g4.1)', async () => {
     // Simulate host seed-then-live: rebuild slot → seed ACP after (re)mount.
     const w = mountClarify()

--- a/web/src/lib/inbox/useGatesInbox.ts
+++ b/web/src/lib/inbox/useGatesInbox.ts
@@ -1292,10 +1292,9 @@ function connectActiveRunWs(runId: string, opts?: { fromReconnect?: boolean }) {
       return
     }
     if (m.type === 'acp') {
-      if (typeof m.busy === 'boolean') {
-        clarifyLiveBusy.value = !!m.busy
-        if (!m.busy) busySeedRetry.stop()
-      }
+      // ACP/sandbox busy is observational only — must not overwrite platform
+      // session busy (clarifyLiveBusy) or stop busySeedRetry (g1.2).
+      // Tear-down / stop retry only from review queue_state idle / turn_done / error.
       applyOrBufferAcpFrame(m as { nodeId?: string; events?: AcpEvent[]; busy?: boolean })
       return
     }

--- a/web/src/lib/run/streamResumeAcceptance.test.ts
+++ b/web/src/lib/run/streamResumeAcceptance.test.ts
@@ -147,4 +147,49 @@ describe('stream resume acceptance (g5.2 three surfaces × four scenarios)', () 
     expect(runEntry).toMatch(/projectDialogueAfterLoad/)
     expect(runWs).toMatch(/projectDialogueAfterLoad/)
   })
+
+  it('g1.2: ACP busy=false must not stop busySeedRetry or clear platform session busy', () => {
+    const inbox = readSrc('lib/inbox/useGatesInbox.ts')
+    const runWs = readSrc('lib/run/useRunDetailWs.ts')
+    // Inbox: acp branch must not assign clarifyLiveBusy or stop retry on !busy.
+    const acpInbox = inbox.slice(inbox.indexOf("if (m.type === 'acp')"))
+    const acpInboxBlock = acpInbox.slice(0, acpInbox.indexOf('return') + 20)
+    expect(acpInboxBlock).not.toMatch(/clarifyLiveBusy\.value = !!m\.busy/)
+    expect(acpInboxBlock).not.toMatch(/if \(!m\.busy\) busySeedRetry\.stop\(\)/)
+    expect(acpInboxBlock).toMatch(/observational only|must not overwrite platform|g1\.2/)
+    // Run: ACP may update liveBusy for LiveLog, but must not stop dialogue retry.
+    const acpRun = runWs.slice(runWs.indexOf("if (m.type === 'acp' && m.nodeId)"))
+    const acpRunBlock = acpRun.slice(0, 600)
+    expect(acpRunBlock).not.toMatch(/if \(!m\.busy\) busySeedRetry\.stop\(\)/)
+    expect(runWs).toMatch(/dialoguePlatformBusy/)
+    expect(runWs).toMatch(/Platform session busy only/)
+  })
+
+  it('g1.3: ReviewComposer exposes isSessionBusy', () => {
+    const composer = readSrc('components/run/ReviewComposer.vue')
+    expect(composer).toMatch(/isSessionBusy:\s*\(\)\s*=>/)
+    expect(composer).toMatch(/chatRef\.value\?\.isSessionBusy/)
+  })
+
+  it('g2.2: Public page wires busySeedRetry + foreground re-seed', () => {
+    const pub = readSrc('views/PublicGateApprovalView.vue')
+    expect(pub).toMatch(/createBusySeedRetryController/)
+    expect(pub).toMatch(/maybeStartPublicBusySeedRetry|startPublicBusySeedRetry/)
+    expect(pub).toMatch(/resumeFromForeground/)
+    const resumeIdx = pub.indexOf('async function resumeFromForeground')
+    expect(resumeIdx).toBeGreaterThan(-1)
+    const resumeSlice = pub.slice(resumeIdx, resumeIdx + 500)
+    expect(resumeSlice).toMatch(/publicRailsFilled = false/)
+    expect(resumeSlice).toMatch(/publicBusySeedRetry\.stop/)
+  })
+
+  it('g2.3: applyAcpEvents false must buffer on all three surfaces', () => {
+    const inbox = readSrc('lib/inbox/useGatesInbox.ts')
+    const runWs = readSrc('lib/run/useRunDetailWs.ts')
+    const pub = readSrc('views/PublicGateApprovalView.vue')
+    expect(inbox).toMatch(/deliverOrBufferDialogueAcp/)
+    expect(runWs).toMatch(/deliverOrBufferDialogueAcp/)
+    expect(pub).toMatch(/applyAcpEvents\(events\) === false/)
+    expect(pub).toMatch(/pendingPublicAcp = events/)
+  })
 })

--- a/web/src/lib/run/useRunDetailWs.ts
+++ b/web/src/lib/run/useRunDetailWs.ts
@@ -82,6 +82,12 @@ export function useRunDetailWs(opts: {
   /** Rails applied via seed or live — stops busy seed retry (g3). */
   let dialogueRailsFilled = false
   let dialogueLiveIncremental = false
+  /**
+   * Platform review/clarify session busy per node (queue_state / turn_begin /
+   * reactSessions). Separate from liveBusy which also tracks ACP sandbox dips
+   * for LiveLog — dialogue seed retry must not go idle on ACP busy=false (g1.2).
+   */
+  const dialoguePlatformBusy: Record<string, boolean> = Object.create(null)
   const busySeedRetry = createBusySeedRetryController()
   const wsReconnect = createWsReconnectController({
     connect: () => connectWs({ fromReconnect: true }),
@@ -113,6 +119,7 @@ export function useRunDetailWs(opts: {
     for (const [nodeId, snap] of Object.entries(sessions)) {
       if (!snap || typeof snap !== 'object') continue
       liveBusy[nodeId] = !!snap.busy
+      dialoguePlatformBusy[nodeId] = !!snap.busy
       if (snap.busy) busyNodes.push(nodeId)
       const frame = {
         event: 'queue_state',
@@ -155,7 +162,10 @@ export function useRunDetailWs(opts: {
     await nextTick()
     flushPendingDialogueAcp()
     const stillEmptyBusy = nodeIds.filter(
-      (nid) => liveBusy[nid] && !dialogueRailsFilled && !dialogueLiveIncremental,
+      (nid) =>
+        (!!dialoguePlatformBusy[nid] || !!liveBusy[nid]) &&
+        !dialogueRailsFilled &&
+        !dialogueLiveIncremental,
     )
     if (stillEmptyBusy.length) {
       startDialogueBusySeedRetry(stillEmptyBusy)
@@ -206,13 +216,20 @@ export function useRunDetailWs(opts: {
     busySeedRetry.start(async (signal) => {
       await runBusySeedRetry({
         signal,
-        isBusy: () => nodeIds.some((nid) => !!liveBusy[nid]),
+        // Platform session busy only — ACP sandbox busy=false must not idle out (g1.2).
+        isBusy: () =>
+          nodeIds.some(
+            (nid) =>
+              !!dialoguePlatformBusy[nid] ||
+              !!run.value.reactSessions?.[nid]?.busy ||
+              !!reviewChatRef.value?.isSessionBusy?.(),
+          ),
         hasContent: () => dialogueRailsFilled,
         liveIncrementalReceived: () => dialogueLiveIncremental,
         seed: async () => {
           let any = false
           for (const nid of nodeIds) {
-            if (!liveBusy[nid]) continue
+            if (!dialoguePlatformBusy[nid] && !run.value.reactSessions?.[nid]?.busy) continue
             if (await seedDialogueNodeOnce(nid)) any = true
           }
           flushPendingDialogueAcp()
@@ -292,6 +309,7 @@ export function useRunDetailWs(opts: {
     pendingDialogueAcp.clear()
     dialogueRailsFilled = false
     dialogueLiveIncremental = false
+    for (const k of Object.keys(dialoguePlatformBusy)) delete dialoguePlatformBusy[k]
     busySeedRetry.stop()
   }
 
@@ -408,8 +426,9 @@ export function useRunDetailWs(opts: {
         const wsEvents: AcpEvent[] = m.events || []
         mergeLiveWsAcpPage(m.nodeId, wsEvents)
         if (typeof m.busy === 'boolean') {
+          // LiveLog / sandbox bridge only. Do not stop dialogue busySeedRetry and
+          // do not treat ACP busy=false as platform session idle (g1.2).
           liveBusy[m.nodeId] = m.busy
-          if (!m.busy) busySeedRetry.stop()
         }
         liveNode.value = m.nodeId
         if (!manual.value) selected.value = m.nodeId
@@ -417,9 +436,14 @@ export function useRunDetailWs(opts: {
         applyOrBufferDialogueAcp(m.nodeId, wsEvents, m.busy)
       } else if (m.type === 'review' && m.nodeId) {
         // Prefer matching producer; components also filter by nodeId defensively.
-        if (m.event === 'turn_begin') liveBusy[m.nodeId] = true
+        // Platform session busy (review) is the authority for dialogue seed retry.
+        if (m.event === 'turn_begin') {
+          liveBusy[m.nodeId] = true
+          dialoguePlatformBusy[m.nodeId] = true
+        }
         if (m.event === 'queue_state' && typeof m.busy === 'boolean') {
           liveBusy[m.nodeId] = !!m.busy
+          dialoguePlatformBusy[m.nodeId] = !!m.busy
           if (!m.busy) busySeedRetry.stop()
         }
         if (!selClarify.value || selClarify.value.nodeId === m.nodeId) {
@@ -428,6 +452,7 @@ export function useRunDetailWs(opts: {
         gateApprovalRef.value?.applyReviewFrame?.(m)
         if (m.event === 'turn_done' || m.event === 'error') {
           liveBusy[m.nodeId] = false
+          dialoguePlatformBusy[m.nodeId] = false
           busySeedRetry.stop()
           loadRun(false)
         }

--- a/web/src/views/PublicGateApprovalView.vue
+++ b/web/src/views/PublicGateApprovalView.vue
@@ -18,6 +18,11 @@ import type { AppPreviewPickPayload } from '@/lib/shared/previewPickUrl'
 import { isAbortError } from '@/lib/run/liveLogRehydrate'
 import { createWsReconnectController } from '@/lib/run/wsReconnect'
 import {
+  createBusySeedRetryController,
+  runBusySeedRetry,
+} from '@/lib/run/busySeedRetry'
+import { pickAcpRails } from '@/lib/run/pendingAcpBuffer'
+import {
   formatRemainingSec,
   mergePublicGatePreview,
   parseShareTokenFromHash,
@@ -538,6 +543,7 @@ function syncChatQueueFromPreview() {
   }
   applyPreviewLiveEvents()
   flushPendingPublicAcp()
+  maybeStartPublicBusySeedRetry()
   refreshLocalChatBusy()
 }
 
@@ -552,6 +558,58 @@ function toAcpEvents(
 
 let pendingPublicAcp: AcpEvent[] | null = null
 let publicWs: WebSocket | undefined
+/** Thought/message rails applied via seed or live — stops busy seed retry. */
+let publicRailsFilled = false
+let publicLiveIncremental = false
+const publicBusySeedRetry = createBusySeedRetryController()
+
+function markPublicRailsFromEvents(events: AcpEvent[] | undefined) {
+  const rails = pickAcpRails(events || [])
+  if (rails.thought || rails.message) {
+    publicRailsFilled = true
+  }
+}
+
+function publicSessionBusy(): boolean {
+  const p = preview.value
+  if (!p) return false
+  const waiting = typeof p.waiting === 'number' ? p.waiting : 0
+  return !!p.sessionBusy || waiting > 0 || !!chatRef.value?.isSessionBusy?.()
+}
+
+function startPublicBusySeedRetry() {
+  publicBusySeedRetry.start(async (signal) => {
+    await runBusySeedRetry({
+      signal,
+      isBusy: () => publicSessionBusy(),
+      hasContent: () => publicRailsFilled,
+      liveIncrementalReceived: () => publicLiveIncremental,
+      seed: async () => {
+        await loadPreview({ silent: true })
+        const events = toAcpEvents(preview.value?.liveEvents)
+        if (!events.length) return publicRailsFilled
+        const applied = deliverPublicAcp(events)
+        if (applied) markPublicRailsFromEvents(events)
+        return publicRailsFilled
+      },
+    })
+  })
+}
+
+/** Start busy-guarded seed when session busy and rails still empty (g2.2). */
+function maybeStartPublicBusySeedRetry() {
+  if (!publicSessionBusy()) {
+    publicBusySeedRetry.stop()
+    return
+  }
+  if (publicRailsFilled || publicLiveIncremental) {
+    publicBusySeedRetry.stop()
+    return
+  }
+  // Already looping — do not reset from silent poll / sync re-entry.
+  if (!publicBusySeedRetry.aborted) return
+  startPublicBusySeedRetry()
+}
 
 function deliverPublicAcp(events: AcpEvent[] | undefined): boolean {
   if (!events?.length) return true
@@ -565,6 +623,7 @@ function deliverPublicAcp(events: AcpEvent[] | undefined): boolean {
     return false
   }
   pendingPublicAcp = null
+  markPublicRailsFromEvents(events)
   return true
 }
 
@@ -593,7 +652,11 @@ function handlePublicWsMessage(raw: string) {
   }
   if (typ === 'acp') {
     const events = Array.isArray(m.events) ? (m.events as AcpEvent[]) : []
-    deliverPublicAcp(events)
+    // ACP busy (if present) must not stop publicBusySeedRetry — platform sessionBusy is authority (g1.2).
+    if (deliverPublicAcp(events)) {
+      const rails = pickAcpRails(events)
+      if (rails.thought || rails.message) publicLiveIncremental = true
+    }
     refreshLocalChatBusy()
   }
 }
@@ -640,10 +703,13 @@ function connectPublicEvents() {
 }
 
 function stopPublicEvents() {
+  publicBusySeedRetry.stop()
   publicWsReconnect.markIntentionalClose()
   publicWs?.close()
   publicWs = undefined
   pendingPublicAcp = null
+  publicRailsFilled = false
+  publicLiveIncremental = false
 }
 
 function clearHash() {
@@ -968,6 +1034,10 @@ async function resumeFromForeground() {
     return
   }
   startRemainingTick()
+  // Same depth as hard load: re-seed liveEvents under busy guard (g2.2).
+  publicRailsFilled = false
+  publicLiveIncremental = false
+  publicBusySeedRetry.stop()
   await loadPreview({ silent: true, issueNonce: true })
   if (canPoll()) startPoll()
 }


### PR DESCRIPTION
Platform session busy stays authoritative for live slots and busySeedRetry;
ACP sandbox busy=false no longer tears down retry. Expose isSessionBusy from
ReviewComposer, add Public busySeedRetry, and lock the screenshot resume probe.

Co-authored-by: Cursor <cursoragent@cursor.com>
