### PR TITLE
fix: keep Run detail switcher in left pane and drop connecting preview tab

### DIFF
--- a/web/src/components/run/ReactConnectingState.test.ts
+++ b/web/src/components/run/ReactConnectingState.test.ts
@@ -108,4 +108,34 @@ describe('ReactConnectingState', () => {
     expect(wrapper.text()).toContain('正在拉取镜像…')
     expect(wrapper.text()).not.toContain('正在启动 Agent…')
   })
+
+  it('stage chrome only shows pipeline tab — no fake previewTab (g2.1)', () => {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const wrapper = mount(ReactConnectingState, {
+      props: { mode: 'stage' },
+      global: { plugins: [i18n], stubs: { Icon: true } },
+    })
+    expect(wrapper.get('[data-testid="react-connecting-stage"]').exists()).toBe(true)
+    expect(wrapper.get('[data-testid="react-connecting-tab-pipeline"]').text()).toContain('流水线产物')
+    expect(wrapper.text()).not.toContain('产物预览')
+    expect(wrapper.find('[data-testid="react-connecting-stage-tabs"]').text()).not.toMatch(/预览/)
+  })
+
+  it('stage chrome English copy has no Artifact preview tab (g2.1)', () => {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'en',
+      messages: { en: { ...enCommon, ...enPages } },
+    })
+    const wrapper = mount(ReactConnectingState, {
+      props: { mode: 'stage' },
+      global: { plugins: [i18n], stubs: { Icon: true } },
+    })
+    expect(wrapper.get('[data-testid="react-connecting-tab-pipeline"]').text()).toContain('Pipeline artifacts')
+    expect(wrapper.text()).not.toContain('Artifact preview')
+  })
 })

--- a/web/src/components/run/ReactConnectingState.vue
+++ b/web/src/components/run/ReactConnectingState.vue
@@ -27,12 +27,13 @@ const { t } = useI18n()
     data-testid="react-connecting-stage"
     aria-busy="true"
   >
-    <div class="flex shrink-0 gap-1 border-b border-line px-3 py-2">
-      <span class="rounded-md bg-elevated px-2.5 py-1 text-[11px] text-txt2">
+    <!-- plan g2.1: match ReactArtifactStage chrome — only pipeline tab, no fake previewTab -->
+    <div class="flex shrink-0 gap-1 border-b border-line px-3 py-2" data-testid="react-connecting-stage-tabs">
+      <span
+        class="rounded-md bg-elevated px-2.5 py-1 text-[11px] text-txt2"
+        data-testid="react-connecting-tab-pipeline"
+      >
         {{ t('pages.reactArtifactStage.pipelineTab') }}
-      </span>
-      <span class="px-2.5 py-1 text-[11px] text-txt3">
-        {{ t('pages.reactArtifactStage.previewTab') }}
       </span>
     </div>
     <div class="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 p-5 text-center">

