### PR TITLE
fix(web): createProject wizard reuses current app locale

### DIFF
--- a/web/e2e/onboarding-wizard.spec.ts
+++ b/web/e2e/onboarding-wizard.spec.ts
@@ -336,8 +336,9 @@ test('新建项目 create 模式：首步项目名 → create+bootstrap', async 
 
   await page.getByTestId('onboarding-project-name').fill('中国象棋')
   await page.getByTestId('onboarding-next').click()
-  await expect(page.getByTestId('onboarding-language-zh-CN')).toBeVisible()
-  await page.getByTestId('onboarding-next').click()
+  // createProject skips language: project name → overview
+  await expect(page.getByTestId('onboarding-language-zh-CN')).toHaveCount(0)
+  await expect(page.getByTestId('onboarding-overview-agents')).toBeVisible()
   await page.getByTestId('onboarding-next').click()
   await page.getByTestId('onboarding-next').click()
   await fillOpenCodeAuth(page, 'sk-create-e2e')

--- a/web/src/components/onboarding/OnboardingWizard.test.ts
+++ b/web/src/components/onboarding/OnboardingWizard.test.ts
@@ -308,8 +308,8 @@ describe('OnboardingWizard', () => {
     await wrapper.find('[data-testid="onboarding-project-name"]').setValue('支付中台')
     await wrapper.find('[data-testid="onboarding-next"]').trigger('click')
     await nextTick()
-    // language → overview → acp → apiKey
-    for (let i = 0; i < 3; i++) {
+    // overview → acp → apiKey (no language step in createProject)
+    for (let i = 0; i < 2; i++) {
       await wrapper.find('[data-testid="onboarding-next"]').trigger('click')
       await nextTick()
     }
@@ -363,10 +363,28 @@ describe('OnboardingWizard', () => {
     await wrapper.find('[data-testid="onboarding-project-name"]').setValue('支付中台')
     await wrapper.find('[data-testid="onboarding-next"]').trigger('click')
     await nextTick()
-    await wrapper.find('[data-testid="onboarding-next"]').trigger('click')
-    await nextTick()
+    // projectName → overview directly (no language step)
     expect(wrapper.find('[data-testid="onboarding-overview-agents"]').text()).toBe(
       'pages.onboarding.overview.agentsListDerived',
     )
+  })
+
+  it('createProject skips language step and does not overwrite approving-locale (g2.1)', async () => {
+    localStorage.setItem('approving-locale', 'zh-CN')
+    const { locale } = await import('@/lib/shared/locale')
+    locale.value = 'zh-CN'
+    vi.stubGlobal('navigator', { language: 'en-US' })
+
+    const wrapper = await mountWizard({ mode: 'createProject', projectId: '' })
+    expect(wrapper.find('[data-testid="onboarding-language-zh-CN"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="onboarding-project-name"]').exists()).toBe(true)
+    expect(localStorage.getItem('approving-locale')).toBe('zh-CN')
+    expect(locale.value).toBe('zh-CN')
+
+    await wrapper.find('[data-testid="onboarding-later"]').trigger('click')
+    await nextTick()
+    expect(localStorage.getItem('approving-locale')).toBe('zh-CN')
+    expect(locale.value).toBe('zh-CN')
+    vi.unstubAllGlobals()
   })
 })

--- a/web/src/components/onboarding/OnboardingWizard.vue
+++ b/web/src/components/onboarding/OnboardingWizard.vue
@@ -152,8 +152,13 @@ watch(
   () => props.open,
   (open) => {
     if (open) {
-      draft.value = freshOnboardingDraft()
-      void setLocale(draft.value.language)
+      const mode = props.mode || 'firstInstall'
+      const inheritAppLocale = mode === 'createProject'
+      draft.value = freshOnboardingDraft({ inheritAppLocale })
+      // createProject must not overwrite the user's saved locale with browser/OS.
+      if (!inheritAppLocale) {
+        void setLocale(draft.value.language)
+      }
       creating.value = false
       createError.value = ''
       phase.value = 'wizard'

--- a/web/src/lib/pm/onboardingWizard.test.ts
+++ b/web/src/lib/pm/onboardingWizard.test.ts
@@ -27,6 +27,7 @@ import {
 } from './onboardingWizard'
 import { i18n } from '@/lib/shared/i18n'
 import { loadLocaleMessages } from '@/lib/shared/loadLocaleMessages'
+import { locale } from '@/lib/shared/locale'
 
 beforeAll(async () => {
   const [zh, en] = await Promise.all([loadLocaleMessages('zh-CN'), loadLocaleMessages('en')])
@@ -38,6 +39,7 @@ describe('onboardingWizard', () => {
   beforeEach(() => {
     localStorage.clear()
     i18n.global.locale.value = 'zh-CN'
+    locale.value = 'zh-CN'
   })
 
   it('starts with language and defaults it from the system locale', () => {
@@ -203,7 +205,26 @@ describe('onboardingWizard', () => {
     expect(deriveOnboardingAgentNames(DEFAULT_PROJECT_ID, 'ignored')).toEqual([...ONBOARDING_AGENT_NAMES])
     expect(deriveOnboardingAgentNames('p1', '支付中台')[0]).toBe('支付中台AI技术产品')
     expect(onboardingStepsForMode('createProject')[0]?.id).toBe('projectName')
+    expect(onboardingStepsForMode('createProject').map((s) => s.id)).toEqual([
+      'projectName',
+      'overview',
+      'acp',
+      'apiKey',
+      'git',
+      'review',
+    ])
+    expect(onboardingStepsForMode('createProject').some((s) => s.id === 'language')).toBe(false)
     expect(onboardingStepsForMode('firstInstall')[0]?.id).toBe('language')
+  })
+
+  it('createProject draft inherits app locale, not browser language (g1.2)', () => {
+    locale.value = 'zh-CN'
+    i18n.global.locale.value = 'zh-CN'
+    vi.stubGlobal('navigator', { language: 'en-US' })
+    expect(detectSystemLocale()).toBe('en')
+    expect(freshOnboardingDraft().language).toBe('en')
+    expect(freshOnboardingDraft({ inheritAppLocale: true }).language).toBe('zh-CN')
+    vi.unstubAllGlobals()
   })
 
   it('auto-open keys on the default workflow, not on having been seen', () => {

--- a/web/src/lib/pm/onboardingWizard.ts
+++ b/web/src/lib/pm/onboardingWizard.ts
@@ -3,6 +3,7 @@ import { getRegionPolicy } from '@/lib/shared/regionPolicy'
 import type { GitCredentialType } from '@/lib/agent/gitCredentialAnalysis'
 import type { AppLocale } from '@/lib/shared/loadLocaleMessages'
 import type { ThemeName } from '@/lib/shared/theme'
+import { locale } from '@/lib/shared/locale'
 import { theme } from '@/lib/shared/theme'
 import { DEFAULT_OPENCODE_PROVIDER } from '@/lib/agent/openCodeProvider'
 import { normalizeAgentName, validateAgentName } from '@/lib/agent/agentIO'
@@ -74,9 +75,10 @@ export const ONBOARDING_STEPS: OnboardingStep[] = BASE_ONBOARDING_STEPS
 
 export function onboardingStepsForMode(mode: OnboardingMode): OnboardingStep[] {
   if (mode === 'createProject') {
+    // New project is not first-install: skip language/theme; inherit app prefs.
     return [
       { id: 'projectName', labelKey: 'pages.onboarding.steps.projectName' },
-      ...BASE_ONBOARDING_STEPS,
+      ...BASE_ONBOARDING_STEPS.filter((s) => s.id !== 'language'),
     ]
   }
   return BASE_ONBOARDING_STEPS
@@ -261,11 +263,15 @@ export function shouldAutoOpenOnboarding(
   return needsOnboarding(workflows, agents, projectId)
 }
 
-export function freshOnboardingDraft(): OnboardingDraft {
+/**
+ * @param opts.inheritAppLocale — createProject: seed from current app locale
+ *   (not browser/OS). firstInstall/retry keep detectSystemLocale().
+ */
+export function freshOnboardingDraft(opts?: { inheritAppLocale?: boolean }): OnboardingDraft {
   return {
     step: 0,
     projectName: '',
-    language: detectSystemLocale(),
+    language: opts?.inheritAppLocale ? locale.value : detectSystemLocale(),
     theme: theme.value,
     startPath: 'apiKey',
     acpBackend: APIKEY_BACKEND,


### PR DESCRIPTION
Skip language/theme step and avoid setLocale on open so new-project
setup inherits the user's saved preference instead of browser language.

Co-authored-by: Cursor <cursoragent@cursor.com>
