### PR TITLE
feat: default from-baseline workflows onto the home dashboard

### DIFF
--- a/server/internal/handlers/onboarding_test.go
+++ b/server/internal/handlers/onboarding_test.go
@@ -122,6 +122,36 @@ func TestCreateWorkflowFromBaselineAPI(t *testing.T) {
 	if created["id"] == "" {
 		t.Fatal("missing new workflow id")
 	}
+	if created["showOnHome"] != true {
+		t.Fatalf("from-baseline showOnHome=%v want true (plan g1.1 / g1.2)", created["showOnHome"])
+	}
+	got := hn.do("GET", "/api/workflows/"+created["id"].(string), nil)
+	if got.Code != http.StatusOK {
+		t.Fatalf("GET created: %d %s", got.Code, got.Body.String())
+	}
+	var fetched map[string]any
+	if err := json.Unmarshal(got.Body.Bytes(), &fetched); err != nil {
+		t.Fatal(err)
+	}
+	if fetched["showOnHome"] != true || fetched["status"] != "published" {
+		t.Fatalf("persisted from-baseline: %#v", fetched)
+	}
+	ignored := hn.do("POST", "/api/workflows/from-baseline", map[string]any{
+		"projectId":  pid,
+		"name":       "Client cannot hide",
+		"showOnHome": false,
+		"repos":      []map[string]any{{"url": "https://github.com/acme/other.git"}},
+	})
+	if ignored.Code != http.StatusCreated {
+		t.Fatalf("create with showOnHome false in body: %d %s", ignored.Code, ignored.Body.String())
+	}
+	var ignoredBody map[string]any
+	if err := json.Unmarshal(ignored.Body.Bytes(), &ignoredBody); err != nil {
+		t.Fatal(err)
+	}
+	if ignoredBody["showOnHome"] != true {
+		t.Fatalf("client showOnHome=false must not stick: %#v", ignoredBody)
+	}
 	variables, ok := created["variables"].([]any)
 	if !ok {
 		t.Fatalf("missing variables: %#v", created["variables"])

--- a/server/internal/services/onboarding.go
+++ b/server/internal/services/onboarding.go
@@ -138,6 +138,12 @@ func (s *OnboardingService) CreateFromBaseline(req CreateBaselineWorkflowRequest
 		_ = s.WF.Delete(wf.ID)
 		return models.WorkflowDef{}, fmt.Errorf("publish baseline workflow: %w", err)
 	}
+	// Align with Bootstrap: Save still forces showOnHome=false; open Home after publish.
+	published, err = s.WF.UpdateShowOnHome(published.ID, true)
+	if err != nil {
+		_ = s.WF.Delete(published.ID)
+		return models.WorkflowDef{}, fmt.Errorf("show workflow on home: %w", err)
+	}
 	return published, nil
 }
 

--- a/server/internal/services/onboarding_test.go
+++ b/server/internal/services/onboarding_test.go
@@ -408,6 +408,50 @@ func assertDefaultWorkflowGraph(t *testing.T, g models.Graph) {
 	}
 }
 
