### PR TITLE
Keep run detail live by patching chrome while clarify is busy

### DIFF
--- a/web/LIB_DOMAIN_MAP.json
+++ b/web/LIB_DOMAIN_MAP.json
@@ -98,6 +98,7 @@
       "liveLogRehydrate.ts",
       "liveLogSnapshotCache.ts",
       "mergeAcpEvents.ts",
+      "mergeRunChrome.ts",
       "nodeEventsResponse.ts",
       "outputSourceOptions.ts",
       "pendingAcpBuffer.ts",
@@ -182,7 +183,7 @@
     "inbox": 21,
     "pm": 7,
     "project": 4,
-    "run": 53,
+    "run": 54,
     "shared": 37
   }
 }

--- a/web/src/lib/run/mergeRunChrome.test.ts
+++ b/web/src/lib/run/mergeRunChrome.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import type { Run } from '@/lib/shared/types'
+import {
+  artifactsListFingerprint,
+  mergeRunChromeFields,
+  reactSessionsBusyFingerprint,
+  runChromeFingerprint,
+  runSnapshotUnchanged,
+} from './mergeRunChrome'
+
+function run(over: Partial<Run> = {}): Run {
+  return {
+    id: 'run-1',
+    workflowId: 'wf',
+    workflowName: 'wf',
+    status: 'running',
+    trigger: 'manual',
+    startedAt: '2026-01-01T00:00:00Z',
+    durationSec: 0,
+    progress: 0.2,
+    nodeRuns: { n1: { nodeId: 'n1', status: 'running', outputs: {} } },
+    artifacts: [{ id: 'a1', name: 'plan.json', kind: 'json', nodeId: 'n1', sizeBytes: 10, createdAt: '', workflowName: '' }],
+    reactSessions: {
+      n1: { busy: true, waiting: 0, items: [{ id: 'q1', text: 'hello' }] },
+    },
+    clarify: { nodeId: 'n1', turns: [{ role: 'agent', text: 'streaming', at: 't' }], done: false },
+    ...over,
+  } as unknown as Run
+}
+
+describe('mergeRunChromeFields (g1.1)', () => {
+  it('patches status, progress, nodeRuns, artifacts and keeps dialogue buffers', () => {
+    const current = run()
+    const sessions = current.reactSessions
+    const clarify = current.clarify
+    const snapshot = run({
+      status: 'waiting_human',
+      progress: 0.6,
+      durationSec: 12,
+      nodeRuns: { n1: { nodeId: 'n1', status: 'waiting_human', outputs: {} } },
+      artifacts: [
+        {
+          id: 'a1',
+          name: 'plan.json',
+          kind: 'json',
+          nodeId: 'n1',
+          sizeBytes: 99,
+          revision: 2,
+          updatedAt: 't2',
+          createdAt: '',
+          workflowName: '',
+        },
+      ],
+      reactSessions: { n1: { busy: false, waiting: 0, items: [] } },
+      clarify: { nodeId: 'n1', turns: [], done: true },
+    })
+
+    const merged = mergeRunChromeFields(current, snapshot)
+    expect(merged.status).toBe('waiting_human')
+    expect(merged.progress).toBe(0.6)
+    expect(merged.nodeRuns.n1.status).toBe('waiting_human')
+    expect(merged.artifacts[0].sizeBytes).toBe(99)
+    expect(merged.reactSessions).toBe(sessions)
+    expect(merged.clarify).toBe(clarify)
+    expect(merged.clarify?.turns[0].text).toBe('streaming')
+  })
+
+  it('reuses the artifacts array when the list fingerprint is unchanged (g2.2)', () => {
+    const current = run()
+    const snapshot = run({
+      artifacts: current.artifacts.map((a) => ({ ...a })),
+    })
+    const merged = mergeRunChromeFields(current, snapshot)
+    expect(merged.artifacts).toBe(current.artifacts)
+    expect(artifactsListFingerprint(merged.artifacts)).toBe(artifactsListFingerprint(current.artifacts))
+  })
+
+  it('runSnapshotUnchanged is true for identical chrome + busy flags', () => {
+    const a = run()
+    const b = run()
+    expect(runChromeFingerprint(a)).toBe(runChromeFingerprint(b))
+    expect(reactSessionsBusyFingerprint(a)).toBe(reactSessionsBusyFingerprint(b))
+    expect(runSnapshotUnchanged(a, b)).toBe(true)
+    expect(runSnapshotUnchanged(a, run({ progress: 0.9 }))).toBe(false)
+  })
+})

