### PR TITLE
feat: move Agent Studio import/new into AGENTS list header

### DIFF
--- a/web/e2e/project-agents-tab.spec.ts
+++ b/web/e2e/project-agents-tab.spec.ts
@@ -156,7 +156,11 @@ test('项目详情智能体 Tab：嵌入 Studio、过滤他项目、隐藏创建
 
   const body = await page.locator('[data-testid="project-agents-tab"]').innerText()
   expect(body).not.toContain('创建 Agent 团队')
-  expect(body).toMatch(/新建 Agent|New Agent/)
+  await expect(page.getByTestId('agent-studio-action-row')).toHaveCount(0)
+  await expect(page.getByTestId('agent-org-import')).toBeVisible()
+  await expect(page.getByTestId('agent-org-create-agent')).toBeVisible()
+  await expect(page.getByRole('button', { name: '新建 Agent' })).toBeVisible()
+  await expect(page.getByRole('button', { name: '导入' })).toBeVisible()
 
   await expect(page.getByTestId('project-tab-sharedAgent')).toBeVisible()
 

--- a/web/src/components/agent/AgentOrgSidebar.test.ts
+++ b/web/src/components/agent/AgentOrgSidebar.test.ts
@@ -508,6 +508,48 @@ describe('AgentOrgSidebar agent name text color', () => {
     await btn.trigger('click')
     expect(wrapper.emitted('create-team')).toBeTruthy()
   })
+
+  it('列表头可触发导入与新建 Agent（22px 图标）', async () => {
+    const wrapper = mountSidebar()
+    const importBtn = wrapper.find('[data-testid="agent-org-import"]')
+    const createBtn = wrapper.find('[data-testid="agent-org-create-agent"]')
+    expect(importBtn.exists()).toBe(true)
+    expect(createBtn.exists()).toBe(true)
+    expect(importBtn.classes()).toContain('h-[22px]')
+    expect(createBtn.classes()).toContain('w-[22px]')
+    expect(importBtn.attributes('aria-label')).toBe('导入')
+    expect(createBtn.attributes('aria-label')).toBe('新建 Agent')
+    expect(importBtn.text()).not.toContain('导入')
+    expect(createBtn.text()).not.toContain('新建 Agent')
+
+    await importBtn.trigger('click')
+    await createBtn.trigger('click')
+    expect(wrapper.emitted('import')).toBeTruthy()
+    expect(wrapper.emitted('create-agent')).toBeTruthy()
+  })
+
+  it('折叠态不展示导入/新建图标', async () => {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const wrapper = mount(AgentOrgSidebar, {
+      props: {
+        org: sampleOrg,
+        agentNames,
+        activeName: '',
+        collapsed: true,
+      },
+      global: {
+        plugins: [i18n],
+        stubs: { Icon: { template: '<span class="icon" />' }, Teleport: true },
+      },
+    })
+    expect(wrapper.find('[data-testid="agent-org-import"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="agent-org-create-agent"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
 })
 
 describe('AgentOrgSidebar project bracket', () => {

--- a/web/src/components/agent/AgentOrgSidebar.vue
+++ b/web/src/components/agent/AgentOrgSidebar.vue
@@ -31,6 +31,8 @@ const emit = defineEmits<{
   (e: 'rename-agent', name: string): void
   (e: 'remove-from-group', name: string, groupId: string): void
   (e: 'open-manage', agentName?: string): void
+  (e: 'import'): void
+  (e: 'create-agent'): void
   (e: 'create-root-group'): void
   (e: 'create-team'): void
   (e: 'create-child-group', parentId: string): void
@@ -256,6 +258,28 @@ function onDrop(e: DragEvent, row: OrgTreeRow) {
         @click="emit('open-manage')"
       >
         <Icon name="user" :size="12" />
+      </button>
+      <button
+        v-if="!collapsed"
+        type="button"
+        data-testid="agent-org-import"
+        class="flex h-[22px] w-[22px] shrink-0 items-center justify-center text-txt3 transition hover:bg-elevated hover:text-accent-2"
+        :title="t('pages.agentStudio.exportImport.import')"
+        :aria-label="t('pages.agentStudio.exportImport.import')"
+        @click="emit('import')"
+      >
+        <Icon name="input" :size="12" />
+      </button>
+      <button
+        v-if="!collapsed"
+        type="button"
+        data-testid="agent-org-create-agent"
+        class="flex h-[22px] w-[22px] shrink-0 items-center justify-center text-txt3 transition hover:bg-elevated hover:text-accent-2"
+        :title="t('common.buttons.newAgent')"
+        :aria-label="t('common.buttons.newAgent')"
+        @click="emit('create-agent')"
+      >
+        <Icon name="plus" :size="12" />
       </button>
       <button
         v-if="!collapsed"

--- a/web/src/views/AgentStudioView.test.ts
+++ b/web/src/views/AgentStudioView.test.ts
@@ -1416,16 +1416,21 @@ describe('AgentStudio mobile core path', () => {
     wrapper.unmount()
   })
 
-  it('keeps new/import entries available alongside switch', async () => {
+  it('keeps switch and exposes import/new via org sheet header', async () => {
     mocks.listAgents.mockResolvedValue([agentWithFiles()])
     const wrapper = await mountMobileStudio()
     await flushPromises()
 
     expect(wrapper.find('[data-test="org-switch"]').exists()).toBe(true)
-    expect(wrapper.text()).toContain('导入')
-    expect(wrapper.text()).toContain('新建 Agent')
+    expect(wrapper.find('[data-testid="agent-studio-action-row"]').exists()).toBe(false)
     expect(wrapper.text()).not.toContain('配置可复用的 Agent')
     expect(wrapper.text()).not.toContain('复制进沙箱')
+
+    await wrapper.get('[data-test="org-switch"]').trigger('click')
+    await flushPromises()
+    expect(document.querySelector('[data-test="org-sheet"]')).toBeTruthy()
+    expect(document.querySelector('[data-test="org-sheet-import"]')).toBeTruthy()
+    expect(document.querySelector('[data-test="org-sheet-create-agent"]')).toBeTruthy()
     wrapper.unmount()
   })
 })
@@ -1647,10 +1652,6 @@ describe('AgentStudio copy removal (subtitle + toolbar)', () => {
     'clearToast',
   ]
 
-  function toolbar(wrapper: Awaited<ReturnType<typeof mountStudio>>) {
-    return wrapper.find('.mb-5.flex.shrink-0')
-  }
-
   async function mountStudioEn() {
     const i18n = createI18n({
       legacy: false,
@@ -1671,16 +1672,55 @@ describe('AgentStudio copy removal (subtitle + toolbar)', () => {
           AgentChatTester: true,
           AgentGitGuide: true,
           AgentCreateWizard: true,
-          AgentOrgSidebar: true,
+          AgentOrgSidebar: {
+            template:
+              '<div data-test="sidebar">' +
+              '<button data-testid="agent-org-import" aria-label="Import">Import</button>' +
+              '<button data-testid="agent-org-create-agent" aria-label="New agent">New agent</button>' +
+              '</div>',
+          },
           AgentDataPanel: true,
         },
       },
     })
   }
 
-  it('hides zh subtitle, right-aligns desktop import/new, and does not add a page title', async () => {
+  async function mountStudioWithSidebar() {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const router = await createStudioRouter()
+    return mount(AgentStudioView, {
+      global: {
+        plugins: [i18n, router],
+        stubs: {
+          AppButton: ButtonStub,
+          Icon: true,
+          AppModal: true,
+          CodeEditor: CodeEditorStub,
+          MarkdownSplitEditor: true,
+          ExplorerContextMenu: true,
+          AgentChatTester: true,
+          AgentGitGuide: true,
+          AgentCreateWizard: true,
+          AgentOrgSidebar: {
+            template:
+              '<div data-test="sidebar">' +
+              '<button data-testid="agent-org-import" aria-label="导入">导入</button>' +
+              '<button data-testid="agent-org-create-agent" aria-label="新建 Agent">新建 Agent</button>' +
+              '</div>',
+          },
+          AgentDataPanel: true,
+        },
+      },
+    })
+  }
+
+  it('hides zh subtitle, drops action row, and keeps import/new on sidebar header', async () => {
     mocks.listAgents.mockResolvedValue([agent('public')])
-    const wrapper = await mountStudio()
+    const wrapper = await mountStudioWithSidebar()
     await flushPromises()
 
     const text = wrapper.text()
@@ -1689,24 +1729,24 @@ describe('AgentStudio copy removal (subtitle + toolbar)', () => {
     expect(text).not.toMatch(/改前|改后/)
     expect(wrapper.findAll('h1,h2').some((el) => /Agent\s*(管理|Studio)/i.test(el.text()))).toBe(false)
 
-    const bar = toolbar(wrapper)
-    expect(bar.exists()).toBe(true)
-    expect(bar.classes()).toContain('justify-end')
-    expect(bar.classes()).not.toContain('justify-between')
-    expect(bar.text()).toContain('导入')
-    expect(bar.text()).toContain('新建 Agent')
+    expect(wrapper.find('[data-testid="agent-studio-action-row"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="agent-org-import"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="agent-org-create-agent"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="agent-org-import"]').attributes('aria-label')).toBe('导入')
+    expect(wrapper.find('[data-testid="agent-org-create-agent"]').attributes('aria-label')).toBe('新建 Agent')
     wrapper.unmount()
   })
 
-  it('hides en subtitle and keeps Import / New agent', async () => {
+  it('hides en subtitle and keeps Import / New agent via sidebar', async () => {
     mocks.listAgents.mockResolvedValue([agent('public')])
     const wrapper = await mountStudioEn()
     await flushPromises()
 
     const text = wrapper.text()
     for (const s of subtitleEn) expect(text).not.toContain(s)
-    expect(text).toContain('Import')
-    expect(text).toContain('New agent')
+    expect(wrapper.find('[data-testid="agent-studio-action-row"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="agent-org-import"]').attributes('aria-label')).toBe('Import')
+    expect(wrapper.find('[data-testid="agent-org-create-agent"]').attributes('aria-label')).toBe('New agent')
     wrapper.unmount()
   })
 })
@@ -2142,6 +2182,57 @@ describe('AgentStudioView loading / four-state', () => {
     expect(wrapper.text()).toContain('加载失败')
     expect(wrapper.text()).toContain('重试')
     expect(wrapper.text()).not.toContain('用一个入口拉起整支团队')
+    wrapper.unmount()
+  })
+
+  it('empty state keeps primary CTA and secondary import (standalone)', async () => {
+    mocks.listAgents.mockResolvedValue([])
+    const wrapper = await mountStudio()
+    await flushPromises()
+    expect(wrapper.find('[data-testid="agent-studio-action-row"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="agent-studio-empty-team"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="agent-studio-empty-create-team"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="agent-studio-empty-import"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('创建 Agent 团队')
+    expect(wrapper.text()).toContain('导入')
+    wrapper.unmount()
+  })
+
+  it('embedded empty state keeps new-agent CTA and secondary import', async () => {
+    mocks.listAgents.mockResolvedValue([])
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      messages: { 'zh-CN': { ...common, ...pages } },
+    })
+    const router = await createStudioRouter()
+    const wrapper = trackMount(
+      mount(AgentStudioView, {
+        props: { projectId: 'proj-1', embedded: true },
+        global: {
+          plugins: [i18n, router],
+          stubs: {
+            AppButton: ButtonStub,
+            Icon: true,
+            AppModal: true,
+            CodeEditor: CodeEditorStub,
+            MarkdownSplitEditor: true,
+            ExplorerContextMenu: true,
+            AgentChatTester: true,
+            AgentGitGuide: true,
+            AgentCreateWizard: true,
+            AgentOrgSidebar: true,
+            AgentDataPanel: true,
+          },
+        },
+      }),
+    )
+    await flushPromises()
+    expect(wrapper.find('[data-testid="agent-studio-action-row"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="agent-studio-empty-create"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="agent-studio-empty-import"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('新建 Agent')
+    expect(wrapper.text()).not.toContain('创建 Agent 团队')
     wrapper.unmount()
   })
 })

--- a/web/src/views/AgentStudioView.vue
+++ b/web/src/views/AgentStudioView.vue
@@ -266,34 +266,6 @@ async function createStudioChatTest(
     :aria-busy="loading ? 'true' : 'false'"
   >
     <div
-      class="toolbar-below-tabs mb-5 flex shrink-0 gap-4"
-      data-testid="agent-studio-action-row"
-      :class="isMobile ? 'flex-col items-stretch' : 'justify-end'"
-    >
-      <div class="flex shrink-0 gap-2" :class="isMobile ? 'flex-col' : 'items-center'">
-        <AppButton
-          variant="outline"
-          icon="input"
-          :class="isMobile ? 'min-h-11 w-full justify-center' : ''"
-          @click="triggerImport"
-        >{{ t('pages.agentStudio.exportImport.import') }}</AppButton>
-        <AppButton
-          v-if="showCreateTeam"
-          variant="outline"
-          icon="skills"
-          :class="isMobile ? 'min-h-11 w-full justify-center' : ''"
-          @click="openCreateTeam"
-        >{{ t('pages.agentStudio.createTeam') }}</AppButton>
-        <AppButton
-          variant="primary"
-          icon="plus"
-          :class="isMobile ? 'min-h-11 w-full justify-center' : ''"
-          @click="openCreateAgent"
-        >{{ t('common.buttons.newAgent') }}</AppButton>
-      </div>
-    </div>
-
-    <div
       v-if="error && !loadFailed && !loadDenied && agents.length"
       class="card mb-3 shrink-0 border-err/40 p-3 text-[13px] text-err"
     >{{ t('pages.agentStudio.errorPrefix') }}{{ error }}</div>
@@ -375,18 +347,34 @@ async function createStudioChatTest(
         <template v-if="embedded">
           <h2 class="m-0 text-[18px] font-semibold text-txt">{{ t('pages.agentStudio.emptyProjectTitle') }}</h2>
           <p class="m-0 max-w-md text-[13px] leading-6 text-txt3">{{ t('pages.agentStudio.emptyProjectDesc') }}</p>
-          <AppButton variant="primary" icon="plus" @click="openCreateAgent">
+          <AppButton variant="primary" icon="plus" data-testid="agent-studio-empty-create" @click="openCreateAgent">
             {{ t('common.buttons.newAgent') }}
           </AppButton>
+          <button
+            type="button"
+            data-testid="agent-studio-empty-import"
+            class="text-[12px] text-accent-2 hover:underline"
+            @click="triggerImport"
+          >
+            {{ t('pages.agentStudio.exportImport.import') }}
+          </button>
         </template>
         <template v-else>
           <h2 class="m-0 text-[18px] font-semibold text-txt">{{ t('pages.agentStudio.emptyTeamTitle') }}</h2>
           <p class="m-0 max-w-md text-[13px] leading-6 text-txt3">{{ t('pages.agentStudio.emptyTeamDesc') }}</p>
-          <AppButton variant="primary" icon="skills" @click="openCreateTeam">
+          <AppButton variant="primary" icon="skills" data-testid="agent-studio-empty-create-team" @click="openCreateTeam">
             {{ t('pages.agentStudio.emptyTeamCta') }}
           </AppButton>
           <button type="button" class="text-[12px] text-accent-2 hover:underline" @click="openCreateAgent">
             {{ t('pages.agentStudio.emptyTeamOrSingle') }}
+          </button>
+          <button
+            type="button"
+            data-testid="agent-studio-empty-import"
+            class="text-[12px] text-accent-2 hover:underline"
+            @click="triggerImport"
+          >
+            {{ t('pages.agentStudio.exportImport.import') }}
           </button>
         </template>
       </div>
@@ -412,6 +400,8 @@ async function createStudioChatTest(
         @rename-agent="onSidebarRenameBlocked"
         @remove-from-group="onRemoveFromGroup"
         @open-manage="openAgentManage"
+        @import="triggerImport"
+        @create-agent="openCreateAgent"
         @create-root-group="openCreateRootGroup"
         @create-team="openCreateTeam"
         @create-child-group="openCreateChildGroup"
@@ -857,10 +847,41 @@ async function createStudioChatTest(
           class="absolute inset-x-0 bottom-0 flex h-[70vh] max-h-[70vh] flex-col overflow-hidden rounded-t-xl border-t border-line bg-elevated shadow-card"
         >
           <div class="mx-auto mt-2 h-1 w-10 shrink-0 rounded-full bg-line-strong/70" aria-hidden="true" />
-          <div class="flex shrink-0 items-center gap-2 border-b border-line px-3 py-2.5">
+          <div class="flex shrink-0 items-center gap-1.5 border-b border-line px-3 py-2.5">
             <h3 class="min-w-0 flex-1 truncate text-[14px] font-semibold text-txt">
               {{ t('pages.agentStudio.mobile.orgSheetTitle') }}
             </h3>
+            <button
+              type="button"
+              data-test="org-sheet-import"
+              class="flex min-h-9 min-w-9 shrink-0 items-center justify-center rounded text-txt3 hover:bg-overlay hover:text-txt"
+              :title="t('pages.agentStudio.exportImport.import')"
+              :aria-label="t('pages.agentStudio.exportImport.import')"
+              @click="triggerImport"
+            >
+              <Icon name="input" :size="14" />
+            </button>
+            <button
+              type="button"
+              data-test="org-sheet-create-agent"
+              class="flex min-h-9 min-w-9 shrink-0 items-center justify-center rounded text-txt3 hover:bg-overlay hover:text-txt"
+              :title="t('common.buttons.newAgent')"
+              :aria-label="t('common.buttons.newAgent')"
+              @click="openCreateAgent"
+            >
+              <Icon name="plus" :size="14" />
+            </button>
+            <button
+              v-if="showCreateTeam"
+              type="button"
+              data-test="org-sheet-create-team"
+              class="flex min-h-9 min-w-9 shrink-0 items-center justify-center rounded text-txt3 hover:bg-overlay hover:text-txt"
+              :title="t('pages.agentStudio.org.newTeam')"
+              :aria-label="t('pages.agentStudio.org.newTeam')"
+              @click="openCreateTeam"
+            >
+              <Icon name="skills" :size="14" />
+            </button>
             <AppButton
               size="sm"
               variant="outline"

--- a/web/src/views/toolbarTabClearance.test.ts
+++ b/web/src/views/toolbarTabClearance.test.ts
@@ -36,10 +36,9 @@ describe('project page tab-panel clearance (g1.1)', () => {
 })
 
 describe('Agent Studio action / name bars (g1.2 / g1.3)', () => {
-  it('import/new action row uses toolbar-below-tabs', () => {
-    expect(studioSrc).toMatch(
-      /class="toolbar-below-tabs mb-5 flex shrink-0 gap-4"\s+data-testid="agent-studio-action-row"/,
-    )
+  it('no longer renders independent import/new action row under tabs', () => {
+    expect(studioSrc).not.toMatch(/data-testid="agent-studio-action-row"/)
+    expect(studioSrc).not.toMatch(/toolbar-below-tabs mb-5 flex shrink-0 gap-4/)
   })
 
   it('desktop and mobile name bars use toolbar-inline-row', () => {


### PR DESCRIPTION
Remove the Tab-below action row so the org list and editor reclaim vertical space; expose import, new agent, and create-team as 22px header icons (empty-state secondary import + org-sheet header on narrow screens).

Co-authored-by: Cursor <cursoragent@cursor.com>
