### PR TITLE
fix/prompts tab false dirty

### DIFF
--- a/web/src/components/agent/AgentPromptsPanel.vue
+++ b/web/src/components/agent/AgentPromptsPanel.vue
@@ -1,9 +1,22 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import type { AgentStudioDraft, PromptKey } from '@/lib/agent/agentStudioDraft'
+import {
+  normalizePromptText,
+  type AgentStudioDraft,
+  type PromptKey,
+} from '@/lib/agent/agentStudioDraft'
 
-defineProps<{ draft: AgentStudioDraft }>()
+const props = defineProps<{ draft: AgentStudioDraft }>()
+
+function setPrompt(key: PromptKey, value: string) {
+  props.draft.prompts[key] = normalizePromptText(value)
+}
+
+function onPromptInput(key: PromptKey, event: Event) {
+  const el = event.target
+  if (el instanceof HTMLTextAreaElement) setPrompt(key, el.value)
+}
 
 const { t } = useI18n()
 
@@ -47,11 +60,13 @@ const PROMPT_FRAGMENTS = computed(() => [
         <span class="text-[12px] font-medium text-txt2">{{ f.label }}</span>
         <p class="mb-1.5 text-[11px] text-txt3">{{ f.hint }}</p>
         <textarea
-          v-model="draft.prompts[f.key]"
+          :value="draft.prompts[f.key]"
           rows="3"
           spellcheck="false"
+          :data-testid="'prompt-' + f.key"
           :placeholder="t('pages.agentStudio.prompts.defaultPrefix') + f.placeholder"
           class="w-full resize-y rounded-md border border-line bg-base px-3 py-2 font-mono text-[12px] leading-6 text-txt outline-none focus:border-accent"
+          @input="onPromptInput(f.key, $event)"
         />
       </label>
     </div>

--- a/web/src/components/project/ProjectSharedAgentPanel.test.ts
+++ b/web/src/components/project/ProjectSharedAgentPanel.test.ts
@@ -137,3 +137,74 @@ describe('ProjectSharedAgentPanel chat test picker', () => {
     wrapper.unmount()
   })
 })
+
+function mountPanelWithRealPrompts(projectId = 'proj-a') {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common, ...pages } },
+  })
+  return mount(ProjectSharedAgentPanel, {
+    props: { projectId },
+    global: {
+      plugins: [i18n],
+      stubs: {
+        Icon: true,
+        AgentFilesPanel: true,
+        AgentMcpPanel: true,
+        AgentEnvPanel: true,
+        AgentChatTester: true,
+      },
+    },
+  })
+}
+
+describe('ProjectSharedAgentPanel prompts dirty (g1.3 / g2.1 / g2.2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    apiMocks.listAgents.mockResolvedValue([])
+  })
+
+  it('zero-edit switch to prompts stays clean for empty and CRLF prompts', async () => {
+    apiMocks.getProjectSharedAgentConfig.mockResolvedValue({
+      ...sharedCfg,
+      prompts: { producesContract: '共享\r\n片段' },
+    })
+    const wrapper = mountPanelWithRealPrompts()
+    await flushPromises()
+    const saveBtn = () => wrapper.get('[data-testid="shared-agent-save"]')
+    expect(saveBtn().attributes('disabled')).toBeDefined()
+    await wrapper.get('[data-testid="shared-agent-subtab-prompts"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="prompt-producesContract"]').exists()).toBe(true)
+    expect(saveBtn().attributes('disabled')).toBeDefined()
+    await wrapper.get('[data-testid="shared-agent-subtab-files"]').trigger('click')
+    await flushPromises()
+    expect(saveBtn().attributes('disabled')).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('real prompt edit enables save; put success clears dirty', async () => {
+    apiMocks.getProjectSharedAgentConfig.mockResolvedValue({
+      ...sharedCfg,
+      prompts: { reactOpenSuffix: 'base' },
+    })
+    apiMocks.putProjectSharedAgentConfig.mockImplementation(async (_id: string, body: Record<string, unknown>) => ({
+      ...sharedCfg,
+      ...body,
+    }))
+    const wrapper = mountPanelWithRealPrompts()
+    await flushPromises()
+    await wrapper.get('[data-testid="shared-agent-subtab-prompts"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-testid="prompt-reactOpenSuffix"]').setValue('base-changed')
+    await flushPromises()
+    const save = wrapper.get('[data-testid="shared-agent-save"]')
+    expect(save.attributes('disabled')).toBeUndefined()
+    await save.trigger('click')
+    await flushPromises()
+    expect(apiMocks.putProjectSharedAgentConfig).toHaveBeenCalled()
+    expect(wrapper.get('[data-testid="shared-agent-save"]').attributes('disabled')).toBeDefined()
+    wrapper.unmount()
+  })
+})