+func TestCreateFromBaselineDefaultsShowOnHome(t *testing.T) {
+	svc, projectID := newOnboardingHarness(t)
+	wf, err := svc.CreateFromBaseline(services.CreateBaselineWorkflowRequest{
+		ProjectID: projectID,
+		Name:      "首页可见流水线",
+		Repos:     []services.BaselineRepo{{URL: "https://github.com/acme/app.git"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateFromBaseline: %v", err)
+	}
+	if wf.Status != "published" || !wf.ShowOnHome {
+		t.Fatalf("returned status=%s showOnHome=%v (plan g1.1)", wf.Status, wf.ShowOnHome)
+	}
+	stored, ok := svc.WF.Get(wf.ID)
+	if !ok {
+		t.Fatal("workflow not persisted")
+	}
+	if stored.Status != "published" || !stored.ShowOnHome {
+		t.Fatalf("persisted status=%s showOnHome=%v (plan g1.1)", stored.Status, stored.ShowOnHome)
+	}
+
+	if _, err := svc.CreateFromBaseline(services.CreateBaselineWorkflowRequest{
+		ProjectID: projectID,
+		Name:      "首页可见流水线",
+		Repos:     []services.BaselineRepo{{URL: "https://github.com/acme/app.git"}},
+	}); !errors.Is(err, services.ErrWorkflowNameExists) {
+		t.Fatalf("duplicate name: %v", err)
+	}
+	if n := len(svc.WF.List(projectID)); n != 1 {
+		t.Fatalf("duplicate must not insert, got %d workflows", n)
+	}
+
+	if _, err := svc.CreateFromBaseline(services.CreateBaselineWorkflowRequest{
+		ProjectID: projectID,
+		Name:      "无仓库",
+		Repos:     []services.BaselineRepo{{URL: "  "}},
+	}); !errors.Is(err, services.ErrBaselineReposRequired) {
+		t.Fatalf("empty repos: %v", err)
+	}
+	if n := len(svc.WF.List(projectID)); n != 1 {
+		t.Fatalf("empty repos must not insert, got %d workflows", n)
+	}
+}
+
 func newOnboardingHarness(t *testing.T) (*services.OnboardingService, string) {
 	t.Helper()
 	db, err := database.OpenSQLiteTest(filepath.Join(t.TempDir(), "onboarding.db"))

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -42,7 +42,7 @@ paths:
               $ref: '#/components/schemas/CreateBaselineWorkflowRequest'
       responses:
         '201':
-          description: Published workflow created with the requested name
+          description: Published workflow created with the requested name and showOnHome=true
           content:
             application/json:
               schema:
@@ -549,6 +549,9 @@ components:
         status:
           type: string
           enum: [published]
+        showOnHome:
+          type: boolean
+          description: Always true on a successful from-baseline create
 
     ArtifactListItem:
       type: object

--- a/web/src/components/dashboard/HomeCreateBaselineModal.test.ts
+++ b/web/src/components/dashboard/HomeCreateBaselineModal.test.ts
@@ -174,11 +174,12 @@ describe('HomeCreateBaselineModal (plan g2 / g3 / g4)', () => {
       expect.arrayContaining([expect.objectContaining({ url: 'https://github.com/org/repo' })]),
     )
     expect(mocks.toastSuccess).toHaveBeenCalled()
+    expect(wrapper.emitted('created')).toEqual([[{ id: 'wf-new', name: '需求对齐流水线' }]])
     expect(wrapper.emitted('close')).toBeTruthy()
     wrapper.unmount()
   })
 
-  // plan g3.3 — create failure restores a clickable submit
+  // plan g2.2 — create failure restores a clickable submit and does not emit created
   it('keeps the form open and restores submit after a create failure', async () => {
     mocks.createWorkflowFromBaseline.mockRejectedValue(new Error('create failed'))
     const wrapper = mountModal()
@@ -191,6 +192,8 @@ describe('HomeCreateBaselineModal (plan g2 / g3 / g4)', () => {
     await flushPromises()
     expect(q('home-create-error').text()).toContain('create failed')
     expect((q('home-create-submit').element as HTMLButtonElement).disabled).toBe(false)
+    expect(wrapper.emitted('created')).toBeFalsy()
+    expect(wrapper.emitted('close')).toBeFalsy()
     wrapper.unmount()
   })
 })

--- a/web/src/components/dashboard/HomeCreateBaselineModal.vue
+++ b/web/src/components/dashboard/HomeCreateBaselineModal.vue
@@ -11,7 +11,10 @@ import { useToast } from '@/lib/composables/useToast'
 import type { Project } from '@/lib/shared/types'
 
 const props = defineProps<{ open: boolean }>()
-const emit = defineEmits<{ (e: 'close'): void }>()
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'created', workflow: { id: string; name: string }): void
+}>()
 
 const router = useRouter()
 const toast = useToast()
@@ -134,6 +137,7 @@ async function submit() {
       baselineRepos.value,
     )
     toast.success(t('pages.projectDetail.newWorkflow.created', { name: created.name }))
+    emit('created', { id: created.id, name: created.name })
     emit('close')
   } catch (e: any) {
     createError.value = String(e?.message || e)

--- a/web/src/lib/run/useHomeApproveChat.test.ts
+++ b/web/src/lib/run/useHomeApproveChat.test.ts
@@ -670,4 +670,27 @@ describe('useHomeApproveChat', () => {
     expect(chat.pipelines.value).toHaveLength(0)
     expect(chat.selected.value).toBeNull()
   })
+
+  // plan g2.1 / g2.2 — from-baseline success reloads and selects the new card
+  it('reloadAfterCreate loads the new pipeline and selects it', async () => {
+    const created = { ...approveWf, id: 'wf-new', name: '首页新建', showOnHome: true }
+    const chat = withSetup(() => useHomeApproveChat())
+    await chat.load()
+    expect(chat.pipelines.value.map((w) => w.id)).toEqual(['wf-ap'])
+    mocks.listWorkflows.mockResolvedValue([approveWf, created])
+    await chat.reloadAfterCreate('wf-new')
+    expect(chat.pipelines.value.map((w) => w.id)).toEqual(['wf-ap', 'wf-new'])
+    expect(chat.selectedId.value).toBe('wf-new')
+    expect(localStorage.getItem(HOME_PIPELINE_MEMORY_KEY)).toBe('wf-new')
+  })
+
+  // plan g2.2 — reload failure must not wipe existing home cards
+  it('reloadAfterCreate keeps the previous list when reload fails', async () => {
+    const chat = withSetup(() => useHomeApproveChat())
+    await chat.load()
+    mocks.listWorkflows.mockRejectedValue(new Error('reload failed'))
+    await chat.reloadAfterCreate('wf-new')
+    expect(chat.pipelines.value.map((w) => w.id)).toEqual(['wf-ap'])
+    expect(chat.selectedId.value).toBe('wf-ap')
+  })
 })