--- a/web/src/components/run/RunViewModeSwitcher.vue
+++ b/web/src/components/run/RunViewModeSwitcher.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const props = defineProps<{
+  viewMode: 'canvas' | 'timeline' | 'stats'
+  isMobile: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:viewMode': [mode: 'canvas' | 'timeline' | 'stats']
+}>()
+
+const { t } = useI18n()
+
+const viewModeTrack = ref<HTMLElement | null>(null)
+const viewModeIndicator = ref<Record<string, string>>({
+  opacity: '0',
+  transform: 'translateX(0)',
+  width: '0px',
+})
+
+function updateViewModeIndicator() {
+  const root = viewModeTrack.value
+  if (!root) return
+  const active = root.querySelector<HTMLElement>('[data-view-mode-active="true"]')
+  if (!active) {
+    viewModeIndicator.value = { opacity: '0', transform: 'translateX(0)', width: '0px' }
+    return
+  }
+  viewModeIndicator.value = {
+    opacity: '1',
+    transform: `translateX(${active.offsetLeft}px)`,
+    width: `${active.offsetWidth}px`,
+  }
+}
+
+watch(
+  () => props.viewMode,
+  () => {
+    void nextTick(updateViewModeIndicator)
+  },
+)
+onMounted(() => {
+  void nextTick(updateViewModeIndicator)
+  window.addEventListener('resize', updateViewModeIndicator)
+})
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', updateViewModeIndicator)
+})
+</script>
+
+<template>
+  <div
+    ref="viewModeTrack"
+    class="relative inline-flex rounded-lg border border-line bg-surface/90 p-0.5 text-[12px] backdrop-blur"
+  >
+    <span
+      class="seg-indicator pointer-events-none absolute inset-y-0.5 left-0 rounded-md bg-accent-dim"
+      data-testid="run-view-mode-indicator"
+      :style="viewModeIndicator"
+      aria-hidden="true"
+    />
+    <button
+      v-if="!isMobile"
+      data-testid="view-mode-canvas"
+      class="relative z-[1] rounded-md px-2.5 py-1 font-medium transition-colors"
+      :class="viewMode === 'canvas' ? 'text-accent' : 'text-txt3 hover:text-txt2'"
+      :data-view-mode-active="viewMode === 'canvas' ? 'true' : undefined"
+      @click="emit('update:viewMode', 'canvas')"
+    >
+      {{ t('pages.runDetail.canvas') }}
+    </button>
+    <button
+      data-testid="view-mode-timeline"
+      class="relative z-[1] rounded-md px-2.5 py-1 font-medium transition-colors"
+      :class="viewMode === 'timeline' ? 'text-accent' : 'text-txt3 hover:text-txt2'"
+      :data-view-mode-active="viewMode === 'timeline' ? 'true' : undefined"
+      @click="emit('update:viewMode', 'timeline')"
+    >
+      {{ t('pages.runDetail.timeline') }}
+    </button>
+    <button
+      data-testid="view-mode-stats"
+      class="relative z-[1] rounded-md px-2.5 py-1 font-medium transition-colors"
+      :class="viewMode === 'stats' ? 'text-accent' : 'text-txt3 hover:text-txt2'"
+      :data-view-mode-active="viewMode === 'stats' ? 'true' : undefined"
+      @click="emit('update:viewMode', 'stats')"
+    >
+      {{ t('pages.runDetail.stats') }}
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.seg-indicator {
+  transition:
+    transform var(--dur-ui) var(--ease-out-expo),
+    width var(--dur-ui) var(--ease-out-expo),
+    opacity var(--dur-ui) ease;
+}
+</style>

