### PR TITLE
feat(web): add create workflow entry to home pipeline select

### DIFF
--- a/web/e2e/home-pipeline-select-create.spec.ts
+++ b/web/e2e/home-pipeline-select-create.spec.ts
@@ -1,0 +1,181 @@
+/**
+ * Temp browser acceptance for home pipeline select create footer.
+ * Harness: dashboard-home-chat.html
+ */
+import { expect, test, type Page } from '@playwright/test'
+import { mkdirSync } from 'node:fs'
+
+const SHOT = '/tmp/home-pipeline-select-create-shots'
+mkdirSync(SHOT, { recursive: true })
+
+function approveWorkflow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'wf-approve',
+    name: '自我迭代Ultra',
+    description: '开发前澄清 + 计划',
+    status: 'published',
+    version: 1,
+    updatedAt: '2026-08-10T12:00:00Z',
+    needsRepo: false,
+    showOnHome: true,
+    projectId: 'proj-1',
+    projectName: '综合项目组',
+    nodes: [
+      { id: 'in', type: 'input', label: '开始', position: { x: 0, y: 0 }, config: {} },
+      { id: 'ap', type: 'approve', label: '澄清', position: { x: 0, y: 0 }, config: {} },
+      { id: 'out', type: 'output', label: '结束', position: { x: 0, y: 0 }, config: {} },
+    ],
+    edges: [
+      { id: 'e1', source: 'in', target: 'ap' },
+      { id: 'e2', source: 'ap', target: 'out' },
+    ],
+    ...overrides,
+  }
+}
+
+async function mockApis(page: Page, opts: { workflows?: unknown[] } = {}) {
+  const workflows = opts.workflows ?? [
+    approveWorkflow(),
+    approveWorkflow({ id: 'wf-b', name: 'MiniInfra迭代' }),
+  ]
+
+  await page.route('**/api/workflows**', async (route) => {
+    const req = route.request()
+    const url = req.url()
+    if (req.method() === 'POST' && url.includes('/from-baseline')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(
+          approveWorkflow({ id: 'wf-new', name: '浏览器新建', projectName: '综合项目组' }),
+        ),
+      })
+      return
+    }
+    if (req.method() === 'POST' && url.includes('/runs')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 'run-home', status: 'queued' }),
+      })
+      return
+    }
+    if (req.method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(workflows),
+      })
+      return
+    }
+    await route.continue()
+  })
+
+  await page.route('**/api/projects**', async (route) => {
+    const path = new URL(route.request().url()).pathname
+    if (route.request().method() === 'GET' && (path === '/api/projects' || path.endsWith('/api/projects'))) {
+      // listProjects expects Project[], not { items, total }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ id: 'proj-1', name: '综合项目组' }]),
+      })
+      return
+    }
+    await route.continue()
+  })
+
+  await page.route('**/api/me**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ username: 'e2e', isAdmin: true }),
+    })
+  })
+
+  await page.route('**/api/config**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    })
+  })
+}
+
+test.describe('首页流水线下拉新建入口', () => {
+  test('打开下拉可见新建足栏，点击后打开基线弹窗；轨卡与 + 仍在', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 })
+    await mockApis(page)
+    await page.goto('/dashboard-home-chat.html')
+    await expect(page.getByTestId('dashboard-view')).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByTestId('home-new-workflow')).toBeVisible()
+    await expect(page.getByTestId('home-composer-plus')).toBeVisible()
+
+    await page.getByTestId('home-pipeline-select-trigger').click()
+    await expect(page.getByTestId('home-pipeline-select-panel')).toBeVisible()
+    const create = page.getByTestId('home-pipeline-select-create')
+    await expect(create).toBeVisible()
+    await expect(create).toContainText('新建工作流')
+    await expect(create).not.toHaveAttribute('aria-selected', /.*/)
+
+    await page.screenshot({
+      path: `${SHOT}/01-dropdown-with-create-footer.png`,
+      fullPage: false,
+    })
+
+    await create.click()
+    await expect(page.getByTestId('home-pipeline-select-panel')).toHaveCount(0)
+    await expect(page.getByTestId('home-create-form')).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByTestId('home-create-workflow-name')).toBeVisible()
+
+    await page.screenshot({
+      path: `${SHOT}/02-baseline-modal-from-select.png`,
+      fullPage: false,
+    })
+
+    // composer + still attachment (title present), rail card still present
+    await expect(page.getByTestId('home-new-workflow')).toBeVisible()
+    await expect(page.getByTestId('home-composer-plus')).toBeVisible()
+  })
+
+  test('零流水线时 trigger 可开，仅空状态+新建足栏', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 })
+    await mockApis(page, { workflows: [] })
+    await page.goto('/dashboard-home-chat.html')
+    await expect(page.getByTestId('dashboard-view')).toBeVisible({ timeout: 15_000 })
+
+    const trigger = page.getByTestId('home-pipeline-select-trigger')
+    await expect(trigger).toBeEnabled()
+    await trigger.click()
+    await expect(page.getByTestId('home-pipeline-select-panel')).toBeVisible()
+    await expect(page.getByTestId('home-pipeline-select-empty')).toBeVisible()
+    await expect(page.getByTestId('home-pipeline-select-create')).toBeVisible()
+
+    await page.screenshot({
+      path: `${SHOT}/03-empty-pipelines-create-only.png`,
+      fullPage: false,
+    })
+  })
+
+  test('无匹配搜索仍显示空状态与新建足栏；键盘落到新建后 Enter 打开弹窗', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 })
+    await mockApis(page)
+    await page.goto('/dashboard-home-chat.html')
+    await expect(page.getByTestId('dashboard-view')).toBeVisible({ timeout: 15_000 })
+
+    await page.getByTestId('home-pipeline-select-trigger').click()
+    const search = page.getByTestId('home-pipeline-select-search')
+    await search.fill('zzzz-no-match')
+    await expect(page.getByTestId('home-pipeline-select-empty')).toBeVisible()
+    await expect(page.getByTestId('home-pipeline-select-create')).toBeVisible()
+
+    await page.screenshot({
+      path: `${SHOT}/04-no-match-still-create.png`,
+      fullPage: false,
+    })
+
+    await search.press('Enter')
+    await expect(page.getByTestId('home-pipeline-select-panel')).toHaveCount(0)
+    await expect(page.getByTestId('home-create-form')).toBeVisible({ timeout: 5_000 })
+  })
+})

