### PR TITLE
Unify run-output modal actions onto AppButton

### DIFF
--- a/web/src/components/run/OutputResultCards.vue
+++ b/web/src/components/run/OutputResultCards.vue
@@ -8,6 +8,7 @@ import {
   visualHtmlArtifactName,
 } from '@/lib/run/isVisualHtmlCard'
 import OutputResultCardBody from './OutputResultCardBody.vue'
+import AppButton from '../ui/AppButton.vue'
 import AppModal from '../ui/AppModal.vue'
 import Icon from '../ui/Icon.vue'
 import type { OutputCard, Run } from '@/lib/shared/types'
@@ -238,15 +239,17 @@ function closeEnlarge() {
           class="rounded-md shrink-0 border border-line px-1.5 py-0.5 text-[10px] text-txt3"
           data-testid="output-result-detail-kind"
         >{{ detailKindLabel(currentCard) }}</span>
-        <button
+        <AppButton
           v-if="canEnlarge"
-          type="button"
-          class="rounded-lg inline-flex shrink-0 items-center bg-accent px-2.5 py-1.5 text-[12px] font-medium text-white hover:bg-accent-2"
+          variant="outline"
+          size="sm"
+          icon="expand"
+          class="shrink-0"
           data-testid="output-result-enlarge"
           @click="openEnlarge"
         >
           {{ t('pages.nodeOutput.outputCards.enlarge') }}
-        </button>
+        </AppButton>
       </div>
 
       <div :data-testid="`output-result-card-body-${selectedIndex}`">

--- a/web/src/components/shell/RunOutputPptModal.test.ts
+++ b/web/src/components/shell/RunOutputPptModal.test.ts
@@ -307,7 +307,7 @@ describe('RunOutputPptModal output result cards (g1/g2)', () => {
     wrapper.unmount()
   })
 
-  it('footer only has mark-as-read and emits mark-read (g3.1)', async () => {
+  it('footer has close + mark-as-read; mark-read emits mark-read (g2.1/g2.3)', async () => {
     apiMocks.getRun.mockResolvedValue({
       id: 'run-1',
       title: 't',
@@ -318,12 +318,31 @@ describe('RunOutputPptModal output result cards (g1/g2)', () => {
     await flushPromises()
     expect(wrapper.find('[data-testid="run-output-open-run"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="run-output-done"]').exists()).toBe(false)
+    const closeBtn = wrapper.find('[data-testid="run-output-close"]')
+    expect(closeBtn.exists()).toBe(true)
+    expect(closeBtn.text()).toContain('关闭')
     const markBtn = wrapper.find('[data-testid="run-output-mark-read"]')
     expect(markBtn.exists()).toBe(true)
     expect(markBtn.text()).toContain('标记已读')
     await markBtn.trigger('click')
     expect(wrapper.emitted('mark-read')).toBeTruthy()
     expect(wrapper.emitted('close')).toBeFalsy()
+    expect(push).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('footer close emits close and does not emit mark-read (g2.3)', async () => {
+    apiMocks.getRun.mockResolvedValue({
+      id: 'run-1',
+      title: 't',
+      workflowName: 'wf',
+      artifacts: [],
+    })
+    const wrapper = mountModal()
+    await flushPromises()
+    await wrapper.find('[data-testid="run-output-close"]').trigger('click')
+    expect(wrapper.emitted('close')).toBeTruthy()
+    expect(wrapper.emitted('mark-read')).toBeFalsy()
     expect(push).not.toHaveBeenCalled()
     wrapper.unmount()
   })

--- a/web/src/components/shell/RunOutputPptModal.vue
+++ b/web/src/components/shell/RunOutputPptModal.vue
@@ -3,6 +3,7 @@ import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import AppModal from '@/components/ui/AppModal.vue'
+import AppButton from '@/components/ui/AppButton.vue'
 import OutputResultCards from '@/components/run/OutputResultCards.vue'
 import { api } from '@/lib/api/api'
 import { resolveOutputFocusNodeId } from '@/lib/run/runOutputSelection'
@@ -159,22 +160,20 @@ function openArtifacts() {
       <p class="max-w-md text-sm text-txt2">{{ t('shell.runNotifications.noFinalResultsHint') }}</p>
       <p class="mt-1.5 max-w-md text-xs text-txt3">{{ t('shell.runNotifications.noFinalResultsNote') }}</p>
       <div class="mt-4 flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          class="rounded-lg border border-transparent bg-accent px-3 py-2 text-[13px] text-white hover:brightness-110"
+        <AppButton
+          variant="primary"
           data-testid="run-output-empty-open-run"
           @click="openRunDetail"
         >
           {{ t('shell.runNotifications.openRunDetail') }}
-        </button>
-        <button
-          type="button"
-          class="rounded-md border border-line bg-transparent px-3 py-2 text-[13px] text-txt2 hover:border-line-strong hover:text-txt"
+        </AppButton>
+        <AppButton
+          variant="outline"
           data-testid="run-output-empty-open-artifacts"
           @click="openArtifacts"
         >
           {{ t('shell.runNotifications.viewArtifacts') }}
-        </button>
+        </AppButton>
       </div>
     </div>
     <div
@@ -204,14 +203,17 @@ function openArtifacts() {
     </div>
 
     <template #footer>
-      <button
-        type="button"
-        class="rounded-lg border border-transparent bg-accent px-3 py-2 text-[13px] text-white hover:brightness-110"
+      <AppButton variant="ghost" data-testid="run-output-close" @click="close">
+        {{ t('common.buttons.close') }}
+      </AppButton>
+      <AppButton
+        variant="primary"
+        icon="check"
         data-testid="run-output-mark-read"
         @click="markRead"
       >
         {{ t('shell.runNotifications.markAsRead') }}
-      </button>
+      </AppButton>
     </template>
   </AppModal>
 </template>

--- a/web/src/styles/radiusZeroClearance.test.ts
+++ b/web/src/styles/radiusZeroClearance.test.ts
@@ -98,16 +98,57 @@ describe('radius zero clearance', () => {
     expect(src).toMatch(/\.home-pipeline-select__search\s*\{[^}]*border-radius:\s*8px/s)
   })
 
-  // plan g1.1 / g1.2 / g3.1 — screenshot: 运行产出「放大查看」+ list radius clip
-  it('OutputResultCards enlarge button is rounded and list clips corners', () => {
+  function appButtonOpenTag(src: string, testid: string): string | undefined {
+    return src.match(new RegExp(`<AppButton\\b[^>]*data-testid="${testid}"[^>]*>`))?.[0]
+  }
+
+  function handwrittenButtonOpenTag(src: string, testid: string): string | undefined {
+    return src.match(new RegExp(`<button\\b[^>]*data-testid="${testid}"[^>]*>`))?.[0]
+  }
+
+  // plan g1.1 / g1.2 / g3.1 — AppButton outline sm expand; list still clips corners
+  it('OutputResultCards enlarge is AppButton outline sm expand and list clips corners', () => {
     const src = read('components/run/OutputResultCards.vue')
-    const enlarge = src.match(/<button[\s\S]*?data-testid="output-result-enlarge"[\s\S]*?>/)?.[0]
+    const enlarge = appButtonOpenTag(src, 'output-result-enlarge')
     expect(enlarge).toBeTruthy()
-    expect(enlarge!).toMatch(/\brounded-(?:md|lg)\b/)
+    expect(enlarge!).toMatch(/variant="outline"/)
+    expect(enlarge!).toMatch(/size="sm"/)
+    expect(enlarge!).toMatch(/icon="expand"/)
+    expect(handwrittenButtonOpenTag(src, 'output-result-enlarge')).toBeUndefined()
+    expect(enlarge!).not.toMatch(/\bbg-accent\b/)
+    expect(enlarge!).not.toMatch(/\brounded-lg\b/)
     const list = src.match(/<div[\s\S]*?data-testid="output-result-list"[\s\S]*?>/)?.[0]
     expect(list).toBeTruthy()
     expect(list!).toMatch(/\brounded-lg\b/)
     expect(list!).toMatch(/\boverflow-hidden\b/)
+  })
+
+  // plan g2.1 / g2.2 / g3.1 — RunOutputPptModal footer + empty exits are AppButton
+  it('RunOutputPptModal mark-read / close / empty exits are AppButton with required variants', () => {
+    const src = read('components/shell/RunOutputPptModal.vue')
+    const mark = appButtonOpenTag(src, 'run-output-mark-read')
+    expect(mark).toBeTruthy()
+    expect(mark!).toMatch(/variant="primary"/)
+    expect(mark!).toMatch(/icon="check"/)
+    expect(handwrittenButtonOpenTag(src, 'run-output-mark-read')).toBeUndefined()
+    expect(mark!).not.toMatch(/\brounded-lg\b/)
+    expect(mark!).not.toMatch(/hover:brightness-110/)
+
+    const close = appButtonOpenTag(src, 'run-output-close')
+    expect(close).toBeTruthy()
+    expect(close!).toMatch(/variant="ghost"/)
+
+    const openRun = appButtonOpenTag(src, 'run-output-empty-open-run')
+    expect(openRun).toBeTruthy()
+    expect(openRun!).toMatch(/variant="primary"/)
+    expect(handwrittenButtonOpenTag(src, 'run-output-empty-open-run')).toBeUndefined()
+    expect(openRun!).not.toMatch(/\brounded-lg\b/)
+    expect(openRun!).not.toMatch(/hover:brightness-110/)
+
+    const artifacts = appButtonOpenTag(src, 'run-output-empty-open-artifacts')
+    expect(artifacts).toBeTruthy()
+    expect(artifacts!).toMatch(/variant="outline"/)
+    expect(handwrittenButtonOpenTag(src, 'run-output-empty-open-artifacts')).toBeUndefined()
   })
 
   // plan g2.1 / g3.1 — screenshot: mobile nav drawer 16px floating card


### PR DESCRIPTION
## Summary
- Align run-output modal actions with AppButton: enlarge is outline/sm + expand; footer is ghost Close + primary Mark as read (check); empty-state uses primary + outline.
- Keep existing events (`close` / `mark-read`) and data-testids; Close does not mark as read.
- Extend `radiusZeroClearance` source contracts so handwritten accent buttons cannot regress.

## Test plan
- [ ] Unit: `radiusZeroClearance.test.ts`, `OutputResultCards.test.ts`, `RunOutputPptModal.test.ts`
- [ ] e2e: notifications-center (mark-read) and run-completed-output (enlarge)
- [ ] Visual: enlarge is not solid accent; footer primary is mark-read only


Made with [Cursor](https://cursor.com)