--- a/web/src/components/run/runDetailPanels.smoke.test.ts
+++ b/web/src/components/run/runDetailPanels.smoke.test.ts
@@ -226,6 +226,10 @@ describe('Run detail panel shells (Demo entry assembly)', () => {
     expect(clarify.find('[data-testid="react-connecting-stage"]').exists()).toBe(true)
     expect(clarify.find('[data-testid="react-connecting-sidebar"]').exists()).toBe(true)
     expect(clarify.find('[data-testid="react-connecting-confirm"]').exists()).toBe(false)
+    // plan g2.1 / g2.2: connecting stage has pipeline-only chrome; stage+sidebar both present
+    expect(clarify.get('[data-testid="react-connecting-tab-pipeline"]').text()).toContain('流水线产物')
+    expect(clarify.text()).not.toContain('产物预览')
+    expect(clarify.find('[data-testid="react-artifact-tab-preview"]').exists()).toBe(false)
 
     const review = mount(RunReviewPanel, {
       props: {
@@ -246,5 +250,6 @@ describe('Run detail panel shells (Demo entry assembly)', () => {
     expect(review.find('[data-testid="react-connecting-stage"]').exists()).toBe(true)
     expect(review.find('[data-testid="react-connecting-sidebar"]').exists()).toBe(true)
     expect((review.get('[data-testid="react-connecting-confirm"]').element as HTMLButtonElement).disabled).toBe(true)
+    expect(review.text()).not.toContain('产物预览')
   })
 })

--- a/web/src/views/RunDetailView.test.ts
+++ b/web/src/views/RunDetailView.test.ts
@@ -13,6 +13,7 @@ function read(...parts: string[]) {
 
 /** Entry + panel shells + orchestration composables (Demo「入口只装配」拆分后的源码图). */
 const viewSrc = read('views/RunDetailView.vue')
+const viewModeSwitcherSrc = read('components/run/RunViewModeSwitcher.vue')
 const gatePanelSrc = read('components/run/RunGatePanel.vue')
 const logPanelSrc = read('components/run/RunLogPanel.vue')
 const sandboxPanelSrc = read('components/run/RunSandboxPanel.vue')
@@ -25,6 +26,7 @@ const detailOrchestrationSrc = read('lib/run/useRunDetail.ts')
 
 const src = [
   viewSrc,
+  viewModeSwitcherSrc,
   detailOrchestrationSrc,
   gatePanelSrc,
   logPanelSrc,
@@ -37,7 +39,7 @@ const src = [
 ].join('\n')
 
 /** View shell + extracted orchestration (post structure-sink). */
-const viewOrchestrationSrc = viewSrc + '\n' + detailOrchestrationSrc
+const viewOrchestrationSrc = viewSrc + '\n' + detailOrchestrationSrc + '\n' + viewModeSwitcherSrc
 
 describe('RunDetailView delete run', () => {
   it('exposes delete button, disabled hint, and confirm modal wiring', () => {
@@ -355,11 +357,28 @@ describe('RunDetailView desktop outer sash layout (all node tabs)', () => {
     expect(viewOrchestrationSrc).toMatch(/fullOpen/)
   })
 
-  it('moves view-mode switcher off the outer sash hit target when full-open', () => {
-    expect(viewSrc).toMatch(/data-testid="run-detail-view-mode-switcher"/)
-    expect(viewSrc).toMatch(/outerFullOpen/)
-    expect(viewSrc).toMatch(/md:left-5 md:z-\[1\]/)
-    expect(viewSrc).toMatch(/md:left-3 md:z-10/)
+  it('keeps view-mode switcher inside left pane on default split and above node tabs when full-open (g1)', () => {
+    // plan g1.1 / g1.3: default split mounts switcher inside left canvas/timeline with overflow clip
+    expect(viewSrc).toMatch(/data-testid="run-detail-left-pane"/)
+    expect(viewSrc).toMatch(/overflow-hidden border-r border-line md:block/)
+    // timeline relies on leftPaneStyle.overflow=hidden (desktop); class must stay free of Tailwind `hidden`
+    expect(viewSrc).toMatch(/data-testid="run-timeline-pane"/)
+    expect(viewOrchestrationSrc).toMatch(/overflow: 'hidden'/)
+    expect(viewSrc).toMatch(/RunViewModeSwitcher/)
+    // plan g1.2: full-open mounts switcher in right panel document flow above AppTabs
+    expect(viewSrc).toMatch(/v-if="!isMobile && outerFullOpen"/)
+    expect(viewSrc).toMatch(/data-testid="run-detail-right-panel"[\s\S]*?run-detail-view-mode-switcher[\s\S]*?AppTabs/)
+    // Must not float over the whole split with left-5 (old overlay that covered node tabs)
+    expect(viewSrc).not.toMatch(/md:left-5 md:z-\[1\]/)
+    expect(viewSrc).not.toMatch(/md:absolute md:top-3 md:border-0 md:bg-transparent md:p-0/)
+  })
+
+  it('renders only one view-mode switcher mount at a time (g1.3)', () => {
+    // Mutually exclusive branches: mobile | stats | left(!fullOpen) | right(fullOpen)
+    expect(viewSrc).toMatch(/v-if="isMobile"[\s\S]*?run-detail-view-mode-switcher/)
+    expect(viewSrc).toMatch(/v-else-if="viewMode === 'stats'"[\s\S]*?run-detail-view-mode-switcher/)
+    expect(viewSrc).toMatch(/v-if="!outerFullOpen"[\s\S]*?run-detail-view-mode-switcher/)
+    expect(viewSrc).toMatch(/v-if="!isMobile && outerFullOpen"[\s\S]*?run-detail-view-mode-switcher/)
   })
 
   it('hides outer sash on mobile (no horizontal drag)', () => {

--- a/web/src/views/RunDetailView.vue
+++ b/web/src/views/RunDetailView.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import Icon from '@/components/ui/Icon.vue'
 import AppButton from '@/components/ui/AppButton.vue'
 import StatusPill from '@/components/ui/StatusPill.vue'
@@ -21,6 +20,7 @@ import ArtifactPanel from '@/components/run/ArtifactPanel.vue'
 import RunSandboxEnvPanel from '@/components/run/RunSandboxEnvPanel.vue'
 import ExecutionTimeline from '@/components/run/ExecutionTimeline.vue'
 import ExecutionStatsPanel from '@/components/run/ExecutionStatsPanel.vue'
+import RunViewModeSwitcher from '@/components/run/RunViewModeSwitcher.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import RefreshStrip from '@/components/run/RefreshStrip.vue'
 import HardLoadLayer from '@/components/run/HardLoadLayer.vue'
@@ -212,39 +212,6 @@ const {
   currentLiveLogBootSession,
   onLiveLogBootSession,
 } = useRunDetail()
-
-const viewModeTrack = ref<HTMLElement | null>(null)
-const viewModeIndicator = ref<Record<string, string>>({
-  opacity: '0',
-  transform: 'translateX(0)',
-  width: '0px',
-})
-
-function updateViewModeIndicator() {
-  const root = viewModeTrack.value
-  if (!root) return
-  const active = root.querySelector<HTMLElement>('[data-view-mode-active="true"]')
-  if (!active) {
-    viewModeIndicator.value = { opacity: '0', transform: 'translateX(0)', width: '0px' }
-    return
-  }
-  viewModeIndicator.value = {
-    opacity: '1',
-    transform: `translateX(${active.offsetLeft}px)`,
-    width: `${active.offsetWidth}px`,
-  }
-}
-
-watch(viewMode, () => {
-  void nextTick(updateViewModeIndicator)
-})
-onMounted(() => {
-  void nextTick(updateViewModeIndicator)
-  window.addEventListener('resize', updateViewModeIndicator)
-})
-onBeforeUnmount(() => {
-  window.removeEventListener('resize', updateViewModeIndicator)
-})
 </script>
 
 <template>
@@ -454,55 +421,27 @@ onBeforeUnmount(() => {
         class="flex min-h-0 min-w-0 w-full max-w-full flex-1 flex-col md:flex-row"
         :class="{ 'run-detail-outer-sash-booting': outerSashBooting && desktopOuterSashLayout }"
       >
-      <!-- View mode switcher: always visible so mobile can open stats. -->
+      <!--
+        View mode switcher placement (plan g1):
+        - Mobile: document-flow top bar (always reachable for stats).
+        - Desktop stats: absolute over full-width stats chrome (md:pt-12 keeps clearance).
+        - Desktop canvas/timeline default split: inside left pane only (clipped by overflow).
+        - Desktop full-open: in right panel flow ABOVE node tabs (clickable, does not cover AppTabs).
+        Exactly one mount is active at a time → single data-testid instance.
+      -->
       <div
+        v-if="isMobile"
         data-testid="run-detail-view-mode-switcher"
-        class="flex shrink-0 items-center gap-2 border-b border-line bg-surface px-3 py-2 md:absolute md:top-3 md:border-0 md:bg-transparent md:p-0"
-        :class="
-          outerFullOpen
-            ? 'md:left-5 md:z-[1]'
-            : 'md:left-3 md:z-10'
-        "
+        class="flex shrink-0 items-center gap-2 border-b border-line bg-surface px-3 py-2"
       >
-        <div
-          ref="viewModeTrack"
-          class="relative inline-flex rounded-lg border border-line bg-surface/90 p-0.5 text-[12px] backdrop-blur"
-        >
-          <span
-            class="seg-indicator pointer-events-none absolute inset-y-0.5 left-0 rounded-md bg-accent-dim"
-            data-testid="run-view-mode-indicator"
-            :style="viewModeIndicator"
-            aria-hidden="true"
-          />
-          <button
-            v-if="!isMobile"
-            data-testid="view-mode-canvas"
-            class="relative z-[1] rounded-md px-2.5 py-1 font-medium transition-colors"
-            :class="viewMode === 'canvas' ? 'text-accent' : 'text-txt3 hover:text-txt2'"
-            :data-view-mode-active="viewMode === 'canvas' ? 'true' : undefined"
-            @click="viewMode = 'canvas'"
-          >
-            {{ t('pages.runDetail.canvas') }}
-          </button>
-          <button
-            data-testid="view-mode-timeline"
-            class="relative z-[1] rounded-md px-2.5 py-1 font-medium transition-colors"
-            :class="viewMode === 'timeline' ? 'text-accent' : 'text-txt3 hover:text-txt2'"
-            :data-view-mode-active="viewMode === 'timeline' ? 'true' : undefined"
-            @click="viewMode = 'timeline'"
-          >
-            {{ t('pages.runDetail.timeline') }}
-          </button>
-          <button
-            data-testid="view-mode-stats"
-            class="relative z-[1] rounded-md px-2.5 py-1 font-medium transition-colors"
-            :class="viewMode === 'stats' ? 'text-accent' : 'text-txt3 hover:text-txt2'"
-            :data-view-mode-active="viewMode === 'stats' ? 'true' : undefined"
-            @click="viewMode = 'stats'"
-          >
-            {{ t('pages.runDetail.stats') }}
-          </button>
-        </div>
+        <RunViewModeSwitcher v-model:view-mode="viewMode" :is-mobile="isMobile" />
+      </div>
+      <div
+        v-else-if="viewMode === 'stats'"
+        data-testid="run-detail-view-mode-switcher"
+        class="absolute left-3 top-3 z-10"
+      >
+        <RunViewModeSwitcher v-model:view-mode="viewMode" :is-mobile="isMobile" />
       </div>
 
       <!-- Stats mode: full-width single/multi tabs; single = timeline+panel (no click link); multi = full panel. -->
@@ -594,10 +533,19 @@ onBeforeUnmount(() => {
       <!-- Canvas: desktop only (narrow viewMode is normalized away from canvas). -->
       <div
         v-if="viewMode === 'canvas'"
-        class="relative hidden min-w-0 flex-1 border-r border-line md:block"
+        data-testid="run-detail-left-pane"
+        class="relative hidden min-w-0 flex-1 overflow-hidden border-r border-line md:block"
         :class="outerFullOpen ? 'pointer-events-none' : ''"
         :style="leftPaneStyle"
       >
+        <!-- plan g1.1: switcher floats only inside left canvas when split is open -->
+        <div
+          v-if="!outerFullOpen"
+          data-testid="run-detail-view-mode-switcher"
+          class="absolute left-3 top-3 z-10"
+        >
+          <RunViewModeSwitcher v-model:view-mode="viewMode" :is-mobile="isMobile" />
+        </div>
         <WorkflowCanvas
           :nodes="wf.nodes"
           :edges="wf.edges"
@@ -655,6 +603,14 @@ onBeforeUnmount(() => {
         :class="[isMobile ? 'border-b-0' : '', outerFullOpen ? 'pointer-events-none' : '']"
         :style="leftPaneStyle"
       >
+        <!-- plan g1.1: switcher floats only inside left timeline when split is open -->
+        <div
+          v-if="!isMobile && !outerFullOpen"
+          data-testid="run-detail-view-mode-switcher"
+          class="absolute left-3 top-3 z-10"
+        >
+          <RunViewModeSwitcher v-model:view-mode="viewMode" :is-mobile="isMobile" />
+        </div>
         <ExecutionTimeline
           :run="run"
           :nodes="wf.nodes"
@@ -699,6 +655,14 @@ onBeforeUnmount(() => {
         ]"
         :style="reviewRightPanelStyle"
       >
+        <!-- plan g1.2: full-open keeps switcher clickable above node tabs, not over them -->
+        <div
+          v-if="!isMobile && outerFullOpen"
+          data-testid="run-detail-view-mode-switcher"
+          class="flex shrink-0 items-center gap-2 px-3 pb-1 pt-2"
+        >
+          <RunViewModeSwitcher v-model:view-mode="viewMode" :is-mobile="isMobile" />
+        </div>
         <!-- Mobile detail chrome: back to timeline -->
         <div
           v-if="isMobile && viewMode === 'timeline'"
@@ -1005,12 +969,6 @@ onBeforeUnmount(() => {
 }
 .run-detail-outer-sash.is-full {
   box-shadow: 8px 0 12px rgb(var(--c-accent) / 0.45);
-}
-.seg-indicator {
-  transition:
-    transform var(--dur-ui) var(--ease-out-expo),
-    width var(--dur-ui) var(--ease-out-expo),
-    opacity var(--dur-ui) ease;
 }
 </style>
 


### PR DESCRIPTION
Prevent the canvas/timeline view switcher from overlaying right-side node tabs (including full-open), and align connecting stage chrome with the real artifact stage (pipeline tab only).

Co-authored-by: Cursor <cursoragent@cursor.com>