--- a/web/src/components/dashboard/HomePipelineSelect.test.ts
+++ b/web/src/components/dashboard/HomePipelineSelect.test.ts
@@ -217,6 +217,128 @@ describe('HomePipelineSelect', () => {
     search.dispatchEvent(new Event('input'))
     await flushPromises()
     expect(document.querySelector('[data-testid="home-pipeline-select-empty"]')).toBeTruthy()
+    // plan g1.3 — empty search still shows create footer
+    expect(document.querySelector('[data-testid="home-pipeline-select-create"]')).toBeTruthy()
+    wrapper.unmount()
+  })
+
+  // plan g1.1 / g3.1 / g3.3 — sticky create footer with addCard copy
+  it('renders a pinned create footer with 新建工作流 under the option list', async () => {
+    const wrapper = mountSelect({})
+    await flushPromises()
+    await wrapper.get('[data-testid="home-pipeline-select-trigger"]').trigger('click')
+    await flushPromises()
+    const create = document.querySelector(
+      '[data-testid="home-pipeline-select-create"]',
+    ) as HTMLElement | null
+    expect(create).toBeTruthy()
+    expect(create!.textContent).toContain('新建工作流')
+    expect(create!.getAttribute('aria-selected')).toBeNull()
+    expect(create!.classList.contains('home-pipeline-select__opt--current')).toBe(false)
+    const panel = document.querySelector('[data-testid="home-pipeline-select-panel"]') as HTMLElement
+    expect(panel.lastElementChild).toBe(create)
+    wrapper.unmount()
+  })
+
+  // plan g2.1 / g3.1 — click create emits create and closes panel
+  it('emits create and closes the panel when the footer is clicked', async () => {
+    const wrapper = mountSelect({})
+    await flushPromises()
+    await wrapper.get('[data-testid="home-pipeline-select-trigger"]').trigger('click')
+    await flushPromises()
+    const create = document.querySelector(
+      '[data-testid="home-pipeline-select-create"]',
+    ) as HTMLButtonElement
+    create.click()
+    await flushPromises()
+    expect(wrapper.emitted('create')).toBeTruthy()
+    expect(wrapper.emitted('create')!.length).toBe(1)
+    expect(document.querySelector('[data-testid="home-pipeline-select-panel"]')).toBeNull()
+    wrapper.unmount()
+  })
+
+  // plan g1.3 / g3.1 — zero pipelines: trigger opens create-only panel
+  it('opens a create-only panel when pipelines is empty and not disabled', async () => {
+    const wrapper = mountSelect({ pipelines: [], modelValue: '' })
+    await flushPromises()
+    const trigger = wrapper.get('[data-testid="home-pipeline-select-trigger"]')
+    expect((trigger.element as HTMLButtonElement).disabled).toBe(false)
+    await trigger.trigger('click')
+    await flushPromises()
+    expect(document.querySelector('[data-testid="home-pipeline-select-panel"]')).toBeTruthy()
+    expect(document.querySelector('[data-testid="home-pipeline-select-empty"]')).toBeTruthy()
+    expect(document.querySelector('[data-testid="home-pipeline-select-create"]')).toBeTruthy()
+    wrapper.unmount()
+  })
+
+  it('keeps the trigger disabled while disabled prop is true (sending)', async () => {
+    const wrapper = mountSelect({ pipelines: [], modelValue: '', disabled: true })
+    await flushPromises()
+    expect(
+      (wrapper.get('[data-testid="home-pipeline-select-trigger"]').element as HTMLButtonElement)
+        .disabled,
+    ).toBe(true)
+    await wrapper.get('[data-testid="home-pipeline-select-trigger"]').trigger('click')
+    await flushPromises()
+    expect(document.querySelector('[data-testid="home-pipeline-select-panel"]')).toBeNull()
+    wrapper.unmount()
+  })
+
+  // plan g1.2 / g3.1 — ArrowDown from last option lands on create; Enter emits create
+  it('moves keyboard highlight onto create after the last option and Enter emits create', async () => {
+    const wrapper = mountSelect({})
+    await flushPromises()
+    await wrapper.get('[data-testid="home-pipeline-select-trigger"]').trigger('click')
+    await flushPromises()
+    const search = document.querySelector(
+      '[data-testid="home-pipeline-select-search"]',
+    ) as HTMLInputElement
+    // open sets activeIndex to selected (0); ArrowDown → 1 (wf-b); ArrowDown → create
+    search.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+    search.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+    await flushPromises()
+    const create = document.querySelector(
+      '[data-testid="home-pipeline-select-create"]',
+    ) as HTMLElement
+    expect(create.classList.contains('home-pipeline-select__create--active')).toBe(true)
+    search.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await flushPromises()
+    expect(wrapper.emitted('create')).toBeTruthy()
+    expect(document.querySelector('[data-testid="home-pipeline-select-panel"]')).toBeNull()
+    wrapper.unmount()
+  })
+
+  // plan g1.2 — no matches: Enter triggers create
+  it('triggers create on Enter when search has no matches', async () => {
+    const wrapper = mountSelect({})
+    await flushPromises()
+    await wrapper.get('[data-testid="home-pipeline-select-trigger"]').trigger('click')
+    await flushPromises()
+    const search = document.querySelector(
+      '[data-testid="home-pipeline-select-search"]',
+    ) as HTMLInputElement
+    search.value = 'zzzz-no-match'
+    search.dispatchEvent(new Event('input'))
+    await flushPromises()
+    search.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await flushPromises()
+    expect(wrapper.emitted('create')).toBeTruthy()
+    wrapper.unmount()
+  })
+
+  // plan g1.2 — Escape only closes the panel
+  it('closes the panel on Escape without emitting create', async () => {
+    const wrapper = mountSelect({})
+    await flushPromises()
+    await wrapper.get('[data-testid="home-pipeline-select-trigger"]').trigger('click')
+    await flushPromises()
+    const search = document.querySelector(
+      '[data-testid="home-pipeline-select-search"]',
+    ) as HTMLInputElement
+    search.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await flushPromises()
+    expect(document.querySelector('[data-testid="home-pipeline-select-panel"]')).toBeNull()
+    expect(wrapper.emitted('create')).toBeFalsy()
     wrapper.unmount()
   })
 })

