### PR TITLE
feat(web): move chat test to Agents second-level tab

### DIFF
--- a/web/e2e/project-detail.spec.ts
+++ b/web/e2e/project-detail.spec.ts
@@ -530,7 +530,7 @@ test.describe('ProjectDetailView 共享 Agent / 工作流变量面板布局', ()
     await expect(page.getByTestId('shared-agent-subtab-env')).toBeVisible()
     await expect(page.getByTestId('shared-agent-subtab-prompts')).toBeVisible()
     await expect(page.getByTestId('shared-agent-subtab-meta')).toBeVisible()
-    await expect(page.getByTestId('shared-agent-subtab-test')).toBeVisible()
+    await expect(page.getByTestId('shared-agent-subtab-test')).toHaveCount(0)
     await expect(page.getByTestId('shared-agent-subtab-data')).toHaveCount(0)
 
     await page.getByTestId('shared-agent-subtab-env').click()

--- a/web/src/components/project/ProjectAgentsPanel.test.ts
+++ b/web/src/components/project/ProjectAgentsPanel.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment happy-dom
+import { createI18n } from 'vue-i18n'
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import common from '@/locales/zh-CN/common.json'
+import pages from '@/locales/zh-CN/pages.json'
+import ProjectAgentsPanel from './ProjectAgentsPanel.vue'
+
+const apiMocks = vi.hoisted(() => ({
+  listAgents: vi.fn(),
+  createProjectSharedAgentTest: vi.fn(),
+}))
+
+vi.mock('@/lib/api/api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/api/api')>('@/lib/api/api')
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      listAgents: apiMocks.listAgents,
+      createProjectSharedAgentTest: apiMocks.createProjectSharedAgentTest,
+    },
+  }
+})
+
+async function mountPanel(projectId = 'proj-a', query: Record<string, string> = {}) {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'zh-CN',
+    messages: { 'zh-CN': { ...common, ...pages } },
+  })
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/', component: { template: '<div/>' } }],
+  })
+  await router.push({ path: '/', query })
+  await router.isReady()
+  return mount(ProjectAgentsPanel, {
+    props: { projectId },
+    global: {
+      plugins: [i18n, router],
+      stubs: {
+        Icon: true,
+        AgentStudioView: {
+          template: '<div data-testid="agents-studio-stub">studio</div>',
+        },
+        AgentChatTester: {
+          props: ['profile', 'homeProjectId', 'createTest'],
+          template: '<div data-testid="agents-chat-tester">{{ profile }}</div>',
+        },
+      },
+    },
+  })
+}
+
+describe('ProjectAgentsPanel second-level tabs (g1.1 / g1.2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    apiMocks.listAgents.mockResolvedValue([
+      { name: 'mine', projectId: 'proj-a' },
+      { name: 'other', projectId: 'proj-b' },
+    ])
+    apiMocks.createProjectSharedAgentTest.mockResolvedValue({ id: 1 })
+  })
+
+  it('shows meta | chat-test second-level tabs aligned with confirmed preview', async () => {
+    const wrapper = await mountPanel()
+    await flushPromises()
+    expect(wrapper.get('[data-testid="project-agents-subtab-meta"]').text()).toBe('元信息')
+    expect(wrapper.get('[data-testid="project-agents-subtab-test"]').text()).toBe('对话测试')
+    expect(wrapper.find('[data-testid="agents-studio-stub"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="agents-chat-tester"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('mounts AgentChatTester with current Agent via createProjectSharedAgentTest', async () => {
+    const wrapper = await mountPanel('proj-a', { agent: 'mine' })
+    await flushPromises()
+    await wrapper.get('[data-testid="project-agents-subtab-test"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="project-agents-chat-test"]').exists()).toBe(true)
+    expect(wrapper.get('[data-testid="agents-chat-tester"]').text()).toBe('mine')
+    const vm = wrapper.vm as unknown as {
+      createProjectContextTest: (p: string, payload: { repos?: unknown[] }) => Promise<unknown>
+    }
+    await vm.createProjectContextTest('mine', { repos: [{ name: 'r', url: 'https://x' }] })
+    expect(apiMocks.createProjectSharedAgentTest).toHaveBeenCalledWith('proj-a', {
+      agentName: 'mine',
+      repos: [{ name: 'r', url: 'https://x' }],
+    })
+    wrapper.unmount()
+  })
+
+  it('remounts tester when route agent changes (:key)', async () => {
+    apiMocks.listAgents.mockResolvedValue([
+      { name: 'alpha', projectId: 'proj-a' },
+      { name: 'beta', projectId: 'proj-a' },
+    ])
+    const wrapper = await mountPanel('proj-a', { agent: 'alpha' })
+    await flushPromises()
+    await wrapper.get('[data-testid="project-agents-subtab-test"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.get('[data-testid="agents-chat-tester"]').text()).toBe('alpha')
+    await wrapper.vm.$router.replace({ query: { agent: 'beta' } })
+    await flushPromises()
+    expect(wrapper.get('[data-testid="agents-chat-tester"]').text()).toBe('beta')
+    wrapper.unmount()
+  })
+
+  it('shows empty state when no project-bound agents', async () => {
+    apiMocks.listAgents.mockResolvedValue([{ name: 'other', projectId: 'proj-b' }])
+    const wrapper = await mountPanel('proj-a')
+    await flushPromises()
+    await wrapper.get('[data-testid="project-agents-subtab-test"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="project-agents-chat-test-empty"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="agents-chat-tester"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+})

--- a/web/src/components/project/ProjectAgentsPanel.vue
+++ b/web/src/components/project/ProjectAgentsPanel.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRoute } from 'vue-router'
+import Icon from '@/components/ui/Icon.vue'
+import AgentChatTester from '@/components/agent/AgentChatTester.vue'
+import AgentStudioView from '@/views/AgentStudioView.vue'
+import { api, type CreateAgentTestPayload, type SandboxView } from '@/lib/api/api'
+
+const props = defineProps<{ projectId: string }>()
+
+const { t } = useI18n()
+const route = useRoute()
+
+type AgentsSubTab = 'meta' | 'test'
+
+const subTab = ref<AgentsSubTab>('meta')
+const agents = ref<{ name: string; projectId?: string }[]>([])
+
+const projectAgents = computed(() =>
+  agents.value.filter((a) => a.projectId === props.projectId),
+)
+
+/** Current Agent from Studio URL sync, else first project-bound Agent. */
+const testProfile = computed(() => {
+  const q = typeof route.query.agent === 'string' ? route.query.agent.trim() : ''
+  if (q && projectAgents.value.some((a) => a.name === q)) return q
+  if (q && agents.value.length === 0) return q
+  return projectAgents.value[0]?.name || ''
+})
+
+const subTabs = computed(() => [
+  { k: 'meta' as const, l: t('pages.projectDetail.agents.metaTab') },
+  { k: 'test' as const, l: t('pages.projectDetail.agents.testTab') },
+])
+
+async function loadAgents() {
+  try {
+    const list = await api.listAgents()
+    agents.value = list.map((a) => ({ name: a.name, projectId: a.projectId }))
+  } catch {
+    agents.value = []
+  }
+}
+
+async function createProjectContextTest(
+  profile: string,
+  payload: CreateAgentTestPayload,
+): Promise<SandboxView> {
+  return api.createProjectSharedAgentTest(props.projectId, {
+    agentName: profile,
+    ...(payload.repos ? { repos: payload.repos } : {}),
+    ...(payload.repoUrl ? { repoUrl: payload.repoUrl } : {}),
+  })
+}
+
+watch(
+  () => props.projectId,
+  () => {
+    subTab.value = 'meta'
+    void loadAgents()
+  },
+)
+
+watch(subTab, (next) => {
+  if (next === 'test') void loadAgents()
+})
+
+onMounted(() => {
+  void loadAgents()
+})
+</script>
+
+<template>
+  <div
+    class="flex min-h-0 flex-1 flex-col"
+    data-testid="project-agents-panel"
+  >
+    <div
+      class="scroll-area flex shrink-0 gap-1 overflow-x-auto border-b border-line px-2"
+      data-testid="project-agents-subtabs"
+    >
+      <button
+        v-for="tabItem in subTabs"
+        :key="tabItem.k"
+        type="button"
+        class="shrink-0 whitespace-nowrap px-2.5 py-1.5 text-[12px] transition"
+        :class="
+          subTab === tabItem.k
+            ? 'border-b-2 border-accent text-txt font-semibold'
+            : 'text-txt3 hover:text-txt2'
+        "
+        :data-testid="`project-agents-subtab-${tabItem.k}`"
+        @click="subTab = tabItem.k"
+      >
+        {{ tabItem.l }}
+      </button>
+    </div>
+
+    <!-- Keep Studio mounted so agent selection (route.query.agent) stays synced. -->
+    <div
+      v-show="subTab === 'meta'"
+      class="flex min-h-0 flex-1 flex-col"
+      data-testid="project-agents-meta"
+    >
+      <AgentStudioView :project-id="projectId" embedded />
+    </div>
+
+    <div
+      v-if="subTab === 'test'"
+      class="rounded-lg flex min-h-0 flex-1 flex-col overflow-hidden border border-b-0 border-line bg-surface shadow-[var(--shadow-card)]"
+      data-testid="project-agents-chat-test"
+    >
+      <div
+        v-if="!testProfile"
+        class="flex flex-1 flex-col items-center justify-center gap-2 px-4 text-center text-[13px] text-txt3"
+        data-testid="project-agents-chat-test-empty"
+      >
+        <Icon name="robot" :size="20" />
+        <p>{{ t('pages.projectDetail.agents.noAgentForTest') }}</p>
+      </div>
+      <AgentChatTester
+        v-else
+        :key="testProfile"
+        :profile="testProfile"
+        :home-project-id="projectId"
+        :create-test="createProjectContextTest"
+      />
+    </div>
+  </div>
+</template>

--- a/web/src/components/project/ProjectSharedAgentPanel.interactions.test.ts
+++ b/web/src/components/project/ProjectSharedAgentPanel.interactions.test.ts
@@ -34,8 +34,6 @@ function mountPanel(projectId = 'p1') {
       AgentFilesPanel: FilesStub, AgentMcpPanel: { template: '<div data-testid="mcp"/>' },
       AgentEnvPanel: { emits: ['open-settings-file'], template: '<button data-testid="env-settings" @click="$emit(\'open-settings-file\')"/>' },
       AgentPromptsPanel: { template: '<div data-testid="prompts"/>' },
-      AgentChatTester: { props: ['profile', 'createTest'], template: '<div data-testid="tester">{{profile}}</div>' },
-      ProjectAgentSelect: { props: ['modelValue'], template: '<div data-testid="picker">{{modelValue}}</div>' },
     } },
   })
 }
