### PR TITLE
Make agent startup wait copy user-friendly

### DIFF
--- a/web/src/components/run/ClarifyBootLoader.test.ts
+++ b/web/src/components/run/ClarifyBootLoader.test.ts
@@ -28,7 +28,7 @@ describe('ClarifyBootLoader', () => {
   it('renders starting phase with cycling steps', async () => {
     vi.useFakeTimers()
     const wrapper = mountLoader('starting')
-    expect(wrapper.text()).toMatch(/沙箱|ACP|问题/)
+    expect(wrapper.text()).toMatch(/工作环境|启动 Agent|连接 Agent|问题/)
     vi.advanceTimersByTime(2700)
     await wrapper.vm.$nextTick()
     expect(wrapper.findAll('span.rounded-full, span.h-1\\.5').length).toBeGreaterThan(0)

--- a/web/src/components/run/LiveLogPanel.test.ts
+++ b/web/src/components/run/LiveLogPanel.test.ts
@@ -114,7 +114,7 @@ describe('LiveLogPanel', () => {
     expect(wrapper.find('[data-testid="boot-stage-acp_ready"]').attributes('data-state')).toBe('active')
     expect(wrapper.find('[data-testid="boot-stage-first_event"]').attributes('data-state')).toBe('pending')
     expect(wrapper.text()).toContain('沙箱创建中')
-    expect(wrapper.text()).toContain('ACP 就绪中')
+    expect(wrapper.text()).toContain('正在连接 Agent')
     expect(wrapper.text()).toContain('等待首个事件')
     wrapper.unmount()
   })

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -2974,20 +2974,20 @@
       "pending": "Node not started yet; waiting to enter clarify…",
       "pendingHint": "Clarify starts automatically after upstream nodes complete.",
       "stepSandbox": {
-        "title": "Preparing clarify sandbox…",
-        "hint": "First-time container creation may take a moment."
+        "title": "Preparing the workspace…",
+        "hint": "First-time setup may take a moment."
       },
       "stepRuntime": {
-        "title": "Starting agent runtime…",
-        "hint": "Booting ACP bridge service and dependencies in the container."
+        "title": "Starting the Agent…",
+        "hint": "Setting up the environment. This may take a moment."
       },
       "stepAcp": {
-        "title": "Establishing ACP connection…",
-        "hint": "Handshaking with the agent…"
+        "title": "Connecting to the Agent…",
+        "hint": "Almost ready."
       },
       "stepQuestions": {
-        "title": "Agent is drafting first questions…",
-        "hint": "Organizing key questions to clarify with you."
+        "title": "Preparing the first questions…",
+        "hint": "Gathering what we need to confirm with you."
       }
     },
     "nodeOutput": {
@@ -3061,7 +3061,7 @@
       "nodeNoOutput": "This node produced no output yet"
     },
     "liveLog": {
-      "title": "ACP live log",
+      "title": "Execution log",
       "snapshot": "Snapshot",
       "snapshotTip": "Read-only event copy after the node ended. While running, the live stream is shown and this label does not appear.",
       "builtinMcp": "Built-in MCP calls · {n}",
@@ -3072,7 +3072,7 @@
       "rehydrate": {
         "loading": "Restoring execution log…",
         "errorTitle": "Log recovery failed",
-        "errorBody": "Could not restore this node's ACP execution timeline (event source temporarily unreachable or read failed). This is different from “waiting for the first event” — please retry.",
+        "errorBody": "Could not restore this node's execution log timeline (event source temporarily unreachable or read failed). This is different from “waiting for the first event” — please retry.",
         "retry": "Retry recovery",
         "warnTitle": "Historical log read error",
         "warnBody": "REST rehydrate failed or timed out. Live / cached events below remain valid — the node did not stop because of this.",
@@ -3087,8 +3087,8 @@
             "desc": "Gateway & container provisioning"
           },
           "acpReady": {
-            "title": "ACP ready",
-            "desc": "Waiting for Agent channel readiness"
+            "title": "Connecting to the Agent",
+            "desc": "Waiting until the Agent is ready"
           },
           "firstEvent": {
             "title": "Waiting for first event",
@@ -3486,20 +3486,20 @@
       },
       "repoPlaceholder": "Optional: git clone URL (empty = blank workspace)",
       "stepSandbox": {
-        "title": "Preparing sandbox…",
-        "hint": "First-time container creation may take a moment."
+        "title": "Preparing the workspace…",
+        "hint": "First-time setup may take a moment."
       },
       "stepRuntime": {
-        "title": "Starting agent runtime…",
-        "hint": "Booting ACP bridge service and dependencies in the container."
+        "title": "Starting the Agent…",
+        "hint": "Setting up the environment. This may take a moment."
       },
       "stepAcp": {
-        "title": "Establishing ACP connection…",
-        "hint": "Handshaking with the agent…"
+        "title": "Connecting to the Agent…",
+        "hint": "Almost ready."
       },
       "stepReady": {
         "title": "Almost ready…",
-        "hint": "Finishing initialization."
+        "hint": "Finishing setup."
       },
       "sandboxStartFailed": "Sandbox failed to start",
       "sandboxTimeout": "Sandbox start timed out",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -2974,20 +2974,20 @@
       "pending": "节点尚未执行,等待进入澄清…",
       "pendingHint": "上游节点完成后会自动开启本轮需求澄清。",
       "stepSandbox": {
-        "title": "正在准备澄清沙箱容器…",
-        "hint": "首次为该 Agent 创建容器可能需要一会儿,请稍候。"
+        "title": "正在准备工作环境…",
+        "hint": "第一次启动可能需要一会儿，请稍候。"
       },
       "stepRuntime": {
-        "title": "正在拉起 Agent 运行时…",
-        "hint": "正在容器内启动 ACP 桥接服务与依赖环境。"
+        "title": "正在启动 Agent…",
+        "hint": "正在准备运行环境，请稍候。"
       },
       "stepAcp": {
-        "title": "正在建立 ACP 连接…",
-        "hint": "与 Agent 握手中,马上就好。"
+        "title": "正在连接 Agent…",
+        "hint": "马上就好，请稍候。"
       },
       "stepQuestions": {
-        "title": "Agent 正在生成第一轮问题…",
-        "hint": "正在整理需要向你澄清的关键问题。"
+        "title": "正在整理第一轮问题…",
+        "hint": "正在整理需要向你确认的事项。"
       }
     },
     "nodeOutput": {
@@ -3061,7 +3061,7 @@
       "nodeNoOutput": "该节点尚未产生输出"
     },
     "liveLog": {
-      "title": "ACP 实时日志",
+      "title": "执行日志",
       "snapshot": "快照",
       "snapshotTip": "节点结束后的只读事件副本。运行中为实时流，不会显示此标签。",
       "builtinMcp": "内置 MCP 调用 · {n}",
@@ -3072,7 +3072,7 @@
       "rehydrate": {
         "loading": "正在恢复执行日志…",
         "errorTitle": "日志恢复失败",
-        "errorBody": "无法恢复当前节点的 ACP 执行日志时间线（事件源暂时不可达或读取失败）。这与「尚未产生首个事件」不同，请手动重试。",
+        "errorBody": "无法恢复当前节点的执行日志时间线（事件源暂时不可达或读取失败）。这与「尚未产生首个事件」不同，请手动重试。",
         "retry": "重试恢复",
         "warnTitle": "历史日志读取异常",
         "warnBody": "REST 再水合失败或超时。下方已到达的实时 / 缓存事件仍然有效，节点并未因此中断。",
@@ -3087,8 +3087,8 @@
             "desc": "网关与容器创建中"
           },
           "acpReady": {
-            "title": "ACP 就绪中",
-            "desc": "等待 Agent 通信通道就绪"
+            "title": "正在连接 Agent",
+            "desc": "等待 Agent 可以开始工作"
           },
           "firstEvent": {
             "title": "等待首个事件",
@@ -3486,16 +3486,16 @@
       },
       "repoPlaceholder": "可选:git clone URL(留空则空工作区)",
       "stepSandbox": {
-        "title": "正在准备沙箱容器…",
-        "hint": "首次为该 Agent 创建容器可能需要一会儿,请稍候。"
+        "title": "正在准备工作环境…",
+        "hint": "第一次启动可能需要一会儿，请稍候。"
       },
       "stepRuntime": {
-        "title": "正在拉起 Agent 运行时…",
-        "hint": "正在容器内启动 ACP 桥接服务与依赖环境。"
+        "title": "正在启动 Agent…",
+        "hint": "正在准备运行环境，请稍候。"
       },
       "stepAcp": {
-        "title": "正在建立 ACP 连接…",
-        "hint": "与 Agent 握手中,马上就好。"
+        "title": "正在连接 Agent…",
+        "hint": "马上就好，请稍候。"
       },
       "stepReady": {
         "title": "即将就绪…",


### PR DESCRIPTION
## Summary
- Rewrite Agent startup overlay and execution-log stage copy (zh-CN/en) into spoken language: preparing workspace, starting/connecting the Agent, gathering questions — no protocol names, 拉起/桥接/握手, or 沙箱容器 in the in-scope strings.
- Keep the same wording on ClarifyBootLoader and AgentChatTester parallel steps; i18n keys, layout, and startup logic are unchanged.
- Align tests that locked the old phrases (`ClarifyBootLoader.test.ts`, `LiveLogPanel.test.ts`).

## Test plan
- [x] `cd web && npx vitest run` (full suite green on implement/test nodes)
- [ ] Confirm overlay titles/hints on clarify and Agent tester (zh/en)
- [ ] Confirm execution log `acpReady` stage and panel title
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)