### PR TITLE
feat(web): move chat test into Agent Studio inner tab

### DIFF
--- a/web/src/components/project/ProjectAgentsPanel.test.ts
+++ b/web/src/components/project/ProjectAgentsPanel.test.ts
@@ -1,30 +1,13 @@
 // @vitest-environment happy-dom
 import { createI18n } from 'vue-i18n'
 import { flushPromises, mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { createRouter, createMemoryHistory } from 'vue-router'
 import common from '@/locales/zh-CN/common.json'
 import pages from '@/locales/zh-CN/pages.json'
 import ProjectAgentsPanel from './ProjectAgentsPanel.vue'
 
-const apiMocks = vi.hoisted(() => ({
-  listAgents: vi.fn(),
-  createProjectSharedAgentTest: vi.fn(),
-}))
-
-vi.mock('@/lib/api/api', async () => {
-  const actual = await vi.importActual<typeof import('@/lib/api/api')>('@/lib/api/api')
-  return {
-    ...actual,
-    api: {
-      ...actual.api,
-      listAgents: apiMocks.listAgents,
-      createProjectSharedAgentTest: apiMocks.createProjectSharedAgentTest,
-    },
-  }
-})
-
-async function mountPanel(projectId = 'proj-a', query: Record<string, string> = {}) {
+async function mountPanel(projectId = 'proj-a') {
   const i18n = createI18n({
     legacy: false,
     locale: 'zh-CN',
@@ -34,88 +17,33 @@ async function mountPanel(projectId = 'proj-a', query: Record<string, string> = 
     history: createMemoryHistory(),
     routes: [{ path: '/', component: { template: '<div/>' } }],
   })
-  await router.push({ path: '/', query })
+  await router.push({ path: '/' })
   await router.isReady()
   return mount(ProjectAgentsPanel, {
     props: { projectId },
     global: {
       plugins: [i18n, router],
       stubs: {
-        Icon: true,
         AgentStudioView: {
-          template: '<div data-testid="agents-studio-stub">studio</div>',
-        },
-        AgentChatTester: {
-          props: ['profile', 'homeProjectId', 'createTest'],
-          template: '<div data-testid="agents-chat-tester">{{ profile }}</div>',
+          props: ['projectId', 'embedded'],
+          template:
+            '<div data-testid="agents-studio-stub">studio:{{ projectId }}:{{ embedded }}</div>',
         },
       },
     },
   })
 }
 
-describe('ProjectAgentsPanel second-level tabs (g1.1 / g1.2)', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    apiMocks.listAgents.mockResolvedValue([
-      { name: 'mine', projectId: 'proj-a' },
-      { name: 'other', projectId: 'proj-b' },
-    ])
-    apiMocks.createProjectSharedAgentTest.mockResolvedValue({ id: 1 })
-  })
-
-  it('shows meta | chat-test second-level tabs aligned with confirmed preview', async () => {
+describe('ProjectAgentsPanel embeds Studio only (g1.1 / g1.2)', () => {
+  it('has no outer meta|chat-test subtabs and always embeds AgentStudioView', async () => {
     const wrapper = await mountPanel()
     await flushPromises()
-    expect(wrapper.get('[data-testid="project-agents-subtab-meta"]').text()).toBe('元信息')
-    expect(wrapper.get('[data-testid="project-agents-subtab-test"]').text()).toBe('对话测试')
-    expect(wrapper.find('[data-testid="agents-studio-stub"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="project-agents-subtabs"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="project-agents-subtab-meta"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="project-agents-subtab-test"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="project-agents-chat-test"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="agents-chat-tester"]').exists()).toBe(false)
-    wrapper.unmount()
-  })
-
-  it('mounts AgentChatTester with current Agent via createProjectSharedAgentTest', async () => {
-    const wrapper = await mountPanel('proj-a', { agent: 'mine' })
-    await flushPromises()
-    await wrapper.get('[data-testid="project-agents-subtab-test"]').trigger('click')
-    await flushPromises()
-    expect(wrapper.find('[data-testid="project-agents-chat-test"]').exists()).toBe(true)
-    expect(wrapper.get('[data-testid="agents-chat-tester"]').text()).toBe('mine')
-    const vm = wrapper.vm as unknown as {
-      createProjectContextTest: (p: string, payload: { repos?: unknown[] }) => Promise<unknown>
-    }
-    await vm.createProjectContextTest('mine', { repos: [{ name: 'r', url: 'https://x' }] })
-    expect(apiMocks.createProjectSharedAgentTest).toHaveBeenCalledWith('proj-a', {
-      agentName: 'mine',
-      repos: [{ name: 'r', url: 'https://x' }],
-    })
-    wrapper.unmount()
-  })
-
-  it('remounts tester when route agent changes (:key)', async () => {
-    apiMocks.listAgents.mockResolvedValue([
-      { name: 'alpha', projectId: 'proj-a' },
-      { name: 'beta', projectId: 'proj-a' },
-    ])
-    const wrapper = await mountPanel('proj-a', { agent: 'alpha' })
-    await flushPromises()
-    await wrapper.get('[data-testid="project-agents-subtab-test"]').trigger('click')
-    await flushPromises()
-    expect(wrapper.get('[data-testid="agents-chat-tester"]').text()).toBe('alpha')
-    await wrapper.vm.$router.replace({ query: { agent: 'beta' } })
-    await flushPromises()
-    expect(wrapper.get('[data-testid="agents-chat-tester"]').text()).toBe('beta')
-    wrapper.unmount()
-  })
-
-  it('shows empty state when no project-bound agents', async () => {
-    apiMocks.listAgents.mockResolvedValue([{ name: 'other', projectId: 'proj-b' }])
-    const wrapper = await mountPanel('proj-a')
-    await flushPromises()
-    await wrapper.get('[data-testid="project-agents-subtab-test"]').trigger('click')
-    await flushPromises()
-    expect(wrapper.find('[data-testid="project-agents-chat-test-empty"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="agents-chat-tester"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="agents-studio-stub"]').text()).toBe('studio:proj-a:true')
     wrapper.unmount()
   })
 })

--- a/web/src/components/project/ProjectAgentsPanel.vue
+++ b/web/src/components/project/ProjectAgentsPanel.vue
@@ -1,74 +1,7 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { useRoute } from 'vue-router'
-import Icon from '@/components/ui/Icon.vue'
-import AgentChatTester from '@/components/agent/AgentChatTester.vue'
 import AgentStudioView from '@/views/AgentStudioView.vue'
-import { api, type CreateAgentTestPayload, type SandboxView } from '@/lib/api/api'
 
-const props = defineProps<{ projectId: string }>()
-
-const { t } = useI18n()
-const route = useRoute()
-
-type AgentsSubTab = 'meta' | 'test'
-
-const subTab = ref<AgentsSubTab>('meta')
-const agents = ref<{ name: string; projectId?: string }[]>([])
-
-const projectAgents = computed(() =>
-  agents.value.filter((a) => a.projectId === props.projectId),
-)
-
-/** Current Agent from Studio URL sync, else first project-bound Agent. */
-const testProfile = computed(() => {
-  const q = typeof route.query.agent === 'string' ? route.query.agent.trim() : ''
-  if (q && projectAgents.value.some((a) => a.name === q)) return q
-  if (q && agents.value.length === 0) return q
-  return projectAgents.value[0]?.name || ''
-})
-
-const subTabs = computed(() => [
-  { k: 'meta' as const, l: t('pages.projectDetail.agents.metaTab') },
-  { k: 'test' as const, l: t('pages.projectDetail.agents.testTab') },
-])
-
-async function loadAgents() {
-  try {
-    const list = await api.listAgents()
-    agents.value = list.map((a) => ({ name: a.name, projectId: a.projectId }))
-  } catch {
-    agents.value = []
-  }
-}
-
-async function createProjectContextTest(
-  profile: string,
-  payload: CreateAgentTestPayload,
-): Promise<SandboxView> {
-  return api.createProjectSharedAgentTest(props.projectId, {
-    agentName: profile,
-    ...(payload.repos ? { repos: payload.repos } : {}),
-    ...(payload.repoUrl ? { repoUrl: payload.repoUrl } : {}),
-  })
-}
-
-watch(
-  () => props.projectId,
-  () => {
-    subTab.value = 'meta'
-    void loadAgents()
-  },
-)
-
-watch(subTab, (next) => {
-  if (next === 'test') void loadAgents()
-})
-
-onMounted(() => {
-  void loadAgents()
-})
+defineProps<{ projectId: string }>()
 </script>
 
 <template>
@@ -76,56 +9,6 @@ onMounted(() => {
     class="flex min-h-0 flex-1 flex-col"
     data-testid="project-agents-panel"
   >
-    <div
-      class="scroll-area flex shrink-0 gap-1 overflow-x-auto border-b border-line px-2"
-      data-testid="project-agents-subtabs"
-    >
-      <button
-        v-for="tabItem in subTabs"
-        :key="tabItem.k"
-        type="button"
-        class="shrink-0 whitespace-nowrap px-2.5 py-1.5 text-[12px] transition"
-        :class="
-          subTab === tabItem.k
-            ? 'border-b-2 border-accent text-txt font-semibold'
-            : 'text-txt3 hover:text-txt2'
-        "
-        :data-testid="`project-agents-subtab-${tabItem.k}`"
-        @click="subTab = tabItem.k"
-      >
-        {{ tabItem.l }}
-      </button>
-    </div>
-
-    <!-- Keep Studio mounted so agent selection (route.query.agent) stays synced. -->
-    <div
-      v-show="subTab === 'meta'"
-      class="flex min-h-0 flex-1 flex-col"
-      data-testid="project-agents-meta"
-    >
-      <AgentStudioView :project-id="projectId" embedded />
-    </div>
-
-    <div
-      v-if="subTab === 'test'"
-      class="rounded-lg flex min-h-0 flex-1 flex-col overflow-hidden border border-b-0 border-line bg-surface shadow-[var(--shadow-card)]"
-      data-testid="project-agents-chat-test"
-    >
-      <div
-        v-if="!testProfile"
-        class="flex flex-1 flex-col items-center justify-center gap-2 px-4 text-center text-[13px] text-txt3"
-        data-testid="project-agents-chat-test-empty"
-      >
-        <Icon name="robot" :size="20" />
-        <p>{{ t('pages.projectDetail.agents.noAgentForTest') }}</p>
-      </div>
-      <AgentChatTester
-        v-else
-        :key="testProfile"
-        :profile="testProfile"
-        :home-project-id="projectId"
-        :create-test="createProjectContextTest"
-      />
-    </div>
+    <AgentStudioView :project-id="projectId" :embedded="true" />
   </div>
 </template>

--- a/web/src/components/project/ProjectSharedAgentPanel.test.ts
+++ b/web/src/components/project/ProjectSharedAgentPanel.test.ts
@@ -81,7 +81,7 @@ describe('ProjectSharedAgentPanel without chat test (g2.1)', () => {
     expect(wrapper.find('[data-testid="shared-agent-subtab-test"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="shared-agent-chat-tester"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="shared-agent-test-pick"]').exists()).toBe(false)
-    expect(wrapper.get('[data-testid="shared-agent-help-text"]').text()).toContain('智能体 → 对话测试')
+    expect(wrapper.get('[data-testid="shared-agent-help-text"]').text()).toContain('Agent Studio「对话测试」')
     expect(wrapper.get('[data-testid="shared-agent-help-text"]').text()).not.toContain('仅在此入口')
     wrapper.unmount()
   })

--- a/web/src/lib/agent/useAgentStudio.org.test.ts
+++ b/web/src/lib/agent/useAgentStudio.org.test.ts
@@ -239,7 +239,8 @@ describe('useAgentStudio org and dialogs', () => {
     // Nothing changed → no extra replace.
     studio.syncStudioQuery()
 
-    expect(studio.studioTabs.value).toHaveLength(7)
+    expect(studio.studioTabs.value).toHaveLength(8)
+    expect(studio.studioTabs.value.map((t) => t.k)).toContain('test')
     expect(studio.studioTabLabel.value).toBeTruthy()
     expect(studio.promptCount.value).toBe(0)
 

--- a/web/src/lib/agent/useAgentStudio.ts
+++ b/web/src/lib/agent/useAgentStudio.ts
@@ -26,8 +26,8 @@ import {
   type AgentStudioDraft as Draft,
 } from '@/lib/agent/agentStudioDraft'
 
-export type StudioTab = 'files' | 'mcp' | 'env' | 'prompts' | 'platform-rules' | 'meta' | 'data'
-const STUDIO_TABS: StudioTab[] = ['files', 'mcp', 'env', 'prompts', 'platform-rules', 'meta', 'data']
+export type StudioTab = 'files' | 'mcp' | 'env' | 'prompts' | 'platform-rules' | 'meta' | 'data' | 'test'
+const STUDIO_TABS: StudioTab[] = ['files', 'mcp', 'env', 'prompts', 'platform-rules', 'meta', 'data', 'test']
 
 function isStudioTab(q: unknown): q is StudioTab {
   return typeof q === 'string' && (STUDIO_TABS as readonly string[]).includes(q)
@@ -767,6 +767,7 @@ const studioTabs = computed(() => {
     { k: 'platform-rules' as const, l: t('pages.agentStudio.tabs.platformRules') },
     { k: 'data' as const, l: t('pages.agentStudio.tabs.data') },
     { k: 'meta' as const, l: t('pages.agentStudio.tabs.meta') },
+    { k: 'test' as const, l: t('pages.agentStudio.tabs.test') },
   ]
 })
 const studioTabLabel = computed(() => {

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -176,7 +176,7 @@
       "selectWorkflowGroup": "Select a workflow group on the left",
       "noMatchingGroups": "No matching groups",
       "noMatchingOptions": "No matching options",
-      "noSandboxes": "No sandboxes yet. Node sandboxes are created when workflows run, or start a test sandbox under Project detail → Agents → Chat test.",
+      "noSandboxes": "No sandboxes yet. Node sandboxes are created when workflows run, or start a test sandbox under Agent Studio → Chat test.",
       "noAgents": "No agents yet. Click New agent, or the backend seeds a default on first start.",
       "noPendingGates": "Nothing pending",
       "noPendingGatesForPipeline": "No pending items for this pipeline",

--- a/web/src/locales/en/pages.json
+++ b/web/src/locales/en/pages.json
@@ -992,7 +992,7 @@
       "varsEmptyTitle": "No workflow variables yet",
       "varsEmptyDesc": "Add a row to configure project-level defaults.",
       "sharedAgent": {
-        "extendHint": "Project Runs and Agents → Chat test extend this shared config first, then the chosen Agent overlays same-named keys (Agent wins).",
+        "extendHint": "Project Runs and Agent Studio Chat test extend this shared config first, then the chosen Agent overlays same-named keys (Agent wins).",
         "discard": "Discard",
         "defaultProjectId": "Default project ID",
         "defaultProjectIdDesc": "Stored as defaultProjectId; may fill in when an Agent has no home project.",
@@ -1702,7 +1702,7 @@
     "sandboxes": {
       "title": "Sandboxes",
       "errorPrefix": "Error:",
-      "empty": "No sandboxes. Created on workflow runs or from Project detail → Agents → Chat test.",
+      "empty": "No sandboxes. Created on workflow runs or from Agent Studio → Chat test.",
       "copyId": "Copy ID",
       "copied": "Copied",
       "destroy": "Destroy",
@@ -3597,7 +3597,7 @@
       "destroy": "End & destroy",
       "acpSession": "ACP session",
       "idleHint": "Start a sandbox bound to “{profile}” (workspace / MCP / env) for multi-turn chat testing.",
-      "missingCreateTest": "Chat test launcher not configured. Open Project detail → Agents → Chat test.",
+      "missingCreateTest": "Chat test launcher not configured. Open Chat test inside Agent Studio.",
       "mode": {
         "sectionLabel": "Workspace mode",
         "empty": {

--- a/web/src/locales/userFacingCopy.test.ts
+++ b/web/src/locales/userFacingCopy.test.ts
@@ -55,19 +55,21 @@ describe('user-facing copy remediation keys', () => {
     expect(zh.global.t('pages.projectDetail.pm.inputPh')).toContain('50 MiB')
   })
 
-  it('chat-test entry copy points to Agents → Chat test (g2.2)', () => {
-    expect(zh.global.t('pages.agentChatTester.missingCreateTest')).toContain('智能体 → 对话测试')
-    expect(en.global.t('pages.agentChatTester.missingCreateTest')).toMatch(/Agents → Chat test/i)
-    expect(zh.global.t('pages.sandboxes.empty')).toContain('智能体 → 对话测试')
-    expect(en.global.t('pages.sandboxes.empty')).toMatch(/Agents → Chat test/i)
-    expect(zh.global.t('common.empty.noSandboxes')).toContain('智能体 → 对话测试')
-    expect(en.global.t('common.empty.noSandboxes')).toMatch(/Agents → Chat test/i)
-    expect(zh.global.t('pages.projectDetail.sharedAgent.extendHint')).toContain('智能体 → 对话测试')
+  it('chat-test entry copy points to Agent Studio Chat test (g2.3)', () => {
+    expect(zh.global.t('pages.agentChatTester.missingCreateTest')).toContain('Agent Studio')
+    expect(zh.global.t('pages.agentChatTester.missingCreateTest')).toContain('对话测试')
+    expect(en.global.t('pages.agentChatTester.missingCreateTest')).toMatch(/Agent Studio/i)
+    expect(en.global.t('pages.agentChatTester.missingCreateTest')).toMatch(/Chat test/i)
+    expect(zh.global.t('pages.sandboxes.empty')).toContain('Agent Studio「对话测试」')
+    expect(en.global.t('pages.sandboxes.empty')).toMatch(/Agent Studio → Chat test/i)
+    expect(zh.global.t('common.empty.noSandboxes')).toContain('Agent Studio「对话测试」')
+    expect(en.global.t('common.empty.noSandboxes')).toMatch(/Agent Studio → Chat test/i)
+    expect(zh.global.t('pages.projectDetail.sharedAgent.extendHint')).toContain('Agent Studio「对话测试」')
     expect(zh.global.t('pages.projectDetail.sharedAgent.extendHint')).not.toContain('仅在此入口')
-    expect(en.global.t('pages.projectDetail.sharedAgent.extendHint')).toMatch(/Agents → Chat test/i)
+    expect(en.global.t('pages.projectDetail.sharedAgent.extendHint')).toMatch(/Agent Studio Chat test/i)
     expect(en.global.t('pages.projectDetail.sharedAgent.extendHint')).not.toMatch(/only from this panel/i)
-    expect(zh.global.t('pages.projectDetail.agents.metaTab')).toBe('元信息')
-    expect(zh.global.t('pages.projectDetail.agents.testTab')).toBe('对话测试')
+    expect(zh.global.t('pages.agentStudio.tabs.test')).toBe('对话测试')
+    expect(en.global.t('pages.agentStudio.tabs.test')).toBe('Chat test')
   })
 
   it('pm status/error copy drops internal jargon', () => {

--- a/web/src/locales/zh-CN/common.json
+++ b/web/src/locales/zh-CN/common.json
@@ -176,7 +176,7 @@
       "selectWorkflowGroup": "请在左侧选择工作流分组",
       "noMatchingGroups": "无匹配分组",
       "noMatchingOptions": "无匹配项",
-      "noSandboxes": "暂无沙箱。运行工作流时会按需创建节点沙箱，或前往项目详情「智能体 → 对话测试」启动测试沙箱。",
+      "noSandboxes": "暂无沙箱。运行工作流时会按需创建节点沙箱，或前往 Agent Studio「对话测试」启动测试沙箱。",
       "noAgents": "暂无 Agent。点击右上角\"新建 Agent\"创建,或后端首启会落盘默认 Agent。",
       "noPendingGates": "没有待审批项",
       "noPendingGatesForPipeline": "该流水线没有待审批项",

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -992,7 +992,7 @@
       "varsEmptyTitle": "暂无工作流变量",
       "varsEmptyDesc": "添加一行后，即可配置项目级默认值。",
       "sharedAgent": {
-        "extendHint": "本项目 Run 与「智能体 → 对话测试」会先 extend 此共享配置，再由所选 Agent 同名覆盖（Agent 优先）。",
+        "extendHint": "本项目 Run 与 Agent Studio「对话测试」会先 extend 此共享配置，再由所选 Agent 同名覆盖（Agent 优先）。",
         "discard": "放弃修改",
         "defaultProjectId": "默认项目 ID",
         "defaultProjectIdDesc": "写入共享配置的 defaultProjectId；Agent 未绑定项目时可作补全。",
@@ -1702,7 +1702,7 @@
     "sandboxes": {
       "title": "沙箱",
       "errorPrefix": "出错:",
-      "empty": "暂无沙箱。运行工作流时会按需创建节点沙箱，或前往项目详情「智能体 → 对话测试」启动测试沙箱。",
+      "empty": "暂无沙箱。运行工作流时会按需创建节点沙箱，或前往 Agent Studio「对话测试」启动测试沙箱。",
       "copyId": "复制 ID",
       "copied": "已复制",
       "destroy": "销毁",
@@ -3597,7 +3597,7 @@
       "destroy": "结束并销毁",
       "acpSession": "ACP 会话",
       "idleHint": "启动一个绑定 “{profile}” 配置(工作目录 / MCP / 环境变量)的沙箱,与该 Agent 进行多轮对话测试。",
-      "missingCreateTest": "未配置对话测试启动方式。请从项目详情 → 智能体 → 对话测试进入。",
+      "missingCreateTest": "未配置对话测试启动方式。请从 Agent Studio 内层「对话测试」进入。",
       "mode": {
         "sectionLabel": "工作区模式",
         "empty": {

--- a/web/src/views/AgentStudioView.test.ts
+++ b/web/src/views/AgentStudioView.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   saveAgentsOrg: vi.fn(),
   renameAgent: vi.fn(),
   listProjectRunTags: vi.fn(),
+  createProjectSharedAgentTest: vi.fn(),
 }))
 
 const breakpointMocks = vi.hoisted(() => {
@@ -44,6 +45,7 @@ vi.mock('@/lib/api/api', async () => {
       saveAgentsOrg: mocks.saveAgentsOrg,
       renameAgent: mocks.renameAgent,
       listProjectRunTags: mocks.listProjectRunTags,
+      createProjectSharedAgentTest: mocks.createProjectSharedAgentTest,
     },
   }
 })
@@ -152,6 +154,7 @@ beforeEach(() => {
     agents: {},
     ...org,
   }))
+  mocks.createProjectSharedAgentTest.mockResolvedValue({ id: 1 })
 })
 
 afterEach(() => {
@@ -1002,6 +1005,65 @@ describe('AgentStudio mobile core path', () => {
       expect(wrapper.text()).toContain('建议在桌面使用')
       expect(wrapper.find('agent-data-panel-stub').exists()).toBe(false)
     }
+  })
+
+  it('mounts chat test on mobile instead of desktop-only tip (g2.3)', async () => {
+    mocks.listAgents.mockResolvedValue([agentWithFiles()])
+    const wrapper = await mountMobileStudio()
+    await flushPromises()
+
+    await wrapper.findAll('button').find((b) => b.text() === '对话测试')!.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('建议在桌面使用')
+    expect(wrapper.find('[data-testid="studio-chat-test"]').exists()).toBe(true)
+    expect(wrapper.find('agent-chat-tester-stub').exists()).toBe(true)
+  })
+
+  it('deep-links to chat test with current agent profile (g2.2)', async () => {
+    mocks.listAgents.mockResolvedValue([
+      { ...agentWithFiles(), name: 'alpha' },
+      { ...agentWithFiles(), name: 'beta', projectId: 'proj-default' },
+    ])
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const router = await createStudioRouter({ agent: 'alpha', tab: 'test' })
+    const wrapper = trackMount(
+      mount(AgentStudioView, {
+        global: {
+          plugins: [i18n, router],
+          stubs: {
+            AppButton: ButtonStub,
+            Icon: true,
+            AppModal: true,
+            CodeEditor: CodeEditorStub,
+            MarkdownSplitEditor: true,
+            ExplorerContextMenu: true,
+            AgentChatTester: {
+              props: ['profile', 'homeProjectId', 'createTest'],
+              template:
+                '<div data-testid="studio-chat-tester-stub">{{ profile }}|{{ homeProjectId }}</div>',
+            },
+            AgentGitGuide: true,
+            AgentCreateWizard: true,
+            AgentOrgSidebar: true,
+            AgentDataPanel: true,
+          },
+        },
+      }),
+    )
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="studio-chat-test"]').exists()).toBe(true)
+    expect(wrapper.get('[data-testid="studio-chat-tester-stub"]').text()).toBe(
+      'alpha|proj-default',
+    )
+    // Switching left Agent remounts tester via :key="activeName" (s3).
+    const viewSrc = readFileSync(fileURLToPath(import.meta.url).replace(/\.test\.ts$/, '.vue'), 'utf8')
+    expect(viewSrc).toMatch(/<AgentChatTester[\s\S]*?:key="activeName"/)
   })
 
   it('deep-links to data sub-tab on mobile without desktop-only tip', async () => {
@@ -2113,19 +2175,23 @@ describe('AgentStudioView entry assembly (g3 / Demo main path)', () => {
     expect(src).toMatch(/v-else-if="tab === 'env'/)
     expect(src).toMatch(/v-else-if="tab === 'prompts'/)
     expect(src).toMatch(/tab === 'platform-rules'/)
-    expect(src).not.toMatch(/tab === 'test'/)
+    expect(src).toMatch(/tab === 'test'/)
     expect(src).toMatch(/tab === 'meta'/)
-    // Rejected demo: must not add chat-test as a STUDIO_TABS trailing item (g2.2).
+    // Chat test is a trailing Studio inner tab (g2.1 / g2.2).
     expect(src).toMatch(/const STUDIO_TABS[\s\S]*?=\s*\[[^\]]*\]/)
-    expect(src).not.toMatch(/STUDIO_TABS[^\n]*test/)
-    expect(src).not.toMatch(/'test' as StudioTab|StudioTab.*'test'/)
+    expect(src).toMatch(/StudioTab[\s\S]*'test'/)
+    expect(src).toMatch(/'test' as const/)
+    expect(viewSrc).toContain('AgentChatTester')
+    expect(viewSrc).toMatch(/data-testid="studio-chat-test"/)
+    expect(viewSrc).toMatch(/createStudioChatTest|createProjectSharedAgentTest/)
+    expect(viewSrc).toMatch(/tab !== 'data' && tab !== 'test'/)
   })
 
   it('switches Demo main-path tabs via tab strip without changing labels', async () => {
     mocks.listAgents.mockResolvedValue([agent()])
     const wrapper = await mountStudio({ agent: 'legacy' })
     await flushPromises()
-    expect(wrapper.text()).not.toContain('对话测试')
+    expect(wrapper.text()).toContain('对话测试')
     const mcpBtn = wrapper.findAll('button').find((b) => /MCP/i.test(b.text()))
     expect(mcpBtn).toBeTruthy()
     await mcpBtn!.trigger('click')

--- a/web/src/views/AgentStudioView.vue
+++ b/web/src/views/AgentStudioView.vue
@@ -10,9 +10,12 @@ import AgentEnvPanel from '@/components/agent/AgentEnvPanel.vue'
 import AgentPromptsPanel from '@/components/agent/AgentPromptsPanel.vue'
 import AgentPlatformRulesPanel from '@/components/agent/AgentPlatformRulesPanel.vue'
 import AgentMetaPanel from '@/components/agent/AgentMetaPanel.vue'
+import AgentChatTester from '@/components/agent/AgentChatTester.vue'
 import AgentCreateWizard from '@/components/agent/AgentCreateWizard.vue'
 import CreateAgentTeamWizard from '@/components/agent/CreateAgentTeamWizard.vue'
 import TeamBootstrapPanel from '@/components/agent/TeamBootstrapPanel.vue'
+import { computed } from 'vue'
+import { api, type CreateAgentTestPayload, type SandboxView } from '@/lib/api/api'
 import { useAgentStudio } from '@/lib/agent/useAgentStudio'
 
 const props = defineProps<{ projectId?: string; embedded?: boolean }>()
@@ -237,6 +240,24 @@ const {
   onChromeKeydown,
   UNGROUPED_ID,
 } = useAgentStudio({ projectId: () => props.projectId, embedded: () => !!props.embedded })
+
+/** Embedded: host project id; standalone: Agent's saved home project. */
+const chatHomeProjectId = computed(() => {
+  if (embedded.value && props.projectId?.trim()) return props.projectId.trim()
+  return savedProjectId.value
+})
+
+async function createStudioChatTest(
+  profile: string,
+  payload: CreateAgentTestPayload,
+): Promise<SandboxView> {
+  const pid = chatHomeProjectId.value.trim()
+  return api.createProjectSharedAgentTest(pid, {
+    agentName: profile,
+    ...(payload.repos ? { repos: payload.repos } : {}),
+    ...(payload.repoUrl ? { repoUrl: payload.repoUrl } : {}),
+  })
+}
 </script>
 <template>
   <div
@@ -561,10 +582,10 @@ const {
           @restored="reloadAgentFromServer(activeName)"
         />
 
-        <!-- narrow-screen: non-whitelist tabs show desktop-only tip (files+data allowed) -->
+        <!-- narrow-screen: non-whitelist tabs show desktop-only tip (files+data+test allowed) -->
         <Transition name="ui-fade" mode="out-in">
           <div
-            v-if="tab !== 'files' && isMobile && tab !== 'data'"
+            v-if="tab !== 'files' && isMobile && tab !== 'data' && tab !== 'test'"
             key="mobile-desktop-only"
             class="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 px-5 py-8 text-center"
           >
@@ -656,6 +677,20 @@ const {
             @update:org="org = $event"
             @error="(msg) => (error = msg)"
           />
+
+          <div
+            v-else-if="tab === 'test' && draft"
+            key="test"
+            class="flex min-h-0 flex-1 flex-col overflow-hidden"
+            data-testid="studio-chat-test"
+          >
+            <AgentChatTester
+              :key="activeName"
+              :profile="activeName"
+              :home-project-id="chatHomeProjectId"
+              :create-test="createStudioChatTest"
+            />
+          </div>
         </Transition>
 
       </div>

--- a/web/src/views/ProjectDetailView.vue
+++ b/web/src/views/ProjectDetailView.vue
@@ -957,7 +957,7 @@ const onboardingEmptyDesc = computed(() =>
         </div>
       </div>
 
-      <!-- Agents: second-level meta | chat test (fill remaining main area) -->
+      <!-- Agents: embed Agent Studio (chat test is an inner Studio tab) -->
       <div v-else-if="tab === 'agents'" class="flex min-h-0 flex-1 flex-col" data-testid="project-agents-tab">
         <ProjectAgentsPanel :project-id="projectId" />
       </div>


### PR DESCRIPTION
## Summary
- Move chat test from the project Agents outer meta|test tabs into a trailing Agent Studio inner tab.
- Project Agents now always embeds Studio; `AgentChatTester` follows the selected agent and still starts via `createProjectSharedAgentTest`.
- Mobile whitelist includes the test tab so it is not treated as desktop-only; deep link `studioTab=test` / `tab=test` still works.

## Test plan
- [ ] Open a project Agents page: no outer `元信息 | 对话测试` subtabs; Studio inner tabs include 对话测试
- [ ] Select an agent, click 对话测试: `studio-chat-test` mounts AgentChatTester and can start a sandbox
- [ ] Switch agents: tester follows the current agent / bound project
- [ ] Mobile viewport: 对话测试 is usable (no “建议在桌面使用”)
- [ ] Deep link `?tab=test` (standalone) / `studioTab=test` (embedded) opens the tester
- [ ] Vitest: ProjectAgentsPanel, AgentStudioView, userFacingCopy, useAgentStudio.org (8 tabs including test)