@@ -71,7 +69,6 @@ describe('ProjectSharedAgentPanel interactions', () => {
 
   it('surfaces load/save failures and retries/discards', async () => {
     mocks.getConfig.mockRejectedValueOnce(new Error('load failed'))
-    mocks.listAgents.mockRejectedValueOnce(new Error('agents failed'))
     const w = mountPanel()
     await flushPromises()
     const vm = w.vm as any
@@ -94,7 +91,7 @@ describe('ProjectSharedAgentPanel interactions', () => {
     w.unmount()
   })
 
-  it('opens settings via env, synchronizes agent selection and creates project tests', async () => {
+  it('opens settings via env without a dialogue-test subtab', async () => {
     const w = mountPanel()
     await flushPromises()
     const vm = w.vm as any
@@ -102,14 +99,7 @@ describe('ProjectSharedAgentPanel interactions', () => {
     await w.get('[data-testid="env-settings"]').trigger('click')
     await flushPromises()
     expect(vm.subTab).toBe('files')
-    await w.get('[data-testid="shared-agent-subtab-test"]').trigger('click')
-    expect(vm.testAgentName).toBe('a1')
-    const res = await vm.createProjectContextTest('a1', { repos: [{ name: 'r' }], repoUrl: 'https://x' })
-    expect(res.id).toBe('sandbox')
-    expect(mocks.createTest).toHaveBeenCalledWith('p1', { agentName: 'a1', repos: [{ name: 'r' }], repoUrl: 'https://x' })
-    vm.agents = []
-    vm.syncTestAgentSelection()
-    expect(vm.testAgentName).toBe('')
+    expect(w.find('[data-testid="shared-agent-subtab-test"]').exists()).toBe(false)
     w.unmount()
   })
 
@@ -124,11 +114,11 @@ describe('ProjectSharedAgentPanel interactions', () => {
     w.unmount()
   })
 
-  it('renders every subpanel plus special-region and SSH metadata states', async () => {
+  it('renders every remaining subpanel plus special-region and SSH metadata states', async () => {
     mocks.getConfig.mockResolvedValueOnce({ ...cfg, env: { CURSOR_REGION: 'legacy-special' }, gitSshPrivateKey: 'private', gitSshKnownHosts: 'host key' })
     const w = mountPanel(); await flushPromises()
     const vm = w.vm as any
-    for (const tab of ['mcp', 'env', 'prompts', 'meta', 'test']) {
+    for (const tab of ['mcp', 'env', 'prompts', 'meta']) {
       await w.get(`[data-testid="shared-agent-subtab-${tab}"]`).trigger('click')
       await flushPromises()
     }
@@ -137,9 +127,6 @@ describe('ProjectSharedAgentPanel interactions', () => {
     vm.draft.layout.configRoot = ''
     await w.vm.$nextTick()
     expect(vm.derivedPaths[0].path).toContain('mcp.json')
-    vm.testAgentName = 'a1'
-    vm.syncTestAgentSelection()
-    expect(vm.testAgentName).toBe('a1')
     w.unmount()
   })
 })

--- a/web/src/components/project/ProjectSharedAgentPanel.test.ts
+++ b/web/src/components/project/ProjectSharedAgentPanel.test.ts
@@ -63,77 +63,26 @@ function mountPanel(projectId = 'proj-a') {
   })
 }
 
-describe('ProjectSharedAgentPanel chat test picker', () => {
+describe('ProjectSharedAgentPanel without chat test (g2.1)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     apiMocks.getProjectSharedAgentConfig.mockResolvedValue(sharedCfg)
+    apiMocks.listAgents.mockResolvedValue([{ name: 'mine', projectId: 'proj-a' }])
   })
 
-  it('lists only agents bound to the current project', async () => {
-    apiMocks.listAgents.mockResolvedValue([
-      { name: 'mine', projectId: 'proj-a' },
-      { name: 'other', projectId: 'proj-b' },
-      { name: 'free' },
-    ])
-    const wrapper = mountPanel('proj-a')
-    await flushPromises()
-    await wrapper.get('[data-testid="shared-agent-subtab-test"]').trigger('click')
-    await flushPromises()
-    await wrapper.get('[data-testid="project-agent-select-trigger"]').trigger('click')
-    await flushPromises()
-    expect(wrapper.find('[data-testid="project-agent-select-option-mine"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="project-agent-select-option-other"]').exists()).toBe(false)
-    expect(wrapper.find('[data-testid="shared-agent-chat-tester"]').text()).toBe('mine')
-    wrapper.unmount()
-  })
-
-  it('replaces the standalone hint with an accessible help disclosure', async () => {
-    apiMocks.listAgents.mockResolvedValue([])
+  it('keeps config subtabs and removes dialogue-test entry', async () => {
     const wrapper = mountPanel()
     await flushPromises()
-
-    expect(wrapper.find('[data-testid="shared-agent-hint"]').exists()).toBe(false)
-    const help = wrapper.get('[data-testid="shared-agent-help"]')
-    const summary = help.get('summary')
-    expect(summary.text()).toBe('?')
-    expect(summary.attributes('aria-label')).toContain('extend')
-    expect(summary.classes()).toEqual(expect.arrayContaining(['h-[18px]', 'w-[18px]']))
-    expect(wrapper.get('[data-testid="shared-agent-help-text"]').text()).toContain('extend')
-    expect(wrapper.get('[data-testid="project-shared-agent-panel"]').classes()).toEqual(
-      expect.arrayContaining(['min-h-0', 'flex-1']),
-    )
-    wrapper.unmount()
-  })
-
-  it('shows empty state when no project-bound agents exist', async () => {
-    apiMocks.listAgents.mockResolvedValue([
-      { name: 'other', projectId: 'proj-b' },
-    ])
-    const wrapper = mountPanel('proj-a')
-    await flushPromises()
-    await wrapper.get('[data-testid="shared-agent-subtab-test"]').trigger('click')
-    await flushPromises()
-    expect(wrapper.find('[data-testid="shared-agent-test-empty"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="shared-agent-subtab-files"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="shared-agent-subtab-mcp"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="shared-agent-subtab-env"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="shared-agent-subtab-prompts"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="shared-agent-subtab-meta"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="shared-agent-subtab-test"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="shared-agent-chat-tester"]').exists()).toBe(false)
-    wrapper.unmount()
-  })
-
-  it('filters combobox candidates and drives tester selection', async () => {
-    apiMocks.listAgents.mockResolvedValue([
-      { name: 'alpha', projectId: 'proj-a' },
-      { name: 'beta', projectId: 'proj-a' },
-    ])
-    const wrapper = mountPanel('proj-a')
-    await flushPromises()
-    await wrapper.get('[data-testid="shared-agent-subtab-test"]').trigger('click')
-    await flushPromises()
-    await wrapper.get('[data-testid="project-agent-select-trigger"]').trigger('click')
-    await flushPromises()
-    await wrapper.get('[data-testid="project-agent-select-search"]').setValue('beta')
-    await flushPromises()
-    await wrapper.get('[data-testid="project-agent-select-option-beta"]').trigger('click')
-    await flushPromises()
-    expect(wrapper.find('[data-testid="shared-agent-chat-tester"]').text()).toBe('beta')
+    expect(wrapper.find('[data-testid="shared-agent-test-pick"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="shared-agent-help-text"]').text()).toContain('智能体 → 对话测试')
+    expect(wrapper.get('[data-testid="shared-agent-help-text"]').text()).not.toContain('仅在此入口')
     wrapper.unmount()
   })
 })

--- a/web/src/components/project/ProjectSharedAgentPanel.vue
+++ b/web/src/components/project/ProjectSharedAgentPanel.vue
@@ -1,15 +1,12 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import Icon from '@/components/ui/Icon.vue'
 import AppButton from '@/components/ui/AppButton.vue'
 import AgentFilesPanel from '@/components/agent/AgentFilesPanel.vue'
 import AgentMcpPanel from '@/components/agent/AgentMcpPanel.vue'
 import AgentEnvPanel from '@/components/agent/AgentEnvPanel.vue'
 import AgentPromptsPanel from '@/components/agent/AgentPromptsPanel.vue'
-import AgentChatTester from '@/components/agent/AgentChatTester.vue'
-import ProjectAgentSelect from '@/components/project/ProjectAgentSelect.vue'
-import { api, type CreateAgentTestPayload, type ProjectSharedAgentConfig, type SandboxView } from '@/lib/api/api'
+import { api, type ProjectSharedAgentConfig } from '@/lib/api/api'
 import {
   DEFAULT_CONFIG_ROOT,
   DEFAULT_WORKSPACE_DIR,
@@ -50,7 +47,7 @@ const { t } = useI18n()
 const toast = useToast()
 const { isMobile } = useBreakpoint()
 
-type SubTab = 'files' | 'mcp' | 'env' | 'prompts' | 'meta' | 'test'
+type SubTab = 'files' | 'mcp' | 'env' | 'prompts' | 'meta'
 
 const loading = ref(true)
 const loadError = ref('')
@@ -61,23 +58,6 @@ const subTab = ref<SubTab>('files')
 const justSaved = ref(false)
 const filesPanelRef = ref<InstanceType<typeof AgentFilesPanel> | null>(null)
 let configRootTouched = false
-
-const agents = ref<{ name: string; projectId?: string }[]>([])
-const testAgentName = ref('')
-
-const projectAgents = computed(() =>
-  agents.value.filter((a) => a.projectId === props.projectId),
-)
-
-function syncTestAgentSelection() {
-  const candidates = projectAgents.value
-  if (!candidates.length) {
-    testAgentName.value = ''
-    return
-  }
-  if (candidates.some((a) => a.name === testAgentName.value)) return
-  testAgentName.value = candidates[0]!.name
-}
 
 const dirty = computed(() => {
   if (!draft.value) return false
@@ -104,7 +84,6 @@ const subTabs = computed(() => {
       l: pc ? t('pages.agentStudio.tabs.promptsCount', { n: pc }) : t('pages.agentStudio.tabs.prompts'),
     },
     { k: 'meta' as const, l: t('pages.agentStudio.tabs.meta') },
-    { k: 'test' as const, l: t('pages.projectDetail.sharedAgent.testTab') },
   ]
 })
 
@@ -197,13 +176,8 @@ async function load() {
   loading.value = true
   loadError.value = ''
   try {
-    const [cfg, agentList] = await Promise.all([
-      api.getProjectSharedAgentConfig(props.projectId),
-      api.listAgents().catch(() => [] as { name: string; projectId?: string }[]),
-    ])
+    const cfg = await api.getProjectSharedAgentConfig(props.projectId)
     applyLoaded(cfg)
-    agents.value = agentList.map((a) => ({ name: a.name, projectId: a.projectId }))
-    syncTestAgentSelection()
   } catch (e: unknown) {
     loadError.value = String((e as { message?: string })?.message || e)
     draft.value = null
@@ -283,29 +257,13 @@ function openSettingsInFiles() {
   })
 }
 
-async function createProjectContextTest(
-  profile: string,
-  payload: CreateAgentTestPayload,
-): Promise<SandboxView> {
-  return api.createProjectSharedAgentTest(props.projectId, {
-    agentName: profile,
-    ...(payload.repos ? { repos: payload.repos } : {}),
-    ...(payload.repoUrl ? { repoUrl: payload.repoUrl } : {}),
-  })
-}
-
 watch(
   () => props.projectId,
   () => {
-    testAgentName.value = ''
     subTab.value = 'files'
     void load()
   },
 )
-
-watch(projectAgents, () => {
-  syncTestAgentSelection()
-})
 
 onMounted(() => {
   void load()
@@ -594,46 +552,6 @@ onMounted(() => {
             </table>
           </div>
         </div>
-      </div>
-
-      <div
-        v-if="subTab === 'test'"
-        class="flex min-h-0 flex-1 flex-col overflow-hidden"
-        data-testid="shared-agent-test"
-      >
-        <div
-          class="flex shrink-0 flex-wrap items-start gap-x-3 gap-y-2 border-b border-line px-3 py-2"
-          data-testid="shared-agent-test-toolbar"
-        >
-          <div class="flex min-w-0 items-center gap-2">
-            <span class="shrink-0 text-[12px] text-txt2">
-              {{ t('pages.projectDetail.sharedAgent.pickAgent') }}
-            </span>
-            <ProjectAgentSelect
-              v-model="testAgentName"
-              :agents="projectAgents"
-              data-testid="shared-agent-test-pick"
-            />
-          </div>
-          <p class="w-full text-[11px] leading-5 text-txt3">
-            {{ t('pages.projectDetail.sharedAgent.testHint') }}
-          </p>
-        </div>
-        <div
-          v-if="!projectAgents.length"
-          class="flex flex-1 flex-col items-center justify-center gap-2 px-4 text-center text-[13px] text-txt3"
-          data-testid="shared-agent-test-empty"
-        >
-          <Icon name="robot" :size="20" />
-          <p>{{ t('pages.projectDetail.sharedAgent.noProjectAgents') }}</p>
-        </div>
-        <AgentChatTester
-          v-else-if="testAgentName"
-          :key="testAgentName"
-          :profile="testAgentName"
-          :home-project-id="projectId"
-          :create-test="createProjectContextTest"
-        />
       </div>
     </template>
   </div>

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -176,7 +176,7 @@
       "selectWorkflowGroup": "Select a workflow group on the left",
       "noMatchingGroups": "No matching groups",
       "noMatchingOptions": "No matching options",
-      "noSandboxes": "No sandboxes yet. Node sandboxes are created when workflows run, or start a test sandbox under Project detail → Shared Agent config → Chat test.",
+      "noSandboxes": "No sandboxes yet. Node sandboxes are created when workflows run, or start a test sandbox under Project detail → Agents → Chat test.",
       "noAgents": "No agents yet. Click New agent, or the backend seeds a default on first start.",
       "noPendingGates": "Nothing pending",
       "noPendingGatesForPipeline": "No pending items for this pipeline",

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -992,7 +992,7 @@
       "varsEmptyTitle": "No workflow variables yet",
       "varsEmptyDesc": "Add a row to configure project-level defaults.",
       "sharedAgent": {
-        "extendHint": "Project Runs and project-context chat tests extend this shared config first, then the chosen Agent overlays same-named keys (Agent wins). Chat tests start only from this panel.",
+        "extendHint": "Project Runs and Agents → Chat test extend this shared config first, then the chosen Agent overlays same-named keys (Agent wins).",
         "discard": "Discard",
         "defaultProjectId": "Default project ID",
         "defaultProjectIdDesc": "Stored as defaultProjectId; may fill in when an Agent has no home project.",
@@ -1002,6 +1002,11 @@
         "testHint": "Only Agents bound to this project are listed. Starts with the shared baseline, then overlays the selected Agent.",
         "noAgents": "No Agents yet — create one in Agent Studio first.",
         "noProjectAgents": "No Agents are bound to this project yet. Open Agent management and bind this project in the Agent’s meta tab, then try again."
+      },
+      "agents": {
+        "metaTab": "Meta",
+        "testTab": "Chat test",
+        "noAgentForTest": "No Agents are bound to this project yet. Create or bind an Agent under Meta, then open Chat test."
       },
       "varName": "Name",
       "varValue": "Default",
@@ -1697,7 +1702,7 @@
     "sandboxes": {
       "title": "Sandboxes",
       "errorPrefix": "Error:",
-      "empty": "No sandboxes. Created on workflow runs or from Project detail → Shared Agent config → Chat test.",
+      "empty": "No sandboxes. Created on workflow runs or from Project detail → Agents → Chat test.",
       "copyId": "Copy ID",
       "copied": "Copied",
       "destroy": "Destroy",
@@ -3592,7 +3597,7 @@
       "destroy": "End & destroy",
       "acpSession": "ACP session",
       "idleHint": "Start a sandbox bound to “{profile}” (workspace / MCP / env) for multi-turn chat testing.",
-      "missingCreateTest": "Chat test launcher not configured. Open Project shared Agent config.",
+      "missingCreateTest": "Chat test launcher not configured. Open Project detail → Agents → Chat test.",
       "mode": {
         "sectionLabel": "Workspace mode",
         "empty": {

--- a/web/src/locales/userFacingCopy.test.ts
+++ b/web/src/locales/userFacingCopy.test.ts
@@ -55,6 +55,21 @@ describe('user-facing copy remediation keys', () => {
     expect(zh.global.t('pages.projectDetail.pm.inputPh')).toContain('50 MiB')
   })
 
+  it('chat-test entry copy points to Agents → Chat test (g2.2)', () => {
+    expect(zh.global.t('pages.agentChatTester.missingCreateTest')).toContain('智能体 → 对话测试')
+    expect(en.global.t('pages.agentChatTester.missingCreateTest')).toMatch(/Agents → Chat test/i)
+    expect(zh.global.t('pages.sandboxes.empty')).toContain('智能体 → 对话测试')
+    expect(en.global.t('pages.sandboxes.empty')).toMatch(/Agents → Chat test/i)
+    expect(zh.global.t('common.empty.noSandboxes')).toContain('智能体 → 对话测试')
+    expect(en.global.t('common.empty.noSandboxes')).toMatch(/Agents → Chat test/i)
+    expect(zh.global.t('pages.projectDetail.sharedAgent.extendHint')).toContain('智能体 → 对话测试')
+    expect(zh.global.t('pages.projectDetail.sharedAgent.extendHint')).not.toContain('仅在此入口')
+    expect(en.global.t('pages.projectDetail.sharedAgent.extendHint')).toMatch(/Agents → Chat test/i)
+    expect(en.global.t('pages.projectDetail.sharedAgent.extendHint')).not.toMatch(/only from this panel/i)
+    expect(zh.global.t('pages.projectDetail.agents.metaTab')).toBe('元信息')
+    expect(zh.global.t('pages.projectDetail.agents.testTab')).toBe('对话测试')
+  })
+
   it('pm status/error copy drops internal jargon', () => {
     expect(zh.global.t('pages.projectDetail.pm.busyStreaming')).not.toMatch(/Steam/i)
     expect(zh.global.t('pages.projectDetail.pm.failSandboxDesc')).not.toMatch(/自动收场/)

--- a/web/src/locales/zh-CN/common.json
+++ b/web/src/locales/zh-CN/common.json
@@ -176,7 +176,7 @@
       "selectWorkflowGroup": "请在左侧选择工作流分组",
       "noMatchingGroups": "无匹配分组",
       "noMatchingOptions": "无匹配项",
-      "noSandboxes": "暂无沙箱。运行工作流时会按需创建节点沙箱，或前往项目详情「共享 Agent 配置 → 对话测试」启动测试沙箱。",
+      "noSandboxes": "暂无沙箱。运行工作流时会按需创建节点沙箱，或前往项目详情「智能体 → 对话测试」启动测试沙箱。",
       "noAgents": "暂无 Agent。点击右上角\"新建 Agent\"创建,或后端首启会落盘默认 Agent。",
       "noPendingGates": "没有待审批项",
       "noPendingGatesForPipeline": "该流水线没有待审批项",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -992,7 +992,7 @@
       "varsEmptyTitle": "暂无工作流变量",
       "varsEmptyDesc": "添加一行后，即可配置项目级默认值。",
       "sharedAgent": {
-        "extendHint": "本项目 Run 与「共享 Agent 配置 → 对话测试」会先 extend 此共享配置，再由所选 Agent 同名覆盖（Agent 优先）。对话测试仅在此入口发起。",
+        "extendHint": "本项目 Run 与「智能体 → 对话测试」会先 extend 此共享配置，再由所选 Agent 同名覆盖（Agent 优先）。",
         "discard": "放弃修改",
         "defaultProjectId": "默认项目 ID",
         "defaultProjectIdDesc": "写入共享配置的 defaultProjectId；Agent 未绑定项目时可作补全。",
@@ -1002,6 +1002,11 @@
         "testHint": "仅列出绑定本项目的 Agent。将以共享配置为基底，再 overlay 所选 Agent 启动对话测试。",
         "noAgents": "暂无可用 Agent，请先到 Agent Studio 创建。",
         "noProjectAgents": "本项目尚无绑定 Agent。请前往 Agent 管理，在 Agent 元信息中绑定本项目后再试。"
+      },
+      "agents": {
+        "metaTab": "元信息",
+        "testTab": "对话测试",
+        "noAgentForTest": "本项目尚无绑定 Agent。请先在「元信息」中创建或绑定 Agent，再进行对话测试。"
       },
       "varName": "变量名",
       "varValue": "默认值",
@@ -1697,7 +1702,7 @@
     "sandboxes": {
       "title": "沙箱",
       "errorPrefix": "出错:",
-      "empty": "暂无沙箱。运行工作流时会按需创建节点沙箱，或前往项目详情「共享 Agent 配置 → 对话测试」启动测试沙箱。",
+      "empty": "暂无沙箱。运行工作流时会按需创建节点沙箱，或前往项目详情「智能体 → 对话测试」启动测试沙箱。",
       "copyId": "复制 ID",
       "copied": "已复制",
       "destroy": "销毁",
@@ -3592,7 +3597,7 @@
       "destroy": "结束并销毁",
       "acpSession": "ACP 会话",
       "idleHint": "启动一个绑定 “{profile}” 配置(工作目录 / MCP / 环境变量)的沙箱,与该 Agent 进行多轮对话测试。",
-      "missingCreateTest": "未配置对话测试启动方式。请从项目共享 Agent 配置进入。",
+      "missingCreateTest": "未配置对话测试启动方式。请从项目详情 → 智能体 → 对话测试进入。",
       "mode": {
         "sectionLabel": "工作区模式",
         "empty": {

--- a/web/src/views/AgentStudioView.test.ts
+++ b/web/src/views/AgentStudioView.test.ts
@@ -2115,6 +2115,10 @@ describe('AgentStudioView entry assembly (g3 / Demo main path)', () => {
     expect(src).toMatch(/tab === 'platform-rules'/)
     expect(src).not.toMatch(/tab === 'test'/)
     expect(src).toMatch(/tab === 'meta'/)
+    // Rejected demo: must not add chat-test as a STUDIO_TABS trailing item (g2.2).
+    expect(src).toMatch(/const STUDIO_TABS[\s\S]*?=\s*\[[^\]]*\]/)
+    expect(src).not.toMatch(/STUDIO_TABS[^\n]*test/)
+    expect(src).not.toMatch(/'test' as StudioTab|StudioTab.*'test'/)
   })
 
   it('switches Demo main-path tabs via tab strip without changing labels', async () => {

--- a/web/src/views/ProjectDetailView.metaLayout.test.ts
+++ b/web/src/views/ProjectDetailView.metaLayout.test.ts
@@ -96,7 +96,7 @@ describe('ProjectDetailView meta tab keeps existing chrome and save semantics (g
     const shared = detailSrc.slice(sharedStart, variablesStart)
     const variables = detailSrc.slice(variablesStart, auditStart)
 
-    expect(agents).toMatch(/AgentStudioView/)
+    expect(agents).toMatch(/ProjectAgentsPanel/)
     expect(agents).toMatch(/data-testid="project-agents-tab"/)
     expect(agents).toMatch(/class="flex min-h-0 flex-1 flex-col"/)
 

--- a/web/src/views/ProjectDetailView.vue
+++ b/web/src/views/ProjectDetailView.vue
@@ -19,9 +19,9 @@ import TokenUsageHoverTip from '@/components/ui/TokenUsageHoverTip.vue'
 import ProjectAuditPanel from '@/components/project/ProjectAuditPanel.vue'
 import ProjectNotifyPanel from '@/components/project/ProjectNotifyPanel.vue'
 import ProjectSharedAgentPanel from '@/components/project/ProjectSharedAgentPanel.vue'
+import ProjectAgentsPanel from '@/components/project/ProjectAgentsPanel.vue'
 import RequirementDraftsPanel from '@/components/project/RequirementDraftsPanel.vue'
 import ProjectExternalMcpPanel from '@/components/project/ProjectExternalMcpPanel.vue'
-import AgentStudioView from '@/views/AgentStudioView.vue'
 import { useProjectDetail } from '@/lib/project/useProjectDetail'
 import { DEFAULT_PROJECT_ID } from '@/lib/pm/onboardingWizard'
 
@@ -957,9 +957,9 @@ const onboardingEmptyDesc = computed(() =>
         </div>
       </div>
 
-      <!-- Agents: embedded Agent Studio (fill remaining main area) -->
+      <!-- Agents: second-level meta | chat test (fill remaining main area) -->
       <div v-else-if="tab === 'agents'" class="flex min-h-0 flex-1 flex-col" data-testid="project-agents-tab">
-        <AgentStudioView :project-id="projectId" embedded />
+        <ProjectAgentsPanel :project-id="projectId" />
       </div>
 
       <!-- Shared Agent config: fill remaining main area -->


### PR DESCRIPTION
## Summary
- Move chat test from project shared Agent config into the project Agents second-level tab (alongside Meta), matching the approved preview.
- Shared Agent config now keeps editors only; copy and tests point users to Agents → Chat test.
- `createTest` still calls `createProjectSharedAgentTest` (extend → overlay); switching Agent remounts the tester via `:key`.

## Test plan
- [ ] Open a project → Agents tab: second-level tabs show Meta | Chat test (`project-agents-subtab-meta` / `project-agents-subtab-test`).
- [ ] Chat test idle state binds the current Agent and can start a test.
- [ ] Shared Agent config has no Chat test sub-tab (`shared-agent-subtab-test` count = 0).
- [ ] Agent Studio inner tabs still have no `studio-tab-test`.
- [ ] zh/en copy for missingCreateTest / empty sandboxes / extendHint points to Agents → Chat test.


Made with [Cursor](https://cursor.com)