### PR TITLE
fix(web): clear Tab underlines from toolbar action buttons

### DIFF
--- a/web/src/components/agent/AgentChatTester.vue
+++ b/web/src/components/agent/AgentChatTester.vue
@@ -619,7 +619,7 @@ const toolIcon: Record<string, string> = { completed: 'check', failed: 'close', 
 <template>
   <div class="flex min-h-0 flex-1 flex-col">
     <!-- header / controls -->
-    <div v-if="!embedded" class="flex items-center gap-2 border-b border-line px-4 py-2">
+    <div v-if="!embedded" class="toolbar-inline-row flex items-center gap-2 border-b border-line px-4">
       <AcpStatusPill v-if="acpConnected" :busy="acpBusy" connected />
       <span
         v-else

--- a/web/src/components/agent/AgentEnvPanel.vue
+++ b/web/src/components/agent/AgentEnvPanel.vue
@@ -119,7 +119,7 @@ watch(
 
 <template>
   <div class="flex min-h-0 flex-1 flex-col">
-    <div class="flex items-center gap-2 border-b border-line px-4 py-2">
+    <div class="toolbar-inline-row flex items-center gap-2 border-b border-line px-4">
       <AppButton
         type="button"
         size="sm"

--- a/web/src/components/agent/AgentMcpPanel.vue
+++ b/web/src/components/agent/AgentMcpPanel.vue
@@ -118,7 +118,7 @@ watch(
 
 <template>
   <div class="flex min-h-0 flex-1 flex-col">
-    <div class="flex items-center gap-2 border-b border-line px-4 py-2">
+    <div class="toolbar-inline-row flex items-center gap-2 border-b border-line px-4">
       <button class="rounded border border-line px-2 py-1 text-[11px] text-txt2 hover:border-line-strong" @click="toggleMcpRaw">{{ mcpRaw ? t('pages.agentStudio.mcp.formEdit') : t('pages.agentStudio.mcp.rawJson') }}</button>
       <AppButton
         v-if="!mcpRaw"

--- a/web/src/components/agent/AgentPlatformRulesPanel.vue
+++ b/web/src/components/agent/AgentPlatformRulesPanel.vue
@@ -161,7 +161,7 @@ defineExpose({ load: loadPlatformRules, resetState })
     </aside>
 
     <section class="flex min-h-0 min-w-0 flex-col">
-      <div class="flex items-center justify-between gap-2 border-b border-line px-4 py-2">
+      <div class="toolbar-inline-row flex items-center justify-between gap-2 border-b border-line px-4">
         <div class="flex min-w-0 items-center gap-2">
           <span class="truncate font-mono text-[12px] text-txt2">
             {{ platformRuleOverridden ? `profiles/${agentName}/platform-rules/${platformRuleFile}` : t('pages.agentStudio.platformRules.inheritPath', { file: platformRuleFile }) }}

--- a/web/src/components/project/ProjectSharedAgentPanel.vue
+++ b/web/src/components/project/ProjectSharedAgentPanel.vue
@@ -291,7 +291,7 @@ onMounted(() => {
     </div>
 
     <template v-else-if="draft">
-      <div class="flex shrink-0 items-center gap-2 border-b border-line px-2 py-1">
+      <div class="toolbar-inline-row flex shrink-0 items-center gap-2 border-b border-line px-2">
         <details class="relative shrink-0" data-testid="shared-agent-help">
           <summary
             class="flex h-[18px] w-[18px] cursor-pointer list-none items-center justify-center rounded-full border border-line text-[11px] font-semibold text-accent-2 transition hover:border-accent hover:bg-accent-dim [&::-webkit-details-marker]:hidden"

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -276,6 +276,18 @@ html.light .app-sidebar-card {
   .toolbar-control .chip {
     @apply h-5 shrink-0 py-0 leading-none;
   }
+  /*
+   * Tab / split-line clearance (plan g1.4): keep 8–12px so underlines do not
+   * sit on primary action buttons. Use these instead of per-page magic margins.
+   * - toolbar-below-tabs: stacked content under a Tab row (padding-top 10px)
+   * - toolbar-inline-row: Tab/title + actions sharing a border-b row (py 10px)
+   */
+  .toolbar-below-tabs {
+    @apply pt-2.5;
+  }
+  .toolbar-inline-row {
+    @apply py-2.5;
+  }
   .nav-item {
     @apply flex items-center gap-2.5 px-3 py-[9px] text-sm text-txt2 transition
       hover:bg-elevated hover:text-txt;

--- a/web/src/views/AgentStudioView.vue
+++ b/web/src/views/AgentStudioView.vue
@@ -245,7 +245,8 @@ const {
     :aria-busy="loading ? 'true' : 'false'"
   >
     <div
-      class="mb-5 flex shrink-0 gap-4"
+      class="toolbar-below-tabs mb-5 flex shrink-0 gap-4"
+      data-testid="agent-studio-action-row"
       :class="isMobile ? 'flex-col items-stretch' : 'justify-end'"
     >
       <div class="flex shrink-0 gap-2" :class="isMobile ? 'flex-col' : 'items-center'">
@@ -419,7 +420,7 @@ const {
         <div
           v-if="isMobile"
           data-test="studio-name-bar"
-          class="flex flex-col gap-2 border-b border-line px-4 py-2.5"
+          class="toolbar-inline-row flex flex-col gap-2 border-b border-line px-4"
         >
           <div data-test="studio-name-row-top" class="flex min-w-0 items-center gap-2">
             <Icon name="robot" :size="15" class="shrink-0 text-accent-2" />
@@ -476,7 +477,7 @@ const {
         <div
           v-else
           data-test="studio-name-bar"
-          class="flex items-center gap-2 border-b border-line px-4 py-2"
+          class="toolbar-inline-row flex items-center gap-2 border-b border-line px-4"
         >
           <Icon name="robot" :size="15" class="shrink-0 text-accent-2" />
           <span class="min-w-0 truncate text-[13px] font-medium text-txt" :title="activeName">{{ activeName }}</span>

--- a/web/src/views/ProjectDetailView.vue
+++ b/web/src/views/ProjectDetailView.vue
@@ -348,7 +348,7 @@ const onboardingEmptyDesc = computed(() =>
       <Transition name="ui-fade" mode="out-in">
       <div
         :key="String(tab)"
-        class="flex min-h-0 flex-1 flex-col overflow-hidden"
+        class="toolbar-below-tabs flex min-h-0 flex-1 flex-col overflow-hidden"
         data-testid="project-detail-tab-panel"
       >
       <div

--- a/web/src/views/toolbarTabClearance.test.ts
+++ b/web/src/views/toolbarTabClearance.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment node
+/**
+ * Plan coverage locks for「操作按钮与 Tab 底线错开」:
+ * g1.1 project tab-panel · g1.2 Studio action row · g1.3 inline rows · g1.4 shared tokens
+ */
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const read = (rel: string) => readFileSync(join(root, rel), 'utf8')
+
+const globalCss = read('styles/global.css')
+const detailSrc = read('views/ProjectDetailView.vue')
+const studioSrc = read('views/AgentStudioView.vue')
+const sharedSrc = read('components/project/ProjectSharedAgentPanel.vue')
+const mcpSrc = read('components/agent/AgentMcpPanel.vue')
+const envSrc = read('components/agent/AgentEnvPanel.vue')
+const rulesSrc = read('components/agent/AgentPlatformRulesPanel.vue')
+const chatSrc = read('components/agent/AgentChatTester.vue')
+
+describe('toolbar Tab clearance tokens (g1.4)', () => {
+  it('defines shared toolbar-below-tabs and toolbar-inline-row (8–12px band)', () => {
+    expect(globalCss).toMatch(/\.toolbar-below-tabs\s*\{[\s\S]*?@apply pt-2\.5/)
+    expect(globalCss).toMatch(/\.toolbar-inline-row\s*\{[\s\S]*?@apply py-2\.5/)
+  })
+})
+
+describe('project page tab-panel clearance (g1.1)', () => {
+  it('applies toolbar-below-tabs on project-detail-tab-panel', () => {
+    expect(detailSrc).toMatch(
+      /class="toolbar-below-tabs flex min-h-0 flex-1 flex-col overflow-hidden"\s+data-testid="project-detail-tab-panel"/,
+    )
+  })
+})
+
+describe('Agent Studio action / name bars (g1.2 / g1.3)', () => {
+  it('import/new action row uses toolbar-below-tabs', () => {
+    expect(studioSrc).toMatch(
+      /class="toolbar-below-tabs mb-5 flex shrink-0 gap-4"\s+data-testid="agent-studio-action-row"/,
+    )
+  })
+
+  it('desktop and mobile name bars use toolbar-inline-row', () => {
+    const bars = studioSrc.match(/data-test="studio-name-bar"[\s\S]*?class="([^"]+)"/g) ?? []
+    expect(bars.length).toBeGreaterThanOrEqual(2)
+    for (const bar of bars) {
+      expect(bar).toMatch(/toolbar-inline-row/)
+      expect(bar).not.toMatch(/\bpy-1\b/)
+      expect(bar).not.toMatch(/\bpy-2\b/)
+    }
+  })
+})
+
+describe('same-row toolbars leave the border-b (g1.3)', () => {
+  it('shared Agent save row uses toolbar-inline-row instead of py-1', () => {
+    expect(sharedSrc).toMatch(
+      /class="toolbar-inline-row flex shrink-0 items-center gap-2 border-b border-line px-2"/,
+    )
+    expect(sharedSrc).not.toMatch(/border-b border-line px-2 py-1/)
+  })
+
+  it('MCP / Env / platform rules / chat tester headers use toolbar-inline-row', () => {
+    expect(mcpSrc).toMatch(/class="toolbar-inline-row flex items-center gap-2 border-b border-line px-4"/)
+    expect(envSrc).toMatch(/class="toolbar-inline-row flex items-center gap-2 border-b border-line px-4"/)
+    expect(rulesSrc).toMatch(
+      /class="toolbar-inline-row flex items-center justify-between gap-2 border-b border-line px-4"/,
+    )
+    expect(chatSrc).toMatch(
+      /v-if="!embedded" class="toolbar-inline-row flex items-center gap-2 border-b border-line px-4"/,
+    )
+  })
+})


### PR DESCRIPTION
Add shared toolbar-below-tabs / toolbar-inline-row spacing so project
tabs, Agents nested actions, and Studio same-row toolbars sit 8–12px
off split lines without per-page magic margins.

Co-authored-by: Cursor <cursoragent@cursor.com>
