### PR TITLE
fix: shorten zh-CN shared agent project tab label

### DIFF
--- a/web/e2e/project-detail.spec.ts
+++ b/web/e2e/project-detail.spec.ts
@@ -516,7 +516,7 @@ test.describe('ProjectDetailView 共享 Agent / 工作流变量面板布局', ()
     await page.goto('/project-detail.html')
     await expect(page.getByRole('heading', { name: 'Demo Project' })).toBeVisible({ timeout: 10_000 })
 
-    await page.getByRole('button', { name: '项目共享 Agent 配置' }).click()
+    await page.getByRole('button', { name: '共享Agent配置' }).click()
     await expect(page).toHaveURL(/tab=sharedAgent/)
     const panel = page.getByTestId('project-shared-agent-panel')
     await expect(panel).toBeVisible()
@@ -751,7 +751,7 @@ test.describe('ProjectDetailView 项目信息面板', () => {
     await page.getByTestId('project-meta-footer').getByRole('button', { name: '保存' }).click()
     await expect(page.getByRole('heading', { name: 'Renamed Project' })).toBeVisible({ timeout: 5_000 })
 
-    await page.getByRole('button', { name: '项目共享 Agent 配置' }).click()
+    await page.getByRole('button', { name: '共享Agent配置' }).click()
     await expect(page.getByTestId('project-shared-agent-panel')).toBeVisible()
     await expect(page).toHaveURL(/tab=sharedAgent/)
     await page.getByRole('button', { name: '定时任务' }).click()

--- a/web/e2e/project-env-auth-key.spec.ts
+++ b/web/e2e/project-env-auth-key.spec.ts
@@ -96,7 +96,7 @@ async function gotoSharedAgentEnv(page: import('@playwright/test').Page) {
   await page.goto('/project-detail.html')
   await dismissOnboardingIfOpen(page)
   await expect(page.getByRole('heading', { name: 'Demo Project' })).toBeVisible({ timeout: 10_000 })
-  await page.getByRole('button', { name: '项目共享 Agent 配置' }).click()
+  await page.getByRole('button', { name: '共享Agent配置' }).click()
   await page.getByTestId('shared-agent-subtab-env').click()
 }
 

--- a/web/src/locales/zh-CN/pages.json
+++ b/web/src/locales/zh-CN/pages.json
@@ -327,7 +327,7 @@
         "hint": "仅保存在项目共享配置中，不会写入日志或产物。"
       },
       "git": {
-        "meta": "填写仓库、Git 提交身份，并打开沙箱预览。凭据可跳过，稍后在「项目共享 Agent 配置」里补。",
+        "meta": "填写仓库、Git 提交身份，并打开沙箱预览。凭据可跳过，稍后在「共享Agent配置」里补。",
         "foot": "凭据写入共享配置，不进入综合项目组导出包。"
       },
       "gitUser": {
@@ -383,7 +383,7 @@
         "repoOk": "已写入默认工作流的 repos 变量，clone 到 /root/workspace/{dir}/。启动 Run 时仍可改。",
         "publishedLine": "默认工作流（已发布）",
         "gitOk": "已写入 Git 凭据到共享配置（值已打码）。",
-        "gitSkip": "未配置 Git。私有仓请到项目详情 → 共享 Agent 配置补 Token 或 SSH。",
+        "gitSkip": "未配置 Git。私有仓请到项目详情 → 共享Agent配置补 Token 或 SSH。",
         "gitUserOk": "已写入提交身份：{name} <{email}>。",
         "gitUserSkip": "未填写 Git 提交身份。沙箱会用默认 sandbox / sandbox{'@'}localhost。",
         "preview": "已写入 {vnc}、{mcp} 到共享配置。"
@@ -436,7 +436,7 @@
       "tabPmMemory": "项目记忆",
       "tabCronJobs": "定时任务",
       "tabAgents": "智能体",
-      "tabSharedAgent": "项目共享 Agent 配置",
+      "tabSharedAgent": "共享Agent配置",
       "tabVariables": "工作流变量",
       "tabAudit": "审计",
       "tabMeta": "项目信息",
@@ -2062,7 +2062,7 @@
         "hint": "环境变量会注入该 Agent 的沙箱容器;值支持运行级变量与全局变量 {'${vars.<名字>}'}(如 {'${vars.feature}'})。ACP API Key 须在此配置,平台不再提供全局 Key。",
         "backendAuthTitle": "当前后端所需鉴权变量",
         "backendAuthPreferShared": "不建议在单个 Agent 上新写 Token",
-        "backendAuthPreferSharedBody": "ACP / Git Token 请到「项目共享 Agent 配置」中维护。下方已有行仍可编辑（不影响使用），运行时同名 Token 以共享配置为准。",
+        "backendAuthPreferSharedBody": "ACP / Git Token 请到「共享Agent配置」中维护。下方已有行仍可编辑（不影响使用），运行时同名 Token 以共享配置为准。",
         "backendAuthIntro": "acpBackend={backend} 时,请在下方添加对应 Key(值不会在界面明文回显):",
         "backendAuthMasked": "保存后写入 agent.json,运行时注入沙箱",
         "regionLabel": "站点",
@@ -2525,17 +2525,17 @@
           "remapBody": "已配置的 MCP / Skills / Commands / Rules 可能依赖当前路径。更换 Backend 将按新的 configRoot 重映射；取消则保持原 Backend。"
         },
         "apiKey": {
-          "meta": "Token 类鉴权请写到「项目共享 Agent 配置」；本步可跳过，创建时不会把 API Key 写入单个 Agent。",
+          "meta": "Token 类鉴权请写到「共享Agent配置」；本步可跳过，创建时不会把 API Key 写入单个 Agent。",
           "modeGroup": "鉴权方式",
           "modeApiKey": "粘贴 API Key",
-          "modeApiKeyHint": "仅作参考输入，创建时不会写入单个 Agent.env；请到项目共享 Agent 配置保存",
+          "modeApiKeyHint": "仅作参考输入，创建时不会写入单个 Agent.env；请到共享Agent配置保存",
           "modeCustomConfig": "自定义配置",
           "modeCustomConfigHint": "编辑 settings.json，创建时写入 Agent 文件树",
           "backendBanner": "当前 Backend：{backend}。",
           "alias": "别名（任选其一）",
           "inputLabel": "粘贴 API Key（可选，不会写入 Agent.env）",
-          "inputPlaceholder": "建议跳过，改到项目共享 Agent 配置填写",
-          "skipHint": "推荐直接「跳过」或「下一步」；在项目详情 → 项目共享 Agent 配置中填写 Token。",
+          "inputPlaceholder": "建议跳过，改到共享Agent配置填写",
+          "skipHint": "推荐直接「跳过」或「下一步」；在项目详情 → 共享Agent配置中填写 Token。",
           "notes": {
             "codebuddySite": "Key 与站点绑定；请到与 Agent 步所选站点一致的控制台申请。",
             "traeToken": "官方 CLI 登录令牌须含 trae-lt- 前缀（旗舰版）。",


### PR DESCRIPTION
Use exact title「共享Agent配置」for the project detail tab and entry
guidance, and align E2E getByRole selectors (g1.1–g2.2).

Co-authored-by: Cursor <cursoragent@cursor.com>