--- a/web/src/lib/run/useHomeApproveChat.ts
+++ b/web/src/lib/run/useHomeApproveChat.ts
@@ -287,6 +287,22 @@ export function useHomeApproveChat() {
     }
   }
 
+  /** Reload home cards after from-baseline create (plan g2.1). Keep prior list if reload fails. */
+  async function reloadAfterCreate(preferredId?: string) {
+    const previousWorkflows = workflows.value
+    const previousNames = projectNamesById.value
+    await load()
+    if (loadError.value) {
+      workflows.value = previousWorkflows
+      projectNamesById.value = previousNames
+      return
+    }
+    const id = (preferredId || '').trim()
+    if (id && pipelines.value.some((w) => w.id === id)) {
+      selectPipeline(id)
+    }
+  }
+
   function selectPipeline(id: string) {
     if (!id) return
     selectedId.value = id
@@ -472,6 +488,7 @@ export function useHomeApproveChat() {
     onPaste: attach.onPaste,
     removeAttachment: attach.removeAttachment,
     load,
+    reloadAfterCreate,
     selectPipeline,
     selectPriority,
     hidePipelineFromHome,

--- a/web/src/views/DashboardView.fill.test.ts
+++ b/web/src/views/DashboardView.fill.test.ts
@@ -35,6 +35,8 @@ describe('DashboardView home chat layout', () => {
     expect(src).toMatch(/data-testid="home-go-projects"/)
     expect(src).toMatch(/data-testid="home-new-workflow"/)
     expect(src).toMatch(/HomeCreateBaselineModal/)
+    expect(src).toMatch(/@created="onBaselineCreated"/)
+    expect(src).toMatch(/reloadAfterCreate/)
     expect(src).not.toMatch(/dashboard-kpi-/)
     expect(src).not.toMatch(/dashboard-board-empty/)
     expect(src).not.toMatch(/RunBoardColumn/)

--- a/web/src/views/DashboardView.test.ts
+++ b/web/src/views/DashboardView.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   startRun: vi.fn(),
   getRun: vi.fn(),
   reactReply: vi.fn(),
+  createWorkflowFromBaseline: vi.fn(),
   readStoredProjectId: vi.fn(() => 'proj-1'),
 }))
 
@@ -33,6 +34,7 @@ vi.mock('@/lib/api/api', async () => {
       startRun: mocks.startRun,
       getRun: mocks.getRun,
       reactReply: mocks.reactReply,
+      createWorkflowFromBaseline: mocks.createWorkflowFromBaseline,
     },
   }
 })
