### PR TITLE
feat: replace four page-header subtitles with two-tone slogans

### DIFF
--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -46,7 +46,7 @@
     },
     "tokenAnalytics": {
       "title": "Token usage",
-      "subtitle": "View token usage trends and breakdown across projects",
+      "subtitle": "<strong class=\"font-medium text-warn\">See the finest hair</strong>; <em class=\"not-italic text-n-clarify\">see as if by firelight</em>",
       "loading": "Loading…",
       "loadFailed": "Load failed. Please retry.",
       "retry": "Retry",
@@ -225,7 +225,7 @@
     },
     "projectList": {
       "title": "Projects",
-      "subtitle": "Organize workflows and project settings · shared Agent config and project workflow variables",
+      "subtitle": "<strong class=\"font-medium text-warn\">Grasp the main cord</strong>; <em class=\"not-italic text-n-clarify\">each takes its place</em>",
       "newProject": "New project",
       "empty": "No projects yet",
       "workflowCount": "{n} workflows",
@@ -1342,7 +1342,7 @@
     },
     "gatesInbox": {
       "title": "Needs attention",
-      "subtitleHtml": "<strong class=\"font-medium text-warn\">Human gates</strong> + <em class=\"not-italic text-n-clarify\">Clarify</em> inbox · workflows paused for human action",
+      "subtitleHtml": "<strong class=\"font-medium text-warn\">Plot within the tent</strong>, <em class=\"not-italic text-n-clarify\">win a thousand miles away</em>",
       "statusPending": "Updates available · refresh",
       "statusEditing": "Editing · syncing in background",
       "statusIdle": "Idle · syncing in background",
@@ -1524,7 +1524,7 @@
     },
     "artifacts": {
       "title": "Artifacts",
-      "subtitle": "Outputs from agents/clarify nodes are stored automatically (PRD, design, proposals, etc.) without extra setup or git hosting",
+      "subtitle": "<strong class=\"font-medium text-warn\">Store them in the hills</strong>, <em class=\"not-italic text-n-clarify\">pass them to those who will</em>",
       "groupsTitle": "Workflow groups",
       "groupsCount": "· {n} groups",
       "platformArtifacts": "Platform artifacts",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -46,7 +46,7 @@
     },
     "tokenAnalytics": {
       "title": "用量统计",
-      "subtitle": "查看各项目的 Token 用量趋势和构成",
+      "subtitle": "<strong class=\"font-medium text-warn\">明察秋毫</strong> <em class=\"not-italic text-n-clarify\">洞若观火</em>",
       "loading": "正在加载…",
       "loadFailed": "加载失败，请重试",
       "retry": "重试",
@@ -225,7 +225,7 @@
     },
     "projectList": {
       "title": "项目",
-      "subtitle": "组织工作流与项目配置 · 可设置共享 Agent 配置与项目级工作流变量",
+      "subtitle": "<strong class=\"font-medium text-warn\">纲举目张</strong> <em class=\"not-italic text-n-clarify\">各安其位</em>",
       "newProject": "新建项目",
       "empty": "暂无项目",
       "workflowCount": "{n} 个工作流",
@@ -1342,7 +1342,7 @@
     },
     "gatesInbox": {
       "title": "待办",
-      "subtitleHtml": "<strong class=\"font-medium text-warn\">门禁审批</strong> + <em class=\"not-italic text-n-clarify\">需求澄清</em> 收件箱 · 工作流在此挂起等待人工处理",
+      "subtitleHtml": "<strong class=\"font-medium text-warn\">运筹帷幄之中</strong> <em class=\"not-italic text-n-clarify\">决胜千里之外</em>",
       "statusPending": "有新审批 · 待刷新",
       "statusEditing": "正在填写 · 后台同步中",
       "statusIdle": "空闲 · 后台同步中",
@@ -1524,7 +1524,7 @@
     },
     "artifacts": {
       "title": "产物",
-      "subtitle": "Agent / 澄清等节点的输出自动留存为平台产物(PRD / 设计 / 方案等),无需额外配置,不依赖代码托管平台",
+      "subtitle": "<strong class=\"font-medium text-warn\">藏之名山</strong> <em class=\"not-italic text-n-clarify\">传之其人</em>",
       "groupsTitle": "工作流分组",
       "groupsCount": "· {n} 组",
       "platformArtifacts": "平台产物",

--- a/web/src/views/ArtifactsView.vue
+++ b/web/src/views/ArtifactsView.vue
@@ -323,7 +323,7 @@ onMounted(async () => {
     <div class="mb-5 flex shrink-0 flex-col gap-3 md:flex-row md:items-start md:justify-between">
       <div>
         <h2 class="text-lg font-semibold text-txt">{{ t('pages.artifacts.title') }}</h2>
-        <p class="text-sm text-txt3">{{ t('pages.artifacts.subtitle') }}</p>
+        <p class="text-sm text-txt3" v-html="t('pages.artifacts.subtitle')" />
       </div>
       <ProjectFilter v-model="selectedProject" />
     </div>

--- a/web/src/views/ProjectListView.vue
+++ b/web/src/views/ProjectListView.vue
@@ -106,7 +106,7 @@ onMounted(() => {
     <div class="mb-5 flex shrink-0 flex-col gap-2.5 md:flex-row md:items-start md:justify-between">
       <div class="min-w-0">
         <h2 class="text-lg font-semibold text-txt">{{ t('pages.projectList.title') }}</h2>
-        <p class="text-sm text-txt3">{{ t('pages.projectList.subtitle') }}</p>
+        <p class="text-sm text-txt3" v-html="t('pages.projectList.subtitle')" />
       </div>
       <AppButton class="min-h-[44px] md:min-h-0" variant="primary" icon="plus" @click="openCreate">
         {{ t('pages.projectList.newProject') }}

--- a/web/src/views/TokenAnalyticsView.vue
+++ b/web/src/views/TokenAnalyticsView.vue
@@ -629,7 +629,7 @@ watch([windowSel], () => void load())
       <div class="mb-3 flex flex-wrap items-end justify-between gap-3">
         <div>
           <h1 class="m-0 text-[22px] font-semibold">{{ t('pages.tokenAnalytics.title') }}</h1>
-          <p class="mt-1 text-xs text-txt3">{{ t('pages.tokenAnalytics.subtitle') }}</p>
+          <p class="mt-1 text-xs text-txt3" v-html="t('pages.tokenAnalytics.subtitle')" />
         </div>
         <div
           class="flex gap-1 rounded bg-elevated p-1"


### PR DESCRIPTION
Swap functional inbox/artifacts/token/project subtitles for confirmed ZH/EN slogans and render the three plain-text pages via v-html so yellow/cyan markup displays like GatesInbox.

Co-authored-by: Cursor <cursoragent@cursor.com>
