### PR TITLE
fix: keep login tab title from leaking i18n keys on cold start

### DIFF
--- a/web/src/lib/shared/locale.test.ts
+++ b/web/src/lib/shared/locale.test.ts
@@ -1,20 +1,53 @@
 // @vitest-environment happy-dom
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+type MsgTree = Record<string, unknown>
+
+const { catalogs, resolvePath } = vi.hoisted(() => {
+  function resolvePath(tree: MsgTree | undefined, path: string): unknown {
+    if (!tree) return undefined
+    return path.split('.').reduce<unknown>((node, part) => {
+      if (node && typeof node === 'object' && part in (node as MsgTree)) {
+        return (node as MsgTree)[part]
+      }
+      return undefined
+    }, tree)
+  }
+
+  const catalogs: Record<string, MsgTree> = {
+    'zh-CN': {
+      shell: { appName: 'Grasp' },
+      route: { login: '登录', runs: '运行记录' },
+    },
+    en: {
+      shell: { appName: 'Grasp' },
+      route: { login: 'Login', runs: 'Run history' },
+    },
+  }
+  return { catalogs, resolvePath }
+})
+
 vi.mock('./loadLocaleMessages', () => ({
-  loadLocaleMessages: vi.fn(async (loc: string) => ({ shell: { appName: loc === 'en' ? 'Code Flow' : '代码流' } })),
+  loadLocaleMessages: vi.fn(async (loc: string) => catalogs[loc] ?? catalogs['zh-CN']),
   otherLocale: (loc: string) => (loc === 'en' ? 'zh-CN' : 'en'),
   prefetchLocale: vi.fn(),
 }))
 
 vi.mock('./i18n', () => {
   const locale = { value: 'zh-CN' }
+  let messages: MsgTree = {}
   return {
     i18n: {
       global: {
         locale,
-        setLocaleMessage: vi.fn(),
-        t: (key: string) => (key === 'shell.appName' ? 'Code Flow' : key),
+        setLocaleMessage: vi.fn((_loc: string, next: MsgTree) => {
+          messages = next
+        }),
+        te: (key: string) => typeof resolvePath(messages, key) === 'string',
+        t: (key: string) => {
+          const hit = resolvePath(messages, key)
+          return typeof hit === 'string' ? hit : key
+        },
       },
     },
   }
@@ -22,14 +55,18 @@ vi.mock('./i18n', () => {
 
 import { applyPublicLocale, detectLocale, initLocale, setLocale, updateDocumentTitle, locale } from './locale'
 import { loadLocaleMessages, prefetchLocale } from './loadLocaleMessages'
+import { i18n } from './i18n'
 
 describe('locale', () => {
   beforeEach(() => {
     localStorage.clear()
     document.documentElement.lang = ''
-    document.title = ''
+    document.title = 'Grasp · 开发工作流编排'
     vi.mocked(loadLocaleMessages).mockClear()
     vi.mocked(prefetchLocale).mockClear()
+    vi.mocked(i18n.global.setLocaleMessage).mockClear()
+    // Reset message catalog so each case can simulate empty → loaded.
+    i18n.global.setLocaleMessage('zh-CN', {})
   })
 
   it('detectLocale prefers stored then navigator language', () => {
@@ -73,14 +110,57 @@ describe('locale', () => {
     expect(document.documentElement.lang).toBe('en')
   })
 
-  it('initLocale is idempotent and updateDocumentTitle sets title', async () => {
+  it('updateDocumentTitle skips writing i18n keys when messages are empty', () => {
+    document.title = 'Grasp · 开发工作流编排'
+    updateDocumentTitle('route.login')
+    expect(document.title).toBe('Grasp · 开发工作流编排')
+    expect(document.title).not.toContain('route.login')
+    expect(document.title).not.toContain('shell.appName')
+  })
+
+  it('updateDocumentTitle writes translated login title after messages load', () => {
+    i18n.global.setLocaleMessage('zh-CN', catalogs['zh-CN'])
+    updateDocumentTitle('route.login')
+    expect(document.title).toBe('登录 · Grasp')
+
+    i18n.global.setLocaleMessage('en', catalogs.en)
+    i18n.global.locale.value = 'en'
+    updateDocumentTitle('route.login')
+    expect(document.title).toBe('Login · Grasp')
+
+    updateDocumentTitle('route.runs')
+    expect(document.title).toBe('Run history · Grasp')
+  })
+
+  it('initLocale refreshes the remembered title even when locale string is unchanged', async () => {
+    // Gate the bundle load so we can simulate afterEach before messages arrive.
+    let release!: (v: MsgTree) => void
+    const gate = new Promise<MsgTree>((resolve) => {
+      release = resolve
+    })
+    vi.mocked(loadLocaleMessages).mockImplementationOnce(() => gate)
+
+    vi.resetModules()
+    const cold = await import('./locale')
+    document.title = 'Grasp · 开发工作流编排'
+    cold.updateDocumentTitle('route.login')
+    expect(document.title).toBe('Grasp · 开发工作流编排')
+    expect(document.title).not.toContain('route.login')
+    expect(document.title).not.toContain('shell.appName')
+
+    const before = cold.locale.value
+    release(catalogs['zh-CN'])
+    await cold.initLocale()
+    expect(cold.locale.value).toBe(before)
+    expect(document.title).toBe('登录 · Grasp')
+    expect(document.title).not.toContain('route.login')
+    expect(document.title).not.toContain('shell.appName')
+  })
+
+  it('initLocale is idempotent', async () => {
     const p1 = initLocale()
     const p2 = initLocale()
     expect(p1).toBe(p2)
     await p1
-    updateDocumentTitle('pages.runs.title')
-    expect(document.title).toContain('Code Flow')
-    updateDocumentTitle(undefined)
-    expect(document.title).toBe('Code Flow')
   })
 })

--- a/web/src/lib/shared/locale.ts
+++ b/web/src/lib/shared/locale.ts
@@ -64,6 +64,14 @@ export async function setLocale(next: AppLocale): Promise<void> {
 }
 
 let initPromise: Promise<void> | null = null
+/** Last titleKey from router/App; remembered so initLocale can refresh after messages load. */
+let currentTitleKey: string | undefined
+
+function translationsReady(titleKey: string | undefined): boolean {
+  if (!i18n.global.te('shell.appName')) return false
+  if (titleKey && !i18n.global.te(titleKey)) return false
+  return true
+}
 
 export function initLocale(): Promise<void> {
   if (!initPromise) {
@@ -76,6 +84,9 @@ export function initLocale(): Promise<void> {
       i18n.global.locale.value = initial
       locale.value = initial
       applyHtmlLocale(initial)
+      // Cold start: locale string often stays zh-CN, so App.vue watch will not re-run.
+      // Force-refresh once messages exist so document.title never sticks on raw keys.
+      updateDocumentTitle(currentTitleKey)
 
       const idle = window.requestIdleCallback ?? ((cb: () => void) => setTimeout(cb, 200))
       idle(() => prefetchLocale(otherLocale(initial)))
@@ -85,6 +96,10 @@ export function initLocale(): Promise<void> {
 }
 
 export function updateDocumentTitle(titleKey: string | undefined) {
+  currentTitleKey = titleKey
+  // Messages may still be empty (mount before initLocale). Keep HTML placeholder;
+  // never write raw i18n keys like "route.login · shell.appName" into the tab.
+  if (!translationsReady(titleKey)) return
   const appName = i18n.global.t('shell.appName')
   document.title = titleKey ? `${i18n.global.t(titleKey)} · ${appName}` : appName
 }

--- a/web/src/router/loginDocumentTitle.test.ts
+++ b/web/src/router/loginDocumentTitle.test.ts
@@ -1,0 +1,31 @@
+// @vitest-environment happy-dom
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const routerSrc = readFileSync(join(here, 'index.ts'), 'utf8')
+const zhRoute = JSON.parse(readFileSync(join(here, '../locales/zh-CN/route.json'), 'utf8'))
+const enRoute = JSON.parse(readFileSync(join(here, '../locales/en/route.json'), 'utf8'))
+const zhShell = JSON.parse(readFileSync(join(here, '../locales/zh-CN/shell.json'), 'utf8'))
+const enShell = JSON.parse(readFileSync(join(here, '../locales/en/shell.json'), 'utf8'))
+
+describe('login route titleKey + existing copy (plan g2.2)', () => {
+  it('keeps /login on route.login without renaming keys', () => {
+    expect(routerSrc).toMatch(
+      /path:\s*'\/login'[\s\S]*?meta:\s*\{\s*titleKey:\s*'route\.login'/,
+    )
+  })
+
+  it('zh-CN and en login titles compose to 登录/Login · Grasp', () => {
+    expect(zhRoute.route.login).toBe('登录')
+    expect(enRoute.route.login).toBe('Login')
+    expect(zhShell.shell.appName).toBe('Grasp')
+    expect(enShell.shell.appName).toBe('Grasp')
+    expect(`${zhRoute.route.login} · ${zhShell.shell.appName}`).toBe('登录 · Grasp')
+    expect(`${enRoute.route.login} · ${enShell.shell.appName}`).toBe('Login · Grasp')
+    expect(zhRoute.route.runs).toBe('运行记录')
+    expect(enRoute.route.runs).toBe('Run history')
+  })
+})


### PR DESCRIPTION
Defer document.title until locale messages exist, then refresh after initLocale so the login tab shows 登录/Login · Grasp instead of raw keys.

Co-authored-by: Cursor <cursoragent@cursor.com>
