### PR TITLE
feat(web): add home modal to create a baseline workflow

### DIFF
--- a/web/src/components/dashboard/HomeCreateBaselineModal.test.ts
+++ b/web/src/components/dashboard/HomeCreateBaselineModal.test.ts
@@ -1,0 +1,219 @@
+// @vitest-environment happy-dom
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createI18n } from 'vue-i18n'
+import { DOMWrapper, flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import common from '@/locales/zh-CN/common.json'
+import pages from '@/locales/zh-CN/pages.json'
+import HomeCreateBaselineModal from './HomeCreateBaselineModal.vue'
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  listProjects: vi.fn(),
+  createWorkflowFromBaseline: vi.fn(),
+  toastSuccess: vi.fn(),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: mocks.push }),
+}))
+
+vi.mock('@/lib/api/api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/api/api')>('@/lib/api/api')
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      listProjects: mocks.listProjects,
+      createWorkflowFromBaseline: mocks.createWorkflowFromBaseline,
+    },
+  }
+})
+
+vi.mock('@/lib/composables/useToast', () => ({
+  useToast: () => ({
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: mocks.toastSuccess,
+  }),
+}))
+
+const dir = dirname(fileURLToPath(import.meta.url))
+const modalSrc = readFileSync(join(dir, 'HomeCreateBaselineModal.vue'), 'utf8')
+const menuSrc = readFileSync(join(dir, '../workflow/NewWorkflowMenu.vue'), 'utf8')
+
+const p1 = { id: 'proj-1', name: 'Approving', description: '', variables: [] }
+const p2 = { id: 'proj-2', name: 'Platform', description: '', variables: [] }
+const p3 = { id: 'proj-3', name: 'Demo', description: '', variables: [] }
+
+function q(testid: string) {
+  const el = document.querySelector(`[data-testid="${testid}"]`)
+  if (!el) throw new Error(`missing [data-testid="${testid}"]`)
+  return new DOMWrapper(el)
+}
+
+function qExists(testid: string) {
+  return document.querySelector(`[data-testid="${testid}"]`) != null
+}
+
+function mountModal(open = true) {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common, ...pages } },
+  })
+  return mount(HomeCreateBaselineModal, {
+    props: { open },
+    attachTo: document.body,
+    global: {
+      plugins: [i18n],
+      stubs: { Teleport: false, Transition: false },
+    },
+  })
+}
+
+describe('HomeCreateBaselineModal (plan g2 / g3 / g4)', () => {
+  beforeEach(() => {
+    mocks.push.mockReset()
+    mocks.listProjects.mockReset()
+    mocks.createWorkflowFromBaseline.mockReset()
+    mocks.toastSuccess.mockReset()
+    mocks.listProjects.mockResolvedValue([p1])
+    mocks.createWorkflowFromBaseline.mockResolvedValue({ id: 'wf-new', name: '需求对齐流水线' })
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  // plan g2.2 — exactly one project skips the pick list
+  it('skips project list for a single project and focuses the name field', async () => {
+    const wrapper = mountModal()
+    await flushPromises()
+    expect(qExists('home-create-project-list')).toBe(false)
+    const name = q('home-create-workflow-name')
+    expect(name.element).toBe(document.activeElement)
+    await name.setValue('需求对齐流水线')
+    expect((name.element as HTMLInputElement).value).toBe('需求对齐流水线')
+    expect(document.body.textContent).toContain('项目：Approving')
+    expect(document.body.textContent).not.toContain('从零开始')
+    wrapper.unmount()
+  })
+
+  // plan g2.1 — two or more projects: pick then form; back returns to pick
+  it('uses a two-step wizard when there are multiple projects and can go back', async () => {
+    mocks.listProjects.mockResolvedValue([p1, p2, p3])
+    const wrapper = mountModal()
+    await flushPromises()
+    expect(qExists('home-create-project-list')).toBe(true)
+    expect(qExists('home-create-workflow-name')).toBe(false)
+    expect(q('home-create-pane').classes()).toContain('home-create-step--fwd')
+    await q('home-create-project-proj-2').trigger('click')
+    await flushPromises()
+    expect(qExists('home-create-workflow-name')).toBe(true)
+    expect(document.body.textContent).toContain('第 2 / 2 步')
+    expect(document.body.textContent).toContain('Platform')
+    await q('home-create-workflow-name').setValue('keep-me')
+    await q('home-create-back').trigger('click')
+    await flushPromises()
+    expect(qExists('home-create-project-list')).toBe(true)
+    expect(q('home-create-pane').classes()).toContain('home-create-step--back')
+    await q('home-create-project-proj-2').trigger('click')
+    await flushPromises()
+    expect((q('home-create-workflow-name').element as HTMLInputElement).value).toBe('keep-me')
+    wrapper.unmount()
+  })
+
+  // plan g2.3 — zero projects guides to create a project
+  it('guides the user to create a project when none exist', async () => {
+    mocks.listProjects.mockResolvedValue([])
+    const wrapper = mountModal()
+    await flushPromises()
+    expect(q('home-create-no-project').text()).toContain('请先创建项目')
+    await q('home-create-go-projects').trigger('click')
+    expect(mocks.push).toHaveBeenCalledWith('/projects')
+    expect(mocks.createWorkflowFromBaseline).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  // plan g2.3 — listProjects failure can retry inside the modal
+  it('shows retry when project list fails and does not create', async () => {
+    mocks.listProjects.mockRejectedValueOnce(new Error('network down'))
+    const wrapper = mountModal()
+    await flushPromises()
+    expect(q('home-create-load-error').text()).toContain('无法加载项目列表')
+    mocks.listProjects.mockResolvedValue([p1, p2])
+    await q('home-create-retry').trigger('click')
+    await flushPromises()
+    expect(qExists('home-create-project-list')).toBe(true)
+    expect(mocks.createWorkflowFromBaseline).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  // plan g2.4 — name required, at least one repo URL, no scratch path
+  it('disables submit until name and a repo URL are filled, then creates via baseline API', async () => {
+    const wrapper = mountModal()
+    await flushPromises()
+    const submit = q('home-create-submit')
+    expect((submit.element as HTMLButtonElement).disabled).toBe(true)
+    await q('home-create-workflow-name').setValue('需求对齐流水线')
+    await flushPromises()
+    expect((q('home-create-submit').element as HTMLButtonElement).disabled).toBe(true)
+    const url = document.querySelector('input[placeholder*="https"]') as HTMLInputElement | null
+    expect(url).toBeTruthy()
+    await new DOMWrapper(url!).setValue('https://github.com/org/repo')
+    await flushPromises()
+    expect((q('home-create-submit').element as HTMLButtonElement).disabled).toBe(false)
+    await q('home-create-submit').trigger('click')
+    await flushPromises()
+    expect(mocks.createWorkflowFromBaseline).toHaveBeenCalledWith(
+      'proj-1',
+      '需求对齐流水线',
+      expect.arrayContaining([expect.objectContaining({ url: 'https://github.com/org/repo' })]),
+    )
+    expect(mocks.toastSuccess).toHaveBeenCalled()
+    expect(wrapper.emitted('close')).toBeTruthy()
+    wrapper.unmount()
+  })
+
+  // plan g3.3 — create failure restores a clickable submit
+  it('keeps the form open and restores submit after a create failure', async () => {
+    mocks.createWorkflowFromBaseline.mockRejectedValue(new Error('create failed'))
+    const wrapper = mountModal()
+    await flushPromises()
+    await q('home-create-workflow-name').setValue('X')
+    const url = document.querySelector('input[placeholder*="https"]') as HTMLInputElement | null
+    await new DOMWrapper(url!).setValue('https://example.com/r.git')
+    await flushPromises()
+    await q('home-create-submit').trigger('click')
+    await flushPromises()
+    expect(q('home-create-error').text()).toContain('create failed')
+    expect((q('home-create-submit').element as HTMLButtonElement).disabled).toBe(false)
+    wrapper.unmount()
+  })
+})
+
+describe('HomeCreateBaselineModal motion + regression (plan g3.4 / g4.2)', () => {
+  it('uses transform/opacity step motion and disables translate under reduced motion', () => {
+    expect(modalSrc).toMatch(/home-create-step--fwd/)
+    expect(modalSrc).toMatch(/home-create-step--back/)
+    expect(modalSrc).toMatch(/translateX\(14px\)/)
+    expect(modalSrc).toMatch(/translateX\(-14px\)/)
+    expect(modalSrc).toMatch(/opacity:\s*0/)
+    expect(modalSrc).toMatch(/@media \(prefers-reduced-motion:\s*reduce\)/)
+    expect(modalSrc).toMatch(/prefers-reduced-motion[\s\S]*animation:\s*none/)
+    expect(modalSrc).not.toMatch(/from-scratch|new-workflow-scratch|从零开始/)
+    const appModalSrc = readFileSync(join(dir, '../ui/AppModal.vue'), 'utf8')
+    expect(appModalSrc).toMatch(/transition:\s*opacity 0\.2s ease/)
+    expect(appModalSrc).toMatch(/transition:\s*transform 0\.22s/)
+    expect(appModalSrc).toMatch(/translateY\(12px\) scale\(0\.98\)/)
+  })
+
+  it('keeps project-detail NewWorkflowMenu scratch + baseline options unchanged', () => {
+    expect(menuSrc).toMatch(/data-testid="new-workflow-scratch"/)
+    expect(menuSrc).toMatch(/data-testid="new-workflow-baseline"/)
+    expect(menuSrc).toMatch(/pages\.projectDetail\.newWorkflow\.scratch/)
+  })
+})

--- a/web/src/components/dashboard/HomeCreateBaselineModal.vue
+++ b/web/src/components/dashboard/HomeCreateBaselineModal.vue
@@ -1,0 +1,393 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import AppButton from '@/components/ui/AppButton.vue'
+import AppModal from '@/components/ui/AppModal.vue'
+import Icon from '@/components/ui/Icon.vue'
+import ReposEditor, { type RepoRow } from '@/components/ui/ReposEditor.vue'
+import { api } from '@/lib/api/api'
+import { useToast } from '@/lib/composables/useToast'
+import type { Project } from '@/lib/shared/types'
+
+const props = defineProps<{ open: boolean }>()
+const emit = defineEmits<{ (e: 'close'): void }>()
+
+const router = useRouter()
+const toast = useToast()
+const { t } = useI18n()
+
+type Step = 'loading' | 'error' | 'zero' | 'pick' | 'form'
+
+const step = ref<Step>('loading')
+const stepDir = ref<'fwd' | 'back'>('fwd')
+const projects = ref<Project[]>([])
+const loadError = ref('')
+const selectedProject = ref<Project | null>(null)
+const baselineName = ref('')
+const baselineRepos = ref<RepoRow[]>([{ name: '', url: '', branch: '' }])
+const creating = ref(false)
+const createError = ref('')
+const nameInput = ref<HTMLInputElement | null>(null)
+
+const multiProject = computed(() => projects.value.length > 1)
+
+const modalTitle = computed(() => {
+  if (step.value === 'pick') return t('pages.dashboard.create.pickTitle')
+  if (step.value === 'zero') return t('pages.dashboard.create.emptyTitle')
+  if (step.value === 'error') return t('pages.dashboard.create.loadFailed')
+  return t('pages.projectDetail.newWorkflow.modalTitle')
+})
+
+const stepHint = computed(() => {
+  if (step.value === 'pick') return t('pages.dashboard.create.pickStep')
+  if (step.value === 'form' && selectedProject.value) {
+    return multiProject.value
+      ? t('pages.dashboard.create.formStep', { name: selectedProject.value.name })
+      : t('pages.dashboard.create.formProject', { name: selectedProject.value.name })
+  }
+  return ''
+})
+
+const canSubmit = computed(
+  () =>
+    baselineName.value.trim() !== '' &&
+    baselineRepos.value.some((repo) => repo.url.trim() !== '') &&
+    !!selectedProject.value?.id,
+)
+
+const showBack = computed(() => step.value === 'form' && multiProject.value && !creating.value)
+
+function emptyRepos(): RepoRow[] {
+  return [{ name: '', url: '', branch: '' }]
+}
+
+function applySplit() {
+  const list = projects.value
+  if (list.length === 0) {
+    selectedProject.value = null
+    step.value = 'zero'
+    return
+  }
+  if (list.length === 1) {
+    selectedProject.value = list[0]
+    stepDir.value = 'fwd'
+    step.value = 'form'
+    return
+  }
+  step.value = 'pick'
+}
+
+async function loadProjects() {
+  loadError.value = ''
+  stepDir.value = 'fwd'
+  step.value = 'loading'
+  try {
+    const list = await api.listProjects()
+    projects.value = Array.isArray(list) ? list : []
+    applySplit()
+  } catch (e: any) {
+    loadError.value = String(e?.message || e)
+    step.value = 'error'
+  }
+}
+
+function resetDraft() {
+  baselineName.value = ''
+  baselineRepos.value = emptyRepos()
+  createError.value = ''
+  creating.value = false
+  selectedProject.value = null
+  projects.value = []
+}
+
+function pickProject(project: Project) {
+  selectedProject.value = project
+  stepDir.value = 'fwd'
+  step.value = 'form'
+}
+
+function goBack() {
+  if (!multiProject.value || creating.value) return
+  stepDir.value = 'back'
+  step.value = 'pick'
+}
+
+function close() {
+  if (creating.value) return
+  emit('close')
+}
+
+function goProjects() {
+  emit('close')
+  void router.push('/projects')
+}
+
+async function submit() {
+  if (!canSubmit.value || creating.value || !selectedProject.value) return
+  creating.value = true
+  createError.value = ''
+  try {
+    const created = await api.createWorkflowFromBaseline(
+      selectedProject.value.id,
+      baselineName.value.trim(),
+      baselineRepos.value,
+    )
+    toast.success(t('pages.projectDetail.newWorkflow.created', { name: created.name }))
+    emit('close')
+  } catch (e: any) {
+    createError.value = String(e?.message || e)
+  } finally {
+    creating.value = false
+  }
+}
+
+watch(
+  () => props.open,
+  (open) => {
+    if (!open) {
+      resetDraft()
+      return
+    }
+    resetDraft()
+    void loadProjects()
+  },
+  { immediate: true },
+)
+
+watch(step, async (s) => {
+  if (s !== 'form') return
+  await nextTick()
+  nameInput.value?.focus()
+})
+</script>
+
+<template>
+  <AppModal
+    :open="open"
+    :title="modalTitle"
+    :width="460"
+    close-on-esc
+    :close-on-backdrop="!creating"
+    @close="close"
+  >
+    <template #header>
+      <div class="flex min-w-0 flex-1 items-center gap-2">
+        <button
+          v-if="showBack"
+          type="button"
+          class="home-create-back flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-txt3 hover:bg-elevated hover:text-txt"
+          data-testid="home-create-back"
+          :aria-label="t('pages.dashboard.create.back')"
+          :title="t('pages.dashboard.create.back')"
+          @click="goBack"
+        >
+          <Icon name="arrow-left" :size="16" />
+        </button>
+        <span class="truncate text-[15px] font-semibold text-txt">{{ modalTitle }}</span>
+      </div>
+    </template>
+
+    <p
+      v-if="stepHint"
+      class="mb-3 text-[11px] leading-relaxed text-txt3"
+      data-testid="home-create-steps"
+    >
+      {{ stepHint }}
+    </p>
+
+    <div
+      :key="`${step}-${stepDir}`"
+      class="home-create-step"
+      :class="stepDir === 'back' ? 'home-create-step--back' : 'home-create-step--fwd'"
+      data-testid="home-create-pane"
+    >
+      <div v-if="step === 'loading'" class="py-6 text-center text-sm text-txt3" data-testid="home-create-loading">
+        {{ t('common.loading.inProgress') }}
+      </div>
+
+      <div v-else-if="step === 'error'" data-testid="home-create-load-error">
+        <p class="text-[13px] leading-relaxed text-txt2">{{ t('pages.dashboard.create.loadFailed') }}</p>
+        <p v-if="loadError" class="mt-2 text-[12px] text-err">{{ loadError }}</p>
+      </div>
+
+      <div v-else-if="step === 'zero'" class="py-2 text-center" data-testid="home-create-no-project">
+        <p class="text-[12.5px] leading-relaxed text-txt2">{{ t('pages.dashboard.create.emptyHint') }}</p>
+      </div>
+
+      <div v-else-if="step === 'pick'" class="home-create-project-list" data-testid="home-create-project-list">
+        <button
+          v-for="(p, idx) in projects"
+          :key="p.id"
+          type="button"
+          class="home-create-project-row"
+          :style="{ animationDelay: `${idx * 45}ms` }"
+          :data-testid="`home-create-project-${p.id}`"
+          :aria-checked="selectedProject?.id === p.id ? 'true' : 'false'"
+          @click="pickProject(p)"
+        >
+          <span class="home-create-project-av">{{ (p.name || p.id).slice(0, 1) }}</span>
+          <span class="min-w-0 truncate text-[13px]">{{ p.name || p.id }}</span>
+        </button>
+      </div>
+
+      <div v-else-if="step === 'form'" data-testid="home-create-form">
+        <p class="mb-3 text-[13px] leading-relaxed text-txt2">
+          {{ t('pages.projectDetail.newWorkflow.modalHint') }}
+        </p>
+        <div class="mb-4">
+          <label class="label" for="home-create-workflow-name">
+            {{ t('pages.projectDetail.newWorkflow.nameLabel') }}
+          </label>
+          <input
+            id="home-create-workflow-name"
+            ref="nameInput"
+            v-model="baselineName"
+            class="input"
+            autocomplete="off"
+            data-testid="home-create-workflow-name"
+            :placeholder="t('pages.projectDetail.newWorkflow.namePlaceholder')"
+            :disabled="creating"
+          />
+        </div>
+        <ReposEditor :repos="baselineRepos" :min-rows="1" :editable="!creating" @update:repos="baselineRepos = $event" />
+        <div
+          v-if="createError"
+          class="mt-3 flex items-start gap-2 rounded-md border border-err/30 bg-err/10 px-3 py-2 text-[12px] text-err"
+          role="alert"
+          data-testid="home-create-error"
+        >
+          <Icon name="alert" :size="14" class="mt-0.5 shrink-0" />
+          {{ createError }}
+        </div>
+      </div>
+    </div>
+
+    <template v-if="step === 'error' || step === 'zero' || step === 'form'" #footer>
+      <template v-if="step === 'error'">
+        <AppButton variant="ghost" @click="close">{{ t('common.buttons.cancel') }}</AppButton>
+        <AppButton variant="primary" data-testid="home-create-retry" @click="loadProjects">
+          {{ t('common.buttons.retry') }}
+        </AppButton>
+      </template>
+      <template v-else-if="step === 'zero'">
+        <AppButton variant="ghost" @click="close">{{ t('common.buttons.cancel') }}</AppButton>
+        <AppButton variant="primary" data-testid="home-create-go-projects" @click="goProjects">
+          {{ t('pages.dashboard.create.goProjects') }}
+        </AppButton>
+      </template>
+      <template v-else>
+        <AppButton variant="ghost" :disabled="creating" @click="close">{{ t('common.buttons.cancel') }}</AppButton>
+        <AppButton
+          variant="primary"
+          :loading="creating"
+          :disabled="!canSubmit"
+          data-testid="home-create-submit"
+          @click="submit"
+        >
+          {{ creating ? t('pages.projectDetail.newWorkflow.creating') : t('pages.projectDetail.newWorkflow.create') }}
+        </AppButton>
+      </template>
+    </template>
+  </AppModal>
+</template>
+
+<style scoped>
+.home-create-step--fwd {
+  animation: home-create-in-fwd 0.26s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+.home-create-step--back {
+  animation: home-create-in-back 0.26s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+@keyframes home-create-in-fwd {
+  from {
+    opacity: 0;
+    transform: translateX(14px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@keyframes home-create-in-back {
+  from {
+    opacity: 0;
+    transform: translateX(-14px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.home-create-project-row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-align: left;
+  border: 1px solid rgb(var(--c-line));
+  background: rgb(var(--c-surface));
+  border-radius: 10px;
+  padding: 10px 12px;
+  margin: 0 0 8px;
+  cursor: pointer;
+  animation: home-create-row-in 0.26s cubic-bezier(0.16, 1, 0.3, 1) both;
+  transition:
+    border-color 0.16s ease,
+    background-color 0.16s ease,
+    opacity 0.16s ease,
+    transform 0.16s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.home-create-project-row:hover {
+  border-color: rgb(var(--c-accent));
+  background: rgb(var(--c-accent) / 0.08);
+  transform: translateX(2px);
+}
+.home-create-project-row[aria-checked='true'] {
+  border-color: rgb(var(--c-accent));
+  background: rgb(var(--c-accent) / 0.12);
+}
+.home-create-project-av {
+  width: 24px;
+  height: 24px;
+  border-radius: 7px;
+  background: rgb(var(--c-elevated));
+  color: rgb(var(--c-txt2));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 600;
+  flex: 0 0 auto;
+}
+@keyframes home-create-row-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.home-create-back {
+  transition:
+    background-color 0.16s ease,
+    color 0.16s ease,
+    transform 0.16s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-create-step--fwd,
+  .home-create-step--back,
+  .home-create-project-row {
+    animation: none;
+  }
+  .home-create-project-row:hover,
+  .home-create-back:active {
+    transform: none;
+  }
+}
+</style>

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -30,6 +30,18 @@
         "more": "More actions",
         "hide": "Hide",
         "edit": "Edit"
+      },
+      "create": {
+        "addCard": "New workflow",
+        "pickTitle": "Select a project",
+        "pickStep": "Step 1 of 2 · The baseline workflow will be created in the selected project",
+        "formStep": "Step 2 of 2 · Project: {name}",
+        "formProject": "Project: {name}",
+        "back": "Back",
+        "emptyTitle": "Create a project first",
+        "emptyHint": "A workflow must belong to a project. You have no projects yet — create one first.",
+        "goProjects": "Go to projects",
+        "loadFailed": "Could not load projects"
       }
     },
     "tokenAnalytics": {

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -30,6 +30,18 @@
         "more": "更多操作",
         "hide": "隐藏",
         "edit": "编辑"
+      },
+      "create": {
+        "addCard": "新建工作流",
+        "pickTitle": "选择项目",
+        "pickStep": "第 1 / 2 步 · 基线工作流将创建在所选项目下",
+        "formStep": "第 2 / 2 步 · 项目：{name}",
+        "formProject": "项目：{name}",
+        "back": "上一步",
+        "emptyTitle": "先创建一个项目",
+        "emptyHint": "工作流必须属于一个项目。当前没有可用项目，请先创建项目。",
+        "goProjects": "前往项目",
+        "loadFailed": "无法加载项目列表"
       }
     },
     "tokenAnalytics": {

--- a/web/src/views/DashboardView.fill.test.ts
+++ b/web/src/views/DashboardView.fill.test.ts
@@ -33,6 +33,8 @@ describe('DashboardView home chat layout', () => {
     expect(src).not.toMatch(/data-testid="dashboard-select-project"/)
     expect(src).toMatch(/data-testid="home-pipelines-empty"/)
     expect(src).toMatch(/data-testid="home-go-projects"/)
+    expect(src).toMatch(/data-testid="home-new-workflow"/)
+    expect(src).toMatch(/HomeCreateBaselineModal/)
     expect(src).not.toMatch(/dashboard-kpi-/)
     expect(src).not.toMatch(/dashboard-board-empty/)
     expect(src).not.toMatch(/RunBoardColumn/)

--- a/web/src/views/DashboardView.test.ts
+++ b/web/src/views/DashboardView.test.ts
@@ -973,4 +973,36 @@ describe('DashboardView home composer', () => {
     )
     wrapper.unmount()
   })
+
+  // plan g1.1 — plus card at the end of the rail; not a selectable pipeline
+  it('appends a new-workflow card that opens the baseline modal and ignores context menu', async () => {
+    const wrapper = mountDashboard()
+    await flushPromises()
+    const rail = wrapper.get('[data-testid="home-pipeline-cards"]')
+    const add = wrapper.get('[data-testid="home-new-workflow"]')
+    expect(rail.element.lastElementChild).toBe(add.element)
+    expect(add.text()).toContain('新建工作流')
+    await add.trigger('contextmenu')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="home-pipeline-menu"]').exists()).toBe(false)
+    await add.trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="home-create-workflow-name"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="home-create-project-list"]').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('从零开始')
+    wrapper.unmount()
+  })
+
+  // plan g1.2 — empty pipeline list still offers the same plus card
+  it('keeps the new-workflow card when the home pipeline list is empty', async () => {
+    mocks.listWorkflows.mockResolvedValue([])
+    const wrapper = mountDashboard()
+    await flushPromises()
+    expect(wrapper.find('[data-testid="home-pipelines-empty"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="home-new-workflow"]').exists()).toBe(true)
+    await wrapper.get('[data-testid="home-new-workflow"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="home-create-workflow-name"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
 })

--- a/web/src/views/DashboardView.vue
+++ b/web/src/views/DashboardView.vue
@@ -8,6 +8,7 @@ import HomePrioritySelect from '@/components/dashboard/HomePrioritySelect.vue'
 import Icon from '@/components/ui/Icon.vue'
 import ChatImageThumb from '@/components/ui/ChatImageThumb.vue'
 import ChatImagePreviewModal from '@/components/ui/ChatImagePreviewModal.vue'
+import HomeCreateBaselineModal from '@/components/dashboard/HomeCreateBaselineModal.vue'
 import RunLaunchModal from '@/components/workflow/RunLaunchModal.vue'
 import { useChatImagePreview } from '@/lib/composables/useChatImagePreview'
 import { useHomeApproveChat } from '@/lib/run/useHomeApproveChat'
@@ -77,6 +78,7 @@ const phVisible = ref('')
 const phCursor = ref(false)
 let phTimer: ReturnType<typeof setTimeout> | null = null
 let phHoldTimer: ReturnType<typeof setTimeout> | null = null
+const createBaselineOpen = ref(false)
 const pipelineMenuOpen = ref(false)
 const pipelineMenuX = ref(0)
 const pipelineMenuY = ref(0)
@@ -240,6 +242,14 @@ function onComposerBlur() {
 
 function goProjects() {
   void router.push('/projects')
+}
+
+function openCreateBaseline(e?: Event) {
+  e?.preventDefault()
+  e?.stopPropagation()
+  closePipelineMenu()
+  clearLongPress()
+  createBaselineOpen.value = true
 }
 
 function closePipelineMenu() {
@@ -635,9 +645,11 @@ onBeforeUnmount(() => {
       </div>
 
       <div
-        v-else
-        class="home-pipeline-rail-wrap mt-10 w-full"
+        v-if="!loadError"
+        class="home-pipeline-rail-wrap w-full"
         :class="{
+          'mt-10': loading || pipelines.length > 0,
+          'mt-4': !loading && pipelines.length === 0,
           'home-pipeline-rail-wrap--has-left': pipelineFadeLeft,
           'home-pipeline-rail-wrap--has-right': pipelineFadeRight,
         }"
@@ -723,6 +735,18 @@ onBeforeUnmount(() => {
               </div>
             </div>
           </div>
+          <button
+            type="button"
+            role="listitem"
+            class="home-shell__card home-shell__card--add w-48 shrink-0"
+            data-testid="home-new-workflow"
+            @click="openCreateBaseline"
+            @contextmenu.prevent
+            @pointerdown.stop
+          >
+            <span class="home-shell__card-plus" aria-hidden="true">+</span>
+            <span class="home-shell__card-add-label">{{ t('pages.dashboard.create.addCard') }}</span>
+          </button>
         </div>
 
         <button
@@ -772,6 +796,8 @@ onBeforeUnmount(() => {
         </button>
       </div>
     </Teleport>
+
+    <HomeCreateBaselineModal :open="createBaselineOpen" @close="createBaselineOpen = false" />
 
     <RunLaunchModal
       :open="launchOpen"
@@ -943,6 +969,55 @@ onBeforeUnmount(() => {
 .home-shell__card--selected {
   border-color: rgb(var(--c-accent));
   box-shadow: inset 0 0 0 1px rgb(var(--c-accent));
+}
+
+.home-shell__card--add {
+  min-height: 148px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 1.5px dashed rgb(var(--c-accent) / 0.45);
+  background: linear-gradient(180deg, rgb(var(--c-accent) / 0.08), rgb(var(--c-surface)));
+  cursor: pointer;
+  user-select: none;
+  transition:
+    transform 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 0.2s ease;
+}
+.home-shell__card--add:hover {
+  border-color: rgb(var(--c-accent));
+  transform: translateY(-3px);
+  box-shadow: 0 12px 24px rgb(var(--c-txt) / 0.1);
+}
+.home-shell__card--add:active {
+  transform: translateY(0) scale(0.98);
+}
+.home-shell__card-plus {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: rgb(var(--c-accent));
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  line-height: 1;
+  transition: transform 0.24s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.home-shell__card--add:hover .home-shell__card-plus {
+  transform: rotate(90deg) scale(1.06);
+}
+.home-shell__card--add:active .home-shell__card-plus {
+  transform: rotate(90deg) scale(0.94);
+}
+.home-shell__card-add-label {
+  font-size: 12px;
+  color: rgb(var(--c-accent));
+  font-weight: 600;
 }
 
 .home-shell__card-top {
@@ -1132,6 +1207,14 @@ onBeforeUnmount(() => {
 
   .home-pipeline-rail {
     scroll-behavior: auto;
+  }
+
+  .home-shell__card--add,
+  .home-shell__card--add:hover,
+  .home-shell__card--add:active,
+  .home-shell__card--add:hover .home-shell__card-plus,
+  .home-shell__card--add:active .home-shell__card-plus {
+    transform: none;
   }
 }
 


### PR DESCRIPTION
Let the dashboard plus card open a centered baseline-only wizard so single-project users skip picking, multi-project users can go back, and project-detail scratch creation stays unchanged.

Co-authored-by: Cursor <cursoragent@cursor.com>
