### PR TITLE
feat: add token analytics bar dimensions

### DIFF
--- a/server/internal/services/global_token_stats.go
+++ b/server/internal/services/global_token_stats.go
@@ -423,7 +423,7 @@ type globalAgg struct {
 	projects     map[string]*globalProjectAgg
 	models       map[string]*tokenModelAgg
 	nodeTypes    map[string]int64
-	workflows    map[string]int64
+	workflows    map[string]*globalWorkflowAgg
 	wfNames      map[string]string
 	runs         map[string]*globalRunAgg
 	projBuckets  map[string]map[string]*tokenBucketAgg
@@ -434,6 +434,12 @@ type globalAgg struct {
 
 type globalProjectAgg struct {
 	name                  string
+	total                 int64
+	input, output         int64
+	cacheRead, cacheWrite int64
+}
+
+type globalWorkflowAgg struct {
 	total                 int64
 	input, output         int64
 	cacheRead, cacheWrite int64
@@ -463,7 +469,7 @@ func aggregateGlobalRows(rows []globalTokenUsageRow, loc *time.Location, bucketW
 		projects:     map[string]*globalProjectAgg{},
 		models:       map[string]*tokenModelAgg{},
 		nodeTypes:    map[string]int64{},
-		workflows:    map[string]int64{},
+		workflows:    map[string]*globalWorkflowAgg{},
 		wfNames:      map[string]string{},
 		runs:         map[string]*globalRunAgg{},
 		projBuckets:  map[string]map[string]*tokenBucketAgg{},
@@ -524,7 +530,16 @@ func aggregateGlobalRows(rows []globalTokenUsageRow, loc *time.Location, bucketW
 		}
 
 		if row.source == TokenStatsKindWorkflow && row.workflowID != "" {
-			agg.workflows[row.workflowID] += row.usage.Total()
+			wa := agg.workflows[row.workflowID]
+			if wa == nil {
+				wa = &globalWorkflowAgg{}
+				agg.workflows[row.workflowID] = wa
+			}
+			wa.total += row.usage.Total()
+			wa.input += row.usage.InputTokens
+			wa.output += row.usage.OutputTokens
+			wa.cacheRead += row.usage.CacheReadTokens
+			wa.cacheWrite += row.usage.CacheWriteTokens
 			if row.workflowName != "" {
 				agg.wfNames[row.workflowID] = row.workflowName
 			}
@@ -744,6 +759,26 @@ func projectTrendFromBuckets(buckets map[string]*tokenBucketAgg) []TokenStatsBuc
 
 func buildGlobalModelStats(cur, prev *globalAgg, unknownAliases map[string]string, topN int) ([]TokenStatsModel, []GlobalTokenStatsSeries) {
 	_, ranking := buildModelStats(cur.models, "")
+	topKeys := make(map[string]struct{}, len(ranking))
+	for i := range ranking {
+		row := &ranking[i]
+		if row.Other {
+			continue
+		}
+		topKeys[row.ModelKey] = struct{}{}
+		addModelBucketParts(row, cur.modelBuckets[row.ModelKey])
+	}
+	for i := range ranking {
+		if !ranking[i].Other {
+			continue
+		}
+		for key, buckets := range cur.modelBuckets {
+			if _, ok := topKeys[key]; ok {
+				continue
+			}
+			addModelBucketParts(&ranking[i], buckets)
+		}
+	}
 	series := make([]GlobalTokenStatsSeries, 0, topN)
 	for i, m := range ranking {
 		if m.Other {
@@ -769,6 +804,18 @@ func buildGlobalModelStats(cur, prev *globalAgg, unknownAliases map[string]strin
 	return ranking, series
 }
 
+func addModelBucketParts(row *TokenStatsModel, buckets map[string]*tokenBucketAgg) {
+	for _, bucket := range buckets {
+		if bucket == nil {
+			continue
+		}
+		row.InputTokens += bucket.input
+		row.OutputTokens += bucket.output
+		row.CacheReadTokens += bucket.cacheRead
+		row.CacheWriteTokens += bucket.cacheWrite
+	}
+}
+
 func buildNodeTypeStats(cur *globalAgg) []GlobalTokenStatsNamedBucket {
 	type item struct {
 		name  string
@@ -792,9 +839,46 @@ func buildNodeTypeStats(cur *globalAgg) []GlobalTokenStatsNamedBucket {
 }
 
 func buildGlobalWorkflowRank(cur *globalAgg) []TokenStatsWorkflow {
-	totals := cur.workflows
-	names := cur.wfNames
-	return buildConsumptionRank(totals, names, 0, false)
+	totals := make(map[string]int64, len(cur.workflows))
+	for id, agg := range cur.workflows {
+		if agg != nil {
+			totals[id] = agg.total
+		}
+	}
+	rows := buildConsumptionRank(totals, cur.wfNames, 0, false)
+	topIDs := make(map[string]struct{}, len(rows))
+	for i := range rows {
+		row := &rows[i]
+		if row.Other {
+			continue
+		}
+		topIDs[row.WorkflowID] = struct{}{}
+		if agg := cur.workflows[row.WorkflowID]; agg != nil {
+			setWorkflowParts(row, agg)
+		}
+	}
+	for i := range rows {
+		if !rows[i].Other {
+			continue
+		}
+		for id, agg := range cur.workflows {
+			if _, ok := topIDs[id]; ok || agg == nil {
+				continue
+			}
+			rows[i].InputTokens += agg.input
+			rows[i].OutputTokens += agg.output
+			rows[i].CacheReadTokens += agg.cacheRead
+			rows[i].CacheWriteTokens += agg.cacheWrite
+		}
+	}
+	return rows
+}
+
+func setWorkflowParts(row *TokenStatsWorkflow, agg *globalWorkflowAgg) {
+	row.InputTokens = agg.input
+	row.OutputTokens = agg.output
+	row.CacheReadTokens = agg.cacheRead
+	row.CacheWriteTokens = agg.cacheWrite
 }
 
 func buildHeatmap(cur *globalAgg, topModels, topProjects int) GlobalTokenStatsHeatmap {

--- a/server/internal/services/global_token_stats_test.go
+++ b/server/internal/services/global_token_stats_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -364,6 +365,69 @@ func TestGlobalTokenStatsOmitsWindowDefaultsAll(t *testing.T) {
 	}
 	if res.BucketWidth != TokenStatsBucketWeek {
 		t.Fatalf("all should use week buckets, got %s", res.BucketWidth)
+	}
+}
+
+func TestGlobalTokenStatsRankRowsIncludeTokenParts(t *testing.T) {
+	cur := &globalAgg{
+		models:       map[string]*tokenModelAgg{},
+		modelBuckets: map[string]map[string]*tokenBucketAgg{},
+		workflows:    map[string]*globalWorkflowAgg{},
+		wfNames:      map[string]string{},
+	}
+	for i := 0; i < 11; i++ {
+		key := fmt.Sprintf("model-%02d", i)
+		input := int64(100 - i)
+		output := int64(i + 1)
+		cacheRead := int64(i + 2)
+		cacheWrite := int64(i + 3)
+		total := input + output + cacheRead + cacheWrite
+		cur.models[key] = &tokenModelAgg{total: total}
+		cur.modelBuckets[key] = map[string]*tokenBucketAgg{
+			"2026-07-25": {
+				input: input, output: output,
+				cacheRead: cacheRead, cacheWrite: cacheWrite,
+			},
+		}
+
+		workflowID := fmt.Sprintf("workflow-%02d", i)
+		cur.workflows[workflowID] = &globalWorkflowAgg{
+			total: total, input: input, output: output,
+			cacheRead: cacheRead, cacheWrite: cacheWrite,
+		}
+		cur.wfNames[workflowID] = workflowID
+	}
+
+	modelRows, _ := buildGlobalModelStats(cur, nil, nil, globalTokenStatsTopModels)
+	assertTokenPartsMatchModelTotals(t, modelRows)
+	if len(modelRows) != 11 || !modelRows[len(modelRows)-1].Other {
+		t.Fatalf("expected model Top10 + other, got %+v", modelRows)
+	}
+
+	workflowRows := buildGlobalWorkflowRank(cur)
+	assertTokenPartsMatchWorkflowTotals(t, workflowRows)
+	if len(workflowRows) != 11 || !workflowRows[len(workflowRows)-1].Other {
+		t.Fatalf("expected workflow Top10 + other, got %+v", workflowRows)
+	}
+}
+
+func assertTokenPartsMatchModelTotals(t *testing.T, rows []TokenStatsModel) {
+	t.Helper()
+	for _, row := range rows {
+		parts := row.InputTokens + row.OutputTokens + row.CacheReadTokens + row.CacheWriteTokens
+		if parts != row.Total {
+			t.Fatalf("model %q parts=%d total=%d row=%+v", row.Name, parts, row.Total, row)
+		}
+	}
+}
+
+func assertTokenPartsMatchWorkflowTotals(t *testing.T, rows []TokenStatsWorkflow) {
+	t.Helper()
+	for _, row := range rows {
+		parts := row.InputTokens + row.OutputTokens + row.CacheReadTokens + row.CacheWriteTokens
+		if parts != row.Total {
+			t.Fatalf("workflow %q parts=%d total=%d row=%+v", row.Name, parts, row.Total, row)
+		}
 	}
 }
 

--- a/server/internal/services/project_token_stats.go
+++ b/server/internal/services/project_token_stats.go
@@ -78,18 +78,26 @@ const (
 
 // TokenStatsWorkflow is one consumption-rank row (workflow Top-N, PM, or other).
 type TokenStatsWorkflow struct {
-	WorkflowID string `json:"workflowId,omitempty"`
-	Name       string `json:"name"`
-	Total      int64  `json:"total"`
-	Other      bool   `json:"other,omitempty"`
-	Kind       string `json:"kind,omitempty"` // workflow | pm | other
+	WorkflowID       string `json:"workflowId,omitempty"`
+	Name             string `json:"name"`
+	Total            int64  `json:"total"`
+	InputTokens      int64  `json:"inputTokens,omitempty"`
+	OutputTokens     int64  `json:"outputTokens,omitempty"`
+	CacheReadTokens  int64  `json:"cacheReadTokens,omitempty"`
+	CacheWriteTokens int64  `json:"cacheWriteTokens,omitempty"`
+	Other            bool   `json:"other,omitempty"`
+	Kind             string `json:"kind,omitempty"` // workflow | pm | other
 }
 
 // TokenStatsModel is one model-composition / model-ranking row.
 type TokenStatsModel struct {
-	ModelKey string `json:"modelKey"`
-	Name     string `json:"name"`
-	Total    int64  `json:"total"`
+	ModelKey         string `json:"modelKey"`
+	Name             string `json:"name"`
+	Total            int64  `json:"total"`
+	InputTokens      int64  `json:"inputTokens,omitempty"`
+	OutputTokens     int64  `json:"outputTokens,omitempty"`
+	CacheReadTokens  int64  `json:"cacheReadTokens,omitempty"`
+	CacheWriteTokens int64  `json:"cacheWriteTokens,omitempty"`
 	// Unknown marks the「未知/未分桶」bucket. It is a normal model bucket:
 	// it appears in ranking only when its total places it in Top10; otherwise
 	// its usage is folded into other. other.Unknown must stay false.

--- a/web/e2e/token-analytics-main.ts
+++ b/web/e2e/token-analytics-main.ts
@@ -51,10 +51,19 @@ const MOCK_STATS = {
     cacheReadTokens: 800,
     cacheWriteTokens: 200,
   },
-  projects: [{ projectId: 'p1', name: 'Demo', total: 9000, inputTokens: 5000, outputTokens: 3000, cacheReadTokens: 800, cacheWriteTokens: 200 }],
-  modelRanking: [{ modelKey: 'm1', name: 'Model', total: 9000 }],
+  projects: [
+    { projectId: 'p1', name: 'Demo', total: 7000, inputTokens: 4000, outputTokens: 2200, cacheReadTokens: 600, cacheWriteTokens: 200 },
+    { projectId: 'p2', name: 'Docs', total: 2000, inputTokens: 1000, outputTokens: 800, cacheReadTokens: 200, cacheWriteTokens: 0 },
+  ],
+  modelRanking: [
+    { modelKey: 'm1', name: 'Model', total: 7000, inputTokens: 4000, outputTokens: 2200, cacheReadTokens: 600, cacheWriteTokens: 200 },
+    { modelKey: 'm2', name: 'Model Mini', total: 2000, inputTokens: 1000, outputTokens: 800, cacheReadTokens: 200, cacheWriteTokens: 0 },
+  ],
   nodeTypes: [{ name: 'agent', total: 9000 }],
-  workflows: [{ name: 'wf', total: 9000, kind: 'workflow' }],
+  workflows: [
+    { workflowId: 'w1', name: 'wf', total: 7000, inputTokens: 4000, outputTokens: 2200, cacheReadTokens: 600, cacheWriteTokens: 200, kind: 'workflow' },
+    { workflowId: 'w2', name: 'review', total: 2000, inputTokens: 1000, outputTokens: 800, cacheReadTokens: 200, cacheWriteTokens: 0, kind: 'workflow' },
+  ],
   heatmap: { rows: ['Model'], cols: ['Demo'], grid: [[9000]] },
   topRuns: [
     {

--- a/web/e2e/token-analytics.spec.ts
+++ b/web/e2e/token-analytics.spec.ts
@@ -39,10 +39,19 @@ const MOCK_STATS = {
     cacheReadTokens: 800,
     cacheWriteTokens: 200,
   },
-  projects: [{ projectId: 'p1', name: 'Demo', total: 9000, inputTokens: 5000, outputTokens: 3000, cacheReadTokens: 800, cacheWriteTokens: 200 }],
-  modelRanking: [{ modelKey: 'm1', name: 'Model', total: 9000 }],
+  projects: [
+    { projectId: 'p1', name: 'Demo', total: 7000, inputTokens: 4000, outputTokens: 2200, cacheReadTokens: 600, cacheWriteTokens: 200 },
+    { projectId: 'p2', name: 'Docs', total: 2000, inputTokens: 1000, outputTokens: 800, cacheReadTokens: 200, cacheWriteTokens: 0 },
+  ],
+  modelRanking: [
+    { modelKey: 'm1', name: 'Model', total: 7000, inputTokens: 4000, outputTokens: 2200, cacheReadTokens: 600, cacheWriteTokens: 200 },
+    { modelKey: 'm2', name: 'Model Mini', total: 2000, inputTokens: 1000, outputTokens: 800, cacheReadTokens: 200, cacheWriteTokens: 0 },
+  ],
   nodeTypes: [{ name: 'agent', total: 9000 }],
-  workflows: [{ name: 'wf', total: 9000, kind: 'workflow' }],
+  workflows: [
+    { workflowId: 'w1', name: 'wf', total: 7000, inputTokens: 4000, outputTokens: 2200, cacheReadTokens: 600, cacheWriteTokens: 200, kind: 'workflow' },
+    { workflowId: 'w2', name: 'review', total: 2000, inputTokens: 1000, outputTokens: 800, cacheReadTokens: 200, cacheWriteTokens: 0, kind: 'workflow' },
+  ],
   heatmap: { rows: ['Model'], cols: ['Demo'], grid: [[9000]] },
   topRuns: [
     {
@@ -124,6 +133,24 @@ test.describe('Global token analytics', () => {
     await expect(page.getByRole('button', { name: '按模型' })).toHaveClass(/font-semibold/)
     await page.getByRole('button', { name: '总量（对比上一周期）' }).click()
     await expect(page.getByRole('button', { name: '总量（对比上一周期）' })).toHaveClass(/font-semibold/)
+  })
+
+  test('bar dimensions switch without page errors', async ({ page }) => {
+    const errors: string[] = []
+    page.on('pageerror', (error) => errors.push(error.message))
+    await openStatsPage(page)
+    const bars = page.getByTestId('token-analytics-bars')
+    await expect(bars).toBeVisible()
+    await expect(page.getByTestId('token-analytics-bar-dimension-project')).toHaveClass(/font-semibold/)
+
+    await page.getByTestId('token-analytics-bar-dimension-workflow').click()
+    await expect(page.getByTestId('token-analytics-bar-dimension-workflow')).toHaveClass(/font-semibold/)
+    await expect(bars).toContainText('各工作流用量堆叠对比')
+
+    await page.getByTestId('token-analytics-bar-dimension-model').click()
+    await expect(page.getByTestId('token-analytics-bar-dimension-model')).toHaveClass(/font-semibold/)
+    await expect(bars).toContainText('各模型用量堆叠对比')
+    expect(errors).toEqual([])
   })
 
   test('project table link navigates to project board tab', async ({ page }) => {

--- a/web/src/components/board/token-stats/tokenStatsShared.ts
+++ b/web/src/components/board/token-stats/tokenStatsShared.ts
@@ -1,9 +1,9 @@
 /** Shared Token stats chart colors aligned with approved page.html Demo. */
 export const TOKEN_PART_COLORS = {
-  input: '#3b82f6',
-  output: '#8b5cf6',
-  cacheRead: '#14b8a6',
-  cacheWrite: '#f59e0b',
+  input: '#4f46e5',
+  output: '#7c6dff',
+  cacheRead: '#a99cff',
+  cacheWrite: '#c9c0ff',
 } as const
 
 /** Trend/rank source colors (workflow / pm share purple; PM distinguished by dashed line). */

--- a/web/src/lib/shared/types.ts
+++ b/web/src/lib/shared/types.ts
@@ -227,6 +227,10 @@ export interface TokenStatsWorkflow {
   workflowId?: string
   name: string
   total: number
+  inputTokens?: number
+  outputTokens?: number
+  cacheReadTokens?: number
+  cacheWriteTokens?: number
   other?: boolean
   /** Rank row kind: workflow | pm | other (other = non-top workflows only). */
   kind?: TokenStatsRankKind
@@ -237,6 +241,10 @@ export interface TokenStatsModel {
   modelKey?: string
   name: string
   total: number
+  inputTokens?: number
+  outputTokens?: number
+  cacheReadTokens?: number
+  cacheWriteTokens?: number
   /** 「未知/未分桶」. Shown in ranking only when it ranks in Top10; otherwise its usage is folded into other. */
   unknown?: boolean
   /** Top10 remainder (may include unknown usage that did not qualify). other is not unknown. */

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -75,13 +75,22 @@
         "source": "By source",
         "comp": "By input/output/cache"
       },
+      "barDimensions": {
+        "project": "Project",
+        "workflow": "Workflow",
+        "model": "Model"
+      },
       "charts": {
         "lines": "Line chart",
         "linesHint": "Compare the current range with the previous period; split by project or model",
         "pies": "Share",
         "piesHint": "Click a slice to filter",
         "bars": "Bar chart",
-        "barsHint": "Stacked usage by project",
+        "barsHints": {
+          "project": "Stacked usage by project",
+          "workflow": "Stacked usage by workflow",
+          "model": "Stacked usage by model"
+        },
         "area": "Stacked area",
         "areaHint": "Daily by source, or input/output/cache",
         "heat": "Models vs projects",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -75,13 +75,22 @@
         "source": "按来源",
         "comp": "按输入/输出/缓存"
       },
+      "barDimensions": {
+        "project": "项目",
+        "workflow": "工作流",
+        "model": "模型"
+      },
       "charts": {
         "lines": "折线图",
         "linesHint": "对比当前时间范围与上一周期，也可按项目或模型分开看",
         "pies": "占比",
         "piesHint": "点击扇区可筛选",
         "bars": "柱状图",
-        "barsHint": "各项目用量堆叠对比",
+        "barsHints": {
+          "project": "各项目用量堆叠对比",
+          "workflow": "各工作流用量堆叠对比",
+          "model": "各模型用量堆叠对比"
+        },
         "area": "堆叠面积",
         "areaHint": "按天查看来源，或输入/输出/缓存",
         "heat": "模型与项目对照",

--- a/web/src/views/TokenAnalyticsView.test.ts
+++ b/web/src/views/TokenAnalyticsView.test.ts
@@ -7,6 +7,7 @@ import common from '@/locales/zh-CN/common.json'
 import pages from '@/locales/zh-CN/pages.json'
 import nav from '@/locales/zh-CN/nav.json'
 import route from '@/locales/zh-CN/route.json'
+import { TOKEN_PART_COLORS } from '@/components/board/token-stats/tokenStatsShared'
 
 vi.mock('@/lib/api/api', () => ({
   api: {
@@ -62,10 +63,19 @@ const sampleData = {
   trend: [{ bucket: '2026-07-01', total: 100, workflowTotal: 80, pmTotal: 20, inputTokens: 40, outputTokens: 30, cacheReadTokens: 20, cacheWriteTokens: 10 }],
   prevTrend: [{ bucket: '2026-06-01', total: 80, workflowTotal: 60, pmTotal: 20, inputTokens: 30, outputTokens: 25, cacheReadTokens: 15, cacheWriteTokens: 10 }],
   composition: { inputTokens: 3000, outputTokens: 1500, cacheReadTokens: 400, cacheWriteTokens: 100, total: 5000 },
-  projects: [{ projectId: 'p1', name: 'Approving', total: 3000, inputTokens: 1800, outputTokens: 900, cacheReadTokens: 200, cacheWriteTokens: 100 }],
-  modelRanking: [{ modelKey: 'sonnet', name: 'Sonnet', total: 4000 }],
+  projects: [
+    { projectId: 'p1', name: 'Approving', total: 3000, inputTokens: 1800, outputTokens: 900, cacheReadTokens: 200, cacheWriteTokens: 100 },
+    { projectId: 'p2', name: 'Other project', total: 2000, inputTokens: 1200, outputTokens: 600, cacheReadTokens: 200, cacheWriteTokens: 0 },
+  ],
+  modelRanking: [
+    { modelKey: 'sonnet', name: 'Sonnet', total: 4000, inputTokens: 2400, outputTokens: 1200, cacheReadTokens: 300, cacheWriteTokens: 100 },
+    { modelKey: 'opus', name: 'Opus', total: 1000, inputTokens: 600, outputTokens: 300, cacheReadTokens: 100, cacheWriteTokens: 0 },
+  ],
   nodeTypes: [{ name: 'agent', total: 4000 }],
-  workflows: [{ workflowId: 'w1', name: 'main', total: 3000, kind: 'workflow' as const }],
+  workflows: [
+    { workflowId: 'w1', name: 'main', total: 3000, inputTokens: 1800, outputTokens: 900, cacheReadTokens: 200, cacheWriteTokens: 100, kind: 'workflow' as const },
+    { workflowId: 'w2', name: 'review', total: 2000, inputTokens: 1200, outputTokens: 600, cacheReadTokens: 200, cacheWriteTokens: 0, kind: 'workflow' as const },
+  ],
   heatmap: { rows: ['Sonnet'], cols: ['Approving'], grid: [[3000]] },
   topRuns: [{ runId: 'r1', title: 'Run 1', projectId: 'p1', projectName: 'Approving', workflowName: 'main', modelKey: 'sonnet', modelName: 'Sonnet', total: 500 }],
   projectTrends: [{ key: 'p1', name: 'Approving', trend: [{ bucket: '2026-07-01', total: 100, workflowTotal: 80, pmTotal: 20, inputTokens: 40, outputTokens: 30, cacheReadTokens: 20, cacheWriteTokens: 10 }] }],
@@ -205,6 +215,134 @@ describe('TokenAnalyticsView', () => {
     expect(option.tooltip?.confine).toBe(false)
     expect(option.tooltip?.valueFormatter?.(2_080_982_825)).toBe('2.08B')
     expect(option.yAxis?.axisLabel?.formatter?.(2_500_000_000)).toBe('2.5B')
+    wrapper.unmount()
+  })
+
+  it('defaults and falls back to the first comparable bar dimension', async () => {
+    const cases = [
+      { data: sampleData, active: 'project' },
+      { data: { ...sampleData, projects: sampleData.projects.slice(0, 1) }, active: 'workflow' },
+      {
+        data: {
+          ...sampleData,
+          projects: sampleData.projects.slice(0, 1),
+          workflows: sampleData.workflows.slice(0, 1),
+        },
+        active: 'model',
+      },
+    ]
+    for (const scenario of cases) {
+      vi.mocked(api.getGlobalTokenStats).mockResolvedValueOnce(scenario.data)
+      const wrapper = mount(TokenAnalyticsView, { global: { plugins: [i18n] } })
+      await flushPromises()
+      expect(wrapper.find(`[data-testid="token-analytics-bar-dimension-${scenario.active}"]`).classes())
+        .toContain('font-semibold')
+      wrapper.unmount()
+    }
+  })
+
+  it('disables non-comparable dimensions and hides bars when none are comparable', async () => {
+    vi.mocked(api.getGlobalTokenStats).mockResolvedValueOnce({
+      ...sampleData,
+      projects: sampleData.projects.slice(0, 1),
+      workflows: sampleData.workflows.slice(0, 1),
+      modelRanking: sampleData.modelRanking.slice(0, 1),
+    })
+    const wrapper = mount(TokenAnalyticsView, { global: { plugins: [i18n] } })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="token-analytics-bars"]').exists()).toBe(false)
+    wrapper.unmount()
+
+    vi.mocked(api.getGlobalTokenStats).mockResolvedValueOnce({
+      ...sampleData,
+      projects: sampleData.projects.slice(0, 1),
+    })
+    const fallbackWrapper = mount(TokenAnalyticsView, { global: { plugins: [i18n] } })
+    await flushPromises()
+    const projectButton = fallbackWrapper.find('[data-testid="token-analytics-bar-dimension-project"]')
+    expect(projectButton.attributes('disabled')).toBeDefined()
+    expect(projectButton.classes()).toContain('opacity-40')
+    fallbackWrapper.unmount()
+  })
+
+  it('switches bar dimensions locally and applies bar styling and colors', async () => {
+    const wrapper = mount(TokenAnalyticsView, { global: { plugins: [i18n] } })
+    await flushPromises()
+    vi.mocked(api.getGlobalTokenStats).mockClear()
+    await wrapper.find('[data-testid="token-analytics-bar-dimension-workflow"]').trigger('click')
+    await flushPromises()
+    expect(api.getGlobalTokenStats).not.toHaveBeenCalled()
+
+    const barChart = wrapper.findAllComponents({ name: 'VChart' }).find((chart) => {
+      const option = chart.props('option') as { series?: { type?: string }[] }
+      return option.series?.[0]?.type === 'bar'
+    })
+    const option = barChart!.props('option') as {
+      xAxis: { data: string[] }
+      series: Array<{
+        barMaxWidth: number
+        itemStyle: { color: string }
+        data: Array<{ itemStyle: { borderRadius: number | number[] } }>
+      }>
+    }
+    expect(option.xAxis.data).toEqual(['main', 'review'])
+    expect(option.series.every((series) => series.barMaxWidth === 28)).toBe(true)
+    expect(option.series.map((series) => series.itemStyle.color)).toEqual(
+      Object.values(TOKEN_PART_COLORS),
+    )
+    expect(option.series.some((series) =>
+      series.data.some((item) => Array.isArray(item.itemStyle.borderRadius)),
+    )).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('filters on project/model bars but not workflow or other bars', async () => {
+    const wrapper = mount(TokenAnalyticsView, { global: { plugins: [i18n] } })
+    await flushPromises()
+    const getBarChart = () => wrapper.findAllComponents({ name: 'VChart' }).find((chart) => {
+      const option = chart.props('option') as { series?: { type?: string }[] }
+      return option.series?.[0]?.type === 'bar'
+    })!
+
+    vi.mocked(api.getGlobalTokenStats).mockClear()
+    getBarChart().vm.$emit('click', {
+      componentType: 'series',
+      name: 'Approving',
+      data: { filterKey: 'p1', other: false },
+    })
+    await flushPromises()
+    expect(api.getGlobalTokenStats).toHaveBeenLastCalledWith(
+      expect.objectContaining({ projectId: 'p1' }),
+      expect.anything(),
+    )
+
+    await wrapper.find('[data-testid="token-analytics-bar-dimension-model"]').trigger('click')
+    vi.mocked(api.getGlobalTokenStats).mockClear()
+    getBarChart().vm.$emit('click', {
+      componentType: 'series',
+      name: 'Sonnet',
+      data: { filterKey: 'sonnet', other: false },
+    })
+    await flushPromises()
+    expect(api.getGlobalTokenStats).toHaveBeenLastCalledWith(
+      expect.objectContaining({ modelKey: 'sonnet' }),
+      expect.anything(),
+    )
+
+    await wrapper.find('[data-testid="token-analytics-bar-dimension-workflow"]').trigger('click')
+    vi.mocked(api.getGlobalTokenStats).mockClear()
+    getBarChart().vm.$emit('click', {
+      componentType: 'series',
+      name: 'main',
+      data: { filterKey: undefined, other: false },
+    })
+    getBarChart().vm.$emit('click', {
+      componentType: 'series',
+      name: 'other',
+      data: { filterKey: 'ignored', other: true },
+    })
+    await flushPromises()
+    expect(api.getGlobalTokenStats).not.toHaveBeenCalled()
     wrapper.unmount()
   })
 

--- a/web/src/views/TokenAnalyticsView.vue
+++ b/web/src/views/TokenAnalyticsView.vue
@@ -15,7 +15,13 @@ import {
   statsTooltip,
 } from '@/components/charts/chartTheme'
 import { api } from '@/lib/api/api'
-import type { GlobalTokenStats, TokenStatsWindow } from '@/lib/shared/types'
+import type {
+  GlobalTokenStats,
+  GlobalTokenStatsProjectRow,
+  TokenStatsModel,
+  TokenStatsWindow,
+  TokenStatsWorkflow,
+} from '@/lib/shared/types'
 import { fmtCompactTokenCount, fmtTokenCount } from '@/lib/run/tokenUsage'
 import { displayRunTitle } from '@/lib/run/runTitle'
 import { truncateText } from '@/lib/shared/format'
@@ -42,6 +48,11 @@ const projectSel = ref('')
 const modelSel = ref('')
 const lineMode = ref<'total' | 'project' | 'model'>('total')
 const areaMode = ref<'source' | 'comp'>('source')
+type BarDimension = 'project' | 'workflow' | 'model'
+const BAR_DIMENSIONS: BarDimension[] = ['project', 'workflow', 'model']
+const BAR_MAX_WIDTH = 28
+const BAR_TOP_RADIUS = 4
+const barDimension = ref<BarDimension>('project')
 const loading = ref(true)
 const failed = ref(false)
 const data = ref<GlobalTokenStats | null>(null)
@@ -197,19 +208,95 @@ function buildPieSlices() {
 
 const pieSlices = computed(() => buildPieSlices())
 
+interface BarRow {
+  name: string
+  input: number
+  output: number
+  cacheRead: number
+  cacheWrite: number
+  filterKey?: string
+  other: boolean
+}
+
+function barPartValue(
+  row: GlobalTokenStatsProjectRow | TokenStatsWorkflow | TokenStatsModel,
+  key: TokenPartKey,
+): number {
+  if (key === 'input') return row.inputTokens || 0
+  if (key === 'output') return row.outputTokens || 0
+  if (key === 'cacheRead') return row.cacheReadTokens || 0
+  return row.cacheWriteTokens || 0
+}
+
+function normalizeBarRows(dimension: BarDimension): BarRow[] {
+  if (!data.value) return []
+  let source: Array<GlobalTokenStatsProjectRow | TokenStatsWorkflow | TokenStatsModel>
+  if (dimension === 'project') source = data.value.projects.slice(0, 10)
+  else if (dimension === 'workflow') source = data.value.workflows
+  else source = data.value.modelRanking
+  return source.map((row) => ({
+    name: row.name,
+    input: barPartValue(row, 'input'),
+    output: barPartValue(row, 'output'),
+    cacheRead: barPartValue(row, 'cacheRead'),
+    cacheWrite: barPartValue(row, 'cacheWrite'),
+    filterKey:
+      dimension === 'project'
+        ? (row as GlobalTokenStatsProjectRow).projectId
+        : dimension === 'model'
+          ? (row as TokenStatsModel).modelKey
+          : undefined,
+    other: !!('other' in row && row.other),
+  }))
+}
+
+const barRowsByDimension = computed<Record<BarDimension, BarRow[]>>(() => ({
+  project: normalizeBarRows('project'),
+  workflow: normalizeBarRows('workflow'),
+  model: normalizeBarRows('model'),
+}))
+
+const barDimensionEnabled = computed<Record<BarDimension, boolean>>(() => ({
+  project: barRowsByDimension.value.project.length >= 2,
+  workflow: barRowsByDimension.value.workflow.length >= 2,
+  model: barRowsByDimension.value.model.length >= 2,
+}))
+
+const hasComparableBarDimension = computed(() =>
+  BAR_DIMENSIONS.some((dimension) => barDimensionEnabled.value[dimension]),
+)
+
+function reconcileBarDimension() {
+  if (barDimensionEnabled.value[barDimension.value]) return
+  const fallback = BAR_DIMENSIONS.find((dimension) => barDimensionEnabled.value[dimension])
+  if (fallback) barDimension.value = fallback
+}
+
+function selectBarDimension(dimension: BarDimension) {
+  if (barDimensionEnabled.value[dimension]) barDimension.value = dimension
+}
+
 function barChartOption() {
-  if (!data.value?.projects.length) return null
-  const projs = data.value.projects.slice(0, 10)
+  const rows = barRowsByDimension.value[barDimension.value]
+  if (rows.length < 2) return null
   const partSeries = (key: TokenPartKey) => ({
     type: 'bar' as const,
     stack: 'total',
     name: partLabel(key),
+    barMaxWidth: BAR_MAX_WIDTH,
     itemStyle: { color: TOKEN_PART_COLORS[key] },
-    data: projs.map((p) => {
-      if (key === 'input') return p.inputTokens
-      if (key === 'output') return p.outputTokens
-      if (key === 'cacheRead') return p.cacheReadTokens || 0
-      return p.cacheWriteTokens || 0
+    data: rows.map((row) => {
+      const value = row[key]
+      const topKey = [...TOKEN_PART_KEYS].reverse().find((partKey) => row[partKey] > 0)
+      return {
+        value,
+        filterKey: row.filterKey,
+        other: row.other,
+        itemStyle: {
+          color: TOKEN_PART_COLORS[key],
+          borderRadius: key === topKey ? [BAR_TOP_RADIUS, BAR_TOP_RADIUS, 0, 0] : 0,
+        },
+      }
     }),
   })
   return {
@@ -221,10 +308,10 @@ function barChartOption() {
     },
     xAxis: {
       type: 'category',
-      data: projs.map((p) => p.name),
+      data: rows.map((row) => row.name),
       ...statsAxis(),
       splitLine: { show: false },
-      axisLabel: { ...statsAxis().axisLabel, interval: 0, rotate: projs.length > 6 ? 30 : 0 },
+      axisLabel: { ...statsAxis().axisLabel, interval: 0, rotate: rows.length > 6 ? 30 : 0 },
     },
     yAxis: {
       type: 'value',
@@ -382,6 +469,7 @@ async function load() {
     )
     if (gen !== generation) return
     data.value = res
+    reconcileBarDimension()
     failed.value = false
   } catch (e: unknown) {
     if (gen !== generation) return
@@ -410,12 +498,21 @@ function applySource(s: 'all' | 'workflow' | 'pm') {
 }
 
 function onBarClick(params: unknown) {
-  const ev = params as { name?: string; componentType?: string }
-  if (ev.componentType !== 'series' || !ev.name) return
-  const proj = data.value?.projects.find((p) => p.name === ev.name)
-  if (!proj) return
-  projectSel.value = proj.projectId
-  toast.show(t('pages.tokenAnalytics.filterApplied', { name: proj.name }))
+  const ev = params as {
+    name?: string
+    componentType?: string
+    data?: { filterKey?: string; other?: boolean }
+  }
+  if (
+    ev.componentType !== 'series'
+    || !ev.name
+    || ev.data?.other
+    || !ev.data?.filterKey
+    || barDimension.value === 'workflow'
+  ) return
+  if (barDimension.value === 'project') projectSel.value = ev.data.filterKey
+  else modelSel.value = ev.data.filterKey
+  toast.show(t('pages.tokenAnalytics.filterApplied', { name: ev.name }))
   void load()
 }
 
@@ -718,11 +815,35 @@ watch([windowSel], () => void load())
           </div>
         </section>
 
-        <section id="bars" class="mb-3 rounded-lg border border-line bg-surface p-3.5" data-testid="token-analytics-bars">
+        <section
+          v-if="hasComparableBarDimension"
+          id="bars"
+          class="mb-3 rounded-lg border border-line bg-surface p-3.5"
+          data-testid="token-analytics-bars"
+        >
           <h2 class="m-0 text-sm font-semibold">
             {{ t('pages.tokenAnalytics.charts.bars') }}
-            <em class="ml-2 text-[11px] font-normal text-txt3">{{ t('pages.tokenAnalytics.charts.barsHint') }}</em>
+            <em class="ml-2 text-[11px] font-normal text-txt3">
+              {{ t(`pages.tokenAnalytics.charts.barsHints.${barDimension}`) }}
+            </em>
           </h2>
+          <div class="mt-2 flex gap-1.5">
+            <button
+              v-for="dimension in BAR_DIMENSIONS"
+              :key="dimension"
+              type="button"
+              class="px-2.5 py-1 text-xs"
+              :class="[
+                barDimension === dimension ? 'bg-elevated font-semibold' : 'text-txt3',
+                !barDimensionEnabled[dimension] ? 'cursor-not-allowed opacity-40' : '',
+              ]"
+              :disabled="!barDimensionEnabled[dimension]"
+              :data-testid="`token-analytics-bar-dimension-${dimension}`"
+              @click="selectBarDimension(dimension)"
+            >
+              {{ t(`pages.tokenAnalytics.barDimensions.${dimension}`) }}
+            </button>
+          </div>
           <div class="token-analytics-plot mt-2 h-[200px] overflow-visible" data-testid="token-analytics-plot-bars">
             <VChart
               v-if="barChartOption()"


### PR DESCRIPTION
## Summary
- Token 分析页柱状图支持项目 / 工作流 / 模型三维切换，并按可对比项数量自动降级（三维均不可比时隐藏区块）。
- 后端 GlobalTokenStats 为 workflows 与 modelRanking 补齐可选四段用量字段，供堆叠柱使用。
- 柱宽上限 28px、顶段圆角，TOKEN_PART_COLORS 收归靓紫四阶并同步分析页与 board 消费点。

## Test plan
- [ ] Token 分析页：单项目默认落到工作流/模型；多项目默认项目维度；不可比按钮禁用。
- [ ] 项目/模型柱点击联动筛选，工作流与 other 不筛选。
- [ ] 柱宽不受少类目拉伸，四段配色为靓紫而非青绿/橙。
- [ ] CI：Go 单测、web vitest、token-analytics e2e、lint 通过。


Made with [Cursor](https://cursor.com)