### PR TITLE
fix(web): keep list-card hover borders; collapse agent history by default

### DIFF
--- a/web/src/components/agent/AgentFilesPanel.interactions.test.ts
+++ b/web/src/components/agent/AgentFilesPanel.interactions.test.ts
@@ -144,7 +144,7 @@ describe('AgentFilesPanel interactions', () => {
     await w.get('[data-testid="history"] button').trigger('click')
     await w.findAll('[data-testid="history"] button')[1].trigger('click')
     expect(w.emitted('restored')).toBeTruthy()
-    expect(localStorage.getItem('agent-studio-history-collapsed')).toBe('true')
+    expect(localStorage.getItem('agent-studio-history-collapsed')).toBe('false')
 
     ;(w.vm as any).openPathOrCreate('settings.json', '{}')
     await flushPromises()

--- a/web/src/components/inbox/InboxPendingCard.vue
+++ b/web/src/components/inbox/InboxPendingCard.vue
@@ -66,7 +66,7 @@ function onOpenShare() {
 <template>
   <article
     class="list-card-lift flex w-full shrink-0 flex-col rounded-lg border p-3"
-    :class="active ? 'border-accent/50 bg-accent-dim/40' : 'border-line bg-surface hover:bg-elevated'"
+    :class="active ? 'border-accent/50 bg-accent-dim/40' : 'border-line bg-surface hover:border-line-strong hover:bg-elevated'"
     data-testid="inbox-item-card"
     :data-starting="starting ? 'true' : undefined"
     :data-replying="replying ? 'true' : undefined"

--- a/web/src/lib/agent/useAgentFilesPanel.explorer.test.ts
+++ b/web/src/lib/agent/useAgentFilesPanel.explorer.test.ts
@@ -1,4 +1,7 @@
 // @vitest-environment happy-dom
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { createApp, defineComponent, nextTick, reactive } from 'vue'
 import { createI18n } from 'vue-i18n'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -675,7 +678,7 @@ describe('useAgentFilesPanel explorer', () => {
     app.unmount()
   })
 
-  it('falls back to expanded rails when storage is unavailable', async () => {
+  it('defaults history rail collapsed; explorer stays expanded when storage fails', async () => {
     const getItem = vi.spyOn(localStorage, 'getItem').mockImplementation(() => {
       throw new Error('denied')
     })
@@ -684,14 +687,41 @@ describe('useAgentFilesPanel explorer', () => {
     })
     const { panel, app } = withFilesPanel()
     expect(panel.explorerCollapsed.value).toBe(false)
-    expect(panel.historyCollapsed.value).toBe(false)
-    panel.toggleHistoryCollapsed()
     expect(panel.historyCollapsed.value).toBe(true)
+    expect(panel.workspaceGridStyle.value.gridTemplateColumns).toBe('240px 1fr 28px')
+    panel.toggleHistoryCollapsed()
+    expect(panel.historyCollapsed.value).toBe(false)
+    expect(panel.workspaceGridStyle.value.gridTemplateColumns).toBe('240px 1fr 300px')
     getItem.mockRestore()
     setItem.mockRestore()
 
     panel.writeCollapsedState(panel.EXPLORER_COLLAPSED_KEY, true)
     expect(panel.readCollapsedState(panel.EXPLORER_COLLAPSED_KEY)).toBe(true)
     app.unmount()
+  })
+
+  it('history key null/missing falls back to collapsed; false persists expanded', async () => {
+    localStorage.removeItem('agent-studio-history-collapsed')
+    const { panel: fresh, app: app1 } = withFilesPanel()
+    expect(fresh.readCollapsedState(fresh.HISTORY_COLLAPSED_KEY, true)).toBe(true)
+    expect(fresh.historyCollapsed.value).toBe(true)
+    app1.unmount()
+
+    localStorage.setItem('agent-studio-history-collapsed', 'false')
+    const { panel: expanded, app: app2 } = withFilesPanel()
+    expect(expanded.historyCollapsed.value).toBe(false)
+    expect(expanded.workspaceGridStyle.value.gridTemplateColumns).toBe('240px 1fr 300px')
+    app2.unmount()
+    localStorage.removeItem('agent-studio-history-collapsed')
+  })
+})
+
+describe('other history entries stay collapsed by default (plan g3.1 / g3.3)', () => {
+  it('WorkflowEditorView showVersions defaults false; PreviewFeedbackChat historyExpanded defaults false', () => {
+    const root = join(dirname(fileURLToPath(import.meta.url)), '../..')
+    const wf = readFileSync(join(root, 'views/WorkflowEditorView.vue'), 'utf8')
+    const fb = readFileSync(join(root, 'components/run/PreviewFeedbackChat.vue'), 'utf8')
+    expect(wf).toMatch(/const showVersions = ref\(false\)/)
+    expect(fb).toMatch(/const historyExpanded = ref\(false\)/)
   })
 })

--- a/web/src/lib/agent/useAgentFilesPanel.test.ts
+++ b/web/src/lib/agent/useAgentFilesPanel.test.ts
@@ -51,6 +51,7 @@ function withFilesPanel(isMobile = false) {
 
 describe('useAgentFilesPanel', () => {
   beforeEach(() => {
+    localStorage.clear()
     vi.restoreAllMocks()
   })
 
@@ -95,13 +96,16 @@ describe('useAgentFilesPanel', () => {
   it('uses three-column grid when agentName is set on desktop', async () => {
     const { panel, app } = withFilesPanel()
     await nextTick()
-    expect(panel.workspaceGridStyle.value.gridTemplateColumns).toContain('300px')
+    expect(panel.workspaceGridStyle.value.gridTemplateColumns).toBe('240px 1fr 28px')
     app.unmount()
   })
 
   it('collapses history column to rail width', async () => {
     const { panel, app } = withFilesPanel()
     await nextTick()
+    expect(panel.workspaceGridStyle.value.gridTemplateColumns).toBe('240px 1fr 28px')
+    panel.toggleHistoryCollapsed()
+    expect(panel.workspaceGridStyle.value.gridTemplateColumns).toContain('300px')
     panel.toggleHistoryCollapsed()
     expect(panel.workspaceGridStyle.value.gridTemplateColumns).toContain('28px')
     expect(panel.workspaceGridStyle.value.gridTemplateColumns).not.toContain('300px')

--- a/web/src/lib/agent/useAgentFilesPanel.ts
+++ b/web/src/lib/agent/useAgentFilesPanel.ts
@@ -39,13 +39,13 @@ const SIDEBAR_COLLAPSED_W = '28px'
 const HISTORY_EXPANDED_W = '300px'
 const HISTORY_COLLAPSED_W = '28px'
 
-function readCollapsedState(key: string): boolean {
+function readCollapsedState(key: string, defaultCollapsed = false): boolean {
   try {
     const v = localStorage.getItem(key)
-    if (v === null) return false
+    if (v === null) return defaultCollapsed
     return v === 'true'
   } catch {
-    return false
+    return defaultCollapsed
   }
 }
 
@@ -63,7 +63,8 @@ function toggleExplorerCollapsed() {
   writeCollapsedState(EXPLORER_COLLAPSED_KEY, explorerCollapsed.value)
 }
 
-const historyCollapsed = ref(false)
+/** plan g3.2: version history defaults to collapsed (narrow rail) */
+const historyCollapsed = ref(true)
 function toggleHistoryCollapsed() {
   historyCollapsed.value = !historyCollapsed.value
   writeCollapsedState(HISTORY_COLLAPSED_KEY, historyCollapsed.value)
@@ -635,7 +636,8 @@ watch(
 
 onMounted(() => {
   explorerCollapsed.value = readCollapsedState(EXPLORER_COLLAPSED_KEY)
-  historyCollapsed.value = readCollapsedState(HISTORY_COLLAPSED_KEY)
+  // HISTORY key missing/unavailable → collapsed (true); explorer still defaults expanded
+  historyCollapsed.value = readCollapsedState(HISTORY_COLLAPSED_KEY, true)
   document.addEventListener('click', onDocumentClick)
   document.addEventListener('keydown', onExplorerKeydown)
   document.addEventListener('keydown', onChromeKeydown)

--- a/web/src/views/GatesInboxView.mobileFill.test.ts
+++ b/web/src/views/GatesInboxView.mobileFill.test.ts
@@ -93,6 +93,16 @@ describe('GatesInboxView review/clarify composer mode', () => {
 const EMPTY_CARD_CLASS =
   'card flex min-h-0 flex-1 flex-col items-center justify-center overflow-auto'
 
+describe('GatesInboxView list-card-lift hover padding (plan g2.1)', () => {
+  it('mobile and desktop list scroll areas keep py-0.5 so hover top border is not clipped', () => {
+    expect(vueSrc).toMatch(/ref="listEl" class="scroll-area flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto py-0\.5"/)
+    const scrollMatches = vueSrc.match(
+      /scroll-area flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto py-0\.5/g,
+    )
+    expect(scrollMatches?.length).toBeGreaterThanOrEqual(2)
+  })
+})
+
 describe('GatesInboxView empty inbox fill (plan g1 / g2.1 / g1.3)', () => {
   it('mobile + desktop empty wrappers both include flex-1 and vertical centering (g1.1 g1.2 g2.1)', () => {
     const escaped = EMPTY_CARD_CLASS.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')

--- a/web/src/views/GatesInboxView.vue
+++ b/web/src/views/GatesInboxView.vue
@@ -373,7 +373,8 @@ const listFadeKey = computed(() =>
         class="flex min-h-0 flex-1 flex-col"
         :class="showListRefresh ? 'opacity-[0.55]' : ''"
       >
-        <div ref="listEl" class="scroll-area flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
+        <!-- plan g2.1: py-0.5 so list-card-lift hover translateY(-1px) top border is not clipped -->
+        <div ref="listEl" class="scroll-area flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto py-0.5">
         <Transition name="ui-fade" mode="out-in">
         <div :key="listFadeKey" class="flex flex-col gap-2" data-testid="inbox-list-fade">
         <InboxPendingCard
@@ -511,7 +512,8 @@ const listFadeKey = computed(() =>
     >
       <div class="flex h-full min-h-0 flex-col overflow-hidden">
         <RefreshStrip v-if="showListRefresh" data-testid="gates-inbox-refresh-strip" />
-        <div class="scroll-area flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
+        <!-- plan g2.1: py-0.5 so list-card-lift hover translateY(-1px) top border is not clipped -->
+        <div class="scroll-area flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto py-0.5">
           <Transition name="ui-fade" mode="out-in">
           <div :key="listFadeKey" class="flex flex-col gap-2" data-testid="inbox-list-fade-desktop">
           <InboxPendingCard

--- a/web/src/views/ProjectListView.test.ts
+++ b/web/src/views/ProjectListView.test.ts
@@ -84,15 +84,18 @@ describe('ProjectListView narrow-screen overflow constraints', () => {
     expect(src).toMatch(/data-testid="project-list-cards"/)
     expect(src).toMatch(/data-testid="project-list-skeleton"/)
     expect(src).toMatch(/grid min-w-0 gap-3 sm:grid-cols-2 xl:grid-cols-3/)
-    expect(src).toMatch(/min-w-0 w-full max-w-full flex-col gap-2 overflow-hidden/)
+    // plan g2.2: no card overflow-hidden (lift border); truncate/line-clamp still clip text
+    expect(src).toMatch(/min-w-0 w-full max-w-full flex-col gap-2 rounded-lg border/)
+    expect(src).not.toMatch(/min-w-0 w-full max-w-full flex-col gap-2 overflow-hidden/)
     expect(src).toMatch(/line-clamp-2 break-words/)
+    expect(src).toMatch(/truncate text-sm font-semibold/)
     expect(src).toMatch(/flex min-w-0 flex-wrap items-center gap-x-1\.5 gap-y-0\.5/)
   })
 
   // plan g3.3 — narrow viewport: fill root + list panel is the scroll exit (末卡可达)
   it('uses fill-height root and project-list-panel overflow-y-auto scroll exit (g3.3)', async () => {
     expect(src).toMatch(/flex h-full min-h-0 flex-col/)
-    expect(src).toMatch(/data-testid="project-list-panel"[\s\S]*?class="min-h-0 flex-1 overflow-y-auto"/)
+    expect(src).toMatch(/data-testid="project-list-panel"[\s\S]*?class="min-h-0 flex-1 overflow-y-auto py-0\.5"/)
     const many = Array.from({ length: 12 }, (_, i) => ({
       ...SAMPLE,
       id: `p${i}`,
@@ -102,7 +105,7 @@ describe('ProjectListView narrow-screen overflow constraints', () => {
     const w = mountList()
     await flushPromises()
     const panel = w.get('[data-testid="project-list-panel"]')
-    expect(panel.classes()).toEqual(expect.arrayContaining(['min-h-0', 'flex-1', 'overflow-y-auto']))
+    expect(panel.classes()).toEqual(expect.arrayContaining(['min-h-0', 'flex-1', 'overflow-y-auto', 'py-0.5']))
     const cards = w.findAll('[data-testid="project-list-cards"] button')
     expect(cards.length).toBe(12)
     expect(cards[11].text()).toContain('项目 11')

--- a/web/src/views/ProjectListView.vue
+++ b/web/src/views/ProjectListView.vue
@@ -115,7 +115,7 @@ onMounted(() => {
 
     <div
       data-testid="project-list-panel"
-      class="min-h-0 flex-1 overflow-y-auto"
+      class="min-h-0 flex-1 overflow-y-auto py-0.5"
       :aria-busy="loading ? 'true' : 'false'"
     >
       <div
@@ -195,7 +195,7 @@ onMounted(() => {
             v-for="p in projects"
             :key="p.id"
             type="button"
-            class="list-card-lift flex min-w-0 w-full max-w-full flex-col gap-2 overflow-hidden rounded-lg border border-line bg-surface p-4 text-left hover:border-line-strong hover:bg-elevated"
+            class="list-card-lift flex min-w-0 w-full max-w-full flex-col gap-2 rounded-lg border border-line bg-surface p-4 text-left hover:border-line-strong hover:bg-elevated"
             @click="openProject(p)"
           >
             <div class="flex items-start gap-3">

--- a/web/src/views/RunListView.fill.test.ts
+++ b/web/src/views/RunListView.fill.test.ts
@@ -109,6 +109,12 @@ describe('RunListView sticky table + pager pin (g3)', () => {
     expect(mobile).not.toMatch(/applySortClick/)
     expect(mobile).not.toMatch(/sort-icon/)
   })
+
+  it('mobile data list uses overflow-y-auto p-2 so list-card-lift hover is not clipped (g2.3 regress)', () => {
+    const mobile = src.slice(src.indexOf('<!-- Mobile card list -->'), src.indexOf('<!-- Desktop table -->'))
+    expect(mobile).toMatch(/min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-2/)
+    expect(mobile).toMatch(/list-card-lift/)
+  })
 })
 
 describe('RunListView fill scope lock (g4.3)', () => {

--- a/web/src/views/SandboxListView.vue
+++ b/web/src/views/SandboxListView.vue
@@ -321,10 +321,10 @@ onBeforeUnmount(() => {
       <i class="admin-list-thin-bar bg-accent" />
     </div>
 
-    <!-- Mobile card list -->
+    <!-- Mobile card list — plan g2.1: py-0.5 so list-card-lift hover top border is not clipped -->
     <div
       v-if="isMobile"
-      class="min-h-0 flex-1 overflow-y-auto"
+      class="min-h-0 flex-1 overflow-y-auto py-0.5"
       :class="{ 'table-loading': showTableLoading }"
     >
       <template v-if="initialLoading">

--- a/web/src/views/mobileScrollContract.test.ts
+++ b/web/src/views/mobileScrollContract.test.ts
@@ -22,7 +22,7 @@ describe('mobile scroll contract — list A (plan g1 / g3.1)', () => {
     const src = read('ProjectListView.vue')
     expect(src).toMatch(FILL_ROOT)
     expect(src).toMatch(/mb-5 flex shrink-0/)
-    expect(src).toMatch(/data-testid="project-list-panel"[\s\S]*?class="min-h-0 flex-1 overflow-y-auto"/)
+    expect(src).toMatch(/data-testid="project-list-panel"[\s\S]*?class="min-h-0 flex-1 overflow-y-auto py-0\.5"/)
     expect(src).not.toMatch(/^\s*<div>\s*$/m)
   })
 
@@ -38,7 +38,7 @@ describe('mobile scroll contract — list A (plan g1 / g3.1)', () => {
     const src = read('SandboxListView.vue')
     expect(src).toMatch(FILL_ROOT)
     expect(src).toMatch(/mb-5 flex shrink-0/)
-    expect(src).toMatch(/v-if="isMobile"[\s\S]*?class="min-h-0 flex-1 overflow-y-auto"/)
+    expect(src).toMatch(/v-if="isMobile"[\s\S]*?class="min-h-0 flex-1 overflow-y-auto py-0\.5"/)
     expect(src).toMatch(/card flex min-h-0 flex-1 flex-col overflow-hidden/)
     expect(src).toMatch(/scroll-area min-h-0 flex-1 overflow-auto/)
   })


### PR DESCRIPTION
Add minimal scroll padding so list-card-lift translateY is not clipped,
drop project-card overflow-hidden, and default agent version history to
collapsed when storage is missing or unreadable.

Co-authored-by: Cursor <cursoragent@cursor.com>
