### PR TITLE
fix(web): round enlarge CTA and float mobile nav drawer

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4671,9 +4671,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {

--- a/web/src/components/project/ProjectAuditPanel.vue
+++ b/web/src/components/project/ProjectAuditPanel.vue
@@ -1193,6 +1193,7 @@ onUnmounted(() => {
   background: rgb(var(--c-elevated));
   padding: 3px;
   gap: 2px;
+  border-radius: 8px;
 }
 .seg button {
   border: 0;
@@ -1204,6 +1205,7 @@ onUnmounted(() => {
   color: rgb(var(--c-txt2));
   cursor: pointer;
   font-weight: 500;
+  border-radius: 6px;
 }
 .seg button:hover {
   color: rgb(var(--c-txt));
@@ -1234,6 +1236,7 @@ onUnmounted(() => {
   border: 1px solid rgb(var(--c-line));
   background: rgb(var(--c-surface));
   padding: 0 10px;
+  border-radius: 8px;
 }
 .search:focus-within {
   border-color: rgb(var(--c-accent));
@@ -1282,6 +1285,7 @@ onUnmounted(() => {
   font-weight: 500;
   cursor: pointer;
   white-space: nowrap;
+  border-radius: 8px;
 }
 .btn:hover:not(:disabled) {
   background: rgb(var(--c-elevated));
@@ -1745,6 +1749,7 @@ tr.detail td {
   color: inherit;
   cursor: pointer;
   transition: border-color 0.15s ease, background 0.15s ease;
+  border-radius: 12px;
 }
 .event-card:hover {
   border-color: rgb(var(--c-accent));

--- a/web/src/components/project/RequirementDraftsPanel.vue
+++ b/web/src/components/project/RequirementDraftsPanel.vue
@@ -1229,6 +1229,7 @@ defineExpose({
   padding: 3px;
   background: rgb(var(--c-elevated));
   border: 1px solid rgb(var(--c-line));
+  border-radius: 8px;
 }
 .seg button {
   border: 0;
@@ -1242,6 +1243,7 @@ defineExpose({
   cursor: pointer;
   font-weight: 500;
   white-space: nowrap;
+  border-radius: 6px;
 }
 .seg button:hover {
   color: rgb(var(--c-txt));

--- a/web/src/components/run/GateShareLinkPanel.vue
+++ b/web/src/components/run/GateShareLinkPanel.vue
@@ -365,7 +365,7 @@ function close() {
 
         <button
           type="button"
-          class="inline-flex min-h-11 w-full items-center justify-center gap-2 bg-accent px-3 text-sm font-medium text-white hover:bg-accent-2 disabled:opacity-45"
+          class="rounded-md inline-flex min-h-11 w-full items-center justify-center gap-2 bg-accent px-3 text-sm font-medium text-white hover:bg-accent-2 disabled:opacity-45"
           data-testid="gate-share-create"
           :disabled="busy"
           :aria-busy="busy ? 'true' : undefined"
@@ -419,7 +419,7 @@ function close() {
         <div class="flex flex-wrap gap-2">
           <button
             type="button"
-            class="inline-flex min-h-11 items-center gap-1.5 bg-accent px-3 text-xs font-medium text-white hover:bg-accent-2 disabled:opacity-45"
+            class="rounded-md inline-flex min-h-11 items-center gap-1.5 bg-accent px-3 text-xs font-medium text-white hover:bg-accent-2 disabled:opacity-45"
             data-testid="gate-share-copy"
             :disabled="busy || !copyAllowed"
             :aria-busy="busy ? 'true' : undefined"
@@ -465,7 +465,7 @@ function close() {
         <div class="mt-3 flex gap-2">
           <button
             type="button"
-            class="min-h-11 bg-accent px-3 text-xs font-medium text-white"
+            class="rounded-md min-h-11 bg-accent px-3 text-xs font-medium text-white"
             data-testid="gate-share-confirm-ok"
             :disabled="busy"
             @click="confirmKind === 'regen' ? confirmRegen() : confirmRevoke()"

--- a/web/src/components/run/OutputResultCards.vue
+++ b/web/src/components/run/OutputResultCards.vue
@@ -178,7 +178,7 @@ function closeEnlarge() {
     <!-- Multi-card name+status list (g1.2 / g3.2): no max-height / own overflow. -->
     <div
       v-if="showList"
-      class="rounded-lg mb-3 border border-line bg-base"
+      class="rounded-lg mb-3 overflow-hidden border border-line bg-base"
       role="listbox"
       :aria-label="t('pages.nodeOutput.outputCards.listTitle')"
       data-testid="output-result-list"
@@ -241,7 +241,7 @@ function closeEnlarge() {
         <button
           v-if="canEnlarge"
           type="button"
-          class="inline-flex shrink-0 items-center bg-accent px-2.5 py-1.5 text-[12px] font-medium text-white hover:bg-accent-2"
+          class="rounded-lg inline-flex shrink-0 items-center bg-accent px-2.5 py-1.5 text-[12px] font-medium text-white hover:bg-accent-2"
           data-testid="output-result-enlarge"
           @click="openEnlarge"
         >

--- a/web/src/components/run/UpstreamRequirementContext.vue
+++ b/web/src/components/run/UpstreamRequirementContext.vue
@@ -163,7 +163,7 @@ watch(visible, (isVisible) => {
       </div>
       <button
         type="button"
-        class="enlarge-btn inline-flex shrink-0 items-center gap-1.5 bg-accent px-2.5 py-1 text-[11px] font-medium text-white transition hover:bg-accent-2"
+        class="enlarge-btn inline-flex shrink-0 items-center gap-1.5 rounded-md bg-accent px-2.5 py-1 text-[11px] font-medium text-white transition hover:bg-accent-2"
         data-testid="upstream-enlarge"
         :title="enlargeLabel"
         :aria-label="enlargeLabel"

--- a/web/src/components/shell/AppShell.test.ts
+++ b/web/src/components/shell/AppShell.test.ts
@@ -206,7 +206,12 @@ describe('AppShell (no topbar + floating ball)', () => {
       'utf8',
     )
     expect(src).toMatch(/bg-black\/50 md:hidden/)
-    expect(src).toMatch(/shadow-drawer md:hidden/)
+    expect(src).toMatch(/app-sidebar-card[\s\S]*?md:hidden|md:hidden[\s\S]*?data-testid="mobile-nav-drawer"/)
+    const aside = src.match(/<aside[\s\S]*?data-testid="mobile-nav-drawer"[\s\S]*?>/)?.[0]
+    expect(aside).toBeTruthy()
+    expect(aside!).toMatch(/\bapp-sidebar-card\b/)
+    expect(aside!).toMatch(/\bmd:hidden\b/)
+    expect(aside!).not.toMatch(/\binset-y-0\b/)
     expect(src).not.toMatch(/<AppTopbar/)
   })
 

--- a/web/src/components/shell/AppShell.vue
+++ b/web/src/components/shell/AppShell.vue
@@ -186,13 +186,13 @@ onUnmounted(() => stopShutdownPolling())
       <Transition name="drawer-slide">
         <aside
           v-if="drawerOpen"
-          class="fixed inset-y-0 left-0 z-50 flex w-[min(280px,85vw)] flex-col border-r border-line bg-surface shadow-drawer md:hidden"
+          class="app-sidebar-card fixed bottom-3.5 left-3.5 top-3.5 z-50 flex w-[min(280px,calc(85vw-14px))] flex-col bg-surface md:hidden"
           data-testid="mobile-nav-drawer"
         >
           <div class="safe-area-top flex h-14 items-center justify-between gap-2 px-4">
             <BrandLogo />
             <button
-              class="flex h-11 w-11 items-center justify-center text-txt2 hover:bg-elevated hover:text-txt"
+              class="flex h-11 w-11 items-center justify-center rounded-md text-txt2 hover:bg-elevated hover:text-txt"
               :aria-label="t('shell.aria.closeNav')"
               data-testid="mobile-nav-close"
               @click="closeDrawer"

--- a/web/src/components/shell/StatusMetrics.vue
+++ b/web/src/components/shell/StatusMetrics.vue
@@ -224,7 +224,7 @@ function onBlurTip(id: string) {
       v-else
       ref="compactTrigger"
       type="button"
-      class="sm-item sm-compact relative inline-flex w-full items-center gap-2 border-0 bg-elevated px-2 py-1.5 text-[11px] text-inherit hover:bg-elevated hover:text-txt focus-visible:bg-elevated focus-visible:text-txt focus-visible:outline-none"
+      class="sm-item sm-compact relative inline-flex w-full items-center gap-2 rounded-md border-0 bg-elevated px-2 py-1.5 text-[11px] text-inherit hover:bg-elevated hover:text-txt focus-visible:bg-elevated focus-visible:text-txt focus-visible:outline-none"
       :class="tipOpen === 'compact' ? 'text-txt tip-open' : ''"
       data-testid="status-metrics-compact"
       :aria-label="t('shell.statusMetrics.compactAria')"

--- a/web/src/components/ui/AppDrawer.vue
+++ b/web/src/components/ui/AppDrawer.vue
@@ -11,8 +11,8 @@ const emit = defineEmits<{ (e: 'close'): void }>()
       <div v-if="open" class="fixed inset-0 z-40">
         <div class="absolute inset-0 bg-black/50" @click="emit('close')" />
         <div
-          class="absolute right-0 top-0 flex h-full flex-col border-l border-line bg-surface shadow-drawer"
-          :style="{ width: (width || 420) + 'px', maxWidth: '100vw' }"
+          class="app-sidebar-card absolute bottom-3.5 right-3.5 top-3.5 flex flex-col bg-surface"
+          :style="{ width: (width || 420) + 'px', maxWidth: 'calc(100vw - 28px)' }"
         >
           <div class="flex h-14 shrink-0 items-center gap-2 border-b border-line px-4">
             <div class="flex-1 text-sm font-semibold text-txt">{{ title }}</div>

--- a/web/src/components/ui/LangSelect.vue
+++ b/web/src/components/ui/LangSelect.vue
@@ -92,7 +92,7 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
       class="flex items-center text-txt2 transition hover:bg-elevated hover:text-txt"
       :class="
         variant === 'ghost'
-          ? ['h-8 gap-1.5 border-0 bg-transparent px-2 text-xs', open ? 'bg-elevated text-txt' : '']
+          ? ['h-8 gap-1.5 rounded-md border-0 bg-transparent px-2 text-xs', open ? 'bg-elevated text-txt' : '']
           : ['gap-2 rounded-md border border-line bg-surface px-3 py-1.5 text-sm', open ? 'border-accent/60 text-txt' : '']
       "
       :aria-label="t('shell.langSelect')"

--- a/web/src/styles/radiusZeroClearance.test.ts
+++ b/web/src/styles/radiusZeroClearance.test.ts
@@ -97,4 +97,80 @@ describe('radius zero clearance', () => {
     expect(src).toMatch(/\.home-pipeline-select__panel\s*\{[^}]*border-radius:\s*12px/s)
     expect(src).toMatch(/\.home-pipeline-select__search\s*\{[^}]*border-radius:\s*8px/s)
   })
+
+  // plan g1.1 / g1.2 / g3.1 — screenshot: 运行产出「放大查看」+ list radius clip
+  it('OutputResultCards enlarge button is rounded and list clips corners', () => {
+    const src = read('components/run/OutputResultCards.vue')
+    const enlarge = src.match(/<button[\s\S]*?data-testid="output-result-enlarge"[\s\S]*?>/)?.[0]
+    expect(enlarge).toBeTruthy()
+    expect(enlarge!).toMatch(/\brounded-(?:md|lg)\b/)
+    const list = src.match(/<div[\s\S]*?data-testid="output-result-list"[\s\S]*?>/)?.[0]
+    expect(list).toBeTruthy()
+    expect(list!).toMatch(/\brounded-lg\b/)
+    expect(list!).toMatch(/\boverflow-hidden\b/)
+  })
+
+  // plan g2.1 / g3.1 — screenshot: mobile nav drawer 16px floating card
+  it('AppShell mobile-nav-drawer is app-sidebar-card with inset (not flush inset-y-0)', () => {
+    const src = read('components/shell/AppShell.vue')
+    const aside = src.match(/<aside[\s\S]*?data-testid="mobile-nav-drawer"[\s\S]*?>/)?.[0]
+    expect(aside).toBeTruthy()
+    expect(aside!).toMatch(/\bapp-sidebar-card\b/)
+    expect(aside!).not.toMatch(/\binset-y-0\b/)
+    expect(aside!).toMatch(/\bleft-3\.5\b/)
+    const close = src.match(/<button[\s\S]*?data-testid="mobile-nav-close"[\s\S]*?>/)?.[0]
+    expect(close).toBeTruthy()
+    expect(close!).toMatch(/\brounded-md\b/)
+  })
+
+  it('StatusMetrics compact strip uses control 8px rounded-md', () => {
+    const src = read('components/shell/StatusMetrics.vue')
+    const compact = src.match(/<button[\s\S]*?data-testid="status-metrics-compact"[\s\S]*?>/)?.[0]
+    expect(compact).toBeTruthy()
+    expect(compact!).toMatch(/\brounded-md\b/)
+  })
+
+  it('AppDrawer sheet follows shell 16px via app-sidebar-card', () => {
+    const src = read('components/ui/AppDrawer.vue')
+    expect(src).toMatch(/\bapp-sidebar-card\b/)
+  })
+
+  it('ProjectAuditPanel scoped boxed controls use role radii (plan g3.2)', () => {
+    const src = read('components/project/ProjectAuditPanel.vue')
+    expect(src).toMatch(/\.btn\s*\{[^}]*border-radius:\s*8px/s)
+    expect(src).toMatch(/\.search\s*\{[^}]*border-radius:\s*8px/s)
+    expect(src).toMatch(/\.seg\s*\{[^}]*border-radius:\s*8px/s)
+    expect(src).toMatch(/\.event-card\s*\{[^}]*border-radius:\s*12px/s)
+  })
+
+  it('RequirementDraftsPanel .seg track is control 8px (plan g3.2)', () => {
+    const src = read('components/project/RequirementDraftsPanel.vue')
+    expect(src).toMatch(/\.seg\s*\{[^}]*border-radius:\s*8px/s)
+  })
+
+  it('LangSelect ghost trigger uses control rounded-md (plan g3.2)', () => {
+    const src = read('components/ui/LangSelect.vue')
+    expect(src).toMatch(/variant === 'ghost'[\s\S]*?\brounded-md\b/)
+  })
+
+  it('同源 bg-accent solid keys carry rounded (plan g1.3)', () => {
+    const upstream = read('components/run/UpstreamRequirementContext.vue')
+    const enlarge = upstream.match(/<button[\s\S]*?data-testid="upstream-enlarge"[\s\S]*?>/g)
+    expect(enlarge?.length).toBeGreaterThanOrEqual(1)
+    for (const btn of enlarge!) {
+      if (btn.includes('bg-accent')) expect(btn).toMatch(/\brounded-md\b/)
+    }
+    const share = read('components/run/GateShareLinkPanel.vue')
+    for (const id of ['gate-share-create', 'gate-share-copy', 'gate-share-confirm-ok']) {
+      const btn = share.match(new RegExp(`<button[\\s\\S]*?data-testid="${id}"[\\s\\S]*?>`))?.[0]
+      expect(btn).toBeTruthy()
+      expect(btn!).toMatch(/\brounded-md\b/)
+    }
+    const pub = read('views/PublicGateApprovalView.vue')
+    for (const id of ['public-gate-upstream-enlarge', 'public-gate-upstream-retry']) {
+      const btn = pub.match(new RegExp(`<button[\\s\\S]*?data-testid="${id}"[\\s\\S]*?>`))?.[0]
+      expect(btn).toBeTruthy()
+      expect(btn!).toMatch(/\brounded-md\b/)
+    }
+  })
 })

--- a/web/src/views/PublicGateApprovalView.vue
+++ b/web/src/views/PublicGateApprovalView.vue
@@ -1293,7 +1293,7 @@ defineExpose({ loadPreview, loadUpstreamFull, openUpstreamModal })
           <button
             v-if="hasUpstream"
             type="button"
-            class="inline-flex items-center gap-1.5 bg-accent px-2.5 py-1 text-[11px] font-medium text-white hover:bg-accent-2"
+            class="rounded-md inline-flex items-center gap-1.5 bg-accent px-2.5 py-1 text-[11px] font-medium text-white hover:bg-accent-2"
             data-testid="public-gate-upstream-enlarge"
             @click="openUpstreamModal"
           >
@@ -1379,7 +1379,7 @@ defineExpose({ loadPreview, loadUpstreamFull, openUpstreamModal })
         <p class="text-err">{{ t('pages.gateApproval.upstreamLoadFailed', { error: upstreamLoadErr }) }}</p>
         <button
           type="button"
-          class="inline-flex items-center gap-1.5 bg-accent px-2.5 py-1 text-[11px] font-medium text-white hover:bg-accent-2"
+          class="rounded-md inline-flex items-center gap-1.5 bg-accent px-2.5 py-1 text-[11px] font-medium text-white hover:bg-accent-2"
           data-testid="public-gate-upstream-retry"
           @click="retryUpstreamLoad"
         >


### PR DESCRIPTION
Make screenshot-confirmed surfaces use visible role radii: output-result-enlarge + list overflow clip, mobile-nav-drawer as app-sidebar-card inset float, and leftover scoped/bg-accent controls; lock with radiusZeroClearance (plan g1–g3).

Co-authored-by: Cursor <cursoragent@cursor.com>
