### PR TITLE
fix(onboarding): clone on all agents and show default workflow on Home

### DIFF
--- a/server/internal/services/first_install_embed.go
+++ b/server/internal/services/first_install_embed.go
@@ -53,6 +53,9 @@ func loadFirstInstallAgentTemplate(name string) (Agent, error) {
 		env[k] = v
 	}
 	env = stripTokenKeysFromEnvMap(env)
+	if _, ok := env["GIT_REPOS"]; !ok {
+		env["GIT_REPOS"] = "${vars.repos}"
+	}
 	mcp := cfg.MCP
 	if len(mcp) == 0 {
 		mcp = DefaultPlatformMCP()

--- a/server/internal/services/first_install_embed_test.go
+++ b/server/internal/services/first_install_embed_test.go
@@ -38,6 +38,9 @@ func TestFirstInstallEmbedFSHasWorkspaceMarkdown(t *testing.T) {
 		if len(agent.Files) == 0 {
 			t.Fatalf("%s template Files empty after embed load", name)
 		}
+		if got := agent.Env["GIT_REPOS"]; got != "${vars.repos}" {
+			t.Fatalf("%s GIT_REPOS = %q, want ${vars.repos}", name, got)
+		}
 		for _, f := range agent.Files {
 			if looksLikeCloneURL(f.Content) {
 				t.Fatalf("%s file %s contains a clone URL; first-install files must stay host-agnostic", name, f.Path)

--- a/server/internal/services/onboarding.go
+++ b/server/internal/services/onboarding.go
@@ -161,6 +161,10 @@ func (s *OnboardingService) Bootstrap(projectID string, req OnboardingBootstrapR
 	if err != nil {
 		return OnboardingBootstrapResult{}, fmt.Errorf("publish workflow: %w", err)
 	}
+	published, err = s.WF.UpdateShowOnHome(published.ID, true)
+	if err != nil {
+		return OnboardingBootstrapResult{}, fmt.Errorf("show workflow on home: %w", err)
+	}
 
 	return OnboardingBootstrapResult{
 		AgentIDs:   agentIDs,

--- a/server/internal/services/onboarding_test.go
+++ b/server/internal/services/onboarding_test.go
@@ -95,6 +95,9 @@ func TestOnboardingBootstrapCreatesTeamAndDefaultWorkflow(t *testing.T) {
 		if a.AcpBackend != "cursor" {
 			t.Fatalf("agent %s backend = %q", name, a.AcpBackend)
 		}
+		if got := a.Env["GIT_REPOS"]; got != "${vars.repos}" {
+			t.Fatalf("agent %s GIT_REPOS = %q, want ${vars.repos}", name, got)
+		}
 	}
 
 	wf, ok := svc.WF.Get(res.WorkflowID)
@@ -103,6 +106,9 @@ func TestOnboardingBootstrapCreatesTeamAndDefaultWorkflow(t *testing.T) {
 	}
 	if wf.Name != services.OnboardingWorkflowName || wf.Status != "published" || !wf.NeedsRepo {
 		t.Fatalf("workflow meta: name=%s status=%s needsRepo=%v", wf.Name, wf.Status, wf.NeedsRepo)
+	}
+	if !wf.ShowOnHome {
+		t.Fatal("default workflow should be visible on Home")
 	}
 	assertDefaultWorkflowGraph(t, wf.Graph)
 }
@@ -265,6 +271,9 @@ func TestOnboardingBootstrapIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first: %v", err)
 	}
+	if _, err := svc.WF.UpdateShowOnHome(r1.WorkflowID, false); err != nil {
+		t.Fatalf("hide before second bootstrap: %v", err)
+	}
 	req.APIKey = "k2-rotated"
 	r2, err := svc.Bootstrap(projectID, req)
 	if err != nil {
@@ -282,6 +291,10 @@ func TestOnboardingBootstrapIdempotent(t *testing.T) {
 	shared := svc.SharedAgent.Get(projectID)
 	if shared.Env["APPROVING_CURSOR_API_KEY"] != "k2-rotated" {
 		t.Fatalf("auth not updated: %+v", shared.Env)
+	}
+	wf, ok := svc.WF.Get(r2.WorkflowID)
+	if !ok || !wf.ShowOnHome {
+		t.Fatalf("second bootstrap should restore Home visibility: ok=%v showOnHome=%v", ok, wf.ShowOnHome)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Default first-install agents that omit `GIT_REPOS` now inherit `${vars.repos}`, so Implement / Test / Review / Preview clone like Approve.
- Bootstrap publishes 默认工作流 with Home visibility on, so it appears in the dashboard pipeline picker.
- Re-running the wizard restores Home visibility if it was turned off.

## Test plan
- [x] `go test ./internal/services -run 'TestFirstInstallEmbed|TestOnboardingBootstrap'`
- [x] `go test ./internal/services`
- [ ] Fresh first-install: 默认工作流 on Home; start Implement and confirm sandbox clones `vars.repos`
- [ ] Re-run wizard after hiding the pipeline: it shows on Home again


Made with [Cursor](https://cursor.com)