--- a/web/src/lib/run/mergeRunChrome.ts
+++ b/web/src/lib/run/mergeRunChrome.ts
@@ -1,0 +1,87 @@
+/**
+ * Fine-grained run-detail chrome merge (g1.1).
+ * Patches status / progress / node runs / artifacts without touching dialogue.
+ */
+import type { Artifact, Run } from '@/lib/shared/types'
+import { artifactFingerprint } from '@/lib/run/reactArtifactPreview'
+
+export function artifactsListFingerprint(arts: Artifact[] | undefined): string {
+  if (!arts?.length) return ''
+  return arts.map((a) => `${a.name}:${artifactFingerprint(a)}`).join('|')
+}
+
+/** Canvas / header fields that may update while a clarify session is streaming. */
+export function runChromeFingerprint(run: Run): string {
+  const nodeRuns = Object.entries(run.nodeRuns || {})
+    .map(([k, v]) => `${k}:${v.status}:${v.durationSec ?? ''}:${v.startedAt || ''}`)
+    .sort()
+    .join(',')
+  const exec = Object.entries(run.nodeExecutions || {})
+    .map(([k, list]) => `${k}:${list.length}:${list.map((n) => n.status).join('/')}`)
+    .sort()
+    .join(',')
+  return [
+    run.status,
+    String(run.progress ?? ''),
+    run.startedAt,
+    String(run.durationSec ?? ''),
+    run.currentNodeLabel || '',
+    nodeRuns,
+    exec,
+    artifactsListFingerprint(run.artifacts),
+    run.gate?.nodeId || '',
+    run.error || '',
+    run.failedReason || '',
+    run.failedNode || '',
+  ].join('#')
+}
+
+export function reactSessionsBusyFingerprint(run: Run): string {
+  const sessions = run.reactSessions
+  if (!sessions) return ''
+  return Object.keys(sessions)
+    .sort()
+    .map((k) => `${k}:${sessions[k]?.busy ? '1' : '0'}:${sessions[k]?.waiting ?? 0}`)
+    .join('|')
+}
+
+/**
+ * Merge REST snapshot chrome onto the live run.
+ * Keeps reactSessions / clarify turns so a busy dialogue is not overwritten (g1.1).
+ */
+export function mergeRunChromeFields(current: Run, snapshot: Run): Run {
+  const nextArts = snapshot.artifacts ?? current.artifacts
+  const artifacts =
+    artifactsListFingerprint(current.artifacts) === artifactsListFingerprint(nextArts)
+      ? current.artifacts
+      : nextArts
+  const nodeRuns = snapshot.nodeRuns ?? current.nodeRuns
+  const nodeExecutions = snapshot.nodeExecutions ?? current.nodeExecutions
+  return {
+    ...current,
+    status: snapshot.status,
+    progress: snapshot.progress,
+    startedAt: snapshot.startedAt,
+    durationSec: snapshot.durationSec,
+    currentNodeLabel: snapshot.currentNodeLabel,
+    nodeRuns,
+    nodeExecutions,
+    artifacts,
+    gate: snapshot.gate,
+    trace: snapshot.trace ?? current.trace,
+    git: snapshot.git !== undefined ? snapshot.git : current.git,
+    error: snapshot.error,
+    failedReason: snapshot.failedReason,
+    failedNode: snapshot.failedNode,
+    priority: snapshot.priority ?? current.priority,
+    // reactSessions, clarify, clarifyByNode stay on `current` via spread.
+  }
+}
+
+export function runSnapshotUnchanged(current: Run, snapshot: Run): boolean {
+  return (
+    current.id === snapshot.id &&
+    runChromeFingerprint(current) === runChromeFingerprint(snapshot) &&
+    reactSessionsBusyFingerprint(current) === reactSessionsBusyFingerprint(snapshot)
+  )
+}

