### PR TITLE
feat(web): click StatusMetrics to open /stats

### DIFF
--- a/web/e2e/status-metrics-topbar-main.ts
+++ b/web/e2e/status-metrics-topbar-main.ts
@@ -1,6 +1,6 @@
 import '../src/styles/global.css'
 import { createApp, defineComponent, h } from 'vue'
-import { createMemoryHistory, createRouter } from 'vue-router'
+import { createWebHashHistory, createRouter, RouterView } from 'vue-router'
 import { i18n } from '../src/lib/shared/i18n'
 import { initLocale, setLocale } from '../src/lib/shared/locale'
 import { installIdleScrollbar } from '../src/lib/shared/idleScrollbar'
@@ -83,21 +83,34 @@ async function bootstrap() {
   await setLocale('zh-CN')
 
   const router = createRouter({
-    history: createMemoryHistory(),
-    routes: [{ path: '/', component: { render: () => h('div', 'main') } }],
+    history: createWebHashHistory(),
+    routes: [
+      {
+        path: '/',
+        component: {
+          render: () =>
+            h('main', { class: 'p-6 text-sm text-txt2', 'data-testid': 'page-body' }, [
+              'StatusMetrics E2E harness · scene=',
+              scene,
+            ]),
+        },
+      },
+      {
+        path: '/stats',
+        name: 'stats',
+        component: {
+          render: () =>
+            h('div', { 'data-testid': 'token-analytics-page' }, 'TokenAnalyticsView stub'),
+        },
+      },
+    ],
   })
   await router.push('/')
 
   const Root = defineComponent({
     setup() {
       return () =>
-        h('div', { class: 'min-h-screen bg-base text-txt' }, [
-          h(AppTopbar),
-          h('main', { class: 'p-6 text-sm text-txt2', 'data-testid': 'page-body' }, [
-            'StatusMetrics E2E harness · scene=',
-            scene,
-          ]),
-        ])
+        h('div', { class: 'min-h-screen bg-base text-txt' }, [h(AppTopbar), h(RouterView)])
     },
   })
 

--- a/web/e2e/status-metrics-topbar.spec.ts
+++ b/web/e2e/status-metrics-topbar.spec.ts
@@ -56,11 +56,9 @@ test.describe('StatusMetrics topbar E2E', () => {
     await expect(todayTip).toContainText('4,812')
     await expect(todayTip).not.toContainText('/5m')
 
-    // Click pin (tip-open) still works.
     await page.getByTestId('status-metrics-running').click()
-    await expect(page.getByTestId('status-metrics-running')).toHaveClass(/tip-open/)
-    await expect(page.getByTestId('status-metrics-running').locator('.sm-tip')).toBeVisible()
-    await expect(page.getByTestId('status-metrics-running').locator('.sm-tip')).toContainText(/执行中:\s*3/)
+    await expect(page).toHaveURL(/#\/stats/)
+    await expect(page.getByTestId('token-analytics-page')).toBeVisible()
 
     const shot = path.join(testInfo.outputDir, 'desktop-five-metrics.png')
     await page.locator('header').screenshot({ path: shot })
@@ -80,7 +78,7 @@ test.describe('StatusMetrics topbar E2E', () => {
     await expect(compact).toContainText('3')
     await expect(compact).toContainText('5')
 
-    await compact.click()
+    await compact.hover()
     const tip = compact.locator('.sm-tip')
     await expect(tip).toBeVisible()
     await expect(tip).toContainText(/累计 Token:\s*1,240,582/)
@@ -90,6 +88,11 @@ test.describe('StatusMetrics topbar E2E', () => {
     await expect(tip).not.toContainText('/5m')
     await expect(tip).not.toContainText('5 分钟')
     await expect(tip).not.toContainText('完整值')
+
+    await compact.click()
+    await expect(page).toHaveURL(/#\/stats/)
+    await expect(page.getByTestId('token-analytics-page')).toBeVisible()
+    await expect(tip).toBeHidden()
 
     await page.screenshot({
       path: path.join(OUT, '02-narrow-status-metrics.png'),
@@ -111,13 +114,15 @@ test.describe('StatusMetrics topbar E2E', () => {
     })
   })
 
-  test('metrics are buttons that do not navigate', async ({ page }) => {
+  test('metrics click navigates to stats (plan g2.2)', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 })
     await page.goto('/status-metrics-topbar.html')
     await expect(page.getByTestId('status-metrics')).toBeVisible({ timeout: 15_000 })
-    const urlBefore = page.url()
     await page.getByTestId('status-metrics-today').click()
-    await expect(page).toHaveURL(urlBefore)
-    await expect(page.getByTestId('page-body')).toBeVisible()
+    await expect(page).toHaveURL(/#\/stats/)
+    await expect(page.getByTestId('token-analytics-page')).toBeVisible()
+    await page.getByTestId('status-metrics-tokens').click()
+    await expect(page).toHaveURL(/#\/stats/)
+    await expect(page.getByTestId('token-analytics-page')).toBeVisible()
   })
 })

--- a/web/src/components/shell/StatusMetrics.test.ts
+++ b/web/src/components/shell/StatusMetrics.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import { createMemoryHistory, createRouter } from 'vue-router'
 import { nextTick, ref } from 'vue'
 import shell from '@/locales/zh-CN/shell.json'
 import { PLATFORM_STATUS_POLL_MS } from '@/lib/composables/usePlatformStatusMetrics'
@@ -20,16 +21,38 @@ vi.mock('@/lib/composables/useBreakpoint', () => ({
   useBreakpoint: () => ({ isMobile }),
 }))
 
-function mountMetrics() {
-  const i18n = createI18n({
+function makeI18n() {
+  return createI18n({
     legacy: false,
     locale: 'zh-CN',
     messages: { 'zh-CN': { ...shell } },
   })
-  return mount(StatusMetrics, {
-    global: { plugins: [i18n] },
+}
+
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'home', component: { template: '<div />' } },
+      {
+        path: '/stats',
+        name: 'stats',
+        component: { template: '<div data-testid="token-analytics-page" />' },
+      },
+    ],
+  })
+}
+
+async function mountMetrics(props?: { variant?: 'auto' | 'full' | 'compact' }) {
+  const i18n = makeI18n()
+  const router = makeRouter()
+  await router.push('/')
+  const w = mount(StatusMetrics, {
+    props,
+    global: { plugins: [i18n, router] },
     attachTo: document.body,
   })
+  return { w, router }
 }
 
 describe('StatusMetrics', () => {
@@ -54,7 +77,7 @@ describe('StatusMetrics', () => {
   })
 
   it('renders four desktop metrics with today tokens (plan g2.2)', async () => {
-    const w = mountMetrics()
+    const { w } = await mountMetrics()
     await flushPromises()
     expect(w.find('[data-testid="status-metrics"]').exists()).toBe(true)
     expect(w.find('[data-testid="status-metrics-tokens"]').text()).toContain('1.24M')
@@ -68,7 +91,7 @@ describe('StatusMetrics', () => {
   })
 
   it('keeps lastSuccess on failure and does not flash 0 (plan g2.2)', async () => {
-    const w = mountMetrics()
+    const { w } = await mountMetrics()
     await flushPromises()
     expect(w.find('[data-testid="status-metrics-tokens"]').text()).toContain('1.24M')
 
@@ -81,7 +104,7 @@ describe('StatusMetrics', () => {
   })
 
   it('pauses polling while document is hidden (plan g2.2)', async () => {
-    const w = mountMetrics()
+    const { w } = await mountMetrics()
     await flushPromises()
     const calls = platformStatus.mock.calls.length
 
@@ -107,7 +130,7 @@ describe('StatusMetrics', () => {
       asOf: '2026-08-12T00:00:00Z',
       timezone: 'UTC',
     })
-    const w = mountMetrics()
+    const { w } = await mountMetrics()
     await flushPromises()
     await nextTick()
     expect(w.find('[data-testid="status-metrics-tokens"]').text()).toContain('—')
@@ -119,7 +142,7 @@ describe('StatusMetrics', () => {
 
   it('renders Token·RUN/Q summary under md (plan g2.4)', async () => {
     isMobile.value = true
-    const w = mountMetrics()
+    const { w } = await mountMetrics()
     await flushPromises()
     expect(w.find('[data-testid="status-metrics-compact"]').exists()).toBe(true)
     expect(w.find('[data-testid="status-metrics-tokens"]').exists()).toBe(false)
@@ -136,7 +159,7 @@ describe('StatusMetrics', () => {
   })
 
   it('desktop tips are single-line label: value with exact counts (plan g1.1/g1.2)', async () => {
-    const w = mountMetrics()
+    const { w } = await mountMetrics()
     await flushPromises()
     const tips = {
       tokens: w.find('[data-testid="status-metrics-tokens"] .sm-tip').text(),
@@ -161,7 +184,7 @@ describe('StatusMetrics', () => {
 
   it('compact tip is four label: value rows aligned with desktop (plan g2.3)', async () => {
     isMobile.value = true
-    const w = mountMetrics()
+    const { w } = await mountMetrics()
     await flushPromises()
     const tip = w.find('[data-testid="status-metrics-compact"] .sm-tip')
     const lines = tip.findAll('div').map((d) => d.text())
@@ -178,26 +201,25 @@ describe('StatusMetrics', () => {
     w.unmount()
   })
 
-  it('sidebar compact variant teleports tip above trigger (g1.1)', async () => {
-    const i18n = createI18n({
-      legacy: false,
-      locale: 'zh-CN',
-      messages: { 'zh-CN': { ...shell } },
-    })
+  it('sidebar compact variant teleports tip above trigger on hover (g1.1/g1.3)', async () => {
     const clip = document.createElement('div')
     clip.style.overflow = 'hidden'
     clip.style.height = '120px'
     document.body.appendChild(clip)
 
+    const i18n = makeI18n()
+    const router = makeRouter()
+    await router.push('/')
     const w = mount(StatusMetrics, {
       props: { variant: 'compact' },
-      global: { plugins: [i18n] },
+      global: { plugins: [i18n, router] },
       attachTo: clip,
     })
     await flushPromises()
 
     const trigger = w.find('[data-testid="status-metrics-compact"]')
     expect(trigger.find('.sm-tip').exists()).toBe(false)
+    expect(trigger.attributes('aria-label')).toMatch(/进入统计/)
 
     vi.spyOn(trigger.element as HTMLElement, 'getBoundingClientRect').mockReturnValue({
       top: 320,
@@ -211,7 +233,7 @@ describe('StatusMetrics', () => {
       toJSON: () => ({}),
     } as DOMRect)
 
-    await trigger.trigger('click')
+    await trigger.trigger('mouseenter')
     await flushPromises()
     await nextTick()
 
@@ -223,9 +245,79 @@ describe('StatusMetrics', () => {
     expect(tip.textContent).toMatch(/排队:\s*5/)
     expect(Number.parseInt(tip.style.top, 10)).toBeLessThan(320)
 
+    await trigger.trigger('click')
+    await flushPromises()
+    expect(router.currentRoute.value.name).toBe('stats')
+    const afterClick = document.body.querySelector(
+      '[data-testid="status-metrics-compact-tip"]',
+    ) as HTMLElement | null
+    expect(afterClick?.style.display === 'none' || afterClick == null).toBe(true)
+
     w.unmount()
     clip.remove()
     document.body.innerHTML = ''
+  })
+
+  it('click compact navigates to stats and closes teleport tip (plan g1.1)', async () => {
+    const { w, router } = await mountMetrics({ variant: 'compact' })
+    await flushPromises()
+    const compact = w.find('[data-testid="status-metrics-compact"]')
+    await compact.trigger('mouseenter')
+    await flushPromises()
+    expect(document.body.querySelector('[data-testid="status-metrics-compact-tip"]')).toBeTruthy()
+    await compact.trigger('click')
+    await flushPromises()
+    expect(router.currentRoute.value.name).toBe('stats')
+    expect(router.currentRoute.value.path).toBe('/stats')
+    const tip = document.body.querySelector('[data-testid="status-metrics-compact-tip"]') as HTMLElement | null
+    expect(tip == null || (tip as HTMLElement).style.display === 'none' || getComputedStyle(tip).display === 'none').toBe(true)
+    w.unmount()
+  })
+
+  it('Enter/Space on compact navigates to stats (plan g1.1)', async () => {
+    const { w, router } = await mountMetrics({ variant: 'compact' })
+    await flushPromises()
+    await w.find('[data-testid="status-metrics-compact"]').trigger('keydown', { key: 'Enter' })
+    await flushPromises()
+    expect(router.currentRoute.value.name).toBe('stats')
+    w.unmount()
+
+    const again = await mountMetrics({ variant: 'compact' })
+    await flushPromises()
+    await again.w.find('[data-testid="status-metrics-compact"]').trigger('keydown', { key: ' ' })
+    await flushPromises()
+    expect(again.router.currentRoute.value.name).toBe('stats')
+    again.w.unmount()
+  })
+
+  it('desktop four items navigate to stats instead of pinning tip (plan g1.2)', async () => {
+    const ids = [
+      'status-metrics-tokens',
+      'status-metrics-today',
+      'status-metrics-running',
+      'status-metrics-queued',
+    ] as const
+    for (const id of ids) {
+      const { w, router } = await mountMetrics()
+      await flushPromises()
+      expect(w.find(`[data-testid="${id}"]`).attributes('aria-label')).toMatch(/进入统计/)
+      await w.find(`[data-testid="${id}"]`).trigger('click')
+      await flushPromises()
+      expect(router.currentRoute.value.name).toBe('stats')
+      expect(w.find(`[data-testid="${id}"]`).classes()).not.toContain('tip-open')
+      w.unmount()
+    }
+  })
+
+  it('stays on stats when already there (plan g1.1)', async () => {
+    const { w, router } = await mountMetrics()
+    await router.push({ name: 'stats' })
+    await flushPromises()
+    await w.find('[data-testid="status-metrics-tokens"]').trigger('click')
+    await flushPromises()
+    expect(router.currentRoute.value.name).toBe('stats')
+    expect(router.currentRoute.value.path).toBe('/stats')
+    w.unmount()
   })
 
   it('zero counts still show label: 0 in tip', async () => {
@@ -237,7 +329,7 @@ describe('StatusMetrics', () => {
       asOf: '2026-08-12T00:00:00Z',
       timezone: 'UTC',
     })
-    const w = mountMetrics()
+    const { w } = await mountMetrics()
     await flushPromises()
     expect(w.find('[data-testid="status-metrics-running"] .sm-tip').text()).toMatch(/执行中:\s*0/)
     expect(w.find('[data-testid="status-metrics-queued"] .sm-tip').text()).toMatch(/排队:\s*0/)
@@ -247,7 +339,7 @@ describe('StatusMetrics', () => {
   })
 
   it('uses A-set stroke icon paths (plan g2.4)', async () => {
-    const w = mountMetrics()
+    const { w } = await mountMetrics()
     await flushPromises()
     const html = w.html()
     expect(html).toContain('cx="12" cy="6.6" rx="7.2" ry="3.1"')

--- a/web/src/components/shell/StatusMetrics.vue
+++ b/web/src/components/shell/StatusMetrics.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
 import { useBreakpoint } from '@/lib/composables/useBreakpoint'
 import {
   placeFixedOverlayAbove,
@@ -19,6 +20,7 @@ const props = withDefaults(
 )
 
 const { t } = useI18n()
+const router = useRouter()
 const { isMobile } = useBreakpoint()
 const { metrics, stale } = usePlatformStatusMetrics()
 
@@ -31,18 +33,19 @@ const useCompact = computed(() => {
 /** Sidebar/drawer compact tips Teleport above the trigger to escape overflow-hidden. */
 const usePortaledCompactTip = computed(() => props.variant === 'compact')
 
-/** Which tip is pinned via click/touch (Demo tip-open). */
-const tipOpen = ref<string | null>(null)
 const compactTrigger = ref<HTMLElement | null>(null)
 const compactTip = ref<HTMLElement | null>(null)
 const compactTipHovered = ref(false)
 const compactTipFocused = ref(false)
+/** Hide Teleport tip after click until pointer leaves (plan g1.1). */
+const suppressCompactTip = ref(false)
 const compactTipStyle = ref<FixedOverlayAboveStyle | null>(null)
 
 const compactTipVisible = computed(
   () =>
-  usePortaledCompactTip.value &&
-    (tipOpen.value === 'compact' || compactTipHovered.value || compactTipFocused.value),
+    usePortaledCompactTip.value &&
+    !suppressCompactTip.value &&
+    (compactTipHovered.value || compactTipFocused.value),
 )
 
 async function repositionCompactTip() {
@@ -78,19 +81,24 @@ const running = computed(() => metrics.value?.runningCount ?? 0)
 const queued = computed(() => metrics.value?.queuedCount ?? 0)
 
 function todayAria(): string {
-  return `${t('shell.statusMetrics.today')}: ${fmtFull(today.value)}`
+  return `${t('shell.statusMetrics.today')}: ${fmtFull(today.value)} · ${t('shell.statusMetrics.openStats')}`
 }
 
-function toggleTip(id: string, ev: Event) {
+function statsAria(label: string): string {
+  return `${label} · ${t('shell.statusMetrics.openStats')}`
+}
+
+function goToStats() {
+  suppressCompactTip.value = true
+  compactTipHovered.value = false
+  compactTipFocused.value = false
+  void router.push({ name: 'stats' })
+}
+
+function onActivateKey(ev: KeyboardEvent) {
+  if (ev.key !== 'Enter' && ev.key !== ' ') return
   ev.preventDefault()
-  tipOpen.value = tipOpen.value === id ? null : id
-}
-
-function onBlurTip(id: string) {
-  // Delay so focus can move within the same control without flicker.
-  requestAnimationFrame(() => {
-    if (tipOpen.value === id) tipOpen.value = null
-  })
+  goToStats()
 }
 </script>
 
@@ -106,11 +114,10 @@ function onBlurTip(id: string) {
       <button
         type="button"
         class="sm-item relative inline-flex items-center gap-1.5 border-0 bg-transparent px-1.5 py-1 text-inherit hover:bg-elevated hover:text-txt focus-visible:bg-elevated focus-visible:text-txt focus-visible:outline-none"
-        :class="tipOpen === 'tokens' ? 'bg-elevated text-txt tip-open' : ''"
         data-testid="status-metrics-tokens"
-        :aria-label="t('shell.statusMetrics.tokens')"
-        @click="toggleTip('tokens', $event)"
-        @blur="onBlurTip('tokens')"
+        :aria-label="statsAria(t('shell.statusMetrics.tokens'))"
+        @click="goToStats"
+        @keydown="onActivateKey"
       >
         <svg class="sm-ico block h-3.5 w-3.5 shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <ellipse cx="12" cy="6.6" rx="7.2" ry="3.1" />
@@ -130,11 +137,10 @@ function onBlurTip(id: string) {
       <button
         type="button"
         class="sm-item relative inline-flex items-center gap-1.5 border-0 bg-transparent px-1.5 py-1 text-inherit hover:bg-elevated hover:text-txt focus-visible:bg-elevated focus-visible:text-txt focus-visible:outline-none"
-        :class="tipOpen === 'today' ? 'bg-elevated text-txt tip-open' : ''"
         data-testid="status-metrics-today"
         :aria-label="todayAria()"
-        @click="toggleTip('today', $event)"
-        @blur="onBlurTip('today')"
+        @click="goToStats"
+        @keydown="onActivateKey"
       >
         <svg class="sm-ico block h-3.5 w-3.5 shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <rect x="3.4" y="5.2" width="17.2" height="15.2" rx="2.6" />
@@ -154,11 +160,10 @@ function onBlurTip(id: string) {
       <button
         type="button"
         class="sm-item relative inline-flex items-center gap-1.5 border-0 bg-transparent px-1.5 py-1 text-inherit hover:bg-elevated hover:text-txt focus-visible:bg-elevated focus-visible:text-txt focus-visible:outline-none"
-        :class="tipOpen === 'running' ? 'bg-elevated text-txt tip-open' : ''"
         data-testid="status-metrics-running"
-        :aria-label="t('shell.statusMetrics.running')"
-        @click="toggleTip('running', $event)"
-        @blur="onBlurTip('running')"
+        :aria-label="statsAria(t('shell.statusMetrics.running'))"
+        @click="goToStats"
+        @keydown="onActivateKey"
       >
         <svg class="sm-ico block h-3.5 w-3.5 shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <circle cx="12" cy="12" r="8.2" />
@@ -177,11 +182,10 @@ function onBlurTip(id: string) {
       <button
         type="button"
         class="sm-item relative inline-flex items-center gap-1.5 border-0 bg-transparent px-1.5 py-1 text-inherit hover:bg-elevated hover:text-txt focus-visible:bg-elevated focus-visible:text-txt focus-visible:outline-none"
-        :class="tipOpen === 'queued' ? 'bg-elevated text-txt tip-open' : ''"
         data-testid="status-metrics-queued"
-        :aria-label="t('shell.statusMetrics.queued')"
-        @click="toggleTip('queued', $event)"
-        @blur="onBlurTip('queued')"
+        :aria-label="statsAria(t('shell.statusMetrics.queued'))"
+        @click="goToStats"
+        @keydown="onActivateKey"
       >
         <svg class="sm-ico block h-3.5 w-3.5 shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <path d="M4 7.2h16M4 12h11.5M4 16.8h7" />
@@ -202,14 +206,15 @@ function onBlurTip(id: string) {
       ref="compactTrigger"
       type="button"
       class="sm-item sm-compact relative inline-flex w-full items-center gap-2 rounded-md border-0 bg-elevated px-2 py-1.5 text-[11px] text-inherit hover:bg-elevated hover:text-txt focus-visible:bg-elevated focus-visible:text-txt focus-visible:outline-none"
-      :class="tipOpen === 'compact' ? 'text-txt tip-open' : ''"
+      :class="suppressCompactTip ? 'tip-suppressed' : ''"
       data-testid="status-metrics-compact"
       :aria-label="t('shell.statusMetrics.compactAria')"
-      @click="toggleTip('compact', $event)"
-      @blur="onBlurTip('compact'); compactTipFocused = false"
+      @click="goToStats"
+      @keydown="onActivateKey"
+      @blur="compactTipFocused = false"
       @focus="compactTipFocused = true"
-      @mouseenter="compactTipHovered = true"
-      @mouseleave="compactTipHovered = false"
+      @mouseenter="suppressCompactTip = false; compactTipHovered = true"
+      @mouseleave="compactTipHovered = false; suppressCompactTip = false"
     >
       <span class="inline-flex items-center gap-1.5">
         <svg class="sm-ico block h-[13px] w-[13px] shrink-0 text-txt3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -273,5 +278,10 @@ function onBlurTip(id: string) {
 .sm-item:focus-visible .sm-tip,
 .sm-item.tip-open .sm-tip {
   display: block;
+}
+.sm-item.tip-suppressed .sm-tip,
+.sm-item.tip-suppressed:hover .sm-tip,
+.sm-item.tip-suppressed:focus-visible .sm-tip {
+  display: none;
 }
 </style>

--- a/web/src/locales/en/shell.json
+++ b/web/src/locales/en/shell.json
@@ -63,7 +63,8 @@
       "today": "Today's tokens",
       "running": "Running",
       "queued": "Queued",
-      "compactAria": "Platform status summary"
+      "compactAria": "Platform status summary, open statistics",
+      "openStats": "Open statistics"
     }
   }
 }

--- a/web/src/locales/zh-CN/shell.json
+++ b/web/src/locales/zh-CN/shell.json
@@ -63,7 +63,8 @@
       "today": "今日 Token",
       "running": "执行中",
       "queued": "排队",
-      "compactAria": "平台状态摘要"
+      "compactAria": "平台状态摘要，进入统计",
+      "openStats": "进入统计"
     }
   }
 }


### PR DESCRIPTION
Navigate compact and desktop StatusMetrics to the stats route on click or keyboard, keep hover tooltips, and update unit plus E2E coverage.

Co-authored-by: Cursor <cursoragent@cursor.com>
