### PR TITLE
fix(web): theme JSON code view for light mode (g1–g3)

### DIFF
--- a/web/e2e/clarify-inbox-product-main.ts
+++ b/web/e2e/clarify-inbox-product-main.ts
@@ -368,7 +368,8 @@ const Fixture = defineComponent({
 async function boot() {
   await initLocale()
   await setLocale('zh-CN')
-  setTheme('dark')
+  const theme = new URLSearchParams(location.search).get('theme')
+  setTheme(theme === 'light' ? 'light' : 'dark')
   installIdleScrollbar()
   createApp(Fixture).use(i18n).mount('#app')
 }

--- a/web/e2e/clarify-inbox-product.spec.ts
+++ b/web/e2e/clarify-inbox-product.spec.ts
@@ -72,12 +72,31 @@ test.describe('GatesInbox clarify 产物台', () => {
 
     await page.getByTestId('upstream-modal-mode-raw').click()
     await expect(page.locator('.json-code-view--modal')).toBeVisible()
+    await expect(page.locator('.json-code-view--modal')).toHaveCSS(
+      'background-color',
+      'rgb(30, 30, 30)',
+    )
     await page.screenshot({ path: `${SHOT_DIR}/05-inbox-visual-upstream-modal-json.png`, fullPage: true })
     await page.getByTestId('upstream-modal-mode-structured').click()
     await expect(modalBody).toContainText('复审产物台展示上游澄清需求文档')
 
     await page.keyboard.press('Escape')
     await expect(modalBody).toBeVisible()
+  })
+
+  test('浅色主题下上游原始 JSON 不是黑底（g3.2）', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 })
+    await page.goto('/clarify-inbox-product.html?scenario=visual&theme=light')
+    await expect(page.getByTestId('clarify-product-stage')).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('html')).toHaveClass(/light/)
+    await page.getByTestId('upstream-enlarge').click()
+    await page.getByTestId('upstream-modal-mode-raw').click()
+    const jsonView = page.locator('.json-code-view--modal')
+    await expect(jsonView).toBeVisible()
+    const bg = await jsonView.evaluate((el) => getComputedStyle(el).backgroundColor)
+    expect(bg).not.toBe('rgb(30, 30, 30)')
+    expect(bg).toMatch(/rgb\(\s*25[0-5],\s*25[0-5],\s*25[0-5]\s*\)/)
+    await page.screenshot({ path: `${SHOT_DIR}/07-inbox-visual-upstream-json-light.png`, fullPage: true })
   })
 
   test('三态空态、重试恢复与加载中不闪尚未执行', async ({ page }) => {

--- a/web/e2e/structured-export-harness-main.ts
+++ b/web/e2e/structured-export-harness-main.ts
@@ -81,8 +81,9 @@ const App = defineComponent({
 })
 
 installIdleScrollbar()
-initLocale()
-setLocale(locale as 'zh-CN' | 'en')
-setTheme(theme === 'light' ? 'light' : 'dark')
-
-createApp(App).use(i18n).mount('#app')
+void (async () => {
+  await initLocale()
+  await setLocale(locale as 'zh-CN' | 'en')
+  setTheme(theme === 'light' ? 'light' : 'dark')
+  createApp(App).use(i18n).mount('#app')
+})()

--- a/web/e2e/structured-export-harness.spec.ts
+++ b/web/e2e/structured-export-harness.spec.ts
@@ -86,6 +86,43 @@ test.describe('structured artifact export harness', () => {
     })
   })
 
