### PR TITLE
fix(web): wrap clarify composer by line count and sidebar width

### DIFF
--- a/web/LIB_DOMAIN_MAP.json
+++ b/web/LIB_DOMAIN_MAP.json
@@ -44,6 +44,7 @@
     "inbox": [
       "clarifyDemo.ts",
       "clarifyInboxStage.ts",
+      "composerAutoGrow.ts",
       "gateShareLink.ts",
       "gateUpstream.ts",
       "inboxActiveSelection.ts",
@@ -177,7 +178,7 @@
     "agent": 15,
     "api": 3,
     "composables": 16,
-    "inbox": 20,
+    "inbox": 21,
     "pm": 7,
     "project": 4,
     "run": 53,

--- a/web/src/components/run/ClarifyChat.test.ts
+++ b/web/src/components/run/ClarifyChat.test.ts
@@ -30,6 +30,7 @@ function mountChat(opts: {
   seedHumanText?: string
   seedHumanImages?: { data: string; mimeType: string; name?: string }[]
   hideFinish?: boolean
+  sendLabel?: string
 } = {}) {
   const i18n = createI18n({
     legacy: false,
@@ -54,6 +55,7 @@ function mountChat(opts: {
       seedHumanText: opts.seedHumanText ?? '',
       seedHumanImages: opts.seedHumanImages ?? [],
       hideFinish: opts.hideFinish ?? false,
+      sendLabel: opts.sendLabel,
     },
     global: {
       plugins: [i18n],
@@ -528,6 +530,44 @@ describe('ClarifyChat', () => {
     expect(ta.style.height).toBe('128px')
     expect(wrapper.find('[data-testid="clarify-confirm-flow"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="clarify-confirm-hint"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('splits attach+textarea from send/cancel so input keeps remaining width', async () => {
+    const wrapper = mountChat({ sendLabel: '发送澄清回复' })
+    const inputRow = wrapper.get('[data-testid="clarify-input-row"]')
+    const actionRow = wrapper.get('[data-testid="clarify-action-row"]')
+    expect(inputRow.find('[data-testid="clarify-input"]').exists()).toBe(true)
+    expect(inputRow.find('[data-testid="clarify-attach-btn"]').exists()).toBe(true)
+    expect(inputRow.find('[data-testid="clarify-send-label"]').exists()).toBe(false)
+    expect(inputRow.find('[data-testid="clarify-send-icon"]').exists()).toBe(false)
+    expect(actionRow.find('[data-testid="clarify-send-label"]').exists()).toBe(true)
+    expect(actionRow.find('[data-testid="clarify-send-label"]').text()).toContain('发送澄清回复')
+    expect(wrapper.find('[data-testid="clarify-input"]').classes()).toContain('composer-hint-wrap')
+    wrapper.unmount()
+  })
+
+  it('confirm hint wraps by width and stays visible with send on a separate row', async () => {
+    const wrapper = mountChat({ reviewMode: true })
+    const hint = wrapper.get('[data-testid="clarify-confirm-hint"]')
+    expect(hint.classes().join(' ')).toContain('[overflow-wrap:anywhere]')
+    expect(wrapper.find('[data-testid="clarify-input-row"]').find('[data-testid="clarify-confirm-flow"]').exists()).toBe(
+      false,
+    )
+    expect(wrapper.find('[data-testid="clarify-confirm-flow"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('shows Cancel on the action row (not the input row) while session is busy', async () => {
+    const wrapper = mountChat()
+    await wrapper.find('[data-testid="clarify-input"]').setValue('排队')
+    await clickSend(wrapper)
+    expect(wrapper.find('[data-testid="clarify-input-row"]').find('[data-testid="clarify-review-cancel"]').exists()).toBe(
+      false,
+    )
+    expect(wrapper.find('[data-testid="clarify-action-row"]').find('[data-testid="clarify-review-cancel"]').exists()).toBe(
+      true,
+    )
     wrapper.unmount()
   })
 

--- a/web/src/components/run/ClarifyChat.vue
+++ b/web/src/components/run/ClarifyChat.vue
@@ -464,7 +464,7 @@ const {
                         <input
                           v-model="other[curQuestion.id]"
                           type="text"
-                          class="input min-h-0 flex-1 border-0 bg-transparent p-0 text-[12px] shadow-none focus:border-transparent focus:ring-0"
+                          class="input min-h-0 min-w-0 flex-1 border-0 bg-transparent p-0 text-[12px] shadow-none focus:border-transparent focus:ring-0 [overflow-wrap:anywhere]"
                           :placeholder="translate('pages.clarify.otherPlaceholder')"
                           data-testid="clarify-other-input"
                         />
@@ -513,7 +513,7 @@ const {
                     >
                       {{ translate('pages.clarify.next') }} <Icon name="chevron-right" :size="13" />
                     </button>
-                    <div v-else class="flex items-center gap-2">
+                    <div v-else class="flex flex-wrap items-center gap-2">
                       <button
                         v-if="hasRecommended"
                         class="inline-flex items-center gap-1 rounded-md border border-accent/40 bg-accent/10 px-2.5 py-1.5 text-[12px] font-medium text-accent-2 hover:bg-accent/20 disabled:opacity-50"
@@ -677,10 +677,10 @@ const {
           ><Icon name="close" :size="9" /></button>
         </div>
       </div>
-      <div class="flex items-end gap-2">
+      <div class="flex min-w-0 items-end gap-2" data-testid="clarify-input-row">
         <input ref="fileInput" type="file" multiple class="hidden" @change="onPickFiles" />
         <button
-          class="flex h-10 w-10 items-center justify-center rounded-md border border-line text-txt2 hover:border-line-strong disabled:opacity-50"
+          class="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-line text-txt2 hover:border-line-strong disabled:opacity-50"
           :title="translate('pages.clarify.addImage')"
           data-testid="clarify-attach-btn"
           @click="fileInput?.click()"
@@ -690,7 +690,7 @@ const {
         <textarea
           ref="textareaRef"
           v-model="draft"
-          class="input min-h-[40px] flex-1 resize-none"
+          class="input composer-hint-wrap min-h-[40px] min-w-0 flex-1 resize-none"
           :class="overflowScroll ? 'scroll-area max-h-[128px] overflow-y-auto' : 'overflow-y-hidden'"
           rows="1"
           :placeholder="inputPlaceholder"
@@ -701,9 +701,11 @@ const {
           @compositionend="composing = false"
           @paste="onPaste"
         />
+      </div>
+      <div class="mt-2 flex min-w-0 flex-wrap items-center gap-2" data-testid="clarify-action-row">
         <button
           v-if="sendLabel"
-          class="inline-flex h-10 items-center gap-1 rounded-md bg-accent px-3 text-xs font-semibold text-white hover:bg-accent-2 disabled:opacity-50"
+          class="inline-flex min-h-10 shrink-0 items-center gap-1 rounded-md bg-accent px-3 py-2 text-xs font-semibold text-white hover:bg-accent-2 disabled:opacity-50"
           data-testid="clarify-send-label"
           :disabled="!draft.trim() && !attachments.length && !annotations.length"
           @click="send"
@@ -712,7 +714,7 @@ const {
         </button>
         <button
           v-else
-          class="flex h-10 w-10 items-center justify-center rounded-md bg-accent text-white hover:bg-accent-2 disabled:opacity-50"
+          class="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-accent text-white hover:bg-accent-2 disabled:opacity-50"
           data-testid="clarify-send-icon"
           :disabled="!draft.trim() && !attachments.length && !annotations.length"
           @click="send"
@@ -722,7 +724,7 @@ const {
         <button
           v-if="sessionBusy"
           type="button"
-          class="inline-flex h-10 shrink-0 items-center gap-1 rounded-md border border-line bg-elevated px-3 text-xs font-semibold text-txt2 hover:border-line-strong"
+          class="inline-flex min-h-10 shrink-0 items-center gap-1 rounded-md border border-line bg-elevated px-3 py-2 text-xs font-semibold text-txt2 hover:border-line-strong"
           data-testid="clarify-review-cancel"
           title="Cancel"
           @click="cancelReview"
@@ -730,15 +732,15 @@ const {
           Cancel
         </button>
       </div>
-      <div v-if="!hideFinish" class="mt-2 flex items-center justify-between gap-2">
+      <div v-if="!hideFinish" class="mt-2 flex min-w-0 flex-wrap items-start justify-between gap-2">
         <p
           v-if="reviewMode"
-          class="min-w-0 flex-1 text-[11px] leading-snug text-txt3"
+          class="min-w-0 flex-1 basis-40 text-[11px] leading-snug text-txt3 [overflow-wrap:anywhere]"
           data-testid="clarify-confirm-hint"
         >
           {{ validating ? translate('pages.clarify.validating') : translate('pages.clarify.confirmFlowHint') }}
         </p>
-        <span v-else class="flex-1" />
+        <span v-else class="min-w-0 flex-1" />
         <button
           v-if="useConfirmFlowAction"
           class="inline-flex shrink-0 items-center gap-1 rounded-md bg-ok px-3 py-1.5 text-xs font-semibold text-white hover:bg-ok/90 disabled:opacity-50"
@@ -783,6 +785,29 @@ const {
 </template>
 
 <style scoped>
+/* Placeholder must wrap to the textarea width — UA default often clips the 2nd line. */
+.composer-hint-wrap::placeholder {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  overflow: visible;
+  text-overflow: unset;
+}
+.composer-hint-wrap::-webkit-input-placeholder {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  overflow: visible;
+  text-overflow: unset;
+}
+.composer-hint-wrap::-moz-placeholder {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  overflow: visible;
+  opacity: 1;
+}
+
 /* Card-deck step transition: subtle slide + fade as one card advances. */
 .deck-enter-active,
 .deck-leave-active {

--- a/web/src/components/run/PendingSendQueuePanel.vue
+++ b/web/src/components/run/PendingSendQueuePanel.vue
@@ -78,7 +78,7 @@ function onDrop(toIndex: number, e: DragEvent) {
         v-for="(q, qi) in items"
         :key="q.id || qi"
         data-testid="clarify-queue-item"
-        class="flex items-center gap-2 rounded border border-line bg-surface px-2 py-1 text-[12px] text-txt2 transition-colors"
+        class="flex min-w-0 flex-wrap items-center gap-2 rounded border border-line bg-surface px-2 py-1 text-[12px] text-txt2 transition-colors"
         :class="dragIndex === qi ? 'opacity-60 shadow-sm' : ''"
         draggable="true"
         @dragstart="onDragStart(qi, $event)"

--- a/web/src/components/run/ReviewComposer.test.ts
+++ b/web/src/components/run/ReviewComposer.test.ts
@@ -297,6 +297,11 @@ describe('ReviewComposer gate review semantics (send + confirm)', () => {
     expect(wrapper.find('[data-testid="review-composer-pass"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="review-composer-cold-note"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="review-composer-footer-hint"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="review-composer-footer-hint"]').classes().join(' ')).toContain(
+      '[overflow-wrap:anywhere]',
+    )
+    // g2.1 walkthrough: gate action row already flex-wrap; send/confirm min-w-0 so they
+    // wrap instead of colliding with ParagraphInput (buttons stay below input).
     expect(wrapper.findComponent({ name: 'ParagraphInput' }).exists()).toBe(true)
     wrapper.unmount()
   })

--- a/web/src/components/run/ReviewComposer.vue
+++ b/web/src/components/run/ReviewComposer.vue
@@ -274,11 +274,11 @@ function onConfirm() {
         />
         <div v-if="rejectError" class="mt-1.5 text-[11px] text-err">{{ rejectError }}</div>
       </template>
-      <div class="mt-2 flex flex-wrap gap-2">
+      <div class="mt-2 flex min-w-0 flex-wrap gap-2">
         <button
           v-if="!coldSession && canReject"
           type="button"
-          class="inline-flex flex-1 items-center justify-center gap-1.5 bg-accent/15 px-3 py-2 text-sm font-medium text-accent-2 transition hover:bg-accent/25 disabled:cursor-not-allowed disabled:opacity-50"
+          class="inline-flex min-h-[40px] min-w-0 flex-1 items-center justify-center gap-1.5 bg-accent/15 px-3 py-2 text-sm font-medium text-accent-2 transition hover:bg-accent/25 disabled:cursor-not-allowed disabled:opacity-50"
           data-testid="review-composer-send"
           :disabled="!canSubmitGate"
           @click="onSend"
@@ -289,7 +289,7 @@ function onConfirm() {
         <button
           v-if="canPass"
           type="button"
-          class="inline-flex flex-1 items-center justify-center gap-1.5 bg-ok/15 px-3 py-2 text-sm font-medium text-ok transition hover:bg-ok/25 disabled:cursor-not-allowed disabled:opacity-50"
+          class="inline-flex min-h-[40px] min-w-0 flex-1 items-center justify-center gap-1.5 bg-ok/15 px-3 py-2 text-sm font-medium text-ok transition hover:bg-ok/25 disabled:cursor-not-allowed disabled:opacity-50"
           data-testid="review-composer-pass"
           :disabled="passDisabled"
           :title="passTitle"
@@ -327,7 +327,7 @@ function onConfirm() {
           :interrupted="interrupted"
           :completed-at="streamCompletedAt"
         />
-        <p class="mt-2 text-[11px] leading-relaxed text-txt3" data-testid="review-composer-footer-hint">
+        <p class="mt-2 min-w-0 text-[11px] leading-relaxed text-txt3 [overflow-wrap:anywhere]" data-testid="review-composer-footer-hint">
           {{ gateFooterHint }}
         </p>
       </template>

--- a/web/src/components/run/gateApproval/GateApprovalContentFit.vue
+++ b/web/src/components/run/gateApproval/GateApprovalContentFit.vue
@@ -306,14 +306,14 @@ const {
             <div v-else class="flex min-h-0 flex-1 flex-col">
               <p
                 v-if="isColdSession"
-                class="mb-2 shrink-0 text-[11px] leading-relaxed text-txt3"
+                class="mb-2 min-w-0 shrink-0 text-[11px] leading-relaxed text-txt3 [overflow-wrap:anywhere]"
                 data-testid="gate-cold-help"
               >
                 {{ helpColdText }}
               </p>
               <p
                 v-else-if="usesPreviewIssues && openPreviewIssueCount === 0"
-                class="mb-2 shrink-0 text-[11px] leading-relaxed text-txt3"
+                class="mb-2 min-w-0 shrink-0 text-[11px] leading-relaxed text-txt3 [overflow-wrap:anywhere]"
               >
                 <b class="font-medium text-txt2">{{ t('pages.clarify.confirmFlow') }}</b>
                 {{ t('pages.gateApproval.helpApproveDetail') }}
@@ -323,7 +323,7 @@ const {
               </p>
               <p
                 v-else-if="usesPreviewIssues && openPreviewIssueCount >= 1"
-                class="mb-2 shrink-0 text-[11px] leading-relaxed text-txt3"
+                class="mb-2 min-w-0 shrink-0 text-[11px] leading-relaxed text-txt3 [overflow-wrap:anywhere]"
               >
                 <template v-if="canReactRevise">
                   <b class="font-medium text-txt2">{{ t('pages.reviewComposer.send') }}</b>
@@ -333,7 +333,7 @@ const {
                 </template>
                 <template v-else>{{ helpReviseWithIssuesText }}</template>
               </p>
-              <p v-else-if="canEditProducts" class="mb-2 shrink-0 text-[11px] leading-relaxed text-txt3">
+              <p v-else-if="canEditProducts" class="mb-2 min-w-0 shrink-0 text-[11px] leading-relaxed text-txt3 [overflow-wrap:anywhere]">
                 <b class="font-medium text-txt2">{{ t('pages.clarify.confirmFlow') }}</b>
                 {{ t('pages.gateApproval.helpApproveDetail') }}
                 <span class="mx-1">·</span>

--- a/web/src/components/run/gateApproval/GateApprovalDesktopBody.vue
+++ b/web/src/components/run/gateApproval/GateApprovalDesktopBody.vue
@@ -418,14 +418,14 @@ const {
         <div v-else>
           <p
             v-if="isColdSession"
-            class="mb-2 text-[11px] leading-relaxed text-txt3"
+            class="mb-2 min-w-0 text-[11px] leading-relaxed text-txt3 [overflow-wrap:anywhere]"
             data-testid="gate-cold-help"
           >
             {{ helpColdText }}
           </p>
           <p
             v-else-if="usesPreviewIssues && openPreviewIssueCount === 0"
-            class="mb-2 text-[11px] leading-relaxed text-txt3"
+            class="mb-2 min-w-0 text-[11px] leading-relaxed text-txt3 [overflow-wrap:anywhere]"
           >
             <b class="font-medium text-txt2">{{ t('pages.clarify.confirmFlow') }}</b>
             {{ t('pages.gateApproval.helpApproveDetail') }}
@@ -435,7 +435,7 @@ const {
           </p>
           <p
             v-else-if="usesPreviewIssues && openPreviewIssueCount >= 1"
-            class="mb-2 text-[11px] leading-relaxed text-txt3"
+            class="mb-2 min-w-0 text-[11px] leading-relaxed text-txt3 [overflow-wrap:anywhere]"
           >
             <template v-if="canReactRevise">
               <b class="font-medium text-txt2">{{ t('pages.reviewComposer.send') }}</b>
@@ -445,7 +445,7 @@ const {
             </template>
             <template v-else>{{ helpReviseWithIssuesText }}</template>
           </p>
-          <p v-else-if="canEditProducts" class="mb-2 text-[11px] leading-relaxed text-txt3">
+          <p v-else-if="canEditProducts" class="mb-2 min-w-0 text-[11px] leading-relaxed text-txt3 [overflow-wrap:anywhere]">
             <b class="font-medium text-txt2">{{ t('pages.clarify.confirmFlow') }}</b>
             {{ t('pages.gateApproval.helpApproveDetail') }}
             <span class="mx-1">·</span>

--- a/web/src/components/run/gateApproval/GateApprovalMobileFill.vue
+++ b/web/src/components/run/gateApproval/GateApprovalMobileFill.vue
@@ -273,14 +273,14 @@ const {
             <div v-else class="flex min-h-0 flex-1 flex-col">
               <p
                 v-if="isColdSession"
-                class="mb-2 shrink-0 text-[11px] leading-relaxed text-txt3"
+                class="mb-2 min-w-0 shrink-0 text-[11px] leading-relaxed text-txt3 [overflow-wrap:anywhere]"
                 data-testid="gate-cold-help"
               >
                 {{ helpColdText }}
               </p>
               <p
                 v-else-if="usesPreviewIssues && openPreviewIssueCount === 0"
-                class="mb-2 shrink-0 text-[11px] leading-relaxed text-txt3"
+                class="mb-2 min-w-0 shrink-0 text-[11px] leading-relaxed text-txt3 [overflow-wrap:anywhere]"
               >
                 <b class="font-medium text-txt2">{{ t('pages.clarify.confirmFlow') }}</b>
                 {{ t('pages.gateApproval.helpApproveDetail') }}
@@ -290,7 +290,7 @@ const {
               </p>
               <p
                 v-else-if="usesPreviewIssues && openPreviewIssueCount >= 1"
-                class="mb-2 shrink-0 text-[11px] leading-relaxed text-txt3"
+                class="mb-2 min-w-0 shrink-0 text-[11px] leading-relaxed text-txt3 [overflow-wrap:anywhere]"
               >
                 <template v-if="canReactRevise">
                   <b class="font-medium text-txt2">{{ t('pages.reviewComposer.send') }}</b>

--- a/web/src/components/run/gateApproval/GateHotUnifiedActions.vue
+++ b/web/src/components/run/gateApproval/GateHotUnifiedActions.vue
@@ -59,7 +59,7 @@ const cancelBtnClass = computed(() => {
       {{ t('pages.gateApproval.reviewFeedback.record') }}
     </button>
   </div>
-  <div class="flex flex-wrap gap-2" data-testid="review-composer-actions">
+  <div class="flex min-w-0 flex-wrap gap-2" data-testid="review-composer-actions">
     <button
       v-if="s.showHotReject"
       type="button"

--- a/web/src/components/ui/ParagraphInput.vue
+++ b/web/src/components/ui/ParagraphInput.vue
@@ -9,7 +9,8 @@ import { useChatImagePreview } from '@/lib/composables/useChatImagePreview'
 import { useImageAttachments } from '@/lib/composables/useImageAttachments'
 import { attachmentDisplayName, isImageAttachment } from '@/lib/shared/attachments'
 import type { ClarifyImage } from '@/lib/shared/types'
-import { nextTick, onMounted, ref, watch } from 'vue'
+import { applyComposerAutoGrow, PARAGRAPH_AUTO_GROW_MAX, PARAGRAPH_AUTO_GROW_MIN } from '@/lib/inbox/composerAutoGrow'
+import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 const props = defineProps<{
   disabled?: boolean
@@ -27,6 +28,7 @@ const { preview: imagePreview, openChatImagePreview, closeChatImagePreview } = u
 
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
 const overflowScroll = ref(false)
+let composerResizeObserver: ResizeObserver | null = null
 
 const defaultPlaceholder = computed(() =>
   props.textOnly ? t('common.paragraphInput.placeholderTextOnly') : t('common.paragraphInput.placeholderWithImages'),
@@ -35,10 +37,11 @@ const defaultPlaceholder = computed(() =>
 function autoGrow() {
   const el = textareaRef.value
   if (!el) return
-  el.style.height = 'auto'
-  const h = Math.min(Math.max(el.scrollHeight, 72), 320)
-  el.style.height = `${h}px`
-  overflowScroll.value = el.scrollHeight > 320
+  overflowScroll.value = applyComposerAutoGrow(el, {
+    min: PARAGRAPH_AUTO_GROW_MIN,
+    max: PARAGRAPH_AUTO_GROW_MAX,
+    emptyHint: props.placeholder || defaultPlaceholder.value,
+  })
 }
 
 function onTextInput() {
@@ -66,7 +69,21 @@ watch(
 )
 watch(text, () => nextTick(autoGrow), { immediate: true })
 watch(attachments, () => nextTick(autoGrow), { deep: true })
-onMounted(() => nextTick(autoGrow))
+onMounted(() => {
+  nextTick(() => {
+    autoGrow()
+    const el = textareaRef.value
+    if (el && typeof ResizeObserver !== 'undefined') {
+      composerResizeObserver?.disconnect()
+      composerResizeObserver = new ResizeObserver(() => autoGrow())
+      composerResizeObserver.observe(el)
+    }
+  })
+})
+onBeforeUnmount(() => {
+  composerResizeObserver?.disconnect()
+  composerResizeObserver = null
+})
 </script>
 
 <template>
@@ -111,7 +128,7 @@ onMounted(() => nextTick(autoGrow))
         </button>
       </div>
     </div>
-    <div class="flex items-end gap-2">
+    <div class="flex min-w-0 items-end gap-2">
       <input v-if="!textOnly" ref="fileInput" type="file" multiple class="hidden" @change="onPickFiles" />
       <button
         v-if="!textOnly"
@@ -128,7 +145,7 @@ onMounted(() => nextTick(autoGrow))
         ref="textareaRef"
         v-model="text"
         data-testid="paragraph-input"
-        class="input min-h-[72px] flex-1 resize-none disabled:opacity-60"
+        class="input composer-hint-wrap min-h-[72px] min-w-0 flex-1 resize-none disabled:opacity-60"
         :class="overflowScroll ? 'scroll-area max-h-[320px] overflow-y-auto' : 'overflow-y-hidden'"
         :disabled="disabled"
         :placeholder="placeholder || defaultPlaceholder"
@@ -145,3 +162,21 @@ onMounted(() => nextTick(autoGrow))
     />
   </div>
 </template>
+
+<style scoped>
+.composer-hint-wrap::placeholder {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  overflow: visible;
+  text-overflow: unset;
+}
+.composer-hint-wrap::-webkit-input-placeholder {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  overflow: visible;
+  text-overflow: unset;
+}
+</style>
+

--- a/web/src/lib/inbox/composerAutoGrow.test.ts
+++ b/web/src/lib/inbox/composerAutoGrow.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import {
+  applyComposerAutoGrow,
+  CLARIFY_AUTO_GROW_MAX,
+  CLARIFY_AUTO_GROW_MIN,
+  measureWrappedTextHeight,
+} from './composerAutoGrow'
+
+function makeTextarea(opts: { value?: string; clientWidth: number; scrollHeight: number }) {
+  const el = document.createElement('textarea')
+  el.value = opts.value ?? ''
+  el.placeholder = '请先描述目标…'
+  Object.defineProperty(el, 'clientWidth', { configurable: true, get: () => opts.clientWidth })
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => opts.scrollHeight })
+  document.body.appendChild(el)
+  return el
+}
+
+function withSizerOffsetHeight(height: number, run: () => void) {
+  const proto = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight')
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get() {
+      if ((this as HTMLElement).getAttribute?.('data-composer-sizer') != null) return height
+      return proto?.get ? proto.get.call(this) : 0
+    },
+  })
+  try {
+    run()
+  } finally {
+    if (proto) Object.defineProperty(HTMLElement.prototype, 'offsetHeight', proto)
+  }
+}
+
+describe('composerAutoGrow', () => {
+  it('unlaid-out empty (clientWidth 0) uses scrollHeight and stays at min, not max', () => {
+    const el = makeTextarea({ clientWidth: 0, scrollHeight: 40 })
+    const overflow = applyComposerAutoGrow(el, {
+      min: CLARIFY_AUTO_GROW_MIN,
+      max: CLARIFY_AUTO_GROW_MAX,
+      emptyHint: '请先描述目标…',
+    })
+    expect(el.style.height).toBe('40px')
+    expect(overflow).toBe(false)
+    el.remove()
+  })
+
+  it('wide empty hint wrap (~one line) stays at min, not 128px cap', () => {
+    const el = makeTextarea({ clientWidth: 420, scrollHeight: 128 })
+    withSizerOffsetHeight(40, () => {
+      applyComposerAutoGrow(el, {
+        min: CLARIFY_AUTO_GROW_MIN,
+        max: CLARIFY_AUTO_GROW_MAX,
+        emptyHint: '请先描述目标…',
+      })
+      expect(el.style.height).toBe('40px')
+    })
+    el.remove()
+  })
+
+  it('narrow empty hint wrap grows to N lines below cap', () => {
+    const el = makeTextarea({ clientWidth: 120, scrollHeight: 40 })
+    withSizerOffsetHeight(88, () => {
+      const overflow = applyComposerAutoGrow(el, {
+        min: CLARIFY_AUTO_GROW_MIN,
+        max: CLARIFY_AUTO_GROW_MAX,
+        emptyHint: '请先描述目标…',
+      })
+      expect(el.style.height).toBe('88px')
+      expect(overflow).toBe(false)
+    })
+    el.remove()
+  })
+
+  it('widening from wrapped hint retracts height', () => {
+    const el = makeTextarea({ clientWidth: 80, scrollHeight: 40 })
+    withSizerOffsetHeight(96, () => {
+      applyComposerAutoGrow(el, {
+        min: CLARIFY_AUTO_GROW_MIN,
+        max: CLARIFY_AUTO_GROW_MAX,
+        emptyHint: '请先描述目标…',
+      })
+      expect(el.style.height).toBe('96px')
+    })
+    Object.defineProperty(el, 'clientWidth', { configurable: true, get: () => 480 })
+    withSizerOffsetHeight(40, () => {
+      applyComposerAutoGrow(el, {
+        min: CLARIFY_AUTO_GROW_MIN,
+        max: CLARIFY_AUTO_GROW_MAX,
+        emptyHint: '请先描述目标…',
+      })
+      expect(el.style.height).toBe('40px')
+    })
+    el.remove()
+  })
+
+  it('draft taller than max enables overflow and caps height', () => {
+    const el = makeTextarea({ value: 'a\n'.repeat(20), clientWidth: 0, scrollHeight: 200 })
+    const overflow = applyComposerAutoGrow(el, {
+      min: CLARIFY_AUTO_GROW_MIN,
+      max: CLARIFY_AUTO_GROW_MAX,
+    })
+    expect(el.style.height).toBe('128px')
+    expect(overflow).toBe(true)
+    el.remove()
+  })
+
+  it('measureWrappedTextHeight returns 0 when width is 0', () => {
+    const el = makeTextarea({ clientWidth: 0, scrollHeight: 40 })
+    expect(measureWrappedTextHeight(el, '请先描述目标…')).toBe(0)
+    el.remove()
+  })
+})

--- a/web/src/lib/inbox/composerAutoGrow.ts
+++ b/web/src/lib/inbox/composerAutoGrow.ts
@@ -1,0 +1,70 @@
+/**
+ * Composer textarea height follows visible line count at the current width:
+ * empty draft → placeholder wrap; with draft → soft + hard wrap.
+ * Cap is only an overflow ceiling (wide empty must not sit at max).
+ */
+
+export const CLARIFY_AUTO_GROW_MIN = 40
+export const CLARIFY_AUTO_GROW_MAX = 128
+
+export const PARAGRAPH_AUTO_GROW_MIN = 72
+export const PARAGRAPH_AUTO_GROW_MAX = 320
+
+/** Measure how tall `text` is when wrapped to the textarea's current content box. */
+export function measureWrappedTextHeight(el: HTMLTextAreaElement, text: string): number {
+  const width = el.clientWidth
+  if (width <= 0) return 0
+  const cs = getComputedStyle(el)
+  const sizer = document.createElement('div')
+  sizer.setAttribute('data-composer-sizer', '')
+  sizer.style.position = 'absolute'
+  sizer.style.left = '-9999px'
+  sizer.style.top = '0'
+  sizer.style.visibility = 'hidden'
+  sizer.style.pointerEvents = 'none'
+  sizer.style.whiteSpace = 'pre-wrap'
+  sizer.style.overflowWrap = 'anywhere'
+  sizer.style.wordBreak = 'break-word'
+  sizer.style.width = `${width}px`
+  sizer.style.font = cs.font
+  sizer.style.fontSize = cs.fontSize
+  sizer.style.fontFamily = cs.fontFamily
+  sizer.style.fontWeight = cs.fontWeight
+  sizer.style.letterSpacing = cs.letterSpacing
+  sizer.style.lineHeight = cs.lineHeight
+  sizer.style.padding = cs.padding
+  sizer.style.border = cs.border
+  sizer.style.boxSizing = cs.boxSizing as string
+  sizer.textContent = text.length ? text : '\u00a0'
+  document.body.appendChild(sizer)
+  const h = sizer.offsetHeight
+  sizer.remove()
+  return h
+}
+
+export type ComposerAutoGrowOpts = {
+  min: number
+  max: number
+  /** Placeholder / hint used when the draft is empty. */
+  emptyHint?: string
+}
+
+/**
+ * Set textarea height from visible lines. Returns whether content exceeds max
+ * (caller should enable inner scroll).
+ */
+export function applyComposerAutoGrow(el: HTMLTextAreaElement, opts: ComposerAutoGrowOpts): boolean {
+  const draft = el.value
+  el.style.height = 'auto'
+  const wrapSource = draft || opts.emptyHint || el.placeholder || ''
+  const wrapH = measureWrappedTextHeight(el, wrapSource)
+  // Unlaid-out / tests (clientWidth 0): wrapH is 0 → fall back to native scrollHeight.
+  const contentH = draft
+    ? Math.max(el.scrollHeight, wrapH)
+    : wrapH > 0
+      ? wrapH
+      : el.scrollHeight
+  const h = Math.min(Math.max(contentH, opts.min), opts.max)
+  el.style.height = `${h}px`
+  return contentH > opts.max
+}

--- a/web/src/lib/inbox/useClarifyChat.ts
+++ b/web/src/lib/inbox/useClarifyChat.ts
@@ -31,6 +31,11 @@ import {
 } from '@/lib/shared/attachments'
 import { imgSrc } from '@/lib/shared/compositeText'
 import { useChatImagePreview } from '@/lib/composables/useChatImagePreview'
+import {
+  applyComposerAutoGrow,
+  CLARIFY_AUTO_GROW_MAX,
+  CLARIFY_AUTO_GROW_MIN,
+} from '@/lib/inbox/composerAutoGrow'
 import type { Ref } from 'vue'
 
 /** Element-level clone so queue rows never share annotation object refs with composer. */
@@ -269,17 +274,19 @@ function onUnreadFabClick() {
   void scrollBottom(true)
 }
 
-const AUTO_GROW_MIN = 40
-const AUTO_GROW_MAX = 128
+const AUTO_GROW_MIN = CLARIFY_AUTO_GROW_MIN
+const AUTO_GROW_MAX = CLARIFY_AUTO_GROW_MAX
+
+let composerResizeObserver: ResizeObserver | null = null
 
 function autoGrow() {
   const el = textareaRef.value
   if (!el) return
-  el.style.height = 'auto'
-  const sh = el.scrollHeight
-  const h = Math.min(Math.max(sh, AUTO_GROW_MIN), AUTO_GROW_MAX)
-  el.style.height = `${h}px`
-  overflowScroll.value = sh > AUTO_GROW_MAX
+  overflowScroll.value = applyComposerAutoGrow(el, {
+    min: AUTO_GROW_MIN,
+    max: AUTO_GROW_MAX,
+    emptyHint: inputPlaceholder.value,
+  })
 }
 
 function onTextInput() {
@@ -287,6 +294,8 @@ function onTextInput() {
 }
 
 onBeforeUnmount(() => {
+  composerResizeObserver?.disconnect()
+  composerResizeObserver = null
   unsubStream()
   unsubThought()
   messageReveal.reset()
@@ -618,9 +627,17 @@ function onPaste(e: ClipboardEvent) {
   nextTick(autoGrow)
 }
 
-watch(draft, () => nextTick(autoGrow), { immediate: true })
+watch([draft, inputPlaceholder], () => nextTick(autoGrow), { immediate: true })
 onMounted(() => {
-  nextTick(autoGrow)
+  nextTick(() => {
+    autoGrow()
+    const el = textareaRef.value
+    if (el && typeof ResizeObserver !== 'undefined') {
+      composerResizeObserver?.disconnect()
+      composerResizeObserver = new ResizeObserver(() => autoGrow())
+      composerResizeObserver.observe(el)
+    }
+  })
   // Mount with historical turns: force enter stick (parent v-if remounts on leave/re-enter).
   void enterStickSequence()
 })


### PR DESCRIPTION
Split attach+textarea from send/Cancel so the input keeps remaining width, grow height from wrapped hint or draft lines, and wrap confirm/help copy instead of clipping on a narrow sidebar.

Co-authored-by: Cursor <cursoragent@cursor.com>
