### PR TITLE
feat: align Agent create wizards with onboarding start paths

### DIFF
--- a/web/LIB_DOMAIN_MAP.json
+++ b/web/LIB_DOMAIN_MAP.json
@@ -173,6 +173,7 @@
       "routePending.ts",
       "serviceCommit.ts",
       "sidebarHidden.ts",
+      "startPath.ts",
       "streamMarkdownPreview.ts",
       "theme.ts",
       "types.ts"
@@ -186,6 +187,6 @@
     "pm": 7,
     "project": 4,
     "run": 54,
-    "shared": 37
+    "shared": 38
   }
 }

--- a/web/e2e/agent-create-wizard.spec.ts
+++ b/web/e2e/agent-create-wizard.spec.ts
@@ -44,8 +44,8 @@ test('新建 Agent 五步向导浏览器验收', async ({ page }) => {
   await expect(page.locator('.sec-head h3')).toHaveText('Agent')
   await page.screenshot({ path: path.join(OUT, '02-agent.png'), fullPage: true })
 
-  await page.getByRole('button', { name: /用编码 CLI 账号/ }).click()
-  await page.getByRole('button', { name: /Cursor/ }).click()
+  await page.getByTestId('agent-wizard-path-cli').click()
+  await page.getByTestId('agent-wizard-backend-cursor').click()
   await page.getByRole('button', { name: /^下一步/ }).click()
   await expect(page.locator('.sec-head h3')).toHaveText('API Key')
   await expect(page.getByText('APPROVING_CURSOR_API_KEY', { exact: true })).toBeVisible()

--- a/web/e2e/agent-create-wizard.spec.ts
+++ b/web/e2e/agent-create-wizard.spec.ts
@@ -44,6 +44,7 @@ test('新建 Agent 五步向导浏览器验收', async ({ page }) => {
   await expect(page.locator('.sec-head h3')).toHaveText('Agent')
   await page.screenshot({ path: path.join(OUT, '02-agent.png'), fullPage: true })
 
+  await page.getByRole('button', { name: /用编码 CLI 账号/ }).click()
   await page.getByRole('button', { name: /Cursor/ }).click()
   await page.getByRole('button', { name: /^下一步/ }).click()
   await expect(page.locator('.sec-head h3')).toHaveText('API Key')

--- a/web/src/components/agent/AgentCreateWizard.test.ts
+++ b/web/src/components/agent/AgentCreateWizard.test.ts
@@ -26,6 +26,8 @@ vi.mock('@/lib/api/api', () => ({
     createAgent: (payload: unknown) => createAgent(payload),
     listProjectRunTags: (projectId: string) => listProjectRunTags(projectId),
     getProjectSharedAgentConfig: (projectId: string) => getProjectSharedAgentConfig(projectId),
+    openCodeProviders: async () => ({ providers: [] }),
+    openCodeModels: async () => ({ models: [] }),
   },
 }))
 
@@ -91,6 +93,8 @@ describe('AgentCreateWizard 5-step IA', () => {
     buttonByText('下一步').click()
     await wrapper.vm.$nextTick()
 
+    buttonByText('用编码 CLI 账号').click()
+    await wrapper.vm.$nextTick()
     buttonByText('CodeBuddy').click()
     await wrapper.vm.$nextTick()
     const international = document.body.querySelector(
@@ -99,6 +103,7 @@ describe('AgentCreateWizard 5-step IA', () => {
     expect(international?.getAttribute('aria-checked')).toBe('true')
     expect(document.body.textContent).toContain('Agent')
     expect(document.body.textContent).not.toMatch(/配置步骤[\s\S]*\bACP\b/)
+    expect(document.body.textContent).toContain('从 API Key 开始')
     wrapper.unmount()
   })
 
@@ -107,6 +112,8 @@ describe('AgentCreateWizard 5-step IA', () => {
     fillName('key-agent')
     await wrapper.vm.$nextTick()
     buttonByText('下一步').click()
+    await wrapper.vm.$nextTick()
+    buttonByText('用编码 CLI 账号').click()
     await wrapper.vm.$nextTick()
     buttonByText('Cursor').click()
     await wrapper.vm.$nextTick()
@@ -124,6 +131,34 @@ describe('AgentCreateWizard 5-step IA', () => {
     buttonByText('跳过').click()
     await wrapper.vm.$nextTick()
     expect(document.body.textContent).toContain('Git')
+    wrapper.unmount()
+  })
+
+  it('defaults Agent step to API Key path and creates OpenCode when skipped', async () => {
+    const wrapper = mountWizard()
+    fillName('default-opencode')
+    await wrapper.vm.$nextTick()
+    buttonByText('下一步').click()
+    await wrapper.vm.$nextTick()
+    expect(document.body.textContent).toContain('从 API Key 开始')
+    expect(document.body.querySelector('[data-testid="agent-wizard-path-apiKey"]')).toBeTruthy()
+    expect(document.body.querySelector('[data-testid="agent-wizard-path-apikey-detail"]')).toBeTruthy()
+    expect(document.body.textContent).not.toContain('/root/.cursor')
+    // Skip Agent step — payload stays OpenCode
+    buttonByText('跳过').click()
+    await wrapper.vm.$nextTick()
+    buttonByText('跳过').click()
+    await wrapper.vm.$nextTick()
+    buttonByText('跳过').click()
+    await wrapper.vm.$nextTick()
+    buttonByText('创建并进入 Studio').click()
+    await wrapper.vm.$nextTick()
+    await vi.waitFor(() => {
+      expect(createAgent).toHaveBeenCalled()
+    })
+    const payload = createAgent.mock.calls[0][0]
+    expect(payload.acpBackend).toBe('opencode')
+    expect(payload.layout?.configRoot).toBe('/root/.config/opencode')
     wrapper.unmount()
   })
 
@@ -259,6 +294,8 @@ describe('AgentCreateWizard 5-step IA', () => {
     fillName('region-agent')
     await wrapper.vm.$nextTick()
     buttonByText('Next').click()
+    await wrapper.vm.$nextTick()
+    buttonByText('Use a coding-CLI account').click()
     await wrapper.vm.$nextTick()
     buttonByText('Trae').click()
     await wrapper.vm.$nextTick()

--- a/web/src/components/agent/AgentCreateWizard.vue
+++ b/web/src/components/agent/AgentCreateWizard.vue
@@ -4,6 +4,7 @@ import AppButton from '@/components/ui/AppButton.vue'
 import AgentGitGuide from '@/components/agent/AgentGitGuide.vue'
 import EnvCredentialHelpModal from '@/components/agent/EnvCredentialHelpModal.vue'
 import WizardApiKeyStepPanel from '@/components/agent/WizardApiKeyStepPanel.vue'
+import WizardAcpStartPathPanel from '@/components/agent/WizardAcpStartPathPanel.vue'
 
 import { kvToRec } from '@/lib/agent/agentCreateWizard'
 import { useAgentCreateWizard } from '@/lib/agent/useAgentCreateWizard'
@@ -42,6 +43,7 @@ const {
   selectRegion,
   markConfigured,
   selectAcp,
+  selectStartPath,
   confirmAcpSwitch,
   cancelAcpSwitch,
   syncApiKeyInput,
@@ -59,7 +61,6 @@ const {
   submitCreate,
   chipClass,
   WIZARD_STEPS,
-  ACP_BACKENDS,
 } = useAgentCreateWizard(props, emit)
 </script>
 
@@ -162,58 +163,20 @@ const {
 
                 <template v-else-if="currentStep.id === 'acp'">
                   <p class="sec-meta">{{ t('pages.agentStudio.wizard.acp.meta') }}</p>
-                  <div class="grid grid-cols-2 gap-2.5 sm:grid-cols-3 lg:grid-cols-5">
-                    <button
-                      v-for="b in ACP_BACKENDS"
-                      :key="b.id"
-                      type="button"
-                      class="rounded-lg border px-3 py-3.5 text-center transition"
-                      :class="
-                        draft.acpBackend === b.id
-                          ? 'border-accent bg-accent-dim'
-                          : 'border-line bg-base hover:border-line-strong'
-                      "
-                      @click="selectAcp(b.id)"
-                    >
-                      <strong class="block text-[13px] font-semibold text-txt">{{ b.label }}</strong>
-                      <span class="mt-1 block font-mono text-[10px] text-txt3">{{ b.configRoot }}</span>
-                    </button>
-                  </div>
-                  <div v-if="currentRegionPolicy" class="mt-5 border-t border-dashed border-line pt-4">
-                    <div class="mb-2 text-[12px] font-medium text-txt2">
-                      {{ t('pages.agentStudio.region.title') }}
-                    </div>
-                    <div
-                      class="grid max-w-lg grid-cols-2 gap-2.5"
-                      role="radiogroup"
-                      :aria-label="t('pages.agentStudio.region.title')"
-                    >
-                      <button
-                        v-for="option in currentRegionPolicy.options"
-                        :key="option.id"
-                        type="button"
-                        role="radio"
-                        :aria-checked="currentRegion === option.id"
-                        :aria-label="`${t(option.labelKey)} (${option.id})`"
-                        class="rounded-lg border px-3 py-3 text-left transition"
-                        :class="
-                          currentRegion === option.id
-                            ? 'border-accent bg-accent-dim'
-                            : 'border-line bg-base hover:border-line-strong'
-                        "
-                        @click="selectRegion(option.id)"
-                      >
-                        <strong class="block text-[13px] font-semibold text-txt">
-                          {{ t(option.labelKey) }}
-                        </strong>
-                        <span class="mt-1 block font-mono text-[10px] text-accent-2">{{ option.id }}</span>
-                        <span class="mt-1 block text-[10px] text-txt3">{{ t(option.hintKey) }}</span>
-                      </button>
-                    </div>
-                  </div>
-                  <p class="mt-3 font-mono text-[11px] text-txt3">
-                    configRoot → <span class="text-accent-2">{{ draft.configRoot }}</span>
-                  </p>
+                  <WizardAcpStartPathPanel
+                    :start-path="draft.startPath"
+                    :acp-backend="draft.acpBackend"
+                    :config-root="draft.configRoot"
+                    :region-policy="currentRegionPolicy"
+                    :current-region="currentRegion"
+                    region-as-radios
+                    show-region-hints
+                    show-config-root
+                    test-id-prefix="agent-wizard"
+                    @select-start-path="selectStartPath"
+                    @select-backend="selectAcp"
+                    @select-region="selectRegion"
+                  />
                 </template>
 
                 <template v-else-if="currentStep.id === 'apiKey'">

--- a/web/src/components/agent/CreateAgentTeamWizard.flow.test.ts
+++ b/web/src/components/agent/CreateAgentTeamWizard.flow.test.ts
@@ -81,6 +81,20 @@ function fillBasics(vm: any, name = '登月') {
   vm.draft.background = '把火箭送上天'
 }
 
+/** OpenCode API Key step requires a model before Next (g1.3 default). */
+function ensureOpenCodeModel(vm: any) {
+  if (vm.draft.acpBackend !== 'opencode') return
+  const has = vm.draft.env.some((e: any) => e.k === 'ACP_BRIDGE_MODEL' && String(e.v || '').trim())
+  if (!has) vm.draft.env.push({ k: 'ACP_BRIDGE_MODEL', v: 'openai/gpt-4.1' })
+}
+
+function goNextThrough(vm: any, count: number) {
+  for (let i = 0; i < count; i++) {
+    if (vm.currentStep.id === 'apiKey') ensureOpenCodeModel(vm)
+    vm.goNext()
+  }
+}
+
 describe('CreateAgentTeamWizard flow', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -152,8 +166,15 @@ describe('CreateAgentTeamWizard flow', () => {
 
     // Re-selecting the active backend is a no-op.
     const before = vm.draft.configRoot
-    vm.selectAcp('cursor')
+    vm.selectAcp(vm.draft.acpBackend)
     expect(vm.draft.configRoot).toBe(before)
+    expect(vm.draft.acpBackend).toBe('opencode')
+    expect(vm.draft.startPath).toBe('apiKey')
+
+    vm.selectStartPath('cli')
+    await flushPromises()
+    expect(vm.draft.startPath).toBe('cli')
+    expect(vm.draft.acpBackend).toBe('cursor')
 
     vm.selectAcp('claude_code')
     await flushPromises()
@@ -279,6 +300,7 @@ describe('CreateAgentTeamWizard flow', () => {
     fillBasics(vm)
     vm.goNext()
     vm.goNext()
+    ensureOpenCodeModel(vm)
     vm.goNext()
     await flushPromises()
     expect(vm.currentStep.id).toBe('git')
@@ -303,7 +325,7 @@ describe('CreateAgentTeamWizard flow', () => {
     const vm = w.vm as any
 
     fillBasics(vm)
-    for (let i = 0; i < 4; i++) vm.goNext()
+    goNextThrough(vm, 4)
     await flushPromises()
     expect(vm.currentStep.id).toBe('mcp')
     expect(vm.hasArtifact).toBe(true)
@@ -340,7 +362,7 @@ describe('CreateAgentTeamWizard flow', () => {
     const vm = w.vm as any
 
     fillBasics(vm)
-    for (let i = 0; i < 5; i++) vm.goNext()
+    goNextThrough(vm, 5)
     await flushPromises()
     expect(vm.currentStep.id).toBe('env')
     expect(vm.envSummary).toContain('GIT_REPOS')
@@ -366,7 +388,7 @@ describe('CreateAgentTeamWizard flow', () => {
     await flushPromises()
     emitPanel(w, 'update:apiKeyInput', 'sk-live')
     await flushPromises()
-    for (let i = 0; i < 4; i++) vm.goNext()
+    goNextThrough(vm, 4)
     await flushPromises()
     expect(vm.currentStep.id).toBe('review')
     expect(w.html()).toContain('登月项目组')
@@ -398,7 +420,7 @@ describe('CreateAgentTeamWizard flow', () => {
     mocks.bootstrapAgentTeam.mockRejectedValueOnce(new Error('quota exhausted'))
 
     fillBasics(vm)
-    for (let i = 0; i < 6; i++) vm.goNext()
+    goNextThrough(vm, 6)
     await flushPromises()
     expect(vm.currentStep.id).toBe('review')
 
@@ -418,7 +440,7 @@ describe('CreateAgentTeamWizard flow', () => {
     const vm = w.vm as any
 
     fillBasics(vm)
-    for (let i = 0; i < 6; i++) vm.goNext()
+    goNextThrough(vm, 6)
     await flushPromises()
     expect(vm.currentStep.id).toBe('review')
 

--- a/web/src/components/agent/CreateAgentTeamWizard.vue
+++ b/web/src/components/agent/CreateAgentTeamWizard.vue
@@ -5,12 +5,13 @@ import Icon from '@/components/ui/Icon.vue'
 import AppButton from '@/components/ui/AppButton.vue'
 import AgentGitGuide from '@/components/agent/AgentGitGuide.vue'
 import WizardApiKeyStepPanel from '@/components/agent/WizardApiKeyStepPanel.vue'
+import WizardAcpStartPathPanel from '@/components/agent/WizardAcpStartPathPanel.vue'
 import { api, type TeamBootstrapSession } from '@/lib/api/api'
 import {
-  ACP_BACKENDS,
   TEAM_ENGINEER_COUNT,
   TEAM_WIZARD_STEPS,
   applyTeamAcpBackend,
+  applyTeamStartPath,
   assembleTeamBootstrapPayload,
   artifactStorePreset,
   freshTeamDraft,
@@ -19,6 +20,7 @@ import {
   validateTeamBasics,
   type TeamWizardDraft,
   type WizardBackendId,
+  type StartPath,
 } from '@/lib/agent/agentTeamWizard'
 import { authGuideFor, defaultSettingsPlaceholder } from '@/lib/agent/backendAuthGuide'
 import type { GitCredentialType } from '@/lib/agent/gitCredentialAnalysis'
@@ -121,6 +123,12 @@ function onProjectInput() {
 function selectAcp(id: WizardBackendId) {
   if (id === draft.value.acpBackend) return
   applyTeamAcpBackend(draft.value, id)
+  syncApiKeyInput()
+}
+
+function selectStartPath(path: StartPath) {
+  if (path === draft.value.startPath) return
+  applyTeamStartPath(draft.value, path)
   syncApiKeyInput()
 }
 
@@ -481,34 +489,17 @@ const hasArtifact = computed(() => draft.value.mcp.some((m) => m.name.trim() ===
 
                 <template v-else-if="currentStep.id === 'acp'">
                   <p class="sec-meta">{{ t('pages.agentStudio.teamWizard.acp.meta') }}</p>
-                  <div class="grid grid-cols-2 gap-2.5 sm:grid-cols-3 lg:grid-cols-5">
-                    <button
-                      v-for="b in ACP_BACKENDS"
-                      :key="b.id"
-                      type="button"
-                      class="rounded-lg border px-3 py-3.5 text-center transition"
-                      :class="draft.acpBackend === b.id ? 'border-accent bg-accent-dim' : 'border-line bg-base hover:border-line-strong'"
-                      @click="selectAcp(b.id)"
-                    >
-                      <strong class="block text-[13px] font-semibold text-txt">{{ b.label }}</strong>
-                      <span class="mt-1 block font-mono text-[10px] text-txt3">{{ b.configRoot }}</span>
-                    </button>
-                  </div>
-                  <div v-if="regionPolicy" class="mt-5 border-t border-dashed border-line pt-4">
-                    <div class="mb-2 text-[12px] font-medium text-txt2">{{ t('pages.agentStudio.region.title') }}</div>
-                    <div class="grid max-w-lg grid-cols-2 gap-2.5">
-                      <button
-                        v-for="option in regionPolicy.options"
-                        :key="option.id"
-                        type="button"
-                        class="rounded-lg border px-3 py-3 text-left transition"
-                        :class="currentRegion === option.id ? 'border-accent bg-accent-dim' : 'border-line bg-base'"
-                        @click="selectRegion(option.id)"
-                      >
-                        <strong class="block text-[13px] text-txt">{{ t(option.labelKey) }}</strong>
-                      </button>
-                    </div>
-                  </div>
+                  <WizardAcpStartPathPanel
+                    :start-path="draft.startPath"
+                    :acp-backend="draft.acpBackend"
+                    :config-root="draft.configRoot"
+                    :region-policy="regionPolicy"
+                    :current-region="currentRegion"
+                    test-id-prefix="team-wizard"
+                    @select-start-path="selectStartPath"
+                    @select-backend="selectAcp"
+                    @select-region="selectRegion"
+                  />
                 </template>
 
                 <template v-else-if="currentStep.id === 'apiKey'">

--- a/web/src/components/agent/WizardAcpStartPathPanel.vue
+++ b/web/src/components/agent/WizardAcpStartPathPanel.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import {
+  CLI_BACKENDS,
+  START_PATH_OPTIONS,
+  type StartPath,
+  type WizardBackendId,
+} from '@/lib/agent/agentCreateWizard'
+import { OPENCODE_FALLBACK_PROVIDERS } from '@/lib/agent/openCodeProvider'
+import type { RegionPolicy } from '@/lib/shared/regionPolicy'
+
+defineProps<{
+  startPath: StartPath
+  acpBackend: WizardBackendId
+  configRoot: string
+  regionPolicy: RegionPolicy | null | undefined
+  currentRegion: string
+  /** When true, region buttons expose role=radio + aria (create wizard). */
+  regionAsRadios?: boolean
+  showRegionHints?: boolean
+  showConfigRoot?: boolean
+  testIdPrefix?: string
+}>()
+
+const emit = defineEmits<{
+  selectStartPath: [path: StartPath]
+  selectBackend: [id: WizardBackendId]
+  selectRegion: [id: string]
+}>()
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <div class="grid gap-3 sm:grid-cols-2">
+    <button
+      v-for="option in START_PATH_OPTIONS"
+      :key="option.id"
+      type="button"
+      class="rounded-lg border px-4 py-4 text-left transition"
+      :class="
+        startPath === option.id
+          ? 'border-accent bg-accent-dim'
+          : 'border-line bg-base hover:border-line-strong'
+      "
+      :data-testid="`${testIdPrefix || 'wizard'}-path-${option.id}`"
+      @click="emit('selectStartPath', option.id)"
+    >
+      <strong class="block text-[13px] font-semibold text-txt">{{ t(option.titleKey) }}</strong>
+      <span class="mt-1.5 block text-[11px] leading-5 text-txt3">{{ t(option.descKey) }}</span>
+    </button>
+  </div>
+
+  <div
+    v-if="startPath === 'apiKey'"
+    class="mt-5 border-t border-dashed border-line pt-4"
+    :data-testid="`${testIdPrefix || 'wizard'}-path-apikey-detail`"
+  >
+    <div class="mb-2 text-[12px] font-medium text-txt2">
+      {{ t('pages.onboarding.acp.apiKeyVendorsLabel') }}
+    </div>
+    <div class="flex flex-wrap gap-1.5">
+      <span
+        v-for="p in OPENCODE_FALLBACK_PROVIDERS"
+        :key="p.id"
+        class="rounded-md border border-line px-2 py-1 text-[11px] text-txt2"
+      >{{ t(p.labelKey) }}</span>
+    </div>
+    <p class="mt-3 text-[12px] text-txt3">
+      {{ t('pages.onboarding.acp.apiKeyVendorsHint') }}
+      <code class="ml-1 font-mono text-[11px] text-accent-2">{{ configRoot }}</code>
+    </p>
+  </div>
+
+  <div
+    v-else
+    class="mt-5 border-t border-dashed border-line pt-4"
+    :data-testid="`${testIdPrefix || 'wizard'}-path-cli-detail`"
+  >
+    <div class="mb-2 text-[12px] font-medium text-txt2">
+      {{ t('pages.onboarding.acp.cliLabel') }}
+    </div>
+    <div class="grid grid-cols-2 gap-2.5 sm:grid-cols-4">
+      <button
+        v-for="b in CLI_BACKENDS"
+        :key="b.id"
+        type="button"
+        class="rounded-lg border px-3 py-3.5 text-center transition"
+        :class="
+          acpBackend === b.id
+            ? 'border-accent bg-accent-dim'
+            : 'border-line bg-base hover:border-line-strong'
+        "
+        :data-testid="`${testIdPrefix || 'wizard'}-backend-${b.id}`"
+        @click="emit('selectBackend', b.id)"
+      >
+        <strong class="block text-[13px] font-semibold text-txt">{{ b.label }}</strong>
+        <span class="mt-1 block font-mono text-[10px] text-txt3">{{ b.configRoot }}</span>
+      </button>
+    </div>
+  </div>
+
+  <div v-if="regionPolicy" class="mt-5 border-t border-dashed border-line pt-4">
+    <div class="mb-2 text-[12px] font-medium text-txt2">
+      {{ t('pages.agentStudio.region.title') }}
+    </div>
+    <div
+      class="grid max-w-lg grid-cols-2 gap-2.5"
+      :role="regionAsRadios ? 'radiogroup' : undefined"
+      :aria-label="regionAsRadios ? t('pages.agentStudio.region.title') : undefined"
+    >
+      <button
+        v-for="option in regionPolicy.options"
+        :key="option.id"
+        type="button"
+        :role="regionAsRadios ? 'radio' : undefined"
+        :aria-checked="regionAsRadios ? currentRegion === option.id : undefined"
+        :aria-label="
+          regionAsRadios ? `${t(option.labelKey)} (${option.id})` : undefined
+        "
+        class="rounded-lg border px-3 py-3 text-left transition"
+        :class="
+          currentRegion === option.id
+            ? 'border-accent bg-accent-dim'
+            : 'border-line bg-base hover:border-line-strong'
+        "
+        @click="emit('selectRegion', option.id)"
+      >
+        <strong class="block text-[13px] font-semibold text-txt">{{ t(option.labelKey) }}</strong>
+        <span
+          v-if="regionAsRadios || showRegionHints"
+          class="mt-1 block font-mono text-[10px] text-accent-2"
+        >{{ option.id }}</span>
+        <span v-if="showRegionHints" class="mt-1 block text-[10px] text-txt3">
+          {{ t(option.hintKey) }}
+        </span>
+      </button>
+    </div>
+  </div>
+
+  <p v-if="showConfigRoot" class="mt-3 font-mono text-[11px] text-txt3">
+    configRoot → <span class="text-accent-2">{{ configRoot }}</span>
+  </p>
+</template>

--- a/web/src/components/onboarding/OnboardingWizard.vue
+++ b/web/src/components/onboarding/OnboardingWizard.vue
@@ -35,6 +35,7 @@ import {
   type OnboardingDraft,
   type OnboardingStartPath,
 } from '@/lib/pm/onboardingWizard'
+import { START_PATH_OPTIONS } from '@/lib/shared/startPath'
 
 const props = defineProps<{
   open: boolean
@@ -67,18 +68,7 @@ const themeOptions: { id: ThemeName; labelKey: string; hintKey: string }[] = [
   { id: 'dark', labelKey: 'pages.onboarding.language.themeDark', hintKey: 'pages.onboarding.language.themeDarkHint' },
   { id: 'light', labelKey: 'pages.onboarding.language.themeLight', hintKey: 'pages.onboarding.language.themeLightHint' },
 ]
-const startPathOptions: { id: OnboardingStartPath; titleKey: string; descKey: string }[] = [
-  {
-    id: 'apiKey',
-    titleKey: 'pages.onboarding.acp.paths.apiKey.title',
-    descKey: 'pages.onboarding.acp.paths.apiKey.desc',
-  },
-  {
-    id: 'cli',
-    titleKey: 'pages.onboarding.acp.paths.cli.title',
-    descKey: 'pages.onboarding.acp.paths.cli.desc',
-  },
-]
+const startPathOptions = START_PATH_OPTIONS
 const progressPct = computed(() =>
   phase.value === 'success' ? 100 : ((draft.value.step + 1) / ONBOARDING_STEPS.length) * 100,
 )

--- a/web/src/lib/agent/agentCreateWizard.test.ts
+++ b/web/src/lib/agent/agentCreateWizard.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   assembleCreatePayload,
   applyAcpBackend,
+  applyWizardStartPath,
   buildDefaultRule,
   buildReviewSummary,
   configRootFor,
@@ -11,8 +12,38 @@ import {
   validateBasics,
   AGENT_SETTINGS_PATH,
   parseCustomConfigJson,
+  CLI_BACKENDS,
 } from './agentCreateWizard'
 import { AGENT_OPENCODE_CONFIG_REL_PATH } from './backendAuthGuide'
+
+describe('freshDraft defaults (g1.2)', () => {
+  it('defaults to API Key path with OpenCode', () => {
+    const d = freshDraft()
+    expect(d.startPath).toBe('apiKey')
+    expect(d.acpBackend).toBe('opencode')
+    expect(d.cliBackend).toBe('cursor')
+    expect(d.configRoot).toBe('/root/.config/opencode')
+    expect(CLI_BACKENDS.map((b) => b.id)).toEqual([
+      'cursor',
+      'claude_code',
+      'codebuddy',
+      'trae',
+    ])
+  })
+
+  it('applyWizardStartPath restores last CLI backend', () => {
+    const d = freshDraft()
+    applyAcpBackend(d, 'codebuddy')
+    expect(d.startPath).toBe('cli')
+    expect(d.cliBackend).toBe('codebuddy')
+    applyWizardStartPath(d, 'apiKey')
+    expect(d.acpBackend).toBe('opencode')
+    expect(d.configRoot).toBe('/root/.config/opencode')
+    applyWizardStartPath(d, 'cli')
+    expect(d.acpBackend).toBe('codebuddy')
+    expect(d.cliBackend).toBe('codebuddy')
+  })
+})
 
 describe('configRootFor', () => {
   it('maps backends to protocol roots', () => {
@@ -208,6 +239,8 @@ describe('hasPathDeps / buildReviewSummary', () => {
   it('marks API Key configured when auth env is present', () => {
     const d = freshDraft()
     d.name = 'n'
+    d.acpBackend = 'cursor'
+    d.startPath = 'cli'
     d.env = [{ k: 'APPROVING_CURSOR_API_KEY', v: 'crsr_demo' }]
     const items = buildReviewSummary(d)
     expect(items.find((i) => i.key === 'apiKey')?.kind).toBe('ok')

--- a/web/src/lib/agent/agentCreateWizard.ts
+++ b/web/src/lib/agent/agentCreateWizard.ts
@@ -18,9 +18,18 @@ import {
   switchBackendRegions,
   type BackendId,
 } from '@/lib/shared/regionPolicy'
+import {
+  APIKEY_BACKEND,
+  CLI_BACKEND_DEFAULT,
+  CLI_BACKENDS,
+  START_PATH_OPTIONS,
+  backendForStartPath,
+  syncStartPathFields,
+  type StartPath,
+} from '@/lib/shared/startPath'
 
 export type WizardBackendId = BackendId
-export { ACP_BACKENDS }
+export { ACP_BACKENDS, CLI_BACKENDS, START_PATH_OPTIONS, type StartPath }
 /** Wizard step ids. Internal `acp` is shown as Agent via i18n; capability/env steps are not in WIZARD_STEPS. */
 export type WizardStepId =
   | 'basics'
@@ -63,7 +72,11 @@ export type WizardDraft = {
   step: number
   name: string
   description: string
+  /** apiKey (OpenCode BYOK) or cli (coding-CLI vendor). */
+  startPath: StartPath
   acpBackend: WizardBackendId
+  /** Last CLI-path backend, restored when switching back from apiKey. */
+  cliBackend: WizardBackendId
   authMode: WizardAuthMode
   customConfigContent: string
   gitCredentialType?: GitCredentialType
@@ -127,11 +140,13 @@ export function freshDraft(): WizardDraft {
     step: 0,
     name: '',
     description: '',
-    acpBackend: 'cursor',
+    startPath: 'apiKey',
+    acpBackend: APIKEY_BACKEND,
+    cliBackend: CLI_BACKEND_DEFAULT,
     authMode: 'apiKey',
     customConfigContent: '',
     gitCredentialType: undefined,
-    configRoot: DEFAULT_CONFIG_ROOT,
+    configRoot: configRootFor(APIKEY_BACKEND),
     env: [],
     mcp: [],
     rulesEdited: false,
@@ -148,9 +163,15 @@ export function configRootFor(backend: WizardBackendId): string {
 }
 
 export function applyAcpBackend(draft: WizardDraft, id: WizardBackendId): void {
+  syncStartPathFields(draft, id)
   draft.acpBackend = id
   draft.configRoot = configRootFor(id)
   draft.env = recToKV(switchOpenCodeEnv(switchBackendRegions(kvToRec(draft.env), id), id))
+}
+
+/** Switch start path; CLI restores the last CLI backend that was picked. */
+export function applyWizardStartPath(draft: WizardDraft, path: StartPath): void {
+  applyAcpBackend(draft, backendForStartPath(path, draft.cliBackend))
 }
 
 /** True when switching Backend may remapping path-dependent configs. */
@@ -313,7 +334,7 @@ export function assembleCreatePayload(draft: WizardDraft): Agent {
   const env = stripTokenKeysFromRecord(normalizeWizardRegions(envDraft))
   return {
     name,
-    acpBackend: draft.acpBackend || 'cursor',
+    acpBackend: draft.acpBackend || APIKEY_BACKEND,
     ...(draft.gitCredentialType ? { gitCredentialType: draft.gitCredentialType } : {}),
     files: collectFiles(draft),
     mcp: draft.mcp.filter((m) => m.name.trim()).map(draftMcpToApi),

--- a/web/src/lib/agent/agentTeamWizard.test.ts
+++ b/web/src/lib/agent/agentTeamWizard.test.ts
@@ -30,6 +30,23 @@ describe('agentTeamWizard', () => {
     expect(TEAM_ENGINEER_COUNT).toBe(9)
   })
 
+  it('defaults to OpenCode API Key path (g1.3)', () => {
+    const d = freshTeamDraft()
+    expect(d.startPath).toBe('apiKey')
+    expect(d.acpBackend).toBe('opencode')
+    expect(d.cliBackend).toBe('cursor')
+    expect(d.configRoot).toBe('/root/.config/opencode')
+  })
+
+  it('assembles bootstrap with opencode when Agent step skipped', () => {
+    const d = freshTeamDraft()
+    d.projectName = 'Demo'
+    syncDerivedNames(d)
+    d.background = 'build a pipeline team'
+    const payload = assembleTeamBootstrapPayload(d)
+    expect(payload.acpBackend).toBe('opencode')
+  })
+
   it('syncs derived names from project / prefix', () => {
     const d = freshTeamDraft()
     d.projectName = 'Demo'

--- a/web/src/lib/agent/agentTeamWizard.ts
+++ b/web/src/lib/agent/agentTeamWizard.ts
@@ -1,7 +1,10 @@
 import type { MCPServer } from '@/lib/api/api'
 import {
   ACP_BACKENDS,
+  CLI_BACKENDS,
+  START_PATH_OPTIONS,
   applyAcpBackend,
+  applyWizardStartPath,
   configRootFor,
   kvToRec,
   normalizeWizardRegions,
@@ -11,6 +14,7 @@ import {
   type WizardKV,
   type WizardMCP,
   type WizardAuthMode,
+  type StartPath,
   freshDraft,
   parseCustomConfigJson,
   stripAuthKeysFromEnv,
@@ -20,6 +24,7 @@ import type { GitCredentialType } from '@/lib/agent/gitCredentialAnalysis'
 import { authGuideFor, hasAuthKeyConfigured } from '@/lib/agent/backendAuthGuide'
 import { stripTokenKeysFromKV, stripTokenKeysFromRecord } from '@/lib/agent/tokenEnvKeys'
 import { getRegionPolicy } from '@/lib/shared/regionPolicy'
+import { APIKEY_BACKEND, CLI_BACKEND_DEFAULT } from '@/lib/shared/startPath'
 
 export type TeamWizardStepId = 'team' | 'acp' | 'apiKey' | 'git' | 'mcp' | 'env' | 'review'
 
@@ -53,7 +58,9 @@ export type TeamWizardDraft = {
   rootTouched: boolean
   pipelineTouched: boolean
   pmTouched: boolean
+  startPath: StartPath
   acpBackend: WizardBackendId
+  cliBackend: WizardBackendId
   authMode: WizardAuthMode
   customConfigContent: string
   gitCredentialType?: GitCredentialType
@@ -89,12 +96,14 @@ export function freshTeamDraft(): TeamWizardDraft {
     rootTouched: false,
     pipelineTouched: false,
     pmTouched: false,
-    acpBackend: 'cursor',
+    startPath: 'apiKey',
+    acpBackend: APIKEY_BACKEND,
+    cliBackend: CLI_BACKEND_DEFAULT,
     authMode: 'apiKey',
     customConfigContent: '',
     gitCredentialType: undefined,
     gitUrl: '',
-    configRoot: configRootFor('cursor'),
+    configRoot: configRootFor(APIKEY_BACKEND),
     env: [{ k: 'GIT_REPOS', v: '${vars.repos}' }],
     mcp: [artifactStorePreset()],
     skipped: {},
@@ -122,7 +131,9 @@ export function validateTeamBasics(d: TeamWizardDraft, existingNames: string[]):
 
 function teamDraftAsWizardDraft(d: TeamWizardDraft): WizardDraft {
   const base = freshDraft()
+  base.startPath = d.startPath
   base.acpBackend = d.acpBackend
+  base.cliBackend = d.cliBackend
   base.configRoot = d.configRoot
   base.authMode = d.authMode
   base.customConfigContent = d.customConfigContent
@@ -139,6 +150,18 @@ function teamDraftAsWizardDraft(d: TeamWizardDraft): WizardDraft {
 export function applyTeamAcpBackend(d: TeamWizardDraft, id: WizardBackendId) {
   const w = teamDraftAsWizardDraft(d)
   applyAcpBackend(w, id)
+  d.startPath = w.startPath
+  d.cliBackend = w.cliBackend
+  d.acpBackend = w.acpBackend
+  d.configRoot = w.configRoot
+  d.env = w.env
+}
+
+export function applyTeamStartPath(d: TeamWizardDraft, path: StartPath) {
+  const w = teamDraftAsWizardDraft(d)
+  applyWizardStartPath(w, path)
+  d.startPath = w.startPath
+  d.cliBackend = w.cliBackend
   d.acpBackend = w.acpBackend
   d.configRoot = w.configRoot
   d.env = w.env
@@ -211,7 +234,7 @@ export function assembleTeamBootstrapPayload(d: TeamWizardDraft): TeamBootstrapP
     pipelineGroupName: d.pipelineGroupName.trim() || 'Pipeline(GitHub)',
     pmName: normalizeAgentName(d.pmName),
     background: d.background.trim(),
-    acpBackend: d.acpBackend || 'cursor',
+    acpBackend: d.acpBackend || APIKEY_BACKEND,
     ...(apiKey ? { apiKey } : {}),
     ...(customConfig ? { customConfig } : {}),
     ...(region ? { region } : {}),
@@ -230,5 +253,5 @@ export function teamHasAuth(d: TeamWizardDraft): boolean {
   return hasAuthKeyConfigured(d.env, d.acpBackend)
 }
 
-export { ACP_BACKENDS, recToKV, kvToRec }
-export type { WizardBackendId }
+export { ACP_BACKENDS, CLI_BACKENDS, START_PATH_OPTIONS, recToKV, kvToRec }
+export type { WizardBackendId, StartPath }

--- a/web/src/lib/agent/useAgentCreateWizard.ts
+++ b/web/src/lib/agent/useAgentCreateWizard.ts
@@ -6,8 +6,11 @@ import { useI18n } from 'vue-i18n'
 import { api, type Agent } from '@/lib/api/api'
 import {
   ACP_BACKENDS,
+  CLI_BACKENDS,
+  START_PATH_OPTIONS,
   WIZARD_STEPS,
   applyAcpBackend,
+  applyWizardStartPath,
   assembleCreatePayload,
   buildReviewSummary,
   freshDraft,
@@ -16,11 +19,13 @@ import {
   parseCustomConfigJson,
   stripAuthKeysFromEnv,
   validateBasics,
+  type StartPath,
   type WizardAuthMode,
   type WizardBackendId,
   type WizardDraft,
   type WizardStepId,
 } from '@/lib/agent/agentCreateWizard'
+import { backendForStartPath } from '@/lib/shared/startPath'
 import { authGuideFor, defaultSettingsPlaceholder, hasAuthKeyConfigured } from '@/lib/agent/backendAuthGuide'
 import type { GitCredentialType } from '@/lib/agent/gitCredentialAnalysis'
 import { getRegionPolicy, setRegion } from '@/lib/shared/regionPolicy'
@@ -159,6 +164,19 @@ function selectAcp(id: WizardBackendId) {
     return
   }
   applyAcpBackend(draft.value, id)
+  markConfigured('acp')
+  syncApiKeyInput()
+}
+
+function selectStartPath(path: StartPath) {
+  if (path === draft.value.startPath) return
+  const nextId = backendForStartPath(path, draft.value.cliBackend)
+  if (nextId !== draft.value.acpBackend && hasPathDeps(draft.value)) {
+    pendingAcp.value = nextId
+    showAcpConfirm.value = true
+    return
+  }
+  applyWizardStartPath(draft.value, path)
   markConfigured('acp')
   syncApiKeyInput()
 }
@@ -387,6 +405,7 @@ function chipClass(kind: string) {
   selectRegion,
   markConfigured,
   selectAcp,
+  selectStartPath,
   confirmAcpSwitch,
   cancelAcpSwitch,
   syncApiKeyInput,
@@ -405,5 +424,7 @@ function chipClass(kind: string) {
   chipClass,
   WIZARD_STEPS,
   ACP_BACKENDS,
+  CLI_BACKENDS,
+  START_PATH_OPTIONS,
   }
 }

--- a/web/src/lib/pm/onboardingWizard.ts
+++ b/web/src/lib/pm/onboardingWizard.ts
@@ -1,10 +1,26 @@
 import type { BackendId } from '@/lib/shared/regionPolicy'
-import { ACP_BACKENDS, getRegionPolicy } from '@/lib/shared/regionPolicy'
+import { getRegionPolicy } from '@/lib/shared/regionPolicy'
 import type { GitCredentialType } from '@/lib/agent/gitCredentialAnalysis'
 import type { AppLocale } from '@/lib/shared/loadLocaleMessages'
 import type { ThemeName } from '@/lib/shared/theme'
 import { theme } from '@/lib/shared/theme'
 import { DEFAULT_OPENCODE_PROVIDER } from '@/lib/agent/openCodeProvider'
+import {
+  APIKEY_BACKEND,
+  CLI_BACKEND_DEFAULT,
+  CLI_BACKENDS,
+  type StartPath,
+  startPathForBackend,
+  syncStartPathFields,
+} from '@/lib/shared/startPath'
+
+export {
+  APIKEY_BACKEND as ONBOARDING_APIKEY_BACKEND,
+  CLI_BACKEND_DEFAULT as ONBOARDING_CLI_BACKEND_DEFAULT,
+  CLI_BACKENDS as ONBOARDING_CLI_BACKENDS,
+  startPathForBackend,
+  type StartPath as OnboardingStartPath,
+}
 
 /** Matches models.DefaultProjectID — first-install wizard only opens here. */
 export const DEFAULT_PROJECT_ID = 'proj-default'
@@ -38,27 +54,6 @@ export const ONBOARDING_STEPS: OnboardingStep[] = [
   { id: 'review', labelKey: 'pages.onboarding.steps.review' },
 ]
 
-/**
- * Two ways to start: bring a model-vendor API key (BYOK, served by the OpenCode
- * backend), or sign in with a coding-CLI vendor account (Cursor / Claude Code /
- * CodeBuddy / Trae). The backend step picks a path first, then its detail.
- */
-export type OnboardingStartPath = 'apiKey' | 'cli'
-
-/** BYOK path is served by a single backend; keep the mapping in one place. */
-export const ONBOARDING_APIKEY_BACKEND: BackendId = 'opencode'
-
-export const ONBOARDING_CLI_BACKEND_DEFAULT: BackendId = 'cursor'
-
-/** CLI-account backends, in ACP_BACKENDS order (BYOK backend excluded). */
-export const ONBOARDING_CLI_BACKENDS = ACP_BACKENDS.filter(
-  (b) => b.id !== ONBOARDING_APIKEY_BACKEND,
-)
-
-export function startPathForBackend(backend: BackendId): OnboardingStartPath {
-  return backend === ONBOARDING_APIKEY_BACKEND ? 'apiKey' : 'cli'
-}
-
 export const ONBOARDING_GIT_TYPES: { id: GitCredentialType; labelKey: string }[] = [
   { id: 'github_https', labelKey: 'pages.agentStudio.git.types.github_https' },
   { id: 'gitlab_https', labelKey: 'pages.agentStudio.git.types.gitlab_https' },
@@ -69,7 +64,7 @@ export type OnboardingDraft = {
   step: number
   language: AppLocale
   theme: ThemeName
-  startPath: OnboardingStartPath
+  startPath: StartPath
   acpBackend: BackendId
   /** Last CLI-path backend, so switching paths back restores the pick. */
   cliBackend: BackendId
@@ -214,9 +209,9 @@ export function freshOnboardingDraft(): OnboardingDraft {
     language: detectSystemLocale(),
     theme: theme.value,
     startPath: 'apiKey',
-    acpBackend: ONBOARDING_APIKEY_BACKEND,
-    cliBackend: ONBOARDING_CLI_BACKEND_DEFAULT,
-    region: getRegionPolicy(ONBOARDING_APIKEY_BACKEND)?.defaultRegion || '',
+    acpBackend: APIKEY_BACKEND,
+    cliBackend: CLI_BACKEND_DEFAULT,
+    region: getRegionPolicy(APIKEY_BACKEND)?.defaultRegion || '',
     apiKey: '',
     gitCredentialType: '',
     githubToken: '',
@@ -241,24 +236,20 @@ export function freshOnboardingDraft(): OnboardingDraft {
  * previous backend (region default, and the key, which is vendor-specific).
  */
 export function applyOnboardingBackend(draft: OnboardingDraft, id: BackendId): void {
-  const path = startPathForBackend(id)
-  draft.startPath = path
-  if (path === 'cli') draft.cliBackend = id
+  syncStartPathFields(draft, id)
   if (draft.acpBackend === id) return
   draft.acpBackend = id
   draft.region = getRegionPolicy(id)?.defaultRegion || ''
   draft.apiKey = ''
-  if (id === ONBOARDING_APIKEY_BACKEND && !draft.openCodeProvider) {
+  if (id === APIKEY_BACKEND && !draft.openCodeProvider) {
     draft.openCodeProvider = DEFAULT_OPENCODE_PROVIDER
   }
 }
 
 /** Switch start path; the CLI path restores the last CLI backend that was picked. */
-export function applyStartPath(draft: OnboardingDraft, path: OnboardingStartPath): void {
+export function applyStartPath(draft: OnboardingDraft, path: StartPath): void {
   const id =
-    path === 'apiKey'
-      ? ONBOARDING_APIKEY_BACKEND
-      : draft.cliBackend || ONBOARDING_CLI_BACKEND_DEFAULT
+    path === 'apiKey' ? APIKEY_BACKEND : draft.cliBackend || CLI_BACKEND_DEFAULT
   applyOnboardingBackend(draft, id)
 }
 

--- a/web/src/lib/shared/startPath.test.ts
+++ b/web/src/lib/shared/startPath.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import {
+  APIKEY_BACKEND,
+  CLI_BACKEND_DEFAULT,
+  CLI_BACKENDS,
+  START_PATH_OPTIONS,
+  backendForStartPath,
+  startPathForBackend,
+  syncStartPathFields,
+} from './startPath'
+
+describe('startPath shared model (g1.1)', () => {
+  it('maps backends and path cards', () => {
+    expect(APIKEY_BACKEND).toBe('opencode')
+    expect(CLI_BACKEND_DEFAULT).toBe('cursor')
+    expect(CLI_BACKENDS.map((b) => b.id)).toEqual([
+      'cursor',
+      'claude_code',
+      'codebuddy',
+      'trae',
+    ])
+    expect(startPathForBackend('opencode')).toBe('apiKey')
+    expect(startPathForBackend('cursor')).toBe('cli')
+    expect(backendForStartPath('apiKey', 'trae')).toBe('opencode')
+    expect(backendForStartPath('cli', 'trae')).toBe('trae')
+    expect(backendForStartPath('cli', 'cursor')).toBe('cursor')
+    expect(START_PATH_OPTIONS.map((o) => o.id)).toEqual(['apiKey', 'cli'])
+  })
+
+  it('syncStartPathFields remembers CLI picks', () => {
+    const draft = {
+      startPath: 'apiKey' as const,
+      acpBackend: APIKEY_BACKEND,
+      cliBackend: CLI_BACKEND_DEFAULT,
+    }
+    syncStartPathFields(draft, 'claude_code')
+    expect(draft.startPath).toBe('cli')
+    expect(draft.cliBackend).toBe('claude_code')
+    syncStartPathFields(draft, 'opencode')
+    expect(draft.startPath).toBe('apiKey')
+    expect(draft.cliBackend).toBe('claude_code')
+  })
+})

--- a/web/src/lib/shared/startPath.ts
+++ b/web/src/lib/shared/startPath.ts
@@ -1,0 +1,60 @@
+import { ACP_BACKENDS, type BackendId } from '@/lib/shared/regionPolicy'
+
+/**
+ * Two ways to start an Agent: bring a model-vendor API key (BYOK, served by
+ * OpenCode), or sign in with a coding-CLI vendor account (Cursor / Claude Code /
+ * CodeBuddy / Trae). Shared by onboarding, create-Agent, and team wizards.
+ */
+export type StartPath = 'apiKey' | 'cli'
+
+/** BYOK path is served by a single backend; keep the mapping in one place. */
+export const APIKEY_BACKEND: BackendId = 'opencode'
+
+export const CLI_BACKEND_DEFAULT: BackendId = 'cursor'
+
+/** CLI-account backends, in ACP_BACKENDS order (BYOK backend excluded). */
+export const CLI_BACKENDS = ACP_BACKENDS.filter((b) => b.id !== APIKEY_BACKEND)
+
+export function startPathForBackend(backend: BackendId): StartPath {
+  return backend === APIKEY_BACKEND ? 'apiKey' : 'cli'
+}
+
+/** Resolve the Backend that a path switch should land on. */
+export function backendForStartPath(path: StartPath, cliBackend: BackendId): BackendId {
+  return path === 'apiKey' ? APIKEY_BACKEND : cliBackend || CLI_BACKEND_DEFAULT
+}
+
+/** Path-card i18n; shared so create/team wizards match onboarding copy. */
+export const START_PATH_OPTIONS: {
+  id: StartPath
+  titleKey: string
+  descKey: string
+}[] = [
+  {
+    id: 'apiKey',
+    titleKey: 'pages.onboarding.acp.paths.apiKey.title',
+    descKey: 'pages.onboarding.acp.paths.apiKey.desc',
+  },
+  {
+    id: 'cli',
+    titleKey: 'pages.onboarding.acp.paths.cli.title',
+    descKey: 'pages.onboarding.acp.paths.cli.desc',
+  },
+]
+
+/** Minimal draft shape for path ↔ Backend sync (onboarding / wizard drafts). */
+export type StartPathDraft = {
+  startPath: StartPath
+  acpBackend: BackendId
+  cliBackend: BackendId
+}
+
+/**
+ * Keep startPath / cliBackend aligned with the selected Backend.
+ * Does not touch configRoot / env — callers apply those separately.
+ */
+export function syncStartPathFields(draft: StartPathDraft, id: BackendId): void {
+  const path = startPathForBackend(id)
+  draft.startPath = path
+  if (path === 'cli') draft.cliBackend = id
+}

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -2403,7 +2403,7 @@
           "backgroundHint": "Like a prompt: injected into the sandbox to generate groups and engineers."
         },
         "acp": {
-          "meta": "Used as the default ACP for the PM and engineers."
+          "meta": "Used as the default ACP for the PM and engineers. Pick a start path first — same as onboarding and New Agent."
         },
         "git": {
           "meta": "Optional. Pick GitHub / GitLab / SSH; skip when a Git Token already exists (including project shared).",
@@ -2490,7 +2490,7 @@
           "descHint": "Optional. When set, it is prepended to the default alwaysApply rule."
         },
         "acp": {
-          "meta": "Pick an Agent Backend. CodeBuddy and Trae also require a China or International site; International is the default.",
+          "meta": "Choose how to start: a model-vendor API key, or a coding-CLI vendor account. CodeBuddy and Trae also require a China or International site; International is the default.",
           "remapTitle": "Switch Backend?",
           "remapBody": "MCP / Skills / Commands / Rules may depend on the current paths. Switching remaps to the new configRoot; cancel keeps the current Backend."
         },

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -2403,7 +2403,7 @@
           "backgroundHint": "类似 Prompt：确认后注入沙箱，据此生成根组与工程师团队。"
         },
         "acp": {
-          "meta": "该配置用于 PM 及后续工程师的默认 ACP。"
+          "meta": "该配置用于 PM 及后续工程师的默认 ACP。先选启动方式，与安装引导、新建 Agent 相同。"
         },
         "git": {
           "meta": "可选。点选 GitHub / GitLab / SSH；已有 Token（含项目共享）时本步无需选择。",
@@ -2490,7 +2490,7 @@
           "descHint": "可留空。有值时写入自动生成的默认 alwaysApply 规则前言。"
         },
         "acp": {
-          "meta": "选择 Agent Backend；CodeBuddy 与 Trae 还需选择国内站或国际站，默认国际站。",
+          "meta": "先选启动方式：用模型厂商的 API Key，或用编码 CLI 的厂商账号。CodeBuddy 与 Trae 还需选择国内站或国际站，默认国际站。",
           "remapTitle": "确认更换 Backend？",
           "remapBody": "已配置的 MCP / Skills / Commands / Rules 可能依赖当前路径。更换 Backend 将按新的 configRoot 重映射；取消则保持原 Backend。"
         },


### PR DESCRIPTION
## Summary
- Align **New Agent** and **Create Agent Team** wizards with onboarding’s two start paths: API Key (OpenCode) vs coding CLI (Cursor / Claude Code / CodeBuddy / Trae).
- Default and skip both create OpenCode (`acpBackend=opencode`); CLI path keeps region selection and backend remapping confirmation.
- Register `startPath.ts` in `LIB_DOMAIN_MAP` so the domain-map CI test passes.

## Test plan
- [x] Vitest: startPath / agent create & team wizards / onboarding / component tests
- [x] Playwright: `agent-create-wizard` (path cards via testids, then Cursor)
- [x] CI on this PR: web, web-e2e, web-gate, gate, CodeQL, gitleaks, npm audit