### PR TITLE
fix(web): pin settings buttons to 36px on desktop with 44px mobile touch.

### DIFF
--- a/web/src/components/settings/IntegrationsModal.vue
+++ b/web/src/components/settings/IntegrationsModal.vue
@@ -92,7 +92,7 @@ function cardIconClass(scope: McpServer['scope']): string {
       <div class="flex min-w-0 flex-1 items-center gap-2">
         <button
           type="button"
-          class="inline-flex min-h-11 items-center gap-1 rounded-md px-1 text-[13px] font-semibold text-accent-2 hover:bg-elevated"
+          class="inline-flex min-h-11 items-center gap-1 rounded-md px-1 text-[13px] font-semibold text-accent-2 hover:bg-elevated md:min-h-0"
           data-testid="integrations-modal-back"
           @click="backToCatalog"
         >
@@ -118,7 +118,7 @@ function cardIconClass(scope: McpServer['scope']): string {
         data-testid="integrations-mcp-card"
         @click="openDetail(m)"
       >
-        <div class="flex min-h-11 items-start gap-3">
+        <div class="flex min-h-11 items-start gap-3 md:min-h-0">
           <div
             class="flex h-10 w-10 shrink-0 items-center justify-center rounded-md"
             :class="cardIconClass(m.scope)"

--- a/web/src/components/ui/AppButton.test.ts
+++ b/web/src/components/ui/AppButton.test.ts
@@ -47,4 +47,24 @@ describe('AppButton', () => {
     idle.unmount()
     loading.unmount()
   })
+
+  it('size sm uses h-6 (24px) height token, not padding-driven height', () => {
+    const wrapper = mountBtn({ size: 'sm' })
+    const cls = wrapper.classes().join(' ')
+    expect(cls).toMatch(/\bh-6\b/)
+    expect(cls).toMatch(/\bpx-2.5\b/)
+    expect(cls).toMatch(/\btext-xs\b/)
+    expect(cls).not.toMatch(/\bpy-/)
+    wrapper.unmount()
+  })
+
+  it('size md uses h-9 (36px) height token, not padding-driven height', () => {
+    const wrapper = mountBtn({ size: 'md' })
+    const cls = wrapper.classes().join(' ')
+    expect(cls).toMatch(/\bh-9\b/)
+    expect(cls).toMatch(/\bpx-3.5\b/)
+    expect(cls).toMatch(/\btext-sm\b/)
+    expect(cls).not.toMatch(/\bpy-/)
+    wrapper.unmount()
+  })
 })