--- a/web/src/components/dashboard/HomePipelineSelect.vue
+++ b/web/src/components/dashboard/HomePipelineSelect.vue
@@ -15,6 +15,7 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   (e: 'update:modelValue', v: string): void
+  (e: 'create'): void
 }>()
 
 const { t } = useI18n()
@@ -51,6 +52,10 @@ const filtered = computed(() => {
       p.name.toLowerCase().includes(q) || (p.projectName || '').toLowerCase().includes(q),
   )
 })
+
+/** Create footer is the last keyboard target (index === filtered.length). */
+const createIndex = computed(() => filtered.value.length)
+const createActive = computed(() => activeIndex.value >= createIndex.value)
 
 function escapeHtml(s: string): string {
   return s.replace(/[&<>"']/g, (c) =>
@@ -101,11 +106,12 @@ function onScrollOrResize() {
 }
 
 async function openPanel() {
-  if (props.disabled || !props.pipelines.length) return
+  // plan g1.3 — empty pipelines still open (create-only panel); sending disables via prop
+  if (props.disabled) return
   open.value = true
   search.value = ''
   const idx = props.pipelines.findIndex((p) => p.id === props.modelValue)
-  activeIndex.value = Math.max(0, idx)
+  activeIndex.value = props.pipelines.length ? Math.max(0, idx) : createIndex.value
   await nextTick()
   placePanelBelow()
   searchInput.value?.focus()
@@ -118,7 +124,7 @@ function closePanel() {
 
 function togglePanel(e: MouseEvent) {
   e.stopPropagation()
-  if (props.disabled || !props.pipelines.length) return
+  if (props.disabled) return
   if (open.value) closePanel()
   else void openPanel()
 }
@@ -126,6 +132,13 @@ function togglePanel(e: MouseEvent) {
 function choose(id: string) {
   emit('update:modelValue', id)
   closePanel()
+  trigger.value?.focus()
+}
+
+/** plan g2.1 — emit create; close panel so Dashboard can open HomeCreateBaselineModal */
+function emitCreate() {
+  closePanel()
+  emit('create')
   trigger.value?.focus()
 }
 
@@ -137,11 +150,13 @@ function onDocClick(e: MouseEvent) {
 }
 
 function onSearchInput() {
-  activeIndex.value = 0
+  // Prefer first match; if none, land on create footer (plan g1.2 / g1.3)
+  activeIndex.value = filtered.value.length ? 0 : createIndex.value
 }
 
 function onSearchKeydown(e: KeyboardEvent) {
   const items = filtered.value
+  const maxIdx = createIndex.value // create footer
   if (e.key === 'Escape') {
     e.preventDefault()
     closePanel()
@@ -150,25 +165,35 @@ function onSearchKeydown(e: KeyboardEvent) {
   }
   if (e.key === 'ArrowDown') {
     e.preventDefault()
-    if (!items.length) return
-    activeIndex.value = (activeIndex.value + 1) % items.length
+    if (!items.length) {
+      activeIndex.value = maxIdx
+      return
+    }
+    activeIndex.value = Math.min(activeIndex.value + 1, maxIdx)
     return
   }
   if (e.key === 'ArrowUp') {
     e.preventDefault()
-    if (!items.length) return
-    activeIndex.value = (activeIndex.value - 1 + items.length) % items.length
+    if (!items.length) {
+      activeIndex.value = maxIdx
+      return
+    }
+    activeIndex.value = Math.max(0, activeIndex.value - 1)
     return
   }
   if (e.key === 'Enter') {
     e.preventDefault()
-    if (!items.length) return
+    // plan g1.2 — no matches: Enter triggers create; last arrow target is create
+    if (!items.length || activeIndex.value >= items.length) {
+      emitCreate()
+      return
+    }
     choose(items[activeIndex.value].id)
   }
 }
 
 function onTriggerKeydown(e: KeyboardEvent) {
-  if (props.disabled || !props.pipelines.length) return
+  if (props.disabled) return
   if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
     e.preventDefault()
     if (!open.value) void openPanel()
@@ -182,7 +207,8 @@ function onTriggerKeydown(e: KeyboardEvent) {
 watch(
   () => filtered.value.length,
   (len) => {
-    if (activeIndex.value >= len) activeIndex.value = Math.max(0, len - 1)
+    // Allow activeIndex === len (create footer)
+    if (activeIndex.value > len) activeIndex.value = len
   },
 )
 
@@ -211,7 +237,7 @@ onBeforeUnmount(() => {
       type="button"
       class="home-pipeline-select__trigger"
       data-testid="home-pipeline-select-trigger"
-      :disabled="disabled || !pipelines.length"
+      :disabled="disabled"
       aria-haspopup="listbox"
       :aria-expanded="open"
       aria-controls="home-pipeline-select-panel"
@@ -289,6 +315,17 @@ onBeforeUnmount(() => {
             {{ t('common.empty.noMatchingPipelines') }}
           </div>
         </div>
+        <!-- plan g1.1 — sticky create footer; not a selectable pipeline option -->
+        <button
+          type="button"
+          class="home-pipeline-select__create"
+          data-testid="home-pipeline-select-create"
+          :class="{ 'home-pipeline-select__create--active': createActive }"
+          @click.stop="emitCreate"
+        >
+          <span class="home-pipeline-select__create-plus" aria-hidden="true">+</span>
+          <span>{{ t('pages.dashboard.create.addCard') }}</span>
+        </button>
       </div>
     </Teleport>
   </div>
@@ -347,7 +384,8 @@ onBeforeUnmount(() => {
 
 /* plan g1.1 — panel opens below trigger (top), never bottom/upward.
    Teleported panel uses fixed coords from placePanelBelow(); keep top as
-   the documented downward default if styles apply without inline overrides. */
+   the documented downward default if styles apply without inline overrides.
+   Flex column so create footer stays pinned while the list scrolls. */
 .home-pipeline-select__panel {
   position: fixed;
   left: 0;
@@ -359,11 +397,15 @@ onBeforeUnmount(() => {
   background: rgb(var(--c-elevated));
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
   z-index: 60;
+  display: flex;
+  flex-direction: column;
+  max-height: min(360px, calc(100vh - 24px));
 }
 
 .home-pipeline-select__search-wrap {
   padding: 8px;
   border-bottom: 1px solid rgb(var(--c-line) / 0.7);
+  flex-shrink: 0;
 }
 
 .home-pipeline-select__search {
@@ -390,6 +432,8 @@ onBeforeUnmount(() => {
   max-height: 220px;
   overflow: auto;
   padding: 4px;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .home-pipeline-select__opt {
@@ -443,6 +487,42 @@ onBeforeUnmount(() => {
   text-align: center;
   color: rgb(var(--c-txt3));
   font-size: 12px;
+}
+
+/* plan g1.1 — divider + plus/label; pinned under scrollable list; no aria-selected */
+.home-pipeline-select__create {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  flex-shrink: 0;
+  border: 0;
+  border-top: 1px solid rgb(var(--c-line) / 0.7);
+  background: transparent;
+  color: rgb(var(--c-txt));
+  padding: 10px 14px;
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.home-pipeline-select__create:hover,
+.home-pipeline-select__create--active {
+  background: rgb(var(--c-accent) / 0.1);
+}
+
+.home-pipeline-select__create-plus {
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+  border: 1px solid rgb(var(--c-line));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  line-height: 1;
+  color: rgb(var(--c-txt2));
+  flex-shrink: 0;
 }
 
 @media (max-width: 520px) {

--- a/web/src/views/DashboardView.test.ts
+++ b/web/src/views/DashboardView.test.ts
@@ -559,13 +559,18 @@ describe('DashboardView home composer', () => {
     wrapper.unmount()
   })
 
-  it('disables pipeline combobox when no pipelines are available', async () => {
+  // plan g1.3 / g3.2 — empty list: trigger stays openable for create (not disabled)
+  it('keeps pipeline combobox openable when no pipelines are available', async () => {
     mocks.listWorkflows.mockResolvedValue([])
     const wrapper = mountDashboard()
     await flushPromises()
     const triggerEl = wrapper.get('[data-testid="home-pipeline-select-trigger"]').element as HTMLButtonElement
-    expect(triggerEl.disabled).toBe(true)
+    expect(triggerEl.disabled).toBe(false)
     expect(wrapper.get('[data-testid="home-pipeline-select-trigger"]').text()).toContain('未选择流水线')
+    await wrapper.get('[data-testid="home-pipeline-select-trigger"]').trigger('click')
+    await flushPromises()
+    expect(teleportedExists('home-pipeline-select-panel')).toBe(true)
+    expect(teleportedExists('home-pipeline-select-create')).toBe(true)
     wrapper.unmount()
   })
 
@@ -599,7 +604,11 @@ describe('DashboardView home composer', () => {
     const empty = wrapper.get('[data-testid="home-pipelines-empty"]')
     expect(empty.text()).toContain('首页可见')
     expect(empty.text()).not.toContain('丢失')
-    expect(wrapper.get('[data-testid="home-pipeline-select-trigger"]').element).toHaveProperty('disabled', true)
+    // plan g1.3 — zero visible pipelines: select still openable for create
+    expect(wrapper.get('[data-testid="home-pipeline-select-trigger"]').element).toHaveProperty(
+      'disabled',
+      false,
+    )
     wrapper.unmount()
   })
 
@@ -1053,6 +1062,61 @@ describe('DashboardView home composer', () => {
     expect(wrapper.get('[data-testid="home-create-error"]').text()).toContain('create failed')
     expect(mocks.listWorkflows.mock.calls.length).toBe(callsAfterMount)
     expect(wrapper.find('[data-testid="home-pipeline-card-wf-ap"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  // plan g2.1 / g3.2 — dropdown create opens the same HomeCreateBaselineModal
+  it('opens the baseline modal from the pipeline select create footer', async () => {
+    const wrapper = mountDashboard()
+    await flushPromises()
+    await wrapper.get('[data-testid="home-pipeline-select-trigger"]').trigger('click')
+    await flushPromises()
+    expect(teleportedExists('home-pipeline-select-create')).toBe(true)
+    await teleported('home-pipeline-select-create').trigger('click')
+    await flushPromises()
+    expect(teleportedExists('home-pipeline-select-panel')).toBe(false)
+    expect(wrapper.find('[data-testid="home-create-workflow-name"]').exists()).toBe(true)
+    // plan g2.2 — rail card and composer + unchanged
+    expect(wrapper.find('[data-testid="home-new-workflow"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="home-composer-plus"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  // plan g3.2 — empty list can create from dropdown; composer + still attaches files only
+  it('allows create from dropdown when home pipelines are empty without changing plus', async () => {
+    mocks.listWorkflows.mockResolvedValue([])
+    const wrapper = mountDashboard()
+    await flushPromises()
+    await wrapper.get('[data-testid="home-pipeline-select-trigger"]').trigger('click')
+    await flushPromises()
+    await teleported('home-pipeline-select-create').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="home-create-workflow-name"]').exists()).toBe(true)
+    expect(wrapper.get('[data-testid="home-composer-plus"]').attributes('title')).toBeTruthy()
+    wrapper.unmount()
+  })
+
+  // plan g2.1 / g3.2 — select create success path shares reloadAfterCreate
+  it('selects the new pipeline after create started from the dropdown footer', async () => {
+    const created: Workflow = { ...approveWf, id: 'wf-from-select', name: '下拉新建' }
+    mocks.createWorkflowFromBaseline.mockResolvedValue(created)
+    const wrapper = mountDashboard()
+    await flushPromises()
+    await wrapper.get('[data-testid="home-pipeline-select-trigger"]').trigger('click')
+    await flushPromises()
+    await teleported('home-pipeline-select-create').trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-testid="home-create-workflow-name"]').setValue('下拉新建')
+    const url = wrapper.find('input[placeholder*="https"]')
+    await url.setValue('https://github.com/org/from-select')
+    await flushPromises()
+    mocks.listWorkflows.mockResolvedValue([approveWf, created])
+    await wrapper.get('[data-testid="home-create-submit"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="home-pipeline-card-wf-from-select"]').exists()).toBe(true)
+    expect(wrapper.get('[data-testid="home-pipeline-card-wf-from-select"]').classes()).toContain(
+      'home-shell__card--selected',
+    )
     wrapper.unmount()
   })
 })

--- a/web/src/views/DashboardView.vue
+++ b/web/src/views/DashboardView.vue
@@ -253,6 +253,11 @@ function openCreateBaseline(e?: Event) {
   createBaselineOpen.value = true
 }
 
+/** plan g2.1 — HomePipelineSelect create footer → same baseline modal as rail card */
+function onCreateFromSelect() {
+  openCreateBaseline()
+}
+
 async function onBaselineCreated(payload?: { id?: string }) {
   createBaselineOpen.value = false
   await reloadAfterCreate(payload?.id)
@@ -595,8 +600,9 @@ onBeforeUnmount(() => {
             <HomePipelineSelect
               :pipelines="pipelines"
               :model-value="selectedId"
-              :disabled="!pipelines.length || sending"
+              :disabled="sending"
               @update:model-value="selectPipeline"
+              @create="onCreateFromSelect"
             />
             <HomePrioritySelect
               :model-value="launchPriority"


### PR DESCRIPTION
## Summary
- Add a pinned **New workflow** footer in `HomePipelineSelect` (`data-testid=home-pipeline-select-create`) that emits `create` and reuses `HomeCreateBaselineModal`.
- Keep the rail card (`home-new-workflow`) and composer `+` (attach image) unchanged; empty pipeline lists can still open the dropdown to create.
- Cover footer, keyboard (ArrowDown / Enter / Escape), empty list, and modal wiring with Vitest plus Playwright (`web/e2e/home-pipeline-select-create.spec.ts`).

## Test plan
- [ ] Open the home pipeline dropdown and confirm the footer stays pinned while the list scrolls.
- [ ] Click the footer: panel closes and `HomeCreateBaselineModal` opens; successful create selects the new pipeline.
- [ ] With zero pipelines (not sending), the trigger opens a panel with empty state + create footer.
- [ ] Search with no matches: Enter triggers create; Escape only closes the panel.
- [ ] Rail **New workflow** and composer **+** still behave as before.