--- a/web/src/lib/run/useArtifactPreview.coverage.test.ts
+++ b/web/src/lib/run/useArtifactPreview.coverage.test.ts
@@ -338,6 +338,28 @@ describe('useArtifactPreview coverage', () => {
     app.unmount()
   })
 
+  it('does not reload content when the artifact fingerprint is unchanged (g2.2)', async () => {
+    const { preview, props, app } = mountPreview({
+      artifact: artifact({ id: 'plan', name: 'plan.json', kind: 'json', content: '{"title":"A"}', updatedAt: 't1', revision: 1 }),
+    })
+    await flushPromises()
+    mocks.artifactContent.mockClear()
+    const loads = preview.contentLoadGen
+    props.artifact = artifact({
+      id: 'plan',
+      name: 'plan.json',
+      kind: 'json',
+      content: '{"title":"A"}',
+      updatedAt: 't1',
+      revision: 1,
+    })
+    await flushPromises()
+    expect(mocks.artifactContent).not.toHaveBeenCalled()
+    expect(preview.contentLoadGen).toBe(loads)
+    expect(preview.showStructuredUi.value).toBe(true)
+    app.unmount()
+  })
+
   it('opens, closes, maps, and confirms deletion with guarded and error paths', async () => {
     const { preview, emit, props, app } = mountPreview()
     expect(preview.mapDeleteError({ status: 409 })).toContain('RunNotEnded')

--- a/web/src/lib/run/useArtifactPreview.ts
+++ b/web/src/lib/run/useArtifactPreview.ts
@@ -416,6 +416,8 @@ watch(
     return artifactFingerprint(a)
   },
   (fp, prev) => {
+    // Same content/version fingerprint: skip reload so iframe / StructuredArtifactView stay mounted (g2.2).
+    if (fp && prev && fp === prev) return
     const id = displayArtifact.value?.id
     const sameId = !!prev && !!fp && prev.split(':')[0] === fp.split(':')[0]
     if (!sameId) {

--- a/web/src/lib/run/useRunDetail.actions.test.ts
+++ b/web/src/lib/run/useRunDetail.actions.test.ts
@@ -780,10 +780,28 @@ describe('useRunDetail actions', () => {
     detail.reviewChatRef.value = { isSessionBusy: () => true }
     expect(detail.isClarifySessionBusy()).toBe(true)
 
+    const sessions = { n1: { busy: true, items: [{ id: 'keep', text: 'stream' }] } }
+    detail.run.value = {
+      ...detail.run.value,
+      reactSessions: sessions,
+    } as unknown as Run
+    const turns = detail.run.value.clarifyByNode?.n1
+
     mocks.getRun.mockClear()
+    mocks.getRun.mockResolvedValueOnce({
+      ...detail.run.value,
+      progress: 0.88,
+      reactSessions: { n1: { busy: false, items: [] } },
+    })
     detail.onFocusRefresh()
     await flushPromises()
-    expect(mocks.getRun).not.toHaveBeenCalled()
+    // Busy focus still patches chrome (g1.2) but must not replace dialogue buffers (g1.1).
+    expect(mocks.getRun).toHaveBeenCalled()
+    expect(detail.run.value.progress).toBe(0.88)
+    expect(detail.run.value.reactSessions?.n1?.busy).toBe(true)
+    expect(detail.run.value.reactSessions?.n1?.items?.[0]?.text).toBe('stream')
+    expect(detail.run.value.clarifyByNode?.n1).toBe(turns)
+    expect(detail.refreshing.value).toBe(false)
 
     detail.reviewChatRef.value = null
     detail.run.value = {

--- a/web/src/lib/run/useRunDetail.ts
+++ b/web/src/lib/run/useRunDetail.ts
@@ -21,6 +21,12 @@ import { addClarifyAnnotation, useClarifyDraft } from '@/lib/inbox/useClarifyDra
 import { previewPickLabel, type AppPreviewPickPayload } from '@/lib/shared/previewPickUrl'
 import { resolveNodeDisplayLabelFromNode } from '@/lib/run/resolveNodeDisplayLabel'
 import { applyPreviewArtifactName } from '@/lib/run/reactArtifactPreview'
+import {
+  artifactsListFingerprint,
+  mergeRunChromeFields,
+  runChromeFingerprint,
+  runSnapshotUnchanged,
+} from '@/lib/run/mergeRunChrome'
 import { fmtTime, fmtDuration, formatTrigger } from '@/lib/shared/format'
 import { pickDefaultTimelineNodeId } from '@/lib/run/runStats'
 import { useRunDetailLiveLog } from '@/lib/run/useRunDetailLiveLog'
@@ -350,9 +356,37 @@ async function refreshArtifactPreviewState(frame?: { previewArtifact?: string })
   }
   try {
     const arts = await api.runArtifacts(runId.value)
-    if (Array.isArray(arts)) run.value = { ...run.value, artifacts: arts }
+    if (!Array.isArray(arts)) return
+    if (artifactsListFingerprint(run.value.artifacts) === artifactsListFingerprint(arts)) return
+    run.value = { ...run.value, artifacts: arts }
   } catch {
     /* keep last known artifacts */
+  }
+}
+
+/** Busy-safe REST patch: chrome only, never hard load / dialogue overwrite (g1.1 / g1.3). */
+let chromePatchInflight = false
+async function patchRunChrome() {
+  const id = runId.value
+  if (chromePatchInflight || runLoading.value || loadError.value) return
+  if (isClearlyInvalidRunRouteId(id)) return
+  chromePatchInflight = true
+  try {
+    const snapshot = await api.getRun(id)
+    const prev = run.value
+    const merged = mergeRunChromeFields(prev, snapshot)
+    const artsChanged =
+      artifactsListFingerprint(prev.artifacts) !== artifactsListFingerprint(merged.artifacts)
+    if (runChromeFingerprint(prev) !== runChromeFingerprint(merged)) {
+      run.value = merged
+    }
+    if (artsChanged) {
+      void refreshArtifactPreviewState()
+    }
+  } catch {
+    /* keep last known chrome */
+  } finally {
+    chromePatchInflight = false
   }
 }
 
@@ -375,7 +409,8 @@ const wsApi = useRunDetailWs({
   fetchSandboxLog,
   maybePollSandboxForBoot,
   isClarifySessionBusy,
-  loadRun: (hard = false) => loadRun(hard),
+  loadRun: (hard = false, silent = false) => loadRun(hard, silent),
+  patchRunChrome,
   refreshArtifactPreview: (frame) => {
     void refreshArtifactPreviewState(frame)
   },
@@ -421,6 +456,10 @@ async function fetchRunData(): Promise<true | RunLoadErrorKind> {
   }
   try {
     const r = await api.getRun(id)
+    if (run.value.id === r.id && runSnapshotUnchanged(run.value, r)) {
+      await loadUnknownModelDisplayName(wf.value.projectId)
+      return true
+    }
     run.value = r
     // Prefer the run's own pinned graph so the canvas reflects exactly what
     // executed, even if the live workflow was since edited or deleted. Fall
@@ -451,7 +490,7 @@ async function fetchRunData(): Promise<true | RunLoadErrorKind> {
   }
 }
 
-async function loadRun(hard = false) {
+async function loadRun(hard = false, silent = false) {
   const id = runId.value
   if (hard) {
     runLoading.value = true
@@ -459,7 +498,7 @@ async function loadRun(hard = false) {
     loadErrorKind.value = null
     resetRunState(id)
     teardownRealtime()
-  } else {
+  } else if (!silent) {
     refreshing.value = true
   }
 
@@ -482,7 +521,7 @@ async function loadRun(hard = false) {
     }
   } finally {
     if (hard) runLoading.value = false
-    else refreshing.value = false
+    else if (!silent) refreshing.value = false
   }
 }
 
@@ -497,9 +536,13 @@ onMounted(async () => {
   window.addEventListener('focus', onFocusRefresh)
 })
 function onFocusRefresh() {
-  // Clarify/review mid-turn: skip focus/visibility full reload (keeps stream + input focus).
-  if (isClarifySessionBusy()) return
-  if (!runLoading.value && !loadError.value) loadRun(false)
+  if (runLoading.value || loadError.value) return
+  // Auto / visibility: never hard load (g1.3). Busy → chrome patch only (g1.2).
+  if (isClarifySessionBusy()) {
+    void patchRunChrome()
+    return
+  }
+  void loadRun(false, true)
 }
 function onVisible() {
   if (document.visibilityState === 'visible') onFocusRefresh()
@@ -1269,6 +1312,7 @@ function selectExecution(nodeId: string, idx: number) {
   live,
   isClarifySessionBusy,
   refreshArtifactPreviewState,
+  patchRunChrome,
   wsApi,
   resetRunState,
   classifyRunLoadError,

--- a/web/src/lib/run/useRunDetailWs.coverage.test.ts
+++ b/web/src/lib/run/useRunDetailWs.coverage.test.ts
@@ -92,6 +92,7 @@ function harness(over: {
   const fetchSandboxLog = vi.fn()
   const maybePollSandboxForBoot = vi.fn()
   const loadRun = vi.fn()
+  const patchRunChrome = vi.fn()
   const refreshArtifactPreview = vi.fn()
   const clarifyNode = ref(over.clarifyNode === undefined ? 'n1' : over.clarifyNode)
   const api = useRunDetailWs({
@@ -114,6 +115,7 @@ function harness(over: {
     maybePollSandboxForBoot,
     isClarifySessionBusy: () => over.clarifyBusy ?? false,
     loadRun,
+    patchRunChrome,
     refreshArtifactPreview,
   })
   return {
@@ -136,6 +138,7 @@ function harness(over: {
     fetchSandboxLog,
     maybePollSandboxForBoot,
     loadRun,
+    patchRunChrome,
     refreshArtifactPreview,
     clarifyNode,
   }
@@ -330,7 +333,9 @@ describe('useRunDetailWs coverage', () => {
     for (const type of ['trace', 'react', 'artifact_edit'] as const) socket.message({ type })
     socket.message({ type: 'status' })
     expect(normal.loadRun).toHaveBeenCalledTimes(4)
+    expect(normal.loadRun).toHaveBeenCalledWith(false, true)
     expect(normal.liveNode.value).toBeNull()
+    expect(normal.refreshArtifactPreview).toHaveBeenCalledWith(expect.objectContaining({ type: 'artifact_edit' }))
     normal.api.teardownRealtime()
 
     const busy = harness({ clarifyBusy: true })
@@ -341,7 +346,9 @@ describe('useRunDetailWs coverage', () => {
     expect(busy.refreshArtifactPreview).toHaveBeenCalledWith(
       expect.objectContaining({ previewArtifact: 'preview.png' }),
     )
+    expect(busy.patchRunChrome).toHaveBeenCalled()
     expect(busy.loadRun).not.toHaveBeenCalled()
+    expect(busy.loadRun.mock.calls.every((c) => c[0] !== true)).toBe(true)
     busy.api.teardownRealtime()
   })
 
@@ -366,7 +373,7 @@ describe('useRunDetailWs coverage', () => {
 
     h.rehydrateByNode.n1 = 'ready'
     await vi.advanceTimersByTimeAsync(2000)
-    expect(h.loadRun).toHaveBeenCalledWith(false)
+    expect(h.loadRun).toHaveBeenCalledWith(false, true)
     expect(h.fetchNodeEvents).toHaveBeenCalledWith('n1')
     expect(h.fetchSandboxLog).toHaveBeenCalledWith('n1', { intent: 'silent_poll' })
     expect(h.maybePollSandboxForBoot).toHaveBeenCalled()
@@ -408,6 +415,30 @@ describe('useRunDetailWs coverage', () => {
     expect(focused.selected.value).toBe('kept')
     await vi.advanceTimersByTimeAsync(2000)
     expect(focused.loadRun).not.toHaveBeenCalled()
+    expect(focused.patchRunChrome).toHaveBeenCalled()
     focused.api.teardownRealtime()
+  })
+
+  it('polls queued runs, skips hidden ticks, and never hard-loads on the timer (g1.2 / g1.3)', async () => {
+    vi.useFakeTimers()
+    const queued = harness({ status: 'queued' })
+    await queued.api.initAfterLoadSuccess({
+      applyDetailArtifactsDeepLink: () => false,
+      applyOutputDeepLinkFocus: () => true,
+      defaultNode: 'n1',
+      syncAllMcpCallsFromRun: vi.fn(),
+    })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(queued.loadRun).toHaveBeenCalledWith(false, true)
+    expect(queued.loadRun.mock.calls.every((c) => c[0] !== true)).toBe(true)
+
+    queued.loadRun.mockClear()
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => true })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(queued.loadRun).not.toHaveBeenCalled()
+    expect(queued.patchRunChrome).not.toHaveBeenCalled()
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => false })
+    queued.api.teardownRealtime()
+    vi.useRealTimers()
   })
 })

--- a/web/src/lib/run/useRunDetailWs.ts
+++ b/web/src/lib/run/useRunDetailWs.ts
@@ -48,7 +48,8 @@ export function useRunDetailWs(opts: {
   ) => Promise<void> | void
   maybePollSandboxForBoot: () => void
   isClarifySessionBusy: () => boolean
-  loadRun: (hard?: boolean) => Promise<void> | void
+  loadRun: (hard?: boolean, silent?: boolean) => Promise<void> | void
+  patchRunChrome?: () => Promise<void> | void
   refreshArtifactPreview?: (frame?: { previewArtifact?: string }) => void
 }) {
   const {
@@ -71,6 +72,7 @@ export function useRunDetailWs(opts: {
     maybePollSandboxForBoot,
     isClarifySessionBusy,
     loadRun,
+    patchRunChrome,
     refreshArtifactPreview,
   } = opts
 
@@ -340,38 +342,44 @@ export function useRunDetailWs(opts: {
     connectWs()
     if (!timer) {
       timer = window.setInterval(() => {
-        if (run.value.status === 'running' || run.value.status === 'waiting_human') {
-          // Clarify/review session busy: skip full loadRun so we do not wipe
-          // live stream / send lock / input focus (narrow updates via WS frames).
-          if (!isClarifySessionBusy()) {
-            loadRun(false)
-          }
-          const sel = selected.value
-          // Only skip REST once we already have displayable live events;
-          // busy-only / empty live frames must keep the 2s poll fallback.
-          const skipPoll =
-            wsConnected &&
-            !!sel &&
-            liveNode.value === sel &&
-            !!eventPages[sel]?.live &&
-            (eventPages[sel]?.events.length || 0) > 0
-          if (!skipPoll && sel) {
-            const rh = rehydrateByNode[sel] || 'idle'
-            // Do not auto-recover from error; keep polling only after ready.
-            if (rh === 'error' || rh === 'loading') {
-              /* stay put */
-            } else if (rh === 'ready') {
-              void fetchNodeEvents(sel)
-            } else {
-              void rehydrateNodeEvents(sel)
-            }
-          }
-          if (nodeTab.value === 'sandbox') {
-            fetchSandboxLog(selected.value, { intent: 'silent_poll' })
-          }
-          // Boot-stage empty state needs fresh sandbox row status/containerStatus.
-          maybePollSandboxForBoot()
+        const active =
+          run.value.status === 'queued' ||
+          run.value.status === 'running' ||
+          run.value.status === 'waiting_human'
+        if (!active) return
+        // Hidden tab: skip the frequent 2s tick (g1.2 / f5).
+        if (typeof document !== 'undefined' && document.hidden) return
+        // Auto path is always soft + silent — never hard load (g1.3).
+        if (isClarifySessionBusy()) {
+          void patchRunChrome?.()
+        } else {
+          loadRun(false, true)
         }
+        const sel = selected.value
+        // Only skip REST once we already have displayable live events;
+        // busy-only / empty live frames must keep the 2s poll fallback.
+        const skipPoll =
+          wsConnected &&
+          !!sel &&
+          liveNode.value === sel &&
+          !!eventPages[sel]?.live &&
+          (eventPages[sel]?.events.length || 0) > 0
+        if (!skipPoll && sel) {
+          const rh = rehydrateByNode[sel] || 'idle'
+          // Do not auto-recover from error; keep polling only after ready.
+          if (rh === 'error' || rh === 'loading') {
+            /* stay put */
+          } else if (rh === 'ready') {
+            void fetchNodeEvents(sel)
+          } else {
+            void rehydrateNodeEvents(sel)
+          }
+        }
+        if (nodeTab.value === 'sandbox') {
+          fetchSandboxLog(selected.value, { intent: 'silent_poll' })
+        }
+        // Boot-stage empty state needs fresh sandbox row status/containerStatus.
+        maybePollSandboxForBoot()
       }, 2000)
     }
   }
@@ -454,7 +462,7 @@ export function useRunDetailWs(opts: {
           liveBusy[m.nodeId] = false
           dialoguePlatformBusy[m.nodeId] = false
           busySeedRetry.stop()
-          loadRun(false)
+          loadRun(false, true)
         }
       } else if (
         m.type === 'trace' ||
@@ -462,16 +470,15 @@ export function useRunDetailWs(opts: {
         m.type === 'react' ||
         m.type === 'artifact_edit'
       ) {
-        // Node finished / transitioned / human artifact edit: pull authoritative snapshot.
-        // Mid-clarify: review/acp frames project the session — skip full-page rebind for
-        // react/status/trace/artifact_edit alike (g3.2 / review v3).
-        // Soft-refresh path unchanged (g2.3).
+        // Auto path: never hard load (g1.3). Busy → chrome patch + shared preview entry (g1.1 / g2.1).
         if (isClarifySessionBusy()) {
+          void patchRunChrome?.()
           if (m.type === 'artifact_edit') refreshArtifactPreview?.(m)
           return
         }
         if (m.type === 'status') liveNode.value = null
-        loadRun(false)
+        loadRun(false, true)
+        if (m.type === 'artifact_edit') refreshArtifactPreview?.(m)
       }
     }
   }

--- a/web/src/views/RunDetailView.test.ts
+++ b/web/src/views/RunDetailView.test.ts
@@ -459,12 +459,14 @@ describe('RunDetailView load failure split', () => {
 describe('RunDetailView clarify session narrow update (g3.2)', () => {
   it('skips react/status/trace/artifact_edit/focus loadRun while clarify session busy', () => {
     expect(src).toMatch(/function isClarifySessionBusy\(/)
-    // All four event types share one busy gate (review v3) — not react-only.
+    expect(src).toMatch(/function patchRunChrome\(/)
+    // All four event types share one busy gate — chrome patch, not hard load.
     expect(src).toMatch(
       /m\.type === 'trace'[\s\S]*?m\.type === 'status'[\s\S]*?m\.type === 'react'[\s\S]*?m\.type === 'artifact_edit'[\s\S]*?if \(isClarifySessionBusy\(\)/,
     )
     expect(src).toMatch(/if \(m\.type === 'artifact_edit'\) refreshArtifactPreview/)
-    expect(src).toMatch(/if \(isClarifySessionBusy\(\)\) return/)
+    expect(src).toMatch(/void patchRunChrome/)
+    expect(src).toMatch(/loadRun\(false, true\)/)
     expect(src).toMatch(/liveBusy\[m\.nodeId\] = true/)
     expect(src).toMatch(/m\.event === 'turn_begin'/)
   })


### PR DESCRIPTION
## Summary
- Run detail stays live during queued/running/waiting_human: 2s REST ticks (and visibility/focus) patch header status, progress, node canvas, and artifact list without tearing down WebSocket or replacing `reactSessions`.
- While a clarify/review session is busy, chrome is merged in place (`mergeRunChromeFields` / `patchRunChrome`); auto paths never hard-load.
- The open artifact tab hot-reloads via shared `refreshArtifactPreviewState` only when the artifact fingerprint changes.

## Test plan
- [ ] Stay on a running run detail page without clicking Refresh: header progress/elapsed update within ~2s; RefreshStrip stays hidden.
- [ ] Stream a clarify/review session: input focus and chat stay mounted while progress/artifacts still update.
- [ ] Open plan/clarified_requirement tab: artifact_edit or fingerprint change updates preview without switching tabs.
- [ ] Hidden tab skips poll ticks; returning to the tab triggers a soft patch.


Made with [Cursor](https://cursor.com)