### PR TITLE
feat: name workflows created from baseline

### DIFF
--- a/server/internal/handlers/onboarding.go
+++ b/server/internal/handlers/onboarding.go
@@ -57,7 +57,8 @@ func (h *Handlers) CreateWorkflowFromBaseline(c *gin.Context) {
 	wf, err := h.Onboarding.CreateFromBaseline(req)
 	if err != nil {
 		switch {
-		case errors.Is(err, services.ErrWorkflowProjectRequired),
+		case errors.Is(err, services.ErrEmptyWorkflowName),
+			errors.Is(err, services.ErrWorkflowProjectRequired),
 			errors.Is(err, services.ErrBaselineReposRequired):
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		case errors.Is(err, services.ErrWorkflowProjectNotFound):

--- a/server/internal/handlers/onboarding_test.go
+++ b/server/internal/handlers/onboarding_test.go
@@ -85,13 +85,23 @@ func TestCreateWorkflowFromBaselineAPI(t *testing.T) {
 
 	if w := hn.do("POST", "/api/workflows/from-baseline", map[string]any{
 		"projectId": pid,
+		"name":      "Empty repositories",
 		"repos":     []map[string]any{{"url": ""}},
 	}); w.Code != http.StatusBadRequest {
 		t.Fatalf("empty repos: %d %s", w.Code, w.Body.String())
 	}
 
+	if w := hn.do("POST", "/api/workflows/from-baseline", map[string]any{
+		"projectId": pid,
+		"name":      "　 ",
+		"repos":     []map[string]any{{"url": "https://github.com/acme/app.git"}},
+	}); w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), services.ErrEmptyWorkflowName.Error()) {
+		t.Fatalf("empty name: %d %s", w.Code, w.Body.String())
+	}
+
 	w := hn.do("POST", "/api/workflows/from-baseline", map[string]any{
 		"projectId": pid,
+		"name":      "  Requirements pipeline  ",
 		"repos": []map[string]any{
 			{"url": "https://github.com/acme/app.git", "name": "", "branch": "main"},
 			{"url": "https://gitlab.com/acme/app.git", "name": ""},
@@ -106,7 +116,7 @@ func TestCreateWorkflowFromBaselineAPI(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
 		t.Fatal(err)
 	}
-	if created["name"] != "app" || created["status"] != "published" || created["needsRepo"] != true {
+	if created["name"] != "Requirements pipeline" || created["status"] != "published" || created["needsRepo"] != true {
 		t.Fatalf("unexpected workflow: %#v", created)
 	}
 	if created["id"] == "" {
@@ -132,10 +142,11 @@ func TestCreateWorkflowFromBaselineAPI(t *testing.T) {
 
 	w = hn.do("POST", "/api/workflows/from-baseline", map[string]any{
 		"projectId": pid,
+		"name":      "Requirements pipeline",
 		"repos":     []map[string]any{{"url": "https://github.com/acme/app.git"}},
 	})
-	if w.Code != http.StatusCreated || jsonField(w.Body.String(), "name") != "app (2)" {
-		t.Fatalf("workflow name not disambiguated: %d %s", w.Code, w.Body.String())
+	if w.Code != http.StatusConflict || !strings.Contains(w.Body.String(), services.ErrWorkflowNameExists.Error()) {
+		t.Fatalf("duplicate workflow name not rejected: %d %s", w.Code, w.Body.String())
 	}
 
 	w = hn.do("GET", "/api/workflows?projectId="+pid, nil)

--- a/server/internal/services/onboarding.go
+++ b/server/internal/services/onboarding.go
@@ -72,6 +72,7 @@ type BaselineRepo struct {
 // CreateBaselineWorkflowRequest is the body for POST /api/workflows/from-baseline.
 type CreateBaselineWorkflowRequest struct {
 	ProjectID string         `json:"projectId"`
+	Name      string         `json:"name"`
 	Repos     []BaselineRepo `json:"repos"`
 }
 
@@ -99,6 +100,10 @@ func (s *OnboardingService) CreateFromBaseline(req CreateBaselineWorkflowRequest
 	if _, ok := s.Projects.Get(projectID); !ok {
 		return models.WorkflowDef{}, ErrWorkflowProjectNotFound
 	}
+	name := strings.TrimSpace(req.Name)
+	if err := s.WF.validateWorkflowName(name, "", projectID); err != nil {
+		return models.WorkflowDef{}, err
+	}
 	repos := normalizeBaselineRepos(req.Repos)
 	if len(repos) == 0 {
 		return models.WorkflowDef{}, ErrBaselineReposRequired
@@ -115,11 +120,6 @@ func (s *OnboardingService) CreateFromBaseline(req CreateBaselineWorkflowRequest
 		return models.WorkflowDef{}, fmt.Errorf("default workflow graph invalid: %w", err)
 	}
 
-	baseName := repos[0].Name
-	name := baseName
-	for suffix := 2; s.WF.NameExists(name, "", projectID); suffix++ {
-		name = fmt.Sprintf("%s (%d)", baseName, suffix)
-	}
 	wf := models.WorkflowDef{
 		ID:          "wf-" + uuid.NewString()[:8],
 		ProjectID:   projectID,

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -25,8 +25,46 @@ tags:
     description: Platform-wide artifact catalog
   - name: agents
     description: Agent Studio export/import (single agent and org-folder)
+  - name: workflows
+    description: Workflow creation and lifecycle
 
 paths:
+  /workflows/from-baseline:
+    post:
+      operationId: createWorkflowFromBaseline
+      tags: [workflows]
+      summary: Create a published workflow from the embedded default baseline
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateBaselineWorkflowRequest'
+      responses:
+        '201':
+          description: Published workflow created with the requested name
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaselineWorkflow'
+        '400':
+          description: Empty name, missing project, or no repository URL
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: A workflow with the same name already exists in the project
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /runs/{id}/gates/{nodeId}/primary-artifacts:
     get:
       operationId: listGatePrimaryArtifacts
@@ -473,6 +511,44 @@ components:
         error:
           type: string
       required: [error]
+
+    CreateBaselineWorkflowRequest:
+      type: object
+      required: [projectId, name, repos]
+      properties:
+        projectId:
+          type: string
+        name:
+          type: string
+          minLength: 1
+          description: Required workflow display name; trimmed and unique within the project
+        repos:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            required: [url]
+            properties:
+              url:
+                type: string
+              name:
+                type: string
+              branch:
+                type: string
+
+    BaselineWorkflow:
+      type: object
+      required: [id, projectId, name, status]
+      properties:
+        id:
+          type: string
+        projectId:
+          type: string
+        name:
+          type: string
+        status:
+          type: string
+          enum: [published]
 
     ArtifactListItem:
       type: object

--- a/web/e2e/project-detail.spec.ts
+++ b/web/e2e/project-detail.spec.ts
@@ -228,7 +228,7 @@ test.describe('ProjectDetailView 流水线操作列', () => {
     await expect(page.getByTestId('new-edit-page')).toBeVisible()
   })
 
-  test('默认基线弹窗复用多仓编辑器，空 URL 禁止创建', async ({ page }) => {
+  test('默认基线弹窗要求工作流名称和仓库 URL 后才能创建', async ({ page }) => {
     await gotoProjectDetail(page, { width: 1280, height: 800 })
 
     await page.getByTestId('new-workflow-button').click()
@@ -237,9 +237,13 @@ test.describe('ProjectDetailView 流水线操作列', () => {
 
     const create = page.getByTestId('create-baseline-workflow')
     await expect(create).toBeDisabled()
+    const workflowName = page.getByTestId('baseline-workflow-name')
+    await expect(workflowName).toHaveAttribute('placeholder', '例如 需求对齐流水线')
     await expect(page.getByRole('dialog').locator('svg')).toHaveCount(3)
 
     await page.getByPlaceholder('仓库地址 https://…/repo.git').fill('https://github.com/acme/app.git')
+    await expect(create).toBeDisabled()
+    await workflowName.fill('需求对齐流水线')
     await expect(create).toBeEnabled()
     await page.getByRole('dialog').getByRole('button', { name: '添加仓库' }).click()
     await expect(page.getByPlaceholder('仓库地址 https://…/repo.git')).toHaveCount(2)

--- a/web/src/lib/api/api.test.ts
+++ b/web/src/lib/api/api.test.ts
@@ -389,10 +389,10 @@ describe('api.saveWorkflow description payload', () => {
 })
 
 describe('api.createWorkflowFromBaseline', () => {
-  it('POSTs projectId and repos to /workflows/from-baseline (plan g2.3)', async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({ id: 'wf-base', name: 'app', status: 'published' }))
+  it('POSTs the workflow name, projectId, and repos to /workflows/from-baseline (plan g3.1)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: 'wf-base', name: 'Requirements', status: 'published' }))
     await expect(
-      api.createWorkflowFromBaseline('p1', [
+      api.createWorkflowFromBaseline('p1', 'Requirements', [
         { name: '', url: 'https://github.com/acme/app.git', branch: 'main' },
       ]),
     ).resolves.toMatchObject({ id: 'wf-base', status: 'published' })
@@ -401,6 +401,7 @@ describe('api.createWorkflowFromBaseline', () => {
     expect(call?.[1]).toMatchObject({ method: 'POST' })
     expect(JSON.parse(String(call?.[1]?.body))).toEqual({
       projectId: 'p1',
+      name: 'Requirements',
       repos: [{ name: '', url: 'https://github.com/acme/app.git', branch: 'main' }],
     })
   })

--- a/web/src/lib/api/clients/workflowsClient.ts
+++ b/web/src/lib/api/clients/workflowsClient.ts
@@ -17,10 +17,10 @@ export const workflowsClient = {
       method: wf.id ? 'PUT' : 'POST',
       body: JSON.stringify(wf),
     }),
-  createWorkflowFromBaseline: (projectId: string, repos: RepoRow[]) =>
+  createWorkflowFromBaseline: (projectId: string, name: string, repos: RepoRow[]) =>
     req<Workflow>('/workflows/from-baseline', {
       method: 'POST',
-      body: JSON.stringify({ projectId, repos }),
+      body: JSON.stringify({ projectId, name, repos }),
     }),
   /** Notify-only: never sends nodes/edges (avoids stale list-cache graph rollback). */
   patchWorkflowNotifyPolicy: (id: string, notifyPolicy: WorkflowNotifyPolicy) =>

--- a/web/src/lib/project/useProjectDetail.ts
+++ b/web/src/lib/project/useProjectDetail.ts
@@ -252,6 +252,7 @@ const draftRestored = ref(false)
 const openMenuId = ref<string | null>(null)
 const newWorkflowMenuOpen = ref(false)
 const baselineModalOpen = ref(false)
+const baselineName = ref('')
 const baselineRepos = ref<RepoRow[]>([{ name: '', url: '', branch: '' }])
 const creatingBaseline = ref(false)
 const baselineCreateError = ref('')
@@ -656,6 +657,7 @@ function newWorkflow() {
 
 function openBaselineModal() {
   newWorkflowMenuOpen.value = false
+  baselineName.value = ''
   baselineRepos.value = [{ name: '', url: '', branch: '' }]
   baselineCreateError.value = ''
   baselineModalOpen.value = true
@@ -668,6 +670,7 @@ function closeBaselineModal() {
 }
 
 const hasValidBaselineRepo = computed(() =>
+  baselineName.value.trim() !== '' &&
   baselineRepos.value.some((repo) => repo.url.trim() !== ''),
 )
 
@@ -676,7 +679,11 @@ async function createFromBaseline() {
   creatingBaseline.value = true
   baselineCreateError.value = ''
   try {
-    const created = await api.createWorkflowFromBaseline(projectId.value, baselineRepos.value)
+    const created = await api.createWorkflowFromBaseline(
+      projectId.value,
+      baselineName.value.trim(),
+      baselineRepos.value,
+    )
     workflows.value = [created, ...workflows.value.filter((workflow) => workflow.id !== created.id)]
     baselineModalOpen.value = false
     toast.success(t('pages.projectDetail.newWorkflow.created', { name: created.name }))
@@ -920,6 +927,7 @@ onBeforeRouteUpdate(async (to, from) => {
   openMenuId,
   newWorkflowMenuOpen,
   baselineModalOpen,
+  baselineName,
   baselineRepos,
   creatingBaseline,
   baselineCreateError,

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -366,6 +366,8 @@
         "baselineDesc": "Use the built-in pipeline and add repositories",
         "modalTitle": "Create from default baseline",
         "modalHint": "Uses the same repository list as Run launch. Add one or more repositories; each is cloned into the workspace.",
+        "nameLabel": "Workflow name (required)",
+        "namePlaceholder": "For example, Requirement alignment",
         "create": "Create",
         "creating": "Creating…",
         "created": "Created workflow \"{name}\""

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -366,6 +366,8 @@
         "baselineDesc": "套用开箱流水线，填仓库即可运行",
         "modalTitle": "从默认基线创建",
         "modalHint": "仓库列表与运行启动页相同。可添加多个，启动时平级 clone 到工作区。",
+        "nameLabel": "工作流名称（必填）",
+        "namePlaceholder": "例如 需求对齐流水线",
         "create": "创建",
         "creating": "正在创建…",
         "created": "已创建工作流「{name}」"

--- a/web/src/views/ProjectDetailView.vue
+++ b/web/src/views/ProjectDetailView.vue
@@ -87,6 +87,7 @@ const {
   openMenuId,
   newWorkflowMenuOpen,
   baselineModalOpen,
+  baselineName,
   baselineRepos,
   creatingBaseline,
   baselineCreateError,
@@ -1229,6 +1230,19 @@ const {
       <p class="mb-3 text-[13px] leading-relaxed text-txt2">
         {{ t('pages.projectDetail.newWorkflow.modalHint') }}
       </p>
+      <div class="mb-4">
+        <label class="label" for="baseline-workflow-name">
+          {{ t('pages.projectDetail.newWorkflow.nameLabel') }}
+        </label>
+        <input
+          id="baseline-workflow-name"
+          v-model="baselineName"
+          class="input"
+          autocomplete="off"
+          data-testid="baseline-workflow-name"
+          :placeholder="t('pages.projectDetail.newWorkflow.namePlaceholder')"
+        />
+      </div>
       <ReposEditor
         :repos="baselineRepos"
         :min-rows="1"


### PR DESCRIPTION
## Summary
- 从默认基线创建工作流时必填独立名称：弹窗增加名称输入，`POST /api/workflows/from-baseline` 按 trim 后的用户名称入库并发布。
- 空名称返回 400，同项目重名返回 409，不再基于仓库名自动命名或追加 `(2)` 后缀。
- 仓库注入与发布行为保持不变；OpenAPI、前后端测试与 Playwright 弹窗用例已对齐。

## Test plan
- [ ] 打开项目详情 → 从默认基线创建：仅填仓库 URL 时创建按钮禁用；填写名称后可创建。
- [ ] 创建成功后流水线列表展示用户填写的名称。
- [ ] 同项目提交相同名称时返回 409「工作流名称已存在」，弹窗不关闭。
- [ ] 仅空白/全角空白名称时返回 400。


Made with [Cursor](https://cursor.com)