+  test('raw JSON code board follows dark and light tokens (g3.2)', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 })
+
+    await page.goto('/structured-export-harness.html?scenario=structured&theme=dark')
+    await expect(page.getByTestId('export-harness-root')).toBeVisible({ timeout: 15_000 })
+    await page.getByTestId('artifact-preview-mode-raw').click()
+    const darkView = page.getByTestId('artifact-preview-raw-json')
+    await expect(darkView).toBeVisible()
+    await expect(darkView).toHaveCSS('background-color', 'rgb(30, 30, 30)')
+    await expect(darkView.locator('.tok-key').first()).toHaveCSS('color', 'rgb(156, 220, 254)')
+    await page.screenshot({
+      path: path.join(shotDir, '05-raw-json-dark.png'),
+      fullPage: true,
+    })
+
+    await page.getByTestId('artifact-preview-zoom').click()
+    const darkModal = page.getByTestId('artifact-preview-zoom-raw-json')
+    await expect(darkModal).toBeVisible()
+    await expect(darkModal).toHaveCSS('background-color', 'rgb(30, 30, 30)')
+    await page.keyboard.press('Escape')
+
+    await page.goto('/structured-export-harness.html?scenario=structured&theme=light')
+    await expect(page.getByTestId('export-harness-root')).toBeVisible({ timeout: 15_000 })
+    await expect(page.locator('html')).toHaveClass(/light/)
+    await page.getByTestId('artifact-preview-mode-raw').click()
+    const lightView = page.getByTestId('artifact-preview-raw-json')
+    await expect(lightView).toBeVisible()
+    const lightBg = await lightView.evaluate((el) => getComputedStyle(el).backgroundColor)
+    expect(lightBg).not.toBe('rgb(30, 30, 30)')
+    expect(lightBg).toMatch(/rgb\(\s*25[0-5],\s*25[0-5],\s*25[0-5]\s*\)/)
+    await expect(lightView.locator('.tok-key').first()).toHaveCSS('color', 'rgb(4, 81, 165)')
+    await page.screenshot({
+      path: path.join(shotDir, '06-raw-json-light.png'),
+      fullPage: true,
+    })
+  })
+
   test('light theme export still produces readable PNG', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 900 })
     await page.goto('/structured-export-harness.html?scenario=structured&theme=light')

--- a/web/src/components/project/ProjectAuditPanel.vue
+++ b/web/src/components/project/ProjectAuditPanel.vue
@@ -1839,9 +1839,6 @@ tr.detail td {
     width: 100%;
   }
 }
-:deep(.tok-key) {
-  color: #7dd3c7;
-}
 :deep(.audit-mask) {
   color: #b45309;
 }