--- a/web/src/components/project/ProjectSharedAgentPanel.vue
+++ b/web/src/components/project/ProjectSharedAgentPanel.vue
@@ -14,13 +14,12 @@ import {
   DEFAULT_CONFIG_ROOT,
   DEFAULT_WORKSPACE_DIR,
   defaultConfigRootFor,
+  draftPayloadJson,
   fromDraft,
-  fromDraftRaw,
+  hydrateStudioDraft,
   kvToRec,
-  normalizeDraftRegions,
   PROMPT_KEYS,
   recToKV,
-  toDraft,
   type AgentStudioDraft,
 } from '@/lib/agent/agentStudioDraft'
 import {
@@ -73,7 +72,7 @@ function syncTestAgentSelection() {
 
 const dirty = computed(() => {
   if (!draft.value) return false
-  return JSON.stringify(fromDraftRaw(draft.value)) !== originalJson.value
+  return draftPayloadJson(draft.value) !== originalJson.value
 })
 
 const promptCount = computed(() =>
@@ -163,7 +162,7 @@ const derivedPaths = computed(() => {
 })
 
 function sharedToDraft(cfg: ProjectSharedAgentConfig): AgentStudioDraft {
-  const d = toDraft({
+  return hydrateStudioDraft({
     name: '__project_shared__',
     projectId: cfg.defaultProjectId || '',
     acpBackend: (cfg.acpBackend as BackendId) || 'cursor',
@@ -176,14 +175,12 @@ function sharedToDraft(cfg: ProjectSharedAgentConfig): AgentStudioDraft {
     layout: cfg.layout || {},
     prompts: cfg.prompts,
   })
-  normalizeDraftRegions(d)
-  return d
 }
 
 function applyLoaded(cfg: ProjectSharedAgentConfig) {
   const d = sharedToDraft(cfg)
   draft.value = d
-  originalJson.value = JSON.stringify(fromDraftRaw(d))
+  originalJson.value = draftPayloadJson(d)
   configRootTouched = false
 }
 

--- a/web/src/lib/agent/agentStudioDraft.test.ts
+++ b/web/src/lib/agent/agentStudioDraft.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import type { Agent } from '@/lib/api/api'
+import {
+  draftPayloadJson,
+  draftPromptsToApi,
+  fromDraft,
+  fromDraftRaw,
+  hydrateStudioDraft,
+  normalizePromptText,
+  PROMPT_KEYS,
+  toDraft,
+} from './agentStudioDraft'
+
+const baseAgent: Agent = {
+  name: '综合代码审查工程师',
+  projectId: 'p1',
+  acpBackend: 'cursor',
+  files: [],
+  mcp: [],
+  env: {},
+  layout: { configRoot: '/root/.cursor', workspaceDir: '/root/workspace' },
+}
+
+describe('prompt dirty serialization (g1.1 / g1.2)', () => {
+  it('normalizePromptText maps CRLF and CR to LF', () => {
+    expect(normalizePromptText('a\r\nb\rc')).toBe('a\nb\nc')
+  })
+
+  it('omits empty and whitespace-only prompts the same as missing prompts', () => {
+    expect(draftPromptsToApi({
+      upstreamArtifactsHeader: '',
+      producesContract: '  \n',
+      reactOpenSuffix: '',
+      producesRetry: '',
+    })).toBeUndefined()
+    expect(draftPromptsToApi(toDraft({ ...baseAgent }).prompts)).toBeUndefined()
+  })
+
+  it('toDraft hydrates missing prompts as empty strings with LF', () => {
+    const d = toDraft({
+      ...baseAgent,
+      prompts: { producesContract: 'hello\r\nworld' },
+    })
+    expect(d.prompts.producesContract).toBe('hello\nworld')
+    expect(d.prompts.upstreamArtifactsHeader).toBe('')
+  })
+
+  it('fromDraft and fromDraftRaw agree on prompts; fromDraft is the dirty baseline', () => {
+    const d = hydrateStudioDraft({
+      ...baseAgent,
+      env: { GIT_SSH_PRIVATE_KEY: 'secret', FOO: '1' },
+      prompts: { reactOpenSuffix: 'x\r\ny' },
+    })
+    const raw = fromDraftRaw(d)
+    const canonical = fromDraft(d)
+    expect(raw.prompts).toEqual(canonical.prompts)
+    expect(canonical.env?.GIT_SSH_PRIVATE_KEY).toBeUndefined()
+    expect(raw.env?.GIT_SSH_PRIVATE_KEY).toBe('secret')
+    expect(JSON.parse(draftPayloadJson(d))).toEqual(canonical)
+  })
+
+  it('textarea-style LF writeback does not change canonical payload', () => {
+    const d = hydrateStudioDraft({
+      ...baseAgent,
+      prompts: { producesRetry: 'line1\r\nline2' },
+    })
+    const before = draftPayloadJson(d)
+    for (const k of PROMPT_KEYS) {
+      d.prompts[k] = normalizePromptText(d.prompts[k])
+    }
+    expect(draftPayloadJson(d)).toBe(before)
+  })
+})

--- a/web/src/lib/agent/agentStudioDraft.ts
+++ b/web/src/lib/agent/agentStudioDraft.ts
@@ -74,6 +74,11 @@ export function emptyPrompts(): PromptDraft {
   return { upstreamArtifactsHeader: '', producesContract: '', reactOpenSuffix: '', producesRetry: '' }
 }
 
+/** Textarea / HTTP payloads treat CRLF and CR as LF; keep draft and dirty compare aligned. */
+export function normalizePromptText(s: string): string {
+  return s.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+}
+
 export function recToKV(rec?: Record<string, string>): KV[] {
   return Object.entries(rec || {}).map(([k, v]) => ({ k, v }))
 }
@@ -121,7 +126,7 @@ export function defaultConfigRootFor(backend: BackendId): string {
 
 export function toDraft(a: Agent): AgentStudioDraft {
   const prompts = emptyPrompts()
-  for (const k of PROMPT_KEYS) prompts[k] = a.prompts?.[k] ?? ''
+  for (const k of PROMPT_KEYS) prompts[k] = normalizePromptText(a.prompts?.[k] ?? '')
   return {
     name: a.name,
     projectId: a.projectId || '',
@@ -144,8 +149,9 @@ export function draftPromptsToApi(p: PromptDraft): AgentPrompts | undefined {
   const out: AgentPrompts = {}
   let any = false
   for (const k of PROMPT_KEYS) {
-    if (p[k].trim()) {
-      out[k] = p[k]
+    const text = normalizePromptText(p[k])
+    if (text.trim()) {
+      out[k] = text
       any = true
     }
   }
@@ -180,6 +186,18 @@ export function fromDraft(d: AgentStudioDraft): Agent {
     delete payload.env.GIT_SSH_KNOWN_HOSTS
   }
   return payload
+}
+
+/** Canonical payload JSON for originalJson / agentDirty (same serializer both sides). */
+export function draftPayloadJson(d: AgentStudioDraft): string {
+  return JSON.stringify(fromDraft(d))
+}
+
+/** Load API agent into a studio draft and apply region normalization before snapshotting. */
+export function hydrateStudioDraft(a: Agent): AgentStudioDraft {
+  const loaded = toDraft(a)
+  normalizeDraftRegions(loaded)
+  return loaded
 }
 
 export type PlatformPresetKind = 'artifact' | 'memory' | 'context' | 'scheduler'

--- a/web/src/lib/agent/useAgentStudio.test.ts
+++ b/web/src/lib/agent/useAgentStudio.test.ts
@@ -192,4 +192,73 @@ describe('useAgentStudio', () => {
 
     app.unmount()
   })
+
+  it('g2.1: switching to prompts then back to files stays clean (empty prompts)', async () => {
+    const { studio, app } = await withAgentStudio()
+    await flushPromises()
+    expect(studio.agentDirty.value).toBe(false)
+    studio.requestStudioTab('prompts')
+    await nextTick()
+    expect(studio.tab.value).toBe('prompts')
+    expect(studio.agentDirty.value).toBe(false)
+    studio.requestStudioTab('files')
+    await nextTick()
+    expect(studio.agentDirty.value).toBe(false)
+    app.unmount()
+  })
+
+  it('g2.1: CRLF prompts + textarea LF writeback does not mark dirty', async () => {
+    mocks.listAgents.mockResolvedValue([
+      {
+        name: 'agent-a',
+        projectId: 'proj-1',
+        acpBackend: 'cursor',
+        prompts: { producesContract: '审查要求\r\n第二行' },
+        env: { GIT_SSH_PRIVATE_KEY: 'k', FOO: 'v' },
+      },
+    ])
+    const { studio, app } = await withAgentStudio()
+    await flushPromises()
+    expect(studio.agentDirty.value).toBe(false)
+    studio.requestStudioTab('prompts')
+    await nextTick()
+    const d = studio.draft.value
+    expect(d).toBeTruthy()
+    if (d) {
+      d.prompts.producesContract = d.prompts.producesContract.replace(/\r\n/g, '\n')
+    }
+    expect(studio.agentDirty.value).toBe(false)
+    studio.requestStudioTab('files')
+    expect(studio.agentDirty.value).toBe(false)
+    app.unmount()
+  })
+
+  it('g2.2: editing a prompt fragment marks dirty; save and discard clear it', async () => {
+    mocks.listAgents.mockResolvedValue([
+      {
+        name: 'agent-a',
+        projectId: 'proj-1',
+        acpBackend: 'cursor',
+        prompts: { reactOpenSuffix: 'hello' },
+      },
+    ])
+    mocks.saveAgent.mockImplementation(async (payload: { name: string }) => payload)
+    const { studio, app } = await withAgentStudio()
+    await flushPromises()
+    expect(studio.agentDirty.value).toBe(false)
+    studio.requestStudioTab('prompts')
+    studio.draft.value!.prompts.reactOpenSuffix = 'hello-edited'
+    expect(studio.agentDirty.value).toBe(true)
+    const saved = await studio.save()
+    expect(saved).toBe(true)
+    expect(studio.agentDirty.value).toBe(false)
+
+    studio.draft.value!.prompts.reactOpenSuffix = 'again'
+    expect(studio.agentDirty.value).toBe(true)
+    studio.discardUnsavedChanges()
+    await nextTick()
+    expect(studio.draft.value!.prompts.reactOpenSuffix).toBe('hello-edited')
+    expect(studio.agentDirty.value).toBe(false)
+    app.unmount()
+  })
 })

--- a/web/src/lib/agent/useAgentStudio.ts
+++ b/web/src/lib/agent/useAgentStudio.ts
@@ -22,7 +22,7 @@ import { AGENT_SETTINGS_PATH } from '@/lib/agent/agentCreateWizard'
 import { useAgentImport } from '@/lib/agent/useAgentImport'
 import { isManagedRegionKey } from '@/lib/shared/regionPolicy'
 import {
-  PROMPT_KEYS, toDraft, fromDraft, fromDraftRaw, normalizeDraftRegions,
+  PROMPT_KEYS, fromDraft, hydrateStudioDraft, draftPayloadJson,
   type AgentStudioDraft as Draft,
 } from '@/lib/agent/agentStudioDraft'
 
@@ -297,9 +297,8 @@ const agentImport = useAgentImport({
       agents.value = list || []
       if (activeName.value && agents.value.some((a) => a.name === activeName.value)) {
         const a = agents.value.find((x) => x.name === activeName.value)!
-        const loaded = toDraft(a)
-        originalJson.value = JSON.stringify(fromDraftRaw(loaded))
-        normalizeDraftRegions(loaded)
+        const loaded = hydrateStudioDraft(a)
+        originalJson.value = draftPayloadJson(loaded)
         draft.value = loaded
       } else if (agents.value.length) {
         select(agents.value[0].name)
@@ -343,7 +342,7 @@ function orgSnapshot(o: AgentOrg): string {
 }
 
 const agentDirty = computed(
-  () => !!draft.value && JSON.stringify(fromDraft(draft.value)) !== originalJson.value,
+  () => !!draft.value && draftPayloadJson(draft.value) !== originalJson.value,
 )
 const orgDirty = computed(() => orgSnapshot(org.value) !== orgBaseline.value)
 const dirty = computed(() => agentDirty.value || orgDirty.value)
@@ -746,9 +745,8 @@ function discardUnsavedChanges() {
   resetOrgFromBaseline()
   const a = agents.value.find((x) => x.name === activeName.value)
   if (!a) return
-  const loaded = toDraft(a)
-  originalJson.value = JSON.stringify(fromDraftRaw(loaded))
-  normalizeDraftRegions(loaded)
+  const loaded = hydrateStudioDraft(a)
+  originalJson.value = draftPayloadJson(loaded)
   draft.value = loaded
   nextTick(() => filesPanelRef.value?.restoreAfterDiscard(snap))
   justSaved.value = false
@@ -871,9 +869,8 @@ function select(
   const a = agents.value.find((x) => x.name === name)
   if (!a) return
   activeName.value = name
-  const loaded = toDraft(a)
-  originalJson.value = JSON.stringify(fromDraftRaw(loaded))
-  normalizeDraftRegions(loaded)
+  const loaded = hydrateStudioDraft(a)
+  originalJson.value = draftPayloadJson(loaded)
   draft.value = loaded
   tab.value = opts?.tab || 'files'
   if (opts?.dataSub) dataSubTab.value = opts.dataSub
@@ -953,7 +950,7 @@ async function save(reason?: string) {
   saving.value = true
   error.value = ''
   try {
-    if (draft.value && JSON.stringify(fromDraft(draft.value)) !== originalJson.value) {
+    if (draft.value && draftPayloadJson(draft.value) !== originalJson.value) {
       const payload = fromDraft(draft.value)
       if (typeof reason === 'string' && reason.trim()) {
         await api.saveAgent(payload, { reason: reason.trim() })
@@ -996,8 +993,9 @@ async function reloadAgentFromServer(name: string) {
     const i = agents.value.findIndex((x) => x.name === name)
     if (i >= 0) agents.value[i] = fresh
     if (activeName.value === name) {
-      draft.value = toDraft(fresh)
-      originalJson.value = JSON.stringify(fromDraft(draft.value))
+      const loaded = hydrateStudioDraft(fresh)
+      draft.value = loaded
+      originalJson.value = draftPayloadJson(loaded)
       justSaved.value = false
     }
     historyRefreshKey.value++

--- a/web/src/views/AgentStudioView.test.ts
+++ b/web/src/views/AgentStudioView.test.ts
@@ -210,16 +210,25 @@ describe('AgentStudio region UI', () => {
     )
   })
 
-  it('makes a missing region dirty and saves the international default', async () => {
+  it('hydrates a missing region without false dirty; later save still writes international default', async () => {
     mocks.listAgents.mockResolvedValue([agent()])
     const wrapper = await mountStudio()
     await flushPromises()
 
+    expect(wrapper.text()).not.toContain('未保存')
+    await wrapper.findAll('button').find((item) => item.text() === '元信息')!.trigger('click')
+    const workspaceInput = wrapper.findAll('input').find((item) => {
+      return (item.element as HTMLInputElement).value === '/root/workspace'
+    })!
+    await workspaceInput.setValue('/root/workspace-hydrated')
     expect(wrapper.text()).toContain('未保存')
     await wrapper.findAll('button').find((item) => item.text() === '保存')!.trigger('click')
     await flushPromises()
     expect(mocks.saveAgent).toHaveBeenCalledWith(
-      expect.objectContaining({ env: { APPROVING_CODEBUDDY_REGION: 'public' } }),
+      expect.objectContaining({
+        env: { APPROVING_CODEBUDDY_REGION: 'public' },
+        layout: expect.objectContaining({ workspaceDir: '/root/workspace-hydrated' }),
+      }),
     )
   })
 


### PR DESCRIPTION
- **fix(web): stop Prompts tab from marking Agent Studio unsaved**
- **test(web): align missing-region dirty assertion with hydrated baseline**
