### PR TITLE
feat(web): restore connecting preview tab with HardLoadLayer

### DIFF
--- a/web/src/components/run/ReactArtifactStage.test.ts
+++ b/web/src/components/run/ReactArtifactStage.test.ts
@@ -94,22 +94,25 @@ describe('ReactArtifactStage', () => {
     resetStageOpenStateForTests(':run-')
   })
 
-  it('defaults to the pipeline grid tab and opens a new preview tab on card click', async () => {
+  it('defaults to chrome preview empty, then opens a named preview tab on card click (g2.1)', async () => {
     const wrapper = mount(ReactArtifactStage, {
       props: {
         artifacts: [art({ id: 'a1', name: 'research.json', kind: 'json' })],
         runId: 'run-1',
+        remoteKind: 'off',
       },
       global: { plugins: [i18n()], stubs },
     })
-    expect(wrapper.get('[data-testid="react-artifact-tab-grid"]').attributes('aria-selected')).toBe('true')
-    expect(wrapper.get('[data-testid="react-artifact-grid"]').text()).toContain('research.json')
-    expect(wrapper.find('[data-testid="react-artifact-tab-research.json"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="react-artifact-tab-preview"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.get('[data-testid="react-artifact-preview-empty"]').text()).toContain('尚未选择产物')
+    expect(wrapper.find('[data-testid="hard-load-layer"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="artifact-preview"]').exists()).toBe(false)
     await wrapper.get('[data-testid="react-artifact-card-research.json"]').trigger('click')
     await flushPromises()
     expect(wrapper.find('[data-testid="react-artifact-tab-grid"]').exists()).toBe(true)
     expect(wrapper.get('[data-testid="react-artifact-tab-research.json"]').attributes('aria-selected')).toBe('true')
     expect(wrapper.get('[data-testid="artifact-preview"]').text()).toBe('research.json|off')
+    expect(wrapper.get('[data-testid="react-artifact-tab-preview"]').attributes('aria-selected')).toBe('false')
     wrapper.unmount()
   })
 
@@ -216,7 +219,8 @@ describe('ReactArtifactStage', () => {
       global: { plugins: [i18n()], stubs },
     })
     await flushPromises()
-    expect(wrapper.get('[data-testid="react-artifact-tab-grid"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.get('[data-testid="react-artifact-tab-preview"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.find('[data-testid="hard-load-layer"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="react-artifact-tab-page.html"]').exists()).toBe(false)
     await wrapper.setProps({ artifacts: [note, page], previewArtifact: 'page.html' })
     await flushPromises()
@@ -777,7 +781,7 @@ describe('ReactArtifactStage', () => {
     wrapper.unmount()
   })
 
-  it('stays on the pipeline grid when only JSON is on stage and still opens on click (s4)', async () => {
+  it('stays on chrome preview empty when only JSON is on stage and still opens on click (s4 g2.1)', async () => {
     const json = art({ id: 'j', name: 'research.json', kind: 'json', nodeId: 'research' })
     const wrapper = mount(ReactArtifactStage, {
       props: {
@@ -790,7 +794,8 @@ describe('ReactArtifactStage', () => {
       global: { plugins: [i18n()], stubs },
     })
     await flushPromises()
-    expect(wrapper.get('[data-testid="react-artifact-tab-grid"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.get('[data-testid="react-artifact-tab-preview"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.get('[data-testid="react-artifact-preview-empty"]').text()).toContain('尚未选择产物')
     expect(wrapper.find('[data-testid="react-artifact-tab-research.json"]').exists()).toBe(false)
     await wrapper.get('[data-testid="react-artifact-card-research.json"]').trigger('click')
     await flushPromises()
@@ -798,7 +803,7 @@ describe('ReactArtifactStage', () => {
     wrapper.unmount()
   })
 
-  it('opens page.html once when it arrives while the user is still on the default grid (s5)', async () => {
+  it('opens page.html once when it arrives while the user is still on the default preview empty (s5 g2.1)', async () => {
     const json = art({ id: 'j', name: 'research.json', kind: 'json', nodeId: 'visual_bqc5' })
     const page = art({ id: 'p', name: 'page.html', kind: 'html', nodeId: 'visual_bqc5' })
     const wrapper = mount(ReactArtifactStage, {
@@ -812,7 +817,8 @@ describe('ReactArtifactStage', () => {
       global: { plugins: [i18n()], stubs },
     })
     await flushPromises()
-    expect(wrapper.get('[data-testid="react-artifact-tab-grid"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.get('[data-testid="react-artifact-tab-preview"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.find('[data-testid="hard-load-layer"]').exists()).toBe(false)
     await wrapper.setProps({ artifacts: [json, page] })
     await flushPromises()
     expect(wrapper.get('[data-testid="react-artifact-tab-page.html"]').attributes('aria-selected')).toBe('true')
@@ -918,7 +924,7 @@ describe('ReactArtifactStage', () => {
     await wrapper.get('[data-testid="react-artifact-tab-close-brand-row-preview.html"]').trigger('click')
     await flushPromises()
     expect(wrapper.find('[data-testid="react-artifact-tab-brand-row-preview.html"]').exists()).toBe(false)
-    expect(wrapper.get('[data-testid="react-artifact-tab-grid"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.get('[data-testid="react-artifact-tab-preview"]').attributes('aria-selected')).toBe('true')
     expect(wrapper.find('[data-testid="react-artifact-card-brand-row-preview.html"]').exists()).toBe(true)
     await wrapper.get('[data-testid="react-artifact-card-brand-row-preview.html"]').trigger('click')
     await flushPromises()

--- a/web/src/components/run/ReactArtifactStage.vue
+++ b/web/src/components/run/ReactArtifactStage.vue
@@ -19,6 +19,7 @@ import type { AppPreviewPickPayload } from '@/lib/shared/previewPickUrl'
 import type { Artifact, ReactAnnotation, Run } from '@/lib/shared/types'
 import {
   REACT_STAGE_TAB_GRID,
+  REACT_STAGE_TAB_PREVIEW,
   REACT_STAGE_TAB_NOVNC,
   approveStageRemoteKind,
   artifactFriendlyNameKey,
@@ -120,7 +121,8 @@ const initialOpen = restoreStageOpenState(
   loadStageOpenState(props.runId, props.nodeId),
   (props.artifacts || []).map((a) => a.name),
 )
-const activeTab = ref(initialOpen?.activeTab || REACT_STAGE_TAB_GRID)
+/** Default to chrome preview empty so connecting→ready does not flash the pipeline grid. */
+const activeTab = ref(initialOpen?.activeTab || REACT_STAGE_TAB_PREVIEW)
 /** True after the user picks a grid tab, card, preview tab, or noVNC — auto-open must not steal focus.
  *  Also set when session open-state restore succeeds so pin auto-activate loses to refresh restore. */
 const userMoved = ref(!!initialOpen)
@@ -369,6 +371,16 @@ function selectGridTab() {
   activeTab.value = REACT_STAGE_TAB_GRID
 }
 
+/** Chrome「产物预览」：无打开卡片时为空态；已有打开卡片则聚焦最近一张。 */
+function selectPreviewChromeTab() {
+  markUserMoved()
+  if (openNames.value.length) {
+    activeTab.value = previewTabId(openNames.value[openNames.value.length - 1])
+    return
+  }
+  activeTab.value = REACT_STAGE_TAB_PREVIEW
+}
+
 function selectPreviewTab(name: string) {
   markUserMoved()
   activeTab.value = previewTabId(name)
@@ -400,7 +412,7 @@ function closeNovnc() {
     activeTab.value = previewTabId(openNames.value[openNames.value.length - 1])
     return
   }
-  activeTab.value = REACT_STAGE_TAB_GRID
+  activeTab.value = REACT_STAGE_TAB_PREVIEW
 }
 
 function onRemotePick(payload: AppPreviewPickPayload) {
@@ -408,6 +420,7 @@ function onRemotePick(payload: AppPreviewPickPayload) {
 }
 
 const showingGrid = computed(() => activeTab.value === REACT_STAGE_TAB_GRID)
+const showingPreviewEmpty = computed(() => activeTab.value === REACT_STAGE_TAB_PREVIEW)
 const activePreviewName = computed(() => previewTabName(activeTab.value))
 
 watch(
@@ -508,7 +521,7 @@ watch(
     const nid = String(props.nodeId || '').trim()
     if (!rid || !nid) {
       openNames.value = []
-      activeTab.value = REACT_STAGE_TAB_GRID
+      activeTab.value = REACT_STAGE_TAB_PREVIEW
       novncOpen.value = false
       userMoved.value = false
       return
@@ -521,7 +534,7 @@ watch(
       )
     ) {
       openNames.value = []
-      activeTab.value = REACT_STAGE_TAB_GRID
+      activeTab.value = REACT_STAGE_TAB_PREVIEW
       novncOpen.value = false
       userMoved.value = false
     }
@@ -537,14 +550,19 @@ watch(
         novncOpen.value = false
         activeTab.value = openNames.value.length
           ? previewTabId(openNames.value[openNames.value.length - 1])
-          : REACT_STAGE_TAB_GRID
+          : REACT_STAGE_TAB_PREVIEW
       }
       return
     }
     // Show the remote tab once kind is live; never steal focus after the user moved.
     novncOpen.value = true
     if (userMoved.value) return
-    if (activeTab.value === REACT_STAGE_TAB_GRID) activeTab.value = REACT_STAGE_TAB_NOVNC
+    if (
+      activeTab.value === REACT_STAGE_TAB_GRID ||
+      activeTab.value === REACT_STAGE_TAB_PREVIEW
+    ) {
+      activeTab.value = REACT_STAGE_TAB_NOVNC
+    }
   },
   { immediate: true },
 )
@@ -620,6 +638,22 @@ onBeforeUnmount(() => {
       >
         <Icon name="dashboard" :size="13" />
         <span class="truncate">{{ t('pages.reactArtifactStage.pipelineTab') }}</span>
+      </button>
+      <button
+        type="button"
+        role="tab"
+        class="inline-flex max-w-[200px] items-center gap-1.5 rounded-md px-2.5 py-1 text-[12px] transition max-md:px-2 max-md:py-0.5 max-md:text-[11px]"
+        :class="
+          showingPreviewEmpty
+            ? 'bg-elevated text-txt'
+            : 'text-txt3 hover:bg-elevated/60 hover:text-txt2'
+        "
+        :aria-selected="showingPreviewEmpty ? 'true' : 'false'"
+        data-testid="react-artifact-tab-preview"
+        @click="selectPreviewChromeTab"
+      >
+        <Icon name="artifact" :size="13" />
+        <span class="truncate">{{ t('pages.reactArtifactStage.previewTab') }}</span>
       </button>
       <div
         v-for="name in openNames"
@@ -811,6 +845,16 @@ onBeforeUnmount(() => {
           </div>
         </div>
       </div>
+    </div>
+
+    <div
+      v-show="showingPreviewEmpty"
+      class="flex min-h-0 flex-1 flex-col items-center justify-center gap-2 p-6 text-center"
+      data-testid="react-artifact-preview-empty"
+    >
+      <Icon name="artifact" :size="26" class="opacity-40" />
+      <p class="text-[13px] font-medium text-txt">{{ t('pages.reactArtifactStage.previewEmptyTitle') }}</p>
+      <p class="max-w-[360px] text-[12px] text-txt3">{{ t('pages.reactArtifactStage.previewEmpty') }}</p>
     </div>
 
     <div

--- a/web/src/components/run/ReactConnectingState.test.ts
+++ b/web/src/components/run/ReactConnectingState.test.ts
@@ -29,6 +29,24 @@ function mountSidebar(locale: 'zh-CN' | 'en') {
   })
 }
 
+function mountStage(locale: 'zh-CN' | 'en' = 'zh-CN') {
+  const i18n = locale === 'zh-CN'
+    ? createI18n({
+        legacy: false,
+        locale,
+        messages: { 'zh-CN': { ...common, ...pages } },
+      })
+    : createI18n({
+        legacy: false,
+        locale,
+        messages: { en: { ...enCommon, ...enPages } },
+      })
+  return mount(ReactConnectingState, {
+    props: { mode: 'stage' },
+    global: { plugins: [i18n], stubs: { Icon: true } },
+  })
+}
+
 describe('ReactConnectingState', () => {
   afterEach(() => {
     vi.useRealTimers()
@@ -109,33 +127,67 @@ describe('ReactConnectingState', () => {
     expect(wrapper.text()).not.toContain('正在启动 Agent…')
   })
 
-  it('stage chrome only shows pipeline tab — no fake previewTab (g2.1)', () => {
-    const i18n = createI18n({
-      legacy: false,
-      locale: 'zh-CN',
-      messages: { 'zh-CN': { ...common, ...pages } },
-    })
-    const wrapper = mount(ReactConnectingState, {
-      props: { mode: 'stage' },
-      global: { plugins: [i18n], stubs: { Icon: true } },
-    })
-    expect(wrapper.get('[data-testid="react-connecting-stage"]').exists()).toBe(true)
-    expect(wrapper.get('[data-testid="react-connecting-tab-pipeline"]').text()).toContain('流水线产物')
-    expect(wrapper.text()).not.toContain('产物预览')
-    expect(wrapper.find('[data-testid="react-connecting-stage-tabs"]').text()).not.toMatch(/预览/)
+  it('stage chrome defaults to clickable preview tab with HardLoadLayer (g1.1 g1.2 g1.3)', () => {
+    const wrapper = mountStage('zh-CN')
+    expect(wrapper.get('[data-testid="react-connecting-stage"]').attributes('aria-busy')).toBe('true')
+    const pipeline = wrapper.get('[data-testid="react-connecting-tab-pipeline"]')
+    const preview = wrapper.get('[data-testid="react-connecting-tab-preview"]')
+    expect(pipeline.element.tagName).toBe('BUTTON')
+    expect(preview.element.tagName).toBe('BUTTON')
+    expect(pipeline.attributes('role')).toBe('tab')
+    expect(preview.attributes('role')).toBe('tab')
+    expect(pipeline.attributes('aria-selected')).toBe('false')
+    expect(preview.attributes('aria-selected')).toBe('true')
+    expect(preview.text()).toContain('产物预览')
+    expect(wrapper.get('[data-testid="hard-load-layer"]').exists()).toBe(true)
+    expect(wrapper.get('[data-testid="hard-load-stage"]').text()).toContain('加载产物内容')
+    expect(wrapper.text()).not.toContain('正在连接 Agent…')
+    expect(wrapper.find('[data-testid="hard-load-retry"]').exists()).toBe(false)
   })
 
-  it('stage chrome English copy has no Artifact preview tab (g2.1)', () => {
-    const i18n = createI18n({
-      legacy: false,
-      locale: 'en',
-      messages: { en: { ...enCommon, ...enPages } },
-    })
-    const wrapper = mount(ReactConnectingState, {
-      props: { mode: 'stage' },
-      global: { plugins: [i18n], stubs: { Icon: true } },
-    })
-    expect(wrapper.get('[data-testid="react-connecting-tab-pipeline"]').text()).toContain('Pipeline artifacts')
-    expect(wrapper.text()).not.toContain('Artifact preview')
+  it('stage chrome English defaults to Artifact preview HardLoadLayer (g1.3)', () => {
+    const wrapper = mountStage('en')
+    expect(wrapper.get('[data-testid="react-connecting-tab-preview"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.get('[data-testid="react-connecting-tab-preview"]').text()).toContain('Artifact preview')
+    expect(wrapper.get('[data-testid="hard-load-stage"]').text()).toMatch(/Loading artifact/i)
+  })
+
+  it('pipeline tab keeps content skeleton without HardLoadLayer (g1.1 f2)', async () => {
+    const wrapper = mountStage('zh-CN')
+    await wrapper.get('[data-testid="react-connecting-tab-pipeline"]').trigger('click')
+    await nextTick()
+    expect(wrapper.get('[data-testid="react-connecting-tab-pipeline"]').attributes('aria-selected')).toBe('true')
+    expect(wrapper.get('[data-testid="react-connecting-tab-preview"]').attributes('aria-selected')).toBe('false')
+    expect(wrapper.find('[data-testid="hard-load-layer"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="react-connecting-pipeline-skeleton"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="react-connecting-pipeline-skeleton"] .animate-pulse').exists()).toBe(true)
+  })
+
+  it('keeps pipeline selection until remount (g1 f3)', async () => {
+    const wrapper = mountStage('zh-CN')
+    await wrapper.get('[data-testid="react-connecting-tab-pipeline"]').trigger('click')
+    await nextTick()
+    expect(wrapper.get('[data-testid="react-connecting-tab-pipeline"]').attributes('aria-selected')).toBe('true')
+    await wrapper.vm.$forceUpdate()
+    await nextTick()
+    expect(wrapper.get('[data-testid="react-connecting-tab-pipeline"]').attributes('aria-selected')).toBe('true')
+  })
+
+  it('does not show stuck or retry within 10s on connecting HardLoadLayer (g1.2 f5)', async () => {
+    vi.useFakeTimers()
+    const wrapper = mountStage('zh-CN')
+    expect(wrapper.find('[data-testid="hard-load-layer"]').exists()).toBe(true)
+    vi.advanceTimersByTime(10_000)
+    await nextTick()
+    expect(wrapper.find('[data-testid="hard-load-stuck"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="hard-load-retry"]').exists()).toBe(false)
+  })
+
+  it('sidebar connecting stays ClarifyBootLoader without preview tabs (f6)', () => {
+    const wrapper = mountSidebar('zh-CN')
+    expect(wrapper.find('[data-testid="react-connecting-sidebar"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="react-connecting-tab-preview"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="hard-load-layer"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="clarify-boot-progress"]').exists()).toBe(true)
   })
 })

--- a/web/src/components/run/ReactConnectingState.vue
+++ b/web/src/components/run/ReactConnectingState.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Icon from '@/components/ui/Icon.vue'
 import ClarifyBootLoader from './ClarifyBootLoader.vue'
+import HardLoadLayer from './HardLoadLayer.vue'
 
 withDefaults(
   defineProps<{
@@ -18,6 +20,16 @@ withDefaults(
 )
 
 const { t } = useI18n()
+
+/** Boot-class threshold: connecting has no REST retry; do not use the 10s default. */
+const CONNECT_PREVIEW_STUCK_MS = 60_000
+
+type ConnectingStageTab = 'pipeline' | 'preview'
+const stageTab = ref<ConnectingStageTab>('preview')
+
+function selectStageTab(tab: ConnectingStageTab) {
+  stageTab.value = tab
+}
 </script>
 
 <template>
@@ -27,22 +39,68 @@ const { t } = useI18n()
     data-testid="react-connecting-stage"
     aria-busy="true"
   >
-    <!-- plan g2.1: match ReactArtifactStage chrome — only pipeline tab, no fake previewTab -->
-    <div class="flex shrink-0 gap-1 border-b border-line px-3 py-2" data-testid="react-connecting-stage-tabs">
-      <span
-        class="rounded-md bg-elevated px-2.5 py-1 text-[11px] text-txt2"
+    <div
+      class="flex shrink-0 gap-1 border-b border-line px-3 py-2"
+      data-testid="react-connecting-stage-tabs"
+      role="tablist"
+    >
+      <button
+        type="button"
+        role="tab"
+        class="rounded-md px-2.5 py-1 text-[11px] transition"
+        :class="
+          stageTab === 'pipeline'
+            ? 'bg-elevated text-txt2'
+            : 'text-txt3 hover:bg-elevated/60 hover:text-txt2'
+        "
+        :aria-selected="stageTab === 'pipeline' ? 'true' : 'false'"
         data-testid="react-connecting-tab-pipeline"
+        @click="selectStageTab('pipeline')"
       >
         {{ t('pages.reactArtifactStage.pipelineTab') }}
-      </span>
+      </button>
+      <button
+        type="button"
+        role="tab"
+        class="rounded-md px-2.5 py-1 text-[11px] transition"
+        :class="
+          stageTab === 'preview'
+            ? 'bg-elevated text-txt2'
+            : 'text-txt3 hover:bg-elevated/60 hover:text-txt2'
+        "
+        :aria-selected="stageTab === 'preview' ? 'true' : 'false'"
+        data-testid="react-connecting-tab-preview"
+        @click="selectStageTab('preview')"
+      >
+        {{ t('pages.reactArtifactStage.previewTab') }}
+      </button>
     </div>
-    <div class="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 p-5 text-center">
+    <div
+      v-if="stageTab === 'pipeline'"
+      class="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 p-5 text-center"
+      data-testid="react-connecting-pipeline-skeleton"
+    >
       <div class="w-full max-w-[420px] space-y-2" aria-hidden="true">
         <div class="h-28 animate-pulse rounded-md bg-elevated" />
         <div class="h-2.5 w-4/5 animate-pulse rounded bg-elevated" />
         <div class="h-2.5 w-1/2 animate-pulse rounded bg-elevated" />
       </div>
       <p class="text-[11px] text-txt3">{{ t('pages.clarify.connectingStageHint') }}</p>
+    </div>
+    <div
+      v-else
+      class="relative min-h-0 flex-1"
+      data-testid="react-connecting-preview-surface"
+    >
+      <HardLoadLayer
+        :overlay="false"
+        :show-retry="false"
+        :stuck-after-ms="CONNECT_PREVIEW_STUCK_MS"
+        :stage="t('pages.artifactPreview.loading')"
+      />
+      <p class="px-4 pb-4 text-center text-[11px] text-txt3">
+        {{ t('pages.clarify.connectingStageHint') }}
+      </p>
     </div>
   </div>
 

--- a/web/src/components/run/runDetailPanels.smoke.test.ts
+++ b/web/src/components/run/runDetailPanels.smoke.test.ts
@@ -143,7 +143,7 @@ describe('Run detail panel shells (Demo entry assembly)', () => {
       },
     })
     expect(clarify.find('[data-testid="react-artifact-tab-grid"]').exists()).toBe(true)
-    expect(clarify.find('[data-testid="react-artifact-tab-preview"]').exists()).toBe(false)
+    expect(clarify.find('[data-testid="react-artifact-tab-preview"]').exists()).toBe(true)
     expect(clarify.find('[data-testid="react-artifact-card-novnc"]').exists()).toBe(true)
     const stage = clarify.findComponent(ReactArtifactStage)
     expect(stage.props('annotatable')).toBe(true)
@@ -226,10 +226,13 @@ describe('Run detail panel shells (Demo entry assembly)', () => {
     expect(clarify.find('[data-testid="react-connecting-stage"]').exists()).toBe(true)
     expect(clarify.find('[data-testid="react-connecting-sidebar"]').exists()).toBe(true)
     expect(clarify.find('[data-testid="react-connecting-confirm"]').exists()).toBe(false)
-    // plan g2.1 / g2.2: connecting stage has pipeline-only chrome; stage+sidebar both present
+    // plan g2.2: connecting stage restores clickable preview tab + HardLoadLayer
     expect(clarify.get('[data-testid="react-connecting-tab-pipeline"]').text()).toContain('流水线产物')
-    expect(clarify.text()).not.toContain('产物预览')
-    expect(clarify.find('[data-testid="react-artifact-tab-preview"]').exists()).toBe(false)
+    expect(clarify.get('[data-testid="react-connecting-tab-preview"]').text()).toContain('产物预览')
+    expect(clarify.get('[data-testid="react-connecting-tab-preview"]').attributes('aria-selected')).toBe('true')
+    expect(clarify.get('[data-testid="hard-load-layer"]').exists()).toBe(true)
+    expect(clarify.get('[data-testid="hard-load-stage"]').text()).toContain('加载产物内容')
+    expect(clarify.find('[data-testid="hard-load-retry"]').exists()).toBe(false)
 
     const review = mount(RunReviewPanel, {
       props: {
@@ -250,6 +253,7 @@ describe('Run detail panel shells (Demo entry assembly)', () => {
     expect(review.find('[data-testid="react-connecting-stage"]').exists()).toBe(true)
     expect(review.find('[data-testid="react-connecting-sidebar"]').exists()).toBe(true)
     expect((review.get('[data-testid="react-connecting-confirm"]').element as HTMLButtonElement).disabled).toBe(true)
-    expect(review.text()).not.toContain('产物预览')
+    expect(review.get('[data-testid="react-connecting-tab-preview"]').text()).toContain('产物预览')
+    expect(review.get('[data-testid="hard-load-layer"]').exists()).toBe(true)
   })
 })

--- a/web/src/lib/run/reactArtifactPreview.test.ts
+++ b/web/src/lib/run/reactArtifactPreview.test.ts
@@ -4,6 +4,7 @@ import type { Artifact, Run } from '@/lib/shared/types'
 import {
   REACT_STAGE_TAB_GRID,
   REACT_STAGE_TAB_NOVNC,
+  REACT_STAGE_TAB_PREVIEW,
   applyPreviewArtifactFromRun,
   applyPreviewArtifactName,
   artifactFingerprint,
@@ -253,7 +254,7 @@ describe('reactArtifactPreview helpers', () => {
     expect(openStagePreviewTab(['a.html', 'b.md'], 'a.html')).toEqual(['a.html', 'b.md'])
     expect(closeStagePreviewTab(['a.html', 'b.md'], 'a.html')).toEqual(['b.md'])
     expect(nextTabAfterClose(['a.html', 'b.md'], 'b.md', previewTabId('b.md'))).toBe(previewTabId('a.html'))
-    expect(nextTabAfterClose(['a.html'], 'a.html', previewTabId('a.html'))).toBe(REACT_STAGE_TAB_GRID)
+    expect(nextTabAfterClose(['a.html'], 'a.html', previewTabId('a.html'))).toBe(REACT_STAGE_TAB_PREVIEW)
     expect(nextTabAfterClose(['a.html', 'b.md'], 'a.html', previewTabId('b.md'))).toBe(previewTabId('b.md'))
     expect(nextTabAfterClose(['a.html'], 'a.html', previewTabId('a.html'), true)).toBe(REACT_STAGE_TAB_NOVNC)
     expect(nextTabAfterClose(['a.html'], 'a.html', REACT_STAGE_TAB_NOVNC)).toBe(REACT_STAGE_TAB_NOVNC)

--- a/web/src/lib/run/reactArtifactPreview.ts
+++ b/web/src/lib/run/reactArtifactPreview.ts
@@ -9,6 +9,8 @@ const FEEDBACK_INDEX_NAME = 'feedback_index.json'
 const FEEDBACK_PREFIX = 'feedback.'
 
 export const REACT_STAGE_TAB_GRID = 'grid'
+/** Chrome “产物预览” empty surface (distinct from per-artifact `preview:` tabs). */
+export const REACT_STAGE_TAB_PREVIEW = 'preview'
 export const REACT_STAGE_TAB_NOVNC = 'novnc'
 export const PREVIEW_TAB_PREFIX = 'preview:'
 
@@ -251,7 +253,11 @@ export function resolveStageRemoteKind(opts: {
   return 'off'
 }
 
-export type ReactStageTab = typeof REACT_STAGE_TAB_GRID | string
+export type ReactStageTab =
+  | typeof REACT_STAGE_TAB_GRID
+  | typeof REACT_STAGE_TAB_PREVIEW
+  | typeof REACT_STAGE_TAB_NOVNC
+  | string
 
 export function previewTabId(name: string): string {
   return PREVIEW_TAB_PREFIX + name
@@ -275,7 +281,7 @@ export function closeStagePreviewTab(openNames: string[], name: string): string[
   return openNames.filter((n) => n !== name)
 }
 
-/** After closing a tab, stay on the current one, else neighbor, else noVNC/grid. */
+/** After closing a tab, stay on the current one, else neighbor, else noVNC/preview empty. */
 export function nextTabAfterClose(
   openNames: string[],
   closed: string,
@@ -288,7 +294,7 @@ export function nextTabAfterClose(
     return currentTab
   }
   if (!remaining.length) {
-    return novncOpen ? REACT_STAGE_TAB_NOVNC : REACT_STAGE_TAB_GRID
+    return novncOpen ? REACT_STAGE_TAB_NOVNC : REACT_STAGE_TAB_PREVIEW
   }
   const i = openNames.indexOf(closed)
   const pick = remaining[Math.min(Math.max(i, 0), remaining.length - 1)] ?? remaining[remaining.length - 1]


### PR DESCRIPTION
Reconnect ReAct connecting stage chrome to a real pipeline/preview tab pair and reuse HardLoadLayer for preview loading; ready stage keeps a chrome preview empty state so connecting→ready no longer flashes HardLoadLayer or the pipeline grid.

Co-authored-by: Cursor <cursoragent@cursor.com>