--- a/web/src/components/ui/AppButton.vue
+++ b/web/src/components/ui/AppButton.vue
@@ -18,7 +18,8 @@ const props = withDefaults(
 const cls = computed(() => {
   const base =
     'inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md font-medium transition outline-none disabled:opacity-50 disabled:cursor-not-allowed'
-  const sizes = props.size === 'sm' ? 'px-2.5 py-1 text-xs' : 'px-3.5 py-2 text-sm'
+  // Height tokens: sm=h-6 (24px), md=h-9 (36px). Vertical padding no longer drives height.
+  const sizes = props.size === 'sm' ? 'h-6 px-2.5 text-xs' : 'h-9 px-3.5 text-sm'
   const variants: Record<string, string> = {
     primary: 'bg-accent text-white hover:bg-accent-2 shadow-glow',
     ghost: 'text-txt2 hover:bg-elevated hover:text-txt',

--- a/web/src/views/PlatformRulesView.vue
+++ b/web/src/views/PlatformRulesView.vue
@@ -211,7 +211,7 @@ onMounted(loadAll)
         <span v-if="savedAt" class="text-xs text-ok">{{ t('pages.settings.saved') }}</span>
         <AppButton
           variant="ghost"
-          size="sm"
+          size="md"
           icon="refresh"
           :disabled="loading || saving || resetting || !canWrite"
           @click="resetToEmbed"
@@ -220,7 +220,7 @@ onMounted(loadAll)
         </AppButton>
         <AppButton
           variant="primary"
-          size="sm"
+          size="md"
           icon="check"
           :disabled="loading || saving || resetting || !canWrite"
           @click="save"
@@ -280,7 +280,7 @@ onMounted(loadAll)
       <button
         v-if="isMobile && mobileStep === 'detail'"
         type="button"
-        class="mt-3 min-h-11 text-xs text-txt3 hover:text-txt2"
+        class="mt-3 min-h-11 text-xs text-txt3 hover:text-txt2 md:min-h-0"
         data-testid="platform-rules-back-list"
         @click="backToRuleList"
       >
@@ -302,7 +302,7 @@ onMounted(loadAll)
       <button
         v-if="isMobile && mobileStep === 'detail'"
         type="button"
-        class="mt-3 min-h-11 text-xs text-txt3 hover:text-txt2"
+        class="mt-3 min-h-11 text-xs text-txt3 hover:text-txt2 md:min-h-0"
         data-testid="platform-rules-back-list"
         @click="backToRuleList"
       >
@@ -338,7 +338,7 @@ onMounted(loadAll)
             class="mb-0.5 flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[12px] transition"
             :class="[
               activeFile === item.file ? 'bg-accent-dim text-txt' : 'text-txt3 hover:bg-elevated hover:text-txt2',
-              isMobile ? 'min-h-11' : '',
+              'min-h-11 md:min-h-0',
             ]"
             data-testid="platform-rules-file"
             @click="selectFile(item.file)"
@@ -363,7 +363,7 @@ onMounted(loadAll)
         <div class="flex shrink-0 items-center gap-2 border-b border-line px-3 py-2">
           <button
             type="button"
-            class="min-h-11 text-[12px] text-txt2 hover:text-txt"
+            class="min-h-11 text-[12px] text-txt2 hover:text-txt md:min-h-0"
             data-testid="platform-rules-back-list"
             @click="backToRuleList"
           >

--- a/web/src/views/SettingsView.test.ts
+++ b/web/src/views/SettingsView.test.ts
@@ -84,7 +84,7 @@ describe('SettingsView loading source lock', () => {
     expect(src).toMatch(/admin-list-thin-bar bg-accent/)
     expect(src).toMatch(/opacity-\[0\.55\]/)
     expect(src).toMatch(/flex-col items-stretch gap-3 md:flex-row md:items-end md:justify-between/)
-    expect(src).toMatch(/min-h-11 w-full md:w-auto/)
+    expect(src).toMatch(/min-h-11 w-full md:min-h-0 md:w-auto/)
   })
 })
 

--- a/web/src/views/SettingsView.vue
+++ b/web/src/views/SettingsView.vue
@@ -245,10 +245,10 @@ onBeforeUnmount(() => {
       </div>
       <div class="flex flex-col gap-2 md:flex-row md:items-center">
         <span v-if="savedAt" class="text-xs text-ok">{{ t('pages.settings.saved') }}</span>
-        <AppButton class="min-h-11 w-full md:w-auto" variant="ghost" size="sm" icon="refresh" :disabled="loading || saving" @click="loadSettings">
+        <AppButton class="min-h-11 w-full md:min-h-0 md:w-auto" variant="ghost" size="md" icon="refresh" :disabled="loading || saving" @click="loadSettings">
           {{ t('common.buttons.reset') }}
         </AppButton>
-        <AppButton class="min-h-11 w-full md:w-auto" variant="primary" size="sm" icon="check" :disabled="loading || saving || !dirty()" @click="save">
+        <AppButton class="min-h-11 w-full md:min-h-0 md:w-auto" variant="primary" size="md" icon="check" :disabled="loading || saving || !dirty()" @click="save">
           {{ saving ? t('common.buttons.saving') : t('common.buttons.save') }}
         </AppButton>
       </div>
@@ -275,7 +275,7 @@ onBeforeUnmount(() => {
             <p v-if="!isAdmin" class="mt-1 text-[11px] text-warn">{{ t('pages.settings.platformRulesCard.readOnly') }}</p>
           </div>
         </div>
-        <AppButton class="min-h-11" variant="primary" size="sm" icon="chevron-right" @click="router.push('/settings/platform-rules')">
+        <AppButton class="min-h-11 md:min-h-0" variant="primary" size="md" icon="chevron-right" @click="router.push('/settings/platform-rules')">
           {{ isAdmin ? t('pages.settings.platformRulesCard.manage') : t('pages.settings.platformRulesCard.view') }}
         </AppButton>
       </div>
@@ -296,9 +296,9 @@ onBeforeUnmount(() => {
           </div>
         </div>
         <AppButton
-          class="min-h-11"
+          class="min-h-11 md:min-h-0"
           variant="primary"
-          size="sm"
+          size="md"
           icon="chevron-right"
           data-testid="settings-integrations-open"
           @click="openIntegrationsModal"

--- a/web/src/views/settings-mobile-layout.test.ts
+++ b/web/src/views/settings-mobile-layout.test.ts
@@ -13,7 +13,8 @@ describe('settings-family narrow-screen stacking (g3)', () => {
   it('Settings header stacks on mobile with full-width touch targets', () => {
     const src = read('SettingsView.vue')
     expect(src).toMatch(/flex-col items-stretch gap-3 md:flex-row md:items-end md:justify-between/)
-    expect(src).toMatch(/min-h-11 w-full md:w-auto/)
+    expect(src).toMatch(/min-h-11 w-full md:min-h-0 md:w-auto/)
+    expect(src).toMatch(/size="md"/)
   })
 
   // plan g2.1 / g2.4: integrations card + modal replace IntegrationsView page layout
@@ -25,11 +26,22 @@ describe('settings-family narrow-screen stacking (g3)', () => {
     expect(modal).toMatch(/flex flex-wrap items-center gap-2/)
     expect(modal).toMatch(/availabilityBadgeClass\(m\.scope\)/)
     expect(modal).not.toMatch(/inline-flex shrink-0 items-center gap-1 rounded-full border/)
-    expect(modal).toMatch(/min-h-11 items-start gap-3/)
+    expect(modal).toMatch(/min-h-11 items-start gap-3 md:min-h-0/)
+    expect(modal).toMatch(/min-h-11 items-center gap-1[\s\S]*md:min-h-0/)
     const settings = read('SettingsView.vue')
     expect(settings).toMatch(/data-testid="settings-integrations-open"/)
-    expect(settings).toMatch(/class="min-h-11"/)
+    expect(settings).toMatch(/class="min-h-11 md:min-h-0"/)
     expect(settings).not.toMatch(/TriggersView/)
+  })
+
+  it('PlatformRulesView desktop header actions use size md; min-h-11 is paired with md:min-h-0', () => {
+    const src = read('PlatformRulesView.vue')
+    expect(src).toMatch(/variant="ghost"\s+size="md"/)
+    expect(src).toMatch(/variant="primary"\s+size="md"/)
+    expect(src).not.toMatch(/size="sm"/)
+    const minH11 = src.match(/min-h-11/g) || []
+    const paired = src.match(/min-h-11[\s\S]{0,80}md:min-h-0/g) || []
+    expect(paired.length).toBe(minH11.length)
   })
 
   it('Notifications controls keep touch height', () => {


### PR DESCRIPTION
AppButton now uses explicit h-6/h-9 height tokens; settings-family views pair min-h-11 with md:min-h-0 so the 44px target only applies below 768px.

Co-authored-by: Cursor <cursoragent@cursor.com>