@@ -59,6 +61,7 @@ const HomePreviewAppModalStub = {
       <button type="button" data-testid="home-image-preview-close" @click="$emit('close')">×</button>
       <button type="button" data-testid="home-image-preview-backdrop" @click="$emit('close')">backdrop</button>
       <slot />
+      <slot name="footer" />
     </div>
   `,
 }
@@ -137,6 +140,7 @@ describe('DashboardView home composer', () => {
     mocks.startRun.mockReset()
     mocks.getRun.mockReset()
     mocks.reactReply.mockReset()
+    mocks.createWorkflowFromBaseline.mockReset()
     mocks.readStoredProjectId.mockReturnValue('proj-1')
     mocks.listWorkflows.mockResolvedValue([approveWf])
     mocks.listProjects.mockResolvedValue([{ id: 'proj-1', name: '综合项目组', description: '', variables: [] }])
@@ -1003,6 +1007,52 @@ describe('DashboardView home composer', () => {
     await wrapper.get('[data-testid="home-new-workflow"]').trigger('click')
     await flushPromises()
     expect(wrapper.find('[data-testid="home-create-workflow-name"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  // plan g2.1 / g2.2 — successful home create reloads cards and selects the new pipeline
+  it('reloads home cards after a successful baseline create', async () => {
+    const created: Workflow = { ...approveWf, id: 'wf-new', name: '首页新建' }
+    mocks.createWorkflowFromBaseline.mockResolvedValue(created)
+    const wrapper = mountDashboard()
+    await flushPromises()
+    const callsAfterMount = mocks.listWorkflows.mock.calls.length
+    await wrapper.get('[data-testid="home-new-workflow"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-testid="home-create-workflow-name"]').setValue('首页新建')
+    const url = wrapper.find('input[placeholder*="https"]')
+    expect(url.exists()).toBe(true)
+    await url.setValue('https://github.com/org/repo')
+    await flushPromises()
+    mocks.listWorkflows.mockResolvedValue([approveWf, created])
+    await wrapper.get('[data-testid="home-create-submit"]').trigger('click')
+    await flushPromises()
+    expect(mocks.createWorkflowFromBaseline).toHaveBeenCalled()
+    expect(mocks.listWorkflows.mock.calls.length).toBeGreaterThan(callsAfterMount)
+    expect(wrapper.find('[data-testid="home-pipeline-card-wf-new"]').exists()).toBe(true)
+    expect(wrapper.get('[data-testid="home-pipeline-card-wf-new"]').classes()).toContain(
+      'home-shell__card--selected',
+    )
+    wrapper.unmount()
+  })
+
+  // plan g2.2 — failed create must not refresh the home pipeline list
+  it('does not reload home cards when baseline create fails', async () => {
+    mocks.createWorkflowFromBaseline.mockRejectedValue(new Error('create failed'))
+    const wrapper = mountDashboard()
+    await flushPromises()
+    const callsAfterMount = mocks.listWorkflows.mock.calls.length
+    await wrapper.get('[data-testid="home-new-workflow"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-testid="home-create-workflow-name"]').setValue('X')
+    const url = wrapper.find('input[placeholder*="https"]')
+    await url.setValue('https://example.com/r.git')
+    await flushPromises()
+    await wrapper.get('[data-testid="home-create-submit"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.get('[data-testid="home-create-error"]').text()).toContain('create failed')
+    expect(mocks.listWorkflows.mock.calls.length).toBe(callsAfterMount)
+    expect(wrapper.find('[data-testid="home-pipeline-card-wf-ap"]').exists()).toBe(true)
     wrapper.unmount()
   })
 })

--- a/web/src/views/DashboardView.vue
+++ b/web/src/views/DashboardView.vue
@@ -50,6 +50,7 @@ const {
   onPaste,
   removeAttachment,
   load,
+  reloadAfterCreate,
   selectPipeline,
   selectPriority,
   hidePipelineFromHome,
@@ -250,6 +251,11 @@ function openCreateBaseline(e?: Event) {
   closePipelineMenu()
   clearLongPress()
   createBaselineOpen.value = true
+}
+
+async function onBaselineCreated(payload?: { id?: string }) {
+  createBaselineOpen.value = false
+  await reloadAfterCreate(payload?.id)
 }
 
 function closePipelineMenu() {
@@ -797,7 +803,11 @@ onBeforeUnmount(() => {
       </div>
     </Teleport>
 
-    <HomeCreateBaselineModal :open="createBaselineOpen" @close="createBaselineOpen = false" />
+    <HomeCreateBaselineModal
+      :open="createBaselineOpen"
+      @close="createBaselineOpen = false"
+      @created="onBaselineCreated"
+    />
 
     <RunLaunchModal
       :open="launchOpen"


### PR DESCRIPTION
## Summary
- `POST /api/workflows/from-baseline` now sets `showOnHome=true` after a successful publish, matching bootstrap onboarding so homepage “新建工作流” cards appear immediately.
- Homepage create modal reloads pipeline cards and selects the new workflow on success; failed creates leave the existing list unchanged.
- Blank create / copy / import still default `showOnHome=false`; PATCH home-visibility is unchanged.

## Test plan
- [ ] Go: `TestCreateFromBaselineDefaultsShowOnHome`, `TestCreateWorkflowFromBaselineAPI`
- [ ] Go: create/copy/import still `showOnHome=false`
- [ ] Vitest: HomeCreateBaselineModal / DashboardView reload and failure paths
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)