### PR TITLE
feat(status): show today's tokens in the topbar instead of 5m rate/peak

### DIFF
--- a/server/internal/handlers/handlers_test.go
+++ b/server/internal/handlers/handlers_test.go
@@ -202,14 +202,10 @@ func TestHealthAndDashboard(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &st); err != nil {
 		t.Fatal(err)
 	}
-	for _, key := range []string{"runningCount", "queuedCount", "asOf", "timezone"} {
+	for _, key := range []string{"runningCount", "queuedCount", "asOf", "timezone", "cumulativeTokens", "todayTokens"} {
 		if _, ok := st[key]; !ok {
 			t.Fatalf("platform-status missing %s: %v", key, st)
 		}
-	}
-	// Token fields may be null; keys should still be present as JSON null.
-	if _, ok := st["cumulativeTokens"]; !ok {
-		t.Fatalf("missing cumulativeTokens: %v", st)
 	}
 }
 

--- a/server/internal/services/dashboard.go
+++ b/server/internal/services/dashboard.go
@@ -14,7 +14,7 @@ type DashboardService struct {
 	db       *gorm.DB
 	projects *ProjectService
 
-	// Process-local cache for 5m token buckets (platform-status hot path).
+	// Process-local cache for today token totals (platform-status hot path).
 	statusMu       sync.Mutex
 	statusCache    map[string]platformStatusCacheEntry
 	statusInflight map[string]*platformStatusCall

--- a/server/internal/services/platform_status.go
+++ b/server/internal/services/platform_status.go
@@ -11,10 +11,9 @@ import (
 const (
 	platformStatusTTL     = 12 * time.Second
 	platformStatusTimeout = 15 * time.Second
-	fiveMinute            = 5 * time.Minute
 )
 
-// PlatformStatusQuery controls timezone for calendar-aligned 5m buckets.
+// PlatformStatusQuery controls timezone for the local-calendar "today" window.
 type PlatformStatusQuery struct {
 	Timezone         string
 	UTCOffsetMinutes *int
@@ -24,17 +23,12 @@ type PlatformStatusQuery struct {
 // PlatformStatusMetrics is the AppTopbar StatusMetrics payload.
 // Token fields use pointers: JSON null = unavailable / never reported; 0 is a real zero.
 type PlatformStatusMetrics struct {
-	CumulativeTokens          *int64     `json:"cumulativeTokens"`
-	Current5mBucketTokens     *int64     `json:"current5mBucketTokens"`
-	TodayMaxCompleted5mTokens *int64     `json:"todayMaxCompleted5mTokens"`
-	RunningCount              int64      `json:"runningCount"`
-	QueuedCount               int64      `json:"queuedCount"`
-	CurrentBucketStart        *time.Time `json:"currentBucketStart,omitempty"`
-	CurrentBucketEnd          *time.Time `json:"currentBucketEnd,omitempty"`
-	PeakBucketStart           *time.Time `json:"peakBucketStart,omitempty"`
-	PeakBucketEnd             *time.Time `json:"peakBucketEnd,omitempty"`
-	AsOf                      time.Time  `json:"asOf"`
-	Timezone                  string     `json:"timezone"`
+	CumulativeTokens *int64    `json:"cumulativeTokens"`
+	TodayTokens      *int64    `json:"todayTokens"`
+	RunningCount     int64     `json:"runningCount"`
+	QueuedCount      int64     `json:"queuedCount"`
+	AsOf             time.Time `json:"asOf"`
+	Timezone         string    `json:"timezone"`
 }
 
 type platformStatusCacheEntry struct {
@@ -52,9 +46,9 @@ type platformUsagePoint struct {
 	total int64
 }
 
-// PlatformStatus returns running/queued counts, cumulative tokens, and calendar
-// 5m current-bucket + today peak. 5m aggregation is process-cached (TTL≈12s)
-// with singleflight so topbar polling does not re-scan every request.
+// PlatformStatus returns running/queued counts, cumulative tokens, and today's
+// token sum (client timezone midnight–asOf). Today aggregation is process-cached
+// (TTL≈12s) with singleflight so topbar polling does not re-scan every request.
 func (s *DashboardService) PlatformStatus(ctx context.Context, q PlatformStatusQuery) (PlatformStatusMetrics, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -69,49 +63,36 @@ func (s *DashboardService) PlatformStatus(ctx context.Context, q PlatformStatusQ
 		now = time.Now().UTC()
 	}
 
-	// Cheap counts always fresh; token/5m path may hit cache.
+	// Cheap counts always fresh; today-token path may hit cache.
 	running, queued := s.countRunStatuses()
 	var cumulative *int64
 	if s.projects != nil {
 		cumulative = s.projects.PlatformTokenBreakdown().Total
 	}
 
-	five, err := s.cachedFiveMinuteMetrics(ctx, tzLabel, loc, now)
+	today, err := s.cachedTodayTokens(ctx, tzLabel, loc, now)
 	if err != nil {
 		return PlatformStatusMetrics{}, err
 	}
 
 	out := PlatformStatusMetrics{
-		CumulativeTokens:          cumulative,
-		RunningCount:              running,
-		QueuedCount:               queued,
-		AsOf:                      now,
-		Timezone:                  tzLabel,
-		CurrentBucketStart:        five.currentStart,
-		CurrentBucketEnd:          five.currentEnd,
-		PeakBucketStart:           five.peakStart,
-		PeakBucketEnd:             five.peakEnd,
-		TodayMaxCompleted5mTokens: five.peakTokens,
+		CumulativeTokens: cumulative,
+		RunningCount:     running,
+		QueuedCount:      queued,
+		AsOf:             now,
+		Timezone:         tzLabel,
 	}
 	if cumulative == nil {
-		// Never reported → rate/peak stay null (UI "—"), not fake zeros.
-		out.Current5mBucketTokens = nil
-		out.TodayMaxCompleted5mTokens = nil
-		out.PeakBucketStart = nil
-		out.PeakBucketEnd = nil
+		// Never reported → today stays null (UI "—"), not a fake zero.
+		out.TodayTokens = nil
 	} else {
-		out.Current5mBucketTokens = five.currentTokens
+		out.TodayTokens = today
 	}
 	return out, nil
 }
 
-type fiveMinuteBundle struct {
-	currentTokens *int64
-	peakTokens    *int64
-	currentStart  *time.Time
-	currentEnd    *time.Time
-	peakStart     *time.Time
-	peakEnd       *time.Time
+type todayTokenBundle struct {
+	todayTokens *int64
 }
 
 func (s *DashboardService) countRunStatuses() (running, queued int64) {
@@ -123,7 +104,7 @@ func (s *DashboardService) countRunStatuses() (running, queued int64) {
 	return count("running"), count("queued")
 }
 
-func (s *DashboardService) cachedFiveMinuteMetrics(ctx context.Context, cacheKey string, loc *time.Location, now time.Time) (fiveMinuteBundle, error) {
+func (s *DashboardService) cachedTodayTokens(ctx context.Context, cacheKey string, loc *time.Location, now time.Time) (*int64, error) {
 	s.statusMu.Lock()
 	if s.statusCache == nil {
 		s.statusCache = map[string]platformStatusCacheEntry{}
@@ -131,7 +112,7 @@ func (s *DashboardService) cachedFiveMinuteMetrics(ctx context.Context, cacheKey
 	if ent, ok := s.statusCache[cacheKey]; ok && now.Before(ent.expires) {
 		m := ent.metrics
 		s.statusMu.Unlock()
-		return fiveMinuteBundleFromMetrics(m), nil
+		return m.TodayTokens, nil
 	}
 	if s.statusInflight == nil {
 		s.statusInflight = map[string]*platformStatusCall{}
@@ -139,23 +120,18 @@ func (s *DashboardService) cachedFiveMinuteMetrics(ctx context.Context, cacheKey
 	if call, ok := s.statusInflight[cacheKey]; ok {
 		s.statusMu.Unlock()
 		call.wg.Wait()
-		return fiveMinuteBundleFromMetrics(call.val), nil
+		return call.val.TodayTokens, nil
 	}
 	call := &platformStatusCall{}
 	call.wg.Add(1)
 	s.statusInflight[cacheKey] = call
 	s.statusMu.Unlock()
 
-	bundle, err := s.computeFiveMinuteMetrics(ctx, loc, now)
+	bundle, err := s.computeTodayTokens(ctx, loc, now)
 	metrics := PlatformStatusMetrics{
-		Current5mBucketTokens:     bundle.currentTokens,
-		TodayMaxCompleted5mTokens: bundle.peakTokens,
-		CurrentBucketStart:        bundle.currentStart,
-		CurrentBucketEnd:          bundle.currentEnd,
-		PeakBucketStart:           bundle.peakStart,
-		PeakBucketEnd:             bundle.peakEnd,
-		AsOf:                      now,
-		Timezone:                  cacheKey,
+		TodayTokens: bundle.todayTokens,
+		AsOf:        now,
+		Timezone:    cacheKey,
 	}
 
 	s.statusMu.Lock()
@@ -171,83 +147,33 @@ func (s *DashboardService) cachedFiveMinuteMetrics(ctx context.Context, cacheKey
 	s.statusMu.Unlock()
 
 	if err != nil {
-		return fiveMinuteBundle{}, err
+		return nil, err
 	}
-	return bundle, nil
+	return bundle.todayTokens, nil
 }
 
-func fiveMinuteBundleFromMetrics(m PlatformStatusMetrics) fiveMinuteBundle {
-	return fiveMinuteBundle{
-		currentTokens: m.Current5mBucketTokens,
-		peakTokens:    m.TodayMaxCompleted5mTokens,
-		currentStart:  m.CurrentBucketStart,
-		currentEnd:    m.CurrentBucketEnd,
-		peakStart:     m.PeakBucketStart,
-		peakEnd:       m.PeakBucketEnd,
-	}
-}
-
-func (s *DashboardService) computeFiveMinuteMetrics(ctx context.Context, loc *time.Location, now time.Time) (fiveMinuteBundle, error) {
+func (s *DashboardService) computeTodayTokens(ctx context.Context, loc *time.Location, now time.Time) (todayTokenBundle, error) {
 	ctx, cancel := context.WithTimeout(ctx, platformStatusTimeout)
 	defer cancel()
 
 	nowLocal := now.In(loc)
 	dayStart := truncateLocalDay(nowLocal)
-	currentStart := truncateFiveMinutes(nowLocal)
-	currentEnd := currentStart.Add(fiveMinute)
 
-	// Scan from local midnight (UTC instant) so "today" peak is complete.
+	// Scan from before local midnight (UTC instant) so timezone edges are complete.
 	points, err := s.loadPlatformUsageSince(ctx, dayStart.UTC().Add(-14*time.Hour))
 	if err != nil {
-		return fiveMinuteBundle{}, err
+		return todayTokenBundle{}, err
 	}
 
-	buckets := map[int64]int64{} // bucket start unix → sum
-	var hasAny bool
+	var sum int64
 	for _, p := range points {
 		local := p.ts.In(loc)
-		if local.Before(dayStart) {
+		if local.Before(dayStart) || local.After(nowLocal) {
 			continue
 		}
-		hasAny = true
-		bStart := truncateFiveMinutes(local)
-		buckets[bStart.Unix()] += p.total
+		sum += p.total
 	}
-
-	cur := buckets[currentStart.Unix()]
-	curPtr := &cur
-
-	var peak *int64
-	var peakStart, peakEnd *time.Time
-	for unix, sum := range buckets {
-		bStart := time.Unix(unix, 0).In(loc)
-		bEnd := bStart.Add(fiveMinute)
-		// Peak = max of completed buckets only (exclude current incomplete).
-		if !bEnd.After(currentStart) && (peak == nil || sum > *peak) {
-			v := sum
-			peak = &v
-			ps, pe := bStart, bEnd
-			peakStart = &ps
-			peakEnd = &pe
-		}
-	}
-	_ = hasAny
-
-	cs, ce := currentStart, currentEnd
-	return fiveMinuteBundle{
-		currentTokens: curPtr,
-		peakTokens:    peak,
-		currentStart:  &cs,
-		currentEnd:    &ce,
-		peakStart:     peakStart,
-		peakEnd:       peakEnd,
-	}, nil
-}
-
-func truncateFiveMinutes(t time.Time) time.Time {
-	t = t.In(t.Location())
-	m := t.Minute() - (t.Minute() % 5)
-	return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), m, 0, 0, t.Location())
+	return todayTokenBundle{todayTokens: &sum}, nil
 }
 
 func (s *DashboardService) loadPlatformUsageSince(ctx context.Context, since time.Time) ([]platformUsagePoint, error) {
@@ -356,7 +282,7 @@ func (s *DashboardService) loadPlatformPMUsageSince(ctx context.Context, since t
 	return out, nil
 }
 
-// ClearPlatformStatusCacheForTest resets the 5m cache (tests only).
+// ClearPlatformStatusCacheForTest resets the today-token cache (tests only).
 func (s *DashboardService) ClearPlatformStatusCacheForTest() {
 	s.statusMu.Lock()
 	defer s.statusMu.Unlock()

--- a/server/internal/services/platform_status_test.go
+++ b/server/internal/services/platform_status_test.go
@@ -30,9 +30,9 @@ func TestPlatformStatus_emptyNullAndTrueZero(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.CumulativeTokens != nil || got.Current5mBucketTokens != nil || got.TodayMaxCompleted5mTokens != nil {
-		t.Fatalf("want null token fields, got cum=%v cur=%v peak=%v",
-			got.CumulativeTokens, got.Current5mBucketTokens, got.TodayMaxCompleted5mTokens)
+	if got.CumulativeTokens != nil || got.TodayTokens != nil {
+		t.Fatalf("want null token fields, got cum=%v today=%v",
+			got.CumulativeTokens, got.TodayTokens)
 	}
 	if got.RunningCount != 0 || got.QueuedCount != 0 {
 		t.Fatalf("want running/queued 0, got %d/%d", got.RunningCount, got.QueuedCount)
@@ -61,8 +61,8 @@ func TestPlatformStatus_emptyNullAndTrueZero(t *testing.T) {
 	}
 }
 
-func TestPlatformStatus_fiveMinuteBucketsAndPeak(t *testing.T) {
-	db, err := database.OpenSQLiteTest(filepath.Join(t.TempDir(), "platform_status_5m.db"))
+func TestPlatformStatus_todayTokensSum(t *testing.T) {
+	db, err := database.OpenSQLiteTest(filepath.Join(t.TempDir(), "platform_status_today.db"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,6 @@ func TestPlatformStatus_fiveMinuteBucketsAndPeak(t *testing.T) {
 	dash := NewDashboardService(db, projects)
 
 	loc := time.FixedZone("UTC+8", 8*3600)
-	// Current incomplete bucket: 14:05–14:10; now = 14:07
 	now := time.Date(2026, 8, 12, 14, 7, 0, 0, loc)
 	mustCreate := func(v any) {
 		t.Helper()
@@ -85,34 +84,31 @@ func TestPlatformStatus_fiveMinuteBucketsAndPeak(t *testing.T) {
 	}
 	mustCreate(&models.WorkflowDef{ID: "wf1", ProjectID: p.ID, Name: "w", Status: "draft", Version: 1})
 
-	// Completed bucket 11:20–11:25 → peak candidate 12104
-	peakStart := time.Date(2026, 8, 12, 11, 22, 0, 0, loc)
-	mustCreate(&models.Run{ID: "run-peak", WorkflowID: "wf1", Status: "completed", StartedAt: peakStart.UTC(), CreatedAt: peakStart.UTC()})
-	srPeak := peakStart.UTC()
+	morning := time.Date(2026, 8, 12, 11, 22, 0, 0, loc)
+	mustCreate(&models.Run{ID: "run-a", WorkflowID: "wf1", Status: "completed", StartedAt: morning.UTC(), CreatedAt: morning.UTC()})
+	srA := morning.UTC()
 	mustCreate(&models.StateRun{
-		RunID: "run-peak", NodeID: "n1", Status: "completed",
-		Usage: &models.TokenUsage{InputTokens: 12104}, StartedAt: &srPeak,
+		RunID: "run-a", NodeID: "n1", Status: "completed",
+		Usage: &models.TokenUsage{InputTokens: 12104}, StartedAt: &srA,
 	})
 
-	// Smaller completed bucket 10:00–10:05
-	smallStart := time.Date(2026, 8, 12, 10, 1, 0, 0, loc)
-	mustCreate(&models.Run{ID: "run-small", WorkflowID: "wf1", Status: "completed", StartedAt: smallStart.UTC(), CreatedAt: smallStart.UTC()})
-	srSmall := smallStart.UTC()
+	mid := time.Date(2026, 8, 12, 10, 1, 0, 0, loc)
+	mustCreate(&models.Run{ID: "run-b", WorkflowID: "wf1", Status: "completed", StartedAt: mid.UTC(), CreatedAt: mid.UTC()})
+	srB := mid.UTC()
 	mustCreate(&models.StateRun{
-		RunID: "run-small", NodeID: "n1", Status: "completed",
-		Usage: &models.TokenUsage{InputTokens: 100}, StartedAt: &srSmall,
+		RunID: "run-b", NodeID: "n1", Status: "completed",
+		Usage: &models.TokenUsage{InputTokens: 100}, StartedAt: &srB,
 	})
 
-	// Current bucket 14:05–14:10 → 4812 (must NOT be peak)
-	curStart := time.Date(2026, 8, 12, 14, 6, 0, 0, loc)
-	mustCreate(&models.Run{ID: "run-cur", WorkflowID: "wf1", Status: "running", StartedAt: curStart.UTC(), CreatedAt: curStart.UTC()})
-	srCur := curStart.UTC()
+	cur := time.Date(2026, 8, 12, 14, 6, 0, 0, loc)
+	mustCreate(&models.Run{ID: "run-c", WorkflowID: "wf1", Status: "running", StartedAt: cur.UTC(), CreatedAt: cur.UTC()})
+	srC := cur.UTC()
 	mustCreate(&models.StateRun{
-		RunID: "run-cur", NodeID: "n1", Status: "running",
-		Usage: &models.TokenUsage{InputTokens: 4812}, StartedAt: &srCur,
+		RunID: "run-c", NodeID: "n1", Status: "running",
+		Usage: &models.TokenUsage{InputTokens: 4812}, StartedAt: &srC,
 	})
 
-	// Yesterday usage should not affect today peak
+	// Yesterday must not enter todayTokens (g1.2/g1.3).
 	yest := time.Date(2026, 8, 11, 15, 0, 0, 0, loc)
 	mustCreate(&models.Run{ID: "run-yest", WorkflowID: "wf1", Status: "completed", StartedAt: yest.UTC(), CreatedAt: yest.UTC()})
 	srY := yest.UTC()
@@ -131,29 +127,13 @@ func TestPlatformStatus_fiveMinuteBucketsAndPeak(t *testing.T) {
 	if got.CumulativeTokens == nil || *got.CumulativeTokens != 12104+100+4812+999999 {
 		t.Fatalf("cumulative=%v", got.CumulativeTokens)
 	}
-	if got.Current5mBucketTokens == nil || *got.Current5mBucketTokens != 4812 {
-		t.Fatalf("current5m=%v want 4812", got.Current5mBucketTokens)
-	}
-	if got.TodayMaxCompleted5mTokens == nil || *got.TodayMaxCompleted5mTokens != 12104 {
-		t.Fatalf("peak=%v want 12104", got.TodayMaxCompleted5mTokens)
-	}
-	if got.CurrentBucketStart == nil || got.CurrentBucketEnd == nil {
-		t.Fatal("expected current bucket bounds")
-	}
-	wantCurStart := time.Date(2026, 8, 12, 14, 5, 0, 0, loc)
-	if !got.CurrentBucketStart.Equal(wantCurStart) {
-		t.Fatalf("current start=%v want %v", got.CurrentBucketStart, wantCurStart)
-	}
-	if got.PeakBucketStart == nil {
-		t.Fatal("expected peak bucket start")
-	}
-	wantPeakStart := time.Date(2026, 8, 12, 11, 20, 0, 0, loc)
-	if !got.PeakBucketStart.In(loc).Equal(wantPeakStart) {
-		t.Fatalf("peak start=%v want %v", got.PeakBucketStart.In(loc), wantPeakStart)
+	wantToday := int64(12104 + 100 + 4812)
+	if got.TodayTokens == nil || *got.TodayTokens != wantToday {
+		t.Fatalf("todayTokens=%v want %d", got.TodayTokens, wantToday)
 	}
 }
 
-func TestPlatformStatus_crossDayPeakReset(t *testing.T) {
+func TestPlatformStatus_crossDayTodayReset(t *testing.T) {
 	db, err := database.OpenSQLiteTest(filepath.Join(t.TempDir(), "platform_status_day.db"))
 	if err != nil {
 		t.Fatal(err)
@@ -182,7 +162,7 @@ func TestPlatformStatus_crossDayPeakReset(t *testing.T) {
 		Usage: &models.TokenUsage{InputTokens: 5000}, StartedAt: &sr1,
 	})
 
-	// New day 00:07 — no completed bucket yet today → peak null
+	// New day 00:07 — yesterday excluded; today zero while cumulative exists (g1.3).
 	day2 := time.Date(2026, 8, 12, 0, 7, 0, 0, loc)
 	got, err := dash.PlatformStatus(context.Background(), PlatformStatusQuery{
 		UTCOffsetMinutes: intPtr(8 * 60),
@@ -191,12 +171,11 @@ func TestPlatformStatus_crossDayPeakReset(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.TodayMaxCompleted5mTokens != nil {
-		t.Fatalf("cross-day peak should reset to null, got %v", *got.TodayMaxCompleted5mTokens)
+	if got.CumulativeTokens == nil || *got.CumulativeTokens != 5000 {
+		t.Fatalf("cumulative=%v want 5000", got.CumulativeTokens)
 	}
-	// Current bucket 00:05–00:10 still empty → 0 (cumulative exists)
-	if got.Current5mBucketTokens == nil || *got.Current5mBucketTokens != 0 {
-		t.Fatalf("current bucket want 0, got %v", got.Current5mBucketTokens)
+	if got.TodayTokens == nil || *got.TodayTokens != 0 {
+		t.Fatalf("cross-day todayTokens want 0, got %v", got.TodayTokens)
 	}
 }
 
@@ -232,8 +211,8 @@ func TestPlatformStatus_cacheHitSkipsRescan(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if first.Current5mBucketTokens == nil || *first.Current5mBucketTokens != 10 {
-		t.Fatalf("first current=%v", first.Current5mBucketTokens)
+	if first.TodayTokens == nil || *first.TodayTokens != 10 {
+		t.Fatalf("first today=%v", first.TodayTokens)
 	}
 
 	// Add more usage in same bucket; cache should still return 10 until TTL.
@@ -247,8 +226,8 @@ func TestPlatformStatus_cacheHitSkipsRescan(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if second.Current5mBucketTokens == nil || *second.Current5mBucketTokens != 10 {
-		t.Fatalf("cache miss? current=%v want stale 10", second.Current5mBucketTokens)
+	if second.TodayTokens == nil || *second.TodayTokens != 10 {
+		t.Fatalf("cache miss? today=%v want stale 10", second.TodayTokens)
 	}
 
 	// After TTL, recompute.
@@ -257,8 +236,8 @@ func TestPlatformStatus_cacheHitSkipsRescan(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if third.Current5mBucketTokens == nil || *third.Current5mBucketTokens != 100 {
-		t.Fatalf("after clear current=%v want 100", third.Current5mBucketTokens)
+	if third.TodayTokens == nil || *third.TodayTokens != 100 {
+		t.Fatalf("after clear today=%v want 100", third.TodayTokens)
 	}
 }
 

--- a/web/e2e/desktop-sidebar-hide.spec.ts
+++ b/web/e2e/desktop-sidebar-hide.spec.ts
@@ -31,8 +31,7 @@ async function mockApi(page: Page) {
       await route.fulfill({
         json: {
           cumulativeTokens: null,
-          current5mBucketTokens: null,
-          todayMaxCompleted5mTokens: null,
+          todayTokens: null,
           runningCount: 0,
           queuedCount: 0,
           asOf: '2026-08-19T00:00:00Z',

--- a/web/e2e/status-metrics-topbar-main.ts
+++ b/web/e2e/status-metrics-topbar-main.ts
@@ -13,36 +13,25 @@ const scene = params.get('scene') || 'ok'
 
 type PlatformPayload = {
   cumulativeTokens: number | null
-  current5mBucketTokens: number | null
-  todayMaxCompleted5mTokens: number | null
+  todayTokens: number | null
   runningCount: number
   queuedCount: number
-  currentBucketStart?: string | null
-  currentBucketEnd?: string | null
-  peakBucketStart?: string | null
-  peakBucketEnd?: string | null
   asOf: string
   timezone: string
 }
 
 const okPayload: PlatformPayload = {
   cumulativeTokens: 1240582,
-  current5mBucketTokens: 4812,
-  todayMaxCompleted5mTokens: 12104,
+  todayTokens: 4812,
   runningCount: 3,
   queuedCount: 5,
-  currentBucketStart: '2026-08-12T06:05:00Z',
-  currentBucketEnd: '2026-08-12T06:10:00Z',
-  peakBucketStart: '2026-08-12T03:20:00Z',
-  peakBucketEnd: '2026-08-12T03:25:00Z',
   asOf: '2026-08-12T06:07:00Z',
   timezone: 'Asia/Shanghai',
 }
 
 const nullPayload: PlatformPayload = {
   cumulativeTokens: null,
-  current5mBucketTokens: null,
-  todayMaxCompleted5mTokens: null,
+  todayTokens: null,
   runningCount: 0,
   queuedCount: 0,
   asOf: '2026-08-12T00:00:00Z',

--- a/web/e2e/status-metrics-topbar.spec.ts
+++ b/web/e2e/status-metrics-topbar.spec.ts
@@ -6,15 +6,17 @@ const OUT = '/tmp/status-metrics-shots'
 fs.mkdirSync(OUT, { recursive: true })
 
 test.describe('StatusMetrics topbar E2E', () => {
-  test('desktop: five metrics left of lang, /5m rate, tip, no TOK labels', async ({ page }, testInfo) => {
+  test('desktop: four metrics left of lang, today tokens, tip, no TOK labels', async ({ page }, testInfo) => {
     await page.setViewportSize({ width: 1280, height: 720 })
     await page.goto('/status-metrics-topbar.html')
     const metrics = page.getByTestId('status-metrics')
     await expect(metrics).toBeVisible({ timeout: 15_000 })
 
     await expect(page.getByTestId('status-metrics-tokens')).toContainText(/1\.24M/i)
-    await expect(page.getByTestId('status-metrics-rate')).toContainText(/\/5m/)
-    await expect(page.getByTestId('status-metrics-peak')).toBeVisible()
+    await expect(page.getByTestId('status-metrics-today')).toContainText(/4\.8K/)
+    await expect(page.getByTestId('status-metrics-today')).not.toContainText(/\/5m/)
+    await expect(page.getByTestId('status-metrics-rate')).toHaveCount(0)
+    await expect(page.getByTestId('status-metrics-peak')).toHaveCount(0)
     await expect(page.getByTestId('status-metrics-running')).toContainText('3')
     await expect(page.getByTestId('status-metrics-queued')).toContainText('5')
     // Visible values are icon+compact numbers (no TOK/5M/PEAK label chips).
@@ -47,12 +49,12 @@ test.describe('StatusMetrics topbar E2E', () => {
     await expect(tokensTip).not.toContainText('完整值')
     await expect(tokensTip).not.toContainText('/5m')
 
-    const rateTip = page.getByTestId('status-metrics-rate').locator('.sm-tip')
-    await page.getByTestId('status-metrics-rate').hover()
-    await expect(rateTip).toBeVisible()
-    await expect(rateTip).toContainText('速率')
-    await expect(rateTip).toContainText('4,812')
-    await expect(rateTip).not.toContainText('/5m')
+    const todayTip = page.getByTestId('status-metrics-today').locator('.sm-tip')
+    await page.getByTestId('status-metrics-today').hover()
+    await expect(todayTip).toBeVisible()
+    await expect(todayTip).toContainText('今日 Token')
+    await expect(todayTip).toContainText('4,812')
+    await expect(todayTip).not.toContainText('/5m')
 
     // Click pin (tip-open) still works.
     await page.getByTestId('status-metrics-running').click()
@@ -68,7 +70,7 @@ test.describe('StatusMetrics topbar E2E', () => {
     })
   })
 
-  test('narrow: Token·RUN/Q summary; compact tip five label:value rows', async ({ page }) => {
+  test('narrow: Token·RUN/Q summary; compact tip four label:value rows', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 })
     await page.goto('/status-metrics-topbar.html')
     await expect(page.getByTestId('status-metrics-compact')).toBeVisible({ timeout: 15_000 })
@@ -82,11 +84,11 @@ test.describe('StatusMetrics topbar E2E', () => {
     const tip = compact.locator('.sm-tip')
     await expect(tip).toBeVisible()
     await expect(tip).toContainText(/累计 Token:\s*1,240,582/)
-    await expect(tip).toContainText(/速率:\s*4,812/)
-    await expect(tip).toContainText(/峰值:\s*12,104/)
+    await expect(tip).toContainText(/今日 Token:\s*4,812/)
     await expect(tip).toContainText(/执行中:\s*3/)
     await expect(tip).toContainText(/排队:\s*5/)
     await expect(tip).not.toContainText('/5m')
+    await expect(tip).not.toContainText('5 分钟')
     await expect(tip).not.toContainText('完整值')
 
     await page.screenshot({
@@ -99,8 +101,7 @@ test.describe('StatusMetrics topbar E2E', () => {
     await page.setViewportSize({ width: 1280, height: 720 })
     await page.goto('/status-metrics-topbar.html?scene=null')
     await expect(page.getByTestId('status-metrics-tokens')).toContainText('—', { timeout: 15_000 })
-    await expect(page.getByTestId('status-metrics-rate')).toContainText('—')
-    await expect(page.getByTestId('status-metrics-peak')).toContainText('—')
+    await expect(page.getByTestId('status-metrics-today')).toContainText('—')
     await expect(page.getByTestId('status-metrics-running')).toContainText('0')
     await expect(page.getByTestId('status-metrics-queued')).toContainText('0')
 
@@ -115,7 +116,7 @@ test.describe('StatusMetrics topbar E2E', () => {
     await page.goto('/status-metrics-topbar.html')
     await expect(page.getByTestId('status-metrics')).toBeVisible({ timeout: 15_000 })
     const urlBefore = page.url()
-    await page.getByTestId('status-metrics-rate').click()
+    await page.getByTestId('status-metrics-today').click()
     await expect(page).toHaveURL(urlBefore)
     await expect(page.getByTestId('page-body')).toBeVisible()
   })

--- a/web/src/components/shell/ShellChromeControls.test.ts
+++ b/web/src/components/shell/ShellChromeControls.test.ts
@@ -43,8 +43,7 @@ vi.mock('@/lib/api/api', () => ({
     artifactDownloadUrl: vi.fn((id: string) => `http://test/api/artifacts/${id}/download`),
     platformStatus: vi.fn().mockResolvedValue({
       cumulativeTokens: null,
-      current5mBucketTokens: null,
-      todayMaxCompleted5mTokens: null,
+      todayTokens: null,
       runningCount: 0,
       queuedCount: 0,
       asOf: '2026-08-12T00:00:00Z',

--- a/web/src/components/shell/StatusMetrics.test.ts
+++ b/web/src/components/shell/StatusMetrics.test.ts
@@ -39,14 +39,9 @@ describe('StatusMetrics', () => {
     platformStatus.mockReset()
     platformStatus.mockResolvedValue({
       cumulativeTokens: 1240582,
-      current5mBucketTokens: 4812,
-      todayMaxCompleted5mTokens: 12104,
+      todayTokens: 4812,
       runningCount: 3,
       queuedCount: 5,
-      currentBucketStart: '2026-08-12T06:05:00Z',
-      currentBucketEnd: '2026-08-12T06:10:00Z',
-      peakBucketStart: '2026-08-12T03:20:00Z',
-      peakBucketEnd: '2026-08-12T03:25:00Z',
       asOf: '2026-08-12T06:07:00Z',
       timezone: 'Asia/Shanghai',
     })
@@ -58,13 +53,15 @@ describe('StatusMetrics', () => {
     document.body.innerHTML = ''
   })
 
-  it('renders five desktop metrics with /5m rate (plan g2.3)', async () => {
+  it('renders four desktop metrics with today tokens (plan g2.2)', async () => {
     const w = mountMetrics()
     await flushPromises()
     expect(w.find('[data-testid="status-metrics"]').exists()).toBe(true)
     expect(w.find('[data-testid="status-metrics-tokens"]').text()).toContain('1.24M')
-    expect(w.find('[data-testid="status-metrics-rate"]').text()).toMatch(/4\.8K\/5m/i)
-    expect(w.find('[data-testid="status-metrics-peak"]').text()).toContain('12.1K')
+    expect(w.find('[data-testid="status-metrics-today"]').text()).toContain('4.8K')
+    expect(w.find('[data-testid="status-metrics-today"]').text()).not.toContain('/5m')
+    expect(w.find('[data-testid="status-metrics-rate"]').exists()).toBe(false)
+    expect(w.find('[data-testid="status-metrics-peak"]').exists()).toBe(false)
     expect(w.find('[data-testid="status-metrics-running"]').text()).toContain('3')
     expect(w.find('[data-testid="status-metrics-queued"]').text()).toContain('5')
     w.unmount()
@@ -104,8 +101,7 @@ describe('StatusMetrics', () => {
   it('shows — for null token fields and 0 for true-zero counts', async () => {
     platformStatus.mockResolvedValue({
       cumulativeTokens: null,
-      current5mBucketTokens: null,
-      todayMaxCompleted5mTokens: null,
+      todayTokens: null,
       runningCount: 0,
       queuedCount: 0,
       asOf: '2026-08-12T00:00:00Z',
@@ -115,8 +111,7 @@ describe('StatusMetrics', () => {
     await flushPromises()
     await nextTick()
     expect(w.find('[data-testid="status-metrics-tokens"]').text()).toContain('—')
-    expect(w.find('[data-testid="status-metrics-rate"]').text()).toContain('—')
-    expect(w.find('[data-testid="status-metrics-peak"]').text()).toContain('—')
+    expect(w.find('[data-testid="status-metrics-today"]').text()).toContain('—')
     expect(w.find('[data-testid="status-metrics-running"]').text()).toContain('0')
     expect(w.find('[data-testid="status-metrics-queued"]').text()).toContain('0')
     w.unmount()
@@ -145,14 +140,13 @@ describe('StatusMetrics', () => {
     await flushPromises()
     const tips = {
       tokens: w.find('[data-testid="status-metrics-tokens"] .sm-tip').text(),
-      rate: w.find('[data-testid="status-metrics-rate"] .sm-tip').text(),
-      peak: w.find('[data-testid="status-metrics-peak"] .sm-tip').text(),
+      today: w.find('[data-testid="status-metrics-today"] .sm-tip').text(),
       running: w.find('[data-testid="status-metrics-running"] .sm-tip').text(),
       queued: w.find('[data-testid="status-metrics-queued"] .sm-tip').text(),
     }
     expect(tips.tokens).toMatch(/累计 Token:\s*1,240,582/)
-    expect(tips.rate).toMatch(/当前 5 分钟速率:\s*4,812/)
-    expect(tips.peak).toMatch(/今日 5 分钟峰值:\s*12,104/)
+    expect(tips.today).toMatch(/今日 Token:\s*4,812/)
+    expect(w.find('[data-testid="status-metrics-today"]').attributes('aria-label')).toMatch(/今日 Token:\s*4,812/)
     expect(tips.running).toMatch(/执行中:\s*3/)
     expect(tips.queued).toMatch(/排队:\s*5/)
     for (const tip of Object.values(tips)) {
@@ -165,21 +159,21 @@ describe('StatusMetrics', () => {
     w.unmount()
   })
 
-  it('compact tip is five label: value rows aligned with desktop (plan g1.3)', async () => {
+  it('compact tip is four label: value rows aligned with desktop (plan g2.3)', async () => {
     isMobile.value = true
     const w = mountMetrics()
     await flushPromises()
     const tip = w.find('[data-testid="status-metrics-compact"] .sm-tip')
     const lines = tip.findAll('div').map((d) => d.text())
-    expect(lines).toHaveLength(5)
+    expect(lines).toHaveLength(4)
     expect(lines[0]).toMatch(/累计 Token:\s*1,240,582/)
-    expect(lines[1]).toMatch(/当前 5 分钟速率:\s*4,812/)
-    expect(lines[2]).toMatch(/今日 5 分钟峰值:\s*12,104/)
-    expect(lines[3]).toMatch(/执行中:\s*3/)
-    expect(lines[4]).toMatch(/排队:\s*5/)
+    expect(lines[1]).toMatch(/今日 Token:\s*4,812/)
+    expect(lines[2]).toMatch(/执行中:\s*3/)
+    expect(lines[3]).toMatch(/排队:\s*5/)
     const tipText = tip.text()
     expect(tipText).not.toMatch(/完整值/)
     expect(tipText).not.toContain('/5m')
+    expect(tipText).not.toMatch(/5 分钟|速率|峰值/)
     expect(tipText).not.toMatch(/窄屏摘要|完整值|totalTokens/i)
     w.unmount()
   })
@@ -237,8 +231,7 @@ describe('StatusMetrics', () => {
   it('zero counts still show label: 0 in tip', async () => {
     platformStatus.mockResolvedValue({
       cumulativeTokens: 0,
-      current5mBucketTokens: 0,
-      todayMaxCompleted5mTokens: 0,
+      todayTokens: 0,
       runningCount: 0,
       queuedCount: 0,
       asOf: '2026-08-12T00:00:00Z',
@@ -249,6 +242,22 @@ describe('StatusMetrics', () => {
     expect(w.find('[data-testid="status-metrics-running"] .sm-tip').text()).toMatch(/执行中:\s*0/)
     expect(w.find('[data-testid="status-metrics-queued"] .sm-tip').text()).toMatch(/排队:\s*0/)
     expect(w.find('[data-testid="status-metrics-tokens"] .sm-tip').text()).toMatch(/累计 Token:\s*0/)
+    expect(w.find('[data-testid="status-metrics-today"] .sm-tip').text()).toMatch(/今日 Token:\s*0/)
+    w.unmount()
+  })
+
+  it('uses A-set stroke icon paths (plan g2.4)', async () => {
+    const w = mountMetrics()
+    await flushPromises()
+    const html = w.html()
+    expect(html).toContain('cx="12" cy="6.6" rx="7.2" ry="3.1"')
+    expect(html).toContain('M4.8 6.6v4.7c0 1.7 3.2 3.1 7.2 3.1s7.2-1.4 7.2-3.1V6.6')
+    expect(html).toContain('M8.2 3v4.2M15.8 3v4.2M3.4 10.2h17.2')
+    expect(html).toContain('M10.3 8.7l5.4 3.3-5.4 3.3z')
+    expect(html).toContain('M4 7.2h16M4 12h11.5M4 16.8h7')
+    expect(html).not.toContain('M13 3L5 14h7l-1 7 8-11h-7l1-7z')
+    expect(html).not.toContain('fill="currentColor"')
+    expect(html).not.toContain('M5 7h14M5 12h14M5 17h10')
     w.unmount()
   })
 })

--- a/web/src/components/shell/StatusMetrics.vue
+++ b/web/src/components/shell/StatusMetrics.vue
@@ -72,17 +72,14 @@ function fmtFull(n: number | null | undefined): string {
   return n.toLocaleString('en-US')
 }
 
-/** Bucket cumulative for StatusMetrics; not Run-level token/s. */
-function fmtFiveMinuteRate(n: number | null | undefined): string {
-  if (n === null || n === undefined) return '—'
-  return `${fmtCompactTokenCount(n)}/5m`
-}
-
 const cumulative = computed(() => metrics.value?.cumulativeTokens ?? null)
-const rate = computed(() => metrics.value?.current5mBucketTokens ?? null)
-const peak = computed(() => metrics.value?.todayMaxCompleted5mTokens ?? null)
+const today = computed(() => metrics.value?.todayTokens ?? null)
 const running = computed(() => metrics.value?.runningCount ?? 0)
 const queued = computed(() => metrics.value?.queuedCount ?? 0)
+
+function todayAria(): string {
+  return `${t('shell.statusMetrics.today')}: ${fmtFull(today.value)}`
+}
 
 function toggleTip(id: string, ev: Event) {
   ev.preventDefault()
@@ -104,7 +101,7 @@ function onBlurTip(id: string) {
     :aria-label="t('shell.statusMetrics.aria')"
     :data-stale="stale ? 'true' : 'false'"
   >
-    <!-- Desktop ≥md (or variant=full): five icon+value items -->
+    <!-- Desktop ≥md (or variant=full): four icon+value items -->
     <template v-if="!useCompact">
       <button
         type="button"
@@ -115,9 +112,10 @@ function onBlurTip(id: string) {
         @click="toggleTip('tokens', $event)"
         @blur="onBlurTip('tokens')"
       >
-        <svg class="sm-ico block h-3.5 w-3.5 shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
-          <circle cx="12" cy="12" r="8" />
-          <path d="M12 8v8M9.5 10.2c.6-.7 1.5-1.1 2.5-1.1 1.7 0 3 1 3 2.4s-1.3 2.4-3 2.4h-1.2c-1.7 0-3 1-3 2.4 0 1.4 1.4 2.3 3.2 2.3 1.1 0 2-.4 2.6-1.1" />
+        <svg class="sm-ico block h-3.5 w-3.5 shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <ellipse cx="12" cy="6.6" rx="7.2" ry="3.1" />
+          <path d="M4.8 6.6v4.7c0 1.7 3.2 3.1 7.2 3.1s7.2-1.4 7.2-3.1V6.6" />
+          <path d="M4.8 11.5v4.7c0 1.7 3.2 3.1 7.2 3.1s7.2-1.4 7.2-3.1v-4.7" />
         </svg>
         <span class="sm-val text-xs leading-none text-txt">{{ fmtCompactTokenCount(cumulative) }}</span>
         <span
@@ -132,44 +130,23 @@ function onBlurTip(id: string) {
       <button
         type="button"
         class="sm-item relative inline-flex items-center gap-1.5 border-0 bg-transparent px-1.5 py-1 text-inherit hover:bg-elevated hover:text-txt focus-visible:bg-elevated focus-visible:text-txt focus-visible:outline-none"
-        :class="tipOpen === 'rate' ? 'bg-elevated text-txt tip-open' : ''"
-        data-testid="status-metrics-rate"
-        :aria-label="t('shell.statusMetrics.rate')"
-        @click="toggleTip('rate', $event)"
-        @blur="onBlurTip('rate')"
+        :class="tipOpen === 'today' ? 'bg-elevated text-txt tip-open' : ''"
+        data-testid="status-metrics-today"
+        :aria-label="todayAria()"
+        @click="toggleTip('today', $event)"
+        @blur="onBlurTip('today')"
       >
-        <svg class="sm-ico block h-3.5 w-3.5 shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
-          <path d="M13 3L5 14h7l-1 7 8-11h-7l1-7z" />
+        <svg class="sm-ico block h-3.5 w-3.5 shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <rect x="3.4" y="5.2" width="17.2" height="15.2" rx="2.6" />
+          <path d="M8.2 3v4.2M15.8 3v4.2M3.4 10.2h17.2" />
+          <circle cx="12" cy="15.2" r="2.6" />
         </svg>
-        <span class="sm-val text-xs leading-none text-txt">{{ fmtFiveMinuteRate(rate) }}</span>
+        <span class="sm-val text-xs leading-none text-txt">{{ fmtCompactTokenCount(today) }}</span>
         <span
           class="rounded-md sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden -translate-x-1/2 whitespace-nowrap border border-line-strong bg-overlay px-2.5 py-1.5 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
           role="tooltip"
         >
-          {{ t('shell.statusMetrics.rate') }}: <span class="font-mono">{{ fmtFull(rate) }}</span>
-        </span>
-      </button>
-      <span class="mx-0.5 h-3.5 w-px shrink-0 bg-line-strong" aria-hidden="true" />
-
-      <button
-        type="button"
-        class="sm-item relative inline-flex items-center gap-1.5 border-0 bg-transparent px-1.5 py-1 text-inherit hover:bg-elevated hover:text-txt focus-visible:bg-elevated focus-visible:text-txt focus-visible:outline-none"
-        :class="tipOpen === 'peak' ? 'bg-elevated text-txt tip-open' : ''"
-        data-testid="status-metrics-peak"
-        :aria-label="t('shell.statusMetrics.peak')"
-        @click="toggleTip('peak', $event)"
-        @blur="onBlurTip('peak')"
-      >
-        <svg class="sm-ico block h-3.5 w-3.5 shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
-          <path d="M3 18h18" />
-          <path d="M5 18V13l4-4 3 3 5-6 2 2v10" />
-        </svg>
-        <span class="sm-val text-xs leading-none text-txt">{{ fmtCompactTokenCount(peak) }}</span>
-        <span
-          class="rounded-md sm-tip pointer-events-none absolute left-1/2 top-[calc(100%+6px)] z-40 hidden -translate-x-1/2 whitespace-nowrap border border-line-strong bg-overlay px-2.5 py-1.5 text-left font-sans text-xs leading-snug text-txt2 shadow-card"
-          role="tooltip"
-        >
-          {{ t('shell.statusMetrics.peak') }}: <span class="font-mono">{{ fmtFull(peak) }}</span>
+          {{ t('shell.statusMetrics.today') }}: <span class="font-mono">{{ fmtFull(today) }}</span>
         </span>
       </button>
       <span class="mx-0.5 h-3.5 w-px shrink-0 bg-line-strong" aria-hidden="true" />
@@ -183,9 +160,9 @@ function onBlurTip(id: string) {
         @click="toggleTip('running', $event)"
         @blur="onBlurTip('running')"
       >
-        <svg class="sm-ico block h-3.5 w-3.5 shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
-          <circle cx="12" cy="12" r="8" />
-          <path d="M10 9.2l5.2 2.8L10 14.8V9.2z" fill="currentColor" stroke="none" />
+        <svg class="sm-ico block h-3.5 w-3.5 shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="8.2" />
+          <path d="M10.3 8.7l5.4 3.3-5.4 3.3z" />
         </svg>
         <span class="sm-val text-xs leading-none text-txt">{{ running }}</span>
         <span
@@ -206,8 +183,8 @@ function onBlurTip(id: string) {
         @click="toggleTip('queued', $event)"
         @blur="onBlurTip('queued')"
       >
-        <svg class="sm-ico block h-3.5 w-3.5 shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
-          <path d="M5 7h14M5 12h14M5 17h10" />
+        <svg class="sm-ico block h-3.5 w-3.5 shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M4 7.2h16M4 12h11.5M4 16.8h7" />
         </svg>
         <span class="sm-val text-xs leading-none text-txt">{{ queued }}</span>
         <span
@@ -219,7 +196,7 @@ function onBlurTip(id: string) {
       </button>
     </template>
 
-    <!-- Narrow &lt;md: Token · RUN/Q; rate/peak only in tip -->
+    <!-- Narrow &lt;md: Token · RUN/Q; today only in tip -->
     <button
       v-else
       ref="compactTrigger"
@@ -235,22 +212,23 @@ function onBlurTip(id: string) {
       @mouseleave="compactTipHovered = false"
     >
       <span class="inline-flex items-center gap-1.5">
-        <svg class="sm-ico block h-[13px] w-[13px] shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
-          <circle cx="12" cy="12" r="8" />
-          <path d="M12 8v8M9.5 10.2c.6-.7 1.5-1.1 2.5-1.1 1.7 0 3 1 3 2.4s-1.3 2.4-3 2.4h-1.2c-1.7 0-3 1-3 2.4 0 1.4 1.4 2.3 3.2 2.3 1.1 0 2-.4 2.6-1.1" />
+        <svg class="sm-ico block h-[13px] w-[13px] shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <ellipse cx="12" cy="6.6" rx="7.2" ry="3.1" />
+          <path d="M4.8 6.6v4.7c0 1.7 3.2 3.1 7.2 3.1s7.2-1.4 7.2-3.1V6.6" />
+          <path d="M4.8 11.5v4.7c0 1.7 3.2 3.1 7.2 3.1s7.2-1.4 7.2-3.1v-4.7" />
         </svg>
         <span class="sm-val text-[11px] font-semibold leading-none text-txt">{{ fmtCompactTokenCount(cumulative) }}</span>
       </span>
       <span class="h-3 w-px shrink-0 bg-line-strong opacity-90" aria-hidden="true" />
       <span class="inline-flex items-center gap-1.5">
-        <svg class="sm-ico block h-[13px] w-[13px] shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
-          <circle cx="12" cy="12" r="8" />
-          <path d="M10 9.2l5.2 2.8L10 14.8V9.2z" fill="currentColor" stroke="none" />
+        <svg class="sm-ico block h-[13px] w-[13px] shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="8.2" />
+          <path d="M10.3 8.7l5.4 3.3-5.4 3.3z" />
         </svg>
         <span class="sm-val text-[11px] font-semibold leading-none text-txt">{{ running }}</span>
         <span class="text-txt3">/</span>
-        <svg class="sm-ico block h-[13px] w-[13px] shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
-          <path d="M5 7h14M5 12h14M5 17h10" />
+        <svg class="sm-ico block h-[13px] w-[13px] shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M4 7.2h16M4 12h11.5M4 16.8h7" />
         </svg>
         <span class="sm-val text-[11px] font-semibold leading-none text-txt">{{ queued }}</span>
       </span>
@@ -260,8 +238,7 @@ function onBlurTip(id: string) {
         role="tooltip"
       >
         <div>{{ t('shell.statusMetrics.tokens') }}: <span class="font-mono">{{ fmtFull(cumulative) }}</span></div>
-        <div>{{ t('shell.statusMetrics.rate') }}: <span class="font-mono">{{ fmtFull(rate) }}</span></div>
-        <div>{{ t('shell.statusMetrics.peak') }}: <span class="font-mono">{{ fmtFull(peak) }}</span></div>
+        <div>{{ t('shell.statusMetrics.today') }}: <span class="font-mono">{{ fmtFull(today) }}</span></div>
         <div>{{ t('shell.statusMetrics.running') }}: <span class="font-mono">{{ running }}</span></div>
         <div>{{ t('shell.statusMetrics.queued') }}: <span class="font-mono">{{ queued }}</span></div>
       </span>
@@ -278,8 +255,7 @@ function onBlurTip(id: string) {
         :style="compactTipStyle ?? undefined"
       >
         <div>{{ t('shell.statusMetrics.tokens') }}: <span class="font-mono">{{ fmtFull(cumulative) }}</span></div>
-        <div>{{ t('shell.statusMetrics.rate') }}: <span class="font-mono">{{ fmtFull(rate) }}</span></div>
-        <div>{{ t('shell.statusMetrics.peak') }}: <span class="font-mono">{{ fmtFull(peak) }}</span></div>
+        <div>{{ t('shell.statusMetrics.today') }}: <span class="font-mono">{{ fmtFull(today) }}</span></div>
         <div>{{ t('shell.statusMetrics.running') }}: <span class="font-mono">{{ running }}</span></div>
         <div>{{ t('shell.statusMetrics.queued') }}: <span class="font-mono">{{ queued }}</span></div>
       </div>

--- a/web/src/lib/api/apiTypes.ts
+++ b/web/src/lib/api/apiTypes.ts
@@ -266,16 +266,10 @@ export interface DashboardStats {
 export interface PlatformStatusMetrics {
   /** Platform cumulative tokens; null = never reported (UI "—"). */
   cumulativeTokens: number | null
-  /** Current calendar-aligned 5m bucket sum; null when unavailable. */
-  current5mBucketTokens: number | null
-  /** Max among today's completed 5m buckets; null when none. */
-  todayMaxCompleted5mTokens: number | null
+  /** Client-timezone calendar-day token sum; null when unavailable. */
+  todayTokens: number | null
   runningCount: number
   queuedCount: number
-  currentBucketStart?: string | null
-  currentBucketEnd?: string | null
-  peakBucketStart?: string | null
-  peakBucketEnd?: string | null
   asOf: string
   timezone?: string
 }

--- a/web/src/lib/composables/usePlatformStatusMetrics.test.ts
+++ b/web/src/lib/composables/usePlatformStatusMetrics.test.ts
@@ -34,8 +34,7 @@ describe('usePlatformStatusMetrics', () => {
     platformStatus.mockReset()
     platformStatus.mockResolvedValue({
       cumulativeTokens: 10,
-      current5mBucketTokens: 1,
-      todayMaxCompleted5mTokens: 2,
+      todayTokens: 1,
       runningCount: 0,
       queuedCount: 0,
       asOf: '2026-08-12T00:00:00Z',

--- a/web/src/locales/en/shell.json
+++ b/web/src/locales/en/shell.json
@@ -60,8 +60,7 @@
     "statusMetrics": {
       "aria": "Platform status metrics",
       "tokens": "Cumulative tokens",
-      "rate": "Current 5-minute rate",
-      "peak": "Today's 5-minute peak",
+      "today": "Today's tokens",
       "running": "Running",
       "queued": "Queued",
       "compactAria": "Platform status summary"

--- a/web/src/locales/zh-CN/shell.json
+++ b/web/src/locales/zh-CN/shell.json
@@ -60,8 +60,7 @@
     "statusMetrics": {
       "aria": "平台状态指标",
       "tokens": "累计 Token",
-      "rate": "当前 5 分钟速率",
-      "peak": "今日 5 分钟峰值",
+      "today": "今日 Token",
       "running": "执行中",
       "queued": "排队",
       "compactAria": "平台状态摘要"


### PR DESCRIPTION
StatusMetrics now reads todayTokens from platform-status (local calendar day)
and uses the A-set stroke icons, so the chrome matches daily usage instead of 5-minute buckets.

Co-authored-by: Cursor <cursoragent@cursor.com>
