### PR TITLE
auto/navigation runs notifications

### DIFF
--- a/web/e2e/notifications-center.spec.ts
+++ b/web/e2e/notifications-center.spec.ts
@@ -58,8 +58,11 @@ test.describe('shell notification center (IA separation)', () => {
     const badge = page.getByTestId('run-notifications-badge')
     await expect(badge).toBeVisible()
     await expect(badge).toHaveText('3')
-    // Sidebar notifications badge shares the same unreadCount.
-    await expect(page.getByTestId('nav-notifications-badge')).toHaveText('3')
+    // Workspace chrome: unread stays on the bell, not a primary 通知 item (plan g2.1).
+    await expect(page.getByTestId('nav-workspace-chrome')).toBeVisible()
+    await expect(page.getByTestId('nav-notifications-badge')).toHaveCount(0)
+    await expect(page.getByRole('link', { name: '运行' })).toBeVisible()
+    await expect(page.getByTestId('nav-workspace-chrome').getByRole('link', { name: '通知' })).toHaveCount(0)
 
     await page.getByTestId('run-notifications-bell').click()
     const panel = page.getByTestId('run-notifications-panel')
@@ -80,10 +83,11 @@ test.describe('shell notification center (IA separation)', () => {
     await expect(page.getByTestId('nav-notifications-badge')).toHaveText('3')
     await expect(page.getByTestId('run-notifications-badge')).toHaveText('3')
 
-    // Workspace dual entry: notifications + gates stay; runs live under settings chrome (plan g1.1)
+    // /notifications uses settings chrome: 通知 is highlighted; 运行/待审批 are not in this sidebar.
+    await expect(page.getByTestId('nav-settings-chrome')).toBeVisible()
     await expect(page.getByRole('link', { name: '通知' })).toBeVisible()
-    await expect(page.getByRole('link', { name: '设置' })).toBeVisible()
-    await expect(page.getByRole('link', { name: '待审批' })).toBeVisible()
+    await expect(page.getByTestId('nav-back-home')).toBeVisible()
+    await expect(page.getByRole('link', { name: '待审批' })).toHaveCount(0)
     await expect(page.getByRole('link', { name: '运行' })).toHaveCount(0)
 
     await page.getByTestId('notifications-filter-unread').click()
@@ -99,7 +103,8 @@ test.describe('shell notification center (IA separation)', () => {
     await settleAuth(page)
 
     await expect(page.getByTestId('run-notifications-badge')).toHaveText('7')
-    await expect(page.getByTestId('nav-notifications-badge')).toHaveText('7')
+    await expect(page.getByTestId('nav-workspace-chrome')).toBeVisible()
+    await expect(page.getByTestId('nav-notifications-badge')).toHaveCount(0)
 
     await page.getByTestId('run-notifications-bell').click()
     const panel = page.getByTestId('run-notifications-panel')
@@ -108,6 +113,12 @@ test.describe('shell notification center (IA separation)', () => {
 
     await page.getByTestId('run-notifications-mark-all').click()
     await expect(page.getByTestId('run-notifications-badge')).toHaveCount(0)
+    await page.keyboard.press('Escape')
+    await expect(page.getByTestId('run-notifications-panel')).toHaveCount(0)
+    await page.getByRole('link', { name: '设置' }).click()
+    await expect(page.getByTestId('nav-settings-chrome')).toBeVisible()
+    await page.getByRole('link', { name: '通知' }).click()
+    await expect(page.getByTestId('notifications-page')).toBeVisible()
     await expect(page.getByTestId('nav-notifications-badge')).toHaveCount(0)
   })
 

--- a/web/src/components/shell/AppSidebarNav.test.ts
+++ b/web/src/components/shell/AppSidebarNav.test.ts
@@ -129,25 +129,28 @@ describe('AppSidebarNav', () => {
     vi.useRealTimers()
   })
 
-  it('shows /gates badge from pending gates and hides /notifications badge when unread is 0', async () => {
-    notifMocks.unreadCount.value = 0
+  it('shows the gates badge without exposing notifications in workspace chrome', async () => {
+    notifMocks.unreadCount.value = 46
     const wrapper = mountNav()
     await flushPromises()
     expect(wrapper.find('[data-testid="nav-gates-badge"]').text()).toBe('2')
+    expect(wrapper.find('[data-to="/notifications"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="nav-notifications-badge"]').exists()).toBe(false)
     wrapper.unmount()
     vi.useRealTimers()
   })
 
-  it('shows /notifications unread badge from the same unreadCount as topbar', async () => {
+  it('shows the notification badge from the shared unreadCount in settings chrome', async () => {
+    routeState.path = '/notifications'
     notifMocks.unreadCount.value = 46
     const wrapper = mountNav()
     await flushPromises()
     const badge = wrapper.find('[data-testid="nav-notifications-badge"]')
     expect(badge.exists()).toBe(true)
     expect(badge.text()).toBe('46')
-    // Gates badge remains independent.
-    expect(wrapper.find('[data-testid="nav-gates-badge"]').text()).toBe('2')
+    expect(wrapper.find('[data-to="/notifications"]').classes()).toContain('active')
+    expect(wrapper.find('[data-testid="nav-settings-chrome"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="nav-gates-badge"]').exists()).toBe(false)
     wrapper.unmount()
     vi.useRealTimers()
   })
@@ -158,7 +161,8 @@ describe('AppSidebarNav', () => {
     expect(wrapper.find('[data-testid="nav-quick-pipelines"]').exists()).toBe(false)
     expect(wrapper.text()).not.toContain('快捷流水线')
     // Primary workspace nav still present (plan g1.1)
-    expect(wrapper.find('[data-to="/notifications"]').exists()).toBe(true)
+    expect(wrapper.find('[data-to="/runs"]').exists()).toBe(true)
+    expect(wrapper.find('[data-to="/notifications"]').exists()).toBe(false)
     expect(wrapper.find('[data-to="/settings"]').exists()).toBe(true)
     expect(wrapper.find('[data-to="/dashboard"]').exists()).toBe(true)
     expect(wrapper.find('[data-to="/gates"]').exists()).toBe(true)
@@ -273,7 +277,8 @@ describe('AppSidebarNav', () => {
     expect(wrapper.find('[data-testid="nav-back-home"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="nav-back-home"]').attributes('data-to')).toBe('/dashboard')
     expect(wrapper.find('[data-to="/projects"]').exists()).toBe(true)
-    expect(wrapper.find('[data-to="/runs"]').exists()).toBe(true)
+    expect(wrapper.find('[data-to="/notifications"]').exists()).toBe(true)
+    expect(wrapper.find('[data-to="/runs"]').exists()).toBe(false)
     expect(wrapper.find('[data-to="/stats"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="nav-settings-integrations"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="nav-quick-pipelines"]').exists()).toBe(false)
@@ -311,6 +316,17 @@ describe('AppSidebarNav', () => {
     await flushPromises()
     expect(wrapper.find('[data-testid="nav-workspace-chrome"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="nav-settings-chrome"]').exists()).toBe(false)
+    wrapper.unmount()
+    vi.useRealTimers()
+  })
+
+  it('uses workspace chrome and highlights runs for the run list', async () => {
+    routeState.path = '/runs'
+    const wrapper = mountNav()
+    await flushPromises()
+    expect(wrapper.find('[data-testid="nav-workspace-chrome"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="nav-settings-chrome"]').exists()).toBe(false)
+    expect(wrapper.find('[data-to="/runs"]').classes()).toContain('active')
     wrapper.unmount()
     vi.useRealTimers()
   })

--- a/web/src/components/shell/AppSidebarNav.vue
+++ b/web/src/components/shell/AppSidebarNav.vue
@@ -27,7 +27,7 @@ const toast = useToast()
 
 // Shared singleton source so approving a gate elsewhere updates the badge immediately.
 const { count: gateCount, peek, refresh } = usePendingGates()
-        // Same unreadCount singleton as shell chrome bell — keep sidebar /notifications badge in sync.
+// Same unreadCount singleton as shell chrome bell — keep the settings notification badge in sync.
 const { unreadCount } = useRunTerminalNotifications()
 const { displayItems, hydrateDisplay, unfavorite, getFavoriteWorkflow, reorderFavorites } = useWorkflowFavorites()
 const { openLaunch } = useWorkflowRunLaunch()
@@ -249,6 +249,11 @@ const settingsItems = settingsNavItems
         >
           <Icon :name="item.icon" :size="17" />
           <span class="flex-1">{{ t(item.labelKey) }}</span>
+          <span
+            v-if="badgeFor(item.to)"
+            class="force-radius-full flex h-5 min-w-5 items-center justify-center rounded-full bg-accent px-1.5 text-[11px] font-semibold text-white"
+            :data-testid="item.to === '/notifications' ? 'nav-notifications-badge' : undefined"
+          >{{ badgeFor(item.to) }}</span>
         </RouterLink>
       </template>
     </div>
@@ -268,7 +273,7 @@ const settingsItems = settingsNavItems
         <span
           v-if="badgeFor(item.to)"
           class="force-radius-full flex h-5 min-w-5 items-center justify-center rounded-full bg-accent px-1.5 text-[11px] font-semibold text-white"
-          :data-testid="item.to === '/notifications' ? 'nav-notifications-badge' : item.to === '/gates' ? 'nav-gates-badge' : undefined"
+          :data-testid="item.to === '/gates' ? 'nav-gates-badge' : undefined"
         >{{ badgeFor(item.to) }}</span>
       </RouterLink>
     </div>

--- a/web/src/data/settingsNav.test.ts
+++ b/web/src/data/settingsNav.test.ts
@@ -10,7 +10,7 @@ describe('settingsNav (plan g2.1 / g2.2 / g2.3)', () => {
   it('lists subnav in the confirmed order', () => {
     expect(settingsNavItems.map((i) => i.labelKey)).toEqual([
       'nav.projects',
-      'nav.runs',
+      'nav.notifications',
       'nav.stats',
       'nav.artifacts',
       'nav.agents',
@@ -21,7 +21,7 @@ describe('settingsNav (plan g2.1 / g2.2 / g2.3)', () => {
     ])
     expect(settingsNavItems.map((i) => i.to)).toEqual([
       '/projects',
-      '/runs',
+      '/notifications',
       '/stats',
       '/artifacts',
       '/agents',
@@ -37,10 +37,10 @@ describe('settingsNav (plan g2.1 / g2.2 / g2.3)', () => {
     expect(isSettingsChrome('/settings/platform-rules')).toBe(true)
     expect(isSettingsChrome('/projects')).toBe(true)
     expect(isSettingsChrome('/projects/abc')).toBe(true)
-    expect(isSettingsChrome('/runs')).toBe(true)
+    expect(isSettingsChrome('/notifications')).toBe(true)
     expect(isSettingsChrome('/dashboard')).toBe(false)
     expect(isSettingsChrome('/gates')).toBe(false)
-    expect(isSettingsChrome('/notifications')).toBe(false)
+    expect(isSettingsChrome('/runs')).toBe(false)
     expect(isSettingsChrome('/runs/rid', true)).toBe(false)
     expect(isSettingsChrome('/sandboxes/sid/console', true)).toBe(false)
   })

--- a/web/src/data/settingsNav.ts
+++ b/web/src/data/settingsNav.ts
@@ -8,12 +8,12 @@ export type SettingsNavItem = SidebarNavItem & {
 }
 
 /**
- * Settings-chrome subnav order (plan g2.1):
- * Projects, Runs, Stats, Artifacts, Agents, Sandboxes, General, Platform rules, Integrations.
+ * Settings-chrome subnav order (plan g1.2):
+ * Projects, Notifications, Stats, Artifacts, Agents, Sandboxes, General, Platform rules, Integrations.
  */
 export const settingsNavItems: SettingsNavItem[] = [
   { to: '/projects', icon: 'folder', labelKey: 'nav.projects' },
-  { to: '/runs', icon: 'runs', labelKey: 'nav.runs' },
+  { to: '/notifications', icon: 'bell', labelKey: 'nav.notifications' },
   { to: '/stats', icon: 'chart', labelKey: 'nav.stats' },
   { to: '/artifacts', icon: 'artifact', labelKey: 'nav.artifacts' },
   { to: '/agents', icon: 'robot', labelKey: 'nav.agents' },
@@ -31,7 +31,7 @@ export const settingsNavItems: SettingsNavItem[] = [
 
 export const SETTINGS_CHROME_PREFIXES = [
   '/projects',
-  '/runs',
+  '/notifications',
   '/stats',
   '/artifacts',
   '/agents',

--- a/web/src/data/sidebarNav.test.ts
+++ b/web/src/data/sidebarNav.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from 'vitest'
 import { sidebarNavGroups } from './sidebarNav'
 
 describe('sidebarNav (plan g1.1)', () => {
-  it('workspace primary is exactly home / gates / notifications / settings', () => {
+  it('workspace primary is exactly home / gates / runs / settings', () => {
     expect(sidebarNavGroups).toHaveLength(1)
     expect(sidebarNavGroups[0].titleKey).toBeUndefined()
     expect(sidebarNavGroups[0].items.map((i) => i.to)).toEqual([
       '/dashboard',
       '/gates',
-      '/notifications',
+      '/runs',
       '/settings',
     ])
   })
@@ -17,7 +17,7 @@ describe('sidebarNav (plan g1.1)', () => {
     const allTos = sidebarNavGroups.flatMap((g) => g.items.map((i) => i.to))
     expect(allTos).not.toContain('/stats')
     expect(allTos).not.toContain('/projects')
-    expect(allTos).not.toContain('/runs')
+    expect(allTos).not.toContain('/notifications')
     expect(allTos).not.toContain('/artifacts')
     expect(allTos).not.toContain('/agents')
     expect(allTos).not.toContain('/sandboxes')
@@ -27,9 +27,9 @@ describe('sidebarNav (plan g1.1)', () => {
     expect(sidebarNavGroups.some((g) => g.titleKey === 'nav.groupConfig')).toBe(false)
   })
 
-  it('keeps notifications and gates label keys for badges (plan g1.2)', () => {
+  it('keeps runs and gates label keys in the workspace nav', () => {
     const items = sidebarNavGroups[0].items
-    expect(items.find((i) => i.to === '/notifications')?.labelKey).toBe('nav.notifications')
+    expect(items.find((i) => i.to === '/runs')?.labelKey).toBe('nav.runs')
     expect(items.find((i) => i.to === '/gates')?.labelKey).toBe('nav.gates')
   })
 })

--- a/web/src/data/sidebarNav.ts
+++ b/web/src/data/sidebarNav.ts
@@ -1,13 +1,13 @@
 export type SidebarNavItem = { to: string; icon: string; labelKey: string }
 export type SidebarNavGroup = { titleKey?: string; items: SidebarNavItem[] }
 
-/** Workspace primary nav: Home / Gates / Notifications / Settings only (plan g1.1). */
+/** Workspace primary nav: Home / Gates / Runs / Settings only (plan g1.1). */
 export const sidebarNavGroups: SidebarNavGroup[] = [
   {
     items: [
       { to: '/dashboard', icon: 'dashboard', labelKey: 'nav.dashboard' },
       { to: '/gates', icon: 'gate', labelKey: 'nav.gates' },
-      { to: '/notifications', icon: 'bell', labelKey: 'nav.notifications' },
+      { to: '/runs', icon: 'runs', labelKey: 'nav.runs' },
       { to: '/settings', icon: 'settings', labelKey: 'nav.settings' },
     ],
   },


### PR DESCRIPTION
- **feat(web): move runs into workspace navigation**
- **test(web): align notifications-center e2e with swapped nav chrome**