--- a/web/src/components/run/ArtifactPreview.vue
+++ b/web/src/components/run/ArtifactPreview.vue
@@ -509,8 +509,6 @@ const modalTitle = computed(() =>
 
 <style scoped>
 .json-code-view {
-  background: #1e1e1e;
-  border: 1px solid rgb(var(--c-line, 38 38 43));
   padding: 12px 14px;
   overflow: auto;
   max-height: 100%;
@@ -518,15 +516,6 @@ const modalTitle = computed(() =>
 .json-code-view--modal {
   border: none;
   max-height: none;
-}
-.json-code-view pre {
-  margin: 0;
-  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
-  font-size: 12.5px;
-  line-height: 1.55;
-  white-space: pre;
-  tab-size: 2;
-  color: #d4d4d4;
 }
 .fallback-tag {
   display: inline-flex;
@@ -538,22 +527,5 @@ const modalTitle = computed(() =>
   color: rgb(var(--c-warn, 251 191 36));
   border: 1px solid rgba(251, 191, 36, 0.35);
   background: rgba(251, 191, 36, 0.08);
-}
-.json-code-view :deep(.tok-key) {
-  color: #9cdcfe;
-}
-.json-code-view :deep(.tok-str) {
-  color: #ce9178;
-}
-.json-code-view :deep(.tok-num) {
-  color: #b5cea8;
-}
-.json-code-view :deep(.tok-bool),
-.json-code-view :deep(.tok-null) {
-  color: #569cd6;
-}
-.json-code-view :deep(.tok-punc),
-.json-code-view :deep(.tok-plain) {
-  color: #d4d4d4;
 }
 </style>

--- a/web/src/components/run/UpstreamRequirementContext.vue
+++ b/web/src/components/run/UpstreamRequirementContext.vue
@@ -348,23 +348,12 @@ watch(visible, (isVisible) => {
   overflow-y: auto;
 }
 .json-code-view {
-  background: #1e1e1e;
-  border: 1px solid rgb(var(--c-line, 38 38 43));
   padding: 12px 14px;
   overflow: auto;
   max-height: 100%;
 }
 .json-code-view--modal {
   max-height: none;
-}
-.json-code-view pre {
-  margin: 0;
-  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
-  font-size: 12.5px;
-  line-height: 1.55;
-  white-space: pre;
-  tab-size: 2;
-  color: #d4d4d4;
 }
 .fallback-tag {
   display: inline-flex;
@@ -376,23 +365,6 @@ watch(visible, (isVisible) => {
   color: rgb(var(--c-warn, 251 191 36));
   border: 1px solid rgba(251, 191, 36, 0.35);
   background: rgba(251, 191, 36, 0.08);
-}
-.json-code-view :deep(.tok-key) {
-  color: #9cdcfe;
-}
-.json-code-view :deep(.tok-str) {
-  color: #ce9178;
-}
-.json-code-view :deep(.tok-num) {
-  color: #b5cea8;
-}
-.json-code-view :deep(.tok-bool),
-.json-code-view :deep(.tok-null) {
-  color: #569cd6;
-}
-.json-code-view :deep(.tok-punc),
-.json-code-view :deep(.tok-plain) {
-  color: #d4d4d4;
 }
 
 @media (max-width: 640px) {

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -30,6 +30,15 @@
   --flow-mask: rgba(10, 10, 11, 0.72);
   --grad-logo: linear-gradient(90deg, #7B61FF 0%, #818CF8 35%, #6366F1 55%, #7B61FF 75%, #A78BFA 100%);
   --grad-logo-size: 200% 100%;
+
+  /* JSON 代码板 — VS Code Dark（g1.1） */
+  --json-bg: #1e1e1e;
+  --json-fg: #d4d4d4;
+  --json-key: #9cdcfe;
+  --json-str: #ce9178;
+  --json-num: #b5cea8;
+  --json-kw: #569cd6;
+  --json-punc: #d4d4d4;
 }
 
 html.light {
@@ -55,6 +64,55 @@ html.light {
   --flow-dot: #d8dce3;
   --flow-mask: rgba(250, 250, 251, 0.72);
   --grad-logo: linear-gradient(90deg, #6D28D9 0%, #7B61FF 30%, #6366F1 55%, #4F46E5 75%, #7B61FF 100%);
+
+  /* JSON 代码板 — VS Code Light+（g1.1） */
+  --json-bg: #ffffff;
+  --json-fg: #393a34;
+  --json-key: #0451a5;
+  --json-str: #a31515;
+  --json-num: #098658;
+  --json-kw: #0000ff;
+  --json-punc: #393a34;
+}
+
+/* JSON 代码板与审计 payload 的 tok-*（g1.2）：选择器限制在容器内，避免波及其他 tok-* */
+.json-code-view {
+  background: var(--json-bg);
+  border: 1px solid rgb(var(--c-line));
+  color: var(--json-fg);
+}
+.json-code-view pre {
+  margin: 0;
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  line-height: 1.55;
+  white-space: pre;
+  tab-size: 2;
+  color: var(--json-fg);
+}
+.json-code-view .tok-key,
+.payload .tok-key {
+  color: var(--json-key);
+}
+.json-code-view .tok-str,
+.payload .tok-str {
+  color: var(--json-str);
+}
+.json-code-view .tok-num,
+.payload .tok-num {
+  color: var(--json-num);
+}
+.json-code-view .tok-bool,
+.json-code-view .tok-null,
+.payload .tok-bool,
+.payload .tok-null {
+  color: var(--json-kw);
+}
+.json-code-view .tok-punc,
+.json-code-view .tok-plain,
+.payload .tok-punc,
+.payload .tok-plain {
+  color: var(--json-punc);
 }
 
 html,

--- a/web/src/styles/global.jsonCodeTokens.test.ts
+++ b/web/src/styles/global.jsonCodeTokens.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * plan g3.1 — JSON 代码板主题令牌契约：
+ * :root = VS Code Dark 现状调色板；html.light = VS Code Light+。
+ * 三处消费点不再硬编码旧 JSON hex。
+ */
+const dir = dirname(fileURLToPath(import.meta.url))
+const css = readFileSync(join(dir, 'global.css'), 'utf8')
+const vueDir = join(dir, '../components')
+
+function block(source: string, selector: string): string {
+  const start = source.indexOf(selector)
+  expect(start).toBeGreaterThanOrEqual(0)
+  const open = source.indexOf('{', start)
+  let depth = 0
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') depth++
+    else if (source[i] === '}') {
+      depth--
+      if (depth === 0) return source.slice(open, i + 1)
+    }
+  }
+  throw new Error(`unclosed ${selector}`)
+}
+
+function token(blockCss: string, name: string): string {
+  const m = blockCss.match(new RegExp(`${name}:\\s*([^;]+);`))
+  expect(m, `${name} in block`).toBeTruthy()
+  return m![1].trim()
+}
+
+const OLD_JSON_HEX = ['#1e1e1e', '#9cdcfe', '#ce9178', '#b5cea8', '#569cd6', '#d4d4d4', '#7dd3c7']
+
+describe('global.css JSON code tokens (g3.1 / g1.1)', () => {
+  const root = block(css, ':root')
+  const light = block(css, 'html.light')
+
+  it('dark :root matches VS Code Dark palette', () => {
+    expect(token(root, '--json-bg')).toBe('#1e1e1e')
+    expect(token(root, '--json-fg')).toBe('#d4d4d4')
+    expect(token(root, '--json-key')).toBe('#9cdcfe')
+    expect(token(root, '--json-str')).toBe('#ce9178')
+    expect(token(root, '--json-num')).toBe('#b5cea8')
+    expect(token(root, '--json-kw')).toBe('#569cd6')
+    expect(token(root, '--json-punc')).toBe('#d4d4d4')
+  })
+
+  it('html.light matches VS Code Light+ corresponding colors', () => {
+    expect(token(light, '--json-bg')).toMatch(/^#(fff|ffffff|fefefe)$/i)
+    expect(token(light, '--json-key')).toBe('#0451a5')
+    expect(token(light, '--json-str')).toBe('#a31515')
+    expect(token(light, '--json-num')).toBe('#098658')
+    expect(token(light, '--json-kw')).toBe('#0000ff')
+    expect(token(light, '--json-punc')).toBe('#393a34')
+    expect(token(light, '--json-fg')).toBe('#393a34')
+  })
+
+  it('binds .json-code-view and tok-* inside code board / payload only (g1.2)', () => {
+    expect(css).toMatch(/\.json-code-view\s*\{[^}]*background:\s*var\(--json-bg\)/s)
+    expect(css).toMatch(/\.json-code-view\s*\{[^}]*border:\s*1px solid rgb\(var\(--c-line\)\)/s)
+    expect(css).toMatch(/\.json-code-view pre\s*\{[^}]*font-size:\s*12\.5px/s)
+    expect(css).toMatch(/\.json-code-view \.tok-key,\s*\n\.payload \.tok-key/)
+    expect(css).toMatch(/color:\s*var\(--json-key\)/)
+    expect(css).toMatch(/color:\s*var\(--json-str\)/)
+    expect(css).toMatch(/color:\s*var\(--json-num\)/)
+    expect(css).toMatch(/color:\s*var\(--json-kw\)/)
+    expect(css).toMatch(/color:\s*var\(--json-punc\)/)
+  })
+})
+
+describe('Vue consumers no longer hardcode JSON palette (g3.1 / g2)', () => {
+  const files = [
+    join(vueDir, 'run/ArtifactPreview.vue'),
+    join(vueDir, 'run/UpstreamRequirementContext.vue'),
+    join(vueDir, 'project/ProjectAuditPanel.vue'),
+  ]
+
+  it.each(files)('%s does not contain old JSON hex', (file) => {
+    const src = readFileSync(file, 'utf8')
+    for (const hex of OLD_JSON_HEX) {
+      expect(src.toLowerCase()).not.toContain(hex)
+    }
+  })
+
+  it('keeps .json-code-view class on ArtifactPreview and UpstreamRequirementContext', () => {
+    const preview = readFileSync(join(vueDir, 'run/ArtifactPreview.vue'), 'utf8')
+    const upstream = readFileSync(join(vueDir, 'run/UpstreamRequirementContext.vue'), 'utf8')
+    expect(preview).toContain('class="json-code-view')
+    expect(upstream).toContain('class="json-code-view')
+    expect(preview).toContain('fallback-tag')
+    expect(upstream).toContain('fallback-tag')
+  })
+})


### PR DESCRIPTION
Move VS Code Dark/Light+ JSON token colors into global CSS variables so
raw JSON and audit payload highlighting follow html.light without a black
code board on the light theme.

Co-authored-by: Cursor <cursoragent@cursor.com>
