### PR TITLE
fix(web): always show GitHub/GitLab/SSH choices on Agent Git step

### DIFF
--- a/web/e2e/agent-create-wizard.spec.ts
+++ b/web/e2e/agent-create-wizard.spec.ts
@@ -99,7 +99,7 @@ test('新建 Agent 五步向导浏览器验收', async ({ page }) => {
   await expect(page.locator('.wiz-rail')).toHaveCount(0)
 })
 
-test('向导能取到项目共享 Git Token 时 Git 步不出现引导（g2.1）', async ({ page }) => {
+test('向导能取到项目共享 Git Token 时 Git 步仍出现三选（plan g3.2）', async ({ page }) => {
   await page.route('**/api/**', async (route) => {
     if (!new URL(route.request().url()).pathname.startsWith('/api/')) {
       await route.continue()
@@ -131,7 +131,16 @@ test('向导能取到项目共享 Git Token 时 Git 步不出现引导（g2.1）
   await page.getByRole('button', { name: /^下一步/ }).click()
   await page.getByRole('button', { name: /^跳过/ }).click()
   await expect(page.locator('.sec-head h3')).toHaveText('Git')
-  await expect(page.locator('[data-test="git-guide"]')).toHaveCount(0)
-  await expect(page.locator('[data-test="git-choice-github_https"]')).toHaveCount(0)
+  await expect(page.locator('[data-test="git-guide"]')).toHaveCount(1)
+  await expect(page.locator('[data-test="git-choice-github_https"]')).toBeVisible()
+  await expect(page.locator('[data-test="git-choice-gitlab_https"]')).toBeVisible()
+  await expect(page.locator('[data-test="git-choice-ssh"]')).toBeVisible()
+  await expect(page.locator('[data-test="git-choice-gitlab_https"]')).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  )
   await expect(page.getByText('调整类型')).toHaveCount(0)
+  await expect(page.getByText(/预选类型/)).toBeVisible()
+  await page.locator('[data-test="git-choice-ssh"]').click()
+  await expect(page.locator('[data-test="git-choice-ssh"]')).toHaveAttribute('aria-pressed', 'true')
 })

--- a/web/src/components/agent/AgentCreateWizard.test.ts
+++ b/web/src/components/agent/AgentCreateWizard.test.ts
@@ -260,7 +260,7 @@ describe('AgentCreateWizard 5-step IA', () => {
     wrapper.unmount()
   })
 
-  it('Git 步在共享 Token 存在时不渲染引导（g2.1）', async () => {
+  it('Git 步在共享 Token 存在时仍渲染三选并可改选（plan g1.2 / g3.2）', async () => {
     getProjectSharedAgentConfig.mockResolvedValue({
       projectId: 'proj-shared',
       env: { GITLAB_TOKEN: '${vars.gitlab_pat}' },
@@ -281,10 +281,26 @@ describe('AgentCreateWizard 5-step IA', () => {
       expect(getProjectSharedAgentConfig).toHaveBeenCalledWith('proj-shared')
     })
     await vi.waitFor(() => {
-      expect(document.body.querySelector('[data-test="git-guide"]')).toBeFalsy()
+      expect(document.body.querySelector('[data-test="git-guide"]')).toBeTruthy()
+      expect(document.body.querySelector('[data-test="git-choice-github_https"]')).toBeTruthy()
+      expect(document.body.querySelector('[data-test="git-choice-gitlab_https"]')).toBeTruthy()
+      expect(document.body.querySelector('[data-test="git-choice-ssh"]')).toBeTruthy()
     })
     expect(document.body.textContent).toContain('Git')
+    expect(document.body.textContent).toContain('预选类型')
+    expect(document.body.textContent).toContain('仍可改选或跳过')
+    expect(document.body.textContent).not.toContain('无需选择')
     expect(document.body.textContent).not.toContain('调整类型')
+
+    const gitlab = document.body.querySelector(
+      '[data-test="git-choice-gitlab_https"]',
+    ) as HTMLButtonElement
+    expect(gitlab.getAttribute('aria-pressed')).toBe('true')
+
+    const ssh = document.body.querySelector('[data-test="git-choice-ssh"]') as HTMLButtonElement
+    ssh.click()
+    await wrapper.vm.$nextTick()
+    expect(ssh.getAttribute('aria-pressed')).toBe('true')
     wrapper.unmount()
   })
 

--- a/web/src/components/agent/AgentEnvPanel.inherited.test.ts
+++ b/web/src/components/agent/AgentEnvPanel.inherited.test.ts
@@ -50,7 +50,7 @@ describe('AgentEnvPanel inherited Git env', () => {
     getProjectSharedAgentConfig.mockReset()
   })
 
-  it('agent 上下文且已绑定项目时读取共享 env，引导因继承 Token 隐藏（g2.1）', async () => {
+  it('agent 上下文且已绑定项目时读取共享 env，引导仍因继承 Token 可见并可预选（plan g3.3）', async () => {
     getProjectSharedAgentConfig.mockResolvedValue({
       projectId: 'proj-1',
       env: { GITLAB_TOKEN: '${vars.gitlab_pat}' },
@@ -63,7 +63,10 @@ describe('AgentEnvPanel inherited Git env', () => {
       expect(getProjectSharedAgentConfig).toHaveBeenCalledWith('proj-1')
     })
     await vi.waitFor(() => {
-      expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(false)
+      expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="git-choice-gitlab_https"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="git-choice-github_https"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="git-choice-ssh"]').exists()).toBe(true)
     })
     wrapper.unmount()
   })

--- a/web/src/components/agent/AgentGitGuide.test.ts
+++ b/web/src/components/agent/AgentGitGuide.test.ts
@@ -43,7 +43,7 @@ function mountGuide(
 }
 
 describe('AgentGitGuide', () => {
-  it('无 Token 时平铺 GitHub / GitLab / SSH，点击立即写入类型（g1.1）', async () => {
+  it('无 Token 时平铺 GitHub / GitLab / SSH，点击立即写入类型（g1.1 / plan g3.1）', async () => {
     const wrapper = mountGuide([])
     expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(true)
     expect(wrapper.get('[data-test="git-choice-github_https"]').text()).toContain('GitHub')
@@ -72,55 +72,66 @@ describe('AgentGitGuide', () => {
     expect(wrapper.emitted('help')).toEqual([['git']])
   })
 
-  it('本地任一 Git Token 隐藏整块引导（g1.2）', () => {
+  it('本地任一 Git Token 仍渲染三选并可改选（plan g1.1 / g1.2 / g3.2）', async () => {
     const wrapper = mountGuide([{ k: 'GITLAB_TOKEN', v: '${vars.gitlab_pat}' }])
-    expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(false)
-    expect(wrapper.text()).not.toContain('GitHub')
-    expect(wrapper.text()).not.toContain('添加推荐变量')
+    expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="git-choice-github_https"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="git-choice-gitlab_https"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="git-choice-ssh"]').exists()).toBe(true)
+    expect(wrapper.emitted('update:credentialType')).toEqual([['gitlab_https']])
+
+    await wrapper.get('[data-test="git-choice-ssh"]').trigger('click')
+    expect(wrapper.emitted('update:credentialType')).toEqual([['gitlab_https'], ['ssh']])
   })
 
-  it('仅继承 Token 时隐藏引导；空本地不覆盖继承（g1.2 / g2.1）', () => {
+  it('仅继承 Token 时仍渲染引导并预选（plan g1.2 / g3.2）', () => {
     const wrapper = mountGuide([], {
       inheritedEnv: { GITLAB_TOKEN: '${vars.gitlab_pat}' },
     })
-    expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="git-choice-gitlab_https"]').exists()).toBe(true)
+    expect(wrapper.emitted('update:credentialType')).toEqual([['gitlab_https']])
   })
 
-  it('仅 ACP API Key、没有 Git Token 时仍显示三选（g1.2）', () => {
+  it('仅 ACP API Key、没有 Git Token 时仍显示三选（plan g3.1）', () => {
     const wrapper = mountGuide([
       { k: 'APPROVING_CURSOR_API_KEY', v: 'sk-test' },
       { k: 'CURSOR_API_KEY', v: 'sk-alt' },
     ])
     expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(true)
     expect(wrapper.find('[data-test="git-choice-github_https"]').exists()).toBe(true)
-  })
-
-  it('隐藏时仅 GITLAB_TOKEN 且无类型则推断为 GitLab（g1.3）', () => {
-    const wrapper = mountGuide([], {
-      inheritedEnv: { GITLAB_TOKEN: '${vars.gitlab_pat}' },
-    })
-    expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(false)
-    expect(wrapper.emitted('update:credentialType')).toEqual([['gitlab_https']])
-  })
-
-  it('隐藏时用户已选类型不被推断覆盖（g1.3）', () => {
-    const wrapper = mountGuide([{ k: 'GITHUB_TOKEN', v: 'ghp-x' }], {
-      credentialType: 'ssh',
-    })
-    expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(false)
     expect(wrapper.emitted('update:credentialType')).toBeUndefined()
   })
 
-  it('多类 Git Token 且无已选类型时仍隐藏且不改写（g1.3）', () => {
+  it('仅一种 Token 且无类型则预选对应卡片（plan g1.2）', () => {
+    const wrapper = mountGuide([], {
+      inheritedEnv: { GITLAB_TOKEN: '${vars.gitlab_pat}' },
+    })
+    expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(true)
+    expect(wrapper.emitted('update:credentialType')).toEqual([['gitlab_https']])
+  })
+
+  it('用户已选类型不被 Token 推断覆盖（plan g1.2）', () => {
+    const wrapper = mountGuide([{ k: 'GITHUB_TOKEN', v: 'ghp-x' }], {
+      credentialType: 'ssh',
+    })
+    expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(true)
+    expect(wrapper.get('[data-test="git-choice-ssh"]').attributes('aria-pressed')).toBe('true')
+    expect(wrapper.emitted('update:credentialType')).toBeUndefined()
+  })
+
+  it('多类 Git Token 且无已选类型时仍可见且不擅自预选（plan g1.2）', () => {
     const wrapper = mountGuide([
       { k: 'GITHUB_TOKEN', v: 'ghp-x' },
       { k: 'GITLAB_TOKEN', v: 'glpat-x' },
     ])
-    expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="git-guide"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="git-choice-github_https"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="git-choice-gitlab_https"]').exists()).toBe(true)
     expect(wrapper.emitted('update:credentialType')).toBeUndefined()
   })
 
-  it('Studio 点选类型不写入 Git Token，也不出现补推荐变量（g1.2 / f5）', async () => {
+  it('Studio 点选类型不写入 Git Token，也不出现补推荐变量（plan g2.1 / g2.2）', async () => {
     const added: string[] = []
     const wrapper = mountGuide([], {
       allowTokenRecommend: false,

--- a/web/src/components/agent/AgentGitGuide.vue
+++ b/web/src/components/agent/AgentGitGuide.vue
@@ -3,7 +3,6 @@ import { computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import AppButton from '@/components/ui/AppButton.vue'
 import {
-  hasConfiguredGitToken,
   inferGitCredentialTypeFromTokens,
   type GitCredentialType,
   type GitEnv,
@@ -26,7 +25,7 @@ const props = defineProps<{
   credentialType?: GitCredentialType
   /** When false (Agent Studio / create wizards), skip injecting Git Token keys. Default true for shared config. */
   allowTokenRecommend?: boolean
-  /** Project shared Agent env used only for hide / infer (agent context). */
+  /** Project shared Agent env used only for preselect / infer (agent context). */
   inheritedEnv?: GitEnv
 }>()
 const emit = defineEmits<{
@@ -35,7 +34,6 @@ const emit = defineEmits<{
 }>()
 const { t } = useI18n()
 
-const hasGitToken = computed(() => hasConfiguredGitToken(props.env, props.inheritedEnv))
 const inferredType = computed(() => inferGitCredentialTypeFromTokens(props.env, props.inheritedEnv))
 const allowTokens = computed(() => props.allowTokenRecommend !== false)
 const showRecommend = computed(() => allowTokens.value && !!props.credentialType)
@@ -55,9 +53,10 @@ const recommendations: Record<GitCredentialType, { key: string; value: string }[
 }
 
 watch(
-  [hasGitToken, () => props.credentialType, inferredType],
-  ([hide, selected, inferred]) => {
-    if (!hide || selected || !inferred) return
+  [() => props.credentialType, inferredType],
+  ([selected, inferred]) => {
+    // Preselect only when a single token type can be inferred and the user has not chosen yet.
+    if (selected || !inferred) return
     emit('update:credentialType', inferred)
   },
   { immediate: true },
@@ -87,7 +86,6 @@ defineExpose({ isGitEnvKey })
 
 <template>
   <section
-    v-if="!hasGitToken"
     class="mb-4 overflow-hidden rounded-lg border border-line bg-surface shadow-sm"
     data-test="git-guide"
   >

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -2424,7 +2424,7 @@
           "meta": "Used as the default ACP for the PM and engineers. Pick a start path first — same as onboarding and New Agent."
         },
         "git": {
-          "meta": "Optional. Pick GitHub / GitLab / SSH; skip when a Git Token already exists (including project shared).",
+          "meta": "Optional. Pick GitHub / GitLab / SSH; an existing token preselects the type—you can still change it or skip.",
           "url": "Repository URL"
         },
         "mcp": {
@@ -2584,7 +2584,7 @@
           }
         },
         "git": {
-          "meta": "Pick GitHub / GitLab / SSH. Skip if a Git Token already exists locally or in project shared config."
+          "meta": "Pick GitHub / GitLab / SSH. An existing token preselects the type; you can still change it or skip, and configure later in Studio."
         },
         "env": {
           "meta": "Environment variables injected into the sandbox. Region keys are managed by the Agent step; secrets stay in the Agent config."

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -2424,7 +2424,7 @@
           "meta": "该配置用于 PM 及后续工程师的默认 ACP。先选启动方式，与安装引导、新建 Agent 相同。"
         },
         "git": {
-          "meta": "可选。点选 GitHub / GitLab / SSH；已有 Token（含项目共享）时本步无需选择。",
+          "meta": "可选。点选 GitHub / GitLab / SSH；已有 Token 时会预选类型，仍可改选或跳过。",
           "url": "仓库 URL"
         },
         "mcp": {
@@ -2584,7 +2584,7 @@
           }
         },
         "git": {
-          "meta": "点选 GitHub / GitLab / SSH 即可；本地或项目共享已有 Token 时无需选择。可跳过，之后在 Studio 再配。"
+          "meta": "点选 GitHub / GitLab / SSH 即可。已有 Token 时会预选类型，仍可改选或跳过，之后也可在 Studio 再配。"
         },
         "env": {
           "meta": "注入沙箱的环境变量。区域保留键由 Agent 步骤统一管理，密钥仅保存在 Agent 配置中。"


### PR DESCRIPTION
Stop hiding AgentGitGuide when a Git token exists so the create wizard
no longer shows a blank Git step; tokens only preselect the matching card.

Co-authored-by: Cursor <cursoragent@cursor.com>
