### PR TITLE
perf/floating ball instant sidebar

### DIFF
--- a/web/e2e/desktop-sidebar-hide.spec.ts
+++ b/web/e2e/desktop-sidebar-hide.spec.ts
@@ -4,6 +4,9 @@ import { fileURLToPath } from 'node:url'
 
 const shotDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '../../../test-screenshots')
 
+/** First navigation compiles the shell on a cold dev server; unrelated to the expand budget. */
+const PAGE_READY_MS = 30_000
+
 async function mockApi(page: Page) {
   await page.route('**/api/**', async (route) => {
     if (!new URL(route.request().url()).pathname.startsWith('/api/')) {
@@ -49,11 +52,66 @@ async function openGates(page: Page) {
   await mockApi(page)
   await page.setViewportSize({ width: 1280, height: 800 })
   await page.goto('/desktop-sidebar-hide.html?start=/gates')
-  await expect(page.getByTestId('page-gates')).toBeVisible({ timeout: 15_000 })
+  await expect(page.getByTestId('page-gates')).toBeVisible({ timeout: PAGE_READY_MS })
 }
 
 function sidebar(page: Page) {
   return page.getByTestId('app-desktop-sidebar')
+}
+
+/**
+ * Arm an in-page stopwatch: capture-phase click timestamp → first frame the sidebar
+ * has width. Measuring inside the page keeps the budget about the app, not about
+ * CDP round-trips or a cold dev server stealing CPU from the poll loop.
+ */
+async function armExpandStopwatch(page: Page) {
+  await page.evaluate(() => {
+    const w = window as unknown as { __sidebarExpandMs?: number | 'timeout' }
+    delete w.__sidebarExpandMs
+    document.addEventListener(
+      'click',
+      () => {
+        const aside = document.querySelector('[data-testid="app-desktop-sidebar"]')
+        if (!aside) return
+        const start = performance.now()
+        const tick = () => {
+          if (aside.getBoundingClientRect().width > 0) {
+            w.__sidebarExpandMs = performance.now() - start
+            return
+          }
+          if (performance.now() - start > 5_000) {
+            w.__sidebarExpandMs = 'timeout'
+            return
+          }
+          requestAnimationFrame(tick)
+        }
+        requestAnimationFrame(tick)
+      },
+      { capture: true, once: true },
+    )
+  })
+}
+
+/** Read the armed stopwatch and assert the app opened the sidebar within budget. */
+async function expectExpandedWithin(page: Page, budgetMs: number) {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          () => (window as unknown as { __sidebarExpandMs?: number | 'timeout' }).__sidebarExpandMs,
+        ),
+      { timeout: 10_000 },
+    )
+    .not.toBe(undefined)
+  const elapsed = await page.evaluate(
+    () => (window as unknown as { __sidebarExpandMs?: number | 'timeout' }).__sidebarExpandMs,
+  )
+  expect(elapsed, 'sidebar never regained width after the ball click').not.toBe('timeout')
+  test.info().annotations.push({
+    type: 'metrics',
+    description: JSON.stringify({ sidebarExpandMs: Math.round(elapsed as number), budgetMs }),
+  })
+  expect(elapsed as number).toBeLessThan(budgetMs)
 }
 
 /** Wait for 232→0 width transition so toBeHidden / edge.x are not sampled mid-animation. */
@@ -67,6 +125,11 @@ async function expectSidebarCollapsed(page: Page) {
 }
 
 test.describe('desktop sidebar hide', () => {
+  // A cold vite dev server transforms the whole shell on the first navigation, which
+  // took >75s on a contended box; the 250ms expand budget is asserted by the in-page
+  // stopwatch, not by this ceiling.
+  test.describe.configure({ timeout: 120_000 })
+
   test('hide from brand, open from floating ball, persist, no toast', async ({ page }) => {
     await openGates(page)
     const aside = sidebar(page)
@@ -102,14 +165,16 @@ test.describe('desktop sidebar hide', () => {
     expect(ballBox?.x ?? 99).toBeLessThan(40)
     expect((ballBox?.y ?? 0) + (ballBox?.height ?? 0)).toBeGreaterThan(700)
     await expect(ball).toHaveAttribute('aria-label', '打开导航')
+    await armExpandStopwatch(page)
     await ball.click()
-    await expect(aside).toBeVisible({ timeout: 250 })
+    await expectExpandedWithin(page, 250)
+    await expect(aside).toBeVisible()
     await expect(page.getByTestId('floating-nav-ball')).toBeHidden()
 
     await hide.click()
     expect(await page.evaluate(() => localStorage.getItem('approving-sidebar-hidden'))).toBe('true')
     await page.reload()
-    await expect(page.getByTestId('page-gates')).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByTestId('page-gates')).toBeVisible({ timeout: PAGE_READY_MS })
     await expectSidebarCollapsed(page)
     await expect(page.getByTestId('floating-nav-ball')).toBeVisible()
   })
@@ -118,7 +183,7 @@ test.describe('desktop sidebar hide', () => {
     await mockApi(page)
     await page.setViewportSize({ width: 1280, height: 800 })
     await page.goto('/desktop-sidebar-hide.html?start=/runs/r1')
-    await expect(page.getByTestId('page-run')).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByTestId('page-run')).toBeVisible({ timeout: PAGE_READY_MS })
     await expect(page.getByTestId('desktop-nav-hide')).toBeVisible()
     await page.getByTestId('desktop-nav-hide').click()
     await expectSidebarCollapsed(page)
@@ -132,24 +197,26 @@ test.describe('desktop sidebar hide', () => {
     await expect(page.getByTestId('app-full-main')).not.toHaveClass(/pl-11/)
     await page.screenshot({ path: path.join(shotDir, '03-full-run-hidden-ball.png') })
 
+    await armExpandStopwatch(page)
     await ball.click()
-    await expect(sidebar(page)).toBeVisible({ timeout: 250 })
+    await expectExpandedWithin(page, 250)
+    await expect(sidebar(page)).toBeVisible()
     await expect(page.getByTestId('floating-nav-ball')).toBeHidden()
 
     await page.getByTestId('desktop-nav-hide').click()
     await page.goto('/desktop-sidebar-hide.html?start=/workflows/wf-1/edit')
-    await expect(page.getByTestId('page-editor')).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByTestId('page-editor')).toBeVisible({ timeout: PAGE_READY_MS })
     await expect(page.getByTestId('floating-nav-ball')).toBeVisible()
     await expect(page.getByTestId('desktop-nav-edge-open')).toHaveCount(0)
     await page.screenshot({ path: path.join(shotDir, '04-full-editor-hidden-ball.png') })
 
     await page.goto('/desktop-sidebar-hide.html?start=/sandboxes/42/console')
-    await expect(page.getByTestId('page-console')).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByTestId('page-console')).toBeVisible({ timeout: PAGE_READY_MS })
     await expect(page.getByTestId('floating-nav-ball')).toBeVisible()
     await page.screenshot({ path: path.join(shotDir, '05-full-console-hidden-ball.png') })
 
     await page.goto('/desktop-sidebar-hide.html?start=/gates')
-    await expect(page.getByTestId('page-gates')).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByTestId('page-gates')).toBeVisible({ timeout: PAGE_READY_MS })
     await expect(page.getByTestId('desktop-nav-edge-open')).toHaveCount(0)
     await expect(page.getByTestId('floating-nav-ball')).toBeVisible()
     await page.screenshot({ path: path.join(shotDir, '06-back-to-gates-floating-ball.png') })

--- a/web/e2e/desktop-sidebar-hide.spec.ts
+++ b/web/e2e/desktop-sidebar-hide.spec.ts
@@ -103,7 +103,7 @@ test.describe('desktop sidebar hide', () => {
     expect((ballBox?.y ?? 0) + (ballBox?.height ?? 0)).toBeGreaterThan(700)
     await expect(ball).toHaveAttribute('aria-label', '打开导航')
     await ball.click()
-    await expect(aside).toBeVisible({ timeout: 5_000 })
+    await expect(aside).toBeVisible({ timeout: 250 })
     await expect(page.getByTestId('floating-nav-ball')).toBeHidden()
 
     await hide.click()
@@ -133,7 +133,7 @@ test.describe('desktop sidebar hide', () => {
     await page.screenshot({ path: path.join(shotDir, '03-full-run-hidden-ball.png') })
 
     await ball.click()
-    await expect(sidebar(page)).toBeVisible({ timeout: 5_000 })
+    await expect(sidebar(page)).toBeVisible({ timeout: 250 })
     await expect(page.getByTestId('floating-nav-ball')).toBeHidden()
 
     await page.getByTestId('desktop-nav-hide').click()

--- a/web/src/components/shell/AppShell.test.ts
+++ b/web/src/components/shell/AppShell.test.ts
@@ -53,13 +53,14 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import AppShell from './AppShell.vue'
 
-function mountShell(opts?: { stubSidebar?: boolean }) {
+function mountShell(opts?: { stubSidebar?: boolean; attachToBody?: boolean }) {
   const i18n = createI18n({
     legacy: false,
     locale: 'zh-CN',
     messages: { 'zh-CN': { ...common, ...pages, ...shell } },
   })
   return mount(AppShell, {
+    attachTo: opts?.attachToBody ? document.body : undefined,
     slots: { default: '<div data-testid="main">内容</div>' },
     global: {
       plugins: [i18n],
@@ -130,22 +131,33 @@ describe('AppShell (no topbar + floating ball)', () => {
     wrapper.unmount()
   })
 
-  it('click floating ball pins sidebar with exit animation (g2.2 / g2.3)', async () => {
+  it('click floating ball pins sidebar immediately, ball exits in parallel (g1.1 / g2.2)', async () => {
     setSidebarHidden(true)
     const wrapper = mountShell()
     const ball = wrapper.find('[data-testid="floating-nav-ball"]')
     expect(ball.attributes('aria-label')).toBe('打开导航')
     await ball.trigger('click')
+    expect(sidebarHidden.value).toBe(false)
     expect(wrapper.find('[data-testid="floating-nav-ball-wrap"]').attributes('data-exiting')).toBe(
       'true',
     )
-    expect(sidebarHidden.value).toBe(true)
-    await vi.advanceTimersByTimeAsync(320)
+    await vi.advanceTimersByTimeAsync(200)
     await nextTick()
     expect(sidebarHidden.value).toBe(false)
     expect(wrapper.find('[data-testid="floating-nav-ball-wrap"]').attributes('data-exiting')).toBe(
       'false',
     )
+    wrapper.unmount()
+  })
+
+  it('moves focus to desktop-nav-hide after pinning from the ball (g2.3)', async () => {
+    setSidebarHidden(true)
+    const wrapper = mountShell({ stubSidebar: false, attachToBody: true })
+    await wrapper.find('[data-testid="floating-nav-ball"]').trigger('click')
+    expect(sidebarHidden.value).toBe(false)
+    await nextTick()
+    await nextTick()
+    expect(document.activeElement).toBe(wrapper.find('[data-testid="desktop-nav-hide"]').element)
     wrapper.unmount()
   })
 

--- a/web/src/components/shell/FloatingNavBall.test.ts
+++ b/web/src/components/shell/FloatingNavBall.test.ts
@@ -57,18 +57,45 @@ describe('FloatingNavBall (g2.1–g2.5)', () => {
     wrapper.unmount()
   })
 
-  it('pins on click and runs exit animation; ignores repeat during exit (g2.3)', async () => {
+  it('pins on click without waiting for the exit animation (g1.1)', async () => {
     setSidebarHidden(true)
     const wrapper = mountBall()
     await wrapper.find('[data-testid="floating-nav-ball"]').trigger('click')
+    expect(sidebarHidden.value).toBe(false)
     expect(wrapper.find('[data-testid="floating-nav-ball-wrap"]').attributes('data-exiting')).toBe(
       'true',
     )
-    await wrapper.find('[data-testid="floating-nav-ball"]').trigger('click')
-    expect(sidebarHidden.value).toBe(true)
-    await vi.advanceTimersByTimeAsync(320)
+    await vi.advanceTimersByTimeAsync(200)
     await nextTick()
     expect(sidebarHidden.value).toBe(false)
+    expect(wrapper.find('[data-testid="floating-nav-ball-wrap"]').attributes('data-exiting')).toBe(
+      'false',
+    )
+    wrapper.unmount()
+  })
+
+  it('ignores repeat clicks during the exit animation (g2.3)', async () => {
+    setSidebarHidden(true)
+    const wrapper = mountBall()
+    const ball = wrapper.find('[data-testid="floating-nav-ball"]')
+    await ball.trigger('click')
+    await ball.trigger('click')
+    expect(sidebarHidden.value).toBe(false)
+    await vi.advanceTimersByTimeAsync(200)
+    await nextTick()
+    expect(sidebarHidden.value).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('reappears at once when the sidebar is hidden again mid-exit (g2.1)', async () => {
+    setSidebarHidden(true)
+    const wrapper = mountBall()
+    await wrapper.find('[data-testid="floating-nav-ball"]').trigger('click')
+    setSidebarHidden(true)
+    await nextTick()
+    const wrap = wrapper.find('[data-testid="floating-nav-ball-wrap"]')
+    expect(wrap.attributes('data-exiting')).toBe('false')
+    expect(wrap.classes()).toContain('pointer-events-auto')
     wrapper.unmount()
   })
 

--- a/web/src/components/shell/FloatingNavBall.vue
+++ b/web/src/components/shell/FloatingNavBall.vue
@@ -21,7 +21,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const { isMobile } = useBreakpoint()
 
-const EXIT_MS = 320
+const EXIT_MS = 200
 const exiting = ref(false)
 let exitTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -67,22 +67,20 @@ watch(sidebarHidden, (hidden) => {
 async function pinDesktop() {
   if (!sidebarHidden.value || exiting.value) return
   clearExitTimer()
-  exiting.value = true
 
-  const finish = async () => {
-    showDesktopSidebar()
-    exiting.value = false
-    await focusDesktopNavControl('hide')
+  const reducedMotion = prefersReducedMotion()
+  // Ball exit runs alongside the sidebar; it must never gate showDesktopSidebar.
+  exiting.value = !reducedMotion
+  showDesktopSidebar()
+
+  if (!reducedMotion) {
+    exitTimer = setTimeout(() => {
+      exitTimer = null
+      exiting.value = false
+    }, EXIT_MS)
   }
 
-  if (prefersReducedMotion()) {
-    await finish()
-    return
-  }
-  exitTimer = setTimeout(() => {
-    exitTimer = null
-    void finish()
-  }, EXIT_MS)
+  await focusDesktopNavControl('hide')
 }
 
 function onActivate() {
@@ -104,7 +102,7 @@ onBeforeUnmount(() => {
     :class="[
       wrapClass,
       exiting
-        ? 'duration-[320ms] ease-[cubic-bezier(0.4,0,0.2,1)]'
+        ? 'duration-[200ms] ease-[cubic-bezier(0.4,0,0.2,1)]'
         : '',
     ]"
     data-testid="floating-nav-ball-wrap"

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -383,8 +383,8 @@ html.light .app-sidebar-card {
   /* Floating visible: overflow visible so card shadow is not square-clipped (gray corner).
      Collapsed / docked: overflow-hidden via utility classes on the aside. */
   transition:
-    width 0.32s cubic-bezier(0.22, 1, 0.36, 1),
-    border-right-width 0.32s cubic-bezier(0.22, 1, 0.36, 1);
+    width 0.18s cubic-bezier(0.22, 1, 0.36, 1),
+    border-right-width 0.18s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
- **perf(web): expand desktop sidebar on floating ball click without waiting for exit**
- **test(web): make desktop-sidebar-hide expand budget measurable, not latency